### PR TITLE
#3040: implement rpow, rdiv, and rsub for the reciprocal ops

### DIFF
--- a/docs/source/libraries/tt_dnn.rst
+++ b/docs/source/libraries/tt_dnn.rst
@@ -365,6 +365,8 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.multigammaln
 
+.. autofunction:: tt_lib.tensor.assign
+
 .. autofunction:: tt_lib.tensor.isclose
 
 .. autofunction:: tt_lib.tensor.i0
@@ -376,6 +378,8 @@ Tensor elementwise operations
 .. autofunction:: tt_lib.tensor.logical_or
 
 .. autofunction:: tt_lib.tensor.logical_ori
+
+.. autofunction:: tt_lib.tensor.polygamma
 
 Tensor relational operations
 ----------------------------------
@@ -475,6 +479,12 @@ Broadcast and Reduce
 
 .. autofunction:: tt_lib.tensor.reduce
 
+
+.. autofunction:: tt_lib.tensor.rpow
+
+.. autofunction:: tt_lib.tensor.rsub
+
+.. autofunction:: tt_lib.tensor.rdiv
 
 Fallback Operations
 ===================
@@ -652,3 +662,11 @@ Other Operations
 .. autofunction:: tt_lib.tensor.swiglu
 
 .. autofunction:: tt_lib.tensor.embeddings
+
+.. autofunction:: tt_lib.tensor.rpow
+
+.. autofunction:: tt_lib.tensor.rsub
+
+.. autofunction:: tt_lib.tensor.rdiv
+
+.. autofunction:: tt_lib.tensor.nextafter

--- a/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
@@ -1530,3 +1530,28 @@ def gen_dtype_layout_device_bert(
                 )
 
     return result
+
+
+def gen_polygamma_args(
+    input_shapes,
+    supported_dtypes,
+    supported_layouts,
+    on_device,
+    low=-1,
+    high=10,
+    dtype=torch.bfloat16,
+):
+    for input_info in gen_scalar_args(
+        input_shapes,
+        supported_dtypes,
+        supported_layouts,
+        on_device,
+        "k",
+        low,
+        high,
+        dtype,
+    ):
+        # the n(int) order of the polygamma function is b/w 1 to 10
+        k_order = np.random.randint(1, 10)
+        input_info.update({"k": k_order})
+        yield input_info

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -428,6 +428,10 @@ op_map = {
         "tt_lib_op": tt_lib_ops.eltwise_erfinv,
         "pytorch_op": pytorch_ops.erfinv,
     },
+    "eltwise-nextafter": {
+        "tt_lib_op": tt_lib_ops.eltwise_nextafter,
+        "pytorch_op": pytorch_ops.nextafter,
+    },
     "eltwise-subalpha": {
         "tt_lib_op": tt_lib_ops.eltwise_subalpha,
         "pytorch_op": pytorch_ops.subalpha,
@@ -439,6 +443,10 @@ op_map = {
     "eltwise-logit": {
         "tt_lib_op": tt_lib_ops.eltwise_logit,
         "pytorch_op": pytorch_ops.logit,
+    },
+    "eltwise-polygamma": {
+        "tt_lib_op": tt_lib_ops.eltwise_polygamma,
+        "pytorch_op": pytorch_ops.polygamma,
     },
     "eltwise-logical_xori": {
         "tt_lib_op": tt_lib_ops.eltwise_logical_xori,
@@ -475,6 +483,18 @@ op_map = {
     "eltwise-signbit": {
         "tt_lib_op": tt_lib_ops.eltwise_signbit,
         "pytorch_op": pytorch_ops.signbit,
+    },
+    "eltwise-rpow": {
+        "tt_lib_op": tt_lib_ops.eltwise_rpow,
+        "pytorch_op": pytorch_ops.eltwise_rpow,
+    },
+    "eltwise-rdiv": {
+        "tt_lib_op": tt_lib_ops.eltwise_rdiv,
+        "pytorch_op": pytorch_ops.eltwise_rdiv,
+    },
+    "eltwise-rsub": {
+        "tt_lib_op": tt_lib_ops.eltwise_rsub,
+        "pytorch_op": pytorch_ops.eltwise_rsub,
     },
     # Eltwise binary
     "eltwise-ne": {
@@ -564,6 +584,14 @@ op_map = {
     "eltwise-logaddexp2": {
         "tt_lib_op": tt_lib_ops.eltwise_logaddexp2,
         "pytorch_op": pytorch_ops.logaddexp2,
+    },
+    "eltwise-assign_binary": {
+        "tt_lib_op": tt_lib_ops.eltwise_assign_binary,
+        "pytorch_op": pytorch_ops.assign_binary,
+    },
+    "eltwise-assign_unary": {
+        "tt_lib_op": tt_lib_ops.eltwise_assign_unary,
+        "pytorch_op": pytorch_ops.assign_unary,
     },
     "eltwise-logical_or": {
         "tt_lib_op": tt_lib_ops.eltwise_logical_or,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_composite.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_composite.py
@@ -36,7 +36,6 @@ reference_pcc["swish"] = reference_pcc["silu"]
 reference_pcc["softplus"] = 0.9984
 
 
-
 def custom_compare(*args, **kwargs):
     function = kwargs.pop("function")
     if function in [
@@ -51,9 +50,7 @@ def custom_compare(*args, **kwargs):
     ]:
         comparison_func = comparison_funcs.comp_equal
     else:
-        comparison_func = partial(
-            comparison_funcs.comp_pcc, pcc=reference_pcc[function]
-        )
+        comparison_func = partial(comparison_funcs.comp_pcc, pcc=reference_pcc[function])
     result = comparison_func(*args, **kwargs)
     return result
 
@@ -117,6 +114,8 @@ if is_wormhole_b0():
                 "digamma",
                 "lgamma",
                 "multigammaln",
+                "polygamma",
+                "nextafter",
             ),
             shapes,
         )
@@ -142,6 +141,7 @@ def test_run_eltwise_composite_test(fn, input_shapes, device, function_level_def
     options["digamma"] = (1, 1000)
     options["lgamma"] = (0.1, 1e32)
     options["multigammaln"] = (1.6, 1e32)
+    options["polygamma"] = (1, 10)
 
     options["sinh"] = (-9, 9)
     options["tanhshrink"] = (-100, 100)
@@ -191,6 +191,8 @@ def test_run_eltwise_composite_test(fn, input_shapes, device, function_level_def
         "logit",
         "logical_xor",
         "isclose",
+        "assign_binary",
+        "nextafter",
     ]:
         num_inputs = 2
 
@@ -218,6 +220,8 @@ def test_run_eltwise_composite_test(fn, input_shapes, device, function_level_def
         test_args.update({"bias": np.random.randint(1, 100)})
     elif fn in ["logit"]:
         test_args.update({"eps": np.random.randint(-1e-6, 1e6)})
+    elif fn in ["polygamma"]:
+        test_args.update({"k": np.random.randint(1, 10)})
     elif fn in ["logical_ori", "logical_andi", "logical_xori", "logical_noti"]:
         test_args.update({"immediate": np.random.randint(0, 100)})
     elif fn in ["isclose"]:
@@ -225,6 +229,7 @@ def test_run_eltwise_composite_test(fn, input_shapes, device, function_level_def
             {
                 "rtol": random.choice([1e-3, 1e-5, 1e-7]),
                 "atol": random.choice([1e-2, 1e-4, 1e-6]),
+                "equal_nan": random.choice([False, True]),
             }
         )
     run_single_pytorch_test(

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_copy.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_copy.py
@@ -67,6 +67,56 @@ class TestCopy:
             test_args,
         )
 
+    def test_run_assign_unary_op(
+        self,
+        input_shapes,
+        input_mem_config,
+        dst_mem_config,
+        device,
+        function_level_defaults,
+    ):
+        input_shapes = input_shapes * 2
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ] * len(input_shapes)
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args["input_mem_config"] = [input_mem_config, dst_mem_config]
+        del test_args["output_mem_config"]
+        comparison_func = comparison_funcs.comp_pcc
+        run_single_pytorch_test(
+            "eltwise-assign_unary",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+    def test_run_assign_binary_op(
+        self,
+        input_shapes,
+        input_mem_config,
+        dst_mem_config,
+        device,
+        function_level_defaults,
+    ):
+        input_shapes = input_shapes * 2
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ] * len(input_shapes)
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args["input_mem_config"] = [input_mem_config, dst_mem_config]
+        del test_args["output_mem_config"]
+        comparison_func = comparison_funcs.comp_pcc
+        run_single_pytorch_test(
+            "eltwise-assign_binary",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
     def test_run_clone_op(
         self,
         input_shapes,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
@@ -40,13 +40,6 @@ if is_wormhole_b0():
     shapes = [
         shapes[0],
     ]
-    input_mem_cfgs = [
-        input_mem_cfgs[0],
-    ]
-    #output_mem_cfgs = [
-    #    output_mem_cfgs[0],
-    #]
-
 
 @pytest.mark.parametrize(
     "input_shapes",
@@ -69,9 +62,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args.update(
@@ -104,9 +95,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-1e6, high=1e6), torch.bfloat16
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-1e6, high=1e6), torch.bfloat16)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         comparison_func = comparison_funcs.comp_pcc
@@ -134,9 +123,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         comparison_func = comparison_funcs.comp_pcc
@@ -163,9 +150,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.int32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.int32)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         comparison_func = comparison_funcs.comp_pcc
@@ -188,12 +173,10 @@ class TestEltwiseUnary:
         input_mem_config,
         output_mem_config,
     ):
-        if (is_wormhole_b0() and fast_and_appx):
+        if is_wormhole_b0() and fast_and_appx:
             pytest.skip("Gelu appx mode not working for WH b0")
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args["fast_and_appx"] = fast_and_appx
@@ -218,9 +201,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=1, high=1e8), torch.bfloat16
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=1, high=1e8), torch.bfloat16)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args["fast_and_appx"] = fast_and_appx
@@ -245,9 +226,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-10, high=10), torch.bfloat16
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-10, high=10), torch.bfloat16)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args["fast_and_appx"] = fast_and_appx
@@ -382,9 +361,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=0, high=100), torch.float32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=0, high=100), torch.float32)
         ]
         comparison_func = partial(comparison_funcs.comp_pcc)
         run_single_pytorch_test(
@@ -395,9 +372,7 @@ class TestEltwiseUnary:
             device,
         )
 
-    @pytest.mark.parametrize(
-        "relu_type, limit_type", [["min", "lower"], ["max", "upper"]]
-    )
+    @pytest.mark.parametrize("relu_type, limit_type", [["min", "lower"], ["max", "upper"]])
     @pytest.mark.parametrize("input_value", [-2.0, -1.0, 0.0, 1.0, 2.0])
     @pytest.mark.parametrize("limit", [-2.0, -1.0, 0.0, 1.0, 2.0])
     def test_run_eltwise_relu_limit_ops(
@@ -475,9 +450,7 @@ class TestEltwiseUnary:
         )
 
     @pytest.mark.parametrize("log_kind", ["log", "log2", "log10"])
-    @pytest.mark.parametrize(
-        "range", [{"low": 1e-6, "high": 1.0}, {"low": 1, "high": 100000}]
-    )
+    @pytest.mark.parametrize("range", [{"low": 1e-6, "high": 1.0}, {"low": 1, "high": 100000}])
     def test_run_eltwise_log_ops(
         self,
         log_kind,
@@ -490,9 +463,7 @@ class TestEltwiseUnary:
     ):
         datagen_func = [
             generation_funcs.gen_func_with_cast(
-                partial(
-                    generation_funcs.gen_rand, low=range["low"], high=range["high"]
-                ),
+                partial(generation_funcs.gen_rand, low=range["low"], high=range["high"]),
                 torch.float32,
             )
         ]
@@ -616,9 +587,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args.update({"scalar": scalar})
@@ -638,9 +607,7 @@ class TestEltwiseUnary:
             test_args,
         )
 
-    @pytest.mark.parametrize(
-        "unary_kind", ["add_unary", "sub_unary", "mul_unary", "div_unary"]
-    )
+    @pytest.mark.parametrize("unary_kind", ["add_unary", "sub_unary", "mul_unary", "div_unary"])
     @pytest.mark.parametrize("scalar", [-2.0, 1.0, 2.0, 8.0])
     def test_run_eltwise_binop_to_unary_ops(
         self,
@@ -653,9 +620,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
         ]
         comparison_func = comparison_funcs.comp_pcc
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
@@ -676,9 +641,7 @@ class TestEltwiseUnary:
         )
 
     @pytest.mark.parametrize("clip_kind", ["clip", "hardtanh"])
-    @pytest.mark.parametrize(
-        "clip_range", ({"low": -2.0, "high": 2.0}, {"low": -5.5, "high": 27.5})
-    )
+    @pytest.mark.parametrize("clip_range", ({"low": -2.0, "high": 2.0}, {"low": -5.5, "high": 27.5}))
     def test_run_eltwise_clip_ops(
         self,
         clip_kind,
@@ -690,9 +653,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-10, high=10), torch.float32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-10, high=10), torch.float32)
         ]
         comparison_func = comparison_funcs.comp_pcc
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
@@ -723,9 +684,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args.update({"alpha": alpha})
@@ -757,9 +716,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args.update({"negative_slope": negative_slope})
@@ -791,9 +748,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-4, high=10), torch.float32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-4, high=10), torch.float32)
         ]
         comparison_func = partial(comparison_funcs.comp_pcc)
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
@@ -856,9 +811,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args["fast_and_appx"] = fast_and_appx
@@ -878,9 +831,7 @@ class TestEltwiseUnary:
             test_args,
         )
 
-    @pytest.mark.parametrize(
-        "fn_kind", ["isinf", "isposinf", "isneginf", "isnan", "isfinite"]
-    )
+    @pytest.mark.parametrize("fn_kind", ["isinf", "isposinf", "isneginf", "isnan", "isfinite"])
     def test_run_eltwise_inf_nan_ops(
         self,
         input_shapes,
@@ -910,6 +861,7 @@ class TestEltwiseUnary:
             datagen_func,
             comparison_func,
             device,
+            test_args,
         )
 
     def test_run_eltwise_tan_op(
@@ -933,4 +885,77 @@ class TestEltwiseUnary:
             datagen_func,
             comparison_func,
             device,
+        )
+
+    @pytest.mark.parametrize("fn_kind", ["rpow", "rsub", "rdiv"])
+    def test_run_eltwise_reverse_ops(
+        self,
+        input_shapes,
+        fn_kind,
+        device,
+        function_level_defaults,
+        input_mem_config,
+        output_mem_config,
+    ):
+        values = {"rdiv": (1.0, 100.0), "rsub": (1.0, 50.0), "rpow": (5.0, 10.0)}
+        low_v, high_v = values[fn_kind]
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(
+                partial(generation_funcs.gen_rand, low=low_v, high=high_v),
+                torch.bfloat16,
+            )
+        ]
+        comparison_func = comparison_funcs.comp_pcc
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update(
+            {
+                "input_mem_config": [input_mem_config],
+                "output_mem_config": output_mem_config,
+                "factor": 4.0,
+            }
+        )
+        run_single_pytorch_test(
+            f"eltwise-{fn_kind}",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+
+    @pytest.mark.parametrize("fn_kind", ["rsub", "rdiv"])
+    def test_run_eltwise_reverse_neg_ops(
+        self,
+        input_shapes,
+        fn_kind,
+        device,
+        function_level_defaults,
+        input_mem_config,
+        output_mem_config,
+    ):
+        values = {"rdiv": (1.0, 100.0), "rsub": (1.0, 50.0), "rpow": (5.0, 10.0)}
+        low_v, high_v = values[fn_kind]
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(
+                partial(generation_funcs.gen_rand, low=low_v, high=high_v),
+                torch.bfloat16,
+            )
+        ]
+        comparison_func = comparison_funcs.comp_pcc
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update(
+            {
+                "input_mem_config": [input_mem_config],
+                "output_mem_config": output_mem_config,
+                "factor": pi,
+            }
+        )
+        run_single_pytorch_test(
+            f"eltwise-{fn_kind}",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
         )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_stats.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_stats.py
@@ -19,7 +19,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, gene
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
 from tests.tt_eager.python_api_testing.sweep_tests.common import is_wormhole_b0, skip_for_wormhole_b0
 import tt_lib as ttl
-
+import numpy as np
 
 fns = ["std_hw", "mean_hw", "var_hw", "normalize_hw"]
 
@@ -61,3 +61,10 @@ class TestStats:
             device,
             test_args,
         )
+
+class TestEPS:
+    def test_basic_gs(self):
+        assert ttl.device.EPS_GS == 0.001953125
+
+    def test_basic_whb0(self):
+        assert np.isclose(ttl.device.EPS_WHB0, 1.19209e-07)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -58,6 +58,7 @@ def normalize_hw(x, *args, **kwargs):
             x[i, j, :, :] = (x[i, j, :, :] - mx[i, j, :, :]) / sx[i, j, :, :]
     return x
 
+
 def var_global(x, *args, **kwargs):
     return torch.var(x, [0, 1, 2, 3], keepdim=True)
 
@@ -69,11 +70,13 @@ def std_global(x, *args, **kwargs):
 def mean_global(x, *args, **kwargs):
     return torch.mean(x, [0, 1, 2, 3], keepdim=True)
 
+
 def normalize_global(x, *args, **kwargs):
     mx = mean_global(x)
     sx = std_global(x)
-    x = (x-mx)/sx
+    x = (x - mx) / sx
     return x
+
 
 # Ternary Ops
 def sum(x, *args, dim, **kwargs):
@@ -258,6 +261,10 @@ def nez(x, *args, **kwargs):
     return (x != 0.0).to(x.dtype)
 
 
+def assign_unary(x, *args, **kwargs):
+    return torch.clone(x)
+
+
 def sign(x, *args, **kwargs):
     return torch.sign(x)
 
@@ -321,9 +328,7 @@ def softmax_in_place(x, *args, **kwargs):
 
 
 def ref_stable_softmax(x):
-    torch.set_printoptions(
-        precision=2, threshold=1000, sci_mode=False, edgeitems=8, linewidth=480
-    )
+    torch.set_printoptions(precision=2, threshold=1000, sci_mode=False, edgeitems=8, linewidth=480)
     z = x  # - torch.max(x, dim=3, keepdim=True)[0]
     numerator = torch.exp(z)
     # print(x.shape)
@@ -367,16 +372,12 @@ def layernorm(x, y, z, *args, **kwargs):
     z = z.squeeze(0)
     z = z.squeeze(0)
 
-    return torch.nn.functional.layer_norm(
-        input=x, normalized_shape=y.shape, weight=y, bias=z, eps=1e-05
-    )
+    return torch.nn.functional.layer_norm(input=x, normalized_shape=y.shape, weight=y, bias=z, eps=1e-05)
 
 
 def layernorm_noweights(x, *args, **kwargs):
     last = x.shape[3]
-    return torch.nn.functional.layer_norm(
-        input=x, normalized_shape=(last,), weight=None, bias=None, eps=1e-05
-    )
+    return torch.nn.functional.layer_norm(input=x, normalized_shape=(last,), weight=None, bias=None, eps=1e-05)
 
 
 def groupnorm_noweights(x, *args, **kwargs):
@@ -396,18 +397,14 @@ def add_layernorm(x, y, z, w, *args, **kwargs):
     z = z.squeeze(0)
     z = z.squeeze(0)
 
-    return torch.nn.functional.layer_norm(
-        input=res, normalized_shape=z.shape, weight=z, bias=w, eps=1e-05
-    )
+    return torch.nn.functional.layer_norm(input=res, normalized_shape=z.shape, weight=z, bias=w, eps=1e-05)
 
 
 def add_layernorm_noweights(x, y, *args, **kwargs):
     res = x + y
     last = res.shape[3]
 
-    return torch.nn.functional.layer_norm(
-        input=res, normalized_shape=(last,), weight=None, bias=None, eps=1e-05
-    )
+    return torch.nn.functional.layer_norm(input=res, normalized_shape=(last,), weight=None, bias=None, eps=1e-05)
 
 
 def scale_mask_softmax_in_place(x, y, scale, *args, **kwargs):
@@ -423,6 +420,10 @@ def rsqrt(x, *args, **kwargs):
 
 def logit(x, *args, eps, **kwargs):
     return torch.special.logit(x, eps=eps)
+
+
+def polygamma(x, *args, k, **kwargs):
+    return torch.special.polygamma(n=k, input=x)
 
 
 def logical_xori(x, *args, **kwargs):
@@ -655,6 +656,10 @@ def atan2(x, y, *args, **kwargs):
     return torch.atan2(y, x)
 
 
+def nextafter(x, y, *args, **kwargs):
+    return torch.nextafter(x, y)
+
+
 def logical_and(x, y, *args, **kwargs):
     result = torch.logical_and(x, y)
     return result
@@ -675,8 +680,13 @@ def lerp_binary(x, y, *args, weight, **kwargs):
     return torch.lerp(x, y, weight)
 
 
-def isclose(x, y, *args, rtol, atol, **kwargs):
-    return torch.isclose(x, y, rtol=rtol, atol=atol)
+def assign_binary(x, y, *args, **kwargs):
+    y.copy_(x)
+    return y
+
+
+def isclose(x, y, *args, rtol, atol, equal_nan, **kwargs):
+    return torch.isclose(x, y, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
 def xlogy(x, y, *args, **kwargs):
@@ -781,8 +791,10 @@ def reduce_sum(x, dims=None, keepdim=True, *args, **kwargs):
 def reduce_max(x, dims=None, keepdim=True, *args, **kwargs):
     return torch.amax(x, dims, keepdim)
 
+
 def reduce_min(x, dims=None, keepdim=True, *args, **kwargs):
     return torch.amin(x, dims, keepdim)
+
 
 def flatten(x, *args, **kwargs):
     return torch.flatten(x)
@@ -832,9 +844,7 @@ def tilize_with_zero_padding(x, *args, **kwargs):
     )
 
 
-def tilize_with_val_padding(
-    x, output_tensor_shape, input_tensor_start, pad_value, *args, **kwargs
-):
+def tilize_with_val_padding(x, output_tensor_shape, input_tensor_start, pad_value, *args, **kwargs):
     pad = torch.nn.functional.pad(
         x,
         tuple(
@@ -864,10 +874,7 @@ def untilize_with_unpadding(x, output_tensor_start, output_tensor_end, *args, **
 ################################################
 def pad(x, *args, output_tensor_shape, input_tensor_start, pad_value, **kwargs):
     input_tensor_shape = x.shape
-    input_tensor_end = tuple(
-        input_tensor_start[i] + input_tensor_shape[i]
-        for i in range(len(input_tensor_shape))
-    )
+    input_tensor_end = tuple(input_tensor_start[i] + input_tensor_shape[i] for i in range(len(input_tensor_shape)))
     out = torch.full(output_tensor_shape, pad_value, dtype=torch.bfloat16)
     out[
         input_tensor_start[0] : input_tensor_end[0],
@@ -969,6 +976,7 @@ def bert_large_ff1_matmul(x, y, z, *args, **kwargs):
     ref_bmm = ref_bmm + z
     return ref_bmm
 
+
 def bert_large_selfout_matmul(x, y, z, *args, **kwargs):
     ref_bmm = torch.matmul(x, y)
     ref_bmm = ref_bmm + z
@@ -978,3 +986,18 @@ def bert_large_ff2_matmul(x, y, z, *args, **kwargs):
     ref_bmm = torch.matmul(x, y)
     ref_bmm = ref_bmm + z
     return ref_bmm
+
+def eltwise_rpow(x, *args, **kwargs):
+    dim = kwargs["factor"]
+    return torch.pow(dim, x)
+
+
+def eltwise_rsub(x, *args, **kwargs):
+    dim = kwargs["factor"]
+    return torch.sub(dim, x)
+
+
+def eltwise_rdiv(x, *args, **kwargs):
+    dim = kwargs["factor"]
+    return dim / x
+

--- a/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_binary_assign.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_binary_assign.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+def function_assign_binary(x,y):
+    if x.shape != y.shape or x.is_contiguous() != y.is_contiguous():
+      raise ValueError("Tensors x and y do not have the same shape and memory layout.")
+    y.copy_(x)
+    print(y)
+x = torch.tensor([5.0, 5.3, 9.0, 23])
+y = torch.tensor([5.0, 12, 9.0, 23])
+print("Binary Assign : ")
+function_assign_binary(x,y)

--- a/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_binary_nextafter.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_binary_nextafter.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import matplotlib.pyplot as plt
+import numpy as np
+
+torch.manual_seed(2)
+
+
+def custom_nextafter(x, target):
+    # Eps for GS 0.001953125, WH 1.19209e-07
+    eps = torch.tensor(0.001953125)
+    res = torch.where(x < target, x + eps, x)
+    res = torch.where(x > target, x - eps, res)
+    return res
+
+
+x = np.linspace(-100, 100, 50)
+x = torch.from_numpy(x)
+target = np.linspace(-50, 50, 50)
+target = torch.from_numpy(target)
+lhs = torch.nextafter(x, target)
+rhs = custom_nextafter(x, target)
+
+plt.plot(x, lhs, "-b", label="torch custom_nextafter")
+plt.plot(x, rhs, "+r", label="custom custom_nextafter")
+plt.legend(loc="lower center")
+plt.show()

--- a/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_unary_assign.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_unary_assign.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+def function_assign_unary(x):
+  y = x.clone()
+  return y
+x = torch.tensor([5.0, 5.3, 9.0, 23])
+print("Unary Assign : ")
+z = function_assign_unary(x)
+print(z)

--- a/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_unary_polygamma.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/reference_eltwise/eltwise_unary_polygamma.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+
+
+def polygamma_series(n, x, terms=10):
+    term = 0.0
+    pos_neg = 1 if n % 2 else -1
+
+    for k in range(terms):
+        term = term + 1 / (x + k) ** (n + 1)
+
+    return term * pos_neg * math.factorial(n)
+
+
+# Added the support upto the range(1, 10) & n[1, 10]
+x = np.linspace(1, 10, 100)
+x = torch.from_numpy(x)
+n = 2
+
+custom_poly = polygamma_series(n, x)
+torch_poly = torch.polygamma(n, x)
+
+plt.plot(x, torch_poly, "-b", label="torch polygamma")
+plt.plot(x, custom_poly, "+r", label="custom polygamma formula")
+plt.legend(loc="upper center")
+plt.show()

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_assign_binary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_assign_binary_test.yaml
@@ -1,0 +1,18 @@
+---
+test-list:
+  eltwise-assign_binary:
+    shape:
+      start-shape: [1, 1, 1, 2]
+      end-shape: [2, 2, 2048, 2048]
+      interval: [1, 1, 1, 2]
+      num-shapes: 2
+      num-samples: 2048
+    datagen:
+      function: gen_rand
+      args:
+        low: -100
+        high: 100
+      dtype: bfloat16
+    comparison:
+      function: comp_pcc
+    output-file: eltwise_assign_binary_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_assign_unary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_assign_unary_test.yaml
@@ -1,0 +1,18 @@
+---
+test-list:
+  eltwise-assign_unary:
+    shape:
+      start-shape: [1, 1, 1, 2]
+      end-shape: [2, 2, 2048, 2048]
+      interval: [1, 1, 1, 2]
+      num-shapes: 1
+      num-samples: 2048
+    datagen:
+      function: gen_rand
+      args:
+        low: -100
+        high: 100
+      dtype: bfloat16
+    comparison:
+      function: comp_equal
+    output-file: eltwise_assign_unary_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_nextafter_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_nextafter_test.yaml
@@ -1,0 +1,18 @@
+---
+test-list:
+  eltwise-nextafter:
+    shape:
+      start-shape: [1, 1, 1, 2]
+      end-shape: [2, 2, 2048, 2048]
+      interval: [1, 1, 1, 2]
+      num-shapes: 2
+      num-samples: 2048
+    datagen:
+      function: gen_rand
+      args:
+        low: -100
+        high: 100
+    comparison:
+      function: comp_pcc
+    args-gen: gen_dtype_layout_device
+    output-file: eltwise_nextafter_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_polygamma_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/input_type_op_tests/pytorch_eltwise_polygamma_test.yaml
@@ -1,0 +1,19 @@
+---
+test-list:
+  eltwise-polygamma:
+    shape:
+      start-shape: [1, 1, 1, 2]
+      end-shape: [2, 2, 2048, 2048]
+      interval: [1, 1, 1, 2]
+      num-shapes: 1
+      num-samples: 2048
+    datagen:
+      function: gen_rand
+      args:
+        low: 1
+        high: 10
+      dtype: bfloat16
+    comparison:
+      function: comp_pcc
+    args-gen: gen_polygamma_args
+    output-file: eltwise_polygamma_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -642,6 +642,14 @@ def eltwise_logit(x, *args, eps, device, dtype, layout, input_mem_config, output
 
 
 @setup_host_and_device
+def eltwise_polygamma(x, *args, k, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.polygamma(t0, k, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
 def eltwise_logical_xori(
     x,
     *args,
@@ -657,6 +665,27 @@ def eltwise_logical_xori(
     t1 = ttl.tensor.logical_xori(t0, immediate, output_mem_config=output_mem_config)
 
     return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
+def eltwise_assign_binary(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config=ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+    ),
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = ttl.tensor.assign(t0, t1, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t2)
 
 
 @setup_host_and_device
@@ -704,6 +733,7 @@ def eltwise_isclose(
     *args,
     rtol,
     atol,
+    equal_nan,
     device,
     dtype,
     layout,
@@ -713,7 +743,7 @@ def eltwise_isclose(
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttl.tensor.isclose(t0, t1, rtol, atol, output_mem_config=output_mem_config)
+    t2 = ttl.tensor.isclose(t0, t1, rtol, atol, equal_nan, output_mem_config=output_mem_config)
 
     return tt2torch_tensor(t2)
 
@@ -1578,6 +1608,60 @@ def unpad(
 
 
 @setup_host_and_device
+def eltwise_rdiv(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    factor = kwargs["factor"]
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.rdiv(t0, factor, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
+def eltwise_rsub(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    factor = kwargs["factor"]
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.rsub(t0, factor, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
+def eltwise_rpow(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    factor = kwargs["factor"]
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.rpow(t0, factor, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
 def eltwise_power(
     x,
     *args,
@@ -1713,6 +1797,7 @@ eltwise_lez = make_unary_op(ttl.tensor.lez)
 eltwise_gez = make_unary_op(ttl.tensor.gez)
 eltwise_nez = make_unary_op(ttl.tensor.nez)
 eltwise_eqz = make_unary_op(ttl.tensor.eqz)
+eltwise_assign_unary = make_unary_op(ttl.tensor.assign)
 zeros_like = make_unary_op(ttl.tensor.zeros_like)
 ones_like = make_unary_op(ttl.tensor.ones_like)
 # eltwise_logical_not = make_unary_op(ttl.tensor.logical_not)
@@ -1771,7 +1856,8 @@ outer = make_binary_op(ttl.tensor.outer)
 bmm = make_binary_op(ttl.tensor.bmm)
 bert_large_pre_softmax_bmm = make_binary_op(ttl.tensor.bert_large_pre_softmax_bmm)
 bert_large_post_softmax_bmm = make_binary_op(ttl.tensor.bert_large_post_softmax_bmm)
-
+eltwise_bias_gelu = make_binary_op(ttl.tensor.bias_gelu)
+eltwise_nextafter = make_binary_op(ttl.tensor.nextafter)
 eltwise_isfinite = make_unary_op(ttl.tensor.isfinite)
 eltwise_isinf = make_unary_op(ttl.tensor.isinf)
 eltwise_isposinf = make_unary_op(ttl.tensor.isposinf)

--- a/tests/tt_eager/python_api_testing/unit_testing/test_eps.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_eps.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import pytest
+
+import numpy as np
+import tt_lib as ttl
+from tests.tt_eager.python_api_testing.sweep_tests.common import is_wormhole_b0, skip_for_wormhole_b0
+
+
+def test_run_sfpu_attr(device):
+    assert ttl.device.EPS_GS == 0.001953125
+    assert ttl.device.EPS_WHB0 == 1.1920899822825959e-07
+
+
+def test_run_sfpu_eps(device):
+    shape = [1, 1, 32, 32]
+    value = [ttl.device.EPS_GS, ttl.device.EPS_WHB0][is_wormhole_b0()]
+    assert np.isclose(value, device.sfpu_eps())
+
+
+def test_run_sfpu_tensor(device):
+    value = device.sfpu_eps()
+    shape = [1, 1, 32, 32]
+    eps = ttl.tensor.sfpu_eps(shape, ttl.tensor.Layout.ROW_MAJOR, device)
+    eps = eps.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    assert np.isclose( np.ones((1,1,32,32))*value, eps.float()).all()

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -119,7 +119,7 @@ Tensor multigammaln(const Tensor& a, const MemoryConfig& output_mem_config = ope
 Tensor logical_andi(const Tensor& input_a, float immediate, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // ∣input−other∣≤ atol+rtol×∣other∣
-Tensor isclose(const Tensor& input_a, const Tensor& input_b, float rtol, float atol, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor isclose(const Tensor& input_a, const Tensor& input_b, float rtol, float atol, bool equal_nan  = false, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 
 //addcmul(input,tensor1,tensor2,value)=input+value×tensor1×tensor2
@@ -204,6 +204,8 @@ Tensor arange(int32_t start, int32_t end, int32_t step = 1, Device * device = nu
 //on-device tensor creation with shape and filled with value
 Tensor full(const Shape shape, float value, Layout layout = Layout::ROW_MAJOR, Device * device = nullptr, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+//rpow: y = k**(a)
+Tensor rpow(const Tensor& a,float k, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 //clip
 Tensor clip(const Tensor& a,float low, float high, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
@@ -214,8 +216,14 @@ Tensor hardtanh(const Tensor& a,float low = -1.0f, float high = +1.0f, const Mem
 //clamp
 Tensor clamp(const Tensor& a,float low, float high, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+//machine epsilon
+Tensor eps(const Shape shape, Layout layout, Device * device, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 //logit(input, eps)=log(input / 1 - input)
 Tensor logit(const Tensor& input_a, float eps, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+//polygamma
+Tensor polygamma(const Tensor& input_a, uint32_t k, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 Tensor logical_xori(const Tensor& input_a, float immediate, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
@@ -235,6 +243,15 @@ Tensor asinh(const Tensor& input_a, const MemoryConfig& output_mem_config = oper
 
 //acosh(x) = log(x + sqrt(x^2 - 1))
 Tensor acosh(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+//nextafter
+Tensor nextafter(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+//binary assign
+Tensor assign(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+//unary assign
+Tensor assign(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 //atanh[x] = 0.5 * ln((1 + x) / (1 - x))
 Tensor atanh(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
@@ -271,6 +288,9 @@ Tensor reglu(const Tensor& input_a, int32_t dim = -1, const MemoryConfig& output
 Tensor geglu(const Tensor& input_a, int32_t dim = -1, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 // Swish based GLU
 Tensor swiglu(const Tensor& input_a, int32_t dim = -1, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+//on-device tensor creation with shape and filled with value
+Tensor sfpu_eps(const Shape shape, Layout layout, Device * device, const MemoryConfig& output_mem_config);
 
 } //namespace tt_metal
 

--- a/tt_eager/tt_dnn/op_library/copy/copy_op.hpp
+++ b/tt_eager/tt_dnn/op_library/copy/copy_op.hpp
@@ -47,6 +47,17 @@ inline Tensor clone(const Tensor& input_tensor, const MemoryConfig& output_mem_c
     return operation::run(Copy{output_mem_config}, {input_tensor}).at(0);
 }
 
+//unary assign
+inline Tensor assign(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
+    return operation::run(Copy{output_mem_config}, {input_a}).at(0);
+}
+
+// binary assign
+inline Tensor assign(const Tensor& input_a,const Tensor& input_b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
+    operation::run(Copy{input_b.memory_config()}, {input_a, input_b});
+    return input_b;
+}
+
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -21,7 +21,7 @@ enum class UnaryOpType {
     EXP = 0, RECIP = 1, GELU = 2, RELU = 3, SQRT = 4, SIGMOID = 5, LOG = 6, TANH = 7, LOG2 = 8, LOG10 = 9, SIN = 10, COS = 11,
     ABS=12, SIGN=13, SQUARE=14, EQZ = 15, NEZ = 16, GTZ = 17, LTZ = 18, GEZ = 19, LEZ = 20, RELU_MAX = 21, RELU_MIN = 22, POWER = 23, LEAKY_RELU = 24, ELU = 25, EXP2 = 26, HEAVISIDE = 27,
     EXPM1 = 28, SIGNBIT = 29, ASIN = 30, ACOS = 31, RSQRT = 32, RELU6 = 33, ATAN = 34, ERF = 35, ERFC = 36, ISINF = 37, ISPOSINF = 38, ISNEGINF = 39, ISNAN = 40, LOGICAL_NOT_UNARY = 41, ISFINITE = 42,
-    ERFINV = 43, I0 = 44, TAN = 45
+    ERFINV = 43, I0 = 44, TAN = 45, RSUB = 46, RDIV = 47
 };
 
 template <typename T>
@@ -37,6 +37,8 @@ bool is_parametrized_type(T val) {
     case UnaryOpType::HEAVISIDE:
     case UnaryOpType::ERF:
     case UnaryOpType::ERFC:
+    case UnaryOpType::RSUB:
+    case UnaryOpType::RDIV:
         return true;
     default:
         return false;
@@ -144,6 +146,7 @@ constexpr auto power = make_eltwise_unary_with_param<UnaryOpType::POWER, uint32_
 constexpr auto leaky_relu = make_eltwise_unary_with_param<UnaryOpType::LEAKY_RELU>{};
 constexpr auto elu = make_eltwise_unary_with_param<UnaryOpType::ELU>{};
 constexpr auto heaviside = make_eltwise_unary_with_param<UnaryOpType::HEAVISIDE>{};
+constexpr auto rsub = make_eltwise_unary_with_param<UnaryOpType::RSUB>{};
 
 inline Tensor erf(const Tensor &input_tensor, bool fast_and_approx=true, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     return make_eltwise_unary_with_param<UnaryOpType::ERF>{}(input_tensor, fast_and_approx, output_mem_config);
@@ -177,6 +180,8 @@ Tensor mul_unary(float value, const Tensor& input_tensor, const MemoryConfig& ou
 
 Tensor div_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 Tensor div_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+//same as div_unary(value,tensor)
+Tensor rdiv(const Tensor& input_tensor,float value, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 //deg2rad(a) using scale pi/180.
 inline Tensor deg2rad(const Tensor &input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) { return mul_unary(input_tensor, (float)(M_PI/180.0), output_mem_config); }

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -12,6 +12,8 @@
 #include "tt_metal/detail/persistent_kernel_cache.hpp"
 
 #include "tt_dnn/op_library/auto_format.hpp"
+#include "tt_dnn/op_library/math.hpp"
+
 #include "tt_lib_bindings.hpp"
 #include "tt_lib_bindings_tensor.hpp"
 #include "operations/module.hpp"
@@ -40,6 +42,19 @@ void DeviceModule(py::module &m_device) {
         .def("id", &Device::id, "Device's ID")
         .def("arch", &Device::arch, "Device's arch");
 
+    // *** eps constant ***
+    m_device.attr("EPS_GS") = EPS_GS;
+    m_device.attr("EPS_WHB0") = EPS_WHB0;
+
+    pyDevice.def("sfpu_eps", &Device::sfpu_eps, R"doc(
+        Machine epsilon value for current device.
+
+        +------------------+------------------------+-----------------------+-------------+----------+
+        | Argument         | Description            | Data type             | Valid range | Required |
+        +==================+========================+=======================+=============+==========+
+        | device           | return machine epsilon | tt_lib.device.Device  |     NA      | Yes      |
+        +------------------+------------------------+-----------------------+-------------+----------+
+        )doc");
     m_device.def("CreateDevice", [](int device_id) { return CreateDevice(device_id); }, R"doc(
         Creates an instance of TT device.
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
@@ -62,6 +62,38 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+        m_tensor.def("assign", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&assign),
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
+            Copies input tensor ``arg0`` (given by input_a) to ``arg1`` (given by input_b) if their
+            shapes and memory layouts match, and returns input_b tensor.
+
+            Input tensors can be of any data type.
+
+            Output tensor will be of same data type as Input tensor.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input_a", "Tensor assign is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input_b", "Input tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+        m_tensor.def("assign", py::overload_cast<const Tensor&, const MemoryConfig&>(&assign),
+            py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Clones input tensors ``arg0`` (given by input) and returns the output tensor.
+
+            Input tensor can be of any data type.
+
+            Output tensor will be of same data type as Input tensor.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor assign is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
         m_tensor.def("reshape", &reshape,
             py::arg("input").noconvert(), py::arg("W"), py::arg("Z"), py::arg("Y"), py::arg("X"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Returns a tensor with the new shape of ``[W, Z, Y, X]``. The X dimension of input and output tensor must have same size.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
@@ -430,17 +430,21 @@ namespace tt::tt_metal::detail
             )
             .def(
                 py::init<>(
-                    [](const py::object& torch_tensor, DataType data_type) {
+                    [](const py::object& torch_tensor, std::optional<DataType> data_type = std::nullopt) {
                         return detail::convert_torch_tensor_to_tt_tensor(torch_tensor, data_type);
                     }
                 ),
+                py::arg("torch_tensor"),
+                py::arg("data_type") = std::nullopt,
                 py::return_value_policy::move,
                 R"doc(
-                    +---------------+---------------+
-                    | Argument      | Name          |
-                    +===============+===============+
-                    | arg0          | torch_tensor  |
-                    +---------------+---------------+
+                    +--------------+---------------------+
+                    | Argument     | Description         |
+                    +==============+=====================+
+                    | torch_tensor | Pytorch Tensor      |
+                    +--------------+---------------------+
+                    | data_type    | TT Tensor data type |
+                    +--------------+---------------------+
 
                     Example of creating a TT Tensor that uses torch.Tensor's storage as its own storage:
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -8,6 +8,7 @@
 #include "tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
 #include "tt_dnn/op_library/softmax/softmax_op.hpp"
 
+
 namespace tt::tt_metal::detail {
     void TensorModuleXaryOPs( py::module & m_tensor){
 
@@ -137,6 +138,18 @@ namespace tt::tt_metal::detail {
             HEAVISIDE(x) = 0 if x < 0 , 1 if x > 0 , else value.)doc",
             R"doc("value", "float", "")doc"
 
+        );
+        detail::bind_unary_op_with_param(
+            m_tensor, "rdiv", rdiv,
+            py::arg("denominator"),
+            R"doc(Returns tensor  with value ``{1}`` divided by each of respective elements of the input tensor ``{0}``.)doc",
+            R"doc("denominator value which is actually calculated as numerator", "float", ">=0.0")doc"
+        );
+        detail::bind_unary_op_with_param(
+            m_tensor, "rsub", rsub,
+            py::arg("value"),
+            R"doc(Returns tensor  with respective elements of the input tensor ``{0}`` subtracted from the ``{1}``.)doc",
+            R"doc("subtrahent value which is actually calculated as minuend", "float")doc"
         );
         detail::bind_unary_op_with_param(
             m_tensor, "power", power,

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -372,6 +372,18 @@ void Device::deallocate_buffers(){
     allocator::deallocate_buffers(*allocator_);
 }
 
+float Device::sfpu_eps() const {
+
+  float value = std::numeric_limits<float>::epsilon();
+  if( arch() == tt::ARCH::GRAYSKULL  ) {
+    value = tt::tt_metal::EPS_GS;
+  } else if( arch() == tt::ARCH::WORMHOLE_B0 ) {
+    value = tt::tt_metal::EPS_WHB0;
+  }
+
+  return value;
+}
+
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -24,6 +24,9 @@ class Program;
 
 using on_close_device_callback = std::function<void ()>;
 
+static constexpr float  EPS_GS = 0.001953125f;
+static constexpr float  EPS_WHB0 = 1.19209e-7f;
+
 class ActiveDevices {
     enum class ActiveState {
         UNINITIALIZED = 0,
@@ -107,6 +110,9 @@ class Device {
     // Set of logical dispatch core coordinates
     const std::set<CoreCoord> &dispatch_cores() const { return this->dispatch_cores_; }
     void deallocate_buffers();
+
+    // machine epsilon
+    float sfpu_eps() const;
 
    private:
     void check_allocator_is_initialized() const;

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/reverseops.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/reverseops.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_reverseops.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+
+
+namespace ckernel {
+
+//rpow: implemented as a composite operator
+//rpow(a,k) = k**(a)
+
+//RDIV : rdiv(x,y) = y/x
+//implemented as tied multiply operator
+
+//RSUB : rsub(x,y) = y-x
+ALWI void rsub_tile(uint32_t idst,uint32_t param0) {
+    MATH(( llk_math_eltwise_unary_sfpu_rsub<APPROX, SyncHalf>(idst,param0) ));
+}
+
+ALWI void rsub_tile_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_rsub_init<APPROX>() ));
+}
+
+} // namespace ckerne

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -54,6 +54,10 @@
 #include "compute_kernel_api/eltwise_unary/trigonometry.h"
 #endif
 
+#if SFPU_OP_REVERSE_FAMILY_INCLUDE
+#include "compute_kernel_api/eltwise_unary/reverseops.h"
+#endif
+
 #if SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
 #include "compute_kernel_api.h"
 #endif

--- a/tt_metal/src/ckernels/grayskull/common/inc/ckernel_reverseops.h
+++ b/tt_metal/src/ckernels/grayskull/common/inc/ckernel_reverseops.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "ckernel_defs.h"
+#include "ckernel.h"
+#include "noc_nonblocking_api.h"
+
+#include "sfpi.h"
+
+#include "ckernel_sfpu_converter.h"
+
+using namespace sfpi;
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+
+
+template <bool APPROXIMATION_MODE>
+void rsub_init() {
+    ;
+}
+
+
+template <bool APPROXIMATION_MODE, int ITERATIONS=4>
+inline void calculate_rsub(uint value)
+{
+    Converter c_value;
+    c_value.u = value;
+    vFloat arg2 = c_value.f;
+
+    #pragma GCC unroll 4
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat value = dst_reg[0];
+        dst_reg[0] = arg2 - value;
+        dst_reg++;
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/src/ckernels/grayskull/common/inc/ckernel_sfpu_converter.h
+++ b/tt_metal/src/ckernels/grayskull/common/inc/ckernel_sfpu_converter.h
@@ -20,6 +20,11 @@ union Converter {
         c.u = _v;
         return c.f;
     }
+    static uint32_t to_uint(float _f) {
+      Converter c{};
+      c.f = _f;
+      return c.u;
+    }
 };
 
 } // namespace sfpu

--- a/tt_metal/src/ckernels/grayskull/common/inc/cmath_common.h
+++ b/tt_metal/src/ckernels/grayskull/common/inc/cmath_common.h
@@ -21,6 +21,8 @@
 #define FUSE_SQRT_RECIP 0
 #endif
 
+#define EPS 0.001953125 //std::numeric_limits::epsilon() - BF19 aka TF32
+
 using namespace ckernel;
 
 namespace ckernel::math

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_math_eltwise_unary_sfpu_reverseops.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_math_eltwise_unary_sfpu_reverseops.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+#include "llk_math_eltwise_unary_sfpu_common_includes.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_1_param.h"
+#include "ckernel_reverseops.h"
+
+
+namespace ckernel {
+
+    /************** rsub ************/
+
+    template <bool APPROXIMATE>
+    inline void llk_math_eltwise_unary_sfpu_rsub_init() {
+        llk_math_eltwise_unary_sfpu_init<APPROXIMATE>(sfpu::rsub_init<APPROXIMATE>);
+    }
+
+    template <bool APPROXIMATE, DstSync Dst = DstSync::SyncFull>
+    inline void llk_math_eltwise_unary_sfpu_rsub(uint dst_index, uint param0 = 0) {
+        llk_math_eltwise_unary_sfpu_1_param<APPROXIMATE, Dst>
+                                    (ckernel::sfpu::calculate_rsub<APPROXIMATE,4>,
+                                    ckernel::sfpu::calculate_rsub<APPROXIMATE,4>,
+                                    dst_index, Dim::RC, param0);
+    }
+
+}

--- a/tt_metal/src/ckernels/wormhole_b0/common/inc/ckernel_reverseops.h
+++ b/tt_metal/src/ckernels/wormhole_b0/common/inc/ckernel_reverseops.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+
+#include "ckernel_sfpu_converter.h"
+
+#include "sfpi.h"
+using namespace sfpi;
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+
+
+template <bool APPROXIMATION_MODE>
+void rsub_init() {
+    ;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS=8>
+inline void calculate_rsub(uint value)
+{
+    Converter c_value;
+    c_value.u = value;
+    vFloat arg2 = c_value.f;
+
+    #pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat value = dst_reg[0];
+        dst_reg[0] = arg2 - value;
+        dst_reg++;
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/src/ckernels/wormhole_b0/common/inc/cmath_common.h
+++ b/tt_metal/src/ckernels/wormhole_b0/common/inc/cmath_common.h
@@ -22,6 +22,8 @@
 #define FUSE_SQRT_RECIP 0
 #endif
 
+#define EPS 1.19209e-07 //std::numeric_limits::epsilon() for FP32
+
 using namespace ckernel;
 
 namespace ckernel::math

--- a/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_reverseops.h
+++ b/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_reverseops.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_common_includes.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_1_param.h"
+#include "ckernel_reverseops.h"
+
+
+namespace ckernel {
+
+    /************** rsub ************/
+
+    template <bool APPROXIMATE>
+    inline void llk_math_eltwise_unary_sfpu_rsub_init() {
+        llk_math_eltwise_unary_sfpu_init<APPROXIMATE>(sfpu::rsub_init<APPROXIMATE>);
+    }
+
+    template <bool APPROXIMATE, DstSync Dst = DstSync::SyncFull>
+    inline void llk_math_eltwise_unary_sfpu_rsub(uint dst_index, uint param0 = 0) {
+        llk_math_eltwise_unary_sfpu_1_param<APPROXIMATE, Dst>
+                                    (ckernel::sfpu::calculate_rsub<APPROXIMATE,8>,
+                                    ckernel::sfpu::calculate_rsub<APPROXIMATE,8>,
+                                    dst_index, Dim::RC, param0);
+    }
+
+}


### PR DESCRIPTION
         : add rsub, rpow, rdiv ops for WH B0
         : black fmt
         : add docs
         : handle negative sign factors and update doc

#0: unary assign, binary assign operators for tt_dnn
#2729: Add the support for polygamma op
#0: skip neg operator
#0: docs for experimental ops (pending sweep)
#0: update documentation wording
#0: Fix buffer type issue for polygamma
#0: Remove duplicate entries of rpow, rdiv & rpow for docstring
#2350: Add bitwise OR support as fallback operations
#2352: Add bitwise AND support as fallback op
#2351: Add bitwise XOR support as fallback op
#2349: Add bitwise NOT op support as fallback op
#3075: Add the equal_nan variant support for isclose op
     : Update tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
     : Update tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py

#3083: Add bitwise OR, AND, XOR binary op support
#0: Rename clone header as copy header
#3084: Add bitwise shift ops as fallback ops
#0: Update fallback ops conversion wrapper to properly pass through input/output dtypes
#3084: Update dtypes and remove int conversion
#3054: unary assign, binary assign operators for tt_dnn
#2729: Reduce the code usage for polygamma op
#2729: Updated the polygamma op

#3040: implement rpow, rdiv, and rsub for the reciprocal ops
         : add rsub, rpow, rdiv ops for WH B0
         : handle negative sign factors and update doc
         : docs for experimental ops (pending sweep)

#3073: sfpu eps for WHB0 and GS arch
     : move the constants into device and use sfpu_eps in tensor and place tensor operations

#0: Revert "#3084: Update dtypes and remove int conversion"
    This reverts commit a18423940b692f26f8bb751e4eb2374e35cbce5a.
#0: revert e6e3dd6987208aa56b8d02168dba3f7d0ed66b1e #0: revert NOT 18417608c6fa7014d46aab5c50f57d4b870fc5c3 #0: git revert  40194c355ab09ef63156090f2c7544796568dfbe #0: remove file