### PR TITLE
#2220: Fix test_matmul_single_tile_bfp8b  to close device

### DIFF
--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -159,6 +159,8 @@ int main(int argc, char **argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
 
+        pass &= tt_metal::CloseDevice(device);;
+
         pass &= (activations == result_vec); // src1 is identity
 
     } catch (const std::exception &e) {

--- a/tt_metal/llrt/watcher.cpp
+++ b/tt_metal/llrt/watcher.cpp
@@ -502,7 +502,7 @@ void watcher_attach(void *dev,
     }
 
     if (llrt::watcher::logfile != nullptr) {
-        log_info(LogLLRuntime, "Watcher thread detached");
+        log_info(LogLLRuntime, "Watcher thread attached");
         fprintf(watcher::logfile, "At %ds attach device %d\n", watcher::get_elapsed_secs(), device_id);
     }
 
@@ -523,6 +523,7 @@ void watcher_detach(void *old) {
     auto pair = watcher::devices.find(old);
     TT_ASSERT(pair != watcher::devices.end());
     if (watcher::logfile != nullptr) {
+        log_info(LogLLRuntime, "Watcher thread detached");
         fprintf(watcher::logfile, "At %ds detach device %d\n", watcher::get_elapsed_secs(), pair->second->device_id_);
     }
     watcher::devices.erase(old);


### PR DESCRIPTION
test_matmul_single_tile_bfp8b wasn't closing the device leading to watcher errors at tear down.
Also fix a couple debug prints