### PR TITLE
#3508: Command queue and allocator were out of sync, fixed by freeing up the program cache buffers before calling de-allocate buffers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -247,6 +247,7 @@ def device(device_init_destroy):
     import tt_lib as ttl
     device = ttl.device.GetDefaultDevice()
     yield device
+    ttl.device.ClearCommandQueueProgramCache()
     ttl.device.DeallocateBuffers(device)
 
 

--- a/tests/scripts/run_models.sh
+++ b/tests/scripts/run_models.sh
@@ -34,8 +34,7 @@ env pytest models/experimental/deit/tests/test_deit_for_image_classification_wit
 
 env pytest models/experimental/vit/tests/test_vit_image_classification.py -k test_vit_image_classification
 
-env pytest models/demos/metal_BERT_large_15/tests/test_bert_batch_dram.py::test_bert_batch_dram
-env pytest models/demos/metal_BERT_large_15/tests/test_bert_batch_dram.py::test_bert_batch_dram_with_program_cache
+env pytest models/demos/metal_BERT_large_15/tests/test_bert_batch_dram.py
 env pytest models/demos/metal_BERT_large_15/tests/test_demo.py::test_demo
 env pytest models/demos/metal_BERT_large_15/tests/test_demo.py::test_demo_squadv2
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -20,6 +20,7 @@ def setup_tt_tensor(x, device, layout, input_mem_config, dtype):
 def setup_host_and_device(func):
     def wrap(*args, device, **kwargs):
         output = func(*args, device=device, **kwargs)
+        ttl.device.ClearCommandQueueProgramCache()
         ttl.device.DeallocateBuffers(device)
         return output
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -128,6 +128,9 @@ void DeviceModule(py::module &m_device) {
     m_device.def("DeallocateBuffers", &detail::DeallocateBuffers, R"doc(
         Deallocate all buffers associated with Device handle
     )doc");
+    m_device.def("ClearCommandQueueProgramCache", &detail::ClearCommandQueueProgramCache, R"doc(
+        Deallocate the program cache saved by the command queue
+    )doc");
 }
 
 void ProfilerModule(py::module &m_profiler) {

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -245,6 +245,13 @@ namespace tt::tt_metal{
             device->deallocate_buffers();
         }
 
+        inline void ClearCommandQueueProgramCache()
+        {
+            if (detail::GLOBAL_CQ) {
+                ClearProgramCache(*detail::GLOBAL_CQ);
+            }
+        }
+
         inline void GenerateDeviceHeaders(Device *device,
                                           build_kernel_for_riscv_options_t *build_options,
                                           const std::string &op_path_suffix)

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -908,4 +908,10 @@ void Finish(CommandQueue& cq) {
     cq.finish();
 }
 
+void ClearProgramCache(CommandQueue& cq) {
+    detail::DispatchStateCheck(true);
+    cq.program_to_buffer.clear();
+    cq.program_to_dev_map.clear();
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -177,8 +177,6 @@ class CommandQueue {
    private:
     Device* device;
     SystemMemoryWriter sysmem_writer;
-    TSQueue<shared_ptr<Command>>
-        processing_thread_queue;  // These are commands that have not been placed in system memory
     // thread processing_thread;
     map<uint64_t, unique_ptr<Buffer>>
         program_to_buffer;
@@ -201,6 +199,7 @@ class CommandQueue {
     friend void EnqueueWriteBuffer(CommandQueue& cq, Buffer& buffer, vector<uint32_t>& src, bool blocking);
     friend void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking);
     friend void Finish(CommandQueue& cq);
+    friend void ClearProgramCache(CommandQueue& cq);
 };
 
 } // namespace tt::tt_metal


### PR DESCRIPTION
This resolves a bug where the allocator and command queue were out of sync (command queue had stale buffers). 