### PR TITLE
#3289: Optimize/fix dram/l1 noc bank calculations

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/ping_legal_l1s.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/ping_legal_l1s.cpp
@@ -13,11 +13,10 @@ void kernel_main() {
 
     for (uint32_t id = 0; id < NUM_L1_BANKS; id += 1) {
         uint32_t bank_id = id & (NUM_L1_BANKS - 1);
-        uint32_t noc_x = l1_bank_to_noc_x[bank_id];
-        uint32_t noc_y = l1_bank_to_noc_y[bank_id];
+        uint32_t noc_xy = l1_bank_to_noc_xy[noc_index][bank_id];
         uint32_t l1_address = base_l1_address + bank_to_l1_offset[bank_id];
 
-        uint64_t noc_addr = get_noc_addr(noc_x, noc_y, l1_address);
+        uint64_t noc_addr = get_noc_addr_helper(noc_xy, l1_address);
 
         noc_async_read(noc_addr, intermediate_l1_addr, size_bytes);
         noc_async_read_barrier();

--- a/tt_metal/build_kernels_for_riscv/build_kernels_for_riscv.cpp
+++ b/tt_metal/build_kernels_for_riscv/build_kernels_for_riscv.cpp
@@ -1076,12 +1076,8 @@ std::string generate_bank_to_noc_coord_descriptor_string(
 
     ss << "#ifdef KERNEL_BUILD" << endl;
     ss << endl;
-    ss << "extern uint8_t dram_bank_to_noc_x[NUM_DRAM_BANKS];" << endl;
-    ss << "extern uint8_t dram_bank_to_noc_y[NUM_DRAM_BANKS];" << endl;
     ss << "extern uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS];" << endl;
     ss << "extern int32_t bank_to_dram_offset[NUM_DRAM_BANKS];" << endl;
-    ss << "extern uint8_t l1_bank_to_noc_x[NUM_L1_BANKS];" << endl;
-    ss << "extern uint8_t l1_bank_to_noc_y[NUM_L1_BANKS];" << endl;
     ss << "extern uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS];" << endl;
     ss << "extern int32_t bank_to_l1_offset[NUM_L1_BANKS];" << endl;
 
@@ -1089,18 +1085,6 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     ss << "#else // !KERNEL_BUILD (FW_BUILD)" << endl;
     ss << endl;
 
-    ss << "uint8_t dram_bank_to_noc_x[NUM_DRAM_BANKS] __attribute__((used)) = {" << endl;
-    for (unsigned int bank_id = 0; bank_id < dram_bank_map.size(); bank_id++) {
-        ss << "    " << dram_bank_map[bank_id].x << "," << endl;
-    }
-    ss << "};" << endl;
-    ss << endl;
-    ss << "uint8_t dram_bank_to_noc_y[NUM_DRAM_BANKS] __attribute__((used)) = {" << endl;
-    for (unsigned int bank_id = 0; bank_id < dram_bank_map.size(); bank_id++) {
-        ss << "    " << dram_bank_map[bank_id].y << "," << endl;
-    }
-    ss << "};" << endl;
-    ss << endl;
     ss << "uint16_t dram_bank_to_noc_xy[NUM_NOCS][NUM_DRAM_BANKS] __attribute__((used)) = {" << endl;
     for (unsigned int noc = 0; noc < 2; noc++) {
         ss << "    {" << endl;
@@ -1122,18 +1106,6 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     ss << "};" << endl;
     ss << endl;
 
-    ss << "uint8_t l1_bank_to_noc_x[NUM_L1_BANKS] __attribute__((used)) = {" << endl;
-    for (unsigned int bank_id = 0; bank_id < l1_bank_map.size(); bank_id++) {
-        ss << "    " << l1_bank_map[bank_id].x << "," << endl;
-    }
-    ss << "};" << endl;
-    ss << endl;
-    ss << "uint8_t l1_bank_to_noc_y[NUM_L1_BANKS] __attribute__((used)) = {" << endl;
-    for (unsigned int bank_id = 0; bank_id < l1_bank_map.size(); bank_id++) {
-        ss << "    " << l1_bank_map[bank_id].y << "," << endl;
-    }
-    ss << "};" << endl;
-    ss << endl;
     ss << "uint16_t l1_bank_to_noc_xy[NUM_NOCS][NUM_L1_BANKS] __attribute__((used)) = {" << endl;
     for (unsigned int noc = 0; noc < 2; noc++) {
         ss << "    {" << endl;


### PR DESCRIPTION
Remove the _x and _y tables, replace with the pre=calculated _xy table Fix prior dram/l1 noc bank calculations that didn't factor in noc_index