### PR TITLE
#2220: Add kernel names to watcher

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -165,9 +165,9 @@ void Device::initialize_and_launch_firmware() {
     ZoneScoped;
 
     launch_msg_t launch_msg = {
-        .brisc_kernel_id = 0,
-        .ncrisc_kernel_id = 0,
-        .trisc_kernel_id = 0,
+        .brisc_watcher_kernel_id = 0,
+        .ncrisc_watcher_kernel_id = 0,
+        .triscs_watcher_kernel_id = 0,
         .ncrisc_kernel_size16 = 0,
         .mode = DISPATCH_MODE_HOST,
         .brisc_noc_id = 0,

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -13,13 +13,20 @@
 
 #include "third_party/magic_enum/magic_enum.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "llrt/watcher.hpp"
 
 namespace tt {
 
 namespace tt_metal {
 
 Kernel::Kernel(const std::string &kernel_path_file_name, const CoreRangeSet &core_range_set, const std::vector<uint32_t> &compile_args, const std::map<std::string, std::string> &defines) :
-    id_(reinterpret_cast<uintptr_t>(this)), kernel_path_file_name_(kernel_path_file_name), core_range_set_(core_range_set), binary_size16_(0), compile_time_args_(compile_args), defines_(defines) {
+    id_(reinterpret_cast<uintptr_t>(this)),
+    watcher_kernel_id_(llrt::watcher_register_kernel(kernel_path_file_name)),
+    kernel_path_file_name_(kernel_path_file_name),
+    core_range_set_(core_range_set),
+    binary_size16_(0),
+    compile_time_args_(compile_args), defines_(defines) {
+
     for (auto core_range : this->core_range_set_.ranges()) {
         auto start = core_range.start;
         auto end = core_range.end;

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <variant>
 #include <type_traits>
+#include <memory>
 
 #include "build_kernels_for_riscv/build_kernel_options.hpp"
 #include "common/base_types.hpp"
@@ -70,8 +71,11 @@ class Kernel {
 
     void set_runtime_args(const CoreCoord &logical_core, const std::vector<uint32_t> &runtime_args);
 
+    int get_watcher_kernel_id() { return watcher_kernel_id_; }
+
    protected:
     const uintptr_t id_;
+    const int watcher_kernel_id_;
     std::string kernel_path_file_name_;                 // Full kernel path and file name
     CoreRangeSet core_range_set_;
     std::string binary_path_;

--- a/tt_metal/impl/program.cpp
+++ b/tt_metal/impl/program.cpp
@@ -120,7 +120,9 @@ KernelGroup::KernelGroup(const Program& program,
         // Use brisc's noc if brisc specifies a noc
         this->launch_msg.enable_brisc = true;
         this->launch_msg.brisc_noc_id = std::get<DataMovementConfig>(program.get_kernel(brisc_id.value())->config()).noc;
+        this->launch_msg.brisc_watcher_kernel_id = program.get_kernel(brisc_id.value())->get_watcher_kernel_id();
     } else {
+        this->launch_msg.brisc_watcher_kernel_id = 0;
         this->launch_msg.enable_brisc = false;
     }
 
@@ -131,11 +133,19 @@ KernelGroup::KernelGroup(const Program& program,
         this->launch_msg.enable_ncrisc = true;
         this->launch_msg.brisc_noc_id = 1 - std::get<DataMovementConfig>(kernel->config()).noc;
         this->launch_msg.ncrisc_kernel_size16 = kernel->get_binary_size16();
+        this->launch_msg.ncrisc_watcher_kernel_id = program.get_kernel(ncrisc_id.value())->get_watcher_kernel_id();
     } else {
+        this->launch_msg.ncrisc_watcher_kernel_id = 0;
         this->launch_msg.enable_ncrisc = false;
     }
 
-    this->launch_msg.enable_triscs = trisc_id ? true : false;
+    if (trisc_id) {
+        this->launch_msg.enable_triscs = true;
+        this->launch_msg.triscs_watcher_kernel_id = program.get_kernel(trisc_id.value())->get_watcher_kernel_id();
+    } else {
+        this->launch_msg.triscs_watcher_kernel_id = 0;
+        this->launch_msg.enable_triscs = false;
+    }
 
     this->launch_msg.run = RUN_MSG_GO;
 }

--- a/tt_metal/llrt/watcher.hpp
+++ b/tt_metal/llrt/watcher.hpp
@@ -17,5 +17,7 @@ void watcher_detach(void *dev);
 void watcher_sanitize_host_noc_read(const metal_SocDescriptor &soc_d, CoreCoord core, uint64_t addr, uint32_t len);
 void watcher_sanitize_host_noc_write(const metal_SocDescriptor &soc_d, CoreCoord core, uint64_t addr, uint32_t len);
 
+int watcher_register_kernel(const string& name);
+
 } // namespace llrt
 } // namespace tt

--- a/tt_metal/src/ckernels/grayskull/common/inc/cmath_common.h
+++ b/tt_metal/src/ckernels/grayskull/common/inc/cmath_common.h
@@ -12,6 +12,7 @@
 #include "ckernel_globals.h"
 
 #include "fw_debug.h"
+#include "debug_status.h"
 
 #ifndef SFPU_OP_PARAM
 #define SFPU_OP_PARAM 0
@@ -139,7 +140,9 @@ inline uint32_t get_dest_buffer_base()
 inline void wait_math_semaphores()
 {
     // wait while math semaphore is on max, no room to write math results
+    DEBUG_STATUS('W', 'M', 'S', 'W');
     TTI_SEMWAIT(p_stall::STALL_MATH, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_MAX);
+    DEBUG_STATUS('W', 'M', 'S', 'D');
 }
 
 inline void set_math_semaphores()
@@ -170,7 +173,9 @@ inline void clear_dst_reg_addr()
 
 inline void math_dest_wait()
 {
+    DEBUG_STATUS('W', 'D', 'S', 'W');
     TTI_SEMWAIT(p_stall::STALL_MATH, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_MAX);
+    DEBUG_STATUS('W', 'D', 'S', 'D');
 }
 
 inline void dest_section_flip()

--- a/tt_metal/src/ckernels/grayskull/common/inc/cpack_common.h
+++ b/tt_metal/src/ckernels/grayskull/common/inc/cpack_common.h
@@ -10,6 +10,7 @@
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"
 #include "fw_debug.h"
+#include "debug_status.h"
 
 #define TT_OP_SETDMAREG_SHFT(Payload_SigSelSize, Payload_SigSelShft, SetSignalsMode, RegIndex16b) \
   TT_OP(0x45, (((Payload_SigSelSize) << 22) + ((Payload_SigSelShft)) + ((SetSignalsMode) << 7) + ((RegIndex16b) << 0)))
@@ -165,7 +166,9 @@ namespace ckernel::packer
 
    inline void wait_for_unpack_config_done()
    {
+      DEBUG_STATUS('W', 'U', 'C', 'W');
       while (semaphore_read(semaphore::UNPACK_PACK_CONFIG_SYNC) == 0) {}
+      DEBUG_STATUS('W', 'U', 'C', 'D');
    }
 
    inline void configure_pack(uint pack_output, uint relu_config = 0, bool skip_alu_format_set=false)

--- a/tt_metal/src/ckernels/grayskull/common/inc/cunpack_common.h
+++ b/tt_metal/src/ckernels/grayskull/common/inc/cunpack_common.h
@@ -9,6 +9,7 @@
 #include "ckernel.h"
 #include "ckernel_globals.h"
 #include "fw_debug.h"
+#include "debug_status.h"
 
 #ifdef PERF_DUMP
 #include "perf_res_decouple.h"
@@ -127,7 +128,9 @@ namespace ckernel::unpacker
    // Wait for threshold of busy contexts to fall below total available contexts
    inline void wait_for_next_context(const uint num_contexts)
    {
+       DEBUG_STATUS('W', 'N', 'C', 'W');
        while (semaphore_read(semaphore::UNPACK_SYNC) >= num_contexts) {}
+       DEBUG_STATUS('W', 'N', 'C', 'D');
    }
 
    inline void switch_config_context(uint &unp_cfg_context)
@@ -152,12 +155,16 @@ namespace ckernel::unpacker
    // Sync on unpacker idle via waiting busy contexts counter 0
    inline void wait_for_idle()
    {
+       DEBUG_STATUS('W', 'I', 'W');
        while (semaphore_read(semaphore::UNPACK_SYNC) > 0) {}
+       DEBUG_STATUS('W', 'I', 'D');
    }
 
    inline void wait_for_pack_config_done()
    {
+       DEBUG_STATUS('W', 'P', 'C', 'W');
        while (semaphore_read(semaphore::UNPACK_PACK_CONFIG_SYNC) > 0) {}
+       DEBUG_STATUS('W', 'P', 'C', 'D');
    }
 
    inline void configure_unpack_AB(

--- a/tt_metal/src/ckernels/wormhole_b0/common/inc/cmath_common.h
+++ b/tt_metal/src/ckernels/wormhole_b0/common/inc/cmath_common.h
@@ -13,6 +13,7 @@
 #include "ckernel_globals.h"
 
 #include "fw_debug.h"
+#include "debug_status.h"
 
 #ifndef SFPU_OP_PARAM
 #define SFPU_OP_PARAM 0
@@ -146,7 +147,9 @@ inline uint32_t get_dest_buffer_base()
 inline void wait_math_semaphores()
 {
     // wait while math semaphore is on max, no room to write math results
+    DEBUG_STATUS('W', 'M', 'S', 'W');
     TTI_SEMWAIT(p_stall::STALL_MATH|p_stall::STALL_SFPU, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_MAX);
+    DEBUG_STATUS('W', 'M', 'S', 'D');
 }
 
 inline void set_math_semaphores()
@@ -187,7 +190,9 @@ inline void clear_addr_mod_base()
 
 inline void math_dest_wait()
 {
+    DEBUG_STATUS('W', 'D', 'S', 'W');
     TTI_SEMWAIT(p_stall::STALL_MATH|p_stall::STALL_SFPU, semaphore::t6_sem(semaphore::MATH_PACK), p_stall::STALL_ON_MAX);
+    DEBUG_STATUS('W', 'D', 'S', 'D');
 }
 
 inline void dest_section_flip()

--- a/tt_metal/src/ckernels/wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/src/ckernels/wormhole_b0/common/inc/cunpack_common.h
@@ -9,6 +9,7 @@
 #include "ckernel.h"
 #include "ckernel_globals.h"
 #include "fw_debug.h"
+#include "debug_status.h"
 
 #ifdef PERF_DUMP
 #include "perf_res_decouple.h"
@@ -157,7 +158,9 @@ namespace ckernel::unpacker
    // Wait for threshold of busy contexts to fall below total available contexts
    inline void wait_for_next_context(const uint num_contexts)
    {
+       DEBUG_STATUS('W', 'N', 'C', 'W');
        while (semaphore_read(semaphore::UNPACK_SYNC) >= num_contexts) {}
+       DEBUG_STATUS('W', 'N', 'C', 'D');
    }
 
    inline void switch_config_context(uint &unp_cfg_context)
@@ -191,7 +194,9 @@ namespace ckernel::unpacker
    // Sync on unpacker idle via waiting busy contexts counter 0
    inline void wait_for_idle()
    {
+       DEBUG_STATUS('W', 'I', 'W');
        while (semaphore_read(semaphore::UNPACK_SYNC) > 0) {}
+       DEBUG_STATUS('W', 'I', 'D');
    }
 
    inline constexpr uint32_t get_num_faces(const std::uint32_t operand_id)

--- a/tt_metal/src/firmware/riscv/common/dev_msgs.h
+++ b/tt_metal/src/firmware/riscv/common/dev_msgs.h
@@ -39,9 +39,9 @@ enum dispatch_mode {
 };
 
 struct launch_msg_t {  // must be cacheline aligned
-    volatile uint16_t brisc_kernel_id;
-    volatile uint16_t ncrisc_kernel_id;
-    volatile uint16_t trisc_kernel_id;
+    volatile uint16_t brisc_watcher_kernel_id;
+    volatile uint16_t ncrisc_watcher_kernel_id;
+    volatile uint16_t triscs_watcher_kernel_id;
     volatile uint16_t ncrisc_kernel_size16; // size in 16 byte units
     volatile uint8_t mode;
     volatile uint8_t brisc_noc_id;


### PR DESCRIPTION
Generate a unique id for each kernel and register it with the watcher Put id into launch msg
Watcher validates kernel id and reports which kernels are running