### PR TITLE
#3260: Fix WH B0 for erfinv

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
@@ -101,7 +101,6 @@ class TestEltwiseUnary:
             test_args,
         )
 
-    @skip_for_wormhole_b0
     @pytest.mark.parametrize(
         "fn_kind",
         ["erfinv"],
@@ -115,9 +114,14 @@ class TestEltwiseUnary:
         input_mem_config,
         output_mem_config,
     ):
-        datagen_func = [
-            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
-        ]
+        if is_wormhole_b0():
+            datagen_func = [
+                generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-1, high=1), torch.bfloat16)
+            ]
+        else:
+            datagen_func = [
+                generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+            ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         comparison_func = comparison_funcs.comp_pcc
         run_single_pytorch_test(

--- a/tt_metal/src/ckernels/wormhole_b0/common/inc/ckernel_sfpu_erfinv.h
+++ b/tt_metal/src/ckernels/wormhole_b0/common/inc/ckernel_sfpu_erfinv.h
@@ -23,9 +23,8 @@ sfpi_inline vFloat calculate_sqrt_custom(vFloat in)
 {
     vFloat val = in;
     vFloat out;
-    vConstFloatPrgm0 = s2vFloat16b(0x5f37);
     v_if (val != 0.0f){
-        vUInt magic = vConstIntPrgm0;
+        vUInt magic = reinterpret<vUInt>(vFloat(s2vFloat16b(0x5f37)));
         vFloat approx = reinterpret<vFloat>(magic - (reinterpret<vUInt>(val) >> 1));
         for (int r = 0; r < 2; r++)
         {
@@ -69,7 +68,7 @@ inline void calculate_erfinv()
             dst_reg[0] = std::numeric_limits<float>::infinity();
         }v_elseif (v == -1.0f) {
             dst_reg[0] = -std::numeric_limits<float>::infinity();
-        }v_elseif ((v < -1.0f)||(v > 1.0f)) {
+        }v_elseif ((v < -1.0f)||(v > 1.0f)) { //Nan not supported
             dst_reg[0] = std::numeric_limits<float>::quiet_NaN();
         }v_elseif (v < 0.0f) {
             calculate_erfinv_body<true>(v);
@@ -84,7 +83,9 @@ inline void calculate_erfinv()
 
 template <bool APPROXIMATION_MODE>
 void erfinv_init() {
-    ;
+    vConstFloatPrgm0 = 0.692871f; // ln2
+    vConstFloatPrgm1 = 0.1058f;
+    vConstFloatPrgm2 = -0.7166f;
 }
 
 }  // namespace sfpu

--- a/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_erfinv.h
+++ b/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_erfinv.h
@@ -17,8 +17,8 @@ namespace ckernel {
 // New LLK SFPU APIs
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_logical_not_unary_init() {
-    llk_math_eltwise_unary_sfpu_init<APPROXIMATE>(sfpu::logical_erfinv_init<APPROXIMATE>);
+inline void llk_math_eltwise_unary_sfpu_erfinv_init() {
+    llk_math_eltwise_unary_sfpu_init<APPROXIMATE>(sfpu::erfinv_init<APPROXIMATE>);
 }
 
 template <bool APPROXIMATE, DstSync Dst = DstSync::SyncFull>


### PR DESCRIPTION
- Fixed WH B0 issue for erfinv (Works for range [-1,1] )
- Gelu is fixed.So no changes.