### PR TITLE
#3368: Add modified generator for fast_and_approx

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
@@ -1183,18 +1183,28 @@ def gen_elu_args(
 
 
 def gen_fast_and_approx_args(input_shapes, dtypes, layouts, mem_configs):
-    for input_info in gen_dtype_layout_device(
+
+    input_info = gen_dtype_layout_device(
         input_shapes,
         dtypes,
         layouts,
         mem_configs,
-    ):
-        if input_info is not None:
-            input_info.update({"fast_and_approx": True})
-            yield input_info
+    )
 
-            input_info.update({"fast_and_approx": False})
-            yield input_info
+    test_args_combinations = []
+
+    for input_args in input_info:
+        if input_args is not None:
+            input_args_1 = input_args.copy()
+            input_args_2 = input_args.copy()
+
+            input_args_1.update({"fast_and_approx": True})
+            test_args_combinations.append(input_args_1)
+
+            input_args_2.update({"fast_and_approx": False})
+            test_args_combinations.append(input_args_2)
+
+    return test_args_combinations
 
 
 def gen_two_scalar_args(


### PR DESCRIPTION
Add fix for fast_and_approx generator function for sweep tests. Old way used to produce duplicated results for fast_and_approx value in test arguments, bc the dictionary was getting overwritten. 