### PR TITLE
#2925: Extend reshape for row major layout

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_reshape.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_reshape.py
@@ -128,6 +128,160 @@ params += [
             "reshape_dims": [4, 2, 32, -1],
         },
     ),
+    pytest.param(
+        [[4, 4, 32, 32]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [-1, 2, 32, 32],
+        },
+    ),
+    pytest.param(
+        [[4, 4, 32, 32]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [2, -1, 32, 32],
+        },
+    ),
+    pytest.param(
+        [[4, 4, 32, 32]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [4, 1, -1, 32],
+        },
+    ),
+    pytest.param(
+        [[4, 4, 32, 32]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [4, 2, 32, -1],
+        },
+    ),
+    pytest.param(
+        [[2, 3, 4, 4]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [2, 12, 1, 4],
+        },
+    ),
+    pytest.param(
+        [[1, 3, 6, 4]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [3, 1, 3, 8],
+        },
+    ),
+    pytest.param(
+        [[1, 1, 60, 768]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [1, 60, 12, 64],
+        },
+    ),
+    pytest.param(
+        [[2, 4, 128, 4]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [1, 2, 64, 32],
+        },
+    ),
+    pytest.param(
+        [[1, 11, 64, 2]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [1, 11, 1, 128],
+        },
+    ),
+    pytest.param(
+        [[1, 2, 64, 32]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [2, 4, 128, 4],
+        },
+    ),
+    pytest.param(
+        [[3, 2, 2, 32]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.ROW_MAJOR],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            ),
+            "reshape_dims": [1, 3, 1, -1],
+        },
+    ),
 ]
 
 

--- a/tt_eager/tensor/tensor_utils.cpp
+++ b/tt_eager/tensor/tensor_utils.cpp
@@ -178,6 +178,45 @@ const Shape infer_dims_for_reshape(int N, int C, int H, int W, uint32_t old_volu
     return {(uint32_t)N, (uint32_t)C, (uint32_t)H, (uint32_t)W};
 }
 
+const Shape infer_dims_for_reshape_RM(int N, int C, int H, int W, uint32_t old_volume) {
+    vector<int> ns{N, C, H, W};
+    int neg_idx = -1;
+    for (int i = 0; i < ns.size(); i++) {
+        if (ns[i] == -1) {
+            TT_ASSERT(neg_idx == -1, "Only one -1 is allowed in reshape");
+            neg_idx = i;
+        } else {
+            TT_ASSERT(ns[i] > 0, "New shape entries can only have -1 or positive values");
+        }
+    }
+
+    switch (neg_idx) {
+        case 0:
+            TT_ASSERT(old_volume % C*H*W == 0);
+            N = old_volume/(C*H*W);
+            break;
+        case 1:
+            TT_ASSERT(old_volume % N*H*W == 0);
+            C = old_volume/(N*H*W);
+            break;
+        case 2:
+            TT_ASSERT(old_volume % N*C*W == 0);
+            H = old_volume/(N*C*W);
+            break;
+        case 3:
+            TT_ASSERT(old_volume % N*C*H == 0);
+            W = old_volume/(N*C*H);
+            break;
+        case -1: // In case where there is no negative value in ns
+            TT_ASSERT(N*C*H*W == old_volume);
+            break;
+        default:
+            TT_ASSERT(false && "Unexpected neg_idx in reshape!");
+    }
+
+    return {(uint32_t)N, (uint32_t)C, (uint32_t)H, (uint32_t)W};
+}
+
   bool is_arch_gs(const tt::ARCH& arch) {
     return arch == tt::ARCH::GRAYSKULL;
   }

--- a/tt_eager/tensor/tensor_utils.hpp
+++ b/tt_eager/tensor/tensor_utils.hpp
@@ -21,6 +21,8 @@ namespace tt_metal {
 
     const Shape infer_dims_for_reshape(int N, int C, int H, int W, uint32_t old_volume);
 
+    const Shape infer_dims_for_reshape_RM(int N, int C, int H, int W, uint32_t old_volume);
+
     template<typename T>
     static std::size_t compute_volume(const T& shape) {
         return std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<uint32_t>());


### PR DESCRIPTION
Tested for shapes
- [4, 4, 32, 32] to [-1, 2, 32, 32],
- [4, 4, 32, 32] to [2, -1, 32, 32],
- [4, 4, 32, 32] to [4, 1, -1, 32],
- [4, 4, 32, 32] to [4, 2, 32, -1],
- [2, 3, 4, 4] to [2, 12, 1, 4],
- [1, 3, 6, 4] to [3, 1, 3, 8],
- [1, 1, 60, 768] to [1, 60, 12, 64],
- [2, 4, 128, 4] to [1, 2, 64, 32],
- [1, 11, 64, 2] to [1, 11, 1, 128],
- [1, 2, 64, 32] to[2, 4, 128, 4],
- [3, 2, 2, 32]to [1, 3, 1, -1]