### PR TITLE
Add rsub, rdiv and rpow sweeps tests

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
@@ -1540,3 +1540,29 @@ def gen_polygamma_args(
         k_order = np.random.randint(1, 10)
         input_info.update({"k": k_order})
         yield input_info
+
+
+
+def gen_rop_args(
+    input_shapes,
+    supported_dtypes,
+    supported_layouts,
+    on_device,
+    low=-1,
+    high=10,
+    dtype=torch.bfloat16,
+):
+    for input_info in gen_scalar_args(
+        input_shapes,
+        supported_dtypes,
+        supported_layouts,
+        on_device,
+        "factor",
+        low,
+        high,
+        dtype,
+    ):
+        # the n(int) order of the polygamma function is b/w 1 to 10
+        factor = random.randint(1, 10)
+        input_info.update({"factor": factor})
+        yield input_info

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/pytorch_eltwise_rdiv_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/pytorch_eltwise_rdiv_test.yaml
@@ -1,6 +1,6 @@
 ---
 test-list:
-  - eltwise-rsub:
+  - eltwise-rdiv:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]
@@ -27,8 +27,8 @@ test-list:
             data-type: ["BFLOAT16", "BFLOAT8_B"]
             buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
-      output-file: eltwise_rsub_sweep.csv
-  - eltwise-rsub:
+      output-file: eltwise_rdiv_sweep.csv
+  - eltwise-rdiv:
       shape:
         start-shape: [1, 1, 2, 2]
         end-shape: [12, 24, 512, 512]
@@ -55,4 +55,4 @@ test-list:
             data-type: ["BFLOAT16"]
             buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
-      output-file: eltwise_rsub_sweep.csv
+      output-file: eltwise_rdiv_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/pytorch_eltwise_rpow_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/pytorch_eltwise_rpow_test.yaml
@@ -1,11 +1,11 @@
 ---
 test-list:
-  - eltwise-rsub:
+  - eltwise-rpow:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]
         interval: [1, 1, 32, 32]
-        num-shapes: 2
+        num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
@@ -22,18 +22,14 @@ test-list:
             data-layout: ["TILE"]
             data-type: ["BFLOAT16", "BFLOAT8_B"]
             buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-          - input-2:
-            data-layout: ["TILE"]
-            data-type: ["BFLOAT16", "BFLOAT8_B"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
-      output-file: eltwise_rsub_sweep.csv
-  - eltwise-rsub:
+      output-file: eltwise_rpow_sweep.csv
+  - eltwise-rpow:
       shape:
         start-shape: [1, 1, 2, 2]
         end-shape: [12, 24, 512, 512]
         interval: [1, 1, 1, 2]
-        num-shapes: 2
+        num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
@@ -50,9 +46,5 @@ test-list:
             data-layout: ["ROW_MAJOR"]
             data-type: ["BFLOAT16"]
             buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-          - input-2:
-            data-layout: ["ROW_MAJOR"]
-            data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
-      output-file: eltwise_rsub_sweep.csv
+      output-file: eltwise_rpow_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/pytorch_eltwise_rsub_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/pytorch_eltwise_rsub_test.yaml
@@ -1,0 +1,30 @@
+---
+test-list:
+  - eltwise-rsub:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_rop_args
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_rsub_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/pytorch_eltwise_rdiv_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/pytorch_eltwise_rdiv_test.yaml
@@ -1,0 +1,30 @@
+---
+test-list:
+  - eltwise-rdiv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_rop_args
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_rdiv_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/pytorch_eltwise_rpow_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/pytorch_eltwise_rpow_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - eltwise-rpow:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_rop_args
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_rpow_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/pytorch_eltwise_rsub_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/pytorch_eltwise_rsub_test.yaml
@@ -1,0 +1,30 @@
+---
+test-list:
+  - eltwise-rsub:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_rop_args
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_rsub_sweep.csv


### PR DESCRIPTION
New YAML files for sweep test execution together with generation function for this type of operations were added.
The pipelines are passing successfully:
https://github.com/tenstorrent-metal/tt-metal/actions/runs/6571715483
https://github.com/tenstorrent-metal/tt-metal/actions/runs/6571713554
https://github.com/tenstorrent-metal/tt-metal/actions/runs/6571718000