### PR TITLE
#3185: Add sweep test for nextafter

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/pytorch_eltwise_nextafter_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/pytorch_eltwise_nextafter_test.yaml
@@ -1,0 +1,46 @@
+---
+test-list:
+  - eltwise-nextafter:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_nextafter_sweep.csv
+  - eltwise-nextafter:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_nextafter_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/pytorch_eltwise_nextafter_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/pytorch_eltwise_nextafter_test.yaml
@@ -1,0 +1,46 @@
+---
+test-list:
+  - eltwise-nextafter:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_nextafter_sweep.csv
+  - eltwise-nextafter:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_nextafter_sweep.csv


### PR DESCRIPTION
Two variants of `sweep test added: 
1) ci_sweep_tests_working - the one that passes in all cases
2) ci_swepp_tests - fails for large shapes, bfloat8, type mismatch, system memory as well

[post-commit] Run all post-commit workflows: 

Scheduled fast dispatch frequent build and run: https://github.com/tenstorrent-metal/tt-metal/actions/runs/6571721172
Scheduled slow dispatch frequent build and run: https://github.com/tenstorrent-metal/tt-metal/actions/runs/6571039265

[post-commit] Run all post-commit workflows: https://github.com/tenstorrent-metal/tt-metal/actions/runs/6571035798