### PR TITLE
#3292: Microbenchmark for measuring the latency of unicasting vs multicasting the max amount of runtime arguments to a far-away core from the dispatch core

### DIFF
--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -160,7 +160,9 @@ run_microbenchmarks_pipeline_tests() {
 
     export TT_METAL_DEVICE_PROFILER=1
 
+    source build/python_env/bin/activate
     ./tests/scripts/run_moreh_microbenchmark.sh
+    pytest -svv tests/tt_metal/microbenchmarks
 }
 
 run_pipeline_tests() {

--- a/tests/tt_metal/microbenchmarks/noc/test_noc_unicast_vs_multicast_to_single_core_latency.py
+++ b/tests/tt_metal/microbenchmarks/noc/test_noc_unicast_vs_multicast_to_single_core_latency.py
@@ -1,0 +1,49 @@
+import os
+import sys
+sys.path.append(f"{os.environ['PYTHONPATH']}/tt_metal/tools/profiler")
+
+from loguru import logger
+import pytest
+from process_device_log import import_log_run_stats
+import plot_setup
+
+
+def test_noc_unicast_vs_multicast_to_single_core_latency():
+    os.system(f"TT_METAL_SLOW_DISPATCH_MODE=1 TT_METAL_DEVICE_PROFILER=1 {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency")
+    setup = plot_setup.default_setup()
+    setup.timerAnalysis = {
+        "LATENCY": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "BRISC", "timerID": 5},
+            "end": {"risc": "BRISC", "timerID": 6},
+        },
+    }
+    setup.deviceInputLog = "unicast_to_single_core_microbenchmark/profile_log_device.csv"
+    stats = import_log_run_stats(setup)
+    core = [key for key in stats["devices"][0]["cores"].keys() if key != "DEVICE"][0]
+    unicast_cycles = stats["devices"][0]["cores"][core]["riscs"]["TENSIX"]["analysis"]["LATENCY"]["stats"]["First"]
+
+    setup.deviceInputLog = "multicast_to_single_core_microbenchmark/profile_log_device.csv"
+    stats = import_log_run_stats(setup)
+    multicast_cycles = stats["devices"][0]["cores"][core]["riscs"]["TENSIX"]["analysis"]["LATENCY"]["stats"]["First"]
+
+    unicast_cycles_lower_bound = 330
+    unicast_cycles_upper_bound = 400
+    unicast_cycles_within_bounds = unicast_cycles_lower_bound <= unicast_cycles <= unicast_cycles_upper_bound
+
+    multicast_cycles_lower_bound = 450
+    multicast_cycles_upper_bound = 600
+    multicast_cycles_within_bounds = multicast_cycles_lower_bound <= multicast_cycles <= multicast_cycles_upper_bound
+
+    if not unicast_cycles_within_bounds:
+        logger.warning(f"Unicast cycles not within bounds. Received {unicast_cycles}, was expecting between {unicast_cycles_lower_bound} and {unicast_cycles_upper_bound}")
+    else:
+        logger.info(f"Unicast cycles within bounds. Received {unicast_cycles}")
+
+    if not multicast_cycles_within_bounds:
+        logger.warning(f"Multicast cycles not within bounds. Received {multicast_cycles}, was expecting between {multicast_cycles_lower_bound} and {multicast_cycles_upper_bound}")
+    else:
+        logger.info(f"Multicast cycles within bounds. Received {multicast_cycles}")
+
+    assert unicast_cycles_within_bounds and multicast_cycles_within_bounds

--- a/tests/tt_metal/tt_metal/module.mk
+++ b/tests/tt_metal/tt_metal/module.mk
@@ -12,6 +12,7 @@ TT_METAL_TESTS += \
 		 tests/tt_metal/perf_microbenchmark/matmul/matmul_local_l1 \
 		 tests/tt_metal/perf_microbenchmark/noc/test_noc_read_global_l1 \
 		 tests/tt_metal/perf_microbenchmark/noc/test_noc_read_local_l1 \
+		 tests/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency \
 		 tests/tt_metal/perf_microbenchmark/pcie/test_enqueue_rw_buffer \
 		 tests/tt_metal/perf_microbenchmark/pcie/test_rw_buffer \
 		 tests/tt_metal/perf_microbenchmark/pcie/test_rw_device_dram \

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/kernels/multicast_to_single_core.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/kernels/multicast_to_single_core.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "tt_metal/tools/profiler/kernel_profiler.hpp"
+
+void kernel_main() {
+    uint32_t src = 150*1024;
+    uint64_t destination = get_noc_multicast_addr(WORKER_NOC_X, WORKER_NOC_Y, WORKER_NOC_X, WORKER_NOC_Y, src);
+
+    kernel_profiler::mark_time(5);
+    noc_async_write_multicast(src, destination, 1024, 1);
+    noc_async_write_barrier();
+    kernel_profiler::mark_time(6);
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/kernels/unicast_to_single_core.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/kernels/unicast_to_single_core.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "tt_metal/tools/profiler/kernel_profiler.hpp"
+
+void kernel_main() {
+    uint32_t src = 150*1024;
+    uint64_t destination = get_noc_addr(WORKER_NOC_X, WORKER_NOC_Y, src);
+    kernel_profiler::mark_time(5);
+    noc_async_write(src, destination, 1024);
+    noc_async_write_barrier();
+    kernel_profiler::mark_time(6);
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/bfloat16.hpp"
+#include "test_tiles.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/llrt/tt_debug_print_server.hpp"
+#include "tt_metal/test_utils/deprecated/tensor.hpp"
+#include "tt_metal/tools/profiler/op_profiler.hpp"
+
+using namespace tt;
+
+void measure_latency(string kernel_name) {
+    const int device_id = 0;
+    tt_metal::Device *device = tt_metal::CreateDevice(device_id);
+
+    auto dispatch_cores = device->dispatch_cores().begin();
+    CoreCoord producer_logical_core = *dispatch_cores++;
+    CoreCoord consumer_logical_core = *dispatch_cores;
+
+    auto first_worker_physical_core = device->worker_core_from_logical_core({0, 0});
+
+    std::map<string, string> defines = {
+        {"WORKER_NOC_X", std::to_string(first_worker_physical_core.x)},
+        {"WORKER_NOC_Y", std::to_string(first_worker_physical_core.y)},
+    };
+
+    tt_metal::Program program = tt_metal::Program();
+    tt_metal::CreateDataMovementKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/noc/kernels/" + kernel_name + ".cpp",
+        consumer_logical_core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .defines = defines});
+
+    tt::tt_metal::detail::SetProfilerDir(kernel_name + "_microbenchmark");
+    tt::tt_metal::detail::FreshProfilerDeviceLog();
+    detail::CompileProgram(device, program);
+    tt_metal::LaunchProgram(device, program);
+    tt_metal::CloseDevice(device);
+}
+
+int main(int argc, char **argv) {
+    if (getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
+        log_fatal("Test not supported w/ fast dispatch, exiting");
+    }
+
+    measure_latency("multicast_to_single_core");
+    measure_latency("unicast_to_single_core");
+}


### PR DESCRIPTION
Purpose of this PR:
To measure the latency of writing to a core far away from the dispatch core via a unicast vs a multicast. We should see much higher latency when multicasting to a single core due to path reservation. This is specifically to be able to confirm the perf improvements we will see when unicasting runtime args rather than multicasting in fast dispatch.

Script to run 
```bash
pytest -svv tests/tt_metal/microbenchmarks/noc/test_noc_unicast_vs_multicast_to_single_core_latency.py 
```