### PR TITLE
Optimize cb initialization and other minor stuff

### DIFF
--- a/tt_metal/impl/dispatch/kernels/command_queue_producer.cpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_producer.cpp
@@ -13,7 +13,7 @@ FORCE_INLINE
 void program_local_cb(uint32_t num_pages, uint32_t page_size, uint32_t cb_size) {
     uint32_t cb_id = 0;
     uint32_t fifo_addr = DeviceCommand::DATA_SECTION_ADDRESS >> 4;
-    uint32_t fifo_limit = fifo_addr + (cb_size >> 4) - 1;
+    uint32_t fifo_limit = fifo_addr + (cb_size >> 4);
     cb_interface[cb_id].fifo_limit = fifo_limit;  // to check if we need to wrap
     cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
     cb_interface[cb_id].fifo_rd_ptr = fifo_addr;

--- a/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
@@ -58,7 +58,7 @@ void multicore_cb_push_back(uint64_t consumer_noc_encoding, uint32_t consumer_fi
     *CQ_CONSUMER_CB_RECV_PTR += num_to_write;
     *CQ_CONSUMER_CB_WRITE_PTR += (page_size * num_to_write) >> 4;
 
-    if ((*CQ_CONSUMER_CB_WRITE_PTR << 4) > consumer_fifo_limit) {
+    if ((*CQ_CONSUMER_CB_WRITE_PTR << 4) >= consumer_fifo_limit) {
         *CQ_CONSUMER_CB_WRITE_PTR -= consumer_fifo_size >> 4;
     }
 
@@ -88,7 +88,7 @@ void produce(
         writing to the consumer.
     */
     command_ptr += DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER;
-    uint32_t l1_consumer_fifo_limit = get_db_buf_addr(db_buf_switch) + consumer_cb_size - 1;
+    uint32_t l1_consumer_fifo_limit = get_db_buf_addr(db_buf_switch) + consumer_cb_size;
 
     for (uint32_t i = 0; i < num_srcs; i++) {
         const uint32_t bank_base_address = command_ptr[0];

--- a/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
@@ -23,7 +23,7 @@ bool cb_producer_space_available(int32_t num_pages) {
 
     // uint16_t's here because Tensix updates the val at tiles_acked_ptr as uint16 in llk_pop_tiles
     // TODO: I think we could have TRISC update tiles_acked_ptr, and we wouldn't need uint16 here
-    uint16_t pages_acked = (uint16_t)reg_read_barrier(pages_acked_ptr);
+    uint16_t pages_acked = (uint16_t)reg_read(pages_acked_ptr);
     uint16_t free_space_pages_wrap =
         cb_interface[operand].fifo_num_pages - (pages_received - pages_acked);
     free_space_pages = (int32_t)free_space_pages_wrap;

--- a/tt_metal/src/ckernels/grayskull/common/inc/ckernel.h
+++ b/tt_metal/src/ckernels/grayskull/common/inc/ckernel.h
@@ -236,7 +236,7 @@ inline void zerosrc() {
 
 inline void sync_regfile_write(const uint index)
 {
-    volatile uint foo = 0xdeadbeef;
+    volatile uint foo = 0;
     volatile uint *fooptr = &foo;
     *fooptr = regfile[index];
 }

--- a/tt_metal/src/ckernels/grayskull/common/inc/cpack_common.h
+++ b/tt_metal/src/ckernels/grayskull/common/inc/cpack_common.h
@@ -212,8 +212,8 @@ namespace ckernel::packer
       sync_regfile_write(p_gpr_pack::TILE_HEADER+3);
 
       // Config RELU
-      uint apply_relu = reg_read_barrier((uint)&cfg[STACC_RELU_ApplyRelu_ADDR32]);
-      uint relu_threshold  = reg_read_barrier((uint)&cfg[STACC_RELU_ReluThreshold_ADDR32]);
+      uint apply_relu = reg_read((uint)&cfg[STACC_RELU_ApplyRelu_ADDR32]);
+      uint relu_threshold  = reg_read((uint)&cfg[STACC_RELU_ReluThreshold_ADDR32]);
       apply_relu      &= (~STACC_RELU_ApplyRelu_MASK);
       relu_threshold  &= (~STACC_RELU_ReluThreshold_MASK);
       struct {

--- a/tt_metal/src/ckernels/grayskull/common/src/ckernel.cc
+++ b/tt_metal/src/ckernels/grayskull/common/src/ckernel.cc
@@ -36,8 +36,6 @@ uint32_t op_info_offset __attribute__((used)) = 0;
 
 const uint8_t thread_id = COMPILE_FOR_TRISC;
 
-volatile uint local_mem_barrier __attribute__((used));
-
 #define GET_TRISC_RUN_EVAL(x, t) x##t
 #define GET_TRISC_RUN(x, t) GET_TRISC_RUN_EVAL(x, t)
 volatile tt_l1_ptr uint8_t * const trisc_run = &GET_TRISC_RUN(((tt_l1_ptr mailboxes_t *)(MEM_MAILBOX_BASE))->slave_sync.trisc, COMPILE_FOR_TRISC);

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
@@ -66,13 +66,10 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
 
     std::int32_t free_tiles;
     do {
-        std::uint16_t tiles_acked = (std::uint16_t) reg_read_barrier((std::uint32_t)tiles_acked_ptr);
+        std::uint16_t tiles_acked = (std::uint16_t) reg_read((std::uint32_t)tiles_acked_ptr);
         std::uint16_t free_tiles_wrap = cb_interface[output].fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t) free_tiles_wrap;
     } while (free_tiles < num_tiles);
-
-    // TODO: check if this one is really necessary
-    mem_barrier(free_tiles);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
@@ -16,12 +16,6 @@
 
 using namespace ckernel;
 
-// GS RISC-V RTL bug workaround (l1 reads followed by local mem reads causes a hang)
-// in ncrisc.cc/brisc.cc: volatile uint32_t local_mem_barrier;
-void write_to_local_mem_barrier(uint32_t data) {
-    local_mem_barrier = data;
-}
-
 inline void llk_setup_cb_interface() {
 
     volatile tt_l1_ptr std::uint32_t* circular_buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
@@ -32,7 +26,6 @@ inline void llk_setup_cb_interface() {
         uint32_t fifo_size = circular_buffer_config_addr[1];
         uint32_t fifo_num_pages = circular_buffer_config_addr[2];
         uint32_t fifo_page_size = circular_buffer_config_addr[3];
-        write_to_local_mem_barrier(fifo_num_pages);
 
         cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
         cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size - 1;  // Check if there is overflow

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
@@ -28,7 +28,7 @@ inline void llk_setup_cb_interface() {
         uint32_t fifo_page_size = circular_buffer_config_addr[3];
 
         cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size - 1;  // Check if there is overflow
+        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
         cb_interface[cb_id].fifo_size = fifo_size;
         cb_interface[cb_id].fifo_num_pages = fifo_num_pages;
         cb_interface[cb_id].fifo_page_size = fifo_page_size;
@@ -108,7 +108,7 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
     cb_interface[output].fifo_wr_ptr += num_words;
     cb_interface[output].fifo_wr_tile_ptr = 0;
 
-    if (cb_interface[output].fifo_wr_ptr > cb_interface[output].fifo_limit) {
+    if (cb_interface[output].fifo_wr_ptr >= cb_interface[output].fifo_limit) {
         cb_interface[output].fifo_wr_ptr -= cb_interface[output].fifo_size;
     }
 

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
@@ -54,7 +54,7 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
 
     uint16_t num_tiles_recv;
     do {
-        tiles_received = (std::uint16_t) reg_read_barrier((std::uint32_t)tiles_received_ptr);
+        tiles_received = (std::uint16_t) reg_read((std::uint32_t)tiles_received_ptr);
         num_tiles_recv = tiles_received - cb_interface[input].tiles_acked;
     } while (num_tiles_recv < num_tiles_u);
 

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
@@ -16,25 +16,17 @@
 
 using namespace ckernel;
 
-// GS RISC-V RTL bug workaround (l1 reads followed by local mem reads causes a hang)
-// in ncrisc.cc/brisc.cc: volatile uint32_t local_mem_barrier;
-void write_to_local_mem_barrier(uint32_t data) {
-    local_mem_barrier = data;
-}
-
 inline void llk_setup_cb_interface() {
 
     volatile tt_l1_ptr std::uint32_t* buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
 
     for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
 
-        // write_to_local_mem_barrier are needed on GS because of the RTL bug
         // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
         uint32_t fifo_addr = buffer_config_addr[0];
         uint32_t fifo_size = buffer_config_addr[1];
         uint32_t fifo_num_pages = buffer_config_addr[2]; // not used atm
         uint32_t fifo_page_size = buffer_config_addr[3]; // not used atm
-        write_to_local_mem_barrier(fifo_num_pages);
 
         cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
         cb_interface[cb_id].fifo_size = fifo_size;

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
@@ -30,7 +30,7 @@ inline void llk_setup_cb_interface() {
 
         cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
         cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size - 1;  // Check if there is overflow
+        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
         cb_interface[cb_id].tiles_acked = 0;
         cb_interface[cb_id].fifo_page_size = fifo_page_size;
 
@@ -76,7 +76,7 @@ inline void llk_pop_tiles(
     TT_STOREREG(4, (std::uint32_t)&tiles_acked_ptr[0]);
     cb_interface[input].fifo_rd_ptr += num_words;
 
-    if (cb_interface[input].fifo_rd_ptr > cb_interface[input].fifo_limit) {
+    if (cb_interface[input].fifo_rd_ptr >= cb_interface[input].fifo_limit) {
         cb_interface[input].fifo_rd_ptr -= cb_interface[input].fifo_size;
     }
 }

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_unpack_common.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_unpack_common.h
@@ -29,7 +29,7 @@ inline void llk_zero_operand(std::uint32_t operand) {
     TT_SETDMAREG(0, 0, 0, LO_16(p_gpr_unpack::OPERAND_OFFSET_ADDR));
     TT_SETDMAREG(0, 0, 0, HI_16(p_gpr_unpack::OPERAND_OFFSET_ADDR));
 
-    std::uint32_t fifo_base_addr = (cb_interface[input].fifo_limit + 1) - cb_interface[input].fifo_size;
+    std::uint32_t fifo_base_addr = cb_interface[input].fifo_limit - cb_interface[input].fifo_size;
     TT_SETDMAREG(0, fifo_base_addr, 0, LO_16(p_gpr_unpack::p_gpr_unpack::OPERAND_BASE_ADDR));
 
     for (std::uint32_t i = 0; i < cb_interface[input].fifo_size; i++) {

--- a/tt_metal/src/ckernels/wormhole_b0/common/inc/ckernel.h
+++ b/tt_metal/src/ckernels/wormhole_b0/common/inc/ckernel.h
@@ -59,7 +59,6 @@ extern volatile uint tt_reg_ptr * const regfile;
 extern uint tt_reg_ptr * regmem;
 extern volatile uint tt_reg_ptr * const instrn_buffer;
 extern volatile uint tt_reg_ptr *dbg_event_scratch;
-extern volatile uint local_mem_barrier;
 
 extern uint32_t cfg_state_id;
 extern uint32_t dest_offset_id;
@@ -157,7 +156,7 @@ inline void cfg_write(uint cfg_addr32, uint data)
 inline uint cfg_read(uint cfg_addr32)
 {
     // Declared here instead of globally to prevent direct access, which might ignore current state ID
-    volatile uint *cfg_regs = reinterpret_cast<volatile uint *>(TENSIX_CFG_BASE);
+    volatile uint32_t tt_reg_ptr *cfg_regs = reinterpret_cast<volatile uint32_t tt_reg_ptr *>(TENSIX_CFG_BASE);
     return cfg_regs[cfg_addr(cfg_addr32)];
 }
 
@@ -202,10 +201,6 @@ inline void mop_run(const uint8_t type, const uint8_t count)
     TTI_MOP(type, count - 1, 0); // Run the MOP
 }
 
-// Register read (workaround for bug
-// https://yyz-gitlab.local.tenstorrent.com/tenstorrent/tensix/issues/976
-// now handled by the compiler)
-// workaround is needed only for GS
 inline __attribute__((always_inline)) uint32_t reg_read(uint32_t addr)
 {
     volatile uint tt_reg_ptr *p_reg = reinterpret_cast<volatile uint tt_reg_ptr *> (addr);
@@ -446,11 +441,6 @@ inline void llk_get_next_op_info(tt::op_info_t& op_info_struct) {
     if (op_info_offset == OP_INFO_SIZE) {
         op_info_offset = 0; // In case we go out of bounds
     }
-}
-
-inline void mem_barrier(uint32_t data)
-{
-    local_mem_barrier = data;
 }
 
 }

--- a/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_pack.h
+++ b/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_pack.h
@@ -16,12 +16,6 @@
 
 using namespace ckernel;
 
-// GS RISC-V RTL bug workaround (l1 reads followed by local mem reads causes a hang)
-// in ncrisc.cc/brisc.cc: volatile uint32_t local_mem_barrier;
-void write_to_local_mem_barrier(uint32_t data) {
-    local_mem_barrier = data;
-}
-
 inline void llk_setup_cb_interface() {
 
     volatile tt_l1_ptr std::uint32_t* circular_buffer_config_addr = (volatile uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
@@ -32,7 +26,6 @@ inline void llk_setup_cb_interface() {
         uint32_t fifo_size = circular_buffer_config_addr[1];
         uint32_t fifo_num_pages = circular_buffer_config_addr[2];
         uint32_t fifo_page_size = circular_buffer_config_addr[3];
-        write_to_local_mem_barrier(fifo_page_size);
 
         cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
         cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size - 1;  // Check if there is overflow

--- a/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_pack.h
+++ b/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_pack.h
@@ -70,9 +70,6 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         std::uint32_t free_tiles_wrap = cb_interface[output].fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t) free_tiles_wrap;
     } while (free_tiles < num_tiles);
-
-    // TODO: check if this one is really necessary
-    mem_barrier(free_tiles);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_pack.h
+++ b/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_pack.h
@@ -28,7 +28,7 @@ inline void llk_setup_cb_interface() {
         uint32_t fifo_page_size = circular_buffer_config_addr[3];
 
         cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size - 1;  // Check if there is overflow
+        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
         cb_interface[cb_id].fifo_size = fifo_size;
         cb_interface[cb_id].fifo_num_pages = fifo_num_pages;
         cb_interface[cb_id].fifo_page_size = fifo_page_size;
@@ -108,7 +108,7 @@ inline void llk_push_tiles(const std::int32_t operand, const std::int32_t num_ti
     cb_interface[output].fifo_wr_ptr += num_words;
     cb_interface[output].fifo_wr_tile_ptr = 0;
 
-    if (cb_interface[output].fifo_wr_ptr > cb_interface[output].fifo_limit) {
+    if (cb_interface[output].fifo_wr_ptr >= cb_interface[output].fifo_limit) {
         cb_interface[output].fifo_wr_ptr -= cb_interface[output].fifo_size;
     }
 

--- a/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_unpack.h
+++ b/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_unpack.h
@@ -29,7 +29,7 @@ inline void llk_setup_cb_interface() {
 
         cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
         cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size - 1;  // Check if there is overflow
+        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
         cb_interface[cb_id].tiles_acked = 0;
         cb_interface[cb_id].fifo_page_size = fifo_page_size;
 
@@ -74,7 +74,7 @@ inline void llk_pop_tiles(
     TT_STOREREG(4, (std::uint32_t)&tiles_acked_ptr[0]);
     cb_interface[input].fifo_rd_ptr += num_words;
 
-    if (cb_interface[input].fifo_rd_ptr > cb_interface[input].fifo_limit) {
+    if (cb_interface[input].fifo_rd_ptr >= cb_interface[input].fifo_limit) {
         cb_interface[input].fifo_rd_ptr -= cb_interface[input].fifo_size;
     }
 }
@@ -91,7 +91,7 @@ inline void llk_clear_tiles(std::uint32_t operand, std::uint32_t num_tiles) {
 
     //     cb_interface[input].fifo_rd_ptr += num_words;
 
-    //     if (cb_interface[input].f.fifo_rd_ptr > operands[input].fifo_limit) {
+    //     if (cb_interface[input].f.fifo_rd_ptr >= operands[input].fifo_limit) {
     //         cb_interface[input].f.fifo_rd_ptr -= operands[input].fifo_size;
     //     }
 

--- a/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_unpack.h
+++ b/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_io_unpack.h
@@ -15,32 +15,23 @@
 
 using namespace ckernel;
 
-// GS RISC-V RTL bug workaround (l1 reads followed by local mem reads causes a hang)
-// in ncrisc.cc/brisc.cc: volatile uint32_t local_mem_barrier;
-void write_to_local_mem_barrier(uint32_t data) {
-    local_mem_barrier = data;
-}
-
 inline void llk_setup_cb_interface() {
 
     volatile tt_l1_ptr std::uint32_t* circular_buffer_config_addr = (volatile uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
 
     for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
 
-        // write_to_local_mem_barrier are needed on GS because of the RTL bug
         // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
         uint32_t fifo_addr = circular_buffer_config_addr[0];
         uint32_t fifo_size = circular_buffer_config_addr[1];
         uint32_t fifo_num_pages = circular_buffer_config_addr[2]; // not used atm
         uint32_t fifo_page_size = circular_buffer_config_addr[3];
-        write_to_local_mem_barrier(fifo_page_size);
 
         cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
         cb_interface[cb_id].fifo_size = fifo_size;
         cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size - 1;  // Check if there is overflow
         cb_interface[cb_id].tiles_acked = 0;
         cb_interface[cb_id].fifo_page_size = fifo_page_size;
-        //cb_interface[cb_id].tiles_acked1 = 0;
 
         circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG; // move by 3 uint32's
     }

--- a/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/src/ckernels/wormhole_b0/llk_lib/llk_unpack_common.h
@@ -26,7 +26,7 @@ void llk_zero_operand(std::uint32_t operand) {
     TT_SETDMAREG(0, 0, 0, LO_16(p_gpr_unpack::OPERAND_OFFSET_ADDR));
     TT_SETDMAREG(0, 0, 0, HI_16(p_gpr_unpack::OPERAND_OFFSET_ADDR));
 
-    std::uint32_t fifo_base_addr = (cb_interface[input].fifo_limit + 1) - cb_interface[input].fifo_size;
+    std::uint32_t fifo_base_addr = cb_interface[input].fifo_limit - cb_interface[input].fifo_size;
     TT_SETDMAREG(0, LOWER_HALFWORD(fifo_base_addr), 0, LO_16(p_gpr_unpack::p_gpr_unpack::OPERAND_BASE_ADDR));
     TT_SETDMAREG(0, UPPER_HALFWORD(fifo_base_addr), 0, HI_16(p_gpr_unpack::p_gpr_unpack::OPERAND_BASE_ADDR));
 

--- a/tt_metal/src/firmware/riscv/common/circular_buffer.h
+++ b/tt_metal/src/firmware/riscv/common/circular_buffer.h
@@ -9,14 +9,14 @@
 
 struct CQReadInterface {
     uint32_t fifo_size;
-    uint32_t fifo_limit;
+    uint32_t fifo_limit; // range is inclusive of the limit
     uint32_t fifo_rd_ptr;
     uint32_t fifo_rd_toggle;
 };
 
 struct CBInterface {
     uint32_t fifo_size;
-    uint32_t fifo_limit;
+    uint32_t fifo_limit; // range is inclusive of the limit
     uint32_t fifo_page_size;
     uint32_t fifo_num_pages;
 

--- a/tt_metal/src/firmware/riscv/common/circular_buffer.h
+++ b/tt_metal/src/firmware/riscv/common/circular_buffer.h
@@ -23,8 +23,14 @@ struct CBInterface {
     uint32_t fifo_rd_ptr;
     uint32_t fifo_wr_ptr;
 
-    uint16_t tiles_acked;
-    uint16_t tiles_received;
+    // Save a cycle during init by writing 0 to the uint32 below
+    union {
+        uint32_t tiles_acked_received_init;
+        struct {
+            uint16_t tiles_acked;
+            uint16_t tiles_received;
+        };
+    };
 
     // used by packer for in-order packing
     uint32_t fifo_wr_tile_ptr;

--- a/tt_metal/src/firmware/riscv/common/dataflow_api.h
+++ b/tt_metal/src/firmware/riscv/common/dataflow_api.h
@@ -88,7 +88,7 @@ void setup_cb_read_write_interfaces() {
         uint32_t fifo_size = circular_buffer_config_addr[1];
         uint32_t fifo_num_pages = circular_buffer_config_addr[2];
         uint32_t fifo_page_size = circular_buffer_config_addr[3];
-        uint32_t fifo_limit = fifo_addr + fifo_size - 1;
+        uint32_t fifo_limit = fifo_addr + fifo_size;
 
         cb_interface[cb_id].fifo_limit = fifo_limit;  // to check if we need to wrap
         cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
@@ -108,7 +108,7 @@ void setup_cq_read_write_interface() {
     uint fifo_addr = (HOST_CQ_FINISH_PTR + 32) >> 4;  // The fifo starts after the pointer addresses
     uint fifo_size = ((1024 * 1024 * 1024) >> 4) - fifo_addr;
 
-    cq_read_interface.fifo_limit = fifo_addr + fifo_size - 1;
+    cq_read_interface.fifo_limit = fifo_addr + fifo_size;
     cq_read_interface.fifo_rd_ptr = fifo_addr;
     cq_read_interface.fifo_size = fifo_size;
 }
@@ -178,7 +178,7 @@ void cb_push_back(const int32_t operand, const int32_t num_pages) {
 
     // this will basically reset fifo_wr_ptr to fifo_addr -- no other wrap is legal
     // producer always writes into contiguous memory, it cannot wrap
-    if (cb_interface[operand].fifo_wr_ptr > cb_interface[operand].fifo_limit) {
+    if (cb_interface[operand].fifo_wr_ptr >= cb_interface[operand].fifo_limit) {
         // TODO: change this to fifo_wr_ptr
         cb_interface[operand].fifo_wr_ptr -= cb_interface[operand].fifo_size;
     }
@@ -217,7 +217,7 @@ void cb_pop_front(int32_t operand, int32_t num_pages) {
 
     // this will basically reset fifo_rd_ptr to fifo_addr -- no other wrap is legal
     // consumer always reads from contiguous memory, it cannot wrap
-    if (cb_interface[operand].fifo_rd_ptr > cb_interface[operand].fifo_limit) {
+    if (cb_interface[operand].fifo_rd_ptr >= cb_interface[operand].fifo_limit) {
         // TODO: change this to fifo_wr_ptr
         cb_interface[operand].fifo_rd_ptr -= cb_interface[operand].fifo_size;
     }

--- a/tt_metal/src/firmware/riscv/common/dataflow_api.h
+++ b/tt_metal/src/firmware/riscv/common/dataflow_api.h
@@ -94,8 +94,7 @@ void setup_cb_read_write_interfaces() {
         cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
         cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
         cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].tiles_acked = 0;
-        cb_interface[cb_id].tiles_received = 0;
+        cb_interface[cb_id].tiles_acked_received_init = 0;
         cb_interface[cb_id].fifo_num_pages = fifo_num_pages;
         cb_interface[cb_id].fifo_page_size = fifo_page_size;
 

--- a/tt_metal/src/firmware/riscv/common/dataflow_api.h
+++ b/tt_metal/src/firmware/riscv/common/dataflow_api.h
@@ -319,7 +319,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
     do {
         // uint16_t's here because Tensix updates the val at tiles_acked_ptr as uint16 in llk_pop_tiles
         // TODO: I think we could have TRISC update tiles_acked_ptr, and we wouldn't need uint16 here
-        uint16_t pages_acked = (uint16_t)reg_read_barrier(pages_acked_ptr);
+        uint16_t pages_acked = (uint16_t)reg_read(pages_acked_ptr);
         uint16_t free_space_pages_wrap =
             cb_interface[operand].fifo_num_pages - (pages_received - pages_acked);
         free_space_pages = (int32_t)free_space_pages_wrap;
@@ -358,7 +358,7 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
 
     DEBUG_STATUS('C', 'W', 'F', 'W');
     do {
-        pages_received = ((uint16_t)reg_read_barrier(pages_received_ptr)) - pages_acked;
+        pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     } while (pages_received < num_pages);
     DEBUG_STATUS('C', 'W', 'F', 'D');
 }

--- a/tt_metal/src/firmware/riscv/common/dataflow_api.h
+++ b/tt_metal/src/firmware/riscv/common/dataflow_api.h
@@ -46,10 +46,6 @@ extern CQReadInterface cq_read_interface;
 
 inline uint32_t align(uint32_t addr, uint32_t alignment) { return ((addr - 1) | (alignment - 1)) + 1; }
 
-// GS RISC-V RTL bug workaround (l1 reads followed by local mem reads causes a hang)
-// in ncrisc.cc/brisc.cc: volatile uint32_t local_mem_barrier;
-void write_to_local_mem_barrier(uint32_t data) { local_mem_barrier = data; }
-
 constexpr static uint32_t get_arg_addr(int arg_idx) {
     // args are 4B in size
     return L1_ARG_BASE + (arg_idx << 2);
@@ -88,14 +84,11 @@ void setup_cb_read_write_interfaces() {
     volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = (volatile uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
 
     for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
-        // write_to_local_mem_barrier are needed on GS because of the RTL bug
-        // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
         uint32_t fifo_addr = circular_buffer_config_addr[0];
         uint32_t fifo_size = circular_buffer_config_addr[1];
         uint32_t fifo_num_pages = circular_buffer_config_addr[2];
         uint32_t fifo_page_size = circular_buffer_config_addr[3];
         uint32_t fifo_limit = fifo_addr + fifo_size - 1;
-        write_to_local_mem_barrier(fifo_limit);
 
         cb_interface[cb_id].fifo_limit = fifo_limit;  // to check if we need to wrap
         cb_interface[cb_id].fifo_wr_ptr = fifo_addr;

--- a/tt_metal/src/firmware/riscv/common/debug_print_tile.h
+++ b/tt_metal/src/firmware/riscv/common/debug_print_tile.h
@@ -102,7 +102,7 @@ template DebugPrinter operator<< <TSLICE32>(DebugPrinter, TSLICE32 val);
 
 // Macros for printing circular buffer internals
 #define CB_RD_PTR(id) (cb_interface[id].fifo_rd_ptr<<4) // only valid in unpacker thread
-#define CB_RD_LIM(id) (cb_interface[id].fifo_limit<<4)
+#define CB_RD_LIM(id) ((cb_interface[id].fifo_limit_plus_1-1)<<4)
 #define CB_RD_SZ(id) (cb_interface[id].fifo_size<<4)
 
 #define CB_WR_PTR(id) (cb_interface[id].fifo_wr_ptr<<4) // only valid in packer thread

--- a/tt_metal/src/firmware/riscv/common/risc_common.h
+++ b/tt_metal/src/firmware/riscv/common/risc_common.h
@@ -44,7 +44,6 @@ const uint32_t MAX_TILES_PER_PHASE = 2048;
 
 extern uint8_t my_x[NUM_NOCS];
 extern uint8_t my_y[NUM_NOCS];
-extern volatile uint32_t local_mem_barrier;
 
 inline void WRITE_REG(uint32_t addr, uint32_t val) {
   volatile tt_reg_ptr uint32_t* ptr = (volatile tt_reg_ptr uint32_t*)addr;
@@ -104,25 +103,10 @@ inline __attribute__((always_inline)) uint32_t buf_ptr_dec_wrap(uint32_t buf_ptr
   return result;
 }
 
-inline __attribute__((always_inline)) uint32_t reg_read_barrier(uint32_t addr)
-{
-    volatile tt_reg_ptr uint32_t *p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t *> (addr);
-    uint32_t data = p_reg[0];
-    local_mem_barrier = data;
-    return data;
-}
-
 inline __attribute__((always_inline)) uint32_t reg_read(uint32_t addr)
 {
-    return reg_read_barrier(addr);
-}
-
-inline uint32_t reg_read_barrier_l1(uint32_t addr)
-{
     volatile tt_reg_ptr uint32_t *p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t *> (addr);
-    uint32_t data = p_reg[0];
-    local_mem_barrier = data;
-    return data;
+    return p_reg[0];
 }
 
 inline void assert_trisc_reset() {

--- a/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
@@ -42,8 +42,6 @@ volatile tt_l1_ptr uint32_t* instrn_buf[MAX_THREADS];
 volatile tt_l1_ptr uint32_t* pc_buf[MAX_THREADS];
 volatile tt_l1_ptr uint32_t* mailbox[MAX_THREADS];
 
-volatile uint32_t local_mem_barrier __attribute__((used));
-
 uint8_t my_x[NUM_NOCS] __attribute__((used));
 uint8_t my_y[NUM_NOCS] __attribute__((used));
 

--- a/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisc.cc
@@ -15,8 +15,6 @@
 #include "debug_status.h"
 #include "debug_print.h"
 
-volatile uint32_t local_mem_barrier __attribute__((used));
-
 uint32_t halt_stack_ptr_save;
 
 tt_l1_ptr mailboxes_t * const mailboxes = (tt_l1_ptr mailboxes_t *)(MEM_MAILBOX_BASE);


### PR DESCRIPTION
1) tiles_acked and tiles_received are uint16_t, initialized to 0 w/ 2 stores. can use a union to init w/ 1 store
2) write_to_local_mem_barrier is used for the GS arbiter bug workaround. The compiler will take care of this now and in this instance the workaround won’t be needed, saves 1 store
3) fifo_limit is calculated as fifo_addr+fifo_size-1. all the compares against fifo_limit are “fifo_[rd/wr]_ptr > fifo_limit” and can change to “>=” if we remove the “- 1”. saves 1 subtract
4) Remove local_mem_barrier code (now handled by compiler)
5) Use 0 as init value for volatile reg file sync