### PR TITLE
Agrebenisan/unicast rt args one packet

### DIFF
--- a/models/demos/metal_BERT_large_15/tests/test_perf_bert15.py
+++ b/models/demos/metal_BERT_large_15/tests/test_perf_bert15.py
@@ -151,7 +151,7 @@ def test_perf_virtual_machine(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_inference_time, expected_compile_time",
-    ([0.07, 10],),
+    ([0.06, 10],),
 )
 def test_perf_bare_metal(
     use_program_cache,

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
@@ -108,7 +108,7 @@ FORCE_INLINE void write_program_page(uint32_t page_addr, volatile tt_l1_ptr uint
         if constexpr (multicast) {
             noc_async_write_multicast(src, dst_noc_addr, num_bytes, num_recv);
         } else {
-            noc_async_write(src, dst_noc_addr, num_bytes);
+            noc_async_write_one_packet(src, dst_noc_addr, num_bytes);
         }
 
         command_ptr += 5;

--- a/tt_metal/src/firmware/riscv/common/dataflow_api.h
+++ b/tt_metal/src/firmware/riscv/common/dataflow_api.h
@@ -922,6 +922,32 @@ void noc_async_write(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr
     DEBUG_STATUS('N', 'A', 'W', 'D');
 }
 
+// TODO: write docs
+// this issues only a single packet with size <= NOC_MAX_BURST_SIZE (ie maximum packet size)
+FORCE_INLINE
+void noc_async_write_one_packet(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size) {
+
+    DEBUG_STATUS('N', 'W', 'P', 'W');
+    DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr, size);
+    while (!ncrisc_noc_fast_write_ok(noc_index, NCRISC_WR_REG_CMD_BUF));
+    DEBUG_STATUS('N', 'W', 'P', 'D');
+
+    uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
+                                NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) | 0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
+                                0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
+                                NOC_CMD_RESP_MARKED;
+
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_MID, dst_noc_addr >> 32);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_AT_LEN_BE,  size);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    noc_nonposted_writes_num_issued[noc_index] += 1;
+    noc_nonposted_writes_acked[noc_index] += 1;  // num_dests
+ }
+
 template <bool DRAM>
 FORCE_INLINE void noc_async_write_tile(
     const uint32_t id, const InterleavedAddrGenFast<DRAM>& s, std::uint32_t src_local_l1_addr) {


### PR DESCRIPTION
Since we know runtime args are max 1KB per transfer, use the lower-overhead send one packet API.