### PR TITLE
#3084: Add bitwise shift ops as fallback ops

### DIFF
--- a/docs/source/libraries/tt_dnn.rst
+++ b/docs/source/libraries/tt_dnn.rst
@@ -543,6 +543,14 @@ These operations are currently not supported on TT accelerator device and will e
 
 .. autoclass:: tt_lib.fallback_ops.bitwise_not
 
+.. autoclass:: tt_lib.fallback_ops.unary_bitwise_right_shift
+
+.. autoclass:: tt_lib.fallback_ops.unary_bitwise_left_shift
+
+.. autoclass:: tt_lib.fallback_ops.binary_bitwise_right_shift
+
+.. autoclass:: tt_lib.fallback_ops.binary_bitwise_left_shift
+
 Experimental Operations
 =======================
 

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_ops.py
@@ -30,10 +30,8 @@ class TestBitwiseOps:
         x = torch.randint(low=0, high=100, size=input_shapes)
         # Test on host RM
         t0 = ttl.tensor.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            ttl.tensor.DataType.BFLOAT16,
-            ttl.tensor.Layout.ROW_MAJOR,
+            x,
+            ttl.tensor.DataType.UINT32,
         )
         if on_device:
             t0 = t0.to(device)
@@ -64,18 +62,14 @@ class TestBitwiseOps:
         y = torch.randint(low=0, high=200, size=input_shapes)
         # Test on host RM
         t0 = ttl.tensor.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            ttl.tensor.DataType.BFLOAT16,
-            ttl.tensor.Layout.ROW_MAJOR,
+            x,
+            ttl.tensor.DataType.UINT32,
         )
         if on_device:
             t0 = t0.to(device)
         t1 = ttl.tensor.Tensor(
-            y.reshape(-1).tolist(),
-            y.shape,
-            ttl.tensor.DataType.BFLOAT16,
-            ttl.tensor.Layout.ROW_MAJOR,
+            y,
+            ttl.tensor.DataType.UINT32,
         )
         if on_device:
             t1 = t1.to(device)

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_shift_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_shift_ops.py
@@ -29,10 +29,8 @@ class TestBitwiseShiftOps:
         x = torch.randint(low=0, high=100, size=input_shapes)
         # Test on host RM
         t0 = ttl.tensor.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            ttl.tensor.DataType.BFLOAT16,
-            ttl.tensor.Layout.ROW_MAJOR,
+            x,
+            ttl.tensor.DataType.UINT32,
         )
         if on_device:
             t0 = t0.to(device)
@@ -57,19 +55,15 @@ class TestBitwiseShiftOps:
 
         # Test on host RM
         t0 = ttl.tensor.Tensor(
-            x.reshape(-1).tolist(),
-            x.shape,
-            ttl.tensor.DataType.BFLOAT16,
-            ttl.tensor.Layout.ROW_MAJOR,
+            x,
+            ttl.tensor.DataType.UINT32,
         )
         if on_device:
             t0 = t0.to(device)
 
         t1 = ttl.tensor.Tensor(
-            y.reshape(-1).tolist(),
-            y.shape,
-            ttl.tensor.DataType.BFLOAT16,
-            ttl.tensor.Layout.ROW_MAJOR,
+            y,
+            ttl.tensor.DataType.UINT32,
         )
         if on_device:
             t1 = t1.to(device)

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_shift_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_shift_ops.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import tt_lib as ttl
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
+from loguru import logger
+import pytest
+
+
+@pytest.mark.parametrize("on_device", [True, False])
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("shift_kind", ["right", "left"])
+class TestBitwiseShiftOps:
+    @pytest.mark.parametrize("other", [5, 10])
+    def test_bitwise_unary_shift_fallback(self, input_shapes, other, shift_kind, on_device, device):
+        torch.manual_seed(1234)
+
+        x = torch.randint(low=0, high=100, size=input_shapes)
+        # Test on host RM
+        t0 = ttl.tensor.Tensor(
+            x.reshape(-1).tolist(),
+            x.shape,
+            ttl.tensor.DataType.BFLOAT16,
+            ttl.tensor.Layout.ROW_MAJOR,
+        )
+        if on_device:
+            t0 = t0.to(device)
+        if shift_kind == "right":
+            t1 = ttl.fallback_ops.unary_bitwise_right_shift(t0, other)
+            pt_out = torch.bitwise_right_shift(x, other)
+        elif shift_kind == "left":
+            t1 = ttl.fallback_ops.unary_bitwise_left_shift(t0, other)
+            pt_out = torch.bitwise_left_shift(x, other)
+
+        output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        comp_pass, _ = comparison_funcs.comp_equal(pt_out, output)
+        _, comp_out = comparison_funcs.comp_allclose_and_pcc(pt_out, output)
+        logger.info(comp_out)
+        assert comp_pass
+
+    def test_bitwise_binary_shift_fallback(self, input_shapes, shift_kind, on_device, device):
+        torch.manual_seed(1234)
+
+        x = torch.randint(low=10, high=100, size=input_shapes)
+        y = torch.randint(low=1, high=10, size=input_shapes)
+
+        # Test on host RM
+        t0 = ttl.tensor.Tensor(
+            x.reshape(-1).tolist(),
+            x.shape,
+            ttl.tensor.DataType.BFLOAT16,
+            ttl.tensor.Layout.ROW_MAJOR,
+        )
+        if on_device:
+            t0 = t0.to(device)
+
+        t1 = ttl.tensor.Tensor(
+            y.reshape(-1).tolist(),
+            y.shape,
+            ttl.tensor.DataType.BFLOAT16,
+            ttl.tensor.Layout.ROW_MAJOR,
+        )
+        if on_device:
+            t1 = t1.to(device)
+
+        if shift_kind == "right":
+            tout = ttl.fallback_ops.binary_bitwise_right_shift(t0, t1)
+            pt_out = torch.bitwise_right_shift(x, y)
+        elif shift_kind == "left":
+            tout = ttl.fallback_ops.binary_bitwise_left_shift(t0, t1)
+            pt_out = torch.bitwise_left_shift(x, y)
+
+        output = tout.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        comp_pass, _ = comparison_funcs.comp_equal(pt_out, output)
+        _, comp_out = comparison_funcs.comp_allclose_and_pcc(pt_out, output)
+        logger.info(comp_out)
+        assert comp_pass

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
@@ -430,17 +430,21 @@ namespace tt::tt_metal::detail
             )
             .def(
                 py::init<>(
-                    [](const py::object& torch_tensor, DataType data_type) {
+                    [](const py::object& torch_tensor, std::optional<DataType> data_type = std::nullopt) {
                         return detail::convert_torch_tensor_to_tt_tensor(torch_tensor, data_type);
                     }
                 ),
+                py::arg("torch_tensor"),
+                py::arg("data_type") = std::nullopt,
                 py::return_value_policy::move,
                 R"doc(
-                    +---------------+---------------+
-                    | Argument      | Name          |
-                    +===============+===============+
-                    | arg0          | torch_tensor  |
-                    +---------------+---------------+
+                    +--------------+---------------------+
+                    | Argument     | Description         |
+                    +==============+=====================+
+                    | torch_tensor | Pytorch Tensor      |
+                    +--------------+---------------------+
+                    | data_type    | TT Tensor data type |
+                    +--------------+---------------------+
 
                     Example of creating a TT Tensor that uses torch.Tensor's storage as its own storage:
 

--- a/tt_eager/tt_lib/fallback_ops/fallback_ops.py
+++ b/tt_eager/tt_lib/fallback_ops/fallback_ops.py
@@ -762,7 +762,7 @@ def unary_bitwise_or(input: ttl_tensor.Tensor, other: int) -> ttl_tensor.Tensor:
     | other      | Immediate value                               | int         |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_or(input.to(torch.int), other)
+    return torch.bitwise_or(input, other)
 
 
 @convert_tt_tensors_wrapper
@@ -778,7 +778,7 @@ def unary_bitwise_and(input: ttl_tensor.Tensor, other: int) -> ttl_tensor.Tensor
     | other      | Immediate value                               | int         |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_and(input.to(torch.int), other)
+    return torch.bitwise_and(input, other)
 
 
 @convert_tt_tensors_wrapper
@@ -794,7 +794,7 @@ def unary_bitwise_xor(input: ttl_tensor.Tensor, other: int) -> ttl_tensor.Tensor
     | other      | Immediate value                               | int         |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_xor(input.to(torch.int), other)
+    return torch.bitwise_xor(input, other)
 
 
 @convert_tt_tensors_wrapper
@@ -809,7 +809,7 @@ def bitwise_not(input: ttl_tensor.Tensor) -> ttl_tensor.Tensor:
     +------------+-----------------------------------------------+-------------+-----------------+----------+
 
     """
-    return torch.bitwise_not(input.to(torch.int))
+    return torch.bitwise_not(input)
 
 
 @convert_tt_tensors_wrapper
@@ -825,7 +825,7 @@ def binary_bitwise_or(input: ttl_tensor.Tensor, other: ttl_tensor.Tensor) -> ttl
     | other      | Second tensor                                 | Tensor      |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_or(input.to(torch.int), other.to(torch.int))
+    return torch.bitwise_or(input, other)
 
 
 @convert_tt_tensors_wrapper
@@ -841,7 +841,7 @@ def binary_bitwise_and(input: ttl_tensor.Tensor, other: ttl_tensor.Tensor) -> tt
     | other      | Second Tensor                                 | Tensor      |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_and(input.to(torch.int), other.to(torch.int))
+    return torch.bitwise_and(input, other)
 
 
 @convert_tt_tensors_wrapper
@@ -857,7 +857,7 @@ def binary_bitwise_xor(input: ttl_tensor.Tensor, other: ttl_tensor.Tensor) -> tt
     | other      | Second tensor                                 | Tensor      |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_xor(input.to(torch.int), other.to(torch.int))
+    return torch.bitwise_xor(input, other)
 
 
 @convert_tt_tensors_wrapper
@@ -875,7 +875,7 @@ def unary_bitwise_right_shift(input: ttl_tensor.Tensor, other: int) -> ttl_tenso
     | other      | Immediate value                               | int         |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_right_shift(input.to(torch.int), other)
+    return torch.bitwise_right_shift(input, other)
 
 
 @convert_tt_tensors_wrapper
@@ -891,7 +891,7 @@ def unary_bitwise_left_shift(input: ttl_tensor.Tensor, other: int) -> ttl_tensor
     | other      | Immediate value                               | int         |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_left_shift(input.to(torch.int), other)
+    return torch.bitwise_left_shift(input, other)
 
 
 @convert_tt_tensors_wrapper
@@ -909,7 +909,7 @@ def binary_bitwise_right_shift(input: ttl_tensor.Tensor, other: ttl_tensor.Tenso
     | other      | Second tensor                                 | Tensor      |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_right_shift(input.to(torch.int), other.to(torch.int))
+    return torch.bitwise_right_shift(input, other)
 
 
 @convert_tt_tensors_wrapper
@@ -925,4 +925,4 @@ def binary_bitwise_left_shift(input: ttl_tensor.Tensor, other: ttl_tensor.Tensor
     | other      | Second tensor                                 | Tensor      |                 | Yes      |
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
-    return torch.bitwise_left_shift(input.to(torch.int), other.to(torch.int))
+    return torch.bitwise_left_shift(input, other)

--- a/tt_eager/tt_lib/fallback_ops/fallback_ops.py
+++ b/tt_eager/tt_lib/fallback_ops/fallback_ops.py
@@ -858,3 +858,71 @@ def binary_bitwise_xor(input: ttl_tensor.Tensor, other: ttl_tensor.Tensor) -> tt
     +------------+-----------------------------------------------+-------------+-----------------+----------+
     """
     return torch.bitwise_xor(input.to(torch.int), other.to(torch.int))
+
+
+@convert_tt_tensors_wrapper
+def unary_bitwise_right_shift(input: ttl_tensor.Tensor, other: int) -> ttl_tensor.Tensor:
+    """
+    Computes the right arithmetic shift of ``input`` by ``other`` bits. The input tensor must be of integral type.
+    In any case, if the value of the right operand is negative or is greater or equal to the number of bits in the
+    promoted left operand, the behavior is undefined.
+
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    | Argument   | Description                                   | Data type   | Valid range     | Required |
+    +============+===============================================+=============+=================+==========+
+    | input      | Input tensor                                  | Tensor      |                 | Yes      |
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    | other      | Immediate value                               | int         |                 | Yes      |
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    """
+    return torch.bitwise_right_shift(input.to(torch.int), other)
+
+
+@convert_tt_tensors_wrapper
+def unary_bitwise_left_shift(input: ttl_tensor.Tensor, other: int) -> ttl_tensor.Tensor:
+    """
+    Computes the left arithmetic shift of ``input`` by ``other`` bits. The input tensor must be of integral type.
+
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    | Argument   | Description                                   | Data type   | Valid range     | Required |
+    +============+===============================================+=============+=================+==========+
+    | input      | Input tensor                                  | Tensor      |                 | Yes      |
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    | other      | Immediate value                               | int         |                 | Yes      |
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    """
+    return torch.bitwise_left_shift(input.to(torch.int), other)
+
+
+@convert_tt_tensors_wrapper
+def binary_bitwise_right_shift(input: ttl_tensor.Tensor, other: ttl_tensor.Tensor) -> ttl_tensor.Tensor:
+    """
+    Computes the right arithmetic shift of ``input`` by ``other`` bits. The input tensor must be of integral type.
+    In any case, if the value of the right operand is negative or is greater or equal to the number of bits in the
+    promoted left operand, the behavior is undefined.
+
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    | Argument   | Description                                   | Data type   | Valid range     | Required |
+    +============+===============================================+=============+=================+==========+
+    | input      | First tensor                                  | Tensor      |                 | Yes      |
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    | other      | Second tensor                                 | Tensor      |                 | Yes      |
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    """
+    return torch.bitwise_right_shift(input.to(torch.int), other.to(torch.int))
+
+
+@convert_tt_tensors_wrapper
+def binary_bitwise_left_shift(input: ttl_tensor.Tensor, other: ttl_tensor.Tensor) -> ttl_tensor.Tensor:
+    """
+    Computes the left arithmetic shift of ``input`` by ``other`` bits. The input tensor must be of integral type.
+
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    | Argument   | Description                                   | Data type   | Valid range     | Required |
+    +============+===============================================+=============+=================+==========+
+    | input      | First tensor                                  | Tensor      |                 | Yes      |
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    | other      | Second tensor                                 | Tensor      |                 | Yes      |
+    +------------+-----------------------------------------------+-------------+-----------------+----------+
+    """
+    return torch.bitwise_left_shift(input.to(torch.int), other.to(torch.int))


### PR DESCRIPTION
Added bitwise shift ops support as fall back ops for both the unary and binary. Reused the description from pytorch for the shift ops 