### PR TITLE
#3040: implement rpow, rdiv, and rsub for the reciprocal ops

### DIFF
--- a/docs/source/libraries/tt_dnn.rst
+++ b/docs/source/libraries/tt_dnn.rst
@@ -640,3 +640,9 @@ Other Operations
 .. autofunction:: tt_lib.tensor.reglu
 
 .. autofunction:: tt_lib.tensor.swiglu
+
+.. autofunction:: tt_lib.tensor.rpow
+
+.. autofunction:: tt_lib.tensor.rsub
+
+.. autofunction:: tt_lib.tensor.rdiv

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -145,9 +145,9 @@ namespace tt::tt_metal::detail{
 
         detail::bind_unary_op_with_param(
             m_tensor, "rpow", rpow,
-            py::arg("exponent in function call but calculated as base"),
-            R"doc(Returns tensor  raising ``{1}`` value to power of respective elements of the input tensor ``{0}``.)doc",
-            R"doc("exponent value", "float", ">0.0")doc"
+            py::arg("base"),
+            R"doc(Returns tensor  raising ``{1}`` value to power of respective elements of the input exponent tensor ``{0}``.)doc",
+            R"doc("base value", "float", ">0.0")doc"
         );
 
         detail::bind_unary_op_with_param(


### PR DESCRIPTION
#3040: implement rpow, rdiv, and rsub for the reciprocal ops
     : add rsub, rpow, rdiv ops for WH B0
     : black fmt
     : add docs