### PR TITLE
Move slow dispatch functions WriteToBuffer, ReadFromBuffer, LaunchProgram to detail namespace

### DIFF
--- a/docs/source/tt_metal/apis/host_apis.rst
+++ b/docs/source/tt_metal/apis/host_apis.rst
@@ -6,7 +6,6 @@ Host APIs
   host_apis/buffers/buffers
   host_apis/command_queue/command_queue
   host_apis/device_management/device_management
-  host_apis/data_movement/data_movement
   host_apis/kernels/kernels
   host_apis/runtime_args/runtime_args
   host_apis/environment_variables/environment_variables

--- a/docs/source/tt_metal/apis/host_apis/data_movement/ReadFromBuffer.rst
+++ b/docs/source/tt_metal/apis/host_apis/data_movement/ReadFromBuffer.rst
@@ -1,4 +1,0 @@
-ReadFromBuffer
-===============
-
-.. doxygenfunction:: ReadFromBuffer

--- a/docs/source/tt_metal/apis/host_apis/data_movement/WriteToBuffer.rst
+++ b/docs/source/tt_metal/apis/host_apis/data_movement/WriteToBuffer.rst
@@ -1,4 +1,0 @@
-WriteToBuffer
-==============
-
-.. doxygenfunction:: WriteToBuffer

--- a/docs/source/tt_metal/apis/host_apis/data_movement/data_movement.rst
+++ b/docs/source/tt_metal/apis/host_apis/data_movement/data_movement.rst
@@ -1,6 +1,0 @@
-Data Movement
-==================
-
-.. toctree::
-  WriteToBuffer
-  ReadFromBuffer

--- a/docs/source/tt_metal/examples/eltwise_binary.rst
+++ b/docs/source/tt_metal/examples/eltwise_binary.rst
@@ -72,7 +72,7 @@ Extra source tensor
         constexpr float val_to_add = -1.0f;
         std::vector<uint32_t> src1_vec = create_constant_vector_of_bfloat16(dram_buffer_size, val_to_add);
 
-        WriteToBuffer(src1_dram_buffer, src1_vec);
+        detail::WriteToBuffer(src1_dram_buffer, src1_vec);
 
 In this program, we have a second source tensor. We will be adding this to the
 first source tensor.

--- a/tests/tt_eager/dtx/test_dtx.cpp
+++ b/tests/tt_eager/dtx/test_dtx.cpp
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
         std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
         auto input_vector = unpack_uint32_vec_into_bfloat16_vec(input_vec);
-        tt_metal::WriteToBuffer(input_dram_buffer, input_vec);
+        tt_metal::detail::WriteToBuffer(input_dram_buffer, input_vec);
 
 
 
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
             (std::uint32_t) address_map.size()});
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromDeviceL1(device, core, l1_buffer_addr, dram_buffer_size, result_vec);

--- a/tests/tt_eager/dtx/test_dtx_tilized_row_to_col_major.cpp
+++ b/tests/tt_eager/dtx/test_dtx_tilized_row_to_col_major.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
         std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
         auto input_vector = unpack_uint32_vec_into_bfloat16_vec(input_vec);
-        tt_metal::WriteToBuffer(input_dram_buffer, input_vec);
+        tt_metal::detail::WriteToBuffer(input_dram_buffer, input_vec);
 
 
 
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
             (std::uint32_t) address_map.size()});
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromDeviceL1(device, core, l1_buffer_addr, dram_buffer_size, result_vec);

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -10,6 +10,7 @@
 #include "third_party/magic_enum/magic_enum.hpp"
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "tests_common/sfpu_helper/sfpu_helper.hpp"
 #include "tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
@@ -144,7 +145,7 @@ bool run_sfpu_test(string sfpu_name) {
         std::vector<uint32_t> src_vec = sfpu_op_to_init_func.at(sfpu_name)(
             dram_buffer_size, std::chrono::system_clock::now().time_since_epoch().count());
 
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
 
@@ -176,10 +177,10 @@ bool run_sfpu_test(string sfpu_name) {
 
 
         // tt::tt_metal::tt_gdb(device, 0, program->cores(), program->cores_to_ops());
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/matmul/matmul_global_l1.cpp
@@ -1156,14 +1156,14 @@ int main(int argc, char** argv) {
     auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
     auto activations =
         pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-    tt_metal::WriteToBuffer(in0_buffer, activations);
+    tt_metal::detail::WriteToBuffer(in0_buffer, activations);
 
     auto identity =
         create_identity_matrix(Kt * 32, Nt * 32, std::min(Kt, Nt) * 32);
     auto identity_tilized = tilize(identity, Kt * 32, Nt * 32);
     auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    tt_metal::WriteToBuffer(in1_buffer, weights);
+    tt_metal::detail::WriteToBuffer(in1_buffer, weights);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Matmul Parameters Setup
@@ -1219,7 +1219,7 @@ int main(int argc, char** argv) {
     //                      Validation & Teardown
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> result_vec;
-    tt_metal::ReadFromBuffer(out_buffer, result_vec);
+    tt_metal::detail::ReadFromBuffer(out_buffer, result_vec);
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
     auto result_flat_layout = convert_to_flat_layout(result_bfp16);
     auto result_untilized = untilize(result_flat_layout, Mt * 32, Nt * 32);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_read_global_l1.cpp
@@ -203,7 +203,7 @@ int main(int argc, char **argv) {
       for (int c = 0; c < num_cores_c; ++c) {
         l1_buffers.emplace_back(device, total_tiles_size_bytes,
                                 single_tile_size, tt_metal::BufferType::L1);
-        tt_metal::WriteToBuffer(l1_buffers[r * num_cores_c + c],
+        tt_metal::detail::WriteToBuffer(l1_buffers[r * num_cores_c + c],
                                 packed_tensors[r * num_cores_c + c]);
 
         if (single_read || one_buffer_share) break;
@@ -215,7 +215,7 @@ int main(int argc, char **argv) {
     for (int r = 0; r < num_cores_r; ++r) {
       for (int c = 0; c < num_cores_c; ++c) {
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(l1_buffers[r * num_cores_c + c], result_vec);
+        tt_metal::detail::ReadFromBuffer(l1_buffers[r * num_cores_c + c], result_vec);
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
 
         if (print_tensor) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -40,7 +40,7 @@ void measure_latency(string kernel_name) {
     tt::tt_metal::detail::SetProfilerDir(kernel_name + "_microbenchmark");
     tt::tt_metal::detail::FreshProfilerDeviceLog();
     detail::CompileProgram(device, program);
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
     tt_metal::CloseDevice(device);
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/pcie/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/pcie/test_rw_buffer.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
 
       for (int i=0; i<iter; i++) {
         begin = std::chrono::steady_clock::now();
-        tt_metal::WriteToBuffer(buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(buffer, src_vec);
         end = std::chrono::steady_clock::now();
         elapsed_sum += end - begin;
       }
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
       auto elapsed_us = duration_cast<microseconds>(elapsed_sum / iter).count();
       auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) /
                   (elapsed_us / 1000.0 / 1000.0);
-      log_info(LogTest, "WriteToBuffer {}: {:.3f}ms, {:.3f}GB/s",
+      log_info(LogTest, "detail::WriteToBuffer {}: {:.3f}ms, {:.3f}GB/s",
                 buffer_type == 0 ? "DRAM" : "L1", elapsed_us / 1000.0, bw);
     }
 
@@ -98,14 +98,14 @@ int main(int argc, char** argv) {
 
       for (int i=0; i<iter; i++) {
         begin = std::chrono::steady_clock::now();
-        tt_metal::ReadFromBuffer(buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(buffer, result_vec);
         end = std::chrono::steady_clock::now();
         elapsed_sum += end - begin;
       }
       auto elapsed_us = duration_cast<microseconds>(elapsed_sum / iter).count();
       auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) /
                   (elapsed_us / 1000.0 / 1000.0);
-      log_info(LogTest, "ReadFromBuffer {}: {:.3f}ms, {:.3f}GB/s",
+      log_info(LogTest, "detail::ReadFromBuffer {}: {:.3f}ms, {:.3f}GB/s",
                 buffer_type == 0 ? "DRAM" : "L1", elapsed_us / 1000.0, bw);
     }
 

--- a/tests/tt_metal/tt_metal/test_3x3conv_as_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_3x3conv_as_matmul_large_block.cpp
@@ -261,9 +261,9 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
 
         auto activations = pack_bfloat16_vec_into_uint32_vec(src_vec);
-        tt_metal::WriteToBuffer(src0_dram_buffer, activations);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations);
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tilized);
-        tt_metal::WriteToBuffer(src1_dram_buffer, weights);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
         std::cout << "DONE WRITING TO DEVICE. GOING TO CONFIGURE DEVICE WITH PROGRAM" << std::endl;
 
         tt_metal::SetRuntimeArgs(
@@ -289,11 +289,11 @@ int main(int argc, char **argv) {
         // END DEBUG
 
         std::cout << "DONE WRITING address map TO DEVICE L1. GOING TO LAUNCH KERNELS" << std::endl;
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         std::cout << "DONE KERNELS. GOING TO READ FROM DRAM." << std::endl;
 
         std::vector<uint32_t> result_uint32;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_uint32);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_uint32);
         auto result_vec_tilized = unpack_uint32_vec_into_bfloat16_vec(result_uint32);
         assert(golden_act_matrix_tilized.size() == result_vec_tilized.size());
         auto result_vec = untilize(result_vec_tilized, act_rows, weight_cols);

--- a/tests/tt_metal/tt_metal/test_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_add_two_ints.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
         tt_metal::SetRuntimeArgs(program, add_two_ints_kernel, core, first_runtime_args);
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> first_kernel_result;
         tt_metal::detail::ReadFromDeviceL1(device, core, BRISC_L1_RESULT_BASE, sizeof(int), first_kernel_result);
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
         //                  Update Runtime Args and Re-run Application
         ////////////////////////////////////////////////////////////////////////////
         tt_metal::SetRuntimeArgs(program, add_two_ints_kernel, core, second_runtime_args);
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> second_kernel_result;
         tt_metal::detail::ReadFromDeviceL1(device, core, BRISC_L1_RESULT_BASE, sizeof(int), second_kernel_result);

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -9,6 +9,7 @@
 #include <map>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 
 #include "test_tiles.hpp"
@@ -199,7 +200,7 @@ int main(int argc, char **argv) {
         auto src1_dram_buffer = CreateBuffer(device, bcast_vals_nbytes, src1_page_size, tt_metal::BufferType::DRAM);
         uint32_t dram_buffer_src1_addr = src1_dram_buffer.address();
         auto dram_src1_noc_xy = src1_dram_buffer.noc_coordinates();
-        tt_metal::WriteToBuffer(src1_dram_buffer, bcast_tiled_u32);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, bcast_tiled_u32);
 
         bool src0_is_dram = true;
         bool src1_is_dram = true;
@@ -269,16 +270,16 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         auto seed = std::chrono::system_clock::now().time_since_epoch().count();
         vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 10.0f, 0x1234);
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_vec);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
 
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         // The kernel will view the input as TILED32_4FACES
         vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "test_gold_impls.hpp"
 
@@ -105,8 +106,8 @@ int main(int argc, char **argv) {
 
         std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(bytesA, 1.0f, 0x1234);
         std::vector<uint32_t> src1_vec = create_random_vector_of_bfloat16(bytesB, 1.0f, 0x1234, -0.45f);
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_vec);
-        tt_metal::WriteToBuffer(src1_dram_buffer, src1_vec);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, src1_vec);
 
         uint32_t do_bcast = 0;
         tt_metal::SetRuntimeArgs(
@@ -118,10 +119,10 @@ int main(int argc, char **argv) {
             {dram_buffer_dst_addr, 0, Mt, Kt, Nt, Mt*Kt, Kt*Nt, B}
         );
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         {
             // Read the result back from device DRAM and ref comparisone

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -146,7 +146,7 @@ bool test_program_specified_with_core_range_set(tt_metal::Device *device, tt_met
 
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+    tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
     // Reader kernel on all cores reads from same location in DRAM
     std::vector<uint32_t> reader_rt_args = {
@@ -175,11 +175,11 @@ bool test_program_specified_with_core_range_set(tt_metal::Device *device, tt_met
     }
 
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     for (const auto &[core, dst_l1_buffer] : core_to_l1_buffer) {
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_l1_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_l1_buffer, result_vec);
         bool copied_data_correctly = src_vec == result_vec;
         TT_ASSERT(copied_data_correctly);
         pass &= copied_data_correctly;

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 //#include "tt_metal/tools/tt_gdb/tt_gdb.hpp"
 
@@ -103,7 +104,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
 
@@ -127,10 +128,10 @@ int main(int argc, char **argv) {
 
         // tt::tt_metal::tt_gdb(device, 0, program->logical_cores(), program->cores_to_ops());
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat8.hpp"
 // //#include "tt_metal/tools/tt_gdb/tt_gdb.hpp"
 #include "tt_metal/detail/util.hpp"
@@ -102,7 +103,7 @@ int main(int argc, char **argv) {
             dram_buffer_size,
             /*is_exp_a=*/false,
             100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
 
@@ -125,10 +126,10 @@ int main(int argc, char **argv) {
             num_tiles});
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         // ////////////////////////////////////////////////////////////////////////////
         // //                      Validation & Teardown
         // ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
@@ -396,7 +396,7 @@ int main(int argc, char **argv) {
 
         log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         log_info(LogTest, "Matmul test done");
         log_info(LogTest, "Gathering data back from dram and checking against golden");

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 //#include "tt_metal/tools/tt_gdb/tt_gdb.hpp"
 
@@ -106,7 +107,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
 
@@ -130,10 +131,10 @@ int main(int argc, char **argv) {
 
 
         // tt::tt_metal::tt_gdb(device, 0, program->logical_cores(), program->cores_to_ops());
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_l1_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_l1_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/test_dataflow_cb.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -95,7 +96,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
 
@@ -119,10 +120,10 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 // #include "tt_gdb/tt_gdb.hpp"
 
@@ -88,7 +89,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
         std::cout << "Num cores " << num_cores_r * num_cores_c << std::endl;
@@ -111,9 +112,9 @@ int main(int argc, char **argv) {
         }
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         //std::vector<uint32_t> result_vec;
-        //tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        //tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_dram_loopback_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_multi_core.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        pass &= tt_metal::WriteToBuffer(input_dram_buffer, src_vec);
+        pass &= tt_metal::detail::WriteToBuffer(input_dram_buffer, src_vec);
 
 
 
@@ -140,10 +140,10 @@ int main(int argc, char **argv) {
             transient_buffer_size_bytes});
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(output_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(output_dram_buffer, result_vec);
         auto dst_vec = unpack_uint32_vec_into_bfloat16_vec(result_vec);
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_dram_loopback_multi_core_db.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_multi_core_db.cpp
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
         pass &=
-            tt_metal::WriteToBuffer(input_dram_buffer, src_vec);
+            tt_metal::detail::WriteToBuffer(input_dram_buffer, src_vec);
 
 
 
@@ -162,10 +162,10 @@ int main(int argc, char **argv) {
         );
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(output_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(output_dram_buffer, result_vec);
         auto dst_vec = unpack_uint32_vec_into_bfloat16_vec(result_vec);
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -71,7 +72,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::WriteToBuffer(input_dram_buffer, input_vec);
+        tt_metal::detail::WriteToBuffer(input_dram_buffer, input_vec);
 
 
 
@@ -89,10 +90,10 @@ int main(int argc, char **argv) {
             dram_buffer_size});
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(output_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(output_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core_db.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core_db.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -73,7 +74,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
             dram_buffer_size_bytes, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::WriteToBuffer(input_dram_buffer, input_vec);
+        tt_metal::detail::WriteToBuffer(input_dram_buffer, input_vec);
 
 
 
@@ -94,10 +95,10 @@ int main(int argc, char **argv) {
             total_l1_buffer_size_bytes});
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(output_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(output_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_to_l1_multicast.cpp
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
         SHAPE shape = {1, 1, 32, 32};
         tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
         auto activations = pack_bfloat16_vec_into_uint32_vec(tensor.get_values());
-        tt_metal::WriteToBuffer(dram_buffer, activations);
+        tt_metal::detail::WriteToBuffer(dram_buffer, activations);
 
         tt_metal::SetRuntimeArgs(program, mcast_reader_kernel, core, mcast_reader_args);
 
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
 
 
         log_info(LogTest, "Launching kernels");
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         log_info(LogTest, "Kernels done");
 
         for(int i = 0 ; i < grid_size.y; i++) {

--- a/tests/tt_metal/tt_metal/test_dram_to_l1_multicast_loopback_src.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_to_l1_multicast_loopback_src.cpp
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         SHAPE shape = {1, 1, 32, 32};
         tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
         auto activations = pack_bfloat16_vec_into_uint32_vec(tensor.get_values());
-        tt_metal::WriteToBuffer(dram_buffer, activations);
+        tt_metal::detail::WriteToBuffer(dram_buffer, activations);
 
 
         tt_metal::SetRuntimeArgs(program, mcast_reader_kernel, core, mcast_reader_args);
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
 
 
         log_info(LogTest, "Launching kernels");
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         log_info(LogTest, "Kernels done");
 
         for(int i = 0 ; i < grid_size.y; i++) {

--- a/tests/tt_metal/tt_metal/test_eltwise_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_unary.cpp
@@ -233,9 +233,9 @@ bool run_sfpu_all_same_buffer(tt_metal::Device* device, const SfpuConfig& test_c
     }
 
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::WriteToBuffer(input_dram_buffer, packed_input);
-    tt_metal::LaunchProgram(device, program);
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::WriteToBuffer(input_dram_buffer, packed_input);
+    tt_metal::detail::LaunchProgram(device, program);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
 
     return is_close_packed_sfpu_output(dest_buffer_data, packed_golden, test_config.sfpu_op);
 }

--- a/tests/tt_metal/tt_metal/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/test_flatten.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 
 #include "llrt/llrt.hpp"
@@ -155,7 +156,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
 
@@ -180,10 +181,10 @@ int main(int argc, char **argv) {
             num_tiles * 32});
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -308,13 +308,13 @@ int main(int argc, char **argv) {
         auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K, in0_block_w);
-        tt_metal::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bflaot16 32x32 identity
         auto identity_tilized = tilize(identity, K * 32, N * 32);
         auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        tt_metal::WriteToBuffer(src1_dram_buffer, weights);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
         tt_metal::detail::WriteToDeviceL1(device, core, source_addresses_in_l1_addr, source_addresses);
 
 
@@ -330,10 +330,10 @@ int main(int argc, char **argv) {
             core,
             writer_rt_args);
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_graph_interpreter.cpp
+++ b/tests/tt_metal/tt_metal/test_graph_interpreter.cpp
@@ -269,7 +269,7 @@ bool run_chained_sfpu_test(int chain_length) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
 
@@ -279,10 +279,10 @@ bool run_chained_sfpu_test(int chain_length) {
 
 
         // TT_ASSERT(false);
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
@@ -493,8 +493,8 @@ bool run_binary_add_and_then_eltwise_gelu_test() {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_vec);
-        tt_metal::WriteToBuffer(src1_dram_buffer, src1_vec);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, src1_vec);
 
 
 
@@ -504,10 +504,10 @@ bool run_binary_add_and_then_eltwise_gelu_test() {
 
 
         // TT_ASSERT(false);
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
@@ -960,7 +960,7 @@ bool run_forked_binary_test() {
         for(uint32_t i = 0; i < num_dram_channels; i++){
             vector<uint32_t> src_vec = create_random_ones_and_twos_vector_of_bfloat16(
                 src_dram_buffers[i].size(),  std::chrono::system_clock::now().time_since_epoch().count());
-            tt_metal::WriteToBuffer(src_dram_buffers[i], src_vec);
+            tt_metal::detail::WriteToBuffer(src_dram_buffers[i], src_vec);
             src_vecs.push_back(src_vec);
         }
 
@@ -975,10 +975,10 @@ bool run_forked_binary_test() {
         tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, unary_writer_args);
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -8,6 +8,8 @@
 
 #include "common/bfloat16.hpp"
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h"
 
 
@@ -26,10 +28,10 @@ bool test_interleaved_l1_buffer(tt_metal::Device *device, int num_pages_one, int
     std::vector<uint32_t> host_buffer = create_random_vector_of_bfloat16(
         buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    tt_metal::WriteToBuffer(interleaved_buffer, host_buffer);
+    tt_metal::detail::WriteToBuffer(interleaved_buffer, host_buffer);
 
     std::vector<uint32_t> readback_buffer;
-    tt_metal::ReadFromBuffer(interleaved_buffer, readback_buffer);
+    tt_metal::detail::ReadFromBuffer(interleaved_buffer, readback_buffer);
 
     pass &= (host_buffer == readback_buffer);
 
@@ -40,10 +42,10 @@ bool test_interleaved_l1_buffer(tt_metal::Device *device, int num_pages_one, int
     std::vector<uint32_t> second_host_buffer = create_random_vector_of_bfloat16(
         second_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    tt_metal::WriteToBuffer(second_interleaved_buffer, second_host_buffer);
+    tt_metal::detail::WriteToBuffer(second_interleaved_buffer, second_host_buffer);
 
     std::vector<uint32_t> second_readback_buffer;
-    tt_metal::ReadFromBuffer(second_interleaved_buffer, second_readback_buffer);
+    tt_metal::detail::ReadFromBuffer(second_interleaved_buffer, second_readback_buffer);
 
     pass &= (second_host_buffer == second_readback_buffer);
 

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -8,6 +8,7 @@
 #include <math.h>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 
 #include "llrt/llrt.hpp"
@@ -49,10 +50,10 @@ bool test_write_interleaved_sticks_and_then_read_interleaved_sticks(const tt::AR
         auto sticks_buffer = CreateBuffer(device, dram_buffer_size, stick_size, tt_metal::BufferType::DRAM);
         uint32_t dram_buffer_src_addr = sticks_buffer.address();
 
-        tt_metal::WriteToBuffer(sticks_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(sticks_buffer, src_vec);
 
         vector<uint32_t> dst_vec;
-        tt_metal::ReadFromBuffer(sticks_buffer, dst_vec);
+        tt_metal::detail::ReadFromBuffer(sticks_buffer, dst_vec);
 
         pass &= (src_vec == dst_vec);
         pass &= tt_metal::CloseDevice(device);
@@ -157,7 +158,7 @@ bool interleaved_stick_reader_single_bank_tilized_writer_datacopy_test(const tt:
         std::vector<uint32_t> src_vec = create_arange_vector_of_bfloat16(
             dram_buffer_size, false);
 
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
         tt_metal::SetRuntimeArgs(
@@ -180,10 +181,10 @@ bool interleaved_stick_reader_single_bank_tilized_writer_datacopy_test(const tt:
 
         CoreCoord debug_core = {1,1};
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
@@ -323,7 +324,7 @@ bool interleaved_tilized_reader_interleaved_stick_writer_datacopy_test(const tt:
         std::vector<uint32_t> src_vec = create_arange_vector_of_bfloat16(
             dram_buffer_size, false);
 
-        tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
 
@@ -345,10 +346,10 @@ bool interleaved_tilized_reader_interleaved_stick_writer_datacopy_test(const tt:
             (uint32_t) stick_size,
             (uint32_t) log2(stick_size)});
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
@@ -438,7 +439,7 @@ bool test_interleaved_l1_datacopy(const tt::ARCH& arch) {
         TT_ASSERT((buffer_size % num_l1_banks) == 0);
 
         src = CreateBuffer(device, buffer_size, num_bytes_per_page, tt_metal::BufferType::L1);
-        tt_metal::WriteToBuffer(src, host_buffer);
+        tt_metal::detail::WriteToBuffer(src, host_buffer);
 
         tt_metal::SetRuntimeArgs(
             program,
@@ -450,7 +451,7 @@ bool test_interleaved_l1_datacopy(const tt::ARCH& arch) {
         TT_ASSERT((buffer_size % num_dram_banks) == 0);
 
         src = CreateBuffer(device, buffer_size, num_bytes_per_page, tt_metal::BufferType::DRAM);
-        tt_metal::WriteToBuffer(src, host_buffer);
+        tt_metal::detail::WriteToBuffer(src, host_buffer);
 
         tt_metal::SetRuntimeArgs(
             program,
@@ -473,9 +474,9 @@ bool test_interleaved_l1_datacopy(const tt::ARCH& arch) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
-        tt_metal::ReadFromBuffer(dst, readback_buffer);
+        tt_metal::detail::ReadFromBuffer(dst, readback_buffer);
 
     } else {
          dst = CreateBuffer(device, buffer_size, num_bytes_per_page, tt_metal::BufferType::DRAM);
@@ -490,9 +491,9 @@ bool test_interleaved_l1_datacopy(const tt::ARCH& arch) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
-        tt_metal::ReadFromBuffer(dst, readback_buffer);
+        tt_metal::detail::ReadFromBuffer(dst, readback_buffer);
     }
 
     pass = (host_buffer == readback_buffer);

--- a/tests/tt_metal/tt_metal/test_l1_to_l1_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_l1_to_l1_multi_core.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
                 auto src_dram_buffer = CreateBuffer(device, dram_buffer_size, dram_buffer_size, tt_metal::BufferType::DRAM);
                 uint32_t dram_buffer_src_addr = src_dram_buffer.address();
                 auto dram_src_noc_xy = src_dram_buffer.noc_coordinates();
-                tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+                tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
                 auto l1_to_l1_kernel = tt_metal::CreateKernel(
                         program,
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
         for(uint32_t i = 0; i < 10; i++) {

--- a/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "test_tiles.hpp"
@@ -354,13 +355,13 @@ bool test_matmul_large_block(tt_metal::Device *device, bool activations_rm, bool
             auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
             activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         }
-        tt_metal::WriteToBuffer(src0_dram_buffer, activations);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bflaot16 32x32 identity
         auto identity_tilized = tilize(identity, K * 32, N * 32);
         auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        tt_metal::WriteToBuffer(src1_dram_buffer, weights);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
 
 
@@ -380,9 +381,9 @@ bool test_matmul_large_block(tt_metal::Device *device, bool activations_rm, bool
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
@@ -455,7 +455,7 @@ int main(int argc, char **argv) {
 
         log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         log_info(LogTest, "Matmul test done");
 
         log_info(LogTest, "Gathering data back from dram and checking against golden");

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -522,7 +522,7 @@ int main(int argc, char **argv) {
 
         log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         log_info(LogTest, "Matmul test done");
 
         log_info(LogTest, "Gathering data back from dram and checking against golden");

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
@@ -448,7 +448,7 @@ int main(int argc, char **argv) {
 
         log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         log_info(LogTest, "Matmul test done");
 
         log_info(LogTest, "Gathering data back from dram and checking against golden");

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
@@ -394,7 +394,7 @@ int main(int argc, char **argv) {
 
         log_info(LogTest, "Running Matmul {} core test", num_cores_c * num_cores_r);
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         log_info(LogTest, "Matmul test done");
         log_info(LogTest, "Gathering data back from dram and checking against golden");
         for(int i = 0; i < num_cores_r; i++) {

--- a/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "test_tiles.hpp"
@@ -305,13 +306,13 @@ int main(int argc, char **argv) {
         auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K, in0_block_w);
-        tt_metal::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bflaot16 32x32 identity
         auto identity_tilized = tilize(identity, K * 32, N * 32);
         auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        tt_metal::WriteToBuffer(src1_dram_buffer, weights);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
 
 
@@ -329,10 +330,10 @@ int main(int argc, char **argv) {
 
 
         log_info(LogTest, "Launching kernels");
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         log_info(LogTest, "Kernels done");
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
@@ -307,13 +308,13 @@ int main(int argc, char **argv) {
         auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K, in0_block_w);
-        tt_metal::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bflaot16 32x32 identity
         auto identity_tilized = tilize(identity, K * 32, N * 32);
         auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        tt_metal::WriteToBuffer(src1_dram_buffer, weights);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
 
 
@@ -331,10 +332,10 @@ int main(int argc, char **argv) {
 
 
         log_info(LogTest, "Launching kernels");
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         log_info(LogTest, "Kernels done");
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "test_tiles.hpp"
@@ -110,12 +111,12 @@ int main(int argc, char **argv) {
         tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
         auto activations_tile_layout = convert_to_tile_layout(tensor.get_values());
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-        tt_metal::WriteToBuffer(src0_dram_buffer, activations);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations);
 
         auto identity = create_identity_matrix(32, 32, 32); //bflaot16 32x32 identity
         auto weights_tile_layout = convert_to_tile_layout(identity);
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        tt_metal::WriteToBuffer(src1_dram_buffer, weights);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
 
 
@@ -145,10 +146,10 @@ int main(int argc, char **argv) {
             num_tiles});
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat8.hpp"
 #include "tt_metal/detail/util.hpp"
 
@@ -111,7 +112,7 @@ int main(int argc, char **argv) {
             dram_buffer_size,
             /*is_exp_a=*/false,
             100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::WriteToBuffer(src0_dram_buffer, activations);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations);
 
         int num_float_in_tile = 32 * 32;
         std::vector<float> vec(num_float_in_tile, (float)0);
@@ -120,7 +121,7 @@ int main(int argc, char **argv) {
         }
         std::vector<uint32_t> weights = pack_fp32_vec_as_bfp8_tiles(vec, /*row_major_input=*/true, /*is_exp_a=*/false);
 
-        tt_metal::WriteToBuffer(src1_dram_buffer, weights);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
 
 
@@ -150,10 +151,10 @@ int main(int argc, char **argv) {
             num_tiles});
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -10,6 +10,7 @@
 #include "common/bfloat16.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "test_tiles.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
@@ -111,12 +112,12 @@ int main(int argc, char **argv) {
         tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
         auto activations_tile_layout = convert_to_tile_layout(tensor.get_values());
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-        tt_metal::WriteToBuffer(src0_dram_buffer, activations);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations);
 
         auto identity = create_identity_matrix(32, 32, 32); //bflaot16 32x32 identity
         auto weights_tile_layout = convert_to_tile_layout(identity);
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        tt_metal::WriteToBuffer(src1_dram_buffer, weights);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
 
 
@@ -147,10 +148,10 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_l1_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_l1_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "common/core_coord.h"
 // #include "tt_gdb/tt_gdb.hpp"
@@ -81,7 +82,7 @@ void compile_and_configure_program(
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Application
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::WriteToBuffer(src_dram_buffer, src_vec);
+    tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
 
 
 }
@@ -216,10 +217,10 @@ bool test_multi_core_kernel_same_runtime_args(tt_metal::Device *device) {
 
     write_same_runtime_args_to_device(device, program, reader_kernel_id, writer_kernel_id, all_cores, num_tiles, src_dram_buffer, dst_dram_buffer);
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     std::vector<uint32_t> result_vec;
-    tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+    tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
     ////////////////////////////////////////////////////////////////////////////
     //                          Validation
@@ -280,16 +281,16 @@ bool test_multi_core_kernel_unique_runtime_args(tt_metal::Device *device) {
     write_unique_writer_runtime_args_to_device(
         device, program, reader_kernel_id, writer_kernel_id, all_cores, core_blocks, num_tiles, src_dram_buffer, dst_dram_buffer_1, dst_dram_buffer_2, dst_dram_buffer_3);
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     std::vector<uint32_t> result_vec_1;
-    tt_metal::ReadFromBuffer(dst_dram_buffer_1, result_vec_1);
+    tt_metal::detail::ReadFromBuffer(dst_dram_buffer_1, result_vec_1);
 
     std::vector<uint32_t> result_vec_2;
-    tt_metal::ReadFromBuffer(dst_dram_buffer_2, result_vec_2);
+    tt_metal::detail::ReadFromBuffer(dst_dram_buffer_2, result_vec_2);
 
     std::vector<uint32_t> result_vec_3;
-    tt_metal::ReadFromBuffer(dst_dram_buffer_3, result_vec_3);
+    tt_metal::detail::ReadFromBuffer(dst_dram_buffer_3, result_vec_3);
 
 
     ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "test_tiles.hpp"
@@ -232,21 +233,21 @@ int main(int argc, char **argv) {
         tt::deprecated::Tensor<bfloat16> src0_tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
         auto src0_activations_tile_layout = convert_to_tile_layout(src0_tensor.get_values());
         auto src0_activations = pack_bfloat16_vec_into_uint32_vec(src0_activations_tile_layout);
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_activations);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_activations);
 
         tt::deprecated::Tensor<bfloat16> src1_tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::ZEROS, 100, std::chrono::system_clock::now().time_since_epoch().count());
         auto src1_activations_tile_layout = convert_to_tile_layout(src1_tensor.get_values());
         auto src1_activations = pack_bfloat16_vec_into_uint32_vec(src1_activations_tile_layout);
-        tt_metal::WriteToBuffer(src1_dram_buffer, src1_activations);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, src1_activations);
 
 
 
         write_program_runtime_args_to_device(device, program1, reader1_kernel_id, writer1_kernel_id, core, num_tiles, src0_dram_buffer, src1_dram_buffer, dst_dram_buffer);
 
-        tt_metal::LaunchProgram(device, program1);
+        tt_metal::detail::LaunchProgram(device, program1);
 
         std::vector<uint32_t> intermediate_result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, intermediate_result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, intermediate_result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validatie Intermediate Result
@@ -265,16 +266,16 @@ int main(int argc, char **argv) {
         auto identity = create_identity_matrix(32, 32, 32); //bflaot16 32x32 identity
         auto weights_tile_layout = convert_to_tile_layout(identity);
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        tt_metal::WriteToBuffer(src1_dram_buffer, weights);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
 
 
         write_program_runtime_args_to_device(device, program2, reader2_kernel_id, writer2_kernel_id, core, num_tiles, src0_dram_buffer, src1_dram_buffer, dst_dram_buffer);
 
-        tt_metal::LaunchProgram(device, program2);
+        tt_metal::detail::LaunchProgram(device, program2);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_reduce_h.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 
 #include "test_tiles.hpp"
@@ -153,7 +154,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         auto seed = std::chrono::system_clock::now().time_since_epoch().count();
         vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 10.0f, 0x1234, -4.5f);
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_vec);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
 
 
 
@@ -181,11 +182,11 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         // The kernel will view the input as TILED32_4FACES
         vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         TT_ASSERT(result_vec.size() == NC*W*32/2); // we are expecting one tile in H, and half the elements since the vector packs 2 uint16_ts
 

--- a/tests/tt_metal/tt_metal/test_reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_reduce_hw.cpp
@@ -9,6 +9,8 @@
 #include <string>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+
 #include "common/bfloat16.hpp"
 #include "constants.hpp"
 
@@ -147,7 +149,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         auto seed = std::chrono::system_clock::now().time_since_epoch().count();
         vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 1.0f, 0x1234, -0.48f);
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_vec);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
 
 
 
@@ -178,11 +180,11 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         // The kernel will view the input as TILED32_4FACES
         vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         TT_ASSERT(result_vec.size() == NC*32*32/2); // we are expecting one tile in H, and half the elements since the vector packs 2 uint16_ts
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_reduce_w.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "constants.hpp"
 
@@ -144,7 +145,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         auto seed = std::chrono::system_clock::now().time_since_epoch().count();
         vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 1.0f, 0x1234);
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_vec);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
 
 
 
@@ -175,11 +176,11 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         // The kernel will view the input as TILED32_4FACES
         vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         TT_ASSERT(result_vec.size() == NC*H*TILE_WIDTH/2); // we are expecting one tile in H, and half the elements since the vector packs 2 uint16_ts
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -9,6 +9,7 @@
 #include "tt_metal/host_api.hpp"
 #include "common/bfloat16.hpp"
 #include "test_gold_impls.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 
 #include "test_tiles.hpp"
 
@@ -125,7 +126,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 100, 0x1234);
         auto src_4f_16 = u16_from_u32_vector(src0_vec);
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_vec);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
 
 
 
@@ -155,10 +156,10 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_transpose_wh.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_wh.cpp
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         auto seed = std::chrono::system_clock::now().time_since_epoch().count();
         vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 100.0f, 0x1234);
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_vec);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
 
 
 
@@ -157,11 +157,11 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         // The kernel will view the input as TILED32_4FACES
         vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         TT_ASSERT(result_vec.size() == NC*H*W/2); // we are expecting one tile in H, and half the elements since the vector packs 2 uint16_ts
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_unpack_tilize.cpp
+++ b/tests/tt_metal/tt_metal/test_unpack_tilize.cpp
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromDeviceDRAMChannel(

--- a/tests/tt_metal/tt_metal/test_unpack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_unpack_untilize.cpp
@@ -185,7 +185,7 @@ int main(int argc, char **argv) {
 
 
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromDeviceDRAMChannel(

--- a/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "test_gold_impls.hpp"
 
@@ -184,11 +185,11 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::WriteToBuffer(src0_dram_buffer, src0_vec);
+        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
 
         std::vector<uint32_t> src1_vec = create_constant_vector_of_bfloat16(dram_buffer_size, 0.0f);
 
-        tt_metal::WriteToBuffer(src1_dram_buffer, src1_vec);
+        tt_metal::detail::WriteToBuffer(src1_dram_buffer, src1_vec);
 
 
 
@@ -214,10 +215,10 @@ int main(int argc, char **argv) {
             (std::uint32_t)dram_dst_noc_xy.y,
             num_tiles});
 
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::ReadFromBuffer(dst_dram_buffer, result_vec);
+        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
@@ -102,7 +102,7 @@ bool load_all_blank_kernels(tt_metal::Device* device) {
 
     CreateKernel(program, "tt_metal/kernels/compute/blank.cpp", all_cores, ComputeConfig{});
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
     return pass;
 }
 }  // namespace unit_tests::basic::device
@@ -324,7 +324,7 @@ TEST_F(DeviceFixture, ValidateKernelDoesNotTargetHarvestedCores) {
                 .noc = tt_metal::NOC::NOC_0,
                 .compile_args = {l1_address, intermediate_l1_addr, size_bytes}});
 
-        tt_metal::LaunchProgram(this->devices_.at(id), program);
+        tt_metal::detail::LaunchProgram(this->devices_.at(id), program);
 
         std::vector<uint32_t> output;
         for (uint32_t bank_id = 0; bank_id < num_l1_banks; bank_id++) {

--- a/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
@@ -215,7 +215,7 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsCompute) {
                 }
             }
         }
-        tt_metal::LaunchProgram(this->devices_.at(id), program);
+        tt_metal::detail::LaunchProgram(this->devices_.at(id), program);
         EXPECT_TRUE(unit_tests::runtime_args::verify_result_compute(
             this->devices_.at(id), program, core_to_rt_args, KernelType::COMPUTE));
     }

--- a/tests/tt_metal/tt_metal/unit_tests/buffer/test_banked.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/buffer/test_banked.cpp
@@ -121,16 +121,16 @@ bool reader_cb_writer(Device* device, const BankedConfig& cfg, const bool banked
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
     auto input_packed = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, cfg.size_bytes / sizeof(uint32_t));
-    WriteToBuffer(input_buffer, input_packed);
+    detail::WriteToBuffer(input_buffer, input_packed);
     SetRuntimeArgs(program, reader_kernel, cfg.logical_core, reader_runtime_args);
     SetRuntimeArgs(program, writer_kernel, cfg.logical_core, writer_runtime_args);
 
-    LaunchProgram(device, program);
+    detail::LaunchProgram(device, program);
     std::vector<uint32_t> reread_input_packed;
-    ReadFromBuffer(input_buffer, reread_input_packed);
+    detail::ReadFromBuffer(input_buffer, reread_input_packed);
 
     std::vector<uint32_t> output_packed;
-    ReadFromBuffer(output_buffer, output_packed);
+    detail::ReadFromBuffer(output_buffer, output_packed);
 
     pass &= (output_packed == input_packed);
 
@@ -203,7 +203,7 @@ bool reader_datacopy_writer(Device* device, const BankedConfig& cfg) {
     //                      Compile and Execute Appli   cation
     ////////////////////////////////////////////////////////////////////////////
 
-    WriteToBuffer(input_buffer, input_packed);
+    detail::WriteToBuffer(input_buffer, input_packed);
 
     SetRuntimeArgs(
         program,
@@ -223,9 +223,9 @@ bool reader_datacopy_writer(Device* device, const BankedConfig& cfg) {
             (uint32_t)cfg.num_tiles,
         }
     );
-LaunchProgram(device, program);
+detail::LaunchProgram(device, program);
     std::vector<uint32_t> dest_buffer_data;
-    ReadFromBuffer(output_buffer, dest_buffer_data);
+    detail::ReadFromBuffer(output_buffer, dest_buffer_data);
     pass &= input_packed == dest_buffer_data;
 
     return pass;

--- a/tests/tt_metal/tt_metal/unit_tests/buffer/test_simple_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/buffer/test_simple_l1_buffer.cpp
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include "test_buffer_utils.hpp"
 #include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/df/df.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -98,7 +99,7 @@ namespace tt::test::buffer::detail {
 
 
         writeL1Backdoor(device, core, input_local_address, inputs);
-        tt_metal::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
         readL1Backdoor(device, core, input_local_address, byte_size, outputs);
         tt::log_info("input readback inputs[0]={} == readback[0]={}", inputs[0], outputs[0]);
         readL1Backdoor(device, core, output_local_address, byte_size, outputs);

--- a/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -15,7 +15,7 @@ using namespace tt::tt_metal;
 namespace basic_tests::circular_buffer {
 
 void validate_cb_address(Program &program, Device *device, const CoreRangeSet &cr_set, const std::map<CoreCoord, std::map<uint8_t, uint32_t>> &core_to_address_per_buffer_index) {
-    LaunchProgram(device, program);
+    detail::LaunchProgram(device, program);
 
     vector<uint32_t> cb_config_vector;
     uint32_t cb_config_buffer_size = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
@@ -164,7 +164,7 @@ TEST_F(DeviceFixture, TestInvalidCircularBufferAddress) {
     auto cb2 = CreateCircularBuffer(program, cr_set, config2);
 
     initialize_program(program, cr_set);
-    EXPECT_ANY_THROW(LaunchProgram(this->devices_.at(id), program));
+    EXPECT_ANY_THROW(detail::LaunchProgram(this->devices_.at(id), program));
 }
 }
 
@@ -253,7 +253,7 @@ TEST_F(DeviceFixture, TestInvalidUpdateCircularBufferSize) {
 
     // Update size of the first CB
     GetCircularBufferConfig(program, cb_ids[0]).set_total_size(cb_config.page_size / 2);
-    EXPECT_ANY_THROW(LaunchProgram(this->devices_.at(id), program));
+    EXPECT_ANY_THROW(detail::LaunchProgram(this->devices_.at(id), program));
 }
 }
 
@@ -315,7 +315,7 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
         expected_cb_addr += cb_config.page_size;
     }
 
-    LaunchProgram(this->devices_.at(id), program);
+    detail::LaunchProgram(this->devices_.at(id), program);
 
     vector<uint32_t> cb_config_vector;
     uint32_t cb_config_buffer_size = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
@@ -342,7 +342,7 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
     GetCircularBufferConfig(program, cb_ids[1]).set_page_size(1, cb_config.page_size / 2);
     golden_num_pages_per_core[core0][1] = 2;
 
-    LaunchProgram(this->devices_.at(id), program);
+    detail::LaunchProgram(this->devices_.at(id), program);
 
     // addresses should not be changed
     for (const CoreRange &core_range : cr_set.ranges()) {
@@ -425,12 +425,12 @@ TEST_F(DeviceFixture, TestDataCopyWithUpdatedCircularBufferConfig) {
 
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    WriteToBuffer(src_dram_buffer, src_vec);
+    detail::WriteToBuffer(src_dram_buffer, src_vec);
 
-    LaunchProgram(this->devices_.at(id), program);
+    detail::LaunchProgram(this->devices_.at(id), program);
 
     std::vector<uint32_t> result_vec;
-    ReadFromBuffer(dst_dram_buffer, result_vec);
+    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
     EXPECT_EQ(src_vec, result_vec);
 
     std::vector<uint32_t> input_cb_data;
@@ -443,13 +443,13 @@ TEST_F(DeviceFixture, TestDataCopyWithUpdatedCircularBufferConfig) {
 
     // zero out dst buffer
     std::vector<uint32_t> zero_vec = create_constant_vector_of_bfloat16(buffer_size, 0);
-    WriteToBuffer(dst_dram_buffer, zero_vec);
+    detail::WriteToBuffer(dst_dram_buffer, zero_vec);
 
     // relaunch program
-    LaunchProgram(this->devices_.at(id), program);
+    detail::LaunchProgram(this->devices_.at(id), program);
 
     std::vector<uint32_t> second_result_vec;
-    ReadFromBuffer(dst_dram_buffer, second_result_vec);
+    detail::ReadFromBuffer(dst_dram_buffer, second_result_vec);
     EXPECT_EQ(src_vec, second_result_vec);
 
     std::vector<uint32_t> second_cb_data;

--- a/tests/tt_metal/tt_metal/unit_tests/compute/binary/single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/binary/single_core_binary_compute.cpp
@@ -15,6 +15,7 @@
 #include "tt_metal/test_utils/df/df.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 
 using namespace tt;
 using namespace tt::test_utils;
@@ -141,8 +142,8 @@ bool single_core_binary(tt_metal::Device* device, const SingleCoreBinaryConfig& 
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
 
-    tt_metal::WriteToBuffer(input0_dram_buffer, packed_input0);
-    tt_metal::WriteToBuffer(input1_dram_buffer, packed_input1);
+    tt_metal::detail::WriteToBuffer(input0_dram_buffer, packed_input0);
+    tt_metal::detail::WriteToBuffer(input1_dram_buffer, packed_input1);
 
 
     tt_metal::SetRuntimeArgs(
@@ -169,13 +170,13 @@ bool single_core_binary(tt_metal::Device* device, const SingleCoreBinaryConfig& 
             (uint32_t)test_config.num_tiles,
         });
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     pass &= is_close_packed_vectors<bfloat16, uint32_t>(
         dest_buffer_data, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.015f); });
     return pass;

--- a/tests/tt_metal/tt_metal/unit_tests/compute/matmul/single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/matmul/single_core_matmul_compute.cpp
@@ -331,14 +331,14 @@ bool single_core_matmul(tt_metal::Device* device, const SingleCoreMatmulConfig& 
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
 
-    tt_metal::WriteToBuffer(input0_dram_buffer, packed_activation);
-    tt_metal::WriteToBuffer(input1_dram_buffer, packed_identity);
+    tt_metal::detail::WriteToBuffer(input0_dram_buffer, packed_activation);
+    tt_metal::detail::WriteToBuffer(input1_dram_buffer, packed_identity);
     std::vector<uint32_t> input0_dram_readback_packed;
-    tt_metal::ReadFromBuffer(input0_dram_buffer, input0_dram_readback_packed);
+    tt_metal::detail::ReadFromBuffer(input0_dram_buffer, input0_dram_readback_packed);
     EXPECT_TRUE(input0_dram_readback_packed == packed_activation);
     print_vector_fixed_numel_per_row(unpack_vector<bfloat16, uint32_t>(input0_dram_readback_packed), 32);
     std::vector<uint32_t> input1_dram_readback_packed;
-    tt_metal::ReadFromBuffer(input1_dram_buffer, input1_dram_readback_packed);
+    tt_metal::detail::ReadFromBuffer(input1_dram_buffer, input1_dram_readback_packed);
     EXPECT_TRUE(input1_dram_readback_packed == packed_identity);
     print_vector_fixed_numel_per_row(unpack_vector<bfloat16, uint32_t>(input1_dram_readback_packed), 32);
 
@@ -347,7 +347,7 @@ bool single_core_matmul(tt_metal::Device* device, const SingleCoreMatmulConfig& 
     tt_metal::SetRuntimeArgs(program, writer_kernel, cfg.core, writer_rt_args);
 
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Comparison Checking
@@ -362,7 +362,7 @@ bool single_core_matmul(tt_metal::Device* device, const SingleCoreMatmulConfig& 
     // std::vector<uint32_t> input1_l1_readback_packed;
     // std::vector<uint32_t> output_l1_readback_packed;
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     auto dest_buffer_data_unpacked = unpack_vector<bfloat16, uint32_t>(dest_buffer_data);
     if (not cfg.outputs_rm) {
         dest_buffer_data_unpacked = convert_to_flat_layout(dest_buffer_data_unpacked);
@@ -455,8 +455,8 @@ bool single_tile_matmul(tt_metal::Device* device) {
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
 
-    tt_metal::WriteToBuffer(input0_dram_buffer, packed_input0);
-    tt_metal::WriteToBuffer(input1_dram_buffer, packed_input1);
+    tt_metal::detail::WriteToBuffer(input0_dram_buffer, packed_input0);
+    tt_metal::detail::WriteToBuffer(input1_dram_buffer, packed_input1);
 
 
     tt_metal::SetRuntimeArgs(
@@ -484,13 +484,13 @@ bool single_tile_matmul(tt_metal::Device* device) {
         });
 
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     pass &= is_close_packed_vectors<bfloat16, uint32_t>(
         dest_buffer_data, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.015f); });
     return pass;
@@ -583,8 +583,8 @@ bool single_block_matmul(tt_metal::Device* device, uint32_t M, uint32_t K, uint3
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
 
-    tt_metal::WriteToBuffer(input0_dram_buffer, packed_input0);
-    tt_metal::WriteToBuffer(input1_dram_buffer, packed_input1);
+    tt_metal::detail::WriteToBuffer(input0_dram_buffer, packed_input0);
+    tt_metal::detail::WriteToBuffer(input1_dram_buffer, packed_input1);
 
 
     tt_metal::SetRuntimeArgs(
@@ -615,13 +615,13 @@ bool single_block_matmul(tt_metal::Device* device, uint32_t M, uint32_t K, uint3
             (uint32_t)M * N,
         });
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
     sleep(1);
     ////////////////////////////////////////////////////////////////////////////
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     int failed_index;
     pass &= is_close_packed_vectors<bfloat16, uint32_t>(
         dest_buffer_data,
@@ -739,8 +739,8 @@ bool blocked_matmul(tt_metal::Device* device, uint32_t M, uint32_t K, uint32_t N
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
 
-    tt_metal::WriteToBuffer(input0_dram_buffer, packed_input0);
-    tt_metal::WriteToBuffer(input1_dram_buffer, packed_input1);
+    tt_metal::detail::WriteToBuffer(input0_dram_buffer, packed_input0);
+    tt_metal::detail::WriteToBuffer(input1_dram_buffer, packed_input1);
 
 
     tt_metal::SetRuntimeArgs(
@@ -771,13 +771,13 @@ bool blocked_matmul(tt_metal::Device* device, uint32_t M, uint32_t K, uint32_t N
             (uint32_t)M * N,
         });
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
     sleep(1);
     ////////////////////////////////////////////////////////////////////////////
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     int failed_index;
     pass &= is_close_packed_vectors<bfloat16, uint32_t>(
         dest_buffer_data,

--- a/tests/tt_metal/tt_metal/unit_tests/compute/sfpu/sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/sfpu/sfpu_compute.cpp
@@ -213,9 +213,9 @@ bool run_sfpu_all_same_buffer(tt_metal::Device* device, const SfpuConfig& test_c
     }
 
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::WriteToBuffer(input_dram_buffer, packed_input);
-    tt_metal::LaunchProgram(device, program);
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::WriteToBuffer(input_dram_buffer, packed_input);
+    tt_metal::detail::LaunchProgram(device, program);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
 
     return sfpu_util::is_close_packed_sfpu_output(dest_buffer_data, packed_golden, test_config.sfpu_op);
 }

--- a/tests/tt_metal/tt_metal/unit_tests/dram/direct.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/dram/direct.cpp
@@ -58,7 +58,7 @@ bool reader_only(
     ////////////////////////////////////////////////////////////////////////////
 
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
-    tt_metal::WriteToBuffer(input_dram_buffer, inputs);
+    tt_metal::detail::WriteToBuffer(input_dram_buffer, inputs);
 
     tt_metal::SetRuntimeArgs(
         program,
@@ -72,10 +72,10 @@ bool reader_only(
             (uint32_t)byte_size,
         });
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     std::vector<uint32_t> dest_core_data;
-    // tt_metal::ReadFromBuffer(l1_buffer, dest_core_data);
+    // tt_metal::detail::ReadFromBuffer(l1_buffer, dest_core_data);
     tt_metal::detail::ReadFromDeviceL1(device, reader_core, l1_byte_address, byte_size, dest_core_data);
     pass &= (dest_core_data == inputs);
     if (not pass) {
@@ -122,7 +122,7 @@ bool writer_only(
 
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
     tt_metal::detail::WriteToDeviceL1(device, writer_core, l1_byte_address, inputs);
-    // tt_metal::WriteToBuffer(l1_buffer, inputs);
+    // tt_metal::detail::WriteToBuffer(l1_buffer, inputs);
 
 
     tt_metal::SetRuntimeArgs(
@@ -137,10 +137,10 @@ bool writer_only(
             (uint32_t)byte_size,
         });
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     pass &= (dest_buffer_data == inputs);
     if (not pass) {
         std::cout << "Mismatch at Core: " << writer_core.str() << std::endl;
@@ -206,7 +206,7 @@ bool reader_writer(tt_metal::Device* device, const ReaderWriterConfig& test_conf
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
 
-    tt_metal::WriteToBuffer(input_dram_buffer, inputs);
+    tt_metal::detail::WriteToBuffer(input_dram_buffer, inputs);
 
 
     tt_metal::SetRuntimeArgs(
@@ -230,10 +230,10 @@ bool reader_writer(tt_metal::Device* device, const ReaderWriterConfig& test_conf
             (uint32_t)test_config.num_tiles,
         });
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     pass &= inputs == dest_buffer_data;
     return pass;
 }
@@ -310,7 +310,7 @@ bool reader_datacopy_writer(tt_metal::Device* device, const ReaderDatacopyWriter
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
 
-    tt_metal::WriteToBuffer(input_dram_buffer, inputs);
+    tt_metal::detail::WriteToBuffer(input_dram_buffer, inputs);
 
 
     tt_metal::SetRuntimeArgs(
@@ -334,10 +334,10 @@ bool reader_datacopy_writer(tt_metal::Device* device, const ReaderDatacopyWriter
             (uint32_t)test_config.num_tiles,
         });
 
-    tt_metal::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
 
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
     pass &= inputs == dest_buffer_data;
     return pass;
 }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
@@ -215,7 +215,7 @@ void create_and_run_row_pipeline(tt_metal::Device* device, const PipelineRowConf
 
 
     log_info(LogTest, "Writing to device buffer...");
-    tt_metal::WriteToBuffer(src_buffer, src_vec);
+    tt_metal::detail::WriteToBuffer(src_buffer, src_vec);
     log_info(LogTest, "Writing to device buffer Done.");
 
     EnqueueProgram(cq, program, false);
@@ -225,7 +225,7 @@ void create_and_run_row_pipeline(tt_metal::Device* device, const PipelineRowConf
 
     log_info(LogTest, "Reading results from device...");
     std::vector<uint32_t> result_vec;
-    tt_metal::ReadFromBuffer(dst_buffer, result_vec);
+    tt_metal::detail::ReadFromBuffer(dst_buffer, result_vec);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Validation & Teardown

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -364,7 +364,7 @@ std::vector<T> read_data_from_device(const Tensor &tensor, uint32_t size_in_byte
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         EnqueueReadBuffer(*tt::tt_metal::detail::GLOBAL_CQ, *device_buffer, device_data, true);
     } else {
-        ReadFromBuffer(*device_buffer, device_data);
+        ::detail::ReadFromBuffer(*device_buffer, device_data);
     }
 
     return unpack_uint32_vec<T>(device_data);
@@ -382,7 +382,7 @@ inline void write_data_to_device_buffer(const BufferType<T>& data_to_write, Devi
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         EnqueueWriteBuffer(*tt::tt_metal::detail::GLOBAL_CQ, *buffer, uint32_data, false);
     } else {
-        WriteToBuffer(*buffer, uint32_data);
+        ::detail::WriteToBuffer(*buffer, uint32_data);
     }
 }
 

--- a/tt_eager/tt_dnn/op_library/conv/conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/conv_op.cpp
@@ -1097,7 +1097,7 @@ operation::ProgramWithCallbacks conv_as_large_bmm_with_address_map_single_core_(
     // DRAM to L1 writes should 32B aligned
     assert(scratch_pad_for_address_map_l1_address%32 == 0);
     // Create address map metadata buffers in L1
-    // Metadata vectors are copied to L1 buffers from host before calling LaunchProgram
+    // Metadata vectors are copied to L1 buffers from host before calling detail::LaunchProgram
     auto act_address_map_metadata_l1_b0_size = act_address_map_metadata.size() * sizeof(uint32_t);
     auto act_address_map_metadata_l1_buffer = CreateBuffer(device, act_address_map_metadata_l1_b0_size, act_address_map_metadata_l1_b0_size, tt_metal::BufferType::L1);
     uint32_t act_address_map_metadata_l1_address = act_address_map_metadata_l1_buffer.address();

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -127,7 +127,7 @@ std::vector<Tensor> run_without_program_cache(
         // LaunchKernel automatically dumps device data
         op_profiler::dump_device_profiler_results(device, program);
     } else {
-        LaunchProgram(device, program);
+        ::detail::LaunchProgram(device, program);
     }
 
     return output_tensors;
@@ -173,7 +173,7 @@ std::vector<Tensor> run_with_program_cache(
         // LaunchKernel automatically dumps device data
         op_profiler::dump_device_profiler_results(device, program);
     } else {
-        LaunchProgram(device, program);
+        ::detail::LaunchProgram(device, program);
     }
 
     return output_tensors;

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -32,6 +32,34 @@ namespace tt::tt_metal{
             return fd;
         }
 
+        /**
+        * Copies data from a host buffer into the specified buffer
+        *
+        * Return value: void
+        *
+        * | Argument    | Description                                     | Data type               | Valid range                                      | Required |
+        * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
+        * | buffer      | Buffer to send data to                          | const Buffer &          |                                                  | Yes      |
+        * | host_buffer | Buffer on host to copy data from                | std::vector<uint32_t> & | Host buffer size must match buffer               | Yes      |
+        */
+        void WriteToBuffer(const Buffer &buffer, const std::vector<uint32_t> &host_buffer);
+
+        /**
+        * Copies data from a buffer into a host buffer
+        *
+        * Return value: void
+        *
+        * | Argument    | Description                                     | Data type               | Valid range                                      | Required |
+        * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
+        * | buffer      | Buffer to read data from                        | const Buffer &          |                                                  | Yes      |
+        * | host_buffer | Buffer on host to copy data into                | std::vector<uint32_t> & |                                                  | Yes      |
+        */
+        void ReadFromBuffer(const Buffer &buffer, std::vector<uint32_t> &host_buffer);
+
+
+        // Launches all kernels on cores specified with kernels in the program.
+        // All kernels on a given Tensix core must be launched.
+        void LaunchProgram(Device *device, Program &program);
 
         /**
          *  Compiles all kernels within the program, and generates binaries that are written to `$TT_METAL_HOME/built/<device>/kernels/<kernel name>/<kernel hash>`

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -145,30 +145,6 @@ uint32_t CreateSemaphore(Program &program, const std::variant<CoreRange,CoreRang
 Buffer CreateBuffer(Device *device, std::uint64_t size, std::uint64_t page_size, const BufferType buffer_type);
 
 /**
-* Copies data from a host buffer into the specified buffer
-*
-* Return value: void
-*
-* | Argument    | Description                                     | Data type               | Valid range                                      | Required |
-* |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
-* | buffer      | Buffer to send data to                          | const Buffer &          |                                                  | Yes      |
-* | host_buffer | Buffer on host to copy data from                | std::vector<uint32_t> & | Host buffer size must match buffer               | Yes      |
-*/
-void WriteToBuffer(const Buffer &buffer, const std::vector<uint32_t> &host_buffer);
-
-/**
-* Copies data from a buffer into a host buffer
-*
-* Return value: void
-*
-* | Argument    | Description                                     | Data type               | Valid range                                      | Required |
-* |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
-* | buffer      | Buffer to read data from                        | const Buffer &          |                                                  | Yes      |
-* | host_buffer | Buffer on host to copy data into                | std::vector<uint32_t> & |                                                  | Yes      |
-*/
-void ReadFromBuffer(const Buffer &buffer, std::vector<uint32_t> &host_buffer);
-
-/**
 *  Deallocates buffer from device by marking its memory as free.
 *
 *  Return value: void
@@ -178,8 +154,6 @@ void ReadFromBuffer(const Buffer &buffer, std::vector<uint32_t> &host_buffer);
 *  | buffer   | The buffer to deallocate from device | Buffer & |             | Yes      |
 */
 void DeallocateBuffer(Buffer &buffer);
-
-
 
 // ==================================================
 //           COMPILE & EXECUTE KENRNELS
@@ -212,10 +186,6 @@ void SetRuntimeArgs(const Program &program, KernelID kernel, const std::variant<
  * | logical_core | The location of the Tensix core where the runtime args will be written | const CoreCoord &             | Any logical Tensix core coordinate | Yes      |
  */
 std::vector<uint32_t> GetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreCoord &logical_core);
-
-// Launches all kernels on cores specified with kernels in the program.
-// All kernels on a given Tensix core must be launched.
-void LaunchProgram(Device *device, Program &program);
 
 /**
  * Reads a buffer from the device

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -666,7 +666,7 @@ void send_dispatch_kernel_to_device(Device* device) {
 
     launch_msg_t msg = dispatch_program.kernels_on_core(producer_logical_core)->launch_msg;
 
-    // TODO(pkeller): Should use LaunchProgram once we have a mechanism to avoid running all RISCs
+    // TODO(pkeller): Should use detail::LaunchProgram once we have a mechanism to avoid running all RISCs
     tt::llrt::write_launch_msg_to_core(device->id(), producer_physical_core, &msg);
     tt::llrt::write_launch_msg_to_core(device->id(), consumer_physical_core, &msg);
 }


### PR DESCRIPTION
This change also removes TT_METAL_SLOW_DISPATCH_MODE env variable from docs and TT_METAL_SINGLE_CORE_MODE as it's not used anymore. 

