### PR TITLE
#3054: unary assign, binary assign operators for tt_dnn

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_binary_assign.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_binary_assign.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+def function_assign_binary(x,y):
+    if x.shape != y.shape or x.is_contiguous() != y.is_contiguous():
+      raise ValueError("Tensors x and y do not have the same shape and memory layout.")
+    y.copy_(x)
+    print(y)
+x = torch.tensor([5.0, 5.3, 9.0, 23])
+y = torch.tensor([5.0, 12, 9.0, 23])
+print("Binary Assign : ")
+function_assign_binary(x,y)

--- a/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_unary_assign.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_unary_assign.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+def function_assign_unary(x):
+  y = x.clone()
+  return y
+x = torch.tensor([5.0, 5.3, 9.0, 23])
+print("Unary Assign : ")
+z = function_assign_unary(x)
+print(z)

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_assign_binary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_assign_binary_test.yaml
@@ -1,0 +1,18 @@
+---
+test-list:
+  eltwise-assign_binary:
+    shape:
+      start-shape: [1, 1, 1, 2]
+      end-shape: [2, 2, 2048, 2048]
+      interval: [1, 1, 1, 2]
+      num-shapes: 2
+      num-samples: 2048
+    datagen:
+      function: gen_rand
+      args:
+        low: -100
+        high: 100
+      dtype: bfloat16
+    comparison:
+      function: comp_pcc
+    output-file: eltwise_assign_binary_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_assign_unary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_assign_unary_test.yaml
@@ -1,0 +1,18 @@
+---
+test-list:
+  eltwise-assign_unary:
+    shape:
+      start-shape: [1, 1, 1, 2]
+      end-shape: [2, 2, 2048, 2048]
+      interval: [1, 1, 1, 2]
+      num-shapes: 1
+      num-samples: 2048
+    datagen:
+      function: gen_rand
+      args:
+        low: -100
+        high: 100
+      dtype: bfloat16
+    comparison:
+      function: comp_equal
+    output-file: eltwise_assign_unary_sweep.csv

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -967,10 +967,10 @@ Tensor assign(const Tensor& input_a, const MemoryConfig& output_mem_config)
 }
 
 // binary assign
-Tensor _assign_binary(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {
+Tensor _assign_binary(const Tensor& input_a,const Tensor& input_b, const MemoryConfig& output_mem_config) {
     TT_ASSERT( (input_a.layout() == input_b.layout()) , "Input tensors layout need to be same");
-    TT_ASSERT( (input_a.volume() == input_b.volume()) , "Input tensors volume need to be same");
-    Tensor result = clone(input_a, output_mem_config);
+    TT_ASSERT( (input_a.shape() == input_b.shape()) , "Input tensors shape need to be same");
+    Tensor result = copy(input_a, input_b);
     return result;
 }
 Tensor assign(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config)

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -601,9 +601,9 @@ namespace tt::tt_metal::detail{
             Moves input tensor ``arg0`` (given by input_a) to ``arg1`` (given by input_b) if their
             volumes and memory layouts match, and returns input_b tensor.
 
-            Input tensor must have BFLOAT16 data type.
+            Input tensors can be of any data type.
 
-            Output tensor will have BFLOAT16 data type.
+            Output tensor will be of same data type as Input tensor.
 
             .. csv-table::
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
@@ -617,9 +617,9 @@ namespace tt::tt_metal::detail{
             py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Clones input tensors ``arg0`` (given by input) and returns the output tensor.
 
-            Input tensor must have BFLOAT16 data type.
+            Input tensor can be of any data type.
 
-            Output tensor will have BFLOAT16 data type.
+            Output tensor will be of same data type as Input tensor.
 
             .. csv-table::
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"


### PR DESCRIPTION
#3054: unary assign, binary assign operators for tt_dnn

ElemwiseBinary/ELEMWISE_BINARY_ASSIGN | BINARY = copy()
copy(): https://pytorch.org/docs/stable/generated/torch.Tensor.copy_.html

ElemwiseBinary/ELEMWISE_UNARY_ASSIGN | BINARY = clone()
clone() : https://pytorch.org/docs/stable/generated/torch.clone.html