### PR TITLE
#3404: Run hugepage check script as first step of build

### DIFF
--- a/infra/machine_setup/scripts/setup_hugepages.py
+++ b/infra/machine_setup/scripts/setup_hugepages.py
@@ -420,7 +420,7 @@ def main() -> int:
             print("\nCheck failed - huge pages is not enabled")
             return 1
 
-        print("Check passed!")
+        print("Hugepage check passed!")
     elif args.operation == "enable":
         return enable_or_first_pass()
     elif args.operation == "first_pass":

--- a/module.mk
+++ b/module.mk
@@ -111,6 +111,9 @@ set_up_kernels:
 set_up_kernels/clean:
 	python3 $(TT_METAL_HOME)/scripts/set_up_kernels.py --short clean
 
+hugepage-check:
+	bash -c "python3.8 $(TT_METAL_HOME)/infra/machine_setup/scripts/setup_hugepages.py check" || (echo "$?"; exit 1)
+
 ifeq ($(ENABLE_PROFILER), 1)
 CFLAGS += -DPROFILER
 endif
@@ -120,7 +123,15 @@ CFLAGS += -DTRACY_ENABLE -fno-omit-frame-pointer -fPIC
 LDFLAGS += -rdynamic
 endif
 
-LIBS_TO_BUILD = \
+LIBS_TO_BUILD =
+ifdef TT_METAL_ENV_IS_DEV
+LIBS_TO_BUILD += \
+	hugepage-check \
+	python_env/dev \
+	git_hooks
+endif
+
+LIBS_TO_BUILD += \
 	common \
 	build_kernels_for_riscv \
 	set_up_kernels \
@@ -130,12 +141,6 @@ LIBS_TO_BUILD = \
 	tt_metal \
 	tracy \
 	tt_eager
-
-ifdef TT_METAL_ENV_IS_DEV
-LIBS_TO_BUILD += \
-	python_env/dev \
-	git_hooks
-endif
 
 # These must be in dependency order (enforces no circular deps)
 include $(TT_METAL_HOME)/tt_metal/common/common.mk


### PR DESCRIPTION
I didn't want to duplicate logic in UMD for checking hugepage set up and we have the `setup_hugepages.py check` script as part of machine set up so I thought we could use it as first step of the build to check if hugepages are enabled 