### PR TITLE
#3721: type-2 complex tensor support without split/concat

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -593,6 +593,10 @@ The following functions are available,
 
 Complex arithmetic can be carried out for multiply, divide, add and subtract as follows:
 
+.. autofunction:: tt_lib.tensor.complex_add
+
+.. autofunction:: tt_lib.tensor.complex_sub
+
 .. autofunction:: tt_lib.tensor.complex_mul
 
 .. autofunction:: tt_lib.tensor.complex_div
@@ -608,6 +612,12 @@ and then unary operations for,
 .. autofunction:: tt_lib.tensor.conj
 
 .. autofunction:: tt_lib.tensor.complex_recip
+
+Complex Operations (Type 2)
+---------------------------
+Type 2 Complex representation allows for more flexible storage than earlier one while providing same set of
+operations; specifically this storage allows for compute without the cost of split-concat implict in
+the Type 1 contiguous representations.
 
 Other Operations
 ----------------

--- a/tests/tt_eager/python_api_testing/unit_testing/test_complex.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_complex.py
@@ -19,18 +19,17 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 )
 from tests.tt_eager.python_api_testing.sweep_tests.common import (
     is_wormhole_b0,
-    skip_for_wormhole_b0,
 )
 from functools import partial
 
 
 class Complex:
-    def __init__(self, input_shape: torch.Size):
-        val = 1 + torch.arange(0, input_shape.numel()).reshape(input_shape).bfloat16()
-        self._cplx = (
-            val[:, :, :, input_shape[-1] // 2]
-            + val[:, :, :, input_shape[-1] // 2 :] * 1j
-        )
+    def __init__(self, input_shape: torch.Size = None, re=None, im=None):
+        if input_shape:
+            val = 1.0 + torch.arange(0, input_shape.numel()).reshape(input_shape).bfloat16()
+            self._cplx = val[:, :, :, input_shape[-1] // 2] + val[:, :, :, input_shape[-1] // 2 :] * 1j
+        else:
+            self._cplx = re + im * 1j
 
     def reset(self, val: torch.Tensor):
         self._cplx = val
@@ -103,12 +102,8 @@ def test_level1_is_real(memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([1, 1, 32, 64])
     # check real
     x = Complex(input_shape)
-    x = x.add( x.conj() )
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    x = x.add(x.conj())
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
     tt_dev = ttl.tensor.is_real(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.is_real()
@@ -130,12 +125,8 @@ def test_level1_is_imag(memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([1, 1, 32, 64])
     # check real
     x = Complex(input_shape)
-    x = x.sub( x.conj() )
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    x = x.sub(x.conj())
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
     tt_dev = ttl.tensor.is_imag(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.is_imag()
@@ -157,11 +148,7 @@ def test_level1_angle(memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([1, 1, 32, 64])
     # check real
     x = Complex(input_shape)
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
     tt_dev = ttl.tensor.angle(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.angle
@@ -183,11 +170,7 @@ def test_level1_real(memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([1, 1, 32, 64])
     # check real
     x = Complex(input_shape)
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
     tt_dev = ttl.tensor.real(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.real
@@ -255,11 +238,7 @@ def test_level1_conj(memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([1, 1, 32, 64])
     # check abs
     x = Complex(input_shape)
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
     tt_dev = ttl.tensor.conj(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.conj().metal
@@ -286,16 +265,8 @@ def test_level1_add(memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * -0.5
 
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
-    ytt = (
-        ttl.tensor.Tensor(y.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
 
     tt_dev = ttl.tensor.add(xtt, ytt)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -322,16 +293,8 @@ def test_level1_sub(memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * 0.5
 
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
-    ytt = (
-        ttl.tensor.Tensor(y.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
 
     tt_dev = ttl.tensor.sub(xtt, ytt)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -358,16 +321,8 @@ def test_level1_mul(memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * 0.75
 
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
-    ytt = (
-        ttl.tensor.Tensor(y.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
 
     tt_dev = ttl.tensor.complex_mul(xtt, ytt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -392,26 +347,15 @@ def test_level1_div(memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([1, 1, 32, 64])
     # check abs
     x = Complex(input_shape)
-    y = x.div(x)
+    y = Complex(input_shape) * 0.75
 
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
-    ytt = (
-        ttl.tensor.Tensor(y.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
 
     tt_dev = ttl.tensor.complex_div(ytt, xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
     tt_cpu = y.div(x).metal
-
-    if is_wormhole_b0():
-        pass  # pytest.skip("[DIV]: skip assertion for this test on WH B0")
 
     passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.96)
     logger.info(output)
@@ -432,20 +376,381 @@ def test_level1_recip(memcfg, dtype, device, function_level_defaults):
     # check abs
     x = Complex(input_shape)
     x = x.div(x * 0.5)
-    xtt = (
-        ttl.tensor.Tensor(x.metal, dtype)
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .to(device, memcfg)
-    )
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
 
     tt_dev = ttl.tensor.complex_recip(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
     tt_cpu = x.recip().metal
 
+    passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.96)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_real(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check real
+    x = Complex(input_shape)
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.real(xtt, memcfg)
+    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_cpu = x.real
+    passing, output = comp_equal(tt_cpu, tt_dev)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_imag(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check imag
+    x = Complex(input_shape)
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.imag(xtt, memcfg)
+    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_cpu = x.imag
+    passing, output = comp_equal(tt_cpu, tt_dev)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_abs(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check abs
+    x = Complex(input_shape)
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_abs(xtt, memcfg)
+    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_cpu = x.abs().real
+    if is_wormhole_b0():
+        passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.8)
+    else:
+        passing, output = comp_pcc(tt_cpu, tt_dev)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_abs(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check abs
+    x = Complex(input_shape)
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_abs(xtt, memcfg)
+    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_cpu = x.abs().real
+    if is_wormhole_b0():
+        passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.8)
+    else:
+        passing, output = comp_pcc(tt_cpu, tt_dev)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_conj(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check abs
+    x = Complex(input_shape)
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.conj(xtt, memcfg)
+    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
+    tt_cpu = x.conj().metal
+    if is_wormhole_b0():
+        passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.8)
+    else:
+        passing, output = comp_pcc(tt_cpu, tt_dev)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_recip(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check abs
+    x = Complex(input_shape)
+    x = x.div(x * 0.5)
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_recip(xtt, memcfg)
+    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
+    tt_cpu = x.recip().metal
+
     if is_wormhole_b0():
         pass  # pytest.skip("[RECIP]: skip assertion for this test on WH B0")
 
     passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.96)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_add(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check add
+    x = Complex(input_shape)
+    y = Complex(input_shape) * -0.5
+
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    ytt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    tt_dev = ttl.tensor.complex_add(xtt, ytt, memcfg)
+    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
+    tt_cpu = x.add(y).metal
+
+    passing, output = comp_pcc(tt_cpu, tt_dev)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_sub(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check add
+    x = Complex(input_shape)
+    y = Complex(input_shape) * -0.5
+
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    ytt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    tt_dev = ttl.tensor.complex_sub(xtt, ytt, memcfg)
+    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
+
+    tt_cpu = x.sub(y).metal
+
+    passing, output = comp_pcc(tt_cpu, tt_dev)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_mul(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check add
+    x = Complex(input_shape)
+    y = Complex(input_shape) * -0.5
+
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    ytt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    tt_dev = ttl.tensor.complex_mul(xtt, ytt, memcfg)
+    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
+
+    tt_cpu = x.mul(y).metal
+
+    passing, output = comp_pcc(tt_cpu, tt_dev)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_div(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check add
+    x = Complex(input_shape) * 0.5
+    y = Complex(input_shape) * 1
+
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    ytt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    tt_dev = ttl.tensor.complex_div(xtt, xtt, memcfg)
+    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
+
+    tt_cpu = x.div(y).metal
+
+    passing, output = comp_pcc(tt_cpu, tt_dev)
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_is_real(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check abs
+    x = Complex(input_shape)
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(0 * x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.is_real(xtt, memcfg)
+    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_cpu = torch.ones(x.real.shape)
+    if is_wormhole_b0():
+        passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.8)
+    else:
+        passing, output = comp_pcc(tt_cpu, tt_dev)
+    xtt.deallocate()
+    logger.info(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+def test_level2_is_imag(memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([1, 1, 32, 64])
+    # check abs
+    x = Complex(input_shape)
+    xtt = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(0 * x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.is_imag(xtt, memcfg)
+    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_cpu = torch.ones(x.imag.shape)
+    if is_wormhole_b0():
+        passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.8)
+    else:
+        passing, output = comp_pcc(tt_cpu, tt_dev)
     logger.info(output)
     assert passing

--- a/tt_eager/tt_dnn/op_library/complex/complex_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/complex/complex_ops.hpp
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include <array>
 #include "tt_dnn/op_library/composite/composite_ops.hpp"
 
 namespace tt {
@@ -35,20 +36,60 @@ Tensor imag(const Tensor& input, const MemoryConfig& output_mem_config = operati
 Tensor conj(const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 Tensor angle(const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-inline
-Tensor complex_add(const Tensor& input_a, const Tensor& input_b,  const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
-    return add(input_a,input_b,{},output_mem_config);
-}
-
-inline
-Tensor complex_sub(const Tensor& input_a, const Tensor& input_b,  const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
-    return sub(input_a,input_b,{},output_mem_config);
-}
+Tensor complex_add(const Tensor& input_a, const Tensor& input_b,  const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor complex_sub(const Tensor& input_a, const Tensor& input_b,  const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 Tensor complex_abs(const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 Tensor complex_mul(const Tensor& input_a, const Tensor& input_b,  const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 Tensor complex_div(const Tensor& input_a, const Tensor& input_b,  const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 Tensor complex_recip(const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+//////// 2-tensor representation without split-concat and associated dimensional restrictions ////////
+
+class ComplexTensor {
+    private:
+        std::array<Tensor,2> m_real_imag;
+
+    public:
+
+        ComplexTensor(std::array<Tensor,2> val): m_real_imag(val) {
+            TT_ASSERT( m_real_imag[0].shape() == m_real_imag[1].shape() , "Tensor shapes of real and imag should be identical");
+        }
+
+        Tensor operator[](uint32_t index) const {
+            return m_real_imag[index];
+        }
+
+        Tensor real() {
+            return m_real_imag[0];
+        }
+
+        Tensor imag() {
+            return m_real_imag[1];
+        }
+
+        void deallocate() {
+            m_real_imag[0].deallocate();
+            m_real_imag[1].deallocate();
+        }
+};
+
+Tensor is_real(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor is_imag(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor real(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor imag(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+ComplexTensor conj(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor angle(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+ComplexTensor complex_add(const ComplexTensor& input_a, const ComplexTensor& input_b, const MemoryConfig& output_mem_config);
+ComplexTensor complex_sub(const ComplexTensor& input_a, const ComplexTensor& input_b, const MemoryConfig& output_mem_config);
+
+Tensor complex_abs(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+ComplexTensor complex_mul(const ComplexTensor& input_a, const ComplexTensor& input_b,  const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+ComplexTensor complex_div(const ComplexTensor& input_a, const ComplexTensor& input_b,  const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+ComplexTensor complex_recip(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 } //namespace tt_metal
 
 } //namespace tt


### PR DESCRIPTION
#3721: type-2 complex tensor support without split/concat
docs:
![image](https://github.com/tenstorrent-metal/tt-metal/assets/135061812/85e0813e-5d91-41ed-926c-1aaed324f5d8)
