### PR TITLE
Bitwise Op Implementation

### DIFF
--- a/tt_metal/src/ckernels/wormhole_b0/common/inc/ckernel_sfpu.h
+++ b/tt_metal/src/ckernels/wormhole_b0/common/inc/ckernel_sfpu.h
@@ -940,9 +940,13 @@ inline void calculate_bitwise_or(uint value)
     // }
      for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        vInt val = 5;
-        vInt res =  reinterpret<vInt>(v) | other;
-        dst_reg[0] = reinterpret<vFloat>(res);
+        //vInt val = 5;
+        vInt int_v = float_to_int16(v);
+        vInt res_i =  int_v | other;
+
+        vFloat res = int32_to_float(res_i, 0);
+
+        dst_reg[0] = (res);
         dst_reg++;
     }
 }


### PR DESCRIPTION


In this PR tried to add support for Bitwise Ops implementation with uint32 support 
- 2b01c26ab0bba31387512a098ba89045320baa67 - Commit holds implementations of bitwise OR op

@muthutt  - Tried to add uint32 types - Following are the fixes while adding the uint32 type

- 3da40b50f4d28e431ed076c12cd1dba69731f229 - To pass `uint32` as data type for buffer
- c0c19a4dd5fff5f940a2c5ec93d310d16285c562 - Fix for cannot create host buffer for `uint32` and assert issue for the same 
- 751a28b27aba4d554fa6ae4675fedfaf7b100e42 - Fix for unknown format issue backend types

With all the above changes I am currently getting the following error 

```
Data-Format Error: The invalid output (packer) data-formats are not specified in ALL_INVALID_FORMAT_CONVERSIONS for this input data-format
Please add the invalid input to output conversions to ALL_INVALID_FORMAT_CONVERSIONS.
Data-Format Error: The invalid output (packer) data-formats are not specified in ALL_INVALID_FORMAT_CONVERSIONS for this input data-format
Please add the invalid input to output conversions to ALL_INVALID_FORMAT_CONVERSIONS.
Data-Format Error: The invalid output (packer) data-formats are not specified in ALL_INVALID_FORMAT_CONVERSIONS for this input data-format
Please add the invalid input to output conversions to ALL_INVALID_FORMAT_CONVERSIONS.
terminate called after throwing an instance of 'std::runtime_error'
  what():  TT_ASSERT @ tt_metal/build_kernels_for_riscv/data_format.cpp:15: false
backtrace:
 --- tt::check_input_to_output_valid_conversion(tt::DataFormat*, tt::DataFormat*, tt::DataFormat*, tt::DataFormat*)
 --- tt::check_valid_in_out_data_formats(tt::DataFormat*, tt::DataFormat*, tt::DataFormat*, tt::DataFormat*)
 --- tt::tt_metal::generate_data_format_descriptors(tt::build_kernel_for_riscv_options_t*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
 --- /home/ubuntu/uma/tt-metal/build/lib/libtt_metal.so(+0x11a84e) [0x7f5deeb6584e]
 --- /lib/x86_64-linux-gnu/libstdc++.so.6(+0xd6df4) [0x7f5e15fb9df4]
 --- /lib/x86_64-linux-gnu/libpthread.so.0(+0x8609) [0x7f5e33d14609]
 --- /lib/x86_64-linux-gnu/libc.so.6(clone+0x43) [0x7f5e33e4e133]

Fatal Python error: Aborted

Thread 0x00007f5e33b63740 (most recent call first):
  File "/home/ubuntu/uma/tt-metal/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py", line 1249 in eltwise_bitwise_or
  File "/home/ubuntu/uma/tt-metal/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py", line 27 in wrap
  File "/home/ubuntu/uma/tt-metal/tests/tt_eager/python_api_testing/sweep_tests/common.py", line 50 in run_tt_lib_test
  File "/home/ubuntu/uma/tt-metal/tests/ttterminate called recursively
_eager/python_api_testing/sweep_tests/run_pytorch_ci_tests.py", line 67 in run_single_pytorch_teAborted (core dumped)

```