### PR TITLE
Recompile program for each device until kernel compilation is not device dependent

### DIFF
--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -129,16 +129,16 @@ int main(int argc, char **argv) {
         for (int i = 0; i < num_compiles; i++) {
             tt_metal::detail::CompileProgram(device, program);
             if (i == 0) {
-                compute_binaries = compute_kernel->binaries();
+                compute_binaries = compute_kernel->binaries(device->id());
                 TT_ASSERT(compute_binaries.size() == 3, "Expected 3 Compute binaries!");
-                brisc_binaries = riscv0_kernel->binaries();
+                brisc_binaries = riscv0_kernel->binaries(device->id());
                 TT_ASSERT(brisc_binaries.size() == 1, "Expected 1 BRISC binary!");
-                ncrisc_binaries = riscv1_kernel->binaries();
+                ncrisc_binaries = riscv1_kernel->binaries(device->id());
                 TT_ASSERT(ncrisc_binaries.size() == 1, "Expected 1 NCRISC binary!");
             } else {
-                TT_ASSERT(compute_kernel->binaries() == compute_binaries);
-                TT_ASSERT(riscv0_kernel->binaries() == brisc_binaries);
-                TT_ASSERT(riscv1_kernel->binaries() == ncrisc_binaries);
+                TT_ASSERT(compute_kernel->binaries(device->id()) == compute_binaries);
+                TT_ASSERT(riscv0_kernel->binaries(device->id()) == brisc_binaries);
+                TT_ASSERT(riscv1_kernel->binaries(device->id()) == ncrisc_binaries);
             }
             std::string brisc_hex_path = get_latest_kernel_binary_path(device->id(), riscv0_kernel) + "/brisc/brisc.hex";
             ll_api::memory brisc_binary = llrt::get_risc_binary(brisc_hex_path, device->id(), false);

--- a/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
@@ -87,7 +87,21 @@ bool dram_ping(
 bool load_all_blank_kernels(tt_metal::Device* device) {
     bool pass = true;
     tt_metal::Program program = tt_metal::Program();
+    CoreCoord compute_grid_size = device->compute_with_storage_grid_size();
+    CoreRange all_cores = CoreRange(
+        CoreCoord{.x = 0, .y = 0},
+        CoreCoord{.x = 0, .y = 0}
+        // CoreCoord{.x = compute_grid_size.x - 1, .y = compute_grid_size.y -1}
+    );
+    CreateKernel(
+        program, "tt_metal/kernels/dataflow/blank.cpp", all_cores,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
+    CreateKernel(
+        program, "tt_metal/kernels/dataflow/blank.cpp", all_cores,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    CreateKernel(program, "tt_metal/kernels/compute/blank.cpp", all_cores, ComputeConfig{});
 
     tt_metal::LaunchProgram(device, program);
     return pass;

--- a/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
@@ -90,8 +90,7 @@ bool load_all_blank_kernels(tt_metal::Device* device) {
     CoreCoord compute_grid_size = device->compute_with_storage_grid_size();
     CoreRange all_cores = CoreRange(
         CoreCoord{.x = 0, .y = 0},
-        CoreCoord{.x = 0, .y = 0}
-        // CoreCoord{.x = compute_grid_size.x - 1, .y = compute_grid_size.y -1}
+        CoreCoord{.x = compute_grid_size.x - 1, .y = compute_grid_size.y -1}
     );
     CreateKernel(
         program, "tt_metal/kernels/dataflow/blank.cpp", all_cores,

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -157,7 +157,7 @@ ProgramMap ConstructProgramMap(const Device* device, Program& program) {
         }
 
         uint32_t sub_kernel_index = 0;
-        for (const ll_api::memory& kernel_bin : kernel->binaries()) {
+        for (const ll_api::memory& kernel_bin : kernel->binaries(device->id())) {
             kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
                 uint32_t num_bytes = len * sizeof(uint32_t);
                 if ((dst & MEM_LOCAL_BASE) == MEM_LOCAL_BASE) {
@@ -213,7 +213,7 @@ ProgramMap ConstructProgramMap(const Device* device, Program& program) {
     for (KernelID kernel_id : program.kernel_ids()) {
         const Kernel* kernel = detail::GetKernel(program, kernel_id);
 
-        for (const ll_api::memory& kernel_bin : kernel->binaries()) {
+        for (const ll_api::memory& kernel_bin : kernel->binaries(device->id())) {
             kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
                 std::copy(mem_ptr, mem_ptr + len, program_pages.begin() + program_page_idx);
                 program_page_idx = align(program_page_idx + len, noc_transfer_alignment_in_bytes / sizeof(uint32_t));

--- a/tt_metal/impl/program.hpp
+++ b/tt_metal/impl/program.hpp
@@ -92,7 +92,7 @@ class Program {
 
     void compile(Device * device);
 
-    void invalidate_compile() { compile_needed_ = true; }
+    void invalidate_compile();
 
     void invalidate_circular_buffer_allocation();
 
@@ -137,7 +137,7 @@ class Program {
     std::vector<Semaphore> semaphores_;
 
     CoreRangeSet worker_crs_;
-    bool compile_needed_;
+    std::unordered_map<chip_id_t, bool> compile_needed_;
     bool circular_buffer_allocation_needed_;
 
     static constexpr uint8_t core_to_kernel_group_invalid_index = 0xff;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -146,7 +146,7 @@ class Cluster {
         (uint32_t)MEM_TRISC2_SIZE,
         (uint32_t)MEM_TRISC0_BASE,
         (uint32_t)GET_MAILBOX_ADDRESS_HOST(l1_barrier),
-        (uint32_t)GET_MAILBOX_ADDRESS_HOST(l1_barrier)   // ethernet and tensix cores share same barrier address
+        (uint32_t)eth_l1_mem::address_map::ERISC_BARRIER_BASE
     };
 
     tt_driver_host_address_params host_address_params = {

--- a/tt_metal/src/firmware/riscv/grayskull/eth_l1_address_map.h
+++ b/tt_metal/src/firmware/riscv/grayskull/eth_l1_address_map.h
@@ -18,5 +18,7 @@ struct address_map {
   static constexpr std::int32_t FIRMWARE_BASE = 0;
 
   static constexpr std::uint32_t FW_VERSION_ADDR = 0;
+
+  static constexpr std::int32_t ERISC_BARRIER_BASE =0x3E420;
 };
 }  // namespace llk

--- a/tt_metal/src/firmware/riscv/grayskull/eth_l1_address_map.h
+++ b/tt_metal/src/firmware/riscv/grayskull/eth_l1_address_map.h
@@ -19,6 +19,6 @@ struct address_map {
 
   static constexpr std::uint32_t FW_VERSION_ADDR = 0;
 
-  static constexpr std::int32_t ERISC_BARRIER_BASE =0x3E420;
+  static constexpr std::int32_t ERISC_BARRIER_BASE = 0;
 };
 }  // namespace llk

--- a/tt_metal/src/firmware/riscv/wormhole/eth_l1_address_map.h
+++ b/tt_metal/src/firmware/riscv/wormhole/eth_l1_address_map.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace eth_l1_mem {
 
@@ -14,11 +14,34 @@ namespace eth_l1_mem {
 struct address_map {
 
   // Sizes
-  static constexpr std::int32_t FIRMWARE_SIZE = 20 * 1024;           // 20KB = 8KB + 12KB perf buffers
-
+  static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;
+  static constexpr std::int32_t COMMAND_Q_SIZE = 4 * 1024;
+  static constexpr std::int32_t DATA_BUFFER_SIZE_HOST = 4 * 1024;
+  static constexpr std::int32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
+  static constexpr std::int32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
+  static constexpr std::int32_t DATA_BUFFER_SIZE = 24 * 1024;
+  static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
   // Base addresses
-  static constexpr std::int32_t FIRMWARE_BASE = 0x6020;
+  static constexpr std::int32_t L1_EPOCH_Q_BASE = 0x9000; // Epoch Q start in L1.
+  static constexpr std::int32_t FIRMWARE_BASE = 0x9040;
+  static constexpr std::int32_t COMMAND_Q_BASE = L1_EPOCH_Q_BASE + FIRMWARE_SIZE;
+  static constexpr std::int32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
+  static constexpr std::int32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
 
+  // TT Metal Specific
+  static constexpr std::int32_t L1_UNRESERVED_BASE = TILE_HEADER_BUFFER_BASE;
+  //static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = L1_EPOCH_Q_BASE; // Ideally, we can use this address somehow, but currently we need to load some other epoch q objects
+  static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = 0x10e8;
+  static constexpr std::int32_t ERISC_BARRIER_BASE =0x3E420; // TODO UPDATE THIS
+  static constexpr std::int32_t L1_ARG_BASE = 0x3E420;
+  static constexpr std::int32_t L1_ERISCK_INFO = 0x3E400;
+
+  template<std::size_t A, std::size_t B> struct TAssertEquality {
+    static_assert(A==B, "Not equal");
+    static constexpr bool _cResult = (A==B);
+  };
+
+  static constexpr std::int32_t MAX_SIZE = 256*1024;
   static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;
 
   static constexpr std::int32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
@@ -28,4 +51,4 @@ struct address_map {
 
   static constexpr std::uint32_t FW_VERSION_ADDR = 0x210;
 };
-}  // namespace llk
+}  // namespace eth_l1_mem

--- a/tt_metal/src/firmware/riscv/wormhole/eth_l1_address_map.h
+++ b/tt_metal/src/firmware/riscv/wormhole/eth_l1_address_map.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 
 namespace eth_l1_mem {
 
@@ -14,34 +14,13 @@ namespace eth_l1_mem {
 struct address_map {
 
   // Sizes
-  static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;
-  static constexpr std::int32_t COMMAND_Q_SIZE = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_HOST = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
-  static constexpr std::int32_t DATA_BUFFER_SIZE = 24 * 1024;
-  static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
+  static constexpr std::int32_t FIRMWARE_SIZE = 20 * 1024;           // 20KB = 8KB + 12KB perf buffers
+
   // Base addresses
-  static constexpr std::int32_t L1_EPOCH_Q_BASE = 0x9000; // Epoch Q start in L1.
-  static constexpr std::int32_t FIRMWARE_BASE = 0x9040;
-  static constexpr std::int32_t COMMAND_Q_BASE = L1_EPOCH_Q_BASE + FIRMWARE_SIZE;
-  static constexpr std::int32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
-  static constexpr std::int32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
+  static constexpr std::int32_t FIRMWARE_BASE = 0x6020;
 
-  // TT Metal Specific
-  static constexpr std::int32_t L1_UNRESERVED_BASE = TILE_HEADER_BUFFER_BASE;
-  //static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = L1_EPOCH_Q_BASE; // Ideally, we can use this address somehow, but currently we need to load some other epoch q objects
-  static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = 0x10e8;
-  static constexpr std::int32_t ERISC_BARRIER_BASE =0x3E420; // TODO UPDATE THIS
-  static constexpr std::int32_t L1_ARG_BASE = 0x3E420;
-  static constexpr std::int32_t L1_ERISCK_INFO = 0x3E400;
+  static constexpr std::int32_t ERISC_BARRIER_BASE =0x3E400;
 
-  template<std::size_t A, std::size_t B> struct TAssertEquality {
-    static_assert(A==B, "Not equal");
-    static constexpr bool _cResult = (A==B);
-  };
-
-  static constexpr std::int32_t MAX_SIZE = 256*1024;
   static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;
 
   static constexpr std::int32_t RISC_LOCAL_MEM_BASE = 0xffb00000; // Actaul local memory address as seen from risc firmware
@@ -51,4 +30,4 @@ struct address_map {
 
   static constexpr std::uint32_t FW_VERSION_ADDR = 0x210;
 };
-}  // namespace eth_l1_mem
+}  // namespace llk


### PR DESCRIPTION
This addresses #3232 where WH post commit was hanging on running programs on the remote device when remote and mmio device had different harvesting configs because we were not re-generating  headers that rely on harvesting config

Once #3381 is in we can get rid of the changes in program/kernels 



