### PR TITLE
Better multicore dispatch write/read bandwidth

### DIFF
--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -41,6 +41,10 @@ void DeviceCommand::set_data_size(const u32 data_size) { this->desc[this->data_s
 
 u32 DeviceCommand::get_data_size() const { return this->desc[this->data_size_idx]; }
 
+void DeviceCommand::set_producer_consumer_transfer_num_pages(const u32 producer_consumer_transfer_num_pages) {
+    this->desc[this->producer_consumer_transfer_num_pages_idx] = producer_consumer_transfer_num_pages;
+}
+
 void DeviceCommand::add_buffer_transfer_instruction(
     const u32 src,
     const u32 dst,

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -44,6 +44,7 @@ class DeviceCommand {
     static constexpr u32 consumer_cb_num_pages_idx = 10;
     static constexpr u32 num_pages_idx = 11;
     static constexpr u32 data_size_idx = 12;
+    static constexpr u32 producer_consumer_transfer_num_pages_idx = 13;
 
     void wrap();
 
@@ -69,6 +70,8 @@ class DeviceCommand {
     void set_num_pages(const u32 num_pages);
 
     void set_data_size(const u32 data_size);
+
+    void set_producer_consumer_transfer_num_pages(const u32 producer_consumer_transfer_num_pages);
 
     u32 get_data_size() const;
 

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
@@ -35,15 +35,17 @@ void kernel_main() {
         u32 is_program = command_ptr[DeviceCommand::is_program_buffer_idx];
         u32 page_size = command_ptr[DeviceCommand::page_size_idx];
         u32 consumer_cb_size = command_ptr[DeviceCommand::consumer_cb_size_idx];
+        u32 consumer_cb_num_pages = command_ptr[DeviceCommand::consumer_cb_num_pages_idx];
         u32 num_pages = command_ptr[DeviceCommand::num_pages_idx];
+        u32 producer_consumer_transfer_num_pages = command_ptr[DeviceCommand::producer_consumer_transfer_num_pages_idx];
 
         if (is_program) {
             command_ptr = reinterpret_cast<volatile tt_l1_ptr u32*>(program_transfer_start_addr);
-            write_and_launch_program(num_pages, command_ptr, producer_noc_encoding, consumer_cb_size, db_buf_switch);
+            write_and_launch_program(num_pages, command_ptr, producer_noc_encoding, consumer_cb_size, consumer_cb_num_pages, producer_consumer_transfer_num_pages, db_buf_switch);
             wait_for_program_completion(num_workers, command_ptr, tensix_soft_reset_addr);
         } else {
             command_ptr = reinterpret_cast<volatile tt_l1_ptr u32*>(buffer_transfer_start_addr);
-            write_buffers(command_ptr, num_buffer_transfers, consumer_cb_size, producer_noc_encoding, db_buf_switch);
+            write_buffers(command_ptr, num_buffer_transfers, consumer_cb_size, consumer_cb_num_pages, producer_noc_encoding, producer_consumer_transfer_num_pages, db_buf_switch);
         }
 
         if (finish) {


### PR DESCRIPTION
Allow larger than 1 page transfers between producer and consumer leads to 2-3x speedup in write/read bandwidth on GS.