### PR TITLE
#2702: Send the toggle and pointers as part of the same transfer to prevent race conditions

### DIFF
--- a/tt_metal/impl/dispatch/command_queue_interface.cpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.cpp
@@ -7,13 +7,7 @@
 uint32_t get_cq_rd_ptr(chip_id_t chip_id) {
     vector<uint32_t> recv;
     tt::Cluster::instance().read_sysmem_vec(recv, HOST_CQ_READ_PTR, 4, chip_id);
-    return recv.at(0);
-}
-
-uint32_t get_cq_rd_toggle(chip_id_t chip_id) {
-    vector<uint32_t> recv;
-    tt::Cluster::instance().read_sysmem_vec(recv, HOST_CQ_READ_TOGGLE_PTR, 4, chip_id);
-    return recv.at(0);
+    return recv[0];
 }
 
 SystemMemoryWriter::SystemMemoryWriter() {
@@ -25,13 +19,16 @@ SystemMemoryWriter::SystemMemoryWriter() {
 void SystemMemoryWriter::cq_reserve_back(Device* device, uint32_t cmd_size_B) {
     uint32_t cmd_size_16B = (((cmd_size_B - 1) | 31) + 1) >> 4; // Terse way to find next multiple of 32 in 16B words
 
+    uint32_t rd_ptr_and_toggle;
     uint32_t rd_ptr;
     uint32_t rd_toggle;
     do {
-        rd_ptr = get_cq_rd_ptr(device->id());
-        rd_toggle = get_cq_rd_toggle(device->id());
+        rd_ptr_and_toggle = get_cq_rd_ptr(device->id());
+        rd_ptr = rd_ptr_and_toggle & 0x7fffffff;
+        rd_toggle = rd_ptr_and_toggle >> 31;
+
     } while (this->cq_write_interface.fifo_wr_ptr < rd_ptr and
-             this->cq_write_interface.fifo_wr_ptr + cmd_size_16B >= rd_ptr or
+             this->cq_write_interface.fifo_wr_ptr + cmd_size_16B > rd_ptr or
 
              // This is the special case where we wrapped our wr ptr and our rd ptr
              // has not yet moved
@@ -49,18 +46,8 @@ void SystemMemoryWriter::send_write_ptr(Device* device) {
 
     tt_driver_atomics::sfence();
 
-    tt::llrt::write_hex_vec_to_core(chip_id, dispatch_core, {this->cq_write_interface.fifo_wr_ptr}, CQ_WRITE_PTR, false);
-
-    tt_driver_atomics::sfence();
-}
-
-void SystemMemoryWriter::send_write_toggle(Device* device) {
-    static CoreCoord dispatch_core = device->worker_core_from_logical_core(*device->dispatch_cores().begin());
-    uint32_t chip_id = 0;  // TODO(agrebenisan): Remove hard-coding
-
-    tt_driver_atomics::sfence();
-
-    tt::llrt::write_hex_vec_to_core(chip_id, dispatch_core, {this->cq_write_interface.fifo_wr_toggle}, CQ_WRITE_TOGGLE, true);
+    uint32_t write_ptr_and_toggle = this->cq_write_interface.fifo_wr_ptr | (this->cq_write_interface.fifo_wr_toggle << 31);
+    tt::llrt::write_hex_vec_to_core(chip_id, dispatch_core, {write_ptr_and_toggle}, CQ_WRITE_PTR, false);
 
     tt_driver_atomics::sfence();
 }
@@ -77,7 +64,6 @@ void SystemMemoryWriter::cq_push_back(Device* device, uint32_t push_size_B) {
 
         // Flip the toggle
         this->cq_write_interface.fifo_wr_toggle = not this->cq_write_interface.fifo_wr_toggle;
-        this->send_write_toggle(device);
     }
 
     // Notify dispatch core

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -16,8 +16,8 @@ struct SystemMemoryCQWriteInterface {
     // Equation for fifo size is
     // | fifo_wr_ptr + command size B - fifo_rd_ptr |
     // Space available would just be fifo_limit - fifo_size
-    const uint32_t fifo_size = ((1024 * 1024 * 1024) - 96) >> 4;
-    const uint32_t fifo_limit = ((1024 * 1024 * 1024) >> 4) - 1;  // Last possible FIFO address
+    const uint32_t fifo_size = ((DeviceCommand::HUGE_PAGE_SIZE) - CQ_START) >> 4;
+    const uint32_t fifo_limit = ((DeviceCommand::HUGE_PAGE_SIZE) >> 4) - 1;  // Last possible FIFO address
 
     uint32_t fifo_wr_ptr;
     bool fifo_wr_toggle;
@@ -36,7 +36,6 @@ class SystemMemoryWriter {
     void cq_write(Device* device, const uint32_t* data, uint32_t size, uint32_t write_ptr);
 
     void send_write_ptr(Device* device);
-    void send_write_toggle(Device* device);
 
     void cq_push_back(Device* device, uint32_t push_size_B);
 };

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -16,6 +16,7 @@ class DeviceCommand {
     enum class TransferType : uint8_t { RUNTIME_ARGS, CB_CONFIGS, PROGRAM_PAGES, GO_SIGNALS, NUM_TRANSFER_TYPES };
 
     // Constants
+    static constexpr uint32_t HUGE_PAGE_SIZE = 1024 * 1024 * 1024;
     static constexpr uint32_t NUM_ENTRIES_IN_COMMAND_HEADER = 20;
     static constexpr uint32_t NUM_ENTRIES_IN_DEVICE_COMMAND = 5632;
     static constexpr uint32_t NUM_BYTES_IN_DEVICE_COMMAND = NUM_ENTRIES_IN_DEVICE_COMMAND * sizeof(uint32_t);

--- a/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
@@ -53,7 +53,7 @@ uint32_t get_db_cb_rd_ptr_addr(bool db_buf_switch) {
 
 FORCE_INLINE
 uint32_t get_db_cb_wr_ptr_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 96);
+    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + CQ_START);
 }
 
 

--- a/tt_metal/src/firmware/riscv/grayskull/stream_io_map.h
+++ b/tt_metal/src/firmware/riscv/grayskull/stream_io_map.h
@@ -50,14 +50,6 @@ inline __attribute__((always_inline)) volatile uint32_t* get_cq_write_ptr() {
     return reinterpret_cast<volatile uint32_t*>(CQ_WRITE_PTR);
 }
 
-inline __attribute__((always_inline)) volatile uint32_t* get_cq_read_toggle() {
-    return reinterpret_cast<volatile uint32_t*>(CQ_READ_TOGGLE);
-}
-
-inline __attribute__((always_inline)) volatile uint32_t* get_cq_write_toggle() {
-    return reinterpret_cast<volatile uint32_t*>(CQ_WRITE_TOGGLE);
-}
-
 inline __attribute__((always_inline)) volatile tt_l1_ptr uint32_t* get_cq_finish_ptr() {
     return (volatile tt_l1_ptr uint32_t*)(uintptr_t)(STREAM_REG_ADDR(
         get_operand_stream_id(0), STREAM_REMOTE_DEST_BUF_START_REG_INDEX));

--- a/tt_metal/src/firmware/riscv/wormhole/stream_io_map.h
+++ b/tt_metal/src/firmware/riscv/wormhole/stream_io_map.h
@@ -47,14 +47,6 @@ inline __attribute__((always_inline)) volatile uint32_t* get_cq_write_ptr() {
     return reinterpret_cast<volatile uint32_t*>(CQ_WRITE_PTR);
 }
 
-inline __attribute__((always_inline)) volatile uint32_t* get_cq_read_toggle() {
-    return reinterpret_cast<volatile uint32_t*>(CQ_READ_TOGGLE);
-}
-
-inline __attribute__((always_inline)) volatile uint32_t* get_cq_write_toggle() {
-    return reinterpret_cast<volatile uint32_t*>(CQ_WRITE_TOGGLE);
-}
-
 inline __attribute__((always_inline)) volatile uint32_t* get_cq_finish_ptr() {
     return (volatile uint32_t*)(uintptr_t)(STREAM_REG_ADDR(
         get_operand_stream_id(0), STREAM_REMOTE_DEST_BUF_START_REG_INDEX));


### PR DESCRIPTION
There were conditionals that looked at the value of the toggle as well as pointers, but the code had the assumption that the toggle and pointer values arrived in host/device at the same time.

This is not true. Therefore, instead of sending two separate packets, I instead mask the rd/wr pointers with the rd/wr toggles respectively to ensure they arrive to their destinations at the same time.