### PR TITLE
Changing Device_init_destroy fixture to function scope

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -226,7 +226,7 @@ def reset_tensix(request, silicon_arch_name):
         assert result.returncode == 0, "Tensix reset script raised error"
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def device_init_destroy(request):
     import tt_lib as ttl
 


### PR DESCRIPTION
Temporarily for stability until FD CQ race condition can be looked at