### PR TITLE
#3252: update wormhole ops in partiy to GS

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_glu_variants.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_glu_variants.py
@@ -17,28 +17,13 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
     run_single_pytorch_test,
 )
-from tests.tt_eager.python_api_testing.sweep_tests.common import (
-    skip_for_wormhole_b0,
-    is_wormhole_b0,
-)
 
 shapes = [
     [[1, 1, 32, 64]],  # Single core
     [[1, 3, 320, 32 * 8]],  # Multi core
 ]
 input_mem_cfgs = copy.copy(generation_funcs.supported_mem_configs)
-del input_mem_cfgs[1:]
 output_mem_cfgs = copy.copy(generation_funcs.supported_mem_configs)
-if is_wormhole_b0():
-    shapes = [
-        shapes[0],
-    ]
-    input_mem_cfgs = [
-        input_mem_cfgs[0],
-    ]
-    output_mem_cfgs = [
-        output_mem_cfgs[0],
-    ]
 
 
 @pytest.mark.parametrize(
@@ -48,7 +33,6 @@ if is_wormhole_b0():
 @pytest.mark.parametrize("input_mem_config", input_mem_cfgs)
 @pytest.mark.parametrize("output_mem_config", output_mem_cfgs)
 class TestGLUVariants:
-    @skip_for_wormhole_b0
     @pytest.mark.parametrize("fn_kind", ["glu", "reglu", "geglu", "swiglu"])
     def test_all_glu_ops(
         self,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_outer.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_outer.py
@@ -18,30 +18,23 @@ sys.path.append(f"{f}/../../../..")
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from tests.tt_eager.python_api_testing.sweep_tests.common import skip_for_wormhole_b0, is_wormhole_b0
 
 shapes = [
-        # Single core (won't be hit after padding is added for multicast)
-        [[1, 1, 32, 1], [1, 1, 1, 32]],  # no reshape
-        [[1, 1, 2048, 1], [1, 1, 1, 64]],  # LLaMa dimensions (no reshape)
-        # FIXME: padding required for reshape on device
-        # [[1, 1, 1, 32], [1, 1, 1, 32]],    #invoke reshape on lhs
-        # [[1, 1, 1, 32], [1, 1, 32, 1]],    #invoke reshape on both
-        # [[1, 1, 32, 1], [1, 1, 32, 1]],    #invoke reshape on rhs
+    # Single core (won't be hit after padding is added for multicast)
+    [[1, 1, 32, 1], [1, 1, 1, 32]],  # no reshape
+    [[1, 1, 2048, 1], [1, 1, 1, 64]],  # LLaMa dimensions (no reshape)
+    # FIXME: padding required for reshape on device
+    # [[1, 1, 1, 32], [1, 1, 1, 32]],    #invoke reshape on lhs
+    # [[1, 1, 1, 32], [1, 1, 32, 1]],    #invoke reshape on both
+    # [[1, 1, 32, 1], [1, 1, 32, 1]],    #invoke reshape on rhs
 ]
-if is_wormhole_b0():
-    del shapes[1:]
 
-@pytest.mark.parametrize(
-    "input_shapes",
-    shapes
-)
+
+@pytest.mark.parametrize("input_shapes", shapes)
 @pytest.mark.parametrize("dtype", (ttl.tensor.DataType.BFLOAT16,))
 def test_run_outer_test(input_shapes, device, dtype, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ] * 2
     comparison_func = partial(comparison_funcs.comp_pcc)
     run_single_pytorch_test(
@@ -54,6 +47,8 @@ def test_run_outer_test(input_shapes, device, dtype, function_level_defaults):
             "dtype": [dtype, dtype],
             "layout": [ttl.tensor.Layout.ROW_MAJOR, ttl.tensor.Layout.ROW_MAJOR],
             "input_mem_config": [None, None],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
         },
     )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_pad.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_pad.py
@@ -18,7 +18,7 @@ sys.path.append(f"{f}/../../../..")
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from tests.tt_eager.python_api_testing.sweep_tests.common import skip_for_wormhole_b0, is_wormhole_b0
+from tests.tt_eager.python_api_testing.sweep_tests.common import is_grayskull
 import random
 
 # Seed here for fixed params
@@ -26,23 +26,15 @@ import random
 random.seed(213919)
 torch.manual_seed(213919)
 
-params = [
-    pytest.param([[5, 5, 50, 50]], pad_args)
-    for pad_args in generation_funcs.gen_pad_args([[5, 5, 50, 50]])
-]
-if not is_wormhole_b0():
-    params += [
-        pytest.param([[5, 5, 64, 96]], pad_args)
-        for pad_args in generation_funcs.gen_pad_args([[5, 5, 64, 96]])
-    ]
+params = [pytest.param([[5, 5, 50, 50]], pad_args) for pad_args in generation_funcs.gen_pad_args([[5, 5, 50, 50]])]
+if is_grayskull():
+    params += [pytest.param([[5, 5, 64, 96]], pad_args) for pad_args in generation_funcs.gen_pad_args([[5, 5, 64, 96]])]
 
 
 @pytest.mark.parametrize("input_shapes, pad_args", params)
 def test_run_pad_test(input_shapes, pad_args, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
 
     comparison_func = comparison_funcs.comp_equal

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_permute.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_permute.py
@@ -17,15 +17,8 @@ sys.path.append(f"{f}/../../../..")
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from tests.tt_eager.python_api_testing.sweep_tests.common import skip_for_wormhole_b0, is_wormhole_b0
 
-if is_wormhole_b0():
-    params = [
-        pytest.param([[1, 1, 32, 32]], permute_args)
-        for permute_args in generation_funcs.gen_permute_args([[1, 1, 32, 32]])
-    ]
-    del params[8:]
-else:
+if True:
     params = [
         pytest.param([[1, 1, 32, 32]], permute_args)
         for permute_args in generation_funcs.gen_permute_args([[1, 1, 32, 32]])
@@ -37,13 +30,9 @@ else:
 
 
 @pytest.mark.parametrize("input_shapes, permute_args", params)
-def test_run_permute_test(
-    input_shapes, permute_args, device, function_level_defaults
-):
+def test_run_permute_test(input_shapes, permute_args, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = partial(comparison_funcs.comp_equal)
     run_single_pytorch_test(

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_reduce.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_reduce.py
@@ -24,7 +24,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
 )
 from tests.tt_eager.python_api_testing.sweep_tests.common import (
     is_wormhole_b0,
-    skip_for_wormhole_b0,
 )
 
 shapes = (
@@ -32,8 +31,6 @@ shapes = (
     [[1, 1, 32, 3840]],  # Multi core h
     [[1, 3, 32, 3840]],  # Multi core h
 )
-if is_wormhole_b0():
-    shapes = (shapes[0],)
 
 
 @pytest.mark.parametrize("input_shapes", shapes)
@@ -60,11 +57,9 @@ shapes2 = (
     [[1, 1, 3840, 32]],  # Multi core w
     [[1, 3, 3840, 32]],  # Multi core w
 )
-if is_wormhole_b0():
-    shapes2 = (shapes2[0],)
 
 
-@skip_for_wormhole_b0
+@pytest.mark.skipif(is_wormhole_b0(), reason="poor PCC")
 @pytest.mark.parametrize("input_shapes", shapes2)
 @pytest.mark.parametrize("minmax", ["min", "max"])
 def test_run_reduce_max_w_test(input_shapes, minmax, device, function_level_defaults):
@@ -90,9 +85,6 @@ shapes3 = (
     [[1, 3, 512, 512]],  # Multi core hw (== multi core w + multi core h)
 )
 
-if is_wormhole_b0():
-    shapes3 = (shapes3[0],)
-
 
 @pytest.mark.parametrize(
     "input_shapes",
@@ -101,9 +93,7 @@ if is_wormhole_b0():
 @pytest.mark.parametrize("minmax", ["min", "max"])
 def test_run_reduce_max_hw_test(input_shapes, minmax, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = comparison_funcs.comp_equal
     run_single_pytorch_test(
@@ -120,16 +110,12 @@ shapes5 = (
     [[1, 1, 32, 3840]],  # Multi core h
     [[1, 1, 32, 3840]],  # Multi core h
 )
-if is_wormhole_b0():
-    shapes5 = (shapes5[0],)
 
 
 @pytest.mark.parametrize("input_shapes", shapes5)
 def test_run_reduce_sum_h_test(input_shapes, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_checkerboard, low=0, high=100), torch.float32
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_checkerboard, low=0, high=100), torch.float32)
     ]
     comparison_func = partial(comparison_funcs.comp_allclose, atol=0.1, rtol=0)
     run_single_pytorch_test(
@@ -147,16 +133,11 @@ shapes4 = (
     [[1, 3, 3840, 32]],  # Multi core w
 )
 
-if is_wormhole_b0():
-    shapes4 = (shapes4[0],)
-
 
 @pytest.mark.parametrize("input_shapes", shapes4)
 def test_run_reduce_sum_w_test(input_shapes, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_checkerboard, low=0, high=100), torch.float32
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_checkerboard, low=0, high=100), torch.float32)
     ]
     comparison_func = partial(comparison_funcs.comp_allclose, atol=0.1, rtol=0)
     run_single_pytorch_test(
@@ -173,16 +154,12 @@ shapes5 = (
     [[1, 1, 512, 512]],  # Multi core hw (== multi core w + multi core h)
     [[1, 1, 512, 512]],  # Multi core hw (== multi core w + multi core h)
 )
-if is_wormhole_b0():
-    shapes5 = (shapes5[0],)
 
 
 @pytest.mark.parametrize("input_shapes", shapes5)
 def test_run_reduce_sum_hw_test(input_shapes, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_checkerboard, low=0, high=100), torch.float32
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_checkerboard, low=0, high=100), torch.float32)
     ]
     comparison_func = partial(comparison_funcs.comp_allclose, atol=0.1, rtol=0)
     run_single_pytorch_test(

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_reshape.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_reshape.py
@@ -18,7 +18,6 @@ sys.path.append(f"{f}/../../../..")
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
 import tt_lib as ttl
-from tests.tt_eager.python_api_testing.sweep_tests.common import skip_for_wormhole_b0
 
 params = [
     pytest.param([[4, 4, 32, 32]], reshape_args)
@@ -30,8 +29,12 @@ params += [
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.TILE],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "reshape_dims": [-1, 2, 32, 32],
         },
     ),
@@ -40,8 +43,12 @@ params += [
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.TILE],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "reshape_dims": [-1, 2, 32, 64],
         },
     ),
@@ -50,8 +57,12 @@ params += [
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.TILE],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "reshape_dims": [2, -1, 32, 32],
         },
     ),
@@ -60,8 +71,12 @@ params += [
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.TILE],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "reshape_dims": [2, -1, 32, 64],
         },
     ),
@@ -70,8 +85,12 @@ params += [
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.TILE],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "reshape_dims": [4, 2, -1, 32],
         },
     ),
@@ -80,8 +99,12 @@ params += [
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.TILE],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "reshape_dims": [4, 2, -1, 64],
         },
     ),
@@ -90,8 +113,12 @@ params += [
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.TILE],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "reshape_dims": [4, 4, 32, -1],
         },
     ),
@@ -100,22 +127,22 @@ params += [
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.TILE],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "reshape_dims": [4, 2, 32, -1],
         },
     ),
 ]
 
-@skip_for_wormhole_b0
+
 @pytest.mark.parametrize("input_shapes, reshape_args", params)
-def test_run_reshape_test(
-    input_shapes, reshape_args, device, function_level_defaults
-):
+def test_run_reshape_test(input_shapes, reshape_args, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = partial(comparison_funcs.comp_equal)
     run_single_pytorch_test(

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_stats.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_stats.py
@@ -17,21 +17,20 @@ sys.path.append(f"{f}/../../../..")
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from tests.tt_eager.python_api_testing.sweep_tests.common import is_wormhole_b0, skip_for_wormhole_b0
+from tests.tt_eager.python_api_testing.sweep_tests.common import is_wormhole_b0
 import tt_lib as ttl
 import numpy as np
 
 fns = ["std_hw", "mean_hw", "var_hw", "normalize_hw"]
 
+WH = is_wormhole_b0() * -0.01
+WH2 = 10 * WH
 shapes = [
-    [[2, 2, 32, 64], (0.99, 0.85, 0.85, 0.9)],  # Single core
-    [[4, 2, 64, 64], (0.97, 0.82, 0.85, 0.9)],  # Multi core
-    [[8, 6, 32, 96], (0.91, 0.82, 0.85, 0.9)],  # Multi core
+    [[2, 2, 32, 64], (0.99 + WH2, 0.85 + WH, 0.85, 0.9)],  # Single core
+    [[4, 2, 64, 64], (0.97 + WH2, 0.82 + WH, 0.85, 0.9)],  # Multi core
+    [[8, 6, 32, 96], (0.91 + WH, 0.82 + WH, 0.85, 0.9)],  # Multi core
 ]
 
-if is_wormhole_b0():
-    shapes = [ [[1, 1, 32, 32], (0.99, 0.85, 0.85, 0.9)], ]  # Single core
-    fns = ["normalize_hw"]
 
 @pytest.mark.parametrize(
     "input_shapes_and_pcc",
@@ -39,15 +38,11 @@ if is_wormhole_b0():
 )
 class TestStats:
     @pytest.mark.parametrize("fn_kind", fns)
-    def test_run_stats_ops(
-        self, input_shapes_and_pcc, fn_kind, device, function_level_defaults
-    ):
+    def test_run_stats_ops(self, input_shapes_and_pcc, fn_kind, device, function_level_defaults):
         input_shapes, accepted_pcc = input_shapes_and_pcc
         input_shapes = [input_shapes]
         datagen_func = [
-            generation_funcs.gen_func_with_cast(
-                partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32
-            )
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args.update({"input_shapes": input_shapes})
@@ -61,6 +56,7 @@ class TestStats:
             device,
             test_args,
         )
+
 
 class TestEPS:
     def test_basic_gs(self):

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_tilize.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_tilize.py
@@ -17,14 +17,10 @@ sys.path.append(f"{f}/../../../..")
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from tests.tt_eager.python_api_testing.sweep_tests.common import skip_for_wormhole_b0, is_wormhole_b0
 import tt_lib as ttl
 
-shapes = [
-    [[1, 1, 32, 32]], [[3, 1, 320, 384]], [[1, 1, 128, 7328]]
-]
-if is_wormhole_b0():
-    shapes = [ shapes[0] ]
+shapes = [[[1, 1, 32, 32]], [[3, 1, 320, 384]], [[1, 1, 128, 7328]]]
+
 
 @pytest.mark.parametrize(
     "input_shapes",
@@ -36,19 +32,19 @@ if is_wormhole_b0():
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.ROW_MAJOR],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "use_multicore": False,
         },
     ),
 )
 def test_tilize_test(input_shapes, tilize_args, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = comparison_funcs.comp_equal
-    run_single_pytorch_test(
-        "tilize", input_shapes, datagen_func, comparison_func, device, tilize_args
-    )
+    run_single_pytorch_test("tilize", input_shapes, datagen_func, comparison_func, device, tilize_args)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_tilize_with_val_padding.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_tilize_with_val_padding.py
@@ -19,20 +19,13 @@ from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, gene
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
 import tt_lib as ttl
 
-from tests.tt_eager.python_api_testing.sweep_tests.common import skip_for_wormhole_b0
-
-
 params = [
     pytest.param([[5, 5, 50, 50]], tilize_with_val_padding_args)
-    for tilize_with_val_padding_args in generation_funcs.gen_tilize_with_val_padding_args(
-        [[5, 5, 50, 50]]
-    )
+    for tilize_with_val_padding_args in generation_funcs.gen_tilize_with_val_padding_args([[5, 5, 50, 50]])
 ]
 params += [
     pytest.param([[5, 5, 64, 96]], tilize_with_val_padding_args)
-    for tilize_with_val_padding_args in generation_funcs.gen_tilize_with_val_padding_args(
-        [[5, 5, 64, 96]]
-    )
+    for tilize_with_val_padding_args in generation_funcs.gen_tilize_with_val_padding_args([[5, 5, 64, 96]])
 ]
 params += [
     pytest.param(
@@ -40,8 +33,12 @@ params += [
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.ROW_MAJOR],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
             "output_tensor_shape": [1, 1, 128, 7328],
             "input_tensor_start": [0, 0, 0, 0],
             "pad_value": 10,
@@ -49,17 +46,11 @@ params += [
     )
 ]
 
-@skip_for_wormhole_b0
-@pytest.mark.parametrize(
-    "input_shapes, tilize_with_val_padding_args", params
-)
-def test_run_tilize_with_val_padding_test(
-    input_shapes, tilize_with_val_padding_args, device, function_level_defaults
-):
+
+@pytest.mark.parametrize("input_shapes, tilize_with_val_padding_args", params)
+def test_run_tilize_with_val_padding_test(input_shapes, tilize_with_val_padding_args, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = comparison_funcs.comp_equal
     run_single_pytorch_test(

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_tilize_with_zero_padding.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_tilize_with_zero_padding.py
@@ -17,35 +17,30 @@ sys.path.append(f"{f}/../../../..")
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from tests.tt_eager.python_api_testing.sweep_tests.common import skip_for_wormhole_b0, is_wormhole_b0
 import tt_lib as ttl
 
-shapes = [ [[1, 1, 30, 32]], [[3, 1, 315, 384]], [[1, 1, 100, 7104]] ]
-if is_wormhole_b0():
-    shapes = [ shapes[0] ]
+shapes = [[[1, 1, 30, 32]], [[3, 1, 315, 384]], [[1, 1, 100, 7104]]]
 
-@pytest.mark.parametrize(
-    "input_shapes",
-    shapes
-)
+
+@pytest.mark.parametrize("input_shapes", shapes)
 @pytest.mark.parametrize(
     "tilize_with_zero_padding_args",
     (
         {
             "dtype": [ttl.tensor.DataType.BFLOAT16],
             "layout": [ttl.tensor.Layout.ROW_MAJOR],
-            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)],
-            "output_mem_config": ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
         },
     ),
 )
-def test_tilize_with_zero_padding_test(
-    input_shapes, tilize_with_zero_padding_args, device, function_level_defaults
-):
+def test_tilize_with_zero_padding_test(input_shapes, tilize_with_zero_padding_args, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = comparison_funcs.comp_equal
     run_single_pytorch_test(

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_transpose.py
@@ -17,25 +17,17 @@ sys.path.append(f"{f}/../../../..")
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from tests.tt_eager.python_api_testing.sweep_tests.common import skip_for_wormhole_b0, is_wormhole_b0
 
-shape_wh =  [
+shape_wh = [
     [[1, 1, 32, 32]],  # Single core
     [[3, 1, 320, 384]],  # Multi core
 ]
-if is_wormhole_b0():
-    del shape_wh[1:]
 
 
-@pytest.mark.parametrize(
-    "input_shapes",
-    shape_wh
-)
+@pytest.mark.parametrize("input_shapes", shape_wh)
 def test_run_transpose_wh_test(input_shapes, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = partial(comparison_funcs.comp_equal)
     run_single_pytorch_test(
@@ -46,7 +38,7 @@ def test_run_transpose_wh_test(input_shapes, device, function_level_defaults):
         device,
     )
 
-@skip_for_wormhole_b0
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -56,9 +48,7 @@ def test_run_transpose_wh_test(input_shapes, device, function_level_defaults):
 )
 def test_run_transpose_hc_test(input_shapes, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = partial(comparison_funcs.comp_equal)
     run_single_pytorch_test(
@@ -69,22 +59,17 @@ def test_run_transpose_hc_test(input_shapes, device, function_level_defaults):
         device,
     )
 
+
 shape_cn = [
     [[1, 1, 32, 32]],  # Single core
     [[3, 5, 384, 96]],  # Single core
 ]
-if is_wormhole_b0():
-    del shape_cn[1:]
 
-@pytest.mark.parametrize(
-    "input_shapes",
-    shape_cn
-)
+
+@pytest.mark.parametrize("input_shapes", shape_cn)
 def test_run_transpose_cn_test(input_shapes, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = partial(comparison_funcs.comp_equal)
     run_single_pytorch_test(
@@ -95,7 +80,7 @@ def test_run_transpose_cn_test(input_shapes, device, function_level_defaults):
         device,
     )
 
-@skip_for_wormhole_b0
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -105,9 +90,7 @@ def test_run_transpose_cn_test(input_shapes, device, function_level_defaults):
 )
 def test_run_transpose_nh_test(input_shapes, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = partial(comparison_funcs.comp_equal)
     run_single_pytorch_test(
@@ -118,7 +101,7 @@ def test_run_transpose_nh_test(input_shapes, device, function_level_defaults):
         device,
     )
 
-@skip_for_wormhole_b0
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -128,9 +111,7 @@ def test_run_transpose_nh_test(input_shapes, device, function_level_defaults):
 )
 def test_run_transpose_nw_test(input_shapes, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = partial(comparison_funcs.comp_equal)
     run_single_pytorch_test(
@@ -141,7 +122,7 @@ def test_run_transpose_nw_test(input_shapes, device, function_level_defaults):
         device,
     )
 
-@skip_for_wormhole_b0
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -151,9 +132,7 @@ def test_run_transpose_nw_test(input_shapes, device, function_level_defaults):
 )
 def test_run_transpose_cw_test(input_shapes, device, function_level_defaults):
     datagen_func = [
-        generation_funcs.gen_func_with_cast(
-            partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-        )
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]
     comparison_func = partial(comparison_funcs.comp_equal)
     run_single_pytorch_test(


### PR DESCRIPTION
#3252: update wormhole ops equivalency

#0: test_transpose works fully on WH B0
#0: enable more wormhole larged shape tests for sum
#0: glu enabled for WHB0
#0: enable outer for WHB0 at more sizes
#0: fix pad tests for WH B0
#0: permute update
#0: test_reduce.py test fails
#0: stats updated
#0: reshape fix
#0: sum cleanup
#0: enable all tilize
#0: enable all tilize with zero padding
#0: enable tilize with val padding