### PR TITLE
Linear module unit tests with Mistral model input shapes

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
@@ -59,6 +59,23 @@ def gen_rand(size, low=0, high=100):
     return torch.Tensor(size=size).uniform_(low, high)
 
 
+def gen_rand_with_pad(size, low=0, high=100):
+    TILE_WIDTH = 32
+    TILE_HEIGHT = 32
+
+    input_tensor = torch.Tensor(size=size).uniform_(low, high)
+
+    height, width = input_tensor.size(0), input_tensor.size(1)
+
+    pad_height = (TILE_HEIGHT - (height % TILE_HEIGHT)) % TILE_HEIGHT
+    pad_width = (TILE_WIDTH - (width % TILE_WIDTH)) % TILE_WIDTH
+
+    # print(pad_height, pad_width)
+    # Pad the tensor
+    padded_tensor = torch.nn.functional.pad(input_tensor, (0, pad_width, 0, pad_height))
+    return padded_tensor
+
+
 def gen_bin(size, probabilityones=0.5):
     element_count = 1
     for i in size:

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_linear.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_linear.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import tt_lib as ttl
+from functools import partial
+
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.common import (
+    is_wormhole_b0,
+)
+
+shapes  = [
+    [[31, 4096] ,  [4096, 4096]],
+    [[31, 4096] ,  [1024, 4096]],
+    [[31, 4096] ,  [14336, 4096]],
+    [[31, 14336],  [4096, 14336]],
+    [[31, 4096] ,  [32000, 4096]],
+    [[1, 4096] ,  [4096, 4096]],
+    [[1, 4096] ,  [1024, 4096]],
+    [[1, 4096] ,  [14336, 4096]],
+    [[1, 14336],  [4096, 14336]],
+    [[1, 4096] ,  [32000, 4096]],
+]
+
+@pytest.mark.parametrize("input_shapes", shapes)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT16),
+    ids=["BFLOAT16", "BFLOAT16"],
+)
+def test_run_linear_test(input_shapes, device, dtype, function_level_defaults):
+    datagen_func = [
+        generation_funcs.gen_func_with_cast(
+            partial(generation_funcs.gen_rand_with_pad, low=-100, high=100), torch.float32
+        )
+    ] * 2
+    comparison_func = partial(comparison_funcs.comp_pcc)
+    run_single_pytorch_test(
+        "linear",
+        input_shapes,
+        datagen_func,
+        comparison_func,
+        device,
+        {
+            "dtype": [dtype, dtype],
+            "layout": [ttl.tensor.Layout.TILE, ttl.tensor.Layout.TILE],
+            "input_mem_config": [ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)] * 2,
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+        },
+    )


### PR DESCRIPTION
@muthutt and @tt-aho 
- Added a unit test for the `linear` module with the shapes obtained from the mistral model
- Added a `gen_rand_with_pad` to pad the zero to avoid assertion error shape%32==0 

@muthutt If these changes are okay I will cherry-pick these commits to Sai Chand Mistral CPU demo branch if required 
Also test is passed on both GS and WHB0