### PR TITLE
#2388: Cherry-picked squashed commit for halo stride 2 + maxpool

### DIFF
--- a/tests/models/resnet/metalResnetBlock50.py
+++ b/tests/models/resnet/metalResnetBlock50.py
@@ -1290,27 +1290,22 @@ class ResNet(nn.Module):
         # tt_lib.device.DumpDeviceMemoryState(self.device)
         # x = format_tensor(x, tt_lib.tensor.Layout.ROW_MAJOR, self.device, tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM))
 
-        # x = format_tensor(x, tt_lib.tensor.Layout.ROW_MAJOR, self.device, self.memory_config)
-        # x = x.reshape(
-        #     self.conv1_output_shape[0],
-        #     self.conv1_output_shape[1],
-        #     self.conv1_output_shape[2],
-        #     self.conv1_output_shape[3],
-        # )
-        x = tt_lib.tensor.untilize_with_halo(x,
-                                             0xf7ff,   ## pad_val
-                                             self.conv1_output_shape[0],   ## in_n
-                                             self.conv1_output_shape[1],   ## in_h
-                                             self.conv1_output_shape[2],   ## in_w
-                                             2,                            ## stride case
-                                             self.sharded_memory_config)
-        # x_shape = x.shape()
-        # x = x.reshape(
-        #     self.conv1_output_shape[0],
-        #     self.conv1_output_shape[1],
-        #     self.conv1_output_shape[2],
-        #     self.conv1_output_shape[3],
-        # )
+        if self.sharded:
+            x = tt_lib.tensor.untilize_with_halo(x,
+                                                0xf7ff,   ## pad_val
+                                                self.conv1_output_shape[0],   ## in_n
+                                                self.conv1_output_shape[1],   ## in_h
+                                                self.conv1_output_shape[2],   ## in_w
+                                                2,                            ## stride case
+                                                self.sharded_memory_config)
+        else:
+            x = format_tensor(x, tt_lib.tensor.Layout.ROW_MAJOR, self.device, self.memory_config)
+            x = x.reshape(
+                self.conv1_output_shape[0],
+                self.conv1_output_shape[1],
+                self.conv1_output_shape[2],
+                self.conv1_output_shape[3],
+            )
         # print("Running maxpool")
         x = self.maxpool(x)
         # print("Done maxpool")

--- a/tests/models/resnet/test_resnet50_untilize_with_halo_and_conv.py
+++ b/tests/models/resnet/test_resnet50_untilize_with_halo_and_conv.py
@@ -601,7 +601,7 @@ def test_resnet50_conv(use_program_cache, device, N, K, C, H, W, R, S, stride_h,
         )
 
         # Untilize with halo concat
-        conv_input_on_device = tt_lib.tensor.untilize_with_halo(conv_input_on_device, 0x0, N, H, W, in_mem_config)
+        conv_input_on_device = tt_lib.tensor.untilize_with_halo(conv_input_on_device, 0x0, N, H, W, 1, in_mem_config)
 
         # Conv with new reader for sharded untilized with halo inputs
         output_on_device = conv(conv_input_on_device)

--- a/tests/tt_eager/python_api_testing/unit_testing/test_untilize_with_halo_and_max_pool.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_untilize_with_halo_and_max_pool.py
@@ -138,15 +138,15 @@ def test_run_max_pool(
     torch.manual_seed(0)
 
     ## construct the tensor in NCHW shape
-    # act = torch.randn(act_shape, dtype=torch.bfloat16)
+    act = torch.randn(act_shape, dtype=torch.bfloat16)
     # act = torch.zeros(act_shape, dtype=torch.bfloat16)
     # act = torch.ones(act_shape, dtype=torch.bfloat16)
-    act = torch.arange(0, volume(act_shape), dtype=torch.bfloat16).reshape(act_shape)
-    for n in range(act_shape[0]):
-        for c in range(act_shape[1]):
-            for h in range(act_shape[2]):
-                for w in range(act_shape[3]):
-                    act[n, c, h, w] = n + c + h + w
+    # act = torch.arange(0, volume(act_shape), dtype=torch.bfloat16).reshape(act_shape)
+    # for n in range(act_shape[0]):
+    #     for c in range(act_shape[1]):
+    #         for h in range(act_shape[2]):
+    #             for w in range(act_shape[3]):
+    #                 act[n, c, h, w] = 1 + n + h + w + c + torch.rand(1) * 0.15
 
     ## this op expects input tensor as { N, 1, H * W, C }, so rearrange and reshape tensor
     ## but before that, make sure in_c is multiple of tile width
@@ -156,17 +156,10 @@ def test_run_max_pool(
 
     act_shape_padded = (in_n, 1, in_h * in_w, _nearest_32(in_c))
     act_padding = (0, act_shape_padded[3] - act_shape[3])
-    act_padded = torch.nn.functional.pad(act_reshaped, act_padding, value=0xFF7F)
+    act_padded = torch.nn.functional.pad(act_reshaped, act_padding, value=0xF7fF)
     assert act_shape_padded == act_padded.shape
 
-    ttact = ttl.tensor.Tensor(
-        act_padded.flatten().tolist(),
-        act_shape_padded,
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.Layout.TILE,
-    )
     ncores = 1
-    ttact = ttact.to(device, interleaved_mem_config)
     in_height = in_n * in_h * in_w
     out_nhw = in_n * out_h * out_w
     ## NOTE: these should match the max_pool op code for now. Hardcoded Resnet shapes only.
@@ -178,17 +171,37 @@ def test_run_max_pool(
         ncores = 98
     else:
         assert False
-    ttact = ttl.tensor.interleaved_to_sharded(ttact, ncores, [in_height // ncores, act_padded.shape[-1]], ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,)
 
+    # ttl.device.EnableMemoryReports()
+
+    ttact = ttl.tensor.Tensor(
+        act_padded.flatten().tolist(),
+        act_shape_padded,
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.ROW_MAJOR,
+    ).to(device, interleaved_mem_config)
+
+    ttact_tilize = ttl.tensor.tilize(ttact, interleaved_mem_config)    ##, use_multicore=True)
+    ttact.deallocate()
+    ttact_sharded = ttl.tensor.interleaved_to_sharded(ttact_tilize, ncores, [in_height // ncores, act_padded.shape[-1]], ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,)
+    # ttact_tilize.deallocate()
     in_h = int(math.sqrt(act_shape_padded[-2]))
     in_w = in_h
     assert(in_h * in_w == act_shape_padded[-2])
-    out_untilize = ttl.tensor.untilize_with_halo(ttact, 0xf7ff, in_n, in_h, in_w, out_mem_config)
+    out_untilize = ttl.tensor.untilize_with_halo(ttact_sharded, 0xf7ff, in_n, in_h, in_w, 2, out_mem_config)
+    # ttl.device.DumpDeviceMemoryState(device)
+    # ttact_sharded.deallocate()
+
+    # ttact = ttl.tensor.tilize(ttact, interleaved_mem_config)    ##, use_multicore=True)
+    # ttact = ttl.tensor.interleaved_to_sharded(ttact, ncores, [in_height // ncores, act_padded.shape[-1]], ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,)
+    # ttact = ttl.tensor.untilize_with_halo(ttact, 0xf7ff, 2, out_mem_config)
+
 
     assert True
 
     out_padded = ttl.tensor.max_pool2d(
         out_untilize,
+        # ttact,
         in_h,
         in_w,
         kernel_h,
@@ -223,11 +236,20 @@ def test_run_max_pool(
 
     ## test for equivalance
     out_pytorch = out_pytorch.reshape(golden_pytorch.shape)
-    # assert torch.allclose(out_pytorch, golden_pytorch)  ##, rtol=1e-01, atol=1e-01)
     passing_pcc, output_pcc = comp_pcc(golden_pytorch, out_pytorch)
     logger.info(f"Passing PCC = {passing_pcc}")
     logger.info(f"Output PCC = {output_pcc}")
-    # print(f'OUTPUT: {out_pytorch}')
+
+    # print(f'OUTPUT: {out_pytorch[0,:,:,:]}')
     # print(f'GOLDEN: {golden_pytorch}')
+    # torch.save(out_pytorch, 'output.pt')
+    # torch.save(golden_pytorch, 'golden.pt')
+
+    allclose = torch.allclose(out_pytorch, golden_pytorch)
+    isclose = torch.isclose(out_pytorch, golden_pytorch)
+    isequal = torch.equal(out_pytorch, golden_pytorch)
 
     assert passing_pcc
+    assert allclose
+    assert torch.all(isclose)
+    assert isequal

--- a/tt_eager/tt_dnn/op_library/pool/max_pool.cpp
+++ b/tt_eager/tt_dnn/op_library/pool/max_pool.cpp
@@ -109,24 +109,27 @@ operation::ProgramWithCallbacks MaxPool::create_program(const std::vector<Tensor
                                         out_mem_config_,
                                         nblocks_)};
     } else {
-        return {max_pool_2d_multi_core_generic(input, output,
-                                       in_h_, in_w_,
-                                       out_h_, out_w_,
-                                       kernel_size_h_, kernel_size_w_,
-                                       stride_h_, stride_w_,
-                                       pad_h_, pad_w_,
-                                       dilation_h_, dilation_w_,
-                                       out_mem_config_,
-                                       nblocks_)};
-        //return {max_pool_2d_multi_core_sharded_with_halo(input, output,
-        //                               in_h_, in_w_,
-        //                               out_h_, out_w_,
-        //                               kernel_size_h_, kernel_size_w_,
-        //                               stride_h_, stride_w_,
-        //                               pad_h_, pad_w_,
-        //                               dilation_h_, dilation_w_,
-        //                               out_mem_config_,
-        //                               nblocks_)};
+        if (input.memory_config().is_sharded()) {
+        return {max_pool_2d_multi_core_sharded_with_halo(input, output,
+                                        in_h_, in_w_,
+                                        out_h_, out_w_,
+                                        kernel_size_h_, kernel_size_w_,
+                                        stride_h_, stride_w_,
+                                        pad_h_, pad_w_,
+                                        dilation_h_, dilation_w_,
+                                        out_mem_config_,
+                                        nblocks_)};
+        } else {
+            return {max_pool_2d_multi_core_generic(input, output,
+                                        in_h_, in_w_,
+                                        out_h_, out_w_,
+                                        kernel_size_h_, kernel_size_w_,
+                                        stride_h_, stride_w_,
+                                        pad_h_, pad_w_,
+                                        dilation_h_, dilation_w_,
+                                        out_mem_config_,
+                                        nblocks_)};
+        }
     }
 }
 

--- a/tt_eager/tt_dnn/op_library/pool/max_pool.hpp
+++ b/tt_eager/tt_dnn/op_library/pool/max_pool.hpp
@@ -17,6 +17,7 @@ namespace tt {
 namespace tt_metal {
 
 struct MaxPool {
+    uint32_t in_n_; // nbatch
     uint32_t in_h_, in_w_;
     uint32_t out_h_, out_w_;
     uint32_t kernel_size_h_, kernel_size_w_;
@@ -62,7 +63,7 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_generic(const Tensor &inp
                                                                 const MemoryConfig& out_mem_config,
                                                                 uint32_t nblocks);
 operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const Tensor &input, Tensor& output,
-                                                                uint32_t in_h, uint32_t in_w,
+                                                                uint32_t in_n, uint32_t in_h, uint32_t in_w,
                                                                 uint32_t out_h, uint32_t out_w,
                                                                 uint32_t kernel_size_h, uint32_t kernel_size_w,
                                                                 uint32_t stride_h, uint32_t stride_w,
@@ -71,7 +72,7 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const T
                                                                 const MemoryConfig& out_mem_config,
                                                                 uint32_t nblocks);
 Tensor max_pool2d(const Tensor &input,
-                  uint32_t in_h, uint32_t in_w,
+                  uint32_t in_n, uint32_t in_h, uint32_t in_w,
                   uint32_t kernel_size_h, uint32_t kernel_size_w,
                   uint32_t stride_h = 1, uint32_t stride_w = 1,
                   uint32_t pad_h = 0, uint32_t pad_w = 0,               // default: no padding

--- a/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
@@ -1076,7 +1076,7 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const T
     uint32_t in_nhw_per_core_rem_mask = in_nhw_per_core - 1;    // NOTE: assuming in_nhw_per_core is power of 2
 
     // CBs
-    uint32_t multi_buffering_factor = 1;
+    uint32_t multi_buffering_factor = 2;
 
     // scalar CB as coefficient of reduce
     uint32_t in_scalar_cb_id = CB::c_in1;

--- a/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
@@ -1305,6 +1305,17 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const T
                                             0,                  // partial_bottom_image_nrows
                                             0,                  // partial_last_row_nsticks
                                             0,                  // start_stick
+                                            0,                  // 75
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,                  // 80
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,                  // 85
                                             };
     auto reader_config = DataMovementConfig{.processor = DataMovementProcessor::RISCV_0,
                                             .noc = NOC::RISCV_0_default,
@@ -1497,8 +1508,6 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const T
                 log_debug(LogOp, " + out_stick_id range: {} {}", start_out_stick_id, end_out_stick_id);
                 log_debug(LogOp, " + start_out: {} {}", start_out_w_i, start_out_h_i);
                 log_debug(LogOp, " + end_out: {} {}", end_out_w_i, end_out_h_i);
-                // log_debug(LogOp, " + center_in_stick range: {} {}", start_center_in_stick_id, end_center_in_stick_id);
-                // log_debug(LogOp, " + end_in: {} {}", end_in_w_i, end_in_h_i);
                 log_debug(LogOp, " + partial_first_row_nsticks: {}", out_sc.first_partial_right_aligned_row_width);
                 log_debug(LogOp, " + partial_top_image_nrows: {}", out_sc.first_partial_image_num_rows);
                 log_debug(LogOp, " + full_nimages: {}", out_sc.num_full_images);
@@ -1509,6 +1518,17 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const T
                 log_debug(LogOp, " + skip_after_full_image: {}", out_sc.skip_after_full_image);
                 log_debug(LogOp, " + initial_skip: {}", out_sc.initial_skip);
                 log_debug(LogOp, " + start_stick: {}", out_sc.start_stick);
+                log_debug(LogOp, " + ++++++++++++++++++++++");
+                log_debug(LogOp, " + partial_first_row_nsticks: {}", in_sc.first_partial_right_aligned_row_width);
+                log_debug(LogOp, " + partial_top_image_nrows: {}", in_sc.first_partial_image_num_rows);
+                log_debug(LogOp, " + full_nimages: {}", in_sc.num_full_images);
+                log_debug(LogOp, " + partial_bottom_image_nrows: {}", in_sc.last_partial_image_num_rows);
+                log_debug(LogOp, " + partial_last_row_nsticks: {}", in_sc.last_partial_left_aligned_row_width);
+                log_debug(LogOp, " + skip_after_partial_right_aligned_row: {}", in_sc.skip_after_partial_right_aligned_row);
+                log_debug(LogOp, " + skip_after_first_partial_image_row: {}", in_sc.skip_after_first_partial_image_row);
+                log_debug(LogOp, " + skip_after_full_image: {}", in_sc.skip_after_full_image);
+                log_debug(LogOp, " + initial_skip: {}", in_sc.initial_skip);
+                log_debug(LogOp, " + start_stick: {}", in_sc.start_stick);
             }
 
             reader_rt_args[65] = out_sc.initial_skip;

--- a/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
@@ -999,7 +999,7 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core(const Tensor &input, Tens
 
 // this version uses distribution along height = N * H * W
 operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const Tensor &input, Tensor& output,
-                                                                        uint32_t in_h, uint32_t in_w,
+                                                                        uint32_t in_n, uint32_t in_h, uint32_t in_w,
                                                                         uint32_t out_h, uint32_t out_w,
                                                                         uint32_t kernel_size_h, uint32_t kernel_size_w,
                                                                         uint32_t stride_h, uint32_t stride_w,
@@ -1029,7 +1029,7 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const T
     TT_ASSERT((in_nbytes_c & (in_nbytes_c - 1)) == 0, "in_nbytes_c should be power of 2");    // in_nbytes_c is power of 2
     TT_ASSERT((out_nbytes_c & (out_nbytes_c - 1)) == 0, "out_nbytes_c should be power of 2"); // out_nbytes_c is power of 2
 
-    uint32_t nbatch = input_shape[0];
+    uint32_t nbatch = in_n;
     TT_ASSERT(nbatch == output_shape[0], "Mismatch in N for input and output!!");
 
     uint32_t kernel_size_hw = kernel_size_w * kernel_size_h;    // number of valid rows, to read

--- a/tt_eager/tt_dnn/op_library/sharding_utilities.hpp
+++ b/tt_eager/tt_dnn/op_library/sharding_utilities.hpp
@@ -19,6 +19,746 @@
 namespace tt {
 namespace tt_metal {
 
+struct PoolConfig {
+    uint32_t in_w;
+    uint32_t in_h;
+    uint32_t out_w;
+    uint32_t out_h;
+    uint32_t stride_w;
+    uint32_t stride_h;
+    uint32_t pad_w;
+    uint32_t pad_h;
+    uint32_t window_w;
+    uint32_t window_h;
+    uint32_t dilation_w;
+    uint32_t dilation_h;
+};
+
+struct NewShardingConfig {
+    int32_t first_partial_right_aligned_row_width;
+    int32_t first_partial_image_num_rows;
+    int32_t num_full_images;
+    int32_t last_partial_image_num_rows;
+    int32_t last_partial_left_aligned_row_width;
+    int32_t skip_after_partial_right_aligned_row;
+    int32_t skip_after_first_partial_image_row;
+    int32_t skip_after_full_image;
+    int32_t initial_skip;
+    int32_t start_stick;
+};
+
+inline NewShardingConfig get_shard_specs(int32_t start_stick, int32_t end_stick, const PoolConfig& pc, bool to_print = false) {
+    int32_t nsticks_per_core = end_stick - start_stick;
+
+    if (nsticks_per_core < 1) {
+        // range is 0
+        return NewShardingConfig{
+                .first_partial_right_aligned_row_width = 0,
+                .first_partial_image_num_rows = 0,
+                .num_full_images = 0,
+                .last_partial_image_num_rows = 0,
+                .last_partial_left_aligned_row_width = 0,
+                .skip_after_partial_right_aligned_row = 0,
+                .skip_after_first_partial_image_row = 0,
+                .skip_after_full_image = 0,
+                .initial_skip = 0
+            };
+    }
+    if (nsticks_per_core < pc.in_w) {
+        int32_t in_w_i = start_stick % pc.in_w;
+        int32_t in_h_i = (start_stick % (pc.in_w * pc.in_h)) / pc.in_w;
+        int32_t last_in_w_i = (end_stick - 1) % pc.in_w;
+        int32_t last_in_h_i = ((end_stick - 1) % (pc.in_w * pc.in_h)) / pc.in_w;
+        int32_t initial_skip = 0;
+        if ((start_stick % (pc.in_h * pc.in_w) == 0) || (start_stick % pc.stride_h != 0)) {
+            int32_t halo_nsticks = (pc.in_w + 2 * pc.pad_w) * pc.pad_h + pc.window_w / 2;
+            initial_skip = halo_nsticks;
+        }
+        switch(nsticks_per_core) {
+            case 1:
+                // only one stick in the range. need to figure out if there are padding to be attached to it, and in which place
+                if (in_w_i == pc.in_w - 1) {
+                    // this is the last stick in the row
+                    // there needs to be padding sticks attached
+                    if (in_h_i % pc.in_h == pc.in_h - 1) {
+                        // this is the last stick in the image
+                        // there needs to be full padding rows
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 1,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 0,
+                                .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip
+                            };
+                    } else {
+                        // this is just the last stick in the row and not the image
+                        // there are just width padding
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 1,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 0,
+                                .skip_after_partial_right_aligned_row = 2 * (int32_t) pc.pad_w,
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip
+                            };
+                    }
+                } else {
+                    // this is just one stick without any padding
+                    return NewShardingConfig{
+                            .first_partial_right_aligned_row_width = 1,
+                            .first_partial_image_num_rows = 0,
+                            .num_full_images = 0,
+                            .last_partial_image_num_rows = 0,
+                            .last_partial_left_aligned_row_width = 0,
+                            .skip_after_partial_right_aligned_row = 0,
+                            .skip_after_first_partial_image_row = 0,
+                            .skip_after_full_image = 0,
+                            .initial_skip = initial_skip
+                        };
+                }
+            case 2:
+                // two sticks in the range. figure out if there are any padding attached
+                if (in_w_i == pc.in_w - 2) {
+                    // these are two last sticks of the row
+                    // there needs to be padding after
+                    if (in_h_i == pc.in_h - 1) {
+                        // these are the last sticks in the last row of the image
+                        // insert full padding rows
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 2,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 0,
+                                .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip
+                            };
+                    } else {
+                        // just need width padding
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 2,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 0,
+                                .skip_after_partial_right_aligned_row = 2 * (int32_t) pc.pad_w,
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip
+                            };
+                    }
+                } else if (in_w_i == pc.in_w - 1) {
+                    // these are one last stick of the row and one first stick of next row
+                    // there needs to be padding in between
+                    if (in_h_i == pc.in_h - 1) {
+                        // these two sticks belong to different images
+                        // insert full padding rows between them
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 1,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 1,
+                                .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip
+                            };
+                    } else {
+                        // just width padding between then
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 1,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 1,
+                                .skip_after_partial_right_aligned_row = (int32_t) (2 * pc.pad_w),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip
+                            };
+                    }
+                } else {
+                    // no padding needs to be attached
+                    return NewShardingConfig{
+                            .first_partial_right_aligned_row_width = 2,
+                            .first_partial_image_num_rows = 0,
+                            .num_full_images = 0,
+                            .last_partial_image_num_rows = 0,
+                            .last_partial_left_aligned_row_width = 0,
+                            .skip_after_partial_right_aligned_row = 0,
+                            .skip_after_first_partial_image_row = 0,
+                            .skip_after_full_image = 0,
+                            .initial_skip = initial_skip
+                        };
+                }
+
+            default:
+                if (in_h_i == last_in_h_i) {
+                    // all sticks belong to same row
+                    if (last_in_w_i == pc.in_w - 1) {
+                        // these sticks are the last in the row
+                        // insert padding at end
+                        if (in_h_i == pc.in_h - 1) {
+                            // this is the last row
+                            // need full padding rows
+                            return NewShardingConfig{
+                                    .first_partial_right_aligned_row_width = nsticks_per_core,
+                                    .first_partial_image_num_rows = 0,
+                                    .num_full_images = 0,
+                                    .last_partial_image_num_rows = 0,
+                                    .last_partial_left_aligned_row_width = 0,
+                                    .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                    .skip_after_first_partial_image_row = 0,
+                                    .skip_after_full_image = 0,
+                                    .initial_skip = initial_skip
+                                };
+                        } else {
+                            // just width padding needed
+                            return NewShardingConfig{
+                                    .first_partial_right_aligned_row_width = nsticks_per_core,
+                                    .first_partial_image_num_rows = 0,
+                                    .num_full_images = 0,
+                                    .last_partial_image_num_rows = 0,
+                                    .last_partial_left_aligned_row_width = 0,
+                                    .skip_after_partial_right_aligned_row = (int32_t) (2 * pc.pad_w),
+                                    .skip_after_first_partial_image_row = 0,
+                                    .skip_after_full_image = 0,
+                                    .initial_skip = initial_skip
+                                };
+                        }
+                    } else {
+                        // no padding is needed
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 0,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = nsticks_per_core,
+                                .skip_after_partial_right_aligned_row = 0,
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip
+                            };
+                    }
+                } else {
+                    // sticks span two different rows. figure out where does the padding go.
+                    // padding will go at the end of the start row
+                    // find the last stick in the start row
+                    int32_t insert_padding_at = pc.in_w - in_w_i;
+                    if (in_h_i == pc.in_h - 1) {
+                        // sticks span across different images
+                        // full padding rows need to be inserted
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = insert_padding_at,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = nsticks_per_core - insert_padding_at,
+                                .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip
+                            };
+                    } else {
+                        // sticks belong to same image
+                        // only width padding needed
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = insert_padding_at,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = nsticks_per_core - insert_padding_at,
+                                .skip_after_partial_right_aligned_row = (int32_t) (2 * pc.pad_w),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip
+                            };
+                    }
+                }
+        }
+    }
+
+    // First partial right-aligned row
+    int32_t image_row_start_left_width = start_stick % pc.in_w;
+    if (to_print) log_debug("image_row_start_left_width: {}", image_row_start_left_width);
+    int32_t first_partial_right_aligned_row_width = image_row_start_left_width > 0 ? pc.in_w - image_row_start_left_width : 0;
+    if (to_print) log_debug("first_partial_right_aligned_row_width: {}", first_partial_right_aligned_row_width);
+
+    if (first_partial_right_aligned_row_width > nsticks_per_core) {
+        return NewShardingConfig{
+                .first_partial_right_aligned_row_width = nsticks_per_core,
+                .first_partial_image_num_rows = 0,
+                .num_full_images = 0,
+                .last_partial_image_num_rows = 0,
+                .last_partial_left_aligned_row_width = 0,
+                .skip_after_partial_right_aligned_row = 0,
+                .skip_after_first_partial_image_row = 0,
+                .skip_after_full_image = 0
+            };
+    }
+
+    // Last partial left-aligned row
+    int32_t sticks_after_first_partial_row = nsticks_per_core - first_partial_right_aligned_row_width;
+    if (to_print) log_debug("sticks_after_first_partial_row: {}", sticks_after_first_partial_row);
+    int32_t last_partial_left_aligned_row_width = sticks_after_first_partial_row % pc.in_w;
+    if (to_print) log_debug("last_partial_left_aligned_row_width: {}", last_partial_left_aligned_row_width);
+
+    // Figure out how to allocate full image rows to first partial image, full images, or last partial image
+    // This also affects skip after first_partial_right_aligned_row
+    int32_t image_row_start_idx = start_stick / pc.in_w;
+    int32_t image_row_start_idx_after_partial_right_aligned_row = (start_stick + first_partial_right_aligned_row_width) / pc.in_w;
+    int32_t image_row_end_idx = (end_stick - 1) / pc.in_w;
+    int32_t image_start_idx = image_row_start_idx / pc.in_h;
+    int32_t image_start_idx_after_partial_right_aligned_row = image_row_start_idx_after_partial_right_aligned_row / pc.in_h;
+    int32_t image_start_height_after_partial_right_aligned_row = image_row_start_idx_after_partial_right_aligned_row % pc.in_h;
+    int32_t image_end_idx = image_row_end_idx / pc.in_h;
+
+    // Default case: We don't have a partial right aligned row; so we start with either full images, last partial image, or partial left aligned row
+    int32_t skip_after_partial_right_aligned_row = 0;
+    // Case: partial_right_aligned_row > 0 and completes an image
+    if (first_partial_right_aligned_row_width > 0 && image_start_height_after_partial_right_aligned_row == 0) {
+        skip_after_partial_right_aligned_row = pc.window_w - 1 + pc.pad_h * (pc.in_w + 2 * pc.pad_w);
+    // Case: partial_right_aligned_row > 0 and doesn't complete an image
+    } else if (first_partial_right_aligned_row_width > 0) {
+        skip_after_partial_right_aligned_row = pc.window_w - 1;
+    }
+
+    int32_t first_partial_image_num_rows = 0;
+    int32_t skip_after_first_partial_image_row = 0;
+    // Only case where we have first_partial_image_rows: We have at at least 1 completed image and the starting image row is in the middle of an image
+    if (image_end_idx - image_start_idx_after_partial_right_aligned_row > 0 && image_start_height_after_partial_right_aligned_row > 0) {
+        first_partial_image_num_rows = pc.in_h - image_start_height_after_partial_right_aligned_row;
+        skip_after_first_partial_image_row = pc.pad_h * (pc.in_w + 2 * pc.pad_w);
+    }
+
+    // Full images
+    int32_t image_rows_after_first_partial_image = sticks_after_first_partial_row / pc.in_w - first_partial_image_num_rows;
+    if (to_print) log_debug("image_rows_after_first_partial_image: {}", image_rows_after_first_partial_image);
+    int32_t num_full_images = image_rows_after_first_partial_image / pc.in_h;
+    int32_t skip_after_full_image = num_full_images > 0 ? pc.pad_h * (pc.in_w + 2 * pc.pad_w) : 0;
+
+    // Last partial image rows
+    int32_t last_partial_image_num_rows = image_rows_after_first_partial_image % pc.in_h;
+
+    return NewShardingConfig{
+               .first_partial_right_aligned_row_width = first_partial_right_aligned_row_width,
+               .first_partial_image_num_rows = first_partial_image_num_rows,
+               .num_full_images = num_full_images,
+               .last_partial_image_num_rows = last_partial_image_num_rows,
+               .last_partial_left_aligned_row_width = last_partial_left_aligned_row_width,
+               .skip_after_partial_right_aligned_row = skip_after_partial_right_aligned_row,
+               .skip_after_first_partial_image_row = skip_after_first_partial_image_row,
+               .skip_after_full_image = skip_after_full_image
+           };
+}
+
+inline NewShardingConfig get_shard_specs_with_halo(int32_t start_stick, int32_t end_stick, const PoolConfig& pc, bool to_print = false) {
+    int32_t nsticks = end_stick - start_stick;
+
+    if (nsticks < 1) {
+        // range is 0. set everything to 0
+        return NewShardingConfig{
+                .first_partial_right_aligned_row_width = 0,
+                .first_partial_image_num_rows = 0,
+                .num_full_images = 0,
+                .last_partial_image_num_rows = 0,
+                .last_partial_left_aligned_row_width = 0,
+                .skip_after_partial_right_aligned_row = 0,
+                .skip_after_first_partial_image_row = 0,
+                .skip_after_full_image = 0,
+                .initial_skip = 0,
+                .start_stick = 0
+            };
+    }
+
+    // NOTE: all cores have the exact same sized halo, including the left cores' left halo, which is initial_skip (padding), and right cores' right halo
+    int32_t halo_nsticks = (pc.in_w + 2 * pc.pad_w) * pc.pad_h + pc.window_w / 2;
+
+    int32_t halo_nsticks_nopad = pc.in_w + pc.window_w / 2;
+    int32_t halo_start_stick = start_stick - halo_nsticks_nopad;  // this will be -ve for initial cores where start_stick < halo_nsticks
+    int32_t halo_end_stick = end_stick + halo_nsticks_nopad;
+    int32_t nsticks_with_halo = halo_end_stick - halo_start_stick;
+
+    // calculate in_start_id of my current batch
+    int32_t batch_start = (start_stick / (pc.in_h * pc.in_w)) * (pc.in_h * pc.in_w);
+
+    // pad sticks before the data sticks begin, add edge pads
+    int32_t initial_skip = halo_start_stick < batch_start ? ((batch_start - halo_start_stick) + 2 * pc.pad_w) : 0;
+
+    // start with the first valid stick incl. halo
+    // start_stick = halo_start_stick < 0 ? 0 : halo_start_stick;
+    start_stick = halo_start_stick < batch_start ? batch_start : halo_start_stick;
+    end_stick = halo_end_stick; // TODO: take care of max, which would be (in_h * in_w * nbatch + halo_nsticks)
+
+    // log_debug(" -- range with halo: [{},{})", start_stick, end_stick);
+
+    int32_t curr_stick = start_stick;
+
+    int32_t batch_i = curr_stick / (pc.in_h * pc.in_w);
+    int32_t curr_batch_stick = curr_stick % (pc.in_h * pc.in_w);
+    int32_t in_h_i = curr_batch_stick / pc.in_w;
+    int32_t in_w_i = curr_batch_stick % pc.in_w;
+
+    int32_t last_in_w_i = (end_stick - 1) % pc.in_w;
+    int32_t last_in_h_i = ((end_stick - 1) % (pc.in_w * pc.in_h)) / pc.in_w;
+
+    int32_t pad_size = in_h_i * 2 * pc.pad_w;
+    int32_t start_stick_padded = start_stick + pad_size;
+
+    if (in_h_i == last_in_h_i) {
+        // all sticks belong to the same row (neither first partial, nor last partial)
+        return NewShardingConfig{
+                .first_partial_right_aligned_row_width = 0,
+                .first_partial_image_num_rows = 0,
+                .num_full_images = 0,
+                .last_partial_image_num_rows = 0,
+                .last_partial_left_aligned_row_width = nsticks,
+                .skip_after_partial_right_aligned_row = 0,
+                .skip_after_first_partial_image_row = 0,
+                .skip_after_full_image = 0,
+                .initial_skip = initial_skip,
+                .start_stick = start_stick_padded
+            };
+    }
+
+/*
+    if (nsticks < pc.in_w) {
+        switch(nsticks) {
+            case 1:
+                // only one stick in the range. need to figure out if there are padding to be attached to it, and in which place
+                if (in_w_i == pc.in_w - 1) {
+                    // this is the last stick in the row
+                    // there needs to be padding sticks attached
+                    if (in_h_i % pc.in_h == pc.in_h - 1) {
+                        // this is the last stick in the image
+                        // there needs to be full padding rows
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 1,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 0,
+                                .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip,
+                                .start_stick = start_stick_padded
+                            };
+                    } else {
+                        // this is just the last stick in the row and not the image
+                        // there are just width padding
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 1,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 0,
+                                .skip_after_partial_right_aligned_row = 2 * (int32_t) pc.pad_w,
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip,
+                                .start_stick = start_stick_padded
+                            };
+                    }
+                } else {
+                    // this is just one stick without any padding
+                    return NewShardingConfig{
+                            .first_partial_right_aligned_row_width = 1,
+                            .first_partial_image_num_rows = 0,
+                            .num_full_images = 0,
+                            .last_partial_image_num_rows = 0,
+                            .last_partial_left_aligned_row_width = 0,
+                            .skip_after_partial_right_aligned_row = 0,
+                            .skip_after_first_partial_image_row = 0,
+                            .skip_after_full_image = 0,
+                            .initial_skip = initial_skip,
+                            .start_stick = start_stick_padded
+                        };
+                }
+            case 2:
+                // two sticks in the range. figure out if there are any padding attached
+                if (in_w_i == pc.in_w - 2) {
+                    // these are two last sticks of the row
+                    // there needs to be padding after
+                    if (in_h_i == pc.in_h - 1) {
+                        // these are the last sticks in the last row of the image
+                        // insert full padding rows
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 2,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 0,
+                                .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip,
+                                .start_stick = start_stick_padded
+                            };
+                    } else {
+                        // just need width padding
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 2,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 0,
+                                .skip_after_partial_right_aligned_row = 2 * (int32_t) pc.pad_w,
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip,
+                                .start_stick = start_stick_padded
+                            };
+                    }
+                } else if (in_w_i == pc.in_w - 1) {
+                    // these are one last stick of the row and one first stick of next row
+                    // there needs to be padding in between
+                    if (in_h_i == pc.in_h - 1) {
+                        // these two sticks belong to different images
+                        // insert full padding rows between them
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 1,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 1,
+                                .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip,
+                                .start_stick = start_stick_padded
+                            };
+                    } else {
+                        // just width padding between then
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = 1,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 1,
+                                .skip_after_partial_right_aligned_row = (int32_t) (2 * pc.pad_w),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip,
+                                .start_stick = start_stick_padded
+                            };
+                    }
+                } else {
+                    // no padding needs to be attached
+                    return NewShardingConfig{
+                            .first_partial_right_aligned_row_width = 2,
+                            .first_partial_image_num_rows = 0,
+                            .num_full_images = 0,
+                            .last_partial_image_num_rows = 0,
+                            .last_partial_left_aligned_row_width = 0,
+                            .skip_after_partial_right_aligned_row = 0,
+                            .skip_after_first_partial_image_row = 0,
+                            .skip_after_full_image = 0,
+                            .initial_skip = initial_skip,
+                            .start_stick = start_stick_padded
+                        };
+                }
+
+            default:
+                if (in_h_i == last_in_h_i) {
+                    // all sticks belong to same row
+                    if (last_in_w_i == pc.in_w - 1) {
+                        // these sticks are the last in the row
+                        // insert padding at end
+                        if (in_h_i == pc.in_h - 1) {
+                            // this is the last row
+                            // need full padding rows
+                            return NewShardingConfig{
+                                    .first_partial_right_aligned_row_width = nsticks,
+                                    .first_partial_image_num_rows = 0,
+                                    .num_full_images = 0,
+                                    .last_partial_image_num_rows = 0,
+                                    .last_partial_left_aligned_row_width = 0,
+                                    .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                    .skip_after_first_partial_image_row = 0,
+                                    .skip_after_full_image = 0,
+                                    .initial_skip = initial_skip,
+                                    .start_stick = start_stick_padded
+                                };
+                        } else {
+                            // just width padding needed
+                            return NewShardingConfig{
+                                    .first_partial_right_aligned_row_width = nsticks,
+                                    .first_partial_image_num_rows = 0,
+                                    .num_full_images = 0,
+                                    .last_partial_image_num_rows = 0,
+                                    .last_partial_left_aligned_row_width = 0,
+                                    .skip_after_partial_right_aligned_row = (int32_t) (2 * pc.pad_w),
+                                    .skip_after_first_partial_image_row = 0,
+                                    .skip_after_full_image = 0,
+                                    .initial_skip = initial_skip,
+                                    .start_stick = start_stick_padded
+                                };
+                        }
+                    } else {
+                        // no padding is needed
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = nsticks,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = 0,
+                                .skip_after_partial_right_aligned_row = 0,
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip,
+                                .start_stick = start_stick_padded
+                            };
+                    }
+                } else {
+                    // sticks span two different rows. figure out where does the padding go.
+                    // padding will go at the end of the start row
+                    // find the last stick in the start row
+                    int32_t insert_padding_at = pc.in_w - in_w_i;
+                    if (in_h_i == pc.in_h - 1) {
+                        // sticks span across different images
+                        // full padding rows need to be inserted
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = insert_padding_at,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = nsticks - insert_padding_at,
+                                .skip_after_partial_right_aligned_row = (int32_t) (pc.pad_h * (pc.in_w + 2 * pc.pad_w)),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip,
+                                .start_stick = start_stick_padded
+                            };
+                    } else {
+                        // sticks belong to same image
+                        // only width padding needed
+                        return NewShardingConfig{
+                                .first_partial_right_aligned_row_width = insert_padding_at,
+                                .first_partial_image_num_rows = 0,
+                                .num_full_images = 0,
+                                .last_partial_image_num_rows = 0,
+                                .last_partial_left_aligned_row_width = nsticks - insert_padding_at,
+                                .skip_after_partial_right_aligned_row = (int32_t) (2 * pc.pad_w),
+                                .skip_after_first_partial_image_row = 0,
+                                .skip_after_full_image = 0,
+                                .initial_skip = initial_skip,
+                                .start_stick = start_stick_padded
+                            };
+                    }
+                }
+        }
+    }
+*/
+
+    int32_t partial_first_row_nsticks = 0;
+    int32_t skip_after_partial_first_row = 0;
+    if (curr_stick % pc.in_w > 0) {
+        partial_first_row_nsticks = pc.in_w - (curr_stick % pc.in_w);
+        skip_after_partial_first_row = 2 * pc.pad_w;
+    } else {
+        // no partial first row
+        partial_first_row_nsticks = 0;
+        skip_after_partial_first_row = 0;
+    }
+    curr_stick += partial_first_row_nsticks;
+    // NOTE: curr_stick is now at the leftmost edge
+    TT_ASSERT(curr_stick % pc.in_w == 0);
+
+    // full rows
+    int32_t total_full_rows = (end_stick - curr_stick) / pc.in_w;
+
+    // figure out how many of total full rows belong to partial top image, full images, and partial bottom image
+
+    // partial top image rows
+    int32_t partial_top_image_nrows = 0;
+    int32_t skip_after_partial_top_image = 0;
+    if (curr_batch_stick == 0) {
+        // this is beginning of a new image, ie no partial top image
+        partial_top_image_nrows = 0;
+        skip_after_partial_top_image = 0;
+        // if there was a partial top row, insert full padding rows
+        if (partial_first_row_nsticks > 0) {
+            skip_after_partial_first_row += (pc.in_w + 2 * pc.pad_w) * pc.pad_h;
+        }
+    } else {
+        // we have partial top image with (in_h * in_w - curr_batch_stick) sticks
+        // check if my range includes end of this image.
+        if ((batch_i + 1) * (pc.in_h * pc.in_w) < end_stick) {
+            // yes it does
+            int32_t stick_counter = curr_stick;
+            while (stick_counter / (pc.in_h * pc.in_w) == batch_i) {
+                ++ stick_counter;
+            }
+            partial_top_image_nrows = (stick_counter - curr_stick) / pc.in_w;
+            curr_stick += partial_top_image_nrows * pc.in_w;
+            // insert full padding rows
+            skip_after_partial_top_image = (pc.in_w + 2 * pc.pad_w) * pc.pad_h;
+        } else {
+            // no it does not
+            // count this image in the bottom partial image
+            partial_top_image_nrows = 0;
+            skip_after_partial_top_image = 0;
+        }
+    }
+
+    // full images
+    int32_t full_nimages = 0;
+    int32_t skip_after_full_image = 0;
+    // from curr_stick (which is at the left edge), to end_stick, numbewr of rows
+    int32_t rem_full_rows = (end_stick - curr_stick) / pc.in_w;
+    full_nimages = rem_full_rows / pc.in_h;
+    curr_stick += full_nimages * (pc.in_h + pc.in_w);
+    if (full_nimages > 0) {
+        // insert full padding rows
+        skip_after_full_image = (pc.in_w + 2 * pc.pad_w) * pc.pad_h;
+    }
+    // any remaining rows belong to the bottom partial image
+    rem_full_rows = rem_full_rows % pc.in_h;
+
+    // partial bottom image
+    int32_t partial_bottom_image_nrows = rem_full_rows;
+    curr_stick += rem_full_rows * pc.in_w;
+
+    int32_t partial_last_row_nsticks = (end_stick - curr_stick) % pc.in_w;  // TODO: take care of padding and edges etc
+
+    auto sc = NewShardingConfig{
+        .first_partial_right_aligned_row_width = partial_first_row_nsticks,
+        .first_partial_image_num_rows = partial_top_image_nrows,
+        .num_full_images = full_nimages,
+        .last_partial_image_num_rows = partial_bottom_image_nrows,
+        .last_partial_left_aligned_row_width = partial_last_row_nsticks,
+        .skip_after_partial_right_aligned_row = skip_after_partial_first_row,
+        .skip_after_first_partial_image_row = skip_after_partial_top_image,
+        .skip_after_full_image = skip_after_full_image,
+        .initial_skip = initial_skip,
+        .start_stick = start_stick_padded
+    };
+
+    // log_debug(LogOp, "initial_skip: {}", sc.initial_skip);
+    // log_debug(LogOp, "partial_first_row_nsticks: {}", sc.first_partial_right_aligned_row_width);
+    // log_debug(LogOp, "partial_top_image_nrows: {}", sc.first_partial_image_num_rows);
+    // log_debug(LogOp, "full_nimages: {}", sc.num_full_images);
+    // log_debug(LogOp, "partial_bottom_image_nrows: {}", sc.last_partial_image_num_rows);
+    // log_debug(LogOp, "partial_last_row_nsticks: {}", sc.last_partial_left_aligned_row_width);
+    // log_debug(LogOp, "skip_after_partial_first_row: {}", sc.skip_after_partial_right_aligned_row);
+    // log_debug(LogOp, "skip_after_partial_top_image: {}", sc.skip_after_first_partial_image_row);
+    // log_debug(LogOp, "skip_after_full_image: {}", sc.skip_after_full_image);
+
+    return sc;
+}
+
+
 struct ShardingConfig {
     uint32_t first_partial_right_aligned_row_width;
     uint32_t first_partial_image_num_rows;

--- a/tt_eager/tt_dnn/op_library/sharding_utilities.hpp
+++ b/tt_eager/tt_dnn/op_library/sharding_utilities.hpp
@@ -592,6 +592,11 @@ get_inout_shard_specs(int32_t start_stick, int32_t end_stick, const PoolConfig& 
     int32_t curr_out_stick = start_stick;
     int32_t curr_in_stick = start_in_stick;
 
+    // calculate the initial skip in input if starting stick is left-most and not the first in image
+    if (start_out_w_i == 0 && start_out_h_i != 0) {
+        in_sc.initial_skip = 2 * pc.pad_w;
+    }
+
     if (start_out_h_i == end_out_h_i && end_out_w_i != pc.out_w - 1) {
         // all out sticks belong to the same row
         // treating them as last partial with no skip

--- a/tt_eager/tt_dnn/op_library/untilize/untilize_op.hpp
+++ b/tt_eager/tt_dnn/op_library/untilize/untilize_op.hpp
@@ -61,6 +61,7 @@ struct UntilizeWithHalo {
     const uint32_t in_h;
     const uint32_t in_w;
     const uint32_t out_shard_size_max_per_core;
+    const uint32_t stride_;
     const MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
@@ -69,7 +70,7 @@ struct UntilizeWithHalo {
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     tt::stl::reflection::Attributes attributes() const;
 };
-Tensor untilize_with_halo(const Tensor &a, const uint32_t pad_val, const uint32_t &in_b, const uint32_t &in_h, const uint32_t &in_w, const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor untilize_with_halo(const Tensor &a, const uint32_t pad_val, const uint32_t &in_b, const uint32_t &in_h, const uint32_t &in_w, const uint32_t stride = 1, const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 namespace untilize_helpers {
 uint32_t get_num_cores(CoreCoord grid_size, uint32_t nblocks);

--- a/tt_eager/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
@@ -281,6 +281,14 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s2(const Tensor& i
                             .set_globally_allocated_address(output.buffer()->address());
     auto out_cb = CreateCircularBuffer(program, all_cores, out_cb_config);
 
+    // CB for pad val buffer (stick sized)
+    uint32_t pad_cb_id = CB::c_in1;
+    uint32_t pad_cb_pagesize = in_stick_nbytes;
+    uint32_t pad_cb_npages = 1;
+    auto pad_cb_config = CircularBufferConfig(pad_cb_pagesize * pad_cb_npages, {{pad_cb_id, cb_df}})
+                            .set_page_size(pad_cb_id, pad_cb_pagesize);
+    auto pad_cb = CreateCircularBuffer(program, all_cores, pad_cb_config);
+
     {
         log_debug(LogOp, "src cb: id = {}, pagesize = {}, npages = {}", src_cb_id, tile_size, num_input_tiles);
         log_debug(LogOp, "untilize cb: id = {}, pagesize = {}, npages = {}", untilize_out_cb_id, tile_size, num_output_tiles);
@@ -308,7 +316,10 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s2(const Tensor& i
      */
     std::vector<uint32_t> writer_ct_args = {
         (std::uint32_t) untilize_out_cb_id,
-        (std::uint32_t) out_cb_id
+        (std::uint32_t) out_cb_id,
+        (std::uint32_t) pad_cb_id,
+        (std::uint32_t) pad_val,
+        (std::uint32_t) in_c    // stick len
     };
     KernelID writer_kernel_id = CreateDataMovementKernel(
         program,
@@ -333,16 +344,16 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s2(const Tensor& i
         ComputeConfig{
             .compile_args = compute_args});
 
-    // const buffer with pad value
-    uint32_t const_buffer_size = input_shape[3];
-    auto const_buffer = owned_buffer::create(std::vector<bfloat16>(const_buffer_size, bfloat16(uint16_t(pad_val))));
-    const Tensor const_tensor = Tensor(OwnedStorage{const_buffer},
-                                       Shape({1, 1, 1, const_buffer_size}),
-                                       DataType::BFLOAT16,
-                                       Layout::ROW_MAJOR)
-                                    .to(device, MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED,
-                                                             .buffer_type = BufferType::L1});
-    auto const_tensor_addr = const_tensor.buffer()->address();
+    // // const buffer with pad value
+    // uint32_t const_buffer_size = input_shape[3];
+    // auto const_buffer = owned_buffer::create(std::vector<bfloat16>(const_buffer_size, bfloat16(uint16_t(pad_val))));
+    // const Tensor const_tensor = Tensor(OwnedStorage{const_buffer},
+    //                                    Shape({1, 1, 1, const_buffer_size}),
+    //                                    DataType::BFLOAT16,
+    //                                    Layout::ROW_MAJOR)
+    //                                 .to(device, MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED,
+    //                                                          .buffer_type = BufferType::L1});
+    // auto const_tensor_addr = const_tensor.buffer()->address();
 
     // 1D distribution of blocks across all cores
     uint32_t ncores_full = ncores;
@@ -404,7 +415,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s2(const Tensor& i
         0,  // partial_top_image_skip
         0,  // full_image_skip
         0,  // initial_pad_nsticks             // 45
-        const_tensor_addr,
+        0,  // UNUSED const_tensor_addr,
         // sharding config
         0,
         0,

--- a/tt_eager/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
@@ -19,7 +19,35 @@ using namespace tt::constants;
 namespace tt {
 namespace tt_metal {
 
+using range_t = std::array<int32_t, 2>;
+const int32_t NEIGHBORHOOD_DIST = 2;    // => ncores to left and ncores to right
+
 namespace untilize_with_halo_helpers {
+
+range_t calculate_in_range(const range_t& out_range, const PoolConfig& pc) {
+    // given out stick range, calculate corresponding window's center stick input coords
+    range_t in_range;
+    // start of the range
+    {
+        uint32_t out_w_i = out_range[0] % pc.out_w;
+        uint32_t out_h_i = out_range[0] / pc.out_w;
+        uint32_t in_w_i = out_w_i * pc.stride_w;
+        uint32_t in_h_i = out_h_i * pc.stride_h;
+        in_range[0] = in_h_i * pc.in_w + in_w_i;
+    }
+    // end of the range
+    {
+        // uint32_t out_w_i = (out_range[1] - 1) % pc.out_w;
+        // uint32_t out_h_i = (out_range[1] - 1) / pc.out_w;
+        uint32_t out_w_i = out_range[1] % pc.out_w;
+        uint32_t out_h_i = out_range[1] / pc.out_w;
+        // corresponding window's center stick input coords:
+        uint32_t in_w_i = out_w_i * pc.stride_w;
+        uint32_t in_h_i = out_h_i * pc.stride_h;
+        in_range[1] = in_h_i * pc.in_w + in_w_i;
+    }
+    return in_range;
+}
 
 // reader noc coords for left and right neighbors
 std::map<CoreCoord, CoreCoord> left_neighbor_noc_xy, right_neighbor_noc_xy;
@@ -77,7 +105,753 @@ void init_neighbor_noc_xy_mapping(CoreCoord grid_size, uint32_t noc = 0) {
 
 } // namespace untilize_with_halo_helpers
 
-operation::ProgramWithCallbacks untilize_with_halo_multi_core(const Tensor& a, Tensor& output, uint32_t pad_val, const uint32_t &in_b, const uint32_t &in_h, const uint32_t &in_w, const uint32_t &out_shard_size_max_per_core) {
+// The case of stride = 2
+operation::ProgramWithCallbacks untilize_with_halo_multi_core_s2(const Tensor& input, Tensor& output, uint32_t pad_val) {
+    Program program = Program();
+
+    Device *device = input.device();
+    Buffer *src_buffer = input.buffer();
+    Buffer *dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    Shape input_shape = input.shape();
+    Shape output_shape = output.shape();
+
+    DataFormat in_df = datatype_to_dataformat_converter(input.dtype());
+    DataFormat out_df = datatype_to_dataformat_converter(output.dtype());
+    uint32_t in_nbytes = datum_size(in_df);
+    uint32_t out_nbytes = datum_size(out_df);
+
+    DataFormat cb_df = in_df;
+    uint32_t tile_size = tt_metal::detail::TileSize(cb_df);
+
+    uint32_t ntiles = input.volume() / TILE_HW;
+    uint32_t ntiles_per_block = input_shape[3] / TILE_WIDTH;
+    uint32_t nblocks = ceil((float) ntiles / ntiles_per_block);
+    uint32_t block_size_nbytes = input_shape[3] * input.element_size();
+
+    // TODO: hard coded for testing only. need to pass these args in.
+    // These are the input values before inserting and padding or halo
+    uint32_t nbatch = input_shape[0];
+    uint32_t in_h = std::sqrt(input_shape[2]);
+    uint32_t in_w = in_h;
+    TT_ASSERT(in_h * in_w == input_shape[2]);
+    uint32_t in_c = input_shape[3];
+    uint32_t pad_h = 1;
+    uint32_t pad_w = 1;
+    uint32_t window_h = 3;
+    uint32_t window_w = 3;
+    uint32_t stride_h = 2;
+    uint32_t stride_w = 2;
+    uint32_t dilation_h = 1;
+    uint32_t dilation_w = 1;
+
+    // resuting output shape of subsequent pooling op
+    uint32_t out_h = ((in_h + 2 * pad_h - (dilation_h * window_h - 1) - 1) / stride_h) + 1;
+    uint32_t out_w = ((in_w + 2 * pad_w - (dilation_w * window_w - 1) - 1) / stride_w) + 1;
+
+    PoolConfig pc {
+        .in_w = in_w,
+        .in_h = in_h,
+        .out_w = out_w,
+        .out_h = out_h,
+        .stride_w = stride_w,
+        .stride_h = stride_h,
+        .pad_w = pad_w,
+        .pad_h = pad_h,
+        .window_w = window_w,
+        .window_h = window_h,
+        .dilation_w = dilation_w,
+        .dilation_h = dilation_h
+    };
+
+
+    if (0)
+    {
+        log_debug(LogOp, "ntiles: {}", ntiles);
+        log_debug(LogOp, "ntiles_per_block: {}", ntiles_per_block);
+        log_debug(LogOp, "nblocks: {}", nblocks);
+        log_debug(LogOp, "nbatch: {}", nbatch);
+        log_debug(LogOp, "in_h: {}", in_h);
+        log_debug(LogOp, "in_w: {}", in_w);
+        log_debug(LogOp, "in_c: {}", in_c);
+        log_debug(LogOp, "pad_h: {}", pad_h);
+        log_debug(LogOp, "pad_w: {}", pad_w);
+        log_debug(LogOp, "window_h: {}", window_h);
+        log_debug(LogOp, "window_w: {}", window_w);
+        log_debug(LogOp, "stride_h: {}", stride_h);
+        log_debug(LogOp, "stride_w: {}", stride_w);
+    }
+
+    auto grid_size = device->compute_with_storage_grid_size();
+
+    untilize_with_halo_helpers::init_neighbor_noc_xy_mapping(grid_size);
+
+    int32_t ncores_x = grid_size.x;     // distributing data to cores row-wise
+    CoreRangeSet all_cores = input.shard_spec().value().shard_grid;
+    int32_t ncores = 0;
+    for (const auto& core_range : all_cores.ranges()) {
+        ncores += core_range.size();
+    }
+    CoreRangeSet core_range_cliff = CoreRangeSet({});
+    uint32_t nblocks_per_core = input.shard_spec().value().shard_shape[0] / TILE_HEIGHT;
+    uint32_t nblocks_per_core_cliff = 0;
+
+    uint32_t in_hw = in_h * in_w;
+    uint32_t in_nhw = nbatch * in_hw;
+    uint32_t in_stick_nbytes = in_c * in_nbytes;
+    uint32_t in_nsticks = in_nhw;
+    uint32_t in_nsticks_per_batch = in_hw;
+    uint32_t in_nsticks_per_core = in_nhw / ncores;
+
+    if (0)
+    {
+        log_debug(LogOp, "shard_shape: {},{}", input.shard_spec().value().shard_shape[0], input.shard_spec().value().shard_shape[1]);
+        log_debug(LogOp, "ncores: {}", ncores);
+        log_debug(LogOp, "ncores_x: {}", ncores_x);
+        log_debug(LogOp, "nblocks_per_core: {}", nblocks_per_core);
+        log_debug(LogOp, "nblocks_per_core_cliff: {}", nblocks_per_core_cliff);
+        log_debug(LogOp, "in_hw: {}", in_hw);
+        log_debug(LogOp, "in_nhw: {}", in_nhw);
+        log_debug(LogOp, "in_stick_nbytes: {}", in_stick_nbytes);
+        log_debug(LogOp, "in_nsticks_per_batch: {}", in_nsticks_per_batch);
+        log_debug(LogOp, "in_nsticks_per_core: {}", in_nsticks_per_core);
+    }
+
+    int32_t halo_in_nsticks = (in_w + (window_w / 2)) * (window_h / 2);     // input sticks to the writer
+    int32_t halo_out_nsticks = (in_w + 2 * pad_w) * pad_h + window_w / 2;   // output sticks from the writer
+
+    log_debug(LogOp, "halo_in_nsticks: {}", halo_in_nsticks);
+    log_debug(LogOp, "halo_out_nsticks: {}", halo_out_nsticks);
+
+    // For each core, calculate the desired resharding with halo and pad inserted in order to
+    // to obtain resulting **output after the pooling/downsampling op to be equally distributed across all cores**.
+    // The resulting shards with halo and pad could be different across cores.
+    // The resharding is represented as a map:
+    // map :: core -> [l_halo_start, l_halo_end) [local_start, local_end) [r_halo_start, r_halo_end)
+    // (these are global input stick indices, [0, (in_nhw - 1)])
+    // (and l_halo_end == local_start, local_end == r_halo_start)
+    // calculate this core's [left halo, local owned, right halo]. These halo data could be "anywhere".
+    std::map<uint32_t, std::array<range_t, 3>> my_shard;
+    int32_t out_stick_start = 0;   // global "output" stick (after downsample/pool)
+    int32_t pool_out_nsticks_per_core = nbatch * pc.out_h * pc.out_w / ncores;
+    uint32_t max_nsticks = 0;
+    for (uint32_t core = 0; core < ncores; ++ core) {
+        range_t out_range = {out_stick_start, out_stick_start + pool_out_nsticks_per_core};
+        range_t in_range = untilize_with_halo_helpers::calculate_in_range(out_range, pc);  // this represents the "window" center input sticks
+        int32_t l_halo_start = in_range[0] - halo_in_nsticks;
+        int32_t batch_start = (in_range[0] / (in_h * in_w)) * (in_h * in_w);
+        l_halo_start = l_halo_start < batch_start ? batch_start : l_halo_start;
+        int32_t r_halo_end = in_range[1] + halo_in_nsticks;
+        r_halo_end = r_halo_end >= in_nhw ? in_nhw : r_halo_end;
+        my_shard[core] = {{
+            { l_halo_start, in_range[0] }, // l_halo
+            { in_range[0], in_range[1] },                   // local
+            { in_range[1], r_halo_end }  // r_halo
+        }};
+
+        max_nsticks = max_nsticks < (r_halo_end - l_halo_start) ? (r_halo_end - l_halo_start) : max_nsticks;
+
+        out_stick_start += pool_out_nsticks_per_core;
+    }
+    log_debug("max nsticks across all cores = {}", max_nsticks);
+
+    // CBs
+
+    uint32_t src_cb_id = CB::c_in0;
+    uint32_t num_input_tiles = ntiles_per_block * nblocks_per_core;
+    auto src_cb_config = CircularBufferConfig(num_input_tiles * tile_size, {{src_cb_id, cb_df}})
+                            .set_page_size(src_cb_id, tile_size)
+                            .set_globally_allocated_address(input.buffer()->address());
+    auto src_cb = CreateCircularBuffer(program, all_cores, src_cb_config);
+
+    // output of untilize from compute kernel goes into this CB
+    uint32_t untilize_out_cb_id = CB::c_out0;
+    uint32_t num_output_tiles = ntiles_per_block * nblocks_per_core;
+    auto untilize_out_cb_config = CircularBufferConfig(num_output_tiles * tile_size, {{untilize_out_cb_id, cb_df}})
+                                    .set_page_size(untilize_out_cb_id, tile_size);
+    auto untilize_out_cb = CreateCircularBuffer(program, all_cores, untilize_out_cb_config);
+
+    // output after concatenating halo and padding goes into this CB, as input to next op.
+    uint32_t out_cb_id = CB::c_out1;
+    uint32_t out_cb_pagesize = out_nbytes * in_c;
+    uint32_t out_cb_npages = max_nsticks;
+    auto out_cb_config = CircularBufferConfig(out_cb_npages * out_cb_pagesize, {{out_cb_id, cb_df}})
+                            .set_page_size(out_cb_id, out_cb_pagesize)
+                            .set_globally_allocated_address(output.buffer()->address());
+    auto out_cb = CreateCircularBuffer(program, all_cores, out_cb_config);
+
+    {
+        log_debug(LogOp, "src cb: id = {}, pagesize = {}, npages = {}", src_cb_id, tile_size, num_input_tiles);
+        log_debug(LogOp, "untilize cb: id = {}, pagesize = {}, npages = {}", untilize_out_cb_id, tile_size, num_output_tiles);
+        log_debug(LogOp, "out cb: id = {}, pagesize = {}, npages = {}", out_cb_id, out_cb_pagesize, out_cb_npages);
+    }
+
+
+    /** reader
+     */
+
+    std::vector<uint32_t> reader_ct_args = {
+        (std::uint32_t) src_cb_id
+    };
+
+    KernelID reader_kernel_id = CreateDataMovementKernel(
+        program,
+        "tt_metal/kernels/dataflow/reader_unary_sharded.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = reader_ct_args});
+
+    /** writer
+     */
+    std::vector<uint32_t> writer_ct_args = {
+        (std::uint32_t) untilize_out_cb_id,
+        (std::uint32_t) out_cb_id
+    };
+    KernelID writer_kernel_id = CreateDataMovementKernel(
+        program,
+        "tt_metal/kernels/dataflow/writer_unary_sharded_with_halo_s2.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = writer_ct_args});
+
+    /** compute
+     */
+    TT_ASSERT(core_range_cliff.ranges().size() == 0);
+    vector<uint32_t> compute_args = {
+        (uint32_t) nblocks_per_core,    // per_core_block_cnt
+        (uint32_t) ntiles_per_block,    // per_block_ntiles
+    };
+    KernelID untilize_kernel_id = CreateComputeKernel(
+        program,
+        "tt_metal/kernels/compute/untilize.cpp",
+        all_cores,
+        ComputeConfig{
+            .compile_args = compute_args});
+
+    // const buffer with pad value
+    uint32_t const_buffer_size = input_shape[3];
+    auto const_buffer = owned_buffer::create(std::vector<bfloat16>(const_buffer_size, bfloat16(uint16_t(pad_val))));
+    const Tensor const_tensor = Tensor(OwnedStorage{const_buffer},
+                                       Shape({1, 1, 1, const_buffer_size}),
+                                       DataType::BFLOAT16,
+                                       Layout::ROW_MAJOR)
+                                    .to(device, MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED,
+                                                             .buffer_type = BufferType::L1});
+    auto const_tensor_addr = const_tensor.buffer()->address();
+
+    // 1D distribution of blocks across all cores
+    uint32_t ncores_full = ncores;
+    // cliff core not yet supported
+    TT_ASSERT(nblocks_per_core_cliff == 0);
+
+    // reader runtime args
+    vector<uint32_t> reader_rt_args = {
+        ntiles_per_block * nblocks_per_core // ntiles
+    };
+
+    TT_ASSERT(in_nhw % ncores == 0);
+
+    // writer inserts halo and padding where needed
+    vector<uint32_t> writer_rt_args = {
+        ntiles_per_block * nblocks_per_core,  // in_nsticks,                     // 0
+        in_nsticks_per_core,  // UNUSED
+        0,  // partial_first_row_nsticks,
+        pad_w,
+        in_w,
+        0,  // partial_top_image_nrows,        // 5
+        pad_h,
+        in_h,
+        0,  // full_nimages,
+        0,  // partial_bottom_image_nrows,
+        0,  // partial_last_row_nsticks,       // 10
+        0,  // halo_for_left_left_nsticks,
+        0,  // halo_for_left_nsticks,
+        0,  // halo_for_right_nsticks,
+        0,  // halo_for_right_right_nsticks,
+        0,  // local_in_stick_start,           // 15
+        0,  // local_in_stick_end,
+        in_nsticks_per_batch,
+        in_nsticks_per_core,
+        0,  // has_left,
+        0,  // left_noc_x,                     // 20
+        0,  // left_noc_y,
+        0,  // has_right,
+        0,  // right_noc_x,
+        0,  // right_noc_y,
+        0,  // has_left_left,                  // 25
+        0,  // left_left_noc_x,
+        0,  // left_left_noc_y,
+        0,  // has_right_right,
+        0,  // right_right_noc_x,
+        0,  // right_right_noc_y,              // 30
+        in_stick_nbytes,
+        0,  // left_left_nsticks,
+        0,  // left_nsticks,
+        0,  // right_nsticks,
+        0,  // right_right_nsticks,            // 35
+        0,  // right_right_halo_offset,
+        0,  // right_halo_offset,
+        0,  // left_halo_offset,
+        0,  // left_left_halo_offset,
+        0,  // left_halo_pad_i_offset          // 40
+        0,  // right_halo_pad_i_offset
+        0,  // partial_first_row_skip
+        0,  // partial_top_image_skip
+        0,  // full_image_skip
+        0,  // initial_pad_nsticks             // 45
+        const_tensor_addr,
+        // sharding config
+        0,
+        0,
+        0,
+        0,                                     // 50
+        0,
+        0,
+        0,
+        0,
+        0,                                     // 55
+        0,
+        0,
+        0,
+        0,
+        // halo config
+        0,                                     // 60
+        0,
+        0,
+        0,
+        0,
+        0,                                     // 65
+        0,
+        0,
+        0,
+        0,
+        0,                                     // 70
+        0,
+    };
+
+    uint32_t writer_noc = 0;
+
+    TT_ASSERT(window_h == 3 && window_w == 3);
+
+    // Calculate data shuffle config for each core using its shard size:
+    // Given equally distributed input across all cores,
+    // for each core, identify the data to be scattered across its neighborhood:
+    // construct the map (subset of alltoallv primitive)
+    // map :: core -> [ll_start, ll_end] [l_start, l_end] [start, end] [r_start, r_end] [rr_start, rr_end]
+    // where, ll_end == l_start, l_end == start, end == r_start, r_end == rr_start
+    std::map<uint32_t, std::array<uint32_t, (NEIGHBORHOOD_DIST * 2 + 1)>> count_to_send;    // nsticks to push to each neighbor
+    std::map<uint32_t, std::array<range_t, (NEIGHBORHOOD_DIST * 2 + 1)>> range_to_send;     // range to push to each neighbor
+    uint32_t in_stick_start = 0;    // global input stick
+    for (uint32_t core = 0; core < ncores; ++ core) {
+        uint32_t in_stick_end = in_stick_start + in_nsticks_per_core;
+        // log_debug("==== Core {}: in_sticks = [{},{})", core, in_stick_start, in_stick_end);
+        // log_debug(" l_halo = [{},{})", my_shard[core][0][0], my_shard[core][0][1]);
+        // log_debug(" local ({}) = [{},{})", my_shard[core][1][1] - my_shard[core][1][0], my_shard[core][1][0], my_shard[core][1][1]);
+        // log_debug(" r_halo = [{},{})", my_shard[core][2][0], my_shard[core][2][1]);
+
+        // calculate the shuffle config [excl. padding] <-- TODO: see if padding should be handled here or later
+        //   - for each core in the neighborhood:
+        //         calculate range to push to this core
+
+        // first, cores on the left neighborhood (starting left->right):
+        uint32_t count = 0;
+        int32_t range_start = 0, range_end = 0;
+        for (int32_t l_neighbor = NEIGHBORHOOD_DIST; l_neighbor > 0; -- l_neighbor) {
+            int32_t l_core = core - l_neighbor;
+            if (l_core >= 0) {  // this is a valid neighbor
+                count = 0;
+                // see if this neighbor needs anything from me
+                // neighbor's right halo end > in_stick_start
+                uint32_t stick = in_stick_start;
+                range_start = stick;
+                while (stick < my_shard[l_core][2][1]) {
+                    ++ count;
+                    ++ stick;
+                }
+                range_end = stick;
+                count_to_send[core][NEIGHBORHOOD_DIST - l_neighbor] = count;
+                range_to_send[core][NEIGHBORHOOD_DIST - l_neighbor] = { range_start, range_end };
+            }
+        }
+
+        // check if there is data to keep local:
+        // that is, if my full new shard range (incl. halos) intersects with my current shard
+        count = 0;
+        range_start = 0, range_end = 0;
+        int32_t my_shard_start = my_shard[core][0][0];
+        int32_t my_shard_end = my_shard[core][2][1];
+        if (my_shard_end > in_stick_start && my_shard_start < in_stick_end) {
+            uint32_t stick = in_stick_start < my_shard_start ? my_shard_start : in_stick_start;
+            range_start = stick;
+            while (stick < my_shard_end && stick < in_stick_end) {
+                ++ count;
+                ++ stick;
+            }
+            range_end = stick;
+        }
+        count_to_send[core][NEIGHBORHOOD_DIST] = count; // keep local
+        range_to_send[core][NEIGHBORHOOD_DIST] = { range_start, range_end }; // keep local
+
+        // cores on the right neighborhood (starting left->right)
+        range_start = 0, range_end = 0;
+        for (int32_t r_neighbor = 1; r_neighbor <= NEIGHBORHOOD_DIST; ++ r_neighbor) {
+            int32_t r_core = core + r_neighbor;
+            if (r_core < ncores) {  // this is a valid neighbor
+                count = 0;
+                // see if this neighbor needs anything from me
+                // neighbor's left halo start < in_stick_end
+                uint32_t stick = my_shard[r_core][0][0];
+                stick = stick < in_stick_start ? in_stick_start : stick;
+                range_start = stick;
+                while (stick < in_stick_end) {
+                    ++ count;
+                    ++ stick;
+                }
+                range_end = stick;
+                count_to_send[core][NEIGHBORHOOD_DIST + r_neighbor] = count;
+                range_to_send[core][NEIGHBORHOOD_DIST + r_neighbor] = { range_start, range_end };
+            }
+        }
+
+        in_stick_start += in_nsticks_per_core;
+    }
+
+    std::map<uint32_t, std::array<uint32_t, (NEIGHBORHOOD_DIST * 2 + 1)>> count_to_receive; // nsticks pushed from each neighbor
+    for (uint32_t core = 0; core < ncores; ++ core) {
+        // calculate the nsticks I receive from each of my neighbors
+        for (int32_t neighbor = - NEIGHBORHOOD_DIST; neighbor <= NEIGHBORHOOD_DIST; ++ neighbor) {
+            int32_t neighbor_core = core + neighbor;
+            uint32_t count = 0;
+            if (neighbor_core >= 0 && neighbor_core < ncores) {
+                count = count_to_send[neighbor_core][NEIGHBORHOOD_DIST - neighbor];
+            }
+            count_to_receive[core][NEIGHBORHOOD_DIST + neighbor] = count;
+        }
+    }
+
+    std::map<uint32_t, std::array<uint32_t, (NEIGHBORHOOD_DIST * 2 + 1)>> updated_count_to_send;    // nsticks to push to each neighbor
+    for (uint32_t core = 0; core < ncores; ++ core) {
+        // for each core, calculate the offsets where data is to be pushed to
+        // the push will be from locally constructed re-sharded data, so no additional need to insert padding when pushing.
+        for (int32_t neighbor = - NEIGHBORHOOD_DIST; neighbor <= NEIGHBORHOOD_DIST; ++ neighbor) {
+            // calculate the total nsticks incl. padding to be sent to this neighbor
+            range_t to_send = range_to_send[core][NEIGHBORHOOD_DIST + neighbor];
+            NewShardingConfig sc = get_shard_specs(to_send[0], to_send[1], pc);
+            uint32_t count = 0;
+            count += sc.first_partial_right_aligned_row_width + sc.skip_after_partial_right_aligned_row;
+            count += sc.first_partial_image_num_rows * (pc.in_w + 2 * pc.pad_w) + sc.skip_after_first_partial_image_row;
+            count += sc.num_full_images * (pc.in_h * (pc.in_w + 2 * pc.pad_w) + sc.skip_after_full_image);
+            count += sc.last_partial_image_num_rows * (pc.in_w + 2 * pc.pad_w);
+            count += sc.last_partial_left_aligned_row_width;
+            updated_count_to_send[core][NEIGHBORHOOD_DIST + neighbor] = count;
+            // bool to_print = core == 12 && neighbor == 0;
+            // if (to_print) {
+            //     log_debug(LogOp, "== partial_first_row_nsticks: {}", sc.first_partial_right_aligned_row_width);
+            //     log_debug(LogOp, "== skip_after_partial_right_aligned_row: {}", sc.skip_after_partial_right_aligned_row);
+            //     log_debug(LogOp, "== partial_top_image_nrows: {}", sc.first_partial_image_num_rows);
+            //     log_debug(LogOp, "== skip_after_first_partial_image_row: {}", sc.skip_after_first_partial_image_row);
+            //     log_debug(LogOp, "== full_nimages: {}", sc.num_full_images);
+            //     log_debug(LogOp, "== skip_after_full_image: {}", sc.skip_after_full_image);
+            //     log_debug(LogOp, "== partial_bottom_image_nrows: {}", sc.last_partial_image_num_rows);
+            //     log_debug(LogOp, "== partial_last_row_nsticks: {}", sc.last_partial_left_aligned_row_width);
+            //     log_debug(LogOp, "== initial_skip: {}", sc.initial_skip);
+            // }
+        }
+        in_stick_start += in_nsticks_per_core;
+    }
+
+    std::map<uint32_t, std::array<uint32_t, (NEIGHBORHOOD_DIST * 2 + 1)>> updated_count_to_receive; // nsticks pushed from each neighbor
+    std::map<uint32_t, std::array<uint32_t, (NEIGHBORHOOD_DIST * 2 + 1)>> receive_at_offset_nsticks;  // data is to be received at these offsets
+    std::map<uint32_t, int32_t> initial_pad_nsticks;  // any padding to be inserted at the beginning (for left most cores)
+    // in_stick_start = 0;
+    for (uint32_t core = 0; core < ncores; ++ core) {
+        // uint32_t in_stick_end = in_stick_start + in_nsticks_per_core;
+        // NewShardingConfig sc = get_shard_specs_with_halo(in_stick_start, in_stick_end, pc);
+        // if (0) {
+        //     log_debug(LogOp, "============ CORE : {}", core);
+        //     log_debug(LogOp, "== in_stick range: [{} {})", in_stick_start, in_stick_end);
+        //     log_debug(LogOp, "== partial_first_row_nsticks: {}", sc.first_partial_right_aligned_row_width);
+        //     log_debug(LogOp, "== skip_after_partial_right_aligned_row: {}", sc.skip_after_partial_right_aligned_row);
+        //     log_debug(LogOp, "== partial_top_image_nrows: {}", sc.first_partial_image_num_rows);
+        //     log_debug(LogOp, "== skip_after_first_partial_image_row: {}", sc.skip_after_first_partial_image_row);
+        //     log_debug(LogOp, "== full_nimages: {}", sc.num_full_images);
+        //     log_debug(LogOp, "== skip_after_full_image: {}", sc.skip_after_full_image);
+        //     log_debug(LogOp, "== partial_bottom_image_nrows: {}", sc.last_partial_image_num_rows);
+        //     log_debug(LogOp, "== partial_last_row_nsticks: {}", sc.last_partial_left_aligned_row_width);
+        //     log_debug(LogOp, "== initial_skip: {}", sc.initial_skip);
+        // }
+        // record any inital skip to be used in offset calculations
+        // initial_pad_nsticks[core] = sc.initial_skip;
+        initial_pad_nsticks[core] = 0;
+        if (my_shard[core][0][1] - my_shard[core][0][0] < halo_in_nsticks) {
+            initial_pad_nsticks[core] = halo_out_nsticks - (my_shard[core][0][1] - my_shard[core][0][0]);
+        }
+        // uint32_t cumulative_count = sc.initial_skip;
+        uint32_t cumulative_count = initial_pad_nsticks[core];
+        // calculate the nsticks I receive from each of my neighbors
+        for (int32_t neighbor = - NEIGHBORHOOD_DIST; neighbor <= NEIGHBORHOOD_DIST; ++ neighbor) {
+            int32_t neighbor_core = core + neighbor;
+            uint32_t count = 0;
+            if (neighbor_core >= 0 && neighbor_core < ncores) {
+                count = updated_count_to_send[neighbor_core][NEIGHBORHOOD_DIST - neighbor];
+            }
+            updated_count_to_receive[core][NEIGHBORHOOD_DIST + neighbor] = count;
+            receive_at_offset_nsticks[core][NEIGHBORHOOD_DIST + neighbor] = cumulative_count;
+            cumulative_count += count;
+        }
+        // in_stick_start += in_nsticks_per_core;
+    }
+
+    std::map<uint32_t, std::array<uint32_t, (NEIGHBORHOOD_DIST * 2 + 1)>> send_to_offset_nsticks;  // data is to be received at these offsets
+    for (uint32_t core = 0; core < ncores; ++ core) {
+        for (int32_t neighbor = - NEIGHBORHOOD_DIST; neighbor <= NEIGHBORHOOD_DIST; ++ neighbor) {
+            int32_t neighbor_core = core + neighbor;
+            uint32_t offset = 0;
+            if (neighbor_core >= 0 && neighbor_core < ncores) {
+                offset = receive_at_offset_nsticks[neighbor_core][NEIGHBORHOOD_DIST - neighbor];
+            }
+            send_to_offset_nsticks[core][NEIGHBORHOOD_DIST + neighbor] = offset;
+        }
+    }
+
+    std::map<uint32_t, std::array<uint32_t, (NEIGHBORHOOD_DIST * 2 + 1)>> send_from_offset_nsticks; // after adding pad etc, the offset to start send data from
+    in_stick_start = 0;
+    for (uint32_t core = 0; core < ncores; ++ core) {
+        for (int32_t neighbor = - NEIGHBORHOOD_DIST; neighbor <= NEIGHBORHOOD_DIST; ++ neighbor) {
+            bool toprint = core == 1 && neighbor == 2;
+            int32_t neighbor_core = core + neighbor;
+            uint32_t offset = 0;
+            if (neighbor_core >= 0 && neighbor_core < ncores) {
+                NewShardingConfig sc = get_shard_specs(in_stick_start, range_to_send[core][NEIGHBORHOOD_DIST + neighbor][0], pc);
+                offset += sc.first_partial_right_aligned_row_width + sc.skip_after_partial_right_aligned_row;
+                offset += sc.first_partial_image_num_rows * (pc.in_w + 2 * pc.pad_w) + sc.skip_after_first_partial_image_row;
+                // if (sc.first_partial_image_num_rows > 0) {
+                //     offset -= 2 * pc.pad_w;
+                // }
+                offset += sc.num_full_images * (pc.in_h * (pc.in_w + 2 * pc.pad_w) + sc.skip_after_full_image);
+                // if (sc.num_full_images > 0) {
+                //     offset -= sc.num_full_images * 2 * pc.pad_w;
+                // }
+                offset += sc.last_partial_image_num_rows * (pc.in_w + 2 * pc.pad_w);
+                offset += sc.last_partial_left_aligned_row_width;
+                // if (toprint) {
+                //     log_debug(LogOp, "partial_first_row_nsticks: {}", sc.first_partial_right_aligned_row_width);
+                //     log_debug(LogOp, "partial_top_image_nrows: {}", sc.first_partial_image_num_rows);
+                //     log_debug(LogOp, "full_nimages: {}", sc.num_full_images);
+                //     log_debug(LogOp, "partial_bottom_image_nrows: {}", sc.last_partial_image_num_rows);
+                //     log_debug(LogOp, "partial_last_row_nsticks: {}", sc.last_partial_left_aligned_row_width);
+                //     log_debug(LogOp, "skip_after_partial_right_aligned_row: {}", sc.skip_after_partial_right_aligned_row);
+                //     log_debug(LogOp, "skip_after_first_partial_image_row: {}", sc.skip_after_first_partial_image_row);
+                //     log_debug(LogOp, "skip_after_full_image: {}", sc.skip_after_full_image);
+                //     log_debug(LogOp, "initial_skip: {}", sc.initial_skip);
+                //     log_debug(LogOp, "offset: {}", offset);
+                //     log_debug(LogOp, "start_offset: {}", receive_at_offset_nsticks[core][NEIGHBORHOOD_DIST]);
+                // }
+            }
+            send_from_offset_nsticks[core][NEIGHBORHOOD_DIST + neighbor] = offset + receive_at_offset_nsticks[core][NEIGHBORHOOD_DIST];
+        }
+        in_stick_start += in_nsticks_per_core;
+    }
+
+    // Calculate all information needed to copy locally owned data to output shard.
+    in_stick_start = 0;
+    for (uint32_t core = 0; core < ncores; ++ core) {
+        CoreCoord core_coord = {core % ncores_x, core / ncores_x};  // logical
+
+        // set reader rt args
+        SetRuntimeArgs(program, reader_kernel_id, core_coord, reader_rt_args);
+
+        // for each core, identify its sections with padding for the data it locally owns
+        // that is, compute the sharding config
+        uint32_t in_stick_end = in_stick_start + in_nsticks_per_core;
+
+        CoreCoord noc_core = core_coord;  // calculate physical
+        if (writer_noc == 0) {
+            noc_core.x += 1;
+            noc_core.y += 1;
+            if (noc_core.y > 5) {
+                noc_core.y += 1;
+            }
+        } else {
+            TT_ASSERT(false);
+        }
+
+        if (untilize_with_halo_helpers::left_neighbor_noc_xy.count(noc_core) > 0) {
+            CoreCoord left_noc = untilize_with_halo_helpers::left_neighbor_noc_xy.at(noc_core);
+            writer_rt_args[19] = 1;
+            writer_rt_args[20] = left_noc.x;
+            writer_rt_args[21] = left_noc.y;
+            if (untilize_with_halo_helpers::left_neighbor_noc_xy.count(left_noc) > 0) {
+                CoreCoord left_left_noc = untilize_with_halo_helpers::left_neighbor_noc_xy.at(left_noc);
+                writer_rt_args[25] = 1;
+                writer_rt_args[26] = left_left_noc.x;
+                writer_rt_args[27] = left_left_noc.y;
+            } else {
+                writer_rt_args[25] = 0;
+            }
+        } else {
+            writer_rt_args[19] = 0;
+            writer_rt_args[25] = 0;
+        }
+        if (untilize_with_halo_helpers::right_neighbor_noc_xy.count(noc_core) > 0 && (core < ncores - 1)) {
+            CoreCoord right_noc = untilize_with_halo_helpers::right_neighbor_noc_xy.at(noc_core);
+            writer_rt_args[22] = 1;
+            writer_rt_args[23] = right_noc.x;
+            writer_rt_args[24] = right_noc.y;
+            if (untilize_with_halo_helpers::right_neighbor_noc_xy.count(noc_core) > 0 && (core < ncores - 2)) {
+                CoreCoord right_right_noc = untilize_with_halo_helpers::right_neighbor_noc_xy.at(right_noc);
+                writer_rt_args[28] = 1;
+                writer_rt_args[29] = right_right_noc.x;
+                writer_rt_args[30] = right_right_noc.y;
+            } else {
+                writer_rt_args[28] = 0;
+            }
+        } else {
+            writer_rt_args[22] = 0;
+            writer_rt_args[28] = 0;
+        }
+
+        // logically insert padding into locally owned data and generate the sharding config
+        // information to calculate for a core:
+        //  + partial_first_row_nsticks (no pad)
+        //  + skip_after_partial_first_row (pad)
+        //  + partial_first_image_nrows (no pad) + padding per row (pad)
+        //  + skip_after_partial_first_image (pad)
+        //  + full_nimages (no pad) + padding per row (pad) + padding per image (pad)
+        //  + skip_after_full_images (pad)
+        //  + partial_last_image_nrows (no pad) + padding per row (pad)
+        //  + partial_last_row_nsticks (no pad)
+        NewShardingConfig sc = get_shard_specs(in_stick_start, in_stick_end, pc);
+        int32_t partial_first_row_nsticks = sc.first_partial_right_aligned_row_width;
+        int32_t skip_after_partial_first_row = sc.skip_after_partial_right_aligned_row;
+        int32_t partial_first_image_nrows = sc.first_partial_image_num_rows;
+        int32_t skip_after_partial_first_image = sc.skip_after_first_partial_image_row;
+        int32_t full_nimages = sc.num_full_images;
+        int32_t skip_after_full_images = sc.skip_after_full_image;
+        int32_t partial_last_image_nrows = sc.last_partial_image_num_rows;
+        int32_t partial_last_row_nsticks = sc.last_partial_left_aligned_row_width;
+        int32_t initial_skip = sc.initial_skip;
+
+        // uint32_t initial_pad_nsticks = 0;
+        // if (in_stick_start % (in_h * in_w) == 0) {
+        //     // This is start of image. Insert initial padding worth halo size
+        //     initial_pad_nsticks = halo_out_nsticks;
+        // }
+
+        // args for handling local data movement:
+        //     intial_pad_nsticks
+        //     receive_at_offset_nsticks[core][NEIGHBORHOOD_DIST]; // local_offset_nsticks
+        //     partial_first_row_nsticks
+        //     partial_first_row_skip
+        //     partial_top_image_nrows, partial_top_image_skip_per_row
+        //     partial_top_image_skip
+        //     full_nimages, full_image_skip_per_row
+        //     full_image_skip
+        //     partial_bottom_image_nrows, partial_bottom_image_skip_per_row
+        //     partial_last_row_nsticks
+        writer_rt_args[47] = initial_pad_nsticks[core];
+        writer_rt_args[48] = receive_at_offset_nsticks[core][NEIGHBORHOOD_DIST]; // local_offset_nsticks
+        writer_rt_args[49] = partial_first_row_nsticks;
+        writer_rt_args[50] = skip_after_partial_first_row;
+        writer_rt_args[51] = partial_first_image_nrows;
+        writer_rt_args[52] = partial_first_image_nrows > 0 ? 2 * pc.pad_w : 0;                          // partial_top_image_skip_per_row
+        writer_rt_args[53] = partial_first_image_nrows > 0 ? pc.pad_h * (pc.in_w + 2 * pc.pad_w) : 0;   // skip_after_partial_first_image
+        writer_rt_args[54] = full_nimages;
+        writer_rt_args[55] = full_nimages > 0 ? 2 * pc.pad_w : 0;                          // full_nimage_skip_per_row
+        writer_rt_args[56] = full_nimages > 0 ? pc.pad_h * (pc.in_w + 2 * pc.pad_w) : 0;   // full_image_skip
+        writer_rt_args[57] = partial_last_image_nrows;
+        writer_rt_args[58] = partial_last_image_nrows > 0 ? 2 * pc.pad_w : 0;                          // partial_bottom_image_skip_per_row
+        writer_rt_args[59] = partial_last_row_nsticks;
+
+        // args for handling remote data shuffle:
+        //     NEIGHBORHOOD_DIST
+        //     ll_send_count
+        //     ll_send_from_offset
+        //     ll_send_at_offset
+        //     l_send_count
+        //     l_send_from_offset
+        //     l_send_at_offset
+        //     r_send_count
+        //     r_send_from_offset
+        //     r_send_at_offset
+        //     rr_send_count
+        //     rr_send_from_offset
+        //     rr_send_at_offset
+        // LL
+        writer_rt_args[60] = updated_count_to_send[core][0];
+        writer_rt_args[61] = send_from_offset_nsticks[core][0] * in_stick_nbytes;
+        writer_rt_args[62] = send_to_offset_nsticks[core][0] * in_stick_nbytes;
+        // L
+        writer_rt_args[63] = updated_count_to_send[core][1];
+        writer_rt_args[64] = send_from_offset_nsticks[core][1] * in_stick_nbytes;
+        writer_rt_args[65] = send_to_offset_nsticks[core][1] * in_stick_nbytes;
+        // R
+        writer_rt_args[66] = updated_count_to_send[core][3];
+        writer_rt_args[67] = send_from_offset_nsticks[core][3] * in_stick_nbytes;
+        writer_rt_args[68] = send_to_offset_nsticks[core][3] * in_stick_nbytes;
+        // RR
+        writer_rt_args[69] = updated_count_to_send[core][4];
+        writer_rt_args[70] = send_from_offset_nsticks[core][4] * in_stick_nbytes;
+        writer_rt_args[71] = send_to_offset_nsticks[core][4] * in_stick_nbytes;
+
+        SetRuntimeArgs(program, writer_kernel_id, core_coord, writer_rt_args);
+
+        in_stick_start += in_nsticks_per_core;
+    }
+
+    // print stuff for debug
+    in_stick_start = 0;
+    for (uint32_t core = 0; core < ncores; ++ core) {
+        uint32_t in_stick_end = in_stick_start + in_nsticks_per_core;
+        log_debug("==== Core {}:", core);
+        log_debug(" in shard = [{},{})", in_stick_start, in_stick_end);
+        log_debug(" re shard = [{},{}) [{},{}) [{},{})", my_shard[core][0][0], my_shard[core][0][1],
+                                                         my_shard[core][1][0], my_shard[core][1][1],
+                                                         my_shard[core][2][0], my_shard[core][2][1]);
+        for (uint32_t neighbor = 0; neighbor < 2 * NEIGHBORHOOD_DIST + 1; ++ neighbor) {
+            log_debug(" + N {} :: recv: (count = {}, offset = {})\t send: (count = {}, from = {}, to = {}) : [{},{})", neighbor,
+                                                                  updated_count_to_receive[core][neighbor],
+                                                                  receive_at_offset_nsticks[core][neighbor],
+                                                                  updated_count_to_send[core][neighbor],
+                                                                  send_from_offset_nsticks[core][neighbor],
+                                                                  send_to_offset_nsticks[core][neighbor],
+                                                                  range_to_send[core][neighbor][0], range_to_send[core][neighbor][1]);
+        }
+        in_stick_start += in_nsticks_per_core;
+    }
+
+
+    auto override_runtime_arguments_callback = [
+        reader_kernel_id=reader_kernel_id,
+        writer_kernel_id=writer_kernel_id,
+        src_cb=src_cb,
+        out_cb=out_cb
+    ](
+        const void* operation,
+        Program& program,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        const std::vector<Tensor>& output_tensors
+    ) {
+        auto src_buffer = input_tensors.at(0).buffer();
+        auto dst_buffer = output_tensors.at(0).buffer();
+
+        auto& src_cb_config = GetCircularBufferConfig(program, src_cb);
+        src_cb_config.set_globally_allocated_address(src_buffer->address());
+
+        auto& output_cb_config = GetCircularBufferConfig(program, out_cb);
+        output_cb_config.set_globally_allocated_address(dst_buffer->address());
+    };
+
+    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
+}
+
+operation::ProgramWithCallbacks untilize_with_halo_multi_core(const Tensor& a, Tensor& output, uint32_t pad_val) {
     Program program = Program();
 
     Device *device = a.device();
@@ -417,11 +1191,6 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(const Tensor& a, T
         // NOTE: this is always the same for all cores
         uint32_t halo_nsticks = (in_w + window_w / 2 + 2 * pad_w);  // left or right halo
         uint32_t out_nsticks_per_core = local_nsticks + 2 * halo_nsticks;
-        {
-            log_debug(LogOp, "local_nsticks: {}", local_nsticks);
-            log_debug(LogOp, "halo_nsticks: {}", halo_nsticks);
-            log_debug(LogOp, "out_nsticks_per_core: {}", out_nsticks_per_core);
-        }
 
         my_right_halo_offset[i] = my_left_halo_offset[i] + (((initial_pad_nsticks > 0) ? initial_pad_nsticks : halo_nsticks) + local_nsticks) * in_stick_nbytes;
                                     // (in_nsticks_per_core /* local sticks */ + (in_nsticks_per_core / in_w) * 2 /* 2 padding sticks per row */) * in_stick_nbytes;
@@ -435,6 +1204,9 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core(const Tensor& a, T
         if (0)
         {
             log_debug(LogOp, "==== Core {}", i);
+            log_debug(LogOp, "local_nsticks: {}", local_nsticks);
+            log_debug(LogOp, "halo_nsticks: {}", halo_nsticks);
+            log_debug(LogOp, "out_nsticks_per_core: {}", out_nsticks_per_core);
             log_debug(LogOp, "in_stick_start {}", in_stick_start);
             log_debug(LogOp, "my_left_halo = {}", my_left_halo[i]);
             log_debug(LogOp, "my_left_halo_offset = {}", my_left_halo_offset[i]);
@@ -629,6 +1401,9 @@ void UntilizeWithHalo::validate(const std::vector<Tensor> &input_tensors) const 
     TT_ASSERT(input_tensor_a.memory_config().is_sharded());
     TT_ASSERT(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Only works for sharded input");
     TT_ASSERT(input_tensor_a.volume() % TILE_HW == 0);
+
+    // Only stride 1 and 2 mode are supported
+    TT_ASSERT(stride_ == 1 || stride_ == 2, "Only stride 1 and stride 2 modes are supported.");
 }
 
 std::vector<Shape> UntilizeWithHalo::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
@@ -654,14 +1429,22 @@ std::vector<Shape> UntilizeWithHalo::compute_output_shapes(const std::vector<Ten
     // Bb. right right halo:
 
     uint32_t in_nhw = this->in_b * this->in_h * this->in_w;
+    uint32_t nbatch = input_shape[0];
 
     // get ncores from shard shape and input shape
     auto shard_shape = input.shard_spec().value().shard_shape;
     uint32_t ncores = in_nhw / shard_shape[0];
 
+    uint32_t total_nsticks = 1300 * 98; // TODO: use the max val after a full scan
+    switch (nbatch) {
+        case 1:
+            total_nsticks = 480 * 98;
+        case 8:
+            total_nsticks = 1300 * 98;
+    }
+
     // output_shape[0] remains same
     // output_shape[1] remains same
-    // output_shape[3] remains same
     // output_shape[2] changes
     output_shape[2] = this->out_shard_size_max_per_core * ncores;
 
@@ -676,7 +1459,7 @@ std::vector<Tensor> UntilizeWithHalo::create_output_tensors(const std::vector<Te
     auto shard_spec = input_tensor.shard_spec().value();
     auto output_shape = this->compute_output_shapes(input_tensors).at(0);
     uint32_t ncores = input_tensor.shape()[0] * input_tensor.shape()[2] / shard_spec.shard_shape[0];
-    shard_spec.shard_shape[0] = output_shape[2] / ncores;
+    shard_spec.shard_shape[0] = output_shape[0] * output_shape[2] / ncores;
     // log_debug(LogOp, "derived ncores: {}", ncores);
     return {create_sharded_device_tensor(output_shape, input_tensor.dtype(), Layout::ROW_MAJOR, input_tensor.device(), this->output_mem_config, shard_spec)};
 }
@@ -684,7 +1467,16 @@ std::vector<Tensor> UntilizeWithHalo::create_output_tensors(const std::vector<Te
 operation::ProgramWithCallbacks UntilizeWithHalo::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
-    return {untilize_with_halo_multi_core(input_tensor_a, output_tensor, pad_val_, this->in_b, this->in_h, this->in_w, this->out_shard_size_max_per_core)};
+    switch (stride_) {
+        case 1:
+            return { untilize_with_halo_multi_core(input_tensor_a, output_tensor, pad_val_, this->in_b, this->in_h, this->in_w, this->out_shard_size_max_per_core) };
+        case 2:
+            log_debug(LogOp, "Using stride 2 kernel");
+            return { untilize_with_halo_multi_core_s2(input_tensor_a, output_tensor, pad_val_) };
+        default:
+            TT_ASSERT(false, "Unsupported stride value");
+    };
+    return {};
 }
 
 tt::stl::reflection::Attributes UntilizeWithHalo::attributes() const {
@@ -694,11 +1486,12 @@ tt::stl::reflection::Attributes UntilizeWithHalo::attributes() const {
         {"in_h", this->in_h},
         {"in_w", this->in_w},
         {"out_shard_size_max_per_core", this->out_shard_size_max_per_core},
-        {"output_mem_config", this->output_mem_config},
+        {"stride", stride_},
+        {"output_mem_config", output_mem_config_},
     };
 }
 
-Tensor untilize_with_halo(const Tensor &input_tensor_a, const uint32_t pad_val, const uint32_t &in_b, const uint32_t &in_h, const uint32_t &in_w, const MemoryConfig& mem_config) {
+Tensor untilize_with_halo(const Tensor &input_tensor_a, const uint32_t pad_val, const uint32_t &in_b, const uint32_t &in_h, const uint32_t &in_w, const uint32_t stride, const MemoryConfig& mem_config) {
     TT_ASSERT(input_tensor_a.memory_config().is_sharded()); // TODO: Remove from validate?
 
     uint32_t pad_h = 1;
@@ -738,7 +1531,7 @@ Tensor untilize_with_halo(const Tensor &input_tensor_a, const uint32_t pad_val, 
         uint32_t out_nsticks = local_nsticks + 2 * halo_nsticks;
         out_nsticks_max_per_core = std::max(out_nsticks_max_per_core, out_nsticks);
     }
-    return operation::run_without_autoformat(UntilizeWithHalo{pad_val, in_b, in_h, in_w, out_nsticks_max_per_core, mem_config}, {input_tensor_a}).at(0);
+    return operation::run_without_autoformat(UntilizeWithHalo{pad_val, stride, in_b, in_h, in_w, out_nsticks_max_per_core, mem_config}, {input_tensor_a}).at(0);
 }
 
 }  // namespace tt_metal

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -417,6 +417,7 @@ void TensorModule(py::module &m_tensor) {
     )doc");
     m_tensor.def("max_pool2d", &max_pool2d,
         py::arg("input").noconvert(),
+        py::arg("in_n").noconvert(),
         py::arg("in_h").noconvert(), py::arg("in_w").noconvert(),
         py::arg("kernel_h").noconvert(), py::arg("kernel_w").noconvert(),
         py::arg("stride_h") = 1, py::arg("stride_w") = 1,
@@ -430,6 +431,7 @@ void TensorModule(py::module &m_tensor) {
         | Argument          | Description                   | Data type     | Valid range | Required |
         +===================+===============================+===============+=============+==========+
         | input             | Input activations tensor      | Tensor        |             | Yes      |
+        | in_n              | Input nbatch                  | Tensor        |             | Yes      |
         | in_h              | Input height                  | Tensor        |             | Yes      |
         | in_w              | Input width                   | Tensor        |             | Yes      |
         | kernel_h          | kernel window height          | uint32_t      |             | Yes      |

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
@@ -193,6 +193,7 @@ namespace tt::tt_metal::detail{
             py::arg("in_b").noconvert(),
             py::arg("in_h").noconvert(),
             py::arg("in_w").noconvert(),
+            py::arg("stride") = 1,
             py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
             R"doc(
                 Untilizes input tiled data to row major format.

--- a/tt_eager/tt_lib/fused_ops/max_pool.py
+++ b/tt_eager/tt_lib/fused_ops/max_pool.py
@@ -15,13 +15,14 @@ def compute_max_pool_shape(kernel_size, stride, padding, x_shape):
     return [x_shape[0], OH, OW, x_shape[3]]
 
 
-def run_max_pool_on_device_wrapper(device, kernel_size, stride, padding, output_mem_config, nblocks, channels_last=False, reshape_2d=False):
+def run_max_pool_on_device_wrapper(device, in_n, in_h, in_w, kernel_size, stride, padding, output_mem_config, nblocks, channels_last=False, reshape_2d=False):
     def max_pool_2d(x):
-        x_shape_nopad = x.shape_without_padding()
-        out_shape_nopad = compute_max_pool_shape(kernel_size, stride, padding, x_shape_nopad)
-        if reshape_2d and channels_last:
-            x = x.reshape(x_shape_nopad[0], 1, x_shape_nopad[1] * x_shape_nopad[2], x_shape_nopad[3])
-        out = ttl.tensor.max_pool2d(x, x_shape_nopad[1], x_shape_nopad[2], kernel_size, kernel_size, stride, stride, padding, padding, output_mem_config=output_mem_config, nblocks=nblocks, use_multicore=True)
+        # x_shape_nopad = x.shape_without_padding()
+        # out_shape_nopad = compute_max_pool_shape(kernel_size, stride, padding, x_shape_nopad)
+        # if reshape_2d and channels_last:
+        #     x = x.reshape(x_shape_nopad[0], 1, x_shape_nopad[1] * x_shape_nopad[2], x_shape_nopad[3])
+        # out = ttl.tensor.max_pool2d(x, x_shape_nopad[1], x_shape_nopad[2], kernel_size, kernel_size, stride, stride, padding, padding, output_mem_config=output_mem_config, nblocks=nblocks, use_multicore=True)
+        out = ttl.tensor.max_pool2d(x, in_n, in_h, in_w, kernel_size, kernel_size, stride, stride, padding, padding, output_mem_config=output_mem_config, nblocks=nblocks, use_multicore=True)
         # if reshape_2d and channels_last:
         #     out = out.reshape(out_shape_nopad[0], out_shape_nopad[1], out_shape_nopad[2], out_shape_nopad[3])
         return out

--- a/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
+++ b/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
@@ -48,7 +48,7 @@ ALWI bool fill_with_val_async(uint32_t local_src_addr, uint32_t begin_addr, int3
     uint32_t curr_addr = begin_addr;
     uint64_t local_noc_src_addr = get_noc_addr(local_src_addr);
     for (int32_t row_i = 0; row_i < nrows; ++ row_i) {
-        noc_async_read(local_noc_src_addr, curr_addr, row_nbytes);
+        noc_async_read_one_packet(local_noc_src_addr, curr_addr, row_nbytes);
         curr_addr += row_nbytes;
     }
     return true;

--- a/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
+++ b/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
@@ -304,6 +304,7 @@ void kernel_main() {
     uint32_t counter = 0;
     while (counter < reader_i) {
         cb_reserve_back(in_cb_id, 1);
+
         uint32_t out_l1_write_addr_base = get_write_ptr(in_cb_id);
         uint32_t out_l1_write_addr = out_l1_write_addr_base;
         int32_t top_left_local_index = reader_indices_ptr[counter ++];
@@ -312,12 +313,13 @@ void kernel_main() {
             for (uint32_t w = 0; w < window_w; ++ w) {
                 uint32_t stick_offset = top_left_local_index + (w + h_multiples);
                 uint32_t read_offset = in_l1_read_base_addr + (stick_offset << in_nbytes_c_log2);
-                noc_async_read(get_noc_addr(read_offset), out_l1_write_addr, in_nbytes_c);
+                noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, in_nbytes_c);
                 out_l1_write_addr += in_nbytes_c;
             }
         }
         // print_pages(out_l1_write_addr_base, 64, 10, 0);
         noc_async_read_barrier();
+
         cb_push_back(in_cb_id, 1);
     }
 } // kernel_main()

--- a/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
+++ b/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
@@ -9,7 +9,7 @@
 #include "debug_print.h"
 
 SliceRange srr = SliceRange{ .h0 = 0, .h1 = 1, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 };
-SliceRange srt = SliceRange{ .h0 = 0, .h1 = 8, .hs = 1, .w0 = 0, .w1 = 4, .ws = 1 };
+SliceRange srt = SliceRange{ .h0 = 0, .h1 = 16, .hs = 1, .w0 = 0, .w1 = 2, .ws = 1 };
 
 // inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
 //     DPRINT << "======" << ENDL();
@@ -20,18 +20,16 @@ SliceRange srt = SliceRange{ .h0 = 0, .h1 = 8, .hs = 1, .w0 = 0, .w1 = 4, .ws = 
 //     DPRINT << "++++++" << ENDL();
 // }
 
-// inline void print_pages(uint32_t l1_addr, uint32_t pagelen, uint32_t npages) {
-//     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr);
-//     for (uint32_t page = 0; page < npages; ++ page) {
-//         for (uint32_t i = 0; i < pagelen; ++ i) {
-//             if (i == 0) {
-//                 DPRINT << BF16(*ptr) << " ";
-//             }
-//             ptr ++;
-//         }
-//         DPRINT << ENDL();
-//     }
-// }
+inline void print_pages(uint32_t l1_addr, uint32_t pagelen, uint32_t npages, uint32_t start = 0) {
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr) + start * pagelen;
+    for (uint32_t page = 0; page < npages; ++ page) {
+        DPRINT << start + page << ": ";
+        for (uint32_t j = 0; j < pagelen; ++ j, ++ ptr) {
+            DPRINT << BF16(*ptr) << " ";
+        }
+        DPRINT << ENDL();
+    }
+}
 
 // Fill an L1 buffer with the given val
 // WARNING: Use with caution as there's no memory protection. Make sure size is within limits
@@ -180,29 +178,18 @@ void kernel_main() {
 
     int32_t my_core = get_arg_val<int32_t>(64);
 
-    uint32_t partial_first_row_nsticks = get_arg_val<uint32_t>(65);
-    uint32_t partial_first_row_skip = get_arg_val<uint32_t>(66);
-    uint32_t partial_top_image_nrows = get_arg_val<uint32_t>(67);
-    uint32_t partial_top_image_skip = get_arg_val<uint32_t>(68);
-    uint32_t full_nimages = get_arg_val<uint32_t>(69);
-    uint32_t full_images_skip = get_arg_val<uint32_t>(70);
-    uint32_t partial_bottom_image_nrows = get_arg_val<uint32_t>(71);
-    uint32_t partial_last_row_nsticks = get_arg_val<uint32_t>(72);
+    int32_t initial_skip = get_arg_val<int32_t>(65);
+    int32_t partial_first_row_nsticks = get_arg_val<int32_t>(66);
+    int32_t partial_first_row_skip = get_arg_val<int32_t>(67);
+    int32_t partial_top_image_nrows = get_arg_val<int32_t>(68);
+    int32_t partial_top_image_skip = get_arg_val<int32_t>(69);
+    int32_t full_nimages = get_arg_val<int32_t>(70);
+    int32_t full_images_skip = get_arg_val<int32_t>(71);
+    int32_t partial_bottom_image_nrows = get_arg_val<int32_t>(72);
+    int32_t partial_last_row_nsticks = get_arg_val<int32_t>(73);
+    int32_t start_stick = get_arg_val<int32_t>(74);
 
     volatile tt_l1_ptr uint32_t* reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(reader_indices_cb_id));
-
-    uint32_t top_left_i = 0;
-    uint32_t reader_i = 0;
-
-    DPRINT << "partial_first_row_nsticks: " << partial_first_row_nsticks << ENDL();
-    DPRINT << "partial_first_row_skip: " << partial_first_row_skip << ENDL();
-    DPRINT << "partial_top_image_nrows: " << partial_top_image_nrows << ENDL();
-    DPRINT << "partial_top_image_skip: " << partial_top_image_skip << ENDL();
-    DPRINT << "full_nimages: " << full_nimages << ENDL();
-    DPRINT << "full_nimages_skip: " << full_images_skip << ENDL();
-    DPRINT << "partial_bottom_image_nrows: " << partial_bottom_image_nrows << ENDL();
-    DPRINT << "partial_last_row_nsticks: " << partial_last_row_nsticks << ENDL();
-    DPRINT << "TOTAL nsticks = " << partial_first_row_nsticks + partial_top_image_nrows * in_w + full_nimages * in_w * in_h + partial_bottom_image_nrows * in_w + partial_last_row_nsticks << ENDL();
 
     // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 0, .h1 = 1, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
     // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 1, .h1 = 2, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
@@ -213,95 +200,118 @@ void kernel_main() {
     // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 6, .h1 = 7, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
     // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 7, .h1 = 8, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
 
-    // DPRINT << "HAHA 2" << ENDL();
-    // section 1: partial first row
-    for (uint32_t i = 0; i < partial_first_row_nsticks; ++ i) {
-        reader_indices_ptr[reader_i ++] = top_left_i ++;
-    }
-    top_left_i += partial_first_row_skip;
+    uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
 
-    // DPRINT << "HAHA 3" << ENDL();
-    // section 2: partial first image
-    for (uint32_t i = 0; i < partial_top_image_nrows; ++ i) {
-        for (int32_t j = 0; j < in_w; ++ j) {
-            reader_indices_ptr[reader_i ++] = top_left_i ++;
-        }
-        // skip pad
-        top_left_i += 2 * pad_w;
-    }
-    top_left_i += partial_top_image_skip;
+    // print_pages(in_l1_read_base_addr, 64, 13 * 114, 0);
 
-    // DPRINT << "HAHA 4" << ENDL();
-    // section 3: full images
-    for (uint32_t n = 0; n < full_nimages; ++ n) {
-        for (int32_t i = 0; i < in_h; ++ i) {
-            for (int32_t j = 0; j < in_w; ++ j) {
-                reader_indices_ptr[reader_i ++] = top_left_i ++;
-            }
-            // skip pad
-            top_left_i += 2 * pad_w;
-        }
-        // skip pad rows
-        top_left_i += full_images_skip;
-    }
+    DPRINT << "local_in_stick_start: " << (uint) local_in_stick_start << ENDL();
 
-    // DPRINT << "HAHA 5" << ENDL();
-    // section 4: partial last image
-    for (uint32_t i = 0; i < partial_bottom_image_nrows; ++ i) {
-        for (int32_t j = 0; j < in_w; ++ j) {
-            reader_indices_ptr[reader_i ++] = top_left_i ++;
-        }
-        // skip pad
-        top_left_i += 2 * pad_w;
-    }
+    DPRINT << "initial_skip: " << (uint) initial_skip << ENDL();
+    DPRINT << "start_stick: " << (uint) start_stick << ENDL();
+    DPRINT << "partial_first_row_nsticks: " << (uint) partial_first_row_nsticks << ENDL();
+    DPRINT << "partial_first_row_skip: " << (uint) partial_first_row_skip << ENDL();
+    DPRINT << "partial_top_image_nrows: " << (uint) partial_top_image_nrows << ENDL();
+    DPRINT << "partial_top_image_skip: " << (uint) partial_top_image_skip << ENDL();
+    DPRINT << "full_nimages: " << (uint) full_nimages << ENDL();
+    DPRINT << "full_nimages_skip: " << (uint) full_images_skip << ENDL();
+    DPRINT << "partial_bottom_image_nrows: " << (uint) partial_bottom_image_nrows << ENDL();
+    DPRINT << "partial_last_row_nsticks: " << (uint) partial_last_row_nsticks << ENDL();
+    DPRINT << "TOTAL nsticks = " << (uint) partial_first_row_nsticks + partial_top_image_nrows * in_w + full_nimages * in_w * in_h + partial_bottom_image_nrows * in_w + partial_last_row_nsticks << ENDL();
 
-    // DPRINT << "HAHA 6" << ENDL();
-    // section 5: partial last row
-    for (uint32_t i = 0; i < partial_last_row_nsticks; ++ i) {
-        reader_indices_ptr[reader_i ++] = top_left_i ++;
-    }
+    // // section 0: initial skip
+    // uint32_t top_left_i = initial_skip;
+    // uint32_t reader_i = 0;
+
+    // // section 1: partial first row
+    // for (int32_t i = 0; i < partial_first_row_nsticks; ++ i) {
+    //     reader_indices_ptr[reader_i ++] = top_left_i ++;
+    // }
+    // top_left_i += partial_first_row_skip;
+
+    // // section 2: partial first image
+    // for (int32_t i = 0; i < partial_top_image_nrows; ++ i) {
+    //     for (int32_t j = 0; j < in_w; ++ j) {
+    //         reader_indices_ptr[reader_i ++] = top_left_i ++;
+    //     }
+    //     // skip pad per row
+    //     top_left_i += 2 * pad_w;
+    // }
+    // top_left_i += partial_top_image_skip;
+
+    // // section 3: full images
+    // for (int32_t n = 0; n < full_nimages; ++ n) {
+    //     for (int32_t i = 0; i < in_h; ++ i) {
+    //         for (int32_t j = 0; j < in_w; ++ j) {
+    //             reader_indices_ptr[reader_i ++] = top_left_i ++;
+    //         }
+    //         // skip pad per row
+    //         top_left_i += 2 * pad_w;
+    //     }
+    //     // skip pad rows per image
+    //     top_left_i += full_images_skip;
+    // }
+
+    // // section 4: partial last image
+    // for (int32_t i = 0; i < partial_bottom_image_nrows; ++ i) {
+    //     for (int32_t j = 0; j < in_w; ++ j) {
+    //         reader_indices_ptr[reader_i ++] = top_left_i ++;
+    //     }
+    //     // skip pad per row
+    //     top_left_i += 2 * pad_w;
+    // }
+
+    // // section 5: partial last row
+    // for (int32_t i = 0; i < partial_last_row_nsticks; ++ i) {
+    //     reader_indices_ptr[reader_i ++] = top_left_i ++;
+    // }
 
     // DPRINT << "nsticks_per_core = " << nsticks_per_core << ENDL();
     // DPRINT << "reader_i = " << reader_i << ENDL();
     // for (uint32_t i = 0; i < reader_i; ++ i) {
-    //     DPRINT << reader_indices_ptr[i] << ENDL();
+    //     DPRINT << i << ": " << reader_indices_ptr[i] << ENDL();
     // }
 
-    uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
+    uint32_t batch_offset = 0;
     for (uint32_t out_stick_i = 0; out_stick_i < nsticks_per_core; ++ out_stick_i) {
         cb_reserve_back(in_cb_id, 1);
-        uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
+        uint32_t out_l1_write_addr_base = get_write_ptr(in_cb_id);
+        uint32_t out_l1_write_addr = out_l1_write_addr_base;
 
         uint32_t global_out_stick_i = local_out_stick_start + out_stick_i;
+        uint32_t batch_i = global_out_stick_i / nsticks_per_batch;
         uint32_t batch_out_stick_i = global_out_stick_i % nsticks_per_batch;
-        int32_t out_h_i = batch_out_stick_i / out_w;
         int32_t out_w_i = batch_out_stick_i % out_w;
-        // int32_t start_h = ((int32_t) stride_h) * out_h_i - pad_h;
-        // int32_t start_w = ((int32_t) stride_w) * out_w_i - pad_w;
-        int32_t center_h = ((int32_t) stride_h) * out_h_i - pad_h + window_h / 2;
-        int32_t center_w = ((int32_t) stride_w) * out_w_i - pad_w + window_w / 2;
-        int32_t reader_center_i = (center_h + window_h / 2) * (in_w + 2 * pad_w) + (center_w + window_w / 2);
+        int32_t out_h_i = batch_out_stick_i / out_w;
+        DPRINT << "out_stick_i = " << out_stick_i << " :: " << (uint) out_w_i << "," << (uint) out_h_i << ENDL();
 
-        uint32_t reader_i = reader_center_i - (window_h / 2 * (in_w + 2 * pad_w) + window_w / 2);
+        int32_t in_center_w = ((int32_t) stride_w) * out_w_i - pad_w + window_w / 2;
+        int32_t in_center_h = ((int32_t) stride_h) * out_h_i - pad_h + window_h / 2;
+        DPRINT << "center: = " << (uint) in_center_w << "," << (uint) in_center_h << ENDL();
 
-        DPRINT << "out_stick_i = " << out_stick_i << " :: " << (uint) out_h_i << "," << (uint) out_w_i << ENDL();
-        DPRINT << "reader_i: ";
+        if (batch_out_stick_i == 0 && out_stick_i > 0 && local_out_stick_start > 0) {
+            // this is start of a new batch, update offsets
+            batch_offset += ((in_w + 2 * pad_w) * (in_h + pad_h));
+        }
 
-        uint32_t reader_offset = 0;
+        int32_t top_left_local_index = initial_skip + batch_offset + (in_center_w - window_w / 2) + (in_center_h - window_h / 2) * (in_w + 2 * pad_w) - start_stick;
+        DPRINT << "top_left_index: " << (uint) top_left_local_index << ENDL();
+
+        DPRINT << "sticks: ";
         for (uint32_t h = 0; h < window_h; ++ h) {
             for (uint32_t w = 0; w < window_w; ++ w) {
-                DPRINT << reader_i + reader_offset + w << " ";
-                uint32_t l1_offset = reader_indices_ptr[reader_i + reader_offset + w] << in_nbytes_c_log2;  // multiply by stick size for offset
+                uint32_t stick_offset = top_left_local_index + (w + h * (in_w + 2 * pad_w));
+                DPRINT << stick_offset << " ";
+                uint32_t l1_offset = stick_offset * in_nbytes_c;
                 noc_async_read(get_noc_addr(in_l1_read_base_addr + l1_offset), out_l1_write_addr, in_nbytes_c);
                 out_l1_write_addr += in_nbytes_c;
             }
-            reader_offset += in_w + 2 * pad_w;
         }
         DPRINT << ENDL();
 
         noc_async_read_barrier();
 
-        DPRINT << TileSlice(in_cb_id, 0, srt, true, false) << ENDL();
+        // DPRINT << TileSlice(in_cb_id, 0, srt, true, false) << ENDL();
+        // print_pages(out_l1_write_addr_base, 64, 10, 0);
 
         cb_push_back(in_cb_id, 1);
     }

--- a/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
+++ b/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
@@ -247,9 +247,9 @@ void kernel_main() {
         reader_indices_ptr[reader_i ++] = top_left_i;
         top_left_i += in_skip_after_each_stick;
     }
-    if (partial_first_row_nsticks > 0) {
+    // if (partial_first_row_nsticks > 0) {
         top_left_i += in_skip_after_partial_right_aligned_row;  // 2 * pad_w + (stride_h - 1) * in_w_padded;
-    }
+    // }
 
     // section 2: partial first image
     for (int32_t i = 0; i < partial_top_image_nrows; ++ i) {
@@ -260,9 +260,9 @@ void kernel_main() {
         // skip pad per row
         top_left_i += in_skip_after_each_full_row; // 2 * pad_w + (stride_h - 1) * in_w_padded;
     }
-    if (partial_top_image_nrows > 0) {
+    // if (partial_top_image_nrows > 0) {
         top_left_i += in_skip_after_first_partial_image_row; // pad_h * in_w_padded;
-    }
+    // }
 
     // section 3: full images
     for (int32_t n = 0; n < full_nimages; ++ n) {

--- a/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
+++ b/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
@@ -206,7 +206,6 @@ void kernel_main() {
 
     // print_pages(in_l1_read_base_addr, 64, 13 * 114, 0);
 
-    // DPRINT << "local_in_stick_start: " << (uint) local_in_stick_start << ENDL();
     // DPRINT << "initial_skip: " << (uint) initial_skip << ENDL();
     // DPRINT << "start_stick: " << (uint) start_stick << ENDL();
     // DPRINT << "partial_first_row_nsticks: " << (uint) partial_first_row_nsticks << ENDL();
@@ -219,8 +218,19 @@ void kernel_main() {
     // DPRINT << "partial_last_row_nsticks: " << (uint) partial_last_row_nsticks << ENDL();
     // DPRINT << "TOTAL nsticks = " << (uint) partial_first_row_nsticks + partial_top_image_nrows * in_w + full_nimages * in_w * in_h + partial_bottom_image_nrows * in_w + partial_last_row_nsticks << ENDL();
 
+    // DPRINT << "initial_skip: " << (uint) in_initial_skip << ENDL();
+    // DPRINT << "start_stick: " << (uint) in_start_stick << ENDL();
+    // DPRINT << "partial_first_row_nsticks: " << (uint) in_first_partial_right_aligned_row_width << ENDL();
+    // DPRINT << "partial_first_row_skip: " << (uint) in_skip_after_partial_right_aligned_row << ENDL();
+    // DPRINT << "partial_top_image_nrows: " << (uint) in_first_partial_image_num_rows << ENDL();
+    // DPRINT << "partial_top_image_skip: " << (uint) in_skip_after_first_partial_image_row << ENDL();
+    // DPRINT << "full_nimages: " << (uint) in_num_full_images << ENDL();
+    // DPRINT << "full_nimages_skip: " << (uint) in_skip_after_full_image << ENDL();
+    // DPRINT << "partial_bottom_image_nrows: " << (uint) in_last_partial_image_num_rows << ENDL();
+    // DPRINT << "partial_last_row_nsticks: " << (uint) in_last_partial_left_aligned_row_width << ENDL();
+
     // // section 0: initial skip
-    uint32_t top_left_i = 0;
+    uint32_t top_left_i = in_initial_skip;
     uint32_t reader_i = 0;
 
     uint32_t in_w_padded = in_w + 2 * pad_w;
@@ -284,30 +294,10 @@ void kernel_main() {
         top_left_i += stride_w;
     }
 
-
-    // uint32_t batch_offset = 0;
-    // for (uint32_t out_stick_i = 0; out_stick_i < nsticks_per_core; ++ out_stick_i) {
-    //     uint32_t global_out_stick_i = local_out_stick_start + out_stick_i;
-    //     uint32_t batch_i = global_out_stick_i / nsticks_per_batch;
-    //     uint32_t batch_out_stick_i = global_out_stick_i % nsticks_per_batch;
-    //     int32_t out_w_i = batch_out_stick_i % out_w;
-    //     int32_t out_h_i = batch_out_stick_i / out_w;
-    //     // DPRINT << "out_stick_i = " << out_stick_i << " :: " << (uint) out_w_i << "," << (uint) out_h_i << ENDL();
-    //     int32_t in_center_w = ((int32_t) stride_w) * out_w_i - pad_w + (window_w >> 1);
-    //     int32_t in_center_h = ((int32_t) stride_h) * out_h_i - pad_h + (window_h >> 1);
-    //     // DPRINT << "center: = " << (uint) in_center_w << "," << (uint) in_center_h << ENDL();
-    //     if (batch_out_stick_i == 0 && out_stick_i > 0 && local_out_stick_start > 0) {
-    //         // this is start of a new batch, update offsets
-    //         batch_offset += in_w_padded * (in_h + pad_h);
-    //     }
-    //     int32_t top_left_local_index = initial_skip + batch_offset + (in_center_w - (window_w >> 1)) + (in_center_h - (window_h >> 1)) * (in_w_padded) - start_stick;
-    //     reader_indices_ptr[reader_i ++] = top_left_local_index;
+    // DPRINT << "reader_i = " << reader_i << ENDL();
+    // for (uint32_t i = 0; i < reader_i; ++ i) {
+    //     DPRINT << i << ": " << reader_indices_ptr[i] << ENDL();
     // }
-
-    DPRINT << "reader_i = " << reader_i << ENDL();
-    for (uint32_t i = 0; i < reader_i; ++ i) {
-        DPRINT << i << ": " << reader_indices_ptr[i] << ENDL();
-    }
 
     uint32_t counter = 0;
     while (counter < reader_i) {

--- a/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
+++ b/tt_metal/kernels/dataflow/reader_max_pool_2d_multi_core_sharded_with_halo.cpp
@@ -56,13 +56,13 @@ inline bool fill_with_val_async(const InterleavedPow2AddrGenFast<false>& s_const
  */
 void kernel_main() {
     // input tensor address
-    const uint32_t in_addr = get_arg_val<uint32_t>(0);
+    // const uint32_t in_addr = get_arg_val<uint32_t>(0);
 
     const uint32_t window_h = get_arg_val<uint32_t>(2);
     const uint32_t window_w = get_arg_val<uint32_t>(3);
-    const int32_t window_hw = get_arg_val<int32_t>(4);
+    // const int32_t window_hw = get_arg_val<int32_t>(4);
     // window_hw_padded = window_hw rounded up to the tile size (can be multiple tiles)
-    const uint32_t window_hw_padded = get_arg_val<uint32_t>(5);
+    // const uint32_t window_hw_padded = get_arg_val<uint32_t>(5);
 
     const int32_t pad_h = get_arg_val<int32_t>(8);
     const int32_t pad_w = get_arg_val<int32_t>(9);
@@ -76,40 +76,40 @@ void kernel_main() {
     // input tensor height / width / channels
     const int32_t in_h = get_arg_val<int32_t>(16);
     const int32_t in_w = get_arg_val<int32_t>(17);
-    const int32_t in_c = get_arg_val<int32_t>(19);
+    // const int32_t in_c = get_arg_val<int32_t>(19);
 
-    const int32_t in_cb_pagesize = get_arg_val<int32_t>(22);
+    // const int32_t in_cb_pagesize = get_arg_val<int32_t>(22);
     // product of window_hw_padded and in_c padded to the tile size (can be multiple tiles)
-    const int32_t in_cb_page_nelems_padded = get_arg_val<int32_t>(24);
+    // const int32_t in_cb_page_nelems_padded = get_arg_val<int32_t>(24);
 
     // out_w divided by number of out_nelems (== number of blocks per iteration)
-    const int32_t out_w_loop_count = get_arg_val<int32_t>(25);
+    // const int32_t out_w_loop_count = get_arg_val<int32_t>(25);
     const uint32_t in_log_base_2_of_page_size = get_arg_val<uint32_t>(26);
 
-    const uint32_t nbatch = get_arg_val<uint32_t>(27);
+    // const uint32_t nbatch = get_arg_val<uint32_t>(27);
 
-    const uint32_t in_hw = get_arg_val<uint32_t>(28);
+    // const uint32_t in_hw = get_arg_val<uint32_t>(28);
 
     const uint32_t minus_inf_buffer_addr = get_arg_val<uint32_t>(34);
-    const uint32_t minus_inf_buffer_nbytes = get_arg_val<uint32_t>(35);
+    // const uint32_t minus_inf_buffer_nbytes = get_arg_val<uint32_t>(35);
     const uint32_t in_cb_nsticks = get_arg_val<uint32_t>(36);
 
     // the starting offset for assigned batch input row id (batch_offset)
-    uint32_t core_offset_in_stick_id = get_arg_val<uint32_t>(37);
+    // uint32_t core_offset_in_stick_id = get_arg_val<uint32_t>(37);
 
     // compile time args
-    constexpr bool is_in_dram = get_compile_time_arg_val(0) == 1;
+    // constexpr bool is_in_dram = get_compile_time_arg_val(0) == 1;
     // value of 1 in bf16 in a uin32_t
     constexpr uint32_t bf16_one_u32 = get_compile_time_arg_val(2);
     // number of output elements per iteration == number of blocks per iteration
-    constexpr uint32_t out_nelems = get_compile_time_arg_val(3);
-    constexpr bool use_pow2 = get_compile_time_arg_val(4) == 1;
+    // constexpr uint32_t out_nelems = get_compile_time_arg_val(3);
+    // constexpr bool use_pow2 = get_compile_time_arg_val(4) == 1;
 
     constexpr uint32_t stride_h = get_compile_time_arg_val(5);
     constexpr uint32_t stride_w = get_compile_time_arg_val(6);
 
-    constexpr uint32_t reader_noc = get_compile_time_arg_val(7);
-    constexpr uint32_t writer_noc = get_compile_time_arg_val(8);
+    // constexpr uint32_t reader_noc = get_compile_time_arg_val(7);
+    // constexpr uint32_t writer_noc = get_compile_time_arg_val(8);
 
     constexpr uint32_t in_cb_id = tt::CB::c_in0;
     constexpr uint32_t in_scalar_cb_id = tt::CB::c_in1;
@@ -141,42 +141,42 @@ void kernel_main() {
 
     // DPRINT << "HAHA 1" << ENDL();
 
-    uint32_t core_out_w_i_start = get_arg_val<int32_t>(38);
-    uint32_t core_out_h_i_start = get_arg_val<int32_t>(39);
+    // uint32_t core_out_w_i_start = get_arg_val<int32_t>(38);
+    // uint32_t core_out_h_i_start = get_arg_val<int32_t>(39);
     uint32_t nsticks_per_core = get_arg_val<uint32_t>(40);
 
-    uint32_t nsticks_per_core_by_nblocks = get_arg_val<uint32_t>(42);
+    // uint32_t nsticks_per_core_by_nblocks = get_arg_val<uint32_t>(42);
 
     uint32_t local_out_stick_start = get_arg_val<uint32_t>(43);
     uint32_t nsticks_per_batch = get_arg_val<uint32_t>(44);
-    uint32_t local_in_stick_start = get_arg_val<uint32_t>(45);
-    uint32_t local_in_stick_end = get_arg_val<uint32_t>(46);
-    uint32_t in_nsticks_per_batch = get_arg_val<uint32_t>(47);
-    uint32_t in_nsticks_per_core = get_arg_val<uint32_t>(48);
+    // uint32_t local_in_stick_start = get_arg_val<uint32_t>(45);
+    // uint32_t local_in_stick_end = get_arg_val<uint32_t>(46);
+    // uint32_t in_nsticks_per_batch = get_arg_val<uint32_t>(47);
+    // uint32_t in_nsticks_per_core = get_arg_val<uint32_t>(48);
 
-    uint32_t has_left = get_arg_val<uint32_t>(49);
-    uint32_t left_noc_x = get_arg_val<uint32_t>(50);
-    uint32_t left_noc_y = get_arg_val<uint32_t>(51);
-    uint32_t has_right = get_arg_val<uint32_t>(52);
-    uint32_t right_noc_x = get_arg_val<uint32_t>(53);
-    uint32_t right_noc_y = get_arg_val<uint32_t>(54);
+    // uint32_t has_left = get_arg_val<uint32_t>(49);
+    // uint32_t left_noc_x = get_arg_val<uint32_t>(50);
+    // uint32_t left_noc_y = get_arg_val<uint32_t>(51);
+    // uint32_t has_right = get_arg_val<uint32_t>(52);
+    // uint32_t right_noc_x = get_arg_val<uint32_t>(53);
+    // uint32_t right_noc_y = get_arg_val<uint32_t>(54);
 
     // TODO: pass these as runtime args
     uint32_t in_nbytes_c_log2 = 7;  // for in_nbytes_c == 128
     // for in_nsticks_per_core == 1024, remainder mask = 0x3ff
     // uint32_t in_nsticks_per_core_rem_mask = 0x3ff;
-    uint32_t in_nsticks_per_core_rem_mask = get_arg_val<uint32_t>(55);
+    // uint32_t in_nsticks_per_core_rem_mask = get_arg_val<uint32_t>(55);
 
-    uint32_t has_left_left = get_arg_val<uint32_t>(56);
-    uint32_t left_left_noc_x = get_arg_val<uint32_t>(57);
-    uint32_t left_left_noc_y = get_arg_val<uint32_t>(58);
-    uint32_t has_right_right = get_arg_val<uint32_t>(59);
-    uint32_t right_right_noc_x = get_arg_val<uint32_t>(60);
-    uint32_t right_right_noc_y = get_arg_val<uint32_t>(61);
-    uint32_t left_in_stick_start = get_arg_val<uint32_t>(62);
-    uint32_t right_in_stick_end = get_arg_val<uint32_t>(63);
+    // uint32_t has_left_left = get_arg_val<uint32_t>(56);
+    // uint32_t left_left_noc_x = get_arg_val<uint32_t>(57);
+    // uint32_t left_left_noc_y = get_arg_val<uint32_t>(58);
+    // uint32_t has_right_right = get_arg_val<uint32_t>(59);
+    // uint32_t right_right_noc_x = get_arg_val<uint32_t>(60);
+    // uint32_t right_right_noc_y = get_arg_val<uint32_t>(61);
+    // uint32_t left_in_stick_start = get_arg_val<uint32_t>(62);
+    // uint32_t right_in_stick_end = get_arg_val<uint32_t>(63);
 
-    int32_t my_core = get_arg_val<int32_t>(64);
+    // int32_t my_core = get_arg_val<int32_t>(64);
 
     int32_t initial_skip = get_arg_val<int32_t>(65);
     int32_t partial_first_row_nsticks = get_arg_val<int32_t>(66);
@@ -189,135 +189,142 @@ void kernel_main() {
     int32_t partial_last_row_nsticks = get_arg_val<int32_t>(73);
     int32_t start_stick = get_arg_val<int32_t>(74);
 
-    volatile tt_l1_ptr uint32_t* reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(reader_indices_cb_id));
-
-    // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 0, .h1 = 1, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
-    // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 1, .h1 = 2, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
-    // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 2, .h1 = 3, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
-    // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 3, .h1 = 4, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
-    // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 4, .h1 = 5, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
-    // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 5, .h1 = 6, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
-    // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 6, .h1 = 7, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
-    // DPRINT << TileSlice(in_shard_cb_id, 0, SliceRange{ .h0 = 7, .h1 = 8, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 }, true, false) << ENDL();
+    int32_t in_start_stick = get_arg_val<int32_t>(75);
+    int32_t in_first_partial_right_aligned_row_width = get_arg_val<int32_t>(76);
+    int32_t in_first_partial_image_num_rows = get_arg_val<int32_t>(77);
+    int32_t in_num_full_images = get_arg_val<int32_t>(78);
+    int32_t in_last_partial_image_num_rows = get_arg_val<int32_t>(79);
+    int32_t in_last_partial_left_aligned_row_width = get_arg_val<int32_t>(80);
+    int32_t in_initial_skip = get_arg_val<int32_t>(81);
+    int32_t in_skip_after_stick = get_arg_val<int32_t>(82);
+    int32_t in_skip_after_partial_right_aligned_row = get_arg_val<int32_t>(83);
+    int32_t in_skip_after_first_partial_image_row = get_arg_val<int32_t>(84);
+    int32_t in_skip_after_full_image = get_arg_val<int32_t>(85);
 
     uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
+    volatile tt_l1_ptr uint32_t* reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(reader_indices_cb_id));
 
     // print_pages(in_l1_read_base_addr, 64, 13 * 114, 0);
 
-    DPRINT << "local_in_stick_start: " << (uint) local_in_stick_start << ENDL();
-
-    DPRINT << "initial_skip: " << (uint) initial_skip << ENDL();
-    DPRINT << "start_stick: " << (uint) start_stick << ENDL();
-    DPRINT << "partial_first_row_nsticks: " << (uint) partial_first_row_nsticks << ENDL();
-    DPRINT << "partial_first_row_skip: " << (uint) partial_first_row_skip << ENDL();
-    DPRINT << "partial_top_image_nrows: " << (uint) partial_top_image_nrows << ENDL();
-    DPRINT << "partial_top_image_skip: " << (uint) partial_top_image_skip << ENDL();
-    DPRINT << "full_nimages: " << (uint) full_nimages << ENDL();
-    DPRINT << "full_nimages_skip: " << (uint) full_images_skip << ENDL();
-    DPRINT << "partial_bottom_image_nrows: " << (uint) partial_bottom_image_nrows << ENDL();
-    DPRINT << "partial_last_row_nsticks: " << (uint) partial_last_row_nsticks << ENDL();
-    DPRINT << "TOTAL nsticks = " << (uint) partial_first_row_nsticks + partial_top_image_nrows * in_w + full_nimages * in_w * in_h + partial_bottom_image_nrows * in_w + partial_last_row_nsticks << ENDL();
+    // DPRINT << "local_in_stick_start: " << (uint) local_in_stick_start << ENDL();
+    // DPRINT << "initial_skip: " << (uint) initial_skip << ENDL();
+    // DPRINT << "start_stick: " << (uint) start_stick << ENDL();
+    // DPRINT << "partial_first_row_nsticks: " << (uint) partial_first_row_nsticks << ENDL();
+    // DPRINT << "partial_first_row_skip: " << (uint) partial_first_row_skip << ENDL();
+    // DPRINT << "partial_top_image_nrows: " << (uint) partial_top_image_nrows << ENDL();
+    // DPRINT << "partial_top_image_skip: " << (uint) partial_top_image_skip << ENDL();
+    // DPRINT << "full_nimages: " << (uint) full_nimages << ENDL();
+    // DPRINT << "full_nimages_skip: " << (uint) full_images_skip << ENDL();
+    // DPRINT << "partial_bottom_image_nrows: " << (uint) partial_bottom_image_nrows << ENDL();
+    // DPRINT << "partial_last_row_nsticks: " << (uint) partial_last_row_nsticks << ENDL();
+    // DPRINT << "TOTAL nsticks = " << (uint) partial_first_row_nsticks + partial_top_image_nrows * in_w + full_nimages * in_w * in_h + partial_bottom_image_nrows * in_w + partial_last_row_nsticks << ENDL();
 
     // // section 0: initial skip
-    // uint32_t top_left_i = initial_skip;
+    uint32_t top_left_i = 0;
     uint32_t reader_i = 0;
 
-    // // section 1: partial first row
-    // for (int32_t i = 0; i < partial_first_row_nsticks; ++ i) {
-    //     reader_indices_ptr[reader_i ++] = top_left_i ++;
-    // }
+    uint32_t in_w_padded = in_w + 2 * pad_w;
+    // input index offsets:
+    //  between each stick = stride_w
+    //  between each row = + 2 * pad_w + (stride_h - 1) * row_size_padded
+    //  between each batch = + pad_h * row_size_padded
+
+    // section 1: partial first row
+    for (int32_t i = 0; i < partial_first_row_nsticks; ++ i) {
+        reader_indices_ptr[reader_i ++] = top_left_i;
+        top_left_i += stride_w;
+    }
     // top_left_i += partial_first_row_skip;
-
-    // // section 2: partial first image
-    // for (int32_t i = 0; i < partial_top_image_nrows; ++ i) {
-    //     for (int32_t j = 0; j < in_w; ++ j) {
-    //         reader_indices_ptr[reader_i ++] = top_left_i ++;
-    //     }
-    //     // skip pad per row
-    //     top_left_i += 2 * pad_w;
-    // }
-    // top_left_i += partial_top_image_skip;
-
-    // // section 3: full images
-    // for (int32_t n = 0; n < full_nimages; ++ n) {
-    //     for (int32_t i = 0; i < in_h; ++ i) {
-    //         for (int32_t j = 0; j < in_w; ++ j) {
-    //             reader_indices_ptr[reader_i ++] = top_left_i ++;
-    //         }
-    //         // skip pad per row
-    //         top_left_i += 2 * pad_w;
-    //     }
-    //     // skip pad rows per image
-    //     top_left_i += full_images_skip;
-    // }
-
-    // // section 4: partial last image
-    // for (int32_t i = 0; i < partial_bottom_image_nrows; ++ i) {
-    //     for (int32_t j = 0; j < in_w; ++ j) {
-    //         reader_indices_ptr[reader_i ++] = top_left_i ++;
-    //     }
-    //     // skip pad per row
-    //     top_left_i += 2 * pad_w;
-    // }
-
-    // // section 5: partial last row
-    // for (int32_t i = 0; i < partial_last_row_nsticks; ++ i) {
-    //     reader_indices_ptr[reader_i ++] = top_left_i ++;
-    // }
-
-    // DPRINT << "nsticks_per_core = " << nsticks_per_core << ENDL();
-
-    uint32_t batch_offset = 0;
-    for (uint32_t out_stick_i = 0; out_stick_i < nsticks_per_core; ++ out_stick_i) {
-        uint32_t global_out_stick_i = local_out_stick_start + out_stick_i;
-        uint32_t batch_i = global_out_stick_i / nsticks_per_batch;
-        uint32_t batch_out_stick_i = global_out_stick_i % nsticks_per_batch;
-        int32_t out_w_i = batch_out_stick_i % out_w;
-        int32_t out_h_i = batch_out_stick_i / out_w;
-        // DPRINT << "out_stick_i = " << out_stick_i << " :: " << (uint) out_w_i << "," << (uint) out_h_i << ENDL();
-
-        int32_t in_center_w = ((int32_t) stride_w) * out_w_i - pad_w + window_w / 2;
-        int32_t in_center_h = ((int32_t) stride_h) * out_h_i - pad_h + window_h / 2;
-        // DPRINT << "center: = " << (uint) in_center_w << "," << (uint) in_center_h << ENDL();
-
-        if (batch_out_stick_i == 0 && out_stick_i > 0 && local_out_stick_start > 0) {
-            // this is start of a new batch, update offsets
-            batch_offset += ((in_w + 2 * pad_w) * (in_h + pad_h));
-        }
-
-        int32_t top_left_local_index = initial_skip + batch_offset + (in_center_w - window_w / 2) + (in_center_h - window_h / 2) * (in_w + 2 * pad_w) - start_stick;
-        // DPRINT << "top_left_index: " << (uint) top_left_local_index << ENDL();
-
-        // DPRINT << "sticks: ";
-        for (uint32_t h = 0; h < window_h; ++ h) {
-            for (uint32_t w = 0; w < window_w; ++ w) {
-                uint32_t stick_offset = top_left_local_index + (w + h * (in_w + 2 * pad_w));
-                // DPRINT << stick_offset << " ";
-                uint32_t l1_offset = stick_offset * in_nbytes_c;
-                reader_indices_ptr[reader_i ++] = l1_offset;
-            }
-        }
-        // DPRINT << TileSlice(in_cb_id, 0, srt, true, false) << ENDL();
-        // print_pages(out_l1_write_addr_base, 64, 10, 0);
+    if (partial_first_row_nsticks > 0) {
+        top_left_i += 2 * pad_w + (stride_h - 1) * in_w_padded;
     }
 
-    // DPRINT << "reader_i = " << reader_i << ENDL();
-    // for (uint32_t i = 0; i < reader_i; ++ i) {
-    //     DPRINT << i << ": " << reader_indices_ptr[i] << ENDL();
+    // section 2: partial first image
+    for (int32_t i = 0; i < partial_top_image_nrows; ++ i) {
+        for (int32_t j = 0; j < out_w; ++ j) {
+            reader_indices_ptr[reader_i ++] = top_left_i;
+            top_left_i += stride_w;
+        }
+        // skip pad per row
+        top_left_i += 2 * pad_w + (stride_h - 1) * in_w_padded;
+    }
+    // top_left_i += partial_top_image_skip;
+    if (partial_top_image_nrows > 0) {
+        top_left_i += pad_h * in_w_padded;
+    }
+
+    // section 3: full images
+    for (int32_t n = 0; n < full_nimages; ++ n) {
+        for (int32_t i = 0; i < out_h; ++ i) {
+            for (int32_t j = 0; j < out_w; ++ j) {
+                reader_indices_ptr[reader_i ++] = top_left_i;
+                top_left_i += stride_w;
+            }
+            // skip pad per row
+            top_left_i += 2 * pad_w + (stride_h - 1) * in_w_padded;
+        }
+        // skip pad rows per image
+        // top_left_i += full_images_skip;
+        top_left_i += pad_h * in_w_padded;
+    }
+
+    // section 4: partial last image
+    for (int32_t i = 0; i < partial_bottom_image_nrows; ++ i) {
+        for (int32_t j = 0; j < out_w; ++ j) {
+            reader_indices_ptr[reader_i ++] = top_left_i;
+            top_left_i += stride_w;
+        }
+        // skip pad per row
+        top_left_i += 2 * pad_w + (stride_h - 1) * in_w_padded;
+    }
+
+    // section 5: partial last row
+    for (int32_t i = 0; i < partial_last_row_nsticks; ++ i) {
+        reader_indices_ptr[reader_i ++] = top_left_i;
+        top_left_i += stride_w;
+    }
+
+
+    // uint32_t batch_offset = 0;
+    // for (uint32_t out_stick_i = 0; out_stick_i < nsticks_per_core; ++ out_stick_i) {
+    //     uint32_t global_out_stick_i = local_out_stick_start + out_stick_i;
+    //     uint32_t batch_i = global_out_stick_i / nsticks_per_batch;
+    //     uint32_t batch_out_stick_i = global_out_stick_i % nsticks_per_batch;
+    //     int32_t out_w_i = batch_out_stick_i % out_w;
+    //     int32_t out_h_i = batch_out_stick_i / out_w;
+    //     // DPRINT << "out_stick_i = " << out_stick_i << " :: " << (uint) out_w_i << "," << (uint) out_h_i << ENDL();
+    //     int32_t in_center_w = ((int32_t) stride_w) * out_w_i - pad_w + (window_w >> 1);
+    //     int32_t in_center_h = ((int32_t) stride_h) * out_h_i - pad_h + (window_h >> 1);
+    //     // DPRINT << "center: = " << (uint) in_center_w << "," << (uint) in_center_h << ENDL();
+    //     if (batch_out_stick_i == 0 && out_stick_i > 0 && local_out_stick_start > 0) {
+    //         // this is start of a new batch, update offsets
+    //         batch_offset += in_w_padded * (in_h + pad_h);
+    //     }
+    //     int32_t top_left_local_index = initial_skip + batch_offset + (in_center_w - (window_w >> 1)) + (in_center_h - (window_h >> 1)) * (in_w_padded) - start_stick;
+    //     reader_indices_ptr[reader_i ++] = top_left_local_index;
     // }
+
+    DPRINT << "reader_i = " << reader_i << ENDL();
+    for (uint32_t i = 0; i < reader_i; ++ i) {
+        DPRINT << i << ": " << reader_indices_ptr[i] << ENDL();
+    }
 
     uint32_t counter = 0;
     while (counter < reader_i) {
         cb_reserve_back(in_cb_id, 1);
         uint32_t out_l1_write_addr_base = get_write_ptr(in_cb_id);
         uint32_t out_l1_write_addr = out_l1_write_addr_base;
-        for (uint32_t h = 0; h < window_h; ++ h) {
+        int32_t top_left_local_index = reader_indices_ptr[counter ++];
+        uint32_t h_multiples = 0;
+        for (uint32_t h = 0; h < window_h; ++ h, h_multiples += in_w_padded) {
             for (uint32_t w = 0; w < window_w; ++ w) {
-                uint32_t read_offset = in_l1_read_base_addr + reader_indices_ptr[counter ++];
+                uint32_t stick_offset = top_left_local_index + (w + h_multiples);
+                uint32_t read_offset = in_l1_read_base_addr + (stick_offset << in_nbytes_c_log2);
                 noc_async_read(get_noc_addr(read_offset), out_l1_write_addr, in_nbytes_c);
                 out_l1_write_addr += in_nbytes_c;
             }
         }
+        // print_pages(out_l1_write_addr_base, 64, 10, 0);
         noc_async_read_barrier();
         cb_push_back(in_cb_id, 1);
     }

--- a/tt_metal/kernels/dataflow/writer_unary_sharded_with_halo.cpp
+++ b/tt_metal/kernels/dataflow/writer_unary_sharded_with_halo.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
     constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(3);   // pad value to fill pad buffer with
     constexpr uint32_t pad_stick_len  = get_compile_time_arg_val(4);   // stick size (size of the pad val buffer)
 
-    const uint16_t pad_val = pad_val_u32 >> 16;
+    const uint16_t pad_val = pad_val_u32;   // >> 16;
 
     cb_reserve_back(pad_cb_id, 1);
     fill_with_val(get_write_ptr(pad_cb_id), pad_stick_len, pad_val);

--- a/tt_metal/kernels/dataflow/writer_unary_sharded_with_halo_s2.cpp
+++ b/tt_metal/kernels/dataflow/writer_unary_sharded_with_halo_s2.cpp
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+#include "debug_print.h"
+
+SliceRange srr = SliceRange{ .h0 = 0, .h1 = 1, .hs = 8, .w0 = 0, .w1 = 32, .ws = 1 };
+SliceRange srt = SliceRange{ .h0 = 0, .h1 = 8, .hs = 1, .w0 = 0, .w1 = 4, .ws = 1 };
+
+inline void print_sticks(uint32_t l1_addr, uint32_t stick_start, uint32_t nsticks, uint32_t stick_size = 64) {
+    for (uint32_t i = stick_start; i < stick_start + nsticks; ++ i) {
+        volatile tt_l1_ptr uint16_t* l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_addr + i * stick_size * 2);
+        DPRINT << i << ": ";
+        for (uint32_t j = 0; j < stick_size; ++ j) {
+            DPRINT << BF16(l1_ptr[j]) << " ";
+        }
+        DPRINT << ENDL();
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(0);  // has input shard
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(1); // has output shard with padding and halo
+
+    // for this core's local shard
+    uint32_t in_nsticks = get_arg_val<uint32_t>(0);
+    // uint32_t out_nsticks = get_arg_val<uint32_t>(1);
+
+    // uint32_t partial_first_row_nsticks = get_arg_val<uint32_t>(2);
+    uint32_t pad_w = get_arg_val<uint32_t>(3);
+    uint32_t in_w = get_arg_val<uint32_t>(4);
+    // uint32_t partial_top_image_nrows = get_arg_val<uint32_t>(5);
+    uint32_t pad_h = get_arg_val<uint32_t>(6);
+    uint32_t in_h = get_arg_val<uint32_t>(7);
+    // uint32_t full_nimages = get_arg_val<uint32_t>(8);
+    // uint32_t partial_bottom_image_nrows = get_arg_val<uint32_t>(9);
+    // uint32_t partial_last_row_nsticks = get_arg_val<uint32_t>(10);
+    // uint32_t halo_for_left_left_nsticks = get_arg_val<uint32_t>(11);
+    // uint32_t halo_for_left_nsticks = get_arg_val<uint32_t>(12);
+    // uint32_t halo_for_right_nsticks = get_arg_val<uint32_t>(13);
+    // uint32_t halo_for_right_right_nsticks = get_arg_val<uint32_t>(14);
+
+    // uint32_t local_in_stick_start = get_arg_val<uint32_t>(15);
+    // uint32_t local_in_stick_end = get_arg_val<uint32_t>(16);
+    // uint32_t in_nsticks_per_batch = get_arg_val<uint32_t>(17);
+    // uint32_t in_nsticks_per_core = get_arg_val<uint32_t>(18);
+
+    uint32_t has_left = get_arg_val<uint32_t>(19);
+    uint32_t left_noc_x = get_arg_val<uint32_t>(20);
+    uint32_t left_noc_y = get_arg_val<uint32_t>(21);
+    uint32_t has_right = get_arg_val<uint32_t>(22);
+    uint32_t right_noc_x = get_arg_val<uint32_t>(23);
+    uint32_t right_noc_y = get_arg_val<uint32_t>(24);
+    uint32_t has_left_left = get_arg_val<uint32_t>(25);
+    uint32_t left_left_noc_x = get_arg_val<uint32_t>(26);
+    uint32_t left_left_noc_y = get_arg_val<uint32_t>(27);
+    uint32_t has_right_right = get_arg_val<uint32_t>(28);
+    uint32_t right_right_noc_x = get_arg_val<uint32_t>(29);
+    uint32_t right_right_noc_y = get_arg_val<uint32_t>(30);
+
+    uint32_t stick_nbytes = get_arg_val<uint32_t>(31);   // size of 1 stick (in_c_nbytes)
+
+    // // nsticks to push to left left neighbor core
+    // uint32_t left_left_core_nsticks = get_arg_val<uint32_t>(32);
+    // // nsticks to push to left neighbor core
+    // uint32_t left_core_nsticks = get_arg_val<uint32_t>(33);
+    // // nsticks to push to right neighbor core
+    // uint32_t right_core_nsticks = get_arg_val<uint32_t>(34);
+    // // nsticks to push to right right neighbor core
+    // uint32_t right_right_core_nsticks = get_arg_val<uint32_t>(35);
+
+    // // offset on left left neighbor core for its right right halo
+    // uint32_t left_left_core_halo_offset = get_arg_val<uint32_t>(36);
+    // // offset on left neighbor core for its right halo
+    // uint32_t left_core_halo_offset = get_arg_val<uint32_t>(37);
+    // // offset on right neighbor core for its left halo
+    // uint32_t right_core_halo_offset = get_arg_val<uint32_t>(38);
+    // // offset on right right neighbor core for its left left halo
+    // uint32_t right_right_core_halo_offset = get_arg_val<uint32_t>(39);
+
+    // // padding (2) index offset in the halo going to left neighbors
+    // uint32_t left_going_halo_pad_i_offset = get_arg_val<uint32_t>(40);
+    // // padding (2) index offset in the halo going to right neighbors
+    // uint32_t right_going_halo_pad_i_offset = get_arg_val<uint32_t>(41);
+
+    // uint32_t partial_first_row_skip = get_arg_val<uint32_t>(42);
+    // uint32_t partial_top_image_skip = get_arg_val<uint32_t>(43);
+    // uint32_t full_image_skip = get_arg_val<uint32_t>(44);
+
+    // uint32_t initial_pad_nsticks = get_arg_val<uint32_t>(45);
+
+    uint32_t pad_val_buffer_l1_addr = get_arg_val<uint32_t>(46);
+
+    uint32_t initial_pad_nsticks = get_arg_val<uint32_t>(47);
+    uint32_t local_offset_nsticks = get_arg_val<uint32_t>(48);
+    uint32_t partial_first_row_nsticks = get_arg_val<uint32_t>(49);
+    uint32_t partial_first_row_skip = get_arg_val<uint32_t>(50);
+    uint32_t partial_top_image_nrows = get_arg_val<uint32_t>(51);
+    uint32_t partial_top_image_skip_per_row = get_arg_val<uint32_t>(52);
+    uint32_t partial_top_image_skip = get_arg_val<uint32_t>(53);
+    uint32_t full_nimages = get_arg_val<uint32_t>(54);
+    uint32_t full_image_skip_per_row = get_arg_val<uint32_t>(55);
+    uint32_t full_image_skip = get_arg_val<uint32_t>(56);
+    uint32_t partial_bottom_image_nrows = get_arg_val<uint32_t>(57);
+    uint32_t partial_bottom_image_skip_per_row = get_arg_val<uint32_t>(58);
+    uint32_t partial_last_row_nsticks = get_arg_val<uint32_t>(59);
+
+    DPRINT << "intial_pad_nsticks: " << initial_pad_nsticks << ENDL();
+    DPRINT << "local_offset_nsticks: " << local_offset_nsticks << ENDL();
+    DPRINT << "partial_first_row_nsticks: " << partial_first_row_nsticks << ENDL();
+    DPRINT << "partial_first_row_skip: " << partial_first_row_skip << ENDL();
+    DPRINT << "partial_top_image_nrows: " << partial_top_image_nrows << ENDL();
+    DPRINT << "partial_top_image_skip_per_row: " << partial_top_image_skip_per_row << ENDL();
+    DPRINT << "partial_top_image_skip: " << partial_top_image_skip << ENDL();
+    DPRINT << "full_nimages: " << full_nimages << ENDL();
+    DPRINT << "full_image_skip_per_row: " << full_image_skip_per_row << ENDL();
+    DPRINT << "full_image_skip: " << full_image_skip << ENDL();
+    DPRINT << "partial_bottom_image_nrows: " << partial_bottom_image_nrows << ENDL();
+    DPRINT << "partial_bottom_image_skip_per_row: " << partial_bottom_image_skip_per_row << ENDL();
+    DPRINT << "partial_last_row_nsticks: " << partial_last_row_nsticks << ENDL();
+
+    // DPRINT << "0" << ENDL();
+
+    const InterleavedAddrGen<false> s_pad_stick = {
+        .bank_base_address = pad_val_buffer_l1_addr,
+        .page_size = stick_nbytes
+    };
+    uint64_t padding_noc_addr = get_noc_addr(0, s_pad_stick);
+
+    cb_wait_front(in_cb_id, in_nsticks);
+
+    uint32_t in_l1_addr = get_read_ptr(in_cb_id);
+    uint32_t out_base_l1_addr = get_write_ptr(out_cb_id);
+
+    // DPRINT << "==== INPUT:" << ENDL();
+    // print_sticks(in_l1_addr, 0, 128, 64);
+
+    uint32_t halo_nsticks = (in_w + 2 * pad_w) * pad_h + 1; // + 1 is (window_w / 2)
+
+    // DPRINT << "1" << ENDL();
+
+    volatile uint32_t curr_out_l1_addr = out_base_l1_addr;
+
+    // section 0
+    for (uint32_t i = 0; i < initial_pad_nsticks; ++ i) {
+        // this is the beginning of a new image, insert padding sticks instead of halo
+        noc_async_read(padding_noc_addr, curr_out_l1_addr, stick_nbytes);
+        curr_out_l1_addr += stick_nbytes;
+    }
+    curr_out_l1_addr = out_base_l1_addr + local_offset_nsticks * stick_nbytes;
+
+    // section 1
+    volatile uint32_t curr_in_l1_addr = in_l1_addr;
+    for (uint32_t i = 0; i < partial_first_row_nsticks; ++ i) {
+        uint64_t noc_addr = get_noc_addr(curr_in_l1_addr);
+        noc_async_read(noc_addr, curr_out_l1_addr, stick_nbytes);
+        curr_in_l1_addr += stick_nbytes;
+        curr_out_l1_addr += stick_nbytes;
+    }
+    // insert padding sticks
+    for (uint32_t j = 0; j < partial_first_row_skip; ++ j) {
+        noc_async_read(padding_noc_addr, curr_out_l1_addr, stick_nbytes);
+        curr_out_l1_addr += stick_nbytes;
+    }
+
+    // DPRINT << "2" << ENDL();
+
+    // section 2
+    for (uint32_t i = 0; i < partial_top_image_nrows; ++ i) {
+        // data sticks for full row
+        for (uint32_t j = 0; j < in_w; ++ j) {
+            uint64_t noc_addr = get_noc_addr(curr_in_l1_addr);
+            noc_async_read(noc_addr, curr_out_l1_addr, stick_nbytes);
+            curr_in_l1_addr += stick_nbytes;
+            curr_out_l1_addr += stick_nbytes;
+        }
+        // if (i < partial_top_image_nrows - 1) {
+            // padding sticks on the right, left edge
+            for (uint32_t j = 0; j < partial_top_image_skip_per_row; ++ j) {
+                noc_async_read(padding_noc_addr, curr_out_l1_addr, stick_nbytes);
+                curr_out_l1_addr += stick_nbytes;
+            }
+        // }
+    }
+    for (uint32_t j = 0; j < partial_top_image_skip; ++ j) {
+        noc_async_read(padding_noc_addr, curr_out_l1_addr, stick_nbytes);
+        curr_out_l1_addr += stick_nbytes;
+    }
+
+    // DPRINT << "3" << ENDL();
+
+    // section 3
+    for (uint32_t n = 0; n < full_nimages; ++ n) {
+        // full image rows
+        for (uint32_t i = 0; i < in_h; ++ i) {
+            // data sticks for full row
+            for (uint32_t j = 0; j < in_w; ++ j) {
+                uint64_t noc_addr = get_noc_addr(curr_in_l1_addr);
+                noc_async_read(noc_addr, curr_out_l1_addr, stick_nbytes);
+                curr_in_l1_addr += stick_nbytes;
+                curr_out_l1_addr += stick_nbytes;
+            }
+            // if (i < in_h - 1) {
+                // padding sticks after each row except last row
+                for (uint32_t j = 0; j < full_image_skip_per_row; ++ j) {
+                    noc_async_read(padding_noc_addr, curr_out_l1_addr, stick_nbytes);
+                    curr_out_l1_addr += stick_nbytes;
+                }
+            // }
+        }
+        // padding after full image
+        for (uint32_t i = 0; i < full_image_skip; ++ i) {
+            noc_async_read(padding_noc_addr, curr_out_l1_addr, stick_nbytes);
+            curr_out_l1_addr += stick_nbytes;
+        }
+    }
+
+    // noc_async_read_barrier();   // for debug: TODO remove
+    // DPRINT << "4" << ENDL();
+
+    // section 4
+    for (uint32_t i = 0; i < partial_bottom_image_nrows; ++ i) {
+        // data sticks for full row
+        for (uint32_t j = 0; j < in_w; ++ j) {
+            // DPRINT << j << ": " << curr_in_l1_addr << ENDL();
+            // for (volatile uint32_t x = 0; x < 10000; ++ x);
+            uint64_t noc_addr = get_noc_addr(curr_in_l1_addr);
+            noc_async_read(noc_addr, curr_out_l1_addr, stick_nbytes);
+            // noc_async_read_barrier();   // for debug: TODO remove
+            curr_in_l1_addr += stick_nbytes;
+            curr_out_l1_addr += stick_nbytes;
+        }
+        // padding sticks
+        for (uint32_t j = 0; j < partial_bottom_image_skip_per_row; ++ j) {
+            noc_async_read(padding_noc_addr, curr_out_l1_addr, stick_nbytes);
+            curr_out_l1_addr += stick_nbytes;
+        }
+    }
+    // noc_async_read_barrier();   // for debug: TODO remove
+    // print_sticks(out_base_l1_addr, 114, 114, 64);
+
+    // DPRINT << "5" << ENDL();
+
+    // section 5
+    // partial row sticks
+    for (uint32_t i = 0; i < partial_last_row_nsticks; ++ i) {
+        uint64_t noc_addr = get_noc_addr(curr_in_l1_addr);
+        noc_async_read(noc_addr, curr_out_l1_addr, stick_nbytes);
+        curr_in_l1_addr += stick_nbytes;
+        curr_out_l1_addr += stick_nbytes;
+    }
+
+    noc_async_read_barrier();   // make sure everything is read into output locations before sending halos
+
+    // for (int32_t i = 112; i < 224; ++ i) {
+    //     DPRINT << TileSlice(out_cb_id, 0, SliceRange{ .h0 = i, .h1 = i+1, .hs = 8, .w0 = 0, .w1 = 128, .ws = 4 }, true, false) << ENDL();
+    //     DPRINT << TileSlice(out_cb_id, 0, SliceRange{ .h0 = i, .h1 = i+1, .hs = 8, .w0 = 32, .w1 = 128, .ws = 4 }, true, false) << ENDL();
+    //     DPRINT << TileSlice(out_cb_id, 0, SliceRange{ .h0 = i, .h1 = i+1, .hs = 8, .w0 = 64, .w1 = 128, .ws = 4 }, true, false) << ENDL();
+    //     DPRINT << TileSlice(out_cb_id, 0, SliceRange{ .h0 = i, .h1 = i+1, .hs = 8, .w0 = 96, .w1 = 128, .ws = 4 }, true, false) << ENDL();
+    // }
+
+    // Handle data shuffle
+    uint32_t ll_send_count = get_arg_val<uint32_t>(60);
+    uint32_t ll_send_from_offset = get_arg_val<uint32_t>(61);
+    uint32_t ll_send_to_offset = get_arg_val<uint32_t>(62);
+    uint32_t l_send_count = get_arg_val<uint32_t>(63);
+    uint32_t l_send_from_offset = get_arg_val<uint32_t>(64);
+    uint32_t l_send_to_offset = get_arg_val<uint32_t>(65);
+    uint32_t r_send_count = get_arg_val<uint32_t>(66);
+    uint32_t r_send_from_offset = get_arg_val<uint32_t>(67);
+    uint32_t r_send_to_offset = get_arg_val<uint32_t>(68);
+    uint32_t rr_send_count = get_arg_val<uint32_t>(69);
+    uint32_t rr_send_from_offset = get_arg_val<uint32_t>(70);
+    uint32_t rr_send_to_offset = get_arg_val<uint32_t>(71);
+
+    // DPRINT << "has_ll: " << has_left_left << ENDL();
+    // DPRINT << "has_l: " << has_left << ENDL();
+    // DPRINT << "has_r: " << has_right << ENDL();
+    // DPRINT << "has_rr: " << has_right_right << ENDL();
+    // DPRINT << "ll_send_count: " << ll_send_count << ENDL();
+    // DPRINT << "ll_send_from_offset: " << ll_send_from_offset << ENDL();
+    // DPRINT << "ll_send_to_offset: " << ll_send_to_offset << ENDL();
+    // DPRINT << "l_send_count: " << l_send_count << ENDL();
+    // DPRINT << "l_send_from_offset: " << l_send_from_offset << ENDL();
+    // DPRINT << "l_send_to_offset: " << l_send_to_offset << ENDL();
+    // DPRINT << "r_send_count: " << r_send_count << ENDL();
+    // DPRINT << "r_send_from_offset: " << r_send_from_offset << ENDL();
+    // DPRINT << "r_send_to_offset: " << r_send_to_offset << ENDL();
+    // DPRINT << "rr_send_count: " << rr_send_count << ENDL();
+    // DPRINT << "rr_send_from_offset: " << rr_send_from_offset << ENDL();
+    // DPRINT << "rr_send_to_offset: " << rr_send_to_offset << ENDL();
+
+    // NOTE: assuming the base l1 addr are the same on all cores
+
+    // push to LL
+    if (has_left_left) {
+        uint32_t to_l1_addr = out_base_l1_addr + ll_send_to_offset;
+        uint32_t from_l1_addr = out_base_l1_addr + ll_send_from_offset;
+        for (uint32_t i = 0; i < ll_send_count; ++ i) {
+            uint64_t noc_addr = get_noc_addr(left_left_noc_x, left_left_noc_y, to_l1_addr);
+            noc_async_write(from_l1_addr, noc_addr, stick_nbytes);
+            to_l1_addr += stick_nbytes;
+            from_l1_addr += stick_nbytes;
+        }
+    }
+
+    // push to L
+    if (has_left) {
+        uint32_t to_l1_addr = out_base_l1_addr + l_send_to_offset;
+        uint32_t from_l1_addr = out_base_l1_addr + l_send_from_offset;
+        for (uint32_t i = 0; i < l_send_count; ++ i) {
+            uint64_t noc_addr = get_noc_addr(left_noc_x, left_noc_y, to_l1_addr);
+            noc_async_write(from_l1_addr, noc_addr, stick_nbytes);
+            to_l1_addr += stick_nbytes;
+            from_l1_addr += stick_nbytes;
+        }
+    }
+
+    // push to R
+    if (has_right) {
+        uint32_t to_l1_addr = out_base_l1_addr + r_send_to_offset;
+        uint32_t from_l1_addr = out_base_l1_addr + r_send_from_offset;
+        for (uint32_t i = 0; i < r_send_count; ++ i) {
+            uint64_t noc_addr = get_noc_addr(right_noc_x, right_noc_y, to_l1_addr);
+            noc_async_write(from_l1_addr, noc_addr, stick_nbytes);
+            to_l1_addr += stick_nbytes;
+            from_l1_addr += stick_nbytes;
+        }
+    }
+
+    // push to RR
+    if (has_right_right) {
+        uint32_t to_l1_addr = out_base_l1_addr + rr_send_to_offset;
+        uint32_t from_l1_addr = out_base_l1_addr + rr_send_from_offset;
+        for (uint32_t i = 0; i < rr_send_count; ++ i) {
+            uint64_t noc_addr = get_noc_addr(right_right_noc_x, right_right_noc_y, to_l1_addr);
+            noc_async_write(from_l1_addr, noc_addr, stick_nbytes);
+            to_l1_addr += stick_nbytes;
+            from_l1_addr += stick_nbytes;
+        }
+    }
+
+    noc_async_write_barrier();
+
+    DPRINT << "==== PADDED OUTPUT:" << ENDL();
+    for (uint32_t row = 0; row < 14; ++ row) {
+        DPRINT << "=== ROW " << row << ":" << ENDL();
+        print_sticks(out_base_l1_addr, 114 * row, 114, 64);
+        DPRINT << "=== ROW " << row << " END" << ENDL();
+    }
+}

--- a/tt_metal/kernels/dataflow/writer_unary_sharded_with_halo_s2.cpp
+++ b/tt_metal/kernels/dataflow/writer_unary_sharded_with_halo_s2.cpp
@@ -365,10 +365,10 @@ void kernel_main() {
 
     noc_async_write_barrier();
 
-    DPRINT << "==== PADDED OUTPUT:" << ENDL();
-    for (uint32_t row = 0; row < 14; ++ row) {
-        DPRINT << "=== ROW " << row << ":" << ENDL();
-        print_sticks(out_base_l1_addr, 114 * row, 114, 64);
-        DPRINT << "=== ROW " << row << " END" << ENDL();
-    }
+    // DPRINT << "==== PADDED OUTPUT:" << ENDL();
+    // for (uint32_t row = 0; row < 14; ++ row) {
+    //     DPRINT << "=== ROW " << row << ":" << ENDL();
+    //     print_sticks(out_base_l1_addr, 114 * row, 114, 64);
+    //     DPRINT << "=== ROW " << row << " END" << ENDL();
+    // }
 }

--- a/tt_metal/kernels/dataflow/writer_unary_sharded_with_halo_s2.cpp
+++ b/tt_metal/kernels/dataflow/writer_unary_sharded_with_halo_s2.cpp
@@ -345,10 +345,10 @@ void kernel_main() {
 
     noc_async_write_barrier();
 
-    DPRINT << "==== PADDED OUTPUT:" << ENDL();
-    for (uint32_t row = 0; row < 14; ++ row) {
-        DPRINT << "=== ROW " << row << ":" << ENDL();
-        print_sticks(out_base_l1_addr, 114 * row, 114, 64);
-        DPRINT << "=== ROW " << row << " END" << ENDL();
-    }
+    // DPRINT << "==== PADDED OUTPUT:" << ENDL();
+    // for (uint32_t row = 0; row < 14; ++ row) {
+    //     DPRINT << "=== ROW " << row << ":" << ENDL();
+    //     print_sticks(out_base_l1_addr, 114 * row, 114, 64);
+    //     DPRINT << "=== ROW " << row << " END" << ENDL();
+    // }
 }

--- a/tt_metal/src/firmware/riscv/common/dataflow_api.h
+++ b/tt_metal/src/firmware/riscv/common/dataflow_api.h
@@ -865,6 +865,33 @@ void noc_async_read(std::uint64_t src_noc_addr, std::uint32_t dst_local_l1_addr,
     DEBUG_STATUS('N', 'A', 'R', 'D');
 }
 
+// TODO: write docs
+// this issues only a single packet with size <= NOC_MAX_BURST_SIZE (ie maximum packet size)
+FORCE_INLINE
+void noc_async_read_one_packet(std::uint64_t src_noc_addr, std::uint32_t dst_local_l1_addr, std::uint32_t size) {
+    /*
+        Read requests - use static VC
+        Read responses - assigned VCs dynamically
+    */
+
+    DEBUG_STATUS('R', 'P', 'W');
+    while (!ncrisc_noc_fast_read_ok(noc_index, NCRISC_RD_CMD_BUF));
+    DEBUG_STATUS('R', 'P', 'D');
+
+    DEBUG_STATUS('N', 'A', 'R', 'W');
+    DEBUG_SANITIZE_NOC_ADDR(src_noc_addr, size);
+    DEBUG_SANITIZE_WORKER_ADDR(dst_local_l1_addr, size);
+
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dst_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, (uint32_t)src_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID, src_noc_addr >> 32);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE, size);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    noc_reads_num_issued[noc_index] += 1;
+
+    DEBUG_STATUS('N', 'A', 'R', 'D');
+}
+
 template <bool DRAM>
 FORCE_INLINE void noc_async_read_tile(
     const uint32_t id, const InterleavedAddrGenFast<DRAM>& s, std::uint32_t dst_local_l1_addr, uint32_t offset = 0) {


### PR DESCRIPTION
#2388: Untilzie with halo stride 2 cases and maxpool with halo reader

#2388: A large number of updates for maxpool case, stride 2 in untilize with halo

#2388: Syncing maxpool side onging updates

#2388: Compilable stop point

#2388: stride 2 writer working up to left side shuffle, right side still needs debugging

#2388: right going data also works

#2388: Fixed last offset issue on the writer side

#2388: Updated sharding utils to handle reader side info as well

#2388: Some more offset related bugs removed (using % instead of /git statusgit status)

#2388: Update CB size to max, it was not really max

#2388: made end stick inclusive, as end coords would otherwise go OOB

#2388: need to debug low PCC with random data

#2388: Fixed the end range to be excl. and use -1 for nsticks

#2388: Fixed the last bug for batch 8 resnet. It was the initial_pad handling at the case when the first stick in a core is the first stick in new batch

#2388: Minor leftover fixes

#2388: The last one