### PR TITLE
#2193: Store nanogpt intermediate tensors in L1

### DIFF
--- a/models/nanogpt/tt/nanogpt_attention.py
+++ b/models/nanogpt/tt/nanogpt_attention.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn as nn
+import tt_lib
+import math
+from tt_lib.fallback_ops import fallback_ops
+from models.helper_funcs import Linear
+import math
+
+from models.utility_functions import (
+    tt_to_torch_tensor,
+    torch_to_tt_tensor_rm,
+    torch_to_tt_tensor,
+)
+
+
+class TtCausalSelfAttention(nn.Module):
+    def __init__(self, config, state_dict, base_address, device):
+        super().__init__()
+        self.out_mem_config_l1 = tt_lib.tensor.MemoryConfig(
+            True, tt_lib.tensor.BufferType.L1
+        )
+
+        assert config.n_embd % config.n_head == 0
+
+        self.config = config
+        self.block_size = 1024
+
+        self.device = device
+        # Get the weights
+        self.tt_weight_c_attn = state_dict[f"{base_address}.c_attn.weight"]
+        self.tt_weight_c_proj = state_dict[f"{base_address}.c_proj.weight"]
+
+        # Push weights to Ttp device
+        self.tt_weight_c_attn = torch_to_tt_tensor(self.tt_weight_c_attn, self.device)
+
+        self.tt_weight_c_proj = torch_to_tt_tensor(self.tt_weight_c_proj, self.device)
+
+        self.tt_weight_c_attn = tt_lib.tensor.transpose(self.tt_weight_c_attn)
+        self.tt_weight_c_proj = tt_lib.tensor.transpose(self.tt_weight_c_proj)
+
+        # Load biases
+        self.tt_bias_c_attn = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.c_attn.bias"], self.device
+        )
+
+        self.tt_bias_c_proj = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.c_proj.bias"], self.device
+        )
+        self.n_head = self.config.n_head
+        self.n_embd = self.config.n_embd
+
+        self.register_buffer(
+            "bias",
+            torch.tril(torch.ones(self.block_size, self.block_size)).view(
+                1, 1, self.block_size, self.block_size
+            ),
+        )
+
+        self.c_attn = Linear(
+            self.config.n_embd,
+            3 * config.n_embd,
+            self.tt_weight_c_attn,
+            self.tt_bias_c_attn,
+            output_mem_config=self.out_mem_config_l1,
+        )
+        self.c_proj = Linear(
+            self.config.n_embd,
+            self.config.n_embd,
+            self.tt_weight_c_proj,
+            self.tt_bias_c_proj,
+            output_mem_config=self.out_mem_config_l1,
+        )
+
+    def const_tensor(self, shape, value):
+        return tt_lib.tensor.full(
+            shape, value, output_mem_config=self.out_mem_config_l1
+        )
+
+    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+        (
+            _,
+            B,
+            T,
+            C,
+        ) = x.shape()  # batch size, sequence length, embedding dimensionality (n_embd)
+
+        x1 = self.c_attn(x)
+
+        pt_x1 = tt_to_torch_tensor(x1)
+
+        # calculate query, key, values for all heads in batch and move head forward to be the batch dim
+        q, k, v = pt_x1.split(self.n_embd, dim=3)
+
+        k = torch_to_tt_tensor_rm(k, self.device)
+        q = torch_to_tt_tensor_rm(q, self.device)
+        v = torch_to_tt_tensor_rm(v, self.device)
+
+        k = fallback_ops.reshape(k, B, T, self.n_head, C // self.n_head)
+        k = tt_lib.tensor.transpose(k, 1, 2, output_mem_config=self.out_mem_config_l1)
+
+        q = fallback_ops.reshape(q, B, T, self.n_head, C // self.n_head)
+        q = tt_lib.tensor.transpose(q, 1, 2, output_mem_config=self.out_mem_config_l1)
+
+        v = fallback_ops.reshape(v, B, T, self.n_head, C // self.n_head)
+        v = tt_lib.tensor.transpose(v, 1, 2, output_mem_config=self.out_mem_config_l1)
+
+        # manual implementation of attention
+        key_layer_transposed = tt_lib.tensor.transpose(
+            k, output_mem_config=self.out_mem_config_l1
+        )
+        att = tt_lib.tensor.bmm(
+            q, key_layer_transposed, output_mem_config=self.out_mem_config_l1
+        )
+
+        const_att = self.const_tensor(att.shape(), 1.0 / math.sqrt(k.shape()[-1]))
+
+        att = tt_lib.tensor.mul(
+            att, const_att, output_mem_config=self.out_mem_config_l1
+        )
+
+        att = tt_to_torch_tensor(att)
+        att = att.masked_fill(self.bias[:, :, :T, :T] == 0, float("-inf"))
+
+        tt_att = torch_to_tt_tensor_rm(att, self.device, put_on_device=False)
+
+        tt_att = fallback_ops.softmax(tt_att, dim=-1)
+
+        tt_y = tt_lib.tensor.bmm(tt_att, v, output_mem_config=self.out_mem_config_l1)
+
+        tt_y = tt_lib.tensor.transpose_hc(
+            tt_y, output_mem_config=self.out_mem_config_l1
+        )
+        tt_y = fallback_ops.reshape(tt_y, 1, B, T, C)
+
+        # output projection
+        x2 = self.c_proj(tt_y)
+        return x2

--- a/models/nanogpt/tt/nanogpt_block.py
+++ b/models/nanogpt/tt/nanogpt_block.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import tt_lib
+import models.nanogpt.tt.nanogpt_mlp as nanogpt_mlp
+import models.nanogpt.tt.nanogpt_attention as nanogpt_attention
+
+
+from models.utility_functions import (
+    torch_to_tt_tensor_rm,
+)
+
+
+class TtBlock(nn.Module):
+    def __init__(self, config, state_dict, base_address, device):
+        super().__init__()
+        self.out_mem_config_l1 = tt_lib.tensor.MemoryConfig(
+            True, tt_lib.tensor.BufferType.L1
+        )
+        self.device = device
+        self.config = config
+
+        self.beta_1 = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.ln_1.bias"], self.device
+        )
+
+        self.gamma_1 = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.ln_1.weight"], self.device
+        )
+
+        self.ln_1 = tt_lib.tensor.layernorm
+
+        self.attn = nanogpt_attention.TtCausalSelfAttention(
+            config, state_dict, f"{base_address}.attn", device
+        )
+
+        self.beta_2 = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.ln_2.bias"], self.device
+        )
+
+        self.gamma_2 = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.ln_2.weight"], self.device
+        )
+
+        self.ln_2 = tt_lib.tensor.layernorm
+
+        self.mlp = nanogpt_mlp.TtMLP(
+            f"{base_address}.mlp", self.config, state_dict, device
+        )
+
+    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+        tmp = self.attn.forward(
+            self.ln_1(
+                x,
+                eps=1e-5,
+                gamma=self.gamma_1,
+                beta=self.beta_1,
+                output_mem_config=self.out_mem_config_l1,
+            )
+        )
+        x = tt_lib.tensor.add(x, tmp, output_mem_config=self.out_mem_config_l1)
+
+        tmp = self.mlp.forward(
+            self.ln_2(
+                x,
+                eps=1e-5,
+                gamma=self.gamma_2,
+                beta=self.beta_2,
+                output_mem_config=self.out_mem_config_l1,
+            )
+        )
+        x = tt_lib.tensor.add(x, tmp, output_mem_config=self.out_mem_config_l1)
+
+        return x

--- a/models/nanogpt/tt/nanogpt_mlp.py
+++ b/models/nanogpt/tt/nanogpt_mlp.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import tt_lib
+from models.helper_funcs import Linear
+
+from models.utility_functions import torch_to_tt_tensor_rm, torch_to_tt_tensor
+
+
+class TtMLP(torch.nn.Module):
+    def __init__(self, base_address, config, state_dict, device):
+        super().__init__()
+        self.out_mem_config_l1 = tt_lib.tensor.MemoryConfig(
+            True, tt_lib.tensor.BufferType.L1
+        )
+        # Get the weights
+        self.tt_weight_c_fc = state_dict[f"{base_address}.c_fc.weight"]
+        self.tt_weight_c_proj = state_dict[f"{base_address}.c_proj.weight"]
+        self.config = config
+        self.device = device
+
+        # Push weights to Tt device
+        self.tt_weight_c_fc = torch_to_tt_tensor(self.tt_weight_c_fc, self.device)
+
+        self.tt_weight_c_proj = torch_to_tt_tensor(self.tt_weight_c_proj, self.device)
+
+        # Load biases
+        self.tt_bias_c_fc = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.c_fc.bias"], self.device
+        )
+
+        self.tt_bias_c_proj = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.c_proj.bias"], self.device
+        )
+
+        self.tt_weight_c_fc = tt_lib.tensor.transpose(self.tt_weight_c_fc)
+        self.tt_weight_c_proj = tt_lib.tensor.transpose(self.tt_weight_c_proj)
+
+        self.c_fc = Linear(
+            config.n_embd,
+            4 * config.n_embd,
+            self.tt_weight_c_fc,
+            self.tt_bias_c_fc,
+            output_mem_config=self.out_mem_config_l1,
+        )
+        self.c_proj = Linear(
+            4 * config.n_embd,
+            config.n_embd,
+            self.tt_weight_c_proj,
+            self.tt_bias_c_proj,
+            output_mem_config=self.out_mem_config_l1,
+        )
+
+    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+        x1 = self.c_fc(x)
+        x2 = tt_lib.tensor.gelu(x1, output_mem_config=self.out_mem_config_l1)
+        x3 = self.c_proj(x2)
+
+        return x3

--- a/models/nanogpt/tt/nanogpt_model.py
+++ b/models/nanogpt/tt/nanogpt_model.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn as nn
+import tt_lib
+from models.helper_funcs import Linear
+
+import models.nanogpt.tt.nanogpt_block as nanogpt_block
+import tt_lib.fallback_ops as fallback_ops
+from models.utility_functions import (
+    torch_to_tt_tensor_rm,
+    tt_to_torch_tensor,
+)
+
+
+class TtGPT(nn.Module):
+    def __init__(self, config, state_dict, device):
+        super().__init__()
+        self.out_mem_config_l1 = tt_lib.tensor.MemoryConfig(
+            True, tt_lib.tensor.BufferType.L1
+        )
+        assert config.vocab_size is not None
+
+        self.config = config
+        self.config.block_size = 1024
+        base_address = f"transformer"
+        self.device = device
+        self.beta = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.ln_f.bias"], self.device
+        )
+
+        self.gamma = torch_to_tt_tensor_rm(
+            state_dict[f"{base_address}.ln_f.weight"], self.device
+        )
+
+        self.wte = nn.Embedding(config.vocab_size, config.n_embd)
+        self.wpe = nn.Embedding(self.config.block_size, config.n_embd)
+
+        self.wte.weight = torch.nn.Parameter(state_dict[f"{base_address}.wte.weight"])
+
+        self.wpe.weight = torch.nn.Parameter(state_dict[f"{base_address}.wpe.weight"])
+
+        blocks = []
+
+        for i in range(config.n_layer):
+            block = nanogpt_block.TtBlock(
+                self.config, state_dict, f"{base_address}.h.{i}", self.device
+            )
+            blocks.append(block)
+
+        self.h = nn.ModuleList(blocks)
+
+        self.ln_f = tt_lib.tensor.layernorm
+
+        # Push weights to Tt device
+        tt_lm_weight = torch_to_tt_tensor_rm(state_dict["lm_head.weight"], self.device)
+
+        self.lm_head = Linear(
+            self.config.n_embd,
+            self.config.vocab_size,
+            tt_lm_weight,
+            output_mem_config=self.out_mem_config_l1,
+        )
+
+        self.wte.weight = nn.Parameter(
+            state_dict["lm_head.weight"]
+        )  # https://paperswithcode.com/method/weight-tying
+
+    def generate(
+        self,
+        idx: torch.Tensor,
+        max_new_tokens: int = 20,
+        temperature: int = 1.0,
+        top_k=None,
+    ) -> torch.Tensor:
+        """
+        Take a conditioning sequence of indices idx (LongTensor of shape (b,t)) and complete
+        the sequence max_new_tokens times, feeding the predictions back into the model each time.
+        Most likely you'll want to make sure to be in model.eval() mode of operation for this.
+        """
+        for _ in range(max_new_tokens):
+            # if the sequence context is growing too long we must crop it at block_size
+            idx_cond = (
+                idx
+                if idx.size(1) <= self.config.block_size
+                else idx[:, -self.config.block_size :]
+            )
+
+            # forward the model to get the logits for the index in the sequenceß
+            tt_logits = self.forward(idx_cond)
+
+            logits_shapes = tt_logits.shape()
+
+            slice_list = [
+                slice(None),
+                slice(None),
+                slice(logits_shapes[2] - 1, logits_shapes[2]),
+                slice(None),
+            ]
+            tt_logits = fallback_ops.tensor_slice(tt_logits, slice_list)
+
+            tt_temperature = tt_lib.tensor.full(
+                tt_logits.shape(), temperature, output_mem_config=self.out_mem_config_l1
+            )
+
+            tt_temperature = tt_lib.tensor.recip(
+                tt_temperature, output_mem_config=self.out_mem_config_l1
+            )
+            tt_logits = tt_lib.tensor.mul(
+                tt_logits, tt_temperature, output_mem_config=self.out_mem_config_l1
+            )
+
+            logits = tt_to_torch_tensor(tt_logits)
+            # optionally crop the logits to only the top k options
+            if top_k is not None:
+                v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
+                logits[logits < v[:, [-1]]] = -float("Inf")
+
+            # apply softmax to convert logits to (normalized) probabilities
+            tt_logits = torch_to_tt_tensor_rm(logits, self.device, put_on_device=False)
+            tt_probs = fallback_ops.softmax(tt_logits, dim=-1)
+            probs = tt_to_torch_tensor(tt_probs).squeeze(0).squeeze(0)
+
+            # sample from the distribution
+            idx_next = torch.multinomial(probs, num_samples=1)
+
+            # append sampled index to the running sequence and continue
+            idx = torch.cat((idx, idx_next), dim=-1)
+
+        return idx
+
+    def forward(self, idx: torch.Tensor) -> tt_lib.tensor.Tensor:
+        b, t = idx.shape
+        assert (
+            t <= self.config.block_size
+        ), f"Cannot forward sequence of length {t}, block size is only {self.config.block_size}"
+        pos = torch.arange(0, t, dtype=torch.long).unsqueeze(0)  # shape (1, t)
+
+        # forward the GPT model itself
+        tok_emb = self.wte(idx)  # token embeddings of shape (b, t, n_embd)
+        pos_emb = self.wpe(pos)  # position embeddings of shape (1, t, n_embd)
+
+        tt_tok_emb = torch_to_tt_tensor_rm(tok_emb, self.device)
+        tt_pos_emb = torch_to_tt_tensor_rm(pos_emb, self.device)
+
+        tt_x = tt_lib.tensor.add(
+            tt_tok_emb, tt_pos_emb, output_mem_config=self.out_mem_config_l1
+        )
+
+        for block in self.h:
+            tt_x = block.forward(tt_x)
+
+        tt_x = self.ln_f(
+            tt_x,
+            eps=1e-5,
+            gamma=self.gamma,
+            beta=self.beta,
+            output_mem_config=self.out_mem_config_l1,
+        )
+        logits = self.lm_head(tt_x)
+
+        return logits


### PR DESCRIPTION
This PR has the following:

- Stored nanoGPT model's intermediate tensors in the L1 Cache to improve performance.