### PR TITLE
#3162: Add 45 min timeout to benchmarks

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Build tests
         run: make tests
       - name: Run microbenchmark tests
+        timeout-minutes: 45
         run: ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type microbenchmarks
       - name: Upload microbenchmark report csvs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
 because it might hang and hang onto perf runners, stalling other pipelines