### PR TITLE
#2220: Split watcher init/attach into two calls

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -250,14 +250,21 @@ bool Device::initialize(const std::vector<uint32_t>& l1_bank_remap) {
     if (!already_initialized) {
         this->initialize_build();
     }
+
     tt_start_debug_print_server();
+    llrt::watcher_init(this->id(),
+                       [&, this]() { return this->logical_grid_size(); },
+                       [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); }
+                       );
+
+    this->initialize_and_launch_firmware();
+
     llrt::watcher_attach(this, this->id(),
                          [&, this]() { return this->logical_grid_size(); },
                          [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); },
                          [&, this]() -> const std::set<CoreCoord>& { return this->storage_only_cores(); },
                          get_compile_outpath()
                          );
-    this->initialize_and_launch_firmware();
 
     this->initialized_ = true;
     return true;

--- a/tt_metal/llrt/watcher.hpp
+++ b/tt_metal/llrt/watcher.hpp
@@ -11,6 +11,9 @@
 namespace tt {
 namespace llrt {
 
+void watcher_init(int device_id,
+                  std::function<CoreCoord ()>get_grid_size,
+                  std::function<CoreCoord (CoreCoord)>worker_from_logical);
 void watcher_attach(void *dev, int device_id, const std::function<CoreCoord ()>& get_grid_size, const std::function<CoreCoord (CoreCoord)>& worker_from_logical, const std::function<const std::set<CoreCoord> &()>& storage_only_cores, const string& log_path);
 void watcher_detach(void *dev);
 


### PR DESCRIPTION
Watcher state needs to be set up before firmware is launched Watcher attach needs to happen after firmware launch