### PR TITLE
#0: Added an API that allows us to get profiler information by specifying cores instead of program

### DIFF
--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -70,6 +70,19 @@ namespace tt::tt_metal{
         // - Takes the device out of reset
         bool ConfigureDeviceWithProgram(Device *device, Program &program);
 
+
+        /**
+         * Read device side profiler data and dump results into device side CSV log
+         *
+         * Return value: void
+         *
+         * | Argument      | Description                                       | Type                      | Valid Range               | Required |
+         * |---------------|---------------------------------------------------|---------------------------|---------------------------|----------|
+         * | device        | The device holding the program being profiled.    | Device *                  |                           | True     |
+         * | core_coords   | The logical core coordinates being profiled.      | const vector<CoreCoord> & |                           | True     |
+         * */
+        void DumpDeviceProfileResults(Device *device, const vector<CoreCoord>& logical_cores);
+
         /**
          * Read device side profiler data and dump results into device side CSV log
          *

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -17,7 +17,7 @@ namespace detail {
 
 static Profiler tt_metal_profiler = Profiler();
 
-void DumpDeviceProfileResults(Device *device, const Program &program) {
+void DumpDeviceProfileResults(Device *device, const vector<CoreCoord> &logical_cores) {
 #if defined(PROFILER)
     ZoneScoped;
     if (getDeviceProfilerState())
@@ -29,12 +29,17 @@ void DumpDeviceProfileResults(Device *device, const Program &program) {
         }
         TT_ASSERT(tt_is_print_server_running() == false, "Debug print server is running, cannot dump device profiler data");
         auto worker_cores_used_in_program =\
-            device->worker_cores_from_logical_cores(program.logical_cores());
+            device->worker_cores_from_logical_cores(logical_cores);
         auto device_id = device->id();
         tt_metal_profiler.setDeviceArchitecture(device->arch());
         tt_metal_profiler.dumpDeviceResults(device_id, worker_cores_used_in_program);
     }
 #endif
+}
+
+
+void DumpDeviceProfileResults(Device *device, const Program &program) {
+    DumpDeviceProfileResults(device, program.logical_cores());
 }
 
 void SetProfilerDir(std::string output_dir){


### PR DESCRIPTION
This API was added because sometimes at the metal level, you don't have access to the program object.