### PR TITLE
Optimize ncrisc copy to iram

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -149,7 +149,9 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
         case 3: fname = "tensix_thread1/tensix_thread1.hex"; break;
         case 4: fname = "tensix_thread2/tensix_thread2.hex"; break;
         }
-        llrt::test_load_write_read_risc_binary(fname, this->id(), phys_core, riscv_id, true);
+
+        ll_api::memory binary_mem = llrt::get_risc_binary(fname, this->id(), true);
+        llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, riscv_id);
     }
 
     llrt::write_launch_msg_to_core(this->id(), phys_core, launch_msg);
@@ -223,7 +225,6 @@ bool Device::initialize(const std::vector<uint32_t>& l1_bank_remap) {
     if (!already_initialized) {
         this->initialize_build();
     }
-    this->initialize_and_launch_firmware();
     tt_start_debug_print_server();
     llrt::watcher_attach(this, this->id(),
                          [&, this]() { return this->logical_grid_size(); },
@@ -231,6 +232,7 @@ bool Device::initialize(const std::vector<uint32_t>& l1_bank_remap) {
                          [&, this]() -> const std::set<CoreCoord>& { return this->storage_only_cores(); },
                          get_compile_outpath()
                          );
+    this->initialize_and_launch_firmware();
 
     this->initialized_ = true;
     return true;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -151,6 +151,10 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
         }
 
         ll_api::memory binary_mem = llrt::get_risc_binary(fname, this->id(), true);
+        if (riscv_id == 1) {
+            launch_msg->ncrisc_kernel_size16 = llrt::get_binary_code_size16(binary_mem, riscv_id);
+        }
+        log_debug("RISC {} fw binary size: {} in bytes", riscv_id, launch_msg->ncrisc_kernel_size16 * 16);
         llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, riscv_id);
     }
 
@@ -164,7 +168,7 @@ void Device::initialize_and_launch_firmware() {
         .brisc_kernel_id = 0,
         .ncrisc_kernel_id = 0,
         .trisc_kernel_id = 0,
-        .ncrisc_fw_size = 0,
+        .ncrisc_kernel_size16 = 0,
         .mode = DISPATCH_MODE_HOST,
         .brisc_noc_id = 0,
         .enable_brisc = 0,

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -12,6 +12,7 @@
 #include "tt_metal/impl/allocator/basic_allocator.hpp"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "tt_metal/src/firmware/riscv/common/dev_msgs.h"
 
 namespace tt {
 
@@ -123,8 +124,8 @@ class Device {
     void initialize_cluster();
     void initialize_allocator(const std::vector<uint32_t>& l1_bank_remap = {});
     void initialize_build();
-    void initialize_firmware(CoreCoord phys_core);
-    void initialize_hardware();
+    void initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg);
+    void initialize_and_launch_firmware();
     void clear_l1_state();
     // Puts device into reset
     bool close();

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -63,6 +63,7 @@ class Kernel {
     std::string compute_hash() const;
     virtual void set_build_options(build_kernel_for_riscv_options_t &build_options) const = 0;
     virtual void generate_binaries(Device *device, build_kernel_for_riscv_options_t *build_options, const std::string &op_path_suffix) const = 0;
+    inline uint16_t get_binary_size16() const { return binary_size16_; }
     void set_binary_path ( const std::string & binary_path) { binary_path_ = binary_path; }
     void set_binaries(std::vector<ll_api::memory> &&binaries);
     virtual void read_binaries(int device_id) = 0;
@@ -75,6 +76,7 @@ class Kernel {
     CoreRangeSet core_range_set_;
     std::string binary_path_;
     std::vector<ll_api::memory> binaries_;              // DataMovement kernels have one binary each and Compute kernels have three binaries
+    uint16_t binary_size16_;
     std::vector<uint32_t> compile_time_args_;
     std::unordered_map<CoreCoord, std::vector<uint32_t>> core_to_runtime_args_;
     std::map<std::string, std::string> defines_;        // preprocessor defines. this is to be able to generate generic instances.

--- a/tt_metal/impl/program.cpp
+++ b/tt_metal/impl/program.cpp
@@ -125,10 +125,12 @@ KernelGroup::KernelGroup(const Program& program,
     }
 
     if (ncrisc_id) {
+        const Kernel *kernel = program.get_kernel(ncrisc_id.value());
         // Use 1-ncrisc's noc (the other noc) if ncrisc specifies a noc
         // If both brisc and ncrisc set the noc, then this is safe due to prior correctness validation
         this->launch_msg.enable_ncrisc = true;
-        this->launch_msg.brisc_noc_id = 1 - std::get<DataMovementConfig>(program.get_kernel(ncrisc_id.value())->config()).noc;
+        this->launch_msg.brisc_noc_id = 1 - std::get<DataMovementConfig>(kernel->config()).noc;
+        this->launch_msg.ncrisc_kernel_size16 = kernel->get_binary_size16();
     } else {
         this->launch_msg.enable_ncrisc = false;
     }
@@ -193,7 +195,6 @@ struct KernelGroupIntHasher {
 
 void Program::update_kernel_groups() {
     if (core_to_kernel_group_index_table_.size() == 0) {
-
         // Get the extent of the kernels in x, y
         CoreCoord base = {std::numeric_limits<decltype(base.x)>::max(),
                           std::numeric_limits<decltype(base.y)>::max()};

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -136,7 +136,9 @@ namespace internal_ {
 
 void assert_enable_core_mailbox_is_valid_for_core(chip_id_t chip_id, const CoreCoord &core);
 
-bool check_if_riscs_on_specified_core_done(chip_id_t chip_id, const CoreCoord &core);
+void wait_until_cores_done(chip_id_t device_id,
+                           int run_state,
+                           std::unordered_set<CoreCoord>& not_done_phys_cores);
 
 void dispatch(
     chip_id_t chip_id,

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -58,6 +58,7 @@ using CircularBufferConfigVec = std::vector<uint32_t>;
 // made these free functions -- they're copy/paste of the member functions
 // TODO: clean-up epoch_loader / epoch_binary -- a bunch of functions there should not be member functions
 ll_api::memory get_risc_binary(string path, chip_id_t chip_id, bool fw_build);
+uint16_t get_binary_code_size16(const ll_api::memory& mem, int riscv_id);
 
 // TODO: try using "stop" method from device instead, it's the proper way of asserting reset
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -92,18 +92,8 @@ void write_graph_interpreter_op_info_to_core(
 
 void program_brisc_startup_addr(chip_id_t chip_id, const CoreCoord &core);
 
-// for BRISC and NCRISC
-// hex_file_path is relative to the "kernels"/"firwmare" root
-bool test_load_write_read_risc_binary(
-    std::string hex_file_name, chip_id_t chip_id, const CoreCoord &core, int riscv_id, bool fw_build = false);
-
 bool test_load_write_read_risc_binary(
     ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, int riscv_id);
-
-// for TRISCs
-// hex_file_path is relative to the "kernels"/"firwmare" root
-bool test_load_write_read_trisc_binary(
-    std::string hex_file_name, chip_id_t chip_id, const CoreCoord &core, int triscv_id);
 
 bool test_load_write_read_trisc_binary(
     ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, int triscv_id);

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -102,40 +102,11 @@ bool test_load_write_read_trisc_binary(
 // subchannel hard-coded to 0 for now
 CoreCoord get_core_for_dram_channel(int dram_channel_id, chip_id_t chip_id = 0);
 
-enum class TensixRiscsOptions : std::uint32_t {
-    NONE = 0,
-    BRISC_ONLY = static_cast<std::uint32_t>(1 << 1),
-    BRISC_NCRISC = static_cast<std::uint32_t>(1 << 2),
-    BRISC_TRISCS = static_cast<std::uint32_t>(1 << 3),
-    ALL_RISCS = static_cast<std::uint32_t>(1 << 4)
-};
-
-inline bool operator!=(const TensixRiscsOptions lhs, const TensixRiscsOptions rhs) {
-    return static_cast<std::underlying_type<TensixRiscsOptions>::type>(lhs) !=
-           static_cast<std::underlying_type<TensixRiscsOptions>::type>(rhs);
-}
-
-inline bool deduce_if_involves_triscs(const TensixRiscsOptions &riscs_options) {
-    return riscs_options == TensixRiscsOptions::BRISC_TRISCS || riscs_options == TensixRiscsOptions::ALL_RISCS;
-}
-
-inline bool deduce_if_involves_ncrisc(const TensixRiscsOptions &riscs_options) {
-    return riscs_options == TensixRiscsOptions::BRISC_NCRISC || riscs_options == TensixRiscsOptions::ALL_RISCS;
-}
-
 namespace internal_ {
-
-void assert_enable_core_mailbox_is_valid_for_core(chip_id_t chip_id, const CoreCoord &core);
 
 void wait_until_cores_done(chip_id_t device_id,
                            int run_state,
                            std::unordered_set<CoreCoord>& not_done_phys_cores);
-
-void dispatch(
-    chip_id_t chip_id,
-    const TensixRiscsOptions riscs_option,
-    const std::vector<CoreCoord> &dispatch_cores,
-    uint32_t dispatch_done_addr);
 
 }  // namespace internal_
 

--- a/tt_metal/src/firmware/riscv/common/dev_msgs.h
+++ b/tt_metal/src/firmware/riscv/common/dev_msgs.h
@@ -42,7 +42,7 @@ struct launch_msg_t {  // must be cacheline aligned
     volatile uint16_t brisc_kernel_id;
     volatile uint16_t ncrisc_kernel_id;
     volatile uint16_t trisc_kernel_id;
-    volatile uint16_t ncrisc_fw_size;
+    volatile uint16_t ncrisc_kernel_size16; // size in 16 byte units
     volatile uint8_t mode;
     volatile uint8_t brisc_noc_id;
     volatile uint8_t enable_brisc;

--- a/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
@@ -270,6 +270,7 @@ int main() {
 
     // Set ncrisc's resume address to 0 so we know when ncrisc has overwritten it
     mailboxes->ncrisc_halt.resume_addr = 0;
+    mailboxes->slave_sync.ncrisc = RUN_SYNC_MSG_GO;
     deassert_ncrisc_trisc();
     set_ncrisc_kernel_resume_deassert_address();
 
@@ -277,6 +278,8 @@ int main() {
     DEBUG_STATUS('I', 'N', 'W');
     while (mailboxes->slave_sync.ncrisc != RUN_SYNC_MSG_DONE);
     DEBUG_STATUS('I', 'N', 'D');
+
+    mailboxes->launch.run = RUN_MSG_DONE;
 
     // Cleanup profiler buffer incase we never get the go message
     kernel_profiler::init_profiler();


### PR DESCRIPTION
Gather kernel sizes on host
Send ncrisc size to device
brisc now copies based on the kernel size
Requires sync at init to prevent race, so dev init now waits until device side
fw init is complete
