### PR TITLE
#3121: microkernel ops profile + postprocessing tool

### DIFF
--- a/scripts/build_scripts/build_with_profiler_opt.sh
+++ b/scripts/build_scripts/build_with_profiler_opt.sh
@@ -5,6 +5,8 @@ set -eo pipefail
 remove_default_log_locations(){
     rm -rf $TT_METAL_HOME/tt_metal/tools/profiler/logs/ops
     rm -rf $TT_METAL_HOME/tt_metal/tools/profiler/logs/ops_device
+    rm -rf $TT_METAL_HOME/profiler_stats
+    rm -rf $TT_METAL_HOME/profiler_data.csv
 }
 
 if [[ -z "$TT_METAL_HOME" ]]; then
@@ -18,8 +20,18 @@ if [[ -z "$ARCH_NAME" ]]; then
     echo "Must provide ARCH_NAME in environment" 1>&2
     exit 1
 fi
+# Check if profile_unary.py exists
+if [[ ! -f "tests/scripts/profile_unary.py" ]]; then
+    echo "profile_unary.py does not exist in the TT_METAL_HOME directory." 1>&2
+    exit 1
+fi
+
+# Check if postproc_unary.py exists
+if [[ ! -f "tests/scripts/postproc_unary.py" ]]; then
+    echo "postproc_unary.py does not exist in the TT_METAL_HOME directory." 1>&2
+    exit 1
+fi
 
 remove_default_log_locations
 make clean
 make build ENABLE_PROFILER=1
-make programming_examples

--- a/tests/scripts/postproc_unary.py
+++ b/tests/scripts/postproc_unary.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+import numpy as np
+import glob
+import argparse
+import os
+import csv
+import datetime
+from profile_unary import shapes, arch, no_iterations, config
+
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+
+
+def run_io_tasks_in_parallel(tasks):
+    with ThreadPoolExecutor() as executor:
+        running_tasks = [executor.submit(task) for task in tasks]
+        for running_task in running_tasks:
+            running_task.result()
+
+
+def run_cpu_tasks_in_parallel(tasks):
+    data = []
+    with ProcessPoolExecutor(max_workers=100) as executor:
+        running_tasks = [executor.submit(task) for task in tasks]
+        for running_task in running_tasks:
+            data.append(running_task.result)
+    return data
+
+
+# we marked the kernel as 5, 6 time stamp markers
+# we just want to find the diff of 5, 6 for TRISC 0, 1, 2 respectively and write it out
+from tests.tt_eager.python_api_testing.sweep_tests.common import is_wormhole_b0
+
+if is_wormhole_b0():
+    SCALE = 80
+    Wcore, Hcore = 9, 8
+else:
+    SCALE = 120
+    Wcore, Hcore = 12, 9
+
+
+class TRISC:
+    def __init__(self, start_exec_end: np.array):
+        self.start_exec_end = start_exec_end
+
+    @property
+    def start(self):
+        return self.start_exec_end[0]
+
+    @property
+    def exec(self):
+        self.exec = self.start_exec_end[1]
+
+    @property
+    def end(self):
+        self.end = self.start_exec_end[2]
+
+
+from itertools import product
+
+
+def parse_device_log(filename):
+    dd = pd.read_csv(filename, header=1)
+    core_x_col = dd.columns[1]
+    core_y_col = dd.columns[2]
+    timer_id_col = dd.columns[-2]
+    time_col = dd.columns[-1]
+    times = np.zeros((3,), dtype=float)
+    scale = 0
+    for core_x, core_y in product(range(Wcore), range(Hcore)):
+        scale += 1
+        dd_ = dd[dd[core_x_col] == core_x]
+        d = dd_[dd_[core_y_col] == core_y]
+        start = d[d[timer_id_col] == 5].to_numpy()
+        end = d[d[timer_id_col] == 6].to_numpy()
+        try:
+            times = np.vstack([times, (end[:, -1] - start[:, -1]).astype(float)])
+        except Exception as _:
+            pass
+    lct = times[times[:, 1] == times.max(axis=0)[1]]
+    return TRISC(lct[0])
+
+
+def main(args):
+    # times = run_cpu_tasks_in_parallel(map(parse_device_log, glob.glob(f"{args.path}/**/*_log_device.csv", recursive=True)))
+    times = list(map(parse_device_log, glob.glob(f"{args.path}/**/*_log_device.csv", recursive=True)))
+    result = times[0].start_exec_end
+    for idx in range(1, len(times)):
+        # if len(times) < 0 not times[idx]: continue
+        result = np.vstack([result, times[idx].start_exec_end])
+    print(result)
+    print(result.shape)
+    print(result.mean(axis=0))
+    print(result.var(axis=0) ** 0.5)
+
+    fieldnames = [
+        "operator",
+        "shape",
+        "cores",
+        "Repetitions",
+        "TRISC 0",
+        "std (TRISC 0)",
+        "TRISC 1",
+        "std (TRISC 1)",
+        "TRISC 2",
+        "std (TRISC 2)",
+        "Clock speed (MHz)",
+        "Board",
+        "Throughput (mean) samples/s",
+        "Arch",
+        "Config",
+        "Date",
+    ]
+
+    person1 = {
+        "operator": op_name,
+        "shape": shapes,
+        "cores": 1,
+        "Repetitions": no_iterations,
+        "TRISC 0": round(result.mean(axis=0)[0]),
+        "std (TRISC 0)": round(result.var(axis=0)[0] ** 0.5),
+        "TRISC 1": round(result.mean(axis=0)[1]),
+        "std (TRISC 1)": round(result.var(axis=0)[1] ** 0.5),
+        "TRISC 2": round(result.mean(axis=0)[2]),
+        "std (TRISC 2)": round(result.var(axis=0)[2] ** 0.5),
+        "Clock speed (MHz)": 1202,
+        "Board": "e120",
+        "Throughput (mean) samples/s": round(1 / ((result.mean(axis=0)[1]) / (1202000000))),
+        "Arch": arch,
+        "Config": config,
+        "Date": datetime.date.today().strftime("%m/%d/%Y"),
+    }
+
+    csv_file_path = "profiler_data.csv"
+
+    with open(csv_file_path, mode="a", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        if csv_file.tell() == 0:
+            writer.writeheader()
+        writer.writerow(person1)
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path",help="path containing the profile dumps", type=str)
+    return parser
+
+def get_args():
+    parser = make_parser()
+    return parser.parse_args()
+
+# print( parse_device_log("./tt::tt_metal::EltwiseUnary/720/profile_log_device.csv") )
+if __name__ == "__main__":
+    folder_path = get_args().path
+
+    if os.path.exists(folder_path) and os.path.isdir(folder_path):
+        folder_contents = os.listdir(folder_path)
+        parser = make_parser()
+
+        for folder_name in folder_contents:
+            folder_full_path = os.path.join(folder_path, folder_name)
+            args = parser.parse_args(["--path", folder_full_path])
+            op_name = folder_name.split("-")[0]
+
+            try:
+                main(args)
+            except IndexError as e:
+                print(f"An error occurred while processing {folder_full_path}: {e}")

--- a/tests/scripts/profile_unary.py
+++ b/tests/scripts/profile_unary.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+import os
+import sys
+import torch
+from pathlib import Path
+from functools import partial
+from math import pi
+import copy
+import tt_lib as ttl
+import argparse
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.common import is_wormhole_b0
+
+if is_wormhole_b0():
+    shapes = [
+        [[4, 20, 32, 32]],  # 80 cores
+    ]
+    arch = "Wh_B0"
+else:
+    shapes = [
+        [[1, 1, 32, 32]],
+    ]
+    arch = "GS"
+
+default_ops = [
+    "sin",
+    "cos",
+    "tan",
+    "gelu",
+    "sqrt",
+    "exp",
+    "relu",
+    "relu6",
+    "sigmoid",
+    "tanh",
+    "square",
+    "atan",
+    "erfinv",
+    "logical_not_unary",
+    "rsqrt",
+    "exp2",
+    "expm1",
+    "recip",
+    "ltz",
+    "gtz",
+    "lez",
+    "gez",
+    "eqz",
+    "nez",
+    "log",
+    "log2",
+    "log10",
+    "abs",
+    "sign",
+    "log_sigmoid",
+    "asin",
+    "acos",
+    "erf",
+    "erfc",
+    "isinf",
+    "isposinf",
+    "isneginf",
+    "isnan",
+    "isfinite",
+    "heaviside",
+    "elu",
+    "leaky_relu",
+    # "clip",
+    # "hardtanh"
+]
+
+REFERENCE_FOLDER = os.path.join(os.getcwd(), f"profiler_stats_{int(time.time())}")
+
+
+def get_args():
+    parser = argparse.ArgumentParser(usage="python3 profile_unary.py  --shape 1 1 32 32 --ops recip --memory L1'")
+    parser.add_argument("--path", help=f"path prefix for the profile dumps: {REFERENCE_FOLDER} (default)", default=REFERENCE_FOLDER, type=str)
+    parser.add_argument("--memory", help="choices of memory : DRAM (default), L1", default=config, required=False)
+    parser.add_argument("--ops", dest="unary_ops", nargs="+", help="", default=default_ops, required=False)
+    parser.add_argument("--shape", dest="shape", type=int, nargs="+", help="", default=shapes[0], required=False)
+    return parser.parse_args()
+
+
+def comp_any(golden, calculated, pcc=0.99):
+    return True, "all is well"
+
+
+def run_eltwise_unary_ops(
+    args: argparse.Namespace,
+    device,
+    input_shapes,
+    fn_kind,
+    input_mem_config,
+    output_mem_config,
+    function_level_defaults={},
+):
+    ttl.profiler.set_profiler_location(f"{args.path}/{fn_kind}-log.csv")
+
+    data_type = data_type_mapping.get(fn_kind, torch.bfloat16)
+    datagen_func = [
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), data_type)
+    ]
+
+    test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+    test_args.update(
+        {
+            "input_mem_config": [input_mem_config],
+            "output_mem_config": output_mem_config,
+        }
+    )
+
+    if fn_kind in ["gelu", "rsqrt", "erf", "erfc"]:
+        test_args.update(
+            {
+                "fast_and_appx": True,
+            }
+        )
+
+    if fn_kind in op_dict and op_dict[fn_kind] is not None:
+        test_args.update(op_dict[fn_kind])
+    comparison_func = comp_any
+    for repetitions in range(no_iterations):
+        run_single_pytorch_test(
+            f"eltwise-{fn_kind}",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+
+# Default data_type bfloat16
+data_type_mapping = {
+    "relu": torch.float32,
+    "sigmoid": torch.float32,
+    "square": torch.float32,
+    "tanh": torch.float32,
+    "relu6": torch.float32,
+    "add1": torch.float32,
+    "deg2rad": torch.float32,
+    "rad2deg": torch.float32,
+    "gelu": torch.float32,
+    "log": torch.float32,
+    "log2": torch.float32,
+    "log10": torch.float32,
+    "sin": torch.float32,
+    "cos": torch.float32,
+    "clip": torch.float32,
+    "hardtanh": torch.float32,
+    "elu": torch.float32,
+    "leaky relu": torch.float32,
+    "log_sigmoid": torch.float32,
+}
+
+# update this dict if ops have any scalar values
+op_dict = {
+    "elu": {"alpha": 0.5},
+    "heaviside": {"scalar": 0.5},
+    "leaky_relu": {"negative_slope": -0.5},
+    "clip": {"low": -2.0, "high": 2.0},
+    "hardtanh": {"low": -2.0, "high": 2.0},
+}
+
+# update with required config to run "DRAM" or "L1"
+config = "L1"
+
+# number of times you need to run the test case
+no_iterations = 1000
+
+
+def main():
+    args = get_args()
+    input_mem_cfgs = copy.copy(generation_funcs.supported_mem_configs)[args.memory == "L1"]
+    output_mem_cfgs = copy.copy(generation_funcs.supported_mem_configs)[args.memory == "L1"]
+    device = ttl.device.CreateDevice(0)
+
+    for input_shapes in [[args.shape]]:
+        for fn_kind in args.unary_ops:
+            run_eltwise_unary_ops(args, device, input_shapes, fn_kind, input_mem_cfgs, output_mem_cfgs, None)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
@@ -10,12 +10,9 @@ from functools import partial
 from math import pi
 import copy
 
-f = f"{Path(__file__).parent}"
-sys.path.append(f"{f}/..")
-sys.path.append(f"{f}/../..")
-sys.path.append(f"{f}/../../..")
-sys.path.append(f"{f}/../../../..")
-
+#ttl.profiler.set_profiler_location(
+#        f"tt_metal/tools/profiler/logs/BERT_large_post_softmax_bmm_{request.node.callspec.id}"
+#    )
 
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -190,6 +190,9 @@ std::map<string, string> get_defines_impl(UnaryOpType op_type, std::optional<flo
         {init_def, op_init_and_name.first},
         {func_def, op_init_and_name.second}
     };
+#if defined(PROFILER)
+    defines["UNARY_MICROKERNEL_PROFILER"] = "1";
+#endif
     update_macro_defines(op_type, defines);
     return defines;
 }

--- a/tt_metal/kernels/compute/eltwise_sfpu.cpp
+++ b/tt_metal/kernels/compute/eltwise_sfpu.cpp
@@ -13,8 +13,11 @@ void MAIN {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
 
-    init_sfpu(tt::CB::c_in0);
+#ifdef UNARY_MICROKERNEL_PROFILER
+    kernel_profiler::mark_time(5);
+#endif
 
+    init_sfpu(tt::CB::c_in0);
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
         cb_reserve_back(tt::CB::c_out0, per_core_block_dim);
         for(uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
@@ -37,5 +40,8 @@ void MAIN {
         }
         cb_push_back(tt::CB::c_out0, per_core_block_dim);
     }
+#ifdef UNARY_MICROKERNEL_PROFILER
+    kernel_profiler::mark_time(6);
+#endif
 }
 }


### PR DESCRIPTION
Goal is to have a custom tool for profiling a unary eltwise op, with a specific tensor shape, based on L1 or DRAM memory to get throughput, and BRISC, NRISC, TIRSC 0, 1, 2 cycles on microkernel device.

This PR provides a command:
`
   $ ./tests/scripts/profile_unary.py --ops recip --shapes 1 1 32 32 --memory L1 --path ${DUMP_FOLDER_PATH}
`
which will run test for recip op with [1, 1, 32, 32] shape at L1 memory.

The script `postproc_unary.py` will go through all the dumped logs of microkernel performance counters and then generate a CSV of mean, std, for data-load (BRISC), Kernel compute (TRISC-1), and data-store (NRISC) numbers.

`
  $ ./tests/scripts/postproce_unary.py --path ${DUMP_FOLDER_PATH}
`
