### PR TITLE
#2838: Rework kernel groups

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
@@ -25,10 +25,12 @@ class CoreCoordHarness : public ::testing::Test {
     CoreRange cr13 = {.start={0, 0}, .end={1, 2}};
     CoreRange cr14 = {.start={0, 1}, .end={1, 1}};
     CoreRange cr15 = {.start={0, 1}, .end={0, 2}};
+    CoreRange cr16 = {.start={0, 0}, .end={1, 2}};
 
     CoreRange sc1 = {.start={1, 1}, .end={1, 1}};
     CoreRange sc2 = {.start={0, 1}, .end={0, 1}};
     CoreRange sc3 = {.start={0, 2}, .end={0, 2}};
+    CoreRange sc4 = {.start={1, 2}, .end={1, 2}};
 
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");

--- a/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
@@ -18,10 +18,17 @@ class CoreCoordHarness : public ::testing::Test {
     CoreRange cr6 = {.start={0, 0}, .end={6, 4}};
     CoreRange cr7 = {.start={2, 0}, .end={7, 4}};
     CoreRange cr8 = {.start={0, 0}, .end={7, 4}};
-    CoreRange sc1 = CoreCoord(1, 1);
-    CoreRange sc2 = CoreCoord(1, 2);
-    CoreRange sc3 = CoreCoord(1, 3);
+    CoreRange cr9 = {.start={2, 0}, .end={7, 1}};
+    CoreRange cr10 = {.start={0, 2}, .end={1, 2}};
+    CoreRange cr11 = {.start={1, 0}, .end={7, 1}};
+    CoreRange cr12 = {.start={0, 0}, .end={7, 1}};
+    CoreRange cr13 = {.start={0, 0}, .end={1, 2}};
+    CoreRange cr14 = {.start={0, 1}, .end={1, 1}};
+    CoreRange cr15 = {.start={0, 1}, .end={0, 2}};
 
+    CoreRange sc1 = {.start={1, 1}, .end={1, 1}};
+    CoreRange sc2 = {.start={0, 1}, .end={0, 1}};
+    CoreRange sc3 = {.start={0, 2}, .end={0, 2}};
 
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");

--- a/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
@@ -31,12 +31,4 @@ class CoreCoordHarness : public ::testing::Test {
     CoreRange sc2 = {.start={0, 1}, .end={0, 1}};
     CoreRange sc3 = {.start={0, 2}, .end={0, 2}};
     CoreRange sc4 = {.start={1, 2}, .end={1, 2}};
-
-    void SetUp() override {
-        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (not slow_dispatch) {
-            tt::log_fatal("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
-            GTEST_SKIP();
-        }
-    }
 };

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
@@ -10,22 +10,40 @@
 
 namespace basic_tests::CoreRangeSet{
 
-TEST_F(CoreCoordHarness, TestCoreRangeSetMerge)
+TEST_F(CoreCoordHarness, TestCoreRangeSetMergeNoSolution)
+{
+    EXPECT_EQ ( ::CoreRangeSet({sc1}).merge({sc3}).ranges() , std::set<::CoreRange>( {sc1,sc3}) );
+    EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({cr2}).ranges() , std::set<::CoreRange>( {cr1,cr2}) );
+    EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({cr1,cr2}).ranges() , std::set<::CoreRange>( {cr1,cr2}) );
+    EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({cr2}).merge({cr3}).ranges() , std::set<::CoreRange>( {cr1,cr2,cr3}) );
+}
+
+TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreCoord)
 {
     ::CoreRangeSet empty_crs({});
     EXPECT_EQ ( empty_crs.merge({this->sc1}).ranges().size(), 1);
+    EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({sc3, sc4}).ranges() , std::set<::CoreRange>( {cr16}) );
+    EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({sc3}).merge({sc4}).ranges() , std::set<::CoreRange>( {cr16}) );
+    CoreRange rect ( {0,0}, {4,2});
+    std::set<CoreRange> rect_pts;
+    for (unsigned y = rect.start.y; y <= rect.end.y; y++){
+        for (unsigned x = rect.start.x; x <= rect.end.x; x++){
+            rect_pts.insert ( CoreRange( CoreCoord(x, y), CoreCoord(x, y) ) );
+        }
+    }
+    EXPECT_EQ ( empty_crs.merge(rect_pts).ranges(), std::set<::CoreRange>( {rect} ));
+    rect_pts.insert ( { CoreRange ( { 2,0}, {3,5} )});
+    EXPECT_EQ ( empty_crs.merge(rect_pts).ranges(), std::set<::CoreRange>( {rect, CoreRange( {2,3}, {3,5} ) } ));
 
+}
+
+TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreRange)
+{
     EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({cr1}).ranges() , std::set<::CoreRange>( {cr1}) );
-    EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({cr1}).ranges() , std::set<::CoreRange>( {cr1}) );
-    EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({cr2}).merge({cr3}).ranges() , std::set<::CoreRange>( {cr1,cr2,cr3}) );
-    EXPECT_EQ ( ::CoreRangeSet({cr1, cr2, cr3}).merge({cr4}).ranges() , std::set<::CoreRange>( {cr4}) );
-
-    EXPECT_EQ ( ::CoreRangeSet({cr1, cr2}).merge({cr4}).merge({cr6}).ranges() , std::set<::CoreRange>( {cr6}) );
-
     EXPECT_EQ ( ::CoreRangeSet({cr7}).merge({cr6}).merge({cr4}).ranges() , std::set<::CoreRange>( {cr8} ) );
-
     EXPECT_EQ ( ::CoreRangeSet({cr8}).merge({cr7}).merge({cr6}).merge({cr4}).ranges() , std::set<::CoreRange>( {cr8} ) );
-
+    EXPECT_EQ ( ::CoreRangeSet({cr1, cr2, cr3}).merge({cr4}).ranges() , std::set<::CoreRange>( {cr4}) );
+    EXPECT_EQ ( ::CoreRangeSet({cr1, cr2}).merge({cr4}).merge({cr6}).ranges() , std::set<::CoreRange>( {cr6}) );
 }
 
 }

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
@@ -28,13 +28,19 @@ TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreCoord)
     std::set<CoreRange> rect_pts;
     for (unsigned y = rect.start.y; y <= rect.end.y; y++){
         for (unsigned x = rect.start.x; x <= rect.end.x; x++){
-            rect_pts.insert ( CoreRange( CoreCoord(x, y), CoreCoord(x, y) ) );
+            rect_pts.insert ( CoreRange( {x, y}, {x, y} ) );
         }
     }
     EXPECT_EQ ( empty_crs.merge(rect_pts).ranges(), std::set<::CoreRange>( {rect} ));
+
+    // upside-down "T"
     rect_pts.insert ( { CoreRange ( { 2,0}, {3,5} )});
     EXPECT_EQ ( empty_crs.merge(rect_pts).ranges(), std::set<::CoreRange>( {rect, CoreRange( {2,3}, {3,5} ) } ));
 
+    // "H", sub-optimal currently, should be reduced down to 3 CRs instead of 5
+    EXPECT_EQ ( empty_crs.merge( { CoreRange { {0,0}, {1,5} }, CoreRange { {3,0}, {4,5}}, CoreRange { {0,2} , {4,3} }  } ).ranges(),
+                std::set<::CoreRange>( { CoreRange { {0,0}, {1,1} }, CoreRange { {0,2}, {4,3}}, CoreRange{ {0,4}, {1,5}},
+                                       CoreRange { {3,0}, {4,1} }, CoreRange{ {3,4}, {4,5} } } ));
 }
 
 TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreRange)

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_adjacent.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+
+#include "gtest/gtest.h"
+#include "tt_metal/common/core_coord.h"
+#include "core_coord_fixture.hpp"
+
+namespace basic_tests::CoreRange{
+
+TEST_F(CoreCoordHarness, TestCoreRangeAdjacent)
+{
+    EXPECT_TRUE ( this->cr1.adjacent(this->cr9) );
+    EXPECT_TRUE ( this->cr9.adjacent(this->cr1) );
+    EXPECT_TRUE ( this->cr1.adjacent(this->cr10) );
+    EXPECT_TRUE ( this->sc1.adjacent(this->sc2) );
+    EXPECT_TRUE ( this->sc2.adjacent(this->sc3) );
+    EXPECT_TRUE ( this->cr1.adjacent(this->cr3));
+    EXPECT_TRUE ( this->cr3.adjacent(this->cr1));
+    EXPECT_TRUE ( this->cr1.adjacent(this->cr7));
+
+}
+
+TEST_F(CoreCoordHarness, TestCoreRangeNotAdjacent){
+    EXPECT_FALSE ( this->cr2.adjacent(this->cr3));
+    EXPECT_FALSE ( this->cr1.adjacent(this->cr6));
+    EXPECT_FALSE ( this->cr1.adjacent(this->cr11));
+    EXPECT_FALSE ( this->cr6.adjacent(this->sc1));
+    EXPECT_FALSE ( this->cr16.adjacent(this->sc4));
+    EXPECT_FALSE ( this->sc2.adjacent(this->sc4) );
+    EXPECT_FALSE ( this->cr1.adjacent(this->cr2) );
+}
+
+}

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_merge.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_merge.cpp
@@ -16,6 +16,13 @@ TEST_F(CoreCoordHarness, TestCoreRangeMerge)
     EXPECT_EQ ( this->cr4.merge(this->cr5).value(), this->cr6 );
     EXPECT_EQ ( this->cr4.merge(this->cr6).value(), this->cr6 );
     EXPECT_EQ ( this->cr4.merge(this->cr4).value(), this->cr4 );
+    EXPECT_EQ ( this->cr1.merge(this->cr9).value(), this->cr12 );
+    EXPECT_EQ ( this->cr1.merge(this->cr11).value(), this->cr12 );
+    EXPECT_EQ ( this->cr1.merge(this->cr10).value(), this->cr13 );
+    EXPECT_EQ ( this->cr1.merge(this->cr10).value(), this->cr13 );
+    EXPECT_EQ ( this->single_core.merge(this->single_core1).value(), this->cr14 );
+    EXPECT_EQ ( this->single_core1.merge(this->single_core2).value(), this->cr15 );
+
 }
 
 TEST_F(CoreCoordHarness, TestCoreRangeNotMergeable){
@@ -23,7 +30,8 @@ TEST_F(CoreCoordHarness, TestCoreRangeNotMergeable){
     EXPECT_FALSE ( this->cr2.merge(this->cr3));
     EXPECT_FALSE ( this->cr1.merge(this->cr6));
     EXPECT_FALSE ( this->sc1.merge(this->sc3));
-    EXPECT_FALSE ( this->sc1.merge(this->sc2) );
+    EXPECT_FALSE ( this->cr1.merge(this->cr5));
+    EXPECT_FALSE ( this->cr1.merge(this->cr7));
 }
 
 }

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_merge.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_merge.cpp
@@ -20,8 +20,8 @@ TEST_F(CoreCoordHarness, TestCoreRangeMerge)
     EXPECT_EQ ( this->cr1.merge(this->cr11).value(), this->cr12 );
     EXPECT_EQ ( this->cr1.merge(this->cr10).value(), this->cr13 );
     EXPECT_EQ ( this->cr1.merge(this->cr10).value(), this->cr13 );
-    EXPECT_EQ ( this->single_core.merge(this->single_core1).value(), this->cr14 );
-    EXPECT_EQ ( this->single_core1.merge(this->single_core2).value(), this->cr15 );
+    EXPECT_EQ ( this->sc1.merge(this->sc2).value(), this->cr14 );
+    EXPECT_EQ ( this->sc2.merge(this->sc3).value(), this->cr15 );
 
 }
 

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -236,14 +236,13 @@ class CoreRangeSet {
             x_start = x;
           }
           else if ( !grid[y][x] && x_start.has_value()){
-            ranges.push_back( CoreRange( CoreCoord (x_start.value(), y), CoreCoord (x-1, y) ));
+            ranges.push_back( CoreRange( {x_start.value(), y}, {x-1, y} ));
             // std::cout << "added CR " << ranges.back().str() << std::endl;
             x_start = std::nullopt;
-            TT_ASSERT( !x_start.has_value() );
           }
         }
         if (x_start.has_value()){
-          ranges.push_back( CoreRange( CoreCoord (x_start.value(), y), CoreCoord (max_x, y) ) );
+          ranges.push_back( CoreRange( {x_start.value(), y}, {max_x, y} ) );
           // std::cout << "added CR " << ranges.back().str() << std::endl;
         }
         for (const auto & cr : ranges){

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -75,6 +75,15 @@ struct CoreRange {
         return {};
     }
 
+    bool adjacent ( const CoreRange & other ) const
+    {
+        std::size_t x1 = std::max(this->start.x, other.start.x);
+        std::size_t y1 = std::max(this->start.y, other.start.y);
+        std::size_t x2 = std::min(this->end.x, other.end.x);
+        std::size_t y2 = std::min(this->end.y, other.end.y);
+        return ( (x2 + 1 == x1 && y1 <= y2) || (y2 + 1 == y1 && x1 <= x2) );
+    }
+
     bool contains ( const CoreRange & other ) const
     {
         return (other.start.x >= this->start.x ) &&
@@ -86,7 +95,7 @@ struct CoreRange {
     // Merge lined-up (in x or y dimension) intersecting/adjacent rectangles
     std::optional<CoreRange> merge ( const CoreRange & cr) const
     {
-        if ( this->intersects(cr) ){
+        if ( this->intersects(cr) || this->adjacent(cr) ) {
             if ( this->start.x == cr.start.x && this->end.x == cr.end.x )
                 return CoreRange ( {this->start.x, std::min(this->start.y, cr.start.y)} , { this->end.x, std::max( this->end.y, cr.end.y) } );
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -27,7 +27,7 @@ u32 get_noc_multicast_encoding(const CoreCoord& top_left, const CoreCoord& botto
 
 u32 align(u32 addr, u32 alignment) { return ((addr - 1) | (alignment - 1)) + 1; }
 
-ProgramSrcToDstAddrMap ConstructProgramSrcToDstAddrMap(const Device* device, Program& program) {
+ProgramSrcToDstAddrMap ConstructProgramSrcToDstAddrMap(const Device* device, const Program& program) {
     // This function retrieves all the required information to group program binaries into sections,
     // such that each section is the largest amount of data that can be read into the dispatch
     // core's L1 at a time. For each section, it also specifies the relay program information,
@@ -735,7 +735,7 @@ void CommandQueue::enqueue_write_buffer(Buffer& buffer, vector<u32>& src, bool b
     this->enqueue_command(command, blocking);
 }
 
-void CommandQueue::enqueue_program(Program& program, bool blocking) {
+void CommandQueue::enqueue_program(const Program& program, bool blocking) {
     ZoneScopedN("CommandQueue_enqueue_program");
     TT_ASSERT(not blocking, "EnqueueProgram only has support for non-blocking mode currently");
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -95,7 +95,7 @@ struct ProgramSrcToDstAddrMap {
     u32 num_workers;
 };
 
-ProgramSrcToDstAddrMap ConstructProgramSrcToDstAddrMap(const Device* device, Program& program);
+ProgramSrcToDstAddrMap ConstructProgramSrcToDstAddrMap(const Device* device, const Program& program);
 
 // Only contains the types of commands which are enqueued onto the device
 enum class EnqueueCommandType { ENQUEUE_READ_BUFFER, ENQUEUE_WRITE_BUFFER, ENQUEUE_PROGRAM, FINISH, WRAP, INVALID };
@@ -237,7 +237,7 @@ class CommandQueue {
 
     void enqueue_write_buffer(Buffer& buffer, vector<u32>& src, bool blocking);
 
-    void enqueue_program(Program& program, bool blocking);
+    void enqueue_program(const Program& program, bool blocking);
 
     void finish();
 

--- a/tt_metal/impl/program.cpp
+++ b/tt_metal/impl/program.cpp
@@ -255,7 +255,7 @@ void Program::update_kernel_groups() {
             kernel_groups_.push_back(KernelGroup(kg_to_cores.first.brisc_id,
                                                  kg_to_cores.first.ncrisc_id,
                                                  kg_to_cores.first.trisc_id));
-            kernel_groups_.back().core_ranges.merge(kg_to_cores.second);
+            kernel_groups_.back().core_ranges = kernel_groups_.back().core_ranges.merge( kg_to_cores.second);
 
             // Map from core X,Y back to the unique KernelGroup
             for (CoreRange range : kg_to_cores.second) {
@@ -528,7 +528,7 @@ std::vector<CoreCoord> Program::logical_cores() const {
 void Program::construct_core_range_set_for_worker_cores() {
     bool found_kernels = false;
     for (const auto &[kernel_id, kernel] : this->kernel_by_id_) {
-        this->worker_crs_.merge ( kernel->core_range_set());
+        this->worker_crs_ = this->worker_crs_.merge ( kernel->core_range_set() );
         found_kernels = true;
     }
     TT_ASSERT(!found_kernels || this->worker_crs_.ranges().size() >= 1, "Invalid core range set");
@@ -549,11 +549,11 @@ void Program::add_blank_kernels(Device *device) {
     vector<KernelID> blank_ids;
     for (auto& kernel_group : this->kernel_groups_) {
         if (not kernel_group.riscv0_id.has_value())
-            unique_core_ranges_without_brisc_kernel.merge(kernel_group.core_ranges.ranges());
+            unique_core_ranges_without_brisc_kernel = unique_core_ranges_without_brisc_kernel.merge( kernel_group.core_ranges);
         if (not kernel_group.riscv1_id.has_value())
-            unique_core_ranges_without_ncrisc_kernel.merge(kernel_group.core_ranges.ranges());
+            unique_core_ranges_without_ncrisc_kernel = unique_core_ranges_without_ncrisc_kernel.merge(kernel_group.core_ranges);
         if (not kernel_group.compute_id.has_value())
-            unique_core_ranges_without_compute_kernel.merge(kernel_group.core_ranges.ranges());
+            unique_core_ranges_without_compute_kernel = unique_core_ranges_without_compute_kernel.merge( kernel_group.core_ranges);
     }
 
     if (not unique_core_ranges_without_brisc_kernel.ranges().empty()) {

--- a/tt_metal/impl/program.hpp
+++ b/tt_metal/impl/program.hpp
@@ -83,7 +83,7 @@ class Program {
     void init_semaphores ( const Device & device, const CoreCoord &logical_core ) const;
     std::vector<CoreCoord> logical_cores() const;
 
-    CoreRangeSet get_worker_core_range_set() const { return worker_crs_; };
+    const CoreRangeSet& get_worker_core_range_set() const { return worker_crs_; };
 
     std::vector<std::string> cores_to_ops() const;
 


### PR DESCRIPTION
All stored kernel groups are now unique, cores index into the list of kernel groups.  This is another step towards fast dispatch sending a go message (per unique kernel group).