### PR TITLE
Merge 3 SetRuntimeArgs functions into 1, but without perf penalty

### DIFF
--- a/docs/source/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -1,10 +1,6 @@
 Runtime Arguments
 ==================
 
-.. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreCoord &logical_core, const std::vector<uint32_t> &runtime_args)
-
-.. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreRange &core_range, const std::vector<uint32_t> &runtime_args)
-
-.. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreRangeSet &core_range_set, const std::vector<uint32_t> &runtime_args)
+.. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelID kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &logical_core, const std::vector<uint32_t> &runtime_args)
 
 .. doxygenfunction:: GetRuntimeArgs

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -358,6 +358,7 @@ namespace tt::tt_metal{
         }
 
         inline CoreRangeSet GetCoreRangeSet(const std::variant<CoreCoord, CoreRange, CoreRangeSet> &specified_core_spec) {
+            ZoneScoped;
             return std::visit(
                 [](auto&& core_spec) -> CoreRangeSet
                 {

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -211,42 +211,14 @@ void DeallocateBuffer(Buffer &buffer);
  *
  * Return value: void
  *
- * | Argument     | Description                                                            | Type                          | Valid Range                                                      | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------------------------------------|----------|
- * | program      | The program containing kernels, circular buffers, semaphores           | const Program &               |                                                                  | Yes      |
- * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelID (uint64_t)                |                                                                  | Yes      |
- * | logical_core | The location of the Tensix core where the runtime args will be written | const CoreCoord &             | Any logical Tensix core coordinate on which the kernel is placed | Yes      |
- * | runtime_args | The runtime args to be written                                         | const std::vector<uint32_t> & |                                                                  | Yes      |
+ * | Argument     | Description                                                            | Type                                                   | Valid Range                                                         | Required |
+ * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------|----------|
+ * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
+ * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelID (uint64_t)                                    |                                                                     | Yes      |
+ * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::variant<CoreCoord,CoreRange,CoreRangeSet> & | Any logical Tensix core coordinate(s) on which the kernel is placed | Yes      |
+ * | runtime_args | The runtime args to be written                                         | const std::vector<uint32_t> &                          |                                                                     | Yes      |
  */
-void SetRuntimeArgs(const Program &program, KernelID kernel, const CoreCoord &logical_core, const std::vector<uint32_t> &runtime_args);
-
-/**
- * Set runtime args for a kernel that are shared amongst a range of cores. Runtime args are sent to cores during runtime. This API needs to be called to update the runtime args for the kernel.
- *
- * Return value: void
- *
- * | Argument     | Description                                                                                            | Type                          | Valid Range                                                             | Required |
- * |--------------|--------------------------------------------------------------------------------------------------------|-------------------------------|-------------------------------------------------------------------------|----------|
- * | program      | The program containing kernels, circular buffers, semaphores                                           | const Program &               |                                    | Yes      |
- * | kernel_id    | ID of the kernel that will receive the runtime args                                                    | KernelID (uint64_t)                |                                    | Yes      |
- * | core_range   | The range of the Tensix co-ordinates which receive the runtime args (Logical co-ordinates)             | const CoreRange &             | A range of any logical Tensix core coordinate on which the kernel is placed | Yes      |
- * | runtime_args | The runtime args to be written to the core range                                                       | const std::vector<uint32_t> & |                                                                         | Yes      |
- */
-void SetRuntimeArgs(const Program &program, KernelID kernel, const CoreRange &core_range, const std::vector<uint32_t> &runtime_args);
-
-/**
- * Set runtime args for a kernel that are shared amongst a CoreRangeSet. Runtime args are sent to cores during runtime. This API needs to be called to update the runtime args for the kernel.
- *
- * Return value: void
- *
- * | Argument       | Description                                                                                            | Type                          | Valid Range                        | Required |
- * |----------------|--------------------------------------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | program      | The program containing kernels, circular buffers, semaphores                                             | const Program &               |                                    | Yes      |
- * | kernel_id    | ID of the kernel that will receive the runtime args                                                      | KernelID (uint64_t)                |                                    | Yes      |
- * | core_range_set | Set of ranges of Tensix co-ordinates which receive the runtime args (Logical co-ordinates)             | const CoreRangeSet &          | Ranges of any logical Tensix core coordinate on which the kernel is placed | Yes      |
- * | runtime_args   | The runtime args to be written to the core ranges                                                      | const std::vector<uint32_t> & |                                    | Yes      |
- */
-void SetRuntimeArgs(const Program &program, KernelID kernel, const CoreRangeSet &core_range_set, const std::vector<uint32_t> &runtime_args);
+void SetRuntimeArgs(const Program &program, KernelID kernel, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::vector<uint32_t> &runtime_args);
 
 /**
  * Get the runtime args for a kernel.

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -48,7 +48,7 @@ class Kernel {
 
     std::vector<uint32_t> compile_time_args() const { return compile_time_args_; }
 
-    std::map<CoreCoord, std::vector<uint32_t>> const &runtime_args() const { return core_to_runtime_args_; }
+    std::unordered_map<CoreCoord, std::vector<uint32_t>> const &runtime_args() const { return core_to_runtime_args_; }
 
     std::vector<uint32_t> const &runtime_args(const CoreCoord &logical_core);
 
@@ -76,7 +76,7 @@ class Kernel {
     std::string binary_path_;
     std::vector<ll_api::memory> binaries_;              // DataMovement kernels have one binary each and Compute kernels have three binaries
     std::vector<uint32_t> compile_time_args_;
-    std::map<CoreCoord, std::vector<uint32_t>> core_to_runtime_args_;
+    std::unordered_map<CoreCoord, std::vector<uint32_t>> core_to_runtime_args_;
     std::map<std::string, std::string> defines_;        // preprocessor defines. this is to be able to generate generic instances.
     std::set<CoreCoord> logical_cores_;
 


### PR DESCRIPTION
Additional change to use `unordered_map` instead of `map` as the data structure that stores runtime args improves perf