### PR TITLE
More cleanup/optimizations of cb initialization

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -163,10 +163,11 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
         }
 
         ll_api::memory binary_mem = llrt::get_risc_binary(fname, this->id(), true);
+        uint32_t kernel_size16 = llrt::get_binary_code_size16(binary_mem, riscv_id);
         if (riscv_id == 1) {
-            launch_msg->ncrisc_kernel_size16 = llrt::get_binary_code_size16(binary_mem, riscv_id);
+            launch_msg->ncrisc_kernel_size16 = kernel_size16;
         }
-        log_debug("RISC {} fw binary size: {} in bytes", riscv_id, launch_msg->ncrisc_kernel_size16 * 16);
+        log_debug("RISC {} fw binary size: {} in bytes", riscv_id, kernel_size16 * 16);
         llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, riscv_id);
     }
 

--- a/tt_metal/impl/program.cpp
+++ b/tt_metal/impl/program.cpp
@@ -144,6 +144,7 @@ KernelGroup::KernelGroup(const Program& program,
     } else {
         this->launch_msg.ncrisc_watcher_kernel_id = 0;
         this->launch_msg.enable_ncrisc = false;
+        this->launch_msg.ncrisc_kernel_size16 = 0;
     }
 
     if (trisc_id) {

--- a/tt_metal/impl/program.hpp
+++ b/tt_metal/impl/program.hpp
@@ -43,7 +43,9 @@ struct KernelGroup {
     KernelGroup(const Program& program,
                 std::optional<KernelID> brisc_id,
                 std::optional<KernelID> ncrisc_id,
-                std::optional<KernelID> trisc_id);
+                std::optional<KernelID> trisc_id,
+                int last_cb_index,
+                const CoreRangeSet& new_ranges);
 };
 
 class Program {

--- a/tt_metal/src/ckernels/grayskull/common/src/ckernel.cc
+++ b/tt_metal/src/ckernels/grayskull/common/src/ckernel.cc
@@ -43,6 +43,21 @@ volatile tt_l1_ptr uint8_t * const trisc_run = &GET_TRISC_RUN(((tt_l1_ptr mailbo
 
 volatile tt_l1_ptr uint32_t l1_buffer[16] __attribute__ ((section ("l1_data"))) __attribute__ ((aligned (16))) __attribute__((used));
 
+#if !defined(UCK_CHLKC_MATH)
+CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
+#endif
+
+#if defined(UCK_CHLKC_UNPACK)
+constexpr bool cb_init_read = true;
+#else
+constexpr bool cb_init_read = false;
+#endif
+#if defined(UCK_CHLKC_PACK)
+constexpr bool cb_init_write = true;
+#else
+constexpr bool cb_init_write = false;
+#endif
+
 using namespace ckernel;
 
 int main(int argc, char *argv[])
@@ -78,6 +93,10 @@ int main(int argc, char *argv[])
 
         kernel_profiler::init_profiler();
         kernel_profiler::mark_time(CC_MAIN_START);
+
+#if !defined(UCK_CHLKC_MATH)
+        setup_cb_read_write_interfaces(cb_init_read, cb_init_write);
+#endif
 
         DEBUG_STATUS('R');
         kernel_init();

--- a/tt_metal/src/ckernels/grayskull/common/src/ckernel.cc
+++ b/tt_metal/src/ckernels/grayskull/common/src/ckernel.cc
@@ -39,6 +39,7 @@ const uint8_t thread_id = COMPILE_FOR_TRISC;
 #define GET_TRISC_RUN_EVAL(x, t) x##t
 #define GET_TRISC_RUN(x, t) GET_TRISC_RUN_EVAL(x, t)
 volatile tt_l1_ptr uint8_t * const trisc_run = &GET_TRISC_RUN(((tt_l1_ptr mailboxes_t *)(MEM_MAILBOX_BASE))->slave_sync.trisc, COMPILE_FOR_TRISC);
+tt_l1_ptr mailboxes_t * const mailboxes = (tt_l1_ptr mailboxes_t *)(MEM_MAILBOX_BASE);
 } // namespace ckernel
 
 volatile tt_l1_ptr uint32_t l1_buffer[16] __attribute__ ((section ("l1_data"))) __attribute__ ((aligned (16))) __attribute__((used));
@@ -95,7 +96,7 @@ int main(int argc, char *argv[])
         kernel_profiler::mark_time(CC_MAIN_START);
 
 #if !defined(UCK_CHLKC_MATH)
-        setup_cb_read_write_interfaces(cb_init_read, cb_init_write);
+        setup_cb_read_write_interfaces(mailboxes->launch.max_cb_index, cb_init_read, cb_init_write);
 #endif
 
         DEBUG_STATUS('R');

--- a/tt_metal/src/ckernels/grayskull/common/src/ckernel.cc
+++ b/tt_metal/src/ckernels/grayskull/common/src/ckernel.cc
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
         kernel_profiler::mark_time(CC_MAIN_START);
 
 #if !defined(UCK_CHLKC_MATH)
-        setup_cb_read_write_interfaces(mailboxes->launch.max_cb_index, cb_init_read, cb_init_write);
+        setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, cb_init_read, cb_init_write);
 #endif
 
         DEBUG_STATUS('R');

--- a/tt_metal/src/ckernels/grayskull/common/src/ckernel_main.cc
+++ b/tt_metal/src/ckernels/grayskull/common/src/ckernel_main.cc
@@ -28,8 +28,6 @@ volatile tt_reg_ptr uint * const instrn_buffer = reinterpret_cast<volatile uint 
 volatile tt_reg_ptr uint * const pc_buf_base = reinterpret_cast<volatile uint *>(PC_BUF_BASE);
 }
 
-CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
-
 void kernel_launch()
 {
     tt_l1_ptr uint *local_l1_start_addr = (tt_l1_ptr uint *)PREPROCESSOR_EXPAND(MEM_TRISC, COMPILE_FOR_TRISC, _INIT_LOCAL_L1_BASE);

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
@@ -16,35 +16,9 @@
 
 using namespace ckernel;
 
-inline void llk_setup_cb_interface() {
-
-    volatile tt_l1_ptr std::uint32_t* circular_buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
-
-    for (std::uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
-
-        uint32_t fifo_addr = circular_buffer_config_addr[0];
-        uint32_t fifo_size = circular_buffer_config_addr[1];
-        uint32_t fifo_num_pages = circular_buffer_config_addr[2];
-        uint32_t fifo_page_size = circular_buffer_config_addr[3];
-
-        cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
-        cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].fifo_num_pages = fifo_num_pages;
-        cb_interface[cb_id].fifo_page_size = fifo_page_size;
-
-        // local copy used by the packer
-        cb_interface[cb_id].tiles_received = 0;
-        // this is currently used for in-order packing (the default mode)
-        cb_interface[cb_id].fifo_wr_tile_ptr = 0;
-
-        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG; // move by 3 uint32's
-    }
-}
-
 // "llk_setup_outputs" is the old function name that HLKC emits
 inline void llk_setup_outputs() {
-    llk_setup_cb_interface();
+    setup_cb_read_write_interfaces(false, true);
 }
 
 // Blocking call to wait for free space needed to pack N tiles

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_pack.h
@@ -14,11 +14,12 @@
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "llk_pack_common.h"
 
+#include "debug_print.h"
+
 using namespace ckernel;
 
 // "llk_setup_outputs" is the old function name that HLKC emits
 inline void llk_setup_outputs() {
-    setup_cb_read_write_interfaces(false, true);
 }
 
 // Blocking call to wait for free space needed to pack N tiles

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
@@ -16,31 +16,9 @@
 
 using namespace ckernel;
 
-inline void llk_setup_cb_interface() {
-
-    volatile tt_l1_ptr std::uint32_t* buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
-
-    for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
-
-        // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
-        uint32_t fifo_addr = buffer_config_addr[0];
-        uint32_t fifo_size = buffer_config_addr[1];
-        uint32_t fifo_num_pages = buffer_config_addr[2]; // not used atm
-        uint32_t fifo_page_size = buffer_config_addr[3]; // not used atm
-
-        cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
-        cb_interface[cb_id].tiles_acked = 0;
-        cb_interface[cb_id].fifo_page_size = fifo_page_size;
-
-        buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG; // move by 3 uint32's
-    }
-}
-
 // "llk_setup_operands" is the old function name that HLKC emits
 inline void llk_setup_operands() {
-    llk_setup_cb_interface();
+    setup_cb_read_write_interfaces(true, false);
 }
 
 // Wait for N tiles available in the incoming stream

--- a/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
+++ b/tt_metal/src/ckernels/grayskull/llk_lib/llk_io_unpack.h
@@ -18,7 +18,6 @@ using namespace ckernel;
 
 // "llk_setup_operands" is the old function name that HLKC emits
 inline void llk_setup_operands() {
-    setup_cb_read_write_interfaces(true, false);
 }
 
 // Wait for N tiles available in the incoming stream

--- a/tt_metal/src/firmware/riscv/common/circular_buffer.h
+++ b/tt_metal/src/firmware/riscv/common/circular_buffer.h
@@ -42,10 +42,10 @@ extern CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
 
 // NCRISC and BRISC setup read and write
 // TRISC sets up read or write
-inline void setup_cb_read_write_interfaces(uint32_t max_cb_index, bool read, bool write) {
-    volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
+inline void setup_cb_read_write_interfaces(uint32_t start_cb_index, uint32_t max_cb_index, bool read, bool write) {
+    volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE) + start_cb_index * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;
 
-    for (uint32_t cb_id = 0; cb_id < max_cb_index; cb_id++) {
+    for (uint32_t cb_id = start_cb_index; cb_id < max_cb_index; cb_id++) {
 
         // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
         uint32_t fifo_addr = circular_buffer_config_addr[0];

--- a/tt_metal/src/firmware/riscv/common/circular_buffer.h
+++ b/tt_metal/src/firmware/riscv/common/circular_buffer.h
@@ -42,10 +42,10 @@ extern CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
 
 // NCRISC and BRISC setup read and write
 // TRISC sets up read or write
-inline void setup_cb_read_write_interfaces(bool read, bool write) {
+inline void setup_cb_read_write_interfaces(uint32_t max_cb_index, bool read, bool write) {
     volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
 
-    for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
+    for (uint32_t cb_id = 0; cb_id < max_cb_index; cb_id++) {
 
         // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
         uint32_t fifo_addr = circular_buffer_config_addr[0];

--- a/tt_metal/src/firmware/riscv/common/circular_buffer.h
+++ b/tt_metal/src/firmware/riscv/common/circular_buffer.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "hostdevcommon/common_runtime_address_map.h"
+#include "risc_attribs.h"
 
 struct CQReadInterface {
     uint32_t fifo_size;
@@ -35,3 +37,37 @@ struct CBInterface {
     // used by packer for in-order packing
     uint32_t fifo_wr_tile_ptr;
 };
+
+extern CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
+
+// NCRISC and BRISC setup read and write
+// TRISC sets up read or write
+inline void setup_cb_read_write_interfaces(bool read, bool write) {
+    volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
+
+    for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
+
+        // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
+        uint32_t fifo_addr = circular_buffer_config_addr[0];
+        uint32_t fifo_size = circular_buffer_config_addr[1];
+        uint32_t fifo_num_pages = circular_buffer_config_addr[2];
+        uint32_t fifo_page_size = circular_buffer_config_addr[3];
+        uint32_t fifo_limit = fifo_addr + fifo_size;
+
+        cb_interface[cb_id].fifo_limit = fifo_limit;  // to check if we need to wrap
+        if (write) {
+            cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
+        }
+        if (read) {
+            cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
+        }
+        cb_interface[cb_id].fifo_size = fifo_size;
+        cb_interface[cb_id].tiles_acked_received_init = 0;
+        if (write) {
+            cb_interface[cb_id].fifo_num_pages = fifo_num_pages;
+        }
+        cb_interface[cb_id].fifo_page_size = fifo_page_size;
+
+        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;
+    }
+}

--- a/tt_metal/src/firmware/riscv/common/dataflow_api.h
+++ b/tt_metal/src/firmware/riscv/common/dataflow_api.h
@@ -79,40 +79,6 @@ FORCE_INLINE T get_arg_val(int arg_idx) {
  */
 #define get_compile_time_arg_val(arg_idx) KERNEL_COMPILE_TIME_ARG_##arg_idx
 
-// can be used on NCRICS and/or BRISC, as both can act as tile producers into Tensix
-void setup_cb_read_write_interfaces() {
-    volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = (volatile uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
-
-    for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
-        uint32_t fifo_addr = circular_buffer_config_addr[0];
-        uint32_t fifo_size = circular_buffer_config_addr[1];
-        uint32_t fifo_num_pages = circular_buffer_config_addr[2];
-        uint32_t fifo_page_size = circular_buffer_config_addr[3];
-        uint32_t fifo_limit = fifo_addr + fifo_size;
-
-        cb_interface[cb_id].fifo_limit = fifo_limit;  // to check if we need to wrap
-        cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].tiles_acked_received_init = 0;
-        cb_interface[cb_id].fifo_num_pages = fifo_num_pages;
-        cb_interface[cb_id].fifo_page_size = fifo_page_size;
-
-        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;
-    }
-}
-
-// Only the read interface is set up on the device... the write interface
-// belongs to host
-void setup_cq_read_write_interface() {
-    uint fifo_addr = (HOST_CQ_FINISH_PTR + 32) >> 4;  // The fifo starts after the pointer addresses
-    uint fifo_size = ((1024 * 1024 * 1024) >> 4) - fifo_addr;
-
-    cq_read_interface.fifo_limit = fifo_addr + fifo_size;
-    cq_read_interface.fifo_rd_ptr = fifo_addr;
-    cq_read_interface.fifo_size = fifo_size;
-}
-
 // replicated from ckernels_defs.h, which are currently not included in BRISC / NCRISC builds
 // TODO: look into ckernels_defs.h included in NCRISC/BRISC builds
 inline __attribute__((always_inline)) constexpr static std::int32_t GET_L1_TILE_SIZE(uint format) {

--- a/tt_metal/src/firmware/riscv/common/dev_msgs.h
+++ b/tt_metal/src/firmware/riscv/common/dev_msgs.h
@@ -48,7 +48,7 @@ struct launch_msg_t {  // must be cacheline aligned
     volatile uint8_t enable_brisc;
     volatile uint8_t enable_ncrisc;
     volatile uint8_t enable_triscs;
-    volatile uint8_t pad0;
+    volatile uint8_t max_cb_index;
     volatile uint8_t pad1;
     volatile uint8_t run;  // must be in last cacheline of this msg
 };

--- a/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
@@ -35,6 +35,8 @@ constexpr uint32_t RISCV_IC_TRISC1_MASK = 0x4;
 constexpr uint32_t RISCV_IC_TRISC2_MASK = 0x8;
 constexpr uint32_t RISCV_IC_TRISC_ALL_MASK = RISCV_IC_TRISC0_MASK | RISCV_IC_TRISC1_MASK | RISCV_IC_TRISC2_MASK;
 
+constexpr uint32_t num_cbs_to_early_init = 4;  // safe small number to overlap w/ ncrisc copy
+
 tt_l1_ptr mailboxes_t * const mailboxes = (tt_l1_ptr mailboxes_t *)(MEM_MAILBOX_BASE);
 uint32_t ncrisc_kernel_start_offset16;
 
@@ -324,12 +326,13 @@ int main() {
 
         uint32_t noc_index = mailboxes->launch.brisc_noc_id;
 
+        setup_cb_read_write_interfaces(0, num_cbs_to_early_init, true, true);
         finish_ncrisc_copy_and_run();
 
         // Run the BRISC kernel
         DEBUG_STATUS('R');
         if (mailboxes->launch.enable_brisc) {
-            setup_cb_read_write_interfaces(mailboxes->launch.max_cb_index, true, true);
+            setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.max_cb_index, true, true);
             kernel_init();
         } else {
             // This was not initialized in kernel_init

--- a/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
@@ -23,6 +23,7 @@
 #include "risc_attribs.h"
 #include "noc_addr_ranges_gen.h"
 #include "generated_bank_to_noc_coord_mapping.h"
+#include "dataflow_api.h"
 
 #include "debug_status.h"
 #include "debug_print.h"

--- a/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
@@ -23,7 +23,7 @@
 #include "risc_attribs.h"
 #include "noc_addr_ranges_gen.h"
 #include "generated_bank_to_noc_coord_mapping.h"
-#include "dataflow_api.h"
+#include "circular_buffer.h"
 
 #include "debug_status.h"
 #include "debug_print.h"
@@ -50,6 +50,8 @@ uint8_t my_y[NUM_NOCS] __attribute__((used));
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
+
+CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
 #define MEM_MOVER_VIEW_IRAM_BASE_ADDR (0x4 << 12)
 
@@ -315,6 +317,7 @@ int main() {
         // Run the BRISC kernel
         DEBUG_STATUS('R');
         if (mailboxes->launch.enable_brisc) {
+            setup_cb_read_write_interfaces(true, true);
             kernel_init();
         } else {
             noc_local_state_init(noc_index);

--- a/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/brisc/brisc.cc
@@ -329,7 +329,7 @@ int main() {
         // Run the BRISC kernel
         DEBUG_STATUS('R');
         if (mailboxes->launch.enable_brisc) {
-            setup_cb_read_write_interfaces(true, true);
+            setup_cb_read_write_interfaces(mailboxes->launch.max_cb_index, true, true);
             kernel_init();
         } else {
             // This was not initialized in kernel_init

--- a/tt_metal/src/firmware/riscv/targets/brisc/brisck.cc
+++ b/tt_metal/src/firmware/riscv/targets/brisc/brisck.cc
@@ -26,7 +26,6 @@
 #include "debug_print.h"
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
-CQReadInterface cq_read_interface;
 
 uint8_t noc_index = NOC_INDEX;
 
@@ -34,11 +33,7 @@ void kernel_launch() {
 
     firmware_kernel_common_init((void tt_l1_ptr *)MEM_BRISC_INIT_LOCAL_L1_BASE);
 
-#if defined(IS_DISPATCH_KERNEL)
-    setup_cq_read_write_interface();
-#else
-    setup_cb_read_write_interfaces();                // done by both BRISC / NCRISC
-#endif
+    setup_cb_read_write_interfaces(true, true);
 
     noc_local_state_init(noc_index);
 

--- a/tt_metal/src/firmware/riscv/targets/brisc/brisck.cc
+++ b/tt_metal/src/firmware/riscv/targets/brisc/brisck.cc
@@ -25,15 +25,11 @@
 
 #include "debug_print.h"
 
-CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
-
 uint8_t noc_index = NOC_INDEX;
 
 void kernel_launch() {
 
     firmware_kernel_common_init((void tt_l1_ptr *)MEM_BRISC_INIT_LOCAL_L1_BASE);
-
-    setup_cb_read_write_interfaces(true, true);
 
     noc_local_state_init(noc_index);
 

--- a/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisc.cc
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
       kernel_profiler::init_profiler();
       kernel_profiler::mark_time(CC_MAIN_START);
 
-      setup_cb_read_write_interfaces(true, true);
+      setup_cb_read_write_interfaces(mailboxes->launch.max_cb_index, true, true);
 
       DEBUG_STATUS('R');
       kernel_init();

--- a/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisc.cc
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
       kernel_profiler::init_profiler();
       kernel_profiler::mark_time(CC_MAIN_START);
 
-      setup_cb_read_write_interfaces(mailboxes->launch.max_cb_index, true, true);
+      setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, true, true);
 
       DEBUG_STATUS('R');
       kernel_init();

--- a/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisc.cc
+++ b/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisc.cc
@@ -11,6 +11,7 @@
 #include "tools/profiler/kernel_profiler.hpp"
 #include "tt_metal/src/firmware/riscv/common/risc_attribs.h"
 #include "generated_bank_to_noc_coord_mapping.h"
+#include "circular_buffer.h"
 
 #include "debug_status.h"
 #include "debug_print.h"
@@ -25,6 +26,8 @@ uint8_t my_y[NUM_NOCS] __attribute__((used));
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
+
+CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
 namespace kernel_profiler {
 uint32_t wIndex __attribute__((used));
@@ -53,6 +56,8 @@ int main(int argc, char *argv[]) {
 
       kernel_profiler::init_profiler();
       kernel_profiler::mark_time(CC_MAIN_START);
+
+      setup_cb_read_write_interfaces(true, true);
 
       DEBUG_STATUS('R');
       kernel_init();

--- a/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisck.cc
+++ b/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisck.cc
@@ -16,8 +16,6 @@
 
 #include "kernel.cpp"
 
-CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
-
 uint8_t noc_index = NOC_INDEX;
 
 uint32_t noc_reads_num_issued[NUM_NOCS];
@@ -27,8 +25,6 @@ uint32_t noc_nonposted_writes_acked[NUM_NOCS];
 void kernel_launch() {
 
     firmware_kernel_common_init((void tt_l1_ptr *)MEM_NCRISC_INIT_LOCAL_L1_BASE);
-
-    setup_cb_read_write_interfaces(true, true);
 
     noc_local_state_init(noc_index);
 

--- a/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisck.cc
+++ b/tt_metal/src/firmware/riscv/targets/ncrisc/ncrisck.cc
@@ -17,7 +17,6 @@
 #include "kernel.cpp"
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
-CQReadInterface cq_read_interface;
 
 uint8_t noc_index = NOC_INDEX;
 
@@ -29,7 +28,7 @@ void kernel_launch() {
 
     firmware_kernel_common_init((void tt_l1_ptr *)MEM_NCRISC_INIT_LOCAL_L1_BASE);
 
-    setup_cb_read_write_interfaces();
+    setup_cb_read_write_interfaces(true, true);
 
     noc_local_state_init(noc_index);
 


### PR DESCRIPTION
Move cb init from kernel side to fw side to reduce kernel sizes
Split ncrisc iram copy into start/end so work can happen while the copy is in progress
Pass the max cb index to the device to only init the used cbs