### PR TITLE
Host-side runtime optimizations for resnet50

### DIFF
--- a/docs/source/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -4,3 +4,5 @@ Runtime Arguments
 .. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelID kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &logical_core, const std::vector<uint32_t> &runtime_args)
 
 .. doxygenfunction:: GetRuntimeArgs
+
+.. doxygenfunction:: UpdateRuntimeArg

--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -151,15 +151,13 @@ In order for an op to be cachable, it needs to implement the following:
                 CoreCoord core = {0, 0};
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
                     runtime_args[0] = src_dram_buffer->address();
-                    SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
                 }
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
                     runtime_args[0] = dst_dram_buffer->address();
-                    SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
                 }
             };
 

--- a/models/demos/resnet/tests/test_perf_resnet.py
+++ b/models/demos/resnet/tests/test_perf_resnet.py
@@ -82,11 +82,16 @@ def run_perf_resnet(
 
         # enable_persistent_kernel_cache()
 
+        from tracy import Profiler
+
+        tracyProfiler = Profiler()
+        tracyProfiler.enable()
         profiler.start(second_key)
         tt_inputs = tt_resnet50.preprocessing(inputs)
         tt_output = tt_resnet50(tt_inputs)
         tt_lib.device.Synchronize()
         profiler.end(second_key)
+        tracyProfiler.disable()
 
     first_iter_time = profiler.get(first_key)
     second_iter_time = profiler.get(second_key)

--- a/models/demos/resnet/tests/test_perf_resnet.py
+++ b/models/demos/resnet/tests/test_perf_resnet.py
@@ -82,16 +82,11 @@ def run_perf_resnet(
 
         # enable_persistent_kernel_cache()
 
-        from tracy import Profiler
-
-        tracyProfiler = Profiler()
-        tracyProfiler.enable()
         profiler.start(second_key)
         tt_inputs = tt_resnet50.preprocessing(inputs)
         tt_output = tt_resnet50(tt_inputs)
         tt_lib.device.Synchronize()
         profiler.end(second_key)
-        tracyProfiler.disable()
 
     first_iter_time = profiler.get(first_key)
     second_iter_time = profiler.get(second_key)

--- a/models/demos/resnet/tt/metalResnetBlock50.py
+++ b/models/demos/resnet/tt/metalResnetBlock50.py
@@ -734,7 +734,7 @@ hardcoded_conv_blocking_and_parallelization_config = {
 }
 
 
-class Bottleneck:
+class Bottleneck(nn.Module):
     # Bottleneck in torchvision places the stride for downsampling at 3x3 convolution(self.conv2)
     # while original implementation places the stride at the first 1x1 convolution(self.conv1)
     # according to "Deep residual learning for image recognition" https://arxiv.org/abs/1512.03385.
@@ -973,7 +973,7 @@ class Bottleneck:
 
                 self.downsample_or_noop = downsample_conv_op_wrapper(self.downsample_conv_on_tt)
 
-    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         # logger.info("This module input shape - ", self.module_input_shape)
         # conv1 is 1x1 conv
         # logger.info("Running conv1")

--- a/models/demos/resnet/tt/metalResnetBlock50.py
+++ b/models/demos/resnet/tt/metalResnetBlock50.py
@@ -734,7 +734,7 @@ hardcoded_conv_blocking_and_parallelization_config = {
 }
 
 
-class Bottleneck(nn.Module):
+class Bottleneck:
     # Bottleneck in torchvision places the stride for downsampling at 3x3 convolution(self.conv2)
     # while original implementation places the stride at the first 1x1 convolution(self.conv1)
     # according to "Deep residual learning for image recognition" https://arxiv.org/abs/1512.03385.
@@ -973,7 +973,7 @@ class Bottleneck(nn.Module):
 
                 self.downsample_or_noop = downsample_conv_op_wrapper(self.downsample_conv_on_tt)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
         # logger.info("This module input shape - ", self.module_input_shape)
         # conv1 is 1x1 conv
         # logger.info("Running conv1")

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -32,7 +32,7 @@ void ClearKernelCache (int device_id){
 std::unordered_map<std::string, std::string> get_last_program_binary_path(const Program &program, int device_id) {
     std::unordered_map<std::string, std::string> kernel_name_to_last_compiled_dir;
     auto root_dir = get_kernel_compile_outpath(device_id);
-    for (auto kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         tt_metal::Kernel *kernel = detail::GetKernel(program, kernel_id);
         if (not std::filesystem::exists(root_dir + kernel->name())) {
             continue;
@@ -145,7 +145,7 @@ Program create_program(Device *device, const ProgramAttributes &program_attribut
 
 void assert_kernel_binary_path_exists(const Program &program, int device_id, const KernelCacheStatus &kernel_cache_status) {
     auto kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
-    for (auto kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         tt_metal::Kernel *kernel = detail::GetKernel(program, kernel_id);
         auto hash = kernel_name_to_hash.at(kernel->name());
         auto kernel_binary_path = get_kernel_compile_outpath(device_id) + kernel->name() + "/" + hash;
@@ -155,7 +155,7 @@ void assert_kernel_binary_path_exists(const Program &program, int device_id, con
 
 void assert_program_cache_hit_status(const Program &program, bool hit_expected, const KernelCacheStatus &kernel_cache_status) {
     auto kernel_name_to_cache_hit_status = kernel_cache_status.kernel_name_to_cache_hit;
-    for (auto kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         tt_metal::Kernel *kernel = detail::GetKernel(program, kernel_id);
         auto hit_status = kernel_name_to_cache_hit_status.at(kernel->name());
         TT_FATAL(hit_status == hit_expected, "Did not get expected cache status " + std::to_string(hit_expected) + " for kernel " + kernel->name());
@@ -223,7 +223,7 @@ void assert_hash_comparison_for_kernel_type(
     const KernelCacheStatus &kernel_cache_status
 ) {
     auto curr_kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
-    for (auto kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         tt_metal::Kernel *kernel = detail::GetKernel(program, kernel_id);
         auto prev_hash = prev_kernel_name_to_hash.at(kernel->name());
         auto curr_hash = curr_kernel_name_to_hash.at(kernel->name());
@@ -238,7 +238,7 @@ void assert_hash_comparison_for_kernel_type(
 
 void assert_cache_hit_status_for_kernel_type(const Program &program, const std::unordered_map<tt::RISCV, bool> &type_to_cache_hit_status, const KernelCacheStatus &kernel_cache_status) {
     auto kernel_name_to_cache_hit_status = kernel_cache_status.kernel_name_to_cache_hit;
-    for (auto kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         tt_metal::Kernel *kernel = detail::GetKernel(program, kernel_id);
         bool hit_expected = type_to_cache_hit_status.at(kernel->processor());
         auto hit_status = kernel_name_to_cache_hit_status.at(kernel->name());

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -25,7 +25,7 @@ void check_program_is_mapped_to_correct_cores(const tt_metal::Program &program, 
         for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
             for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
                 auto logical_core = CoreCoord{x, y};
-                for (auto kernel_id : program.kernel_ids()) {
+                for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
                     tt_metal::Kernel *kernel = tt_metal::detail::GetKernel(program, kernel_id);
                     TT_FATAL(kernel->is_on_logical_core(logical_core));
                     // Check that compute kernel compile time args are mapped to the correct cores

--- a/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
@@ -79,12 +79,12 @@ bool verify_result_data_movement(
     };
 
     EXPECT_TRUE(
-        program.kernel_ids().size() == 1);
-    tt_metal::Kernel *kernel = tt_metal::detail::GetKernel(program, program.kernel_ids().at(0));
+        program.num_kernels() == 1);
+    tt_metal::Kernel *kernel = tt_metal::detail::GetKernel(program, 0);
     auto processor = kernel->processor();
     auto rt_arg_addr = get_runtime_arg_addr(kernel);
 
-    for (auto kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         const auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
         auto processor = kernel->processor();
         for (const auto &logical_core : kernel->cores_with_runtime_args()) {
@@ -111,10 +111,10 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
         auto program =
             unit_tests::runtime_args::initialize_program_data_movement(this->devices_.at(id), core_range_set);
         ASSERT_TRUE(
-            program.kernel_ids().size() ==
+            program.num_kernels() ==
             1);
         std::vector<uint32_t> initial_runtime_args = {101, 202};
-        SetRuntimeArgs(program, program.kernel_ids().at(0), core_range_set, initial_runtime_args);
+        SetRuntimeArgs(program, 0, core_range_set, initial_runtime_args);
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
@@ -130,7 +130,7 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
             unit_tests::runtime_args::verify_result_data_movement(this->devices_.at(id), program, core_to_rt_args));
 
         std::vector<uint32_t> second_runtime_args = {303, 606};
-        SetRuntimeArgs(program, program.kernel_ids().at(0), first_core_range, second_runtime_args);
+        SetRuntimeArgs(program, 0, first_core_range, second_runtime_args);
         detail::WriteRuntimeArgsToDevice(this->devices_.at(id), program);
         for (auto x = first_core_range.start.x; x <= first_core_range.end.x; x++) {
             for (auto y = first_core_range.start.y; y <= first_core_range.end.y; y++) {
@@ -168,13 +168,13 @@ bool verify_result_compute(
 
 
     EXPECT_TRUE(
-        program.kernel_ids().size() == 1);
-    tt_metal::Kernel *kernel = tt_metal::detail::GetKernel(program, program.kernel_ids().at(0));
+        program.num_kernels() == 1);
+    tt_metal::Kernel *kernel = tt_metal::detail::GetKernel(program, 0);
     auto processor = kernel->processor();
     auto rt_arg_addr = get_runtime_arg_addr(kernel);
     auto rt_result_addr = get_runtime_arg_addr(kernel);
 
-    for (auto kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         const auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
         auto processor = kernel->processor();
         for (const auto &logical_core : kernel->cores_with_runtime_args()) {
@@ -206,7 +206,7 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsCompute) {
         CoreRangeSet core_range_set({first_core_range, second_core_range});
         auto program = unit_tests::runtime_args::initialize_program_compute(this->devices_.at(id), core_range_set);
         std::vector<uint32_t> initial_runtime_args = {101, 202};
-        SetRuntimeArgs(program, program.kernel_ids().at(0), core_range_set, initial_runtime_args);
+        SetRuntimeArgs(program, 0, core_range_set, initial_runtime_args);
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
@@ -232,10 +232,10 @@ TEST_F(DeviceFixture, IllegallyModifyRTArgs) {
         auto program =
             unit_tests::runtime_args::initialize_program_data_movement(this->devices_.at(id), core_range_set);
         ASSERT_TRUE(
-            program.kernel_ids().size() ==
+            program.num_kernels() ==
             1);
         std::vector<uint32_t> initial_runtime_args = {101, 202};
-        SetRuntimeArgs(program, program.kernel_ids().at(0), core_range_set, initial_runtime_args);
+        SetRuntimeArgs(program, 0, core_range_set, initial_runtime_args);
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
@@ -250,7 +250,7 @@ TEST_F(DeviceFixture, IllegallyModifyRTArgs) {
         ASSERT_TRUE(
             unit_tests::runtime_args::verify_result_data_movement(this->devices_.at(id), program, core_to_rt_args));
         std::vector<uint32_t> invalid_runtime_args = {303, 404, 505};
-        EXPECT_ANY_THROW(SetRuntimeArgs(program, program.kernel_ids().at(0), first_core_range, invalid_runtime_args));
+        EXPECT_ANY_THROW(SetRuntimeArgs(program, 0, first_core_range, invalid_runtime_args));
     }
 }
 

--- a/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
@@ -87,8 +87,9 @@ bool verify_result_data_movement(
     for (auto kernel_id : program.kernel_ids()) {
         const auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
         auto processor = kernel->processor();
-        for (const auto &[logical_core, rt_args] : kernel->runtime_args()) {
+        for (const auto &logical_core : kernel->cores_with_runtime_args()) {
             auto expected_rt_args = core_to_rt_args.at(logical_core);
+            auto rt_args = kernel->runtime_args(logical_core);
             EXPECT_TRUE(rt_args == expected_rt_args);
             std::vector<uint32_t> written_args;
             tt_metal::detail::ReadFromDeviceL1(
@@ -176,8 +177,9 @@ bool verify_result_compute(
     for (auto kernel_id : program.kernel_ids()) {
         const auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
         auto processor = kernel->processor();
-        for (const auto &[logical_core, rt_args] : kernel->runtime_args()) {
+        for (const auto &logical_core : kernel->cores_with_runtime_args()) {
             auto expected_rt_args = core_to_rt_args.at(logical_core);
+            auto rt_args = kernel->runtime_args(logical_core);
             EXPECT_TRUE(rt_args == expected_rt_args);
             std::vector<uint32_t> written_args;
             tt_metal::detail::ReadFromDeviceL1(

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -449,7 +449,7 @@ TEST_F(CommandQueueFixture, ComputeRuntimeArgs) {
 
 
     std::vector<uint32_t> initial_runtime_args = {101, 202};
-    SetRuntimeArgs(program, program.kernel_ids().at(0), cr_set, initial_runtime_args);
+    SetRuntimeArgs(program, 0, cr_set, initial_runtime_args);
     EnqueueProgram(*tt::tt_metal::detail::GLOBAL_CQ, program, false);
     Finish(*tt::tt_metal::detail::GLOBAL_CQ);
 

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core/bmm_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core/bmm_op_multi_core.cpp
@@ -187,16 +187,14 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = src_dram_buffer_a->address();
                 runtime_args[1] = src_dram_buffer_b->address();
-                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = dst_dram_buffer->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse/bmm_op_multi_core_reuse.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse/bmm_op_multi_core_reuse.cpp
@@ -213,16 +213,14 @@ tt_metal::operation::ProgramWithCallbacks create_program(
                 CoreCoord core = {(std::size_t) core_idx_x, (std::size_t) core_idx_y};
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_dram_buffer_a->address();
                     runtime_args[8] = src_dram_buffer_b->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = dst_dram_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
                 num_blocks_read++;
             }

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_generalized/bmm_op_multi_core_reuse_generalized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_generalized/bmm_op_multi_core_reuse_generalized.cpp
@@ -218,16 +218,14 @@ tt_metal::operation::ProgramWithCallbacks create_program(
                 CoreCoord core = {(std::size_t) core_idx_x, (std::size_t) core_idx_y};
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_dram_buffer_a->address();
                     runtime_args[8] = src_dram_buffer_b->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = dst_dram_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
                 num_blocks_read++;
             }

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -512,15 +512,14 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
             CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
 
             auto reader_kernel_id = reader_kernel_ids.at(i);
-            auto reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
 
             auto writer_kernel_id = writer_kernel_ids.at(i);
-            auto writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
 
             // in0 sender
             if (!src0_sharded && core_idx_x == 0 and core_idx_y == 0) {
                 reader_runtime_args[0] = src_buffer_a->address();
-                SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
             // in0 receiver
             } else {
 
@@ -532,7 +531,6 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
                 if (bias_tensor.has_value()) {
                     writer_runtime_args[16] = bias_tensor.value().buffer()->address();
                 }
-                SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
             }
         }
         if (src0_sharded) {

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -745,10 +745,10 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
                 CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
 
                 auto reader_kernel_id = reader_kernel_ids.at(i);
-                auto reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
 
                 auto writer_kernel_id = writer_kernel_ids.at(i);
-                auto writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
 
                 uint32_t in0_idx = core_idx_y;
                 uint32_t in1_idx = core_idx_x;
@@ -760,7 +760,6 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
                 // in0 sender
                 if (!src0_sharded && in1_idx == 0) {
                     reader_runtime_args[0] = src_buffer_a->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
                 // in0 receiver
                 } else {
 
@@ -773,11 +772,9 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
                     if (bias_tensor.has_value()) {
                         writer_runtime_args[16] = bias_tensor.value().buffer()->address();
                     }
-                    SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
                 // in1 receiver
                 } else {
                     writer_runtime_args[2] = dst_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
                 }
                 i++;
             }

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_generalized/bmm_op_multi_core_reuse_mcast_generalized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_generalized/bmm_op_multi_core_reuse_mcast_generalized.cpp
@@ -323,17 +323,15 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
 
                 {
                     auto reader_kernel_id = reader_kernel_ids.at(i);
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_dram_buffer_a->address();
                     runtime_args[8] = src_dram_buffer_b->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
 
                 {
                     auto writer_kernel_id = writer_kernel_ids.at(i);
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = dst_dram_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
 
                 i++;
@@ -584,17 +582,15 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
 
                 {
                     auto reader_kernel_id = reader_kernel_ids.at(i);
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_dram_buffer_a->address();
                     runtime_args[8] = src_dram_buffer_b->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
 
                 {
                     auto writer_kernel_id = writer_kernel_ids.at(i);
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = dst_dram_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
 
                 i++;
@@ -845,17 +841,15 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
 
                 {
                     auto reader_kernel_id = reader_kernel_ids.at(i);
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_dram_buffer_a->address();
                     runtime_args[8] = src_dram_buffer_b->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
 
                 {
                     auto writer_kernel_id = writer_kernel_ids.at(i);
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = dst_dram_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
 
                 i++;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
@@ -378,19 +378,17 @@ operation::ProgramWithCallbacks create_program(
 
             {
                 auto reader_kernel_id = reader_kernel_ids.at(i);
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = src_dram_buffer_a->address();
                 runtime_args[8] = src_dram_buffer_b->address();
-                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
             }
 
             {
                 auto writer_kernel_id = writer_kernel_ids.at(i);
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = src_dram_buffer_a->address();
                 runtime_args[8] = src_dram_buffer_b->address();
                 runtime_args[21] = dst_dram_buffer->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_padding/bmm_op_multi_core_reuse_padding.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_padding/bmm_op_multi_core_reuse_padding.cpp
@@ -239,16 +239,14 @@ operation::ProgramWithCallbacks create_program(
                 CoreCoord core = {(std::size_t) core_idx_x, (std::size_t) core_idx_y};
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_dram_buffer_a->address();
                     runtime_args[8] = src_dram_buffer_b->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = dst_dram_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
                 num_blocks_read++;
             }

--- a/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core.cpp
@@ -120,16 +120,14 @@ operation::ProgramWithCallbacks matmul_single_core(const Tensor &a, const Tensor
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_dram_buffer_a->address();
             runtime_args[1] = src_dram_buffer_b->address();
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = dst_dram_buffer->address();
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core_tilize_untilize.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core_tilize_untilize.cpp
@@ -524,18 +524,16 @@ operation::ProgramWithCallbacks bmm_single_core_tilize_untilize(
         auto out_dram_buffer = output_buffers.at(0);
         CoreCoord core = {0, 0};
         {
-            auto runtime_args = GetRuntimeArgs(program, kernel_reader_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, kernel_reader_id, core);
             runtime_args[0] = in0_dram_buffer->address();
             runtime_args[9] = in1_dram_buffer->address();
             if (bias_dram_buffer != nullptr) {
                 runtime_args[22] = bias_dram_buffer->address();
             }
-            SetRuntimeArgs(program, kernel_reader_id, core, runtime_args);
         }
         {
-            auto runtime_args = GetRuntimeArgs(program, kernel_writer_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, kernel_writer_id, core);
             runtime_args[0] = out_dram_buffer->address();
-            SetRuntimeArgs(program, kernel_writer_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/concat/multi_core/concat_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/concat/multi_core/concat_op_multi_core.cpp
@@ -186,15 +186,13 @@ operation::ProgramWithCallbacks concat_multi_core(const std::vector<Tensor> &inp
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
                 std::copy(src_addrs.begin(), src_addrs.end(), runtime_args.begin() + 4);
-                SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
-                SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/concat/single_core/concat_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/concat/single_core/concat_op_single_core.cpp
@@ -146,15 +146,13 @@ operation::ProgramWithCallbacks concat_single_core(const std::vector<Tensor> &in
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             std::copy(src_addrs.begin(), src_addrs.end(), runtime_args.begin() + 4);
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/conv/conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/conv_op.cpp
@@ -637,13 +637,12 @@ operation::ProgramWithCallbacks conv_as_large_bmm_single_core_(const Tensor& a, 
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_dram_buffer_a->address();
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = dst_dram_buffer->address();
             runtime_args[1] = src_dram_buffer_b->address();
             if (has_bias) {
@@ -651,7 +650,6 @@ operation::ProgramWithCallbacks conv_as_large_bmm_single_core_(const Tensor& a, 
                 TT_ASSERT(src_dram_buffer_c != nullptr);
                 runtime_args[25] = src_dram_buffer_c->address();
             }
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
 
@@ -1323,20 +1321,18 @@ operation::ProgramWithCallbacks conv_as_large_bmm_with_address_map_single_core_(
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_dram_buffer_a->address();
             runtime_args[1] = src_dram_buffer_a->noc_coordinates().x;
             runtime_args[2] = src_dram_buffer_a->noc_coordinates().y;
             runtime_args[8] = src_dram_buffer_b->address();
             runtime_args[9] = src_dram_buffer_b->noc_coordinates().x;
             runtime_args[10] = src_dram_buffer_b->noc_coordinates().y;
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = dst_dram_buffer->address();
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv/optimized_conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv/optimized_conv_op.cpp
@@ -1233,13 +1233,12 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_(const Tensor& a, cons
             CoreCoord core = {core_x_i, core_y_i};
 
             if (!src_a_is_sharded) {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_ids[core_i], core);
+                auto & runtime_args = GetRuntimeArgs(program, reader_kernel_ids[core_i], core);
                 runtime_args[0] = src_buffer_a->address();
-                SetRuntimeArgs(program, reader_kernel_ids[core_i], core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_ids[core_i], core);
+                auto & runtime_args = GetRuntimeArgs(program, writer_kernel_ids[core_i], core);
                 runtime_args[0] = dst_buffer->address();
                 runtime_args[1] = src_buffer_b->address();
                 if (has_bias) {
@@ -1247,7 +1246,6 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_(const Tensor& a, cons
                     TT_ASSERT(src_buffer_c != nullptr);
                     runtime_args[2] = src_buffer_c->address();
                 }
-                SetRuntimeArgs(program, writer_kernel_ids[core_i], core, runtime_args);
             }
         }
 

--- a/tt_eager/tt_dnn/op_library/copy/multi_core/copy_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/copy/multi_core/copy_op_multi_core.cpp
@@ -223,15 +223,13 @@ operation::ProgramWithCallbacks copy_multi_core(const Tensor &input, const Tenso
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
                 runtime_args[0] = src_buffer->address();
-                SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
-                SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/copy/single_core/copy_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/copy/single_core/copy_op_single_core.cpp
@@ -174,15 +174,13 @@ operation::ProgramWithCallbacks copy_single_core(const Tensor &input, const Tens
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = src_dram_buffer->address();
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_dram_buffer->address();
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/downsample/downsample_op.cpp
+++ b/tt_eager/tt_dnn/op_library/downsample/downsample_op.cpp
@@ -801,10 +801,9 @@ operation::ProgramWithCallbacks downsample_single_core(const Tensor &a, std::arr
         final_tilize_output_cb_config.set_globally_allocated_address(*dst_buffer);
         for (uint32_t i = 0; i < num_cores; i++) {
             CoreCoord core = {i % num_cores_x, i / num_cores_x};
-            auto runtime_args = GetRuntimeArgs(program, downsample_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, downsample_writer_kernel_id, core);
             runtime_args[8] = src_buffer->address();
             runtime_args[39] = src_buffer->address();
-            SetRuntimeArgs(program, downsample_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/single_core/eltwise_binary_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/single_core/eltwise_binary_op_single_core.cpp
@@ -156,24 +156,21 @@ operation::ProgramWithCallbacks eltwise_binary_single_core(const Tensor &a, cons
         uint32_t num_tiles = input_tensors.at(0).volume() / TILE_HW;
 
         {
-            auto runtime_args = GetRuntimeArgs(program, binary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, binary_reader_kernel_id, core);
             runtime_args[0] = src_buffer_a->address();
             runtime_args[1] = src_buffer_b->address();
             runtime_args[2] = num_tiles;
-            SetRuntimeArgs(program, binary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, eltwise_binary_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, eltwise_binary_kernel_id, core);
             runtime_args[0] = num_tiles;
-            SetRuntimeArgs(program, eltwise_binary_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
             runtime_args[1] = num_tiles;
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/multi_core/eltwise_unary_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/multi_core/eltwise_unary_op_multi_core.cpp
@@ -164,15 +164,13 @@ operation::ProgramWithCallbacks eltwise_unary_multi_core(const Tensor &a, Tensor
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
                 runtime_args[0] = src_buffer->address();
-                SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
-                SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/single_core/eltwise_unary_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/single_core/eltwise_unary_op_single_core.cpp
@@ -116,15 +116,13 @@ operation::ProgramWithCallbacks eltwise_unary_single_core(const Tensor &a, Tenso
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.cpp
+++ b/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.cpp
@@ -274,16 +274,14 @@ operation::ProgramWithCallbacks embeddings_tilized(
                         auto weights_dram_buffer = input_buffers.at(1);
                         {
 
-                            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                             runtime_args[2] = input_dram_buffer->address();
                             runtime_args[3] = weights_dram_buffer->address();
-                            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                         }
 
                         {
-                            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                             runtime_args[0] = output_dram_buffer->address();
-                            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                         }
                     }
                 }
@@ -494,11 +492,10 @@ operation::ProgramWithCallbacks embeddings_rm(
                             auto output_dram_buffer = output_buffers.at(0);
                             {
 
-                                auto runtime_args = GetRuntimeArgs(program, kernIds[idc], core);
+                                auto &runtime_args = GetRuntimeArgs(program, kernIds[idc], core);
                                 runtime_args[4] = input_dram_buffer->address();
                                 runtime_args[5] = weights_dram_buffer->address();
                                 runtime_args[6] = output_dram_buffer->address();
-                                SetRuntimeArgs(program, kernIds[idc], core, runtime_args);
                             }
                         }
                     }

--- a/tt_eager/tt_dnn/op_library/fill_rm/fill_rm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fill_rm/fill_rm_op.cpp
@@ -63,9 +63,8 @@ operation::ProgramWithCallbacks fill_rm_single_core(const Tensor& any, Tensor &o
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/layernorm/layernorm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/layernorm/layernorm_op.cpp
@@ -318,7 +318,7 @@ operation::ProgramWithCallbacks layernorm_(
             CoreCoord core = {i % grid_size.x, i / grid_size.x};
 
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = src_a_dram_buffer->address();
                 if (src_b_dram_buffer != nullptr) {
                     runtime_args[8] = src_b_dram_buffer->address();
@@ -329,13 +329,11 @@ operation::ProgramWithCallbacks layernorm_(
                 if (beta_dram_buffer != nullptr) {
                     runtime_args[7] = beta_dram_buffer->address();
                 }
-                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = dst_dram_buffer->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core_overlap.cpp
+++ b/tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core_overlap.cpp
@@ -178,10 +178,9 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input
         for (uint32_t i = 0; i < num_cores; i++) {
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
             {
-                auto runtime_args = GetRuntimeArgs(program, kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, kernel_id, core);
                 runtime_args[0] = src_buffer->address();
                 runtime_args[1] = dst_buffer->address();
-                SetRuntimeArgs(program, kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads.cpp
@@ -148,15 +148,13 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads(const Tensor &a, Ten
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = src_dram_buffer->address();
-                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = dst_dram_buffer->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp
@@ -166,17 +166,15 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &a,
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = src_dram_buffer->address();
-                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = dst_dram_buffer_query->address();
                 runtime_args[1] = dst_dram_buffer_key->address();
                 runtime_args[2] = dst_dram_buffer_value->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/pad/pad_op.cpp
+++ b/tt_eager/tt_dnn/op_library/pad/pad_op.cpp
@@ -156,16 +156,14 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(const Tensor &a,
         auto dst_buffer = output_buffers.at(0);
         CoreCoord core = {0, 0};
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
             runtime_args[1] = dst_buffer->address();
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = src_buffer->address();
             runtime_args[1] = dst_buffer->address();
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
 
@@ -279,10 +277,9 @@ operation::ProgramWithCallbacks pad_rm_opt(const Tensor &a,
         auto dst_buffer = output_buffers.at(0);
         CoreCoord core = {0, 0};
         {
-            auto runtime_args = GetRuntimeArgs(program, kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, kernel_id, core);
             runtime_args[0] = src_buffer->address();
             runtime_args[1] = dst_buffer->address();
-            SetRuntimeArgs(program, kernel_id, core, runtime_args);
         }
     };
 
@@ -377,10 +374,9 @@ operation::ProgramWithCallbacks pad_rm(const Tensor &a, Tensor &output, const Sh
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, kernel_id, core);
             runtime_args[0] = src_buffer->address();
             runtime_args[1] = dst_buffer->address();
-            SetRuntimeArgs(program, kernel_id, core, runtime_args);
         }
     };
 
@@ -507,15 +503,13 @@ operation::ProgramWithCallbacks pad_tile(const Tensor &a, Tensor& output, const 
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = src_dram_buffer->address();
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_dram_buffer->address();
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/pad/pad_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/pad/pad_op_multi_core.cpp
@@ -338,16 +338,14 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(const Tensor &a,
             for (uint32_t i = 0; i < ncores_w; ++ i) {
                 CoreCoord core = {i, j};
                 {
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_buffer->address();
                     runtime_args[1] = dst_buffer->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
                 {
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = src_buffer->address();
                     runtime_args[1] = dst_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
             }
         }

--- a/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
@@ -654,16 +654,14 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_generic(const Tensor &inp
         for (uint32_t i = 0; i < ncores; ++ i) {
             CoreCoord core{i % ncores_w, i / ncores_w };
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel, core);
                 runtime_args[0] = src_buffer->address();
                 runtime_args[1] = dst_buffer->address();
-                SetRuntimeArgs(program, reader_kernel, core, runtime_args);
             }
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel, core);
                 runtime_args[0] = src_buffer->address();
                 runtime_args[1] = dst_buffer->address();
-                SetRuntimeArgs(program, writer_kernel, core, runtime_args);
             }
         }
         if (input_sharded) {
@@ -985,16 +983,14 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core(const Tensor &input, Tens
         for (uint32_t i = 0; i < ncores_hw; ++ i) {
             CoreCoord core{i % ncores_w, i / ncores_w };
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel, core);
                 runtime_args[0] = src_dram_buffer->address();
                 runtime_args[1] = dst_dram_buffer->address();
-                SetRuntimeArgs(program, reader_kernel, core, runtime_args);
             }
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel, core);
                 runtime_args[0] = src_dram_buffer->address();
                 runtime_args[1] = dst_dram_buffer->address();
-                SetRuntimeArgs(program, writer_kernel, core, runtime_args);
             }
         }
     };
@@ -1590,16 +1586,14 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const T
         for (uint32_t i = 0; i < ncores; ++ i) {
             CoreCoord core{i % ncores_w, i / ncores_w };
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel, core);
                 runtime_args[0] = src_buffer->address();
                 runtime_args[1] = dst_buffer->address();
-                SetRuntimeArgs(program, reader_kernel, core, runtime_args);
             }
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel, core);
                 runtime_args[0] = src_buffer->address();
                 runtime_args[1] = dst_buffer->address();
-                SetRuntimeArgs(program, writer_kernel, core, runtime_args);
             }
         }
         if (input_sharded) {

--- a/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core_sharded_with_halo.cpp
+++ b/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core_sharded_with_halo.cpp
@@ -662,16 +662,14 @@ operation::ProgramWithCallbacks max_pool_2d_multi_core_sharded_with_halo(const T
         for (uint32_t i = 0; i < ncores; ++ i) {
             CoreCoord core{i % ncores_w, i / ncores_w };
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel, core);
                 runtime_args[0] = src_buffer->address();
                 runtime_args[1] = dst_buffer->address();
-                SetRuntimeArgs(program, reader_kernel, core, runtime_args);
             }
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel, core);
                 runtime_args[0] = src_buffer->address();
                 runtime_args[1] = dst_buffer->address();
-                SetRuntimeArgs(program, writer_kernel, core, runtime_args);
             }
         }
         if (input_sharded) {

--- a/tt_eager/tt_dnn/op_library/pool/max_pool_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/pool/max_pool_single_core.cpp
@@ -246,16 +246,14 @@ operation::ProgramWithCallbacks max_pool_2d_single_core(const Tensor &input, Ten
         auto dst_dram_buffer = output_buffers.at(0);
         CoreCoord core = {0, 0};
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel, core);
             runtime_args[0] = src_dram_buffer->address();
             runtime_args[1] = dst_dram_buffer->address();
-            SetRuntimeArgs(program, reader_kernel, core, runtime_args);
         }
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel, core);
             runtime_args[0] = src_dram_buffer->address();
             runtime_args[1] = dst_dram_buffer->address();
-            SetRuntimeArgs(program, writer_kernel, core, runtime_args);
         }
     };
     return {std::move(program), override_runtime_args_callback};

--- a/tt_eager/tt_dnn/op_library/program_cache.hpp
+++ b/tt_eager/tt_dnn/op_library/program_cache.hpp
@@ -11,6 +11,7 @@
 #include "tt_dnn/op_library/operation.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
+#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 namespace tt::tt_metal {
 
 namespace program_cache {
@@ -67,6 +68,7 @@ inline ProgramCache PROGRAM_CACHE{};
 
 template <typename... Args>
 inline std::tuple<operation::ProgramWithCallbacks&, bool> get_or_create(Args&&... args) {
+    ZoneScoped;
     return detail::PROGRAM_CACHE.get_or_create(std::forward<Args>(args)...);
 }
 

--- a/tt_eager/tt_dnn/op_library/reduce/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/tt_eager/tt_dnn/op_library/reduce/multi_core_h/reduce_op_multi_core_h.cpp
@@ -285,15 +285,13 @@ operation::ProgramWithCallbacks reduce_multi_core_h(const Tensor &a, Tensor& out
                 CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_buffer->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = dst_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
             }
         }

--- a/tt_eager/tt_dnn/op_library/reduce/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/tt_eager/tt_dnn/op_library/reduce/multi_core_w/reduce_op_multi_core_w.cpp
@@ -170,15 +170,13 @@ operation::ProgramWithCallbacks reduce_multi_core_w(const Tensor &a, Tensor& out
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = src_dram_buffer->address();
-                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = dst_dram_buffer->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/reduce/single_core/reduce_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/reduce/single_core/reduce_op_single_core.cpp
@@ -164,15 +164,13 @@ operation::ProgramWithCallbacks reduce_single_core(const Tensor &a, Tensor& outp
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_dram_buffer->address();
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = dst_dram_buffer->address();
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/reshape/reshape_op.cpp
+++ b/tt_eager/tt_dnn/op_library/reshape/reshape_op.cpp
@@ -102,15 +102,13 @@ operation::ProgramWithCallbacks reshape_tile_single_core(const Tensor &a, Tensor
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 
@@ -254,15 +252,13 @@ operation::ProgramWithCallbacks reshape_rm_single_core(const Tensor &a, Tensor& 
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/rotary_embedding/multi_core/rotary_embedding_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/rotary_embedding/multi_core/rotary_embedding_op_multi_core.cpp
@@ -332,19 +332,17 @@ operation::ProgramWithCallbacks rotary_embedding_multi_core(const Tensor &input,
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
                 runtime_args[0] = src_buffer->address();
                 runtime_args[1] = cos_buffer->address();
                 runtime_args[2] = sin_buffer->address();
                 runtime_args[6] = cos_sin_start_id;
-                SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
                 runtime_args[3] = cos_sin_offset;
-                SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
             }
             num_tiles_written += num_rows_per_core * Wt;
         }

--- a/tt_eager/tt_dnn/op_library/rotary_embedding/single_core/rotary_embedding_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/rotary_embedding/single_core/rotary_embedding_op_single_core.cpp
@@ -288,19 +288,17 @@ operation::ProgramWithCallbacks rotary_embedding_single_core(const Tensor &input
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
             runtime_args[1] = cos_buffer->address();
             runtime_args[2] = sin_buffer->address();
             runtime_args[6] = cos_sin_start_id;
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
             runtime_args[3] = cos_sin_offset;
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/rotate_half/single_core/rotate_half_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/rotate_half/single_core/rotate_half_op_single_core.cpp
@@ -152,15 +152,13 @@ operation::ProgramWithCallbacks rotate_half_single_core(const Tensor &input, Ten
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -90,6 +90,7 @@ std::vector<Tensor> run_without_program_cache(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) {
     ZoneScoped;
+    ZoneText( operation.get_type_name().c_str(), operation.get_type_name().length() );
 
     auto device = detail::get_device(input_tensors, optional_input_tensors);
     auto output_tensors = operation.create_output_tensors(input_tensors);
@@ -118,6 +119,7 @@ std::vector<Tensor> run_with_program_cache(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) {
     ZoneScoped;
+    ZoneText( operation.get_type_name().c_str(), operation.get_type_name().length() );
 
     auto device = detail::get_device(input_tensors, optional_input_tensors);
     auto output_tensors = operation.create_output_tensors(input_tensors);

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -129,6 +129,7 @@ std::vector<Tensor> run_with_program_cache(
 
     auto& program = program_with_callbacks.program;
     if (cache_hit) {
+        ZoneScopedN ("Cache_hit_set_runtime_args");
         if (program_with_callbacks.override_addresses_callback.has_value()) {
             auto override_addresses_callback = program_with_callbacks.override_addresses_callback.value();
             override_addresses(
@@ -143,10 +144,17 @@ std::vector<Tensor> run_with_program_cache(
         }
     }
 
-    auto do_profile = op_profiler::get_profiler_flag();
-    if (do_profile) { detail::setup_profiler(operation, input_tensors, program); }
+    {
+        ZoneScopedN ("Profiler Check");
+        auto do_profile = op_profiler::get_profiler_flag();
+        if (do_profile) { detail::setup_profiler(operation, input_tensors, program); }
+    }
 
-    const char *TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    const char *TT_METAL_SLOW_DISPATCH_MODE = nullptr;
+    {
+        ZoneScopedN ("Get Env Var");
+        TT_METAL_SLOW_DISPATCH_MODE =  std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    }
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         EnqueueProgram(*tt::tt_metal::detail::GLOBAL_CQ, program, false);
         // Only need to dump device data when in dispatch mode

--- a/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
@@ -193,9 +193,8 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(const Tensor &
                 if (!all_cores.core_coord_in_core_ranges(core)) {
                     continue;
                 }
-                auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
                 runtime_args[0] = src_buffer->address();
-                SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
             }
         }
         auto& cb_out_config = GetCircularBufferConfig(program, cb_output);
@@ -446,9 +445,8 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(const Tensor &
                 if (!all_cores.core_coord_in_core_ranges(core)) {
                     continue;
                 }
-                auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
-                SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
             }
         }
         auto& cb_src0_config = GetCircularBufferConfig(program, cb_src0);

--- a/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.cpp
+++ b/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.cpp
@@ -256,16 +256,14 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
                     CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
 
                     {
-                        auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                        auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                         runtime_args[1] = src_dram_buffer->address();
-                        SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                     }
 
                     {
-                        auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                        auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                         runtime_args[1] = dst_0_dram_buffer->address();
                         runtime_args[2] = dst_1_dram_buffer->address();
-                        SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                     }
                 }
             }

--- a/tt_eager/tt_dnn/op_library/tilize/tilize_multi_core/tilize_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/tilize/tilize_multi_core/tilize_op_multi_core.cpp
@@ -358,14 +358,12 @@ operation::ProgramWithCallbacks tilize_multi_core_interleaved(const Tensor &a, T
         for (uint32_t i = 0; i < ncores; ++ i) {
             CoreCoord core = {i % ncores_x, i / ncores_x};
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = src_buffer->address();
-                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
             }
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/tilize/tilize_single_core/tilize_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/tilize/tilize_single_core/tilize_op_single_core.cpp
@@ -168,15 +168,13 @@ operation::ProgramWithCallbacks tilize_single_core(const Tensor &a, Tensor& outp
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
 
@@ -372,15 +370,13 @@ operation::ProgramWithCallbacks tilize_with_val_padding_single_core(const Tensor
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_concatenate_heads/multi_core_concatenate_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_concatenate_heads/multi_core_concatenate_heads.cpp
@@ -165,15 +165,13 @@ operation::ProgramWithCallbacks multi_core_concat_heads(const Tensor &a, Tensor&
                 CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_dram_buffer->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = dst_dram_buffer->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
             }
         }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_split_fused_qkv_and_split_heads/multi_core_split_fused_qkv_and_split_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_split_fused_qkv_and_split_heads/multi_core_split_fused_qkv_and_split_heads.cpp
@@ -202,17 +202,15 @@ operation::ProgramWithCallbacks multi_core_split_fused_qkv_and_split_heads(const
                 CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                     runtime_args[0] = src_dram_buffer->address();
-                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
                 }
 
                 {
-                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                     runtime_args[0] = dst_dram_buffer_query->address();
                     runtime_args[1] = dst_dram_buffer_key->address();
                     runtime_args[2] = dst_dram_buffer_value->address();
-                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
                 }
             }
         }

--- a/tt_eager/tt_dnn/op_library/untilize/multi_core/untilize_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/multi_core/untilize_op_multi_core.cpp
@@ -573,9 +573,8 @@ operation::ProgramWithCallbacks untilize_multi_core(const Tensor& a, Tensor& out
                 if (!all_cores.core_coord_in_core_ranges(core)) {
                     continue;
                 }
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = src_buffer->address();
-                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
             }
         }
 
@@ -589,9 +588,8 @@ operation::ProgramWithCallbacks untilize_multi_core(const Tensor& a, Tensor& out
                 if (!all_cores.core_coord_in_core_ranges(core)) {
                     continue;
                 }
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };
@@ -865,9 +863,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core(const Tensor 
                 if (!all_cores.core_coord_in_core_ranges(core)) {
                     continue;
                 }
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/untilize/single_core/untilize_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/single_core/untilize_op_single_core.cpp
@@ -159,15 +159,13 @@ operation::ProgramWithCallbacks untilize_single_core(const Tensor &a, Tensor& ou
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
 
@@ -340,15 +338,13 @@ operation::ProgramWithCallbacks untilize_with_unpadding_single_core(const Tensor
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/update_cache/multi_core/update_cache_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/multi_core/update_cache_op_multi_core.cpp
@@ -143,16 +143,14 @@ operation::ProgramWithCallbacks fill_cache_multi_core(const Tensor& cache_tensor
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
                 runtime_args[0] = src_buffer->address();
-                SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
                 runtime_args[2] = start_idx + num_tiles_written;
-                SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
             }
             num_tiles_written += num_tiles_per_core;
         }

--- a/tt_eager/tt_dnn/op_library/update_cache/single_core/update_cache_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/single_core/update_cache_op_single_core.cpp
@@ -175,19 +175,17 @@ operation::ProgramWithCallbacks update_cache_single_core(const Tensor& cache_ten
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
             runtime_args[1] = src_buffer->address();
             runtime_args[5] = cache_tile_idx;
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
             runtime_args[5] = cache_tile_idx;
             runtime_args[6] = tile_update_offset;
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 
@@ -289,16 +287,14 @@ operation::ProgramWithCallbacks fill_cache_single_core(const Tensor& cache_tenso
         CoreCoord core = {0, 0};
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
             runtime_args[2] = start_idx;
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, runtime_args);
         }
     };
 

--- a/tt_eager/tt_lib/fused_ops/conv.py
+++ b/tt_eager/tt_lib/fused_ops/conv.py
@@ -228,6 +228,21 @@ def resnet50_optimized_conv(
     )
     bias_on_device = bias_.to(device)
 
+    opt_conv_parall_conf = tensor.OptimizedConvParallelizationConfig(
+        grid_size=grid_size,
+        per_core_out_matrix_height_ntiles=per_core_out_matrix_h_ntiles,
+        per_core_weight_matrix_width_ntiles=per_core_weight_matrix_w_ntiles,
+    )
+    opt_conv_block_conf = tensor.OptimizedConvBlockConfig(
+        act_block_h_ntiles=act_block_h,
+        act_block_w_ntiles=act_block_w,
+        act_c_num_blocks=act_c_num_blocks,
+        weight_block_w_ntiles=weight_block_w,
+        out_block_h_ntiles=out_block_h,
+        out_subblock_h_ntiles=out_subblock_h,
+        out_subblock_w_ntiles=out_subblock_w,
+    )
+
     def conv_(activation):
         # assert(activation.layout() == tensor.Layout.ROW_MAJOR)
         output = tensor.optimized_conv(
@@ -240,20 +255,8 @@ def resnet50_optimized_conv(
             True,
             fuse_relu,
             math_fidelity,
-            tensor.OptimizedConvParallelizationConfig(
-                grid_size=grid_size,
-                per_core_out_matrix_height_ntiles=per_core_out_matrix_h_ntiles,
-                per_core_weight_matrix_width_ntiles=per_core_weight_matrix_w_ntiles,
-            ),
-            tensor.OptimizedConvBlockConfig(
-                act_block_h_ntiles=act_block_h,
-                act_block_w_ntiles=act_block_w,
-                act_c_num_blocks=act_c_num_blocks,
-                weight_block_w_ntiles=weight_block_w,
-                out_block_h_ntiles=out_block_h,
-                out_subblock_h_ntiles=out_subblock_h,
-                out_subblock_w_ntiles=out_subblock_w,
-            ),
+            opt_conv_parall_conf,
+            opt_conv_block_conf,
             0,
             output_mem_config=activation.memory_config() if output_mem_config is None else output_mem_config,
             output_dtype=output_dtype,
@@ -344,6 +347,20 @@ def resnet50_first_conv(
     P_H = 0
     P_W = 0
 
+    opt_conv_parall_conf = tensor.OptimizedConvParallelizationConfig(
+        grid_size=grid_size,
+        per_core_out_matrix_height_ntiles=per_core_out_matrix_h_ntiles,
+        per_core_weight_matrix_width_ntiles=per_core_weight_matrix_w_ntiles,
+    )
+    opt_conv_block_conf = tensor.OptimizedConvBlockConfig(
+        act_block_h_ntiles=act_block_h,
+        act_block_w_ntiles=act_block_w,
+        weight_block_w_ntiles=weight_block_w,
+        out_block_h_ntiles=out_block_h,
+        out_subblock_h_ntiles=out_subblock_h,
+        out_subblock_w_ntiles=out_subblock_w,
+    )
+
     def conv_(activation):
         # assert(activation.layout() == tensor.Layout.ROW_MAJOR)
         output_plus_bias = tensor.optimized_conv(
@@ -356,19 +373,8 @@ def resnet50_first_conv(
             True,
             fuse_relu,
             math_fidelity,
-            tensor.OptimizedConvParallelizationConfig(
-                grid_size=grid_size,
-                per_core_out_matrix_height_ntiles=per_core_out_matrix_h_ntiles,
-                per_core_weight_matrix_width_ntiles=per_core_weight_matrix_w_ntiles,
-            ),
-            tensor.OptimizedConvBlockConfig(
-                act_block_h_ntiles=act_block_h,
-                act_block_w_ntiles=act_block_w,
-                weight_block_w_ntiles=weight_block_w,
-                out_block_h_ntiles=out_block_h,
-                out_subblock_h_ntiles=out_subblock_h,
-                out_subblock_w_ntiles=out_subblock_w,
-            ),
+            opt_conv_parall_conf,
+            opt_conv_block_conf,
             extra_padding_for_32B_alignment,
             out_mem_config,
             output_dtype,

--- a/tt_eager/tt_lib/fused_ops/conv.py
+++ b/tt_eager/tt_lib/fused_ops/conv.py
@@ -228,21 +228,6 @@ def resnet50_optimized_conv(
     )
     bias_on_device = bias_.to(device)
 
-    opt_conv_parall_conf = tensor.OptimizedConvParallelizationConfig(
-        grid_size=grid_size,
-        per_core_out_matrix_height_ntiles=per_core_out_matrix_h_ntiles,
-        per_core_weight_matrix_width_ntiles=per_core_weight_matrix_w_ntiles,
-    )
-    opt_conv_block_conf = tensor.OptimizedConvBlockConfig(
-        act_block_h_ntiles=act_block_h,
-        act_block_w_ntiles=act_block_w,
-        act_c_num_blocks=act_c_num_blocks,
-        weight_block_w_ntiles=weight_block_w,
-        out_block_h_ntiles=out_block_h,
-        out_subblock_h_ntiles=out_subblock_h,
-        out_subblock_w_ntiles=out_subblock_w,
-    )
-
     def conv_(activation):
         # assert(activation.layout() == tensor.Layout.ROW_MAJOR)
         output = tensor.optimized_conv(
@@ -255,8 +240,20 @@ def resnet50_optimized_conv(
             True,
             fuse_relu,
             math_fidelity,
-            opt_conv_parall_conf,
-            opt_conv_block_conf,
+            tensor.OptimizedConvParallelizationConfig(
+                grid_size=grid_size,
+                per_core_out_matrix_height_ntiles=per_core_out_matrix_h_ntiles,
+                per_core_weight_matrix_width_ntiles=per_core_weight_matrix_w_ntiles,
+            ),
+            tensor.OptimizedConvBlockConfig(
+                act_block_h_ntiles=act_block_h,
+                act_block_w_ntiles=act_block_w,
+                act_c_num_blocks=act_c_num_blocks,
+                weight_block_w_ntiles=weight_block_w,
+                out_block_h_ntiles=out_block_h,
+                out_subblock_h_ntiles=out_subblock_h,
+                out_subblock_w_ntiles=out_subblock_w,
+            ),
             0,
             output_mem_config=activation.memory_config() if output_mem_config is None else output_mem_config,
             output_dtype=output_dtype,
@@ -347,20 +344,6 @@ def resnet50_first_conv(
     P_H = 0
     P_W = 0
 
-    opt_conv_parall_conf = tensor.OptimizedConvParallelizationConfig(
-        grid_size=grid_size,
-        per_core_out_matrix_height_ntiles=per_core_out_matrix_h_ntiles,
-        per_core_weight_matrix_width_ntiles=per_core_weight_matrix_w_ntiles,
-    )
-    opt_conv_block_conf = tensor.OptimizedConvBlockConfig(
-        act_block_h_ntiles=act_block_h,
-        act_block_w_ntiles=act_block_w,
-        weight_block_w_ntiles=weight_block_w,
-        out_block_h_ntiles=out_block_h,
-        out_subblock_h_ntiles=out_subblock_h,
-        out_subblock_w_ntiles=out_subblock_w,
-    )
-
     def conv_(activation):
         # assert(activation.layout() == tensor.Layout.ROW_MAJOR)
         output_plus_bias = tensor.optimized_conv(
@@ -373,8 +356,19 @@ def resnet50_first_conv(
             True,
             fuse_relu,
             math_fidelity,
-            opt_conv_parall_conf,
-            opt_conv_block_conf,
+            tensor.OptimizedConvParallelizationConfig(
+                grid_size=grid_size,
+                per_core_out_matrix_height_ntiles=per_core_out_matrix_h_ntiles,
+                per_core_weight_matrix_width_ntiles=per_core_weight_matrix_w_ntiles,
+            ),
+            tensor.OptimizedConvBlockConfig(
+                act_block_h_ntiles=act_block_h,
+                act_block_w_ntiles=act_block_w,
+                weight_block_w_ntiles=weight_block_w,
+                out_block_h_ntiles=out_block_h,
+                out_subblock_h_ntiles=out_subblock_h,
+                out_subblock_w_ntiles=out_subblock_w,
+            ),
             extra_padding_for_32B_alignment,
             out_mem_config,
             output_dtype,

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -83,7 +83,7 @@ struct CoreRange {
             "Invalid core range for start: {}, end: {}", start.str(), end.str());
     }
 
-    std::optional<CoreRange> intersects ( const CoreRange & other ) const
+    inline std::optional<CoreRange> intersects ( const CoreRange & other ) const
     {
         std::size_t x1 = std::max(this->start.x, other.start.x);
         std::size_t y1 = std::max(this->start.y, other.start.y);
@@ -95,7 +95,7 @@ struct CoreRange {
         return {};
     }
 
-    bool adjacent ( const CoreRange & other ) const
+    inline bool adjacent ( const CoreRange & other ) const
     {
         std::size_t x1 = std::max(this->start.x, other.start.x);
         std::size_t y1 = std::max(this->start.y, other.start.y);
@@ -104,7 +104,7 @@ struct CoreRange {
         return ( (x2 + 1 == x1 && y1 <= y2) || (y2 + 1 == y1 && x1 <= x2) );
     }
 
-    bool contains ( const CoreRange & other ) const
+    inline bool contains ( const CoreRange & other ) const
     {
         return (other.start.x >= this->start.x ) &&
                (other.end.x <= this->end.x) &&
@@ -319,7 +319,7 @@ class CoreRangeSet {
       return this->merge (s.ranges());
     }
 
-    bool core_coord_in_core_ranges(const CoreCoord &core_coord) const {
+    inline bool core_coord_in_core_ranges(const CoreCoord &core_coord) const {
       ZoneScoped;
       for (const auto & cr : this->ranges_) {
         bool in_x_range = (core_coord.x >= cr.start.x) and (core_coord.x <= cr.end.x);
@@ -331,7 +331,7 @@ class CoreRangeSet {
       return false;
     }
 
-    bool intersects ( const CoreRange & cr) const{
+    inline bool intersects ( const CoreRange & cr) const{
       for (const auto & local_cr : this->ranges_) {
         if ( local_cr.intersects(cr) ) return true;
       }

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -16,6 +16,7 @@
 #include "common/assert.hpp"
 #include "common/logger.hpp"
 #include "third_party/umd/device/tt_xy_pair.h"
+#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 
 using std::pair;
 
@@ -219,6 +220,7 @@ struct hash<CoreRange> {
 class CoreRangeSet {
   public:
     CoreRangeSet(const std::set<CoreRange> &core_ranges) : ranges_(core_ranges) {
+      ZoneScoped;
       for (auto outer_it = this->ranges_.begin(); outer_it != this->ranges_.end(); outer_it++) {
         for (auto inner_it = this->ranges_.begin(); inner_it != this->ranges_.end(); inner_it++) {
           if (outer_it == inner_it) {
@@ -318,9 +320,10 @@ class CoreRangeSet {
     }
 
     bool core_coord_in_core_ranges(const CoreCoord &core_coord) const {
-      for (auto core_range : this->ranges_) {
-        bool in_x_range = (core_coord.x >= core_range.start.x) and (core_coord.x <= core_range.end.x);
-        bool in_y_range = (core_coord.y >= core_range.start.y) and (core_coord.y <= core_range.end.y);
+      ZoneScoped;
+      for (const auto & cr : this->ranges_) {
+        bool in_x_range = (core_coord.x >= cr.start.x) and (core_coord.x <= cr.end.x);
+        bool in_y_range = (core_coord.y >= cr.start.y) and (core_coord.y <= cr.end.y);
         if (in_x_range and in_y_range) {
           return true;
         }
@@ -329,7 +332,7 @@ class CoreRangeSet {
     }
 
     bool intersects ( const CoreRange & cr) const{
-      for (auto local_cr : this->ranges_) {
+      for (const auto & local_cr : this->ranges_) {
         if ( local_cr.intersects(cr) ) return true;
       }
       return false;
@@ -340,7 +343,7 @@ class CoreRangeSet {
     std::string str() const {
       if (this->ranges().size() > 0) {
         std::string core_range_set_str = "{";
-        for (auto core_range : this->ranges_) {
+        for (const auto &core_range : this->ranges_) {
           core_range_set_str += core_range.str() + ", ";
         }
         core_range_set_str[core_range_set_str.length() - 2] = '}';

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -112,6 +112,14 @@ struct CoreRange {
                (other.end.y <= this->end.y);
     }
 
+    inline bool contains ( const CoreCoord & other ) const
+    {
+        return (other.x >= this->start.x ) &&
+               (other.x <= this->end.x) &&
+               (other.y >= this->start.y)  &&
+               (other.y <= this->end.y);
+    }
+
     // Merge lined-up (in x or y dimension) intersecting/adjacent rectangles
     std::optional<CoreRange> merge ( const CoreRange & cr) const
     {
@@ -322,11 +330,7 @@ class CoreRangeSet {
     inline bool core_coord_in_core_ranges(const CoreCoord &core_coord) const {
       ZoneScoped;
       for (const auto & cr : this->ranges_) {
-        bool in_x_range = (core_coord.x >= cr.start.x) and (core_coord.x <= cr.end.x);
-        bool in_y_range = (core_coord.y >= cr.start.y) and (core_coord.y <= cr.end.y);
-        if (in_x_range and in_y_range) {
-          return true;
-        }
+        if (cr.contains(core_coord)) return true;
       }
       return false;
     }

--- a/tt_metal/detail/program.hpp
+++ b/tt_metal/detail/program.hpp
@@ -9,17 +9,19 @@
 #include "tt_metal/impl/program.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/impl/buffers/circular_buffer.hpp"
+#include "tt_metal/impl/kernels/kernel_types.hpp"
+
 using namespace tt::tt_metal;
 
 namespace tt::tt_metal::detail{
 
-    inline void AddKernel ( Program & program, Kernel * kernel)
+    inline KernelID AddKernel ( Program & program, Kernel * kernel)
     {
-        program.add_kernel(kernel);
+        return program.add_kernel(kernel);
     }
 
     inline Kernel *GetKernel(const Program &program, KernelID kernel_id) {
-        return program.get_kernel(kernel_id);
+        return program.kernels_.at(kernel_id);
     }
 
     inline std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program &program, CircularBufferID id) {

--- a/tt_metal/detail/reports/compilation_reporter.cpp
+++ b/tt_metal/detail/reports/compilation_reporter.cpp
@@ -111,7 +111,7 @@ void CompilationReporter::flush_program_entry(const Program &program, bool persi
     auto get_num_compute_and_data_movement_kernels = [&]() {
         uint32_t num_compute = 0;
         uint32_t num_data_movement = 0;
-        for (auto kernel_id : program.kernel_ids()) {
+        for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
             const auto kernel = detail::GetKernel(program, kernel_id);
             if (kernel->processor() == tt::RISCV::BRISC or kernel->processor() == tt::RISCV::NCRISC) {
                 num_data_movement++;

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -174,10 +174,26 @@ void DeallocateBuffer(Buffer &buffer);
  */
 void SetRuntimeArgs(const Program &program, KernelID kernel, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::vector<uint32_t> &runtime_args);
 
+
+/**
+ * Update a single runtime arg of a kernel, yielding performance benefits in certain situations. This API can only be called after SetRuntimeArgs has been called on a kernel.
+ *
+ * Return value: void
+ *
+ * | Argument     | Description                                                            | Type                                                   | Valid Range                                                         | Required |
+ * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------|----------|
+ * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
+ * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelID (uint64_t)                                    |                                                                     | Yes      |
+ * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::variant<CoreCoord,CoreRange,CoreRangeSet> & | Any logical Tensix core coordinate(s) on which the kernel is placed | Yes      |
+ * | offset       | Offset into original vector of runtime args                            | size_t                                                 | Within the bounds of the original runtime arg vector                | Yes      |
+ * | value        | The runtime args to be written                                         | uint32_t                                               |                                                                     | Yes      |
+ */
+void UpdateRuntimeArg(const Program &program, KernelID kernel, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, size_t offset, uint32_t value);
+
 /**
  * Get the runtime args for a kernel.
  *
- * Return value: std::vector<uint32_t>
+ * Return value: const std::vector<uint32_t> &
  *
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
@@ -185,7 +201,7 @@ void SetRuntimeArgs(const Program &program, KernelID kernel, const std::variant<
  * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelID (uint64_t)                |                                    | Yes      |
  * | logical_core | The location of the Tensix core where the runtime args will be written | const CoreCoord &             | Any logical Tensix core coordinate | Yes      |
  */
-std::vector<uint32_t> GetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreCoord &logical_core);
+const std::vector<uint32_t>& GetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreCoord &logical_core);
 
 /**
  * Reads a buffer from the device

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -193,7 +193,7 @@ void UpdateRuntimeArg(const Program &program, KernelID kernel, const std::varian
 /**
  * Get the runtime args for a kernel.
  *
- * Return value: const std::vector<uint32_t> &
+ * Return value: std::vector<uint32_t> &
  *
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
@@ -201,7 +201,7 @@ void UpdateRuntimeArg(const Program &program, KernelID kernel, const std::varian
  * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelID (uint64_t)                |                                    | Yes      |
  * | logical_core | The location of the Tensix core where the runtime args will be written | const CoreCoord &             | Any logical Tensix core coordinate | Yes      |
  */
-const std::vector<uint32_t>& GetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreCoord &logical_core);
+std::vector<uint32_t>& GetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreCoord &logical_core);
 
 /**
  * Reads a buffer from the device

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -880,12 +880,19 @@ void EnqueueWriteBuffer(CommandQueue& cq, Buffer& buffer, vector<uint32_t>& src,
 }
 
 void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking) {
+    ZoneScoped;
     detail::DispatchStateCheck(true);
 
     detail::CompileProgram(cq.device, program);
 
-    program.allocate_circular_buffers();
-    detail::ValidateCircularBufferRegion(program, cq.device);
+    {
+        ZoneScopedN("Allocation CB");
+        program.allocate_circular_buffers();
+    }
+    {
+        ZoneScopedN("Validate CB");
+        detail::ValidateCircularBufferRegion(program, cq.device);
+    }
     cq.enqueue_program(program, blocking);
 }
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -103,7 +103,7 @@ ProgramMap ConstructProgramMap(const Device* device, Program& program) {
     // Step 1: Get transfer info for runtime args (soon to just be host data). We
     // want to send host data first because of the higher latency to pull
     // in host data.
-    for (const auto kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         const Kernel* kernel = detail::GetKernel(program, kernel_id);
         uint32_t dst = processor_to_l1_arg_base_addr.at(kernel->processor());
         for (const auto &core_coord : kernel->cores_with_runtime_args()) {
@@ -155,7 +155,7 @@ ProgramMap ConstructProgramMap(const Device* device, Program& program) {
 
     // Step 3: Determine the transfer information for each program binary
     src = 0; // Restart src since it begins in a new page
-    for (KernelID kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         const Kernel* kernel = detail::GetKernel(program, kernel_id);
         vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
             extract_dst_noc_multicast_info(kernel->core_range_set().ranges());
@@ -231,7 +231,7 @@ ProgramMap ConstructProgramMap(const Device* device, Program& program) {
 
     // Create a vector of all program binaries/cbs/semaphores
     uint32_t program_page_idx = 0;
-    for (KernelID kernel_id : program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         const Kernel* kernel = detail::GetKernel(program, kernel_id);
 
         for (const ll_api::memory& kernel_bin : kernel->binaries(device->id())) {
@@ -555,7 +555,7 @@ void EnqueueProgramCommand::process() {
 
     uint32_t start_addr = system_memory_temporary_storage_address;
     constexpr static uint32_t padding_alignment = 16;
-    for (const auto kernel_id : this->program.kernel_ids()) {
+    for (size_t kernel_id = 0; kernel_id < this->program.num_kernels(); kernel_id++) {
         const Kernel* kernel = detail::GetKernel(program, kernel_id);
         for (const auto& c: kernel->cores_with_runtime_args()) {
             const auto & core_runtime_args = kernel->runtime_args(c);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -104,7 +104,7 @@ ProgramMap ConstructProgramMap(const Device* device, Program& program) {
     // want to send host data first because of the higher latency to pull
     // in host data.
     for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
-        const Kernel* kernel = detail::GetKernel(program, kernel_id);
+        Kernel* kernel = detail::GetKernel(program, kernel_id);
         uint32_t dst = processor_to_l1_arg_base_addr.at(kernel->processor());
         for (const auto &core_coord : kernel->cores_with_runtime_args()) {
             CoreCoord physical_core = device->worker_core_from_logical_core(core_coord);
@@ -556,7 +556,7 @@ void EnqueueProgramCommand::process() {
     uint32_t start_addr = system_memory_temporary_storage_address;
     constexpr static uint32_t padding_alignment = 16;
     for (size_t kernel_id = 0; kernel_id < this->program.num_kernels(); kernel_id++) {
-        const Kernel* kernel = detail::GetKernel(program, kernel_id);
+        Kernel* kernel = detail::GetKernel(program, kernel_id);
         for (const auto& c: kernel->cores_with_runtime_args()) {
             const auto & core_runtime_args = kernel->runtime_args(c);
             this->writer.cq_write(this->device, core_runtime_args.data(), core_runtime_args.size() * sizeof(uint32_t), system_memory_temporary_storage_address);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -885,14 +885,9 @@ void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking) {
 
     detail::CompileProgram(cq.device, program);
 
-    {
-        ZoneScopedN("Allocation CB");
-        program.allocate_circular_buffers();
-    }
-    {
-        ZoneScopedN("Validate CB");
-        detail::ValidateCircularBufferRegion(program, cq.device);
-    }
+    program.allocate_circular_buffers();
+    detail::ValidateCircularBufferRegion(program, cq.device);
+
     cq.enqueue_program(program, blocking);
 }
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -37,6 +37,7 @@ Kernel::Kernel(const std::string &kernel_path_file_name, const CoreRangeSet &cor
             }
         }
     }
+    core_to_runtime_args_.reserve ( logical_cores_.size() );
 }
 
 std::string Kernel::name() const {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -97,7 +97,14 @@ std::string Kernel::compute_hash() const {
     );
 }
 
-std::vector<uint32_t> const &Kernel::runtime_args(const CoreCoord &logical_core) {
+void Kernel::update_runtime_arg( const CoreCoord &logical_core, size_t idx, uint32_t value){
+    TT_ASSERT( this->core_to_runtime_args_.find(logical_core) != this->core_to_runtime_args_.end(), "Runtime args for core {} not found", logical_core.str());
+    auto & v = this->core_to_runtime_args_[logical_core];
+    TT_ASSERT( idx < v.size(), "Runtime arg offset {} for Core {} out of bounds", idx, logical_core.str());
+    v[idx] = value;
+}
+
+std::vector<uint32_t> const& Kernel::runtime_args(const CoreCoord &logical_core) {
     // TODO (abhullar): Should this check only be enabled in debug mode?
     // TT_ASSERT(this->is_on_logical_core(logical_core), "Cannot get runtime args for kernel {} that is not placed on core {}", this->name(), logical_core.str());
     return this->core_to_runtime_args_[logical_core];

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -106,10 +106,10 @@ void Kernel::update_runtime_arg( const CoreCoord &logical_core, size_t idx, uint
     v[idx] = value;
 }
 
-std::vector<uint32_t> const& Kernel::runtime_args(const CoreCoord &logical_core) const {
+std::vector<uint32_t>& Kernel::runtime_args(const CoreCoord &logical_core) {
     // TODO (abhullar): Should this check only be enabled in debug mode?
     // TT_ASSERT(this->is_on_logical_core(logical_core), "Cannot get runtime args for kernel {} that is not placed on core {}", this->name(), logical_core.str());
-    return this->core_to_runtime_args_.at(logical_core.x).at(logical_core.y);
+    return this->core_to_runtime_args_[logical_core.x][logical_core.y];
 }
 
 std::pair<uint64_t, uint64_t> DataMovementKernel::get_runtime_args_range() const {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -20,7 +20,6 @@ namespace tt {
 namespace tt_metal {
 
 Kernel::Kernel(const std::string &kernel_path_file_name, const CoreRangeSet &core_range_set, const std::vector<uint32_t> &compile_args, const std::map<std::string, std::string> &defines) :
-    id_(reinterpret_cast<uintptr_t>(this)),
     watcher_kernel_id_(llrt::watcher_register_kernel(kernel_path_file_name)),
     kernel_path_file_name_(kernel_path_file_name),
     core_range_set_(core_range_set),

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -31,8 +31,6 @@ class Kernel {
 
     virtual ~Kernel() {}
 
-    const uintptr_t id() const { return id_; }
-
     std::string kernel_path_file_name() const { return kernel_path_file_name_; }
 
     std::string name() const;
@@ -76,7 +74,6 @@ class Kernel {
     int get_watcher_kernel_id() { return watcher_kernel_id_; }
 
    protected:
-    const uintptr_t id_;
     const int watcher_kernel_id_;
     std::string kernel_path_file_name_;                 // Full kernel path and file name
     CoreRangeSet core_range_set_;

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -51,7 +51,9 @@ class Kernel {
 
     std::unordered_map<CoreCoord, std::vector<uint32_t>> const &runtime_args() const { return core_to_runtime_args_; }
 
-    std::vector<uint32_t> const &runtime_args(const CoreCoord &logical_core);
+    void update_runtime_arg( const CoreCoord &logical_core, size_t idx, uint32_t value);
+
+    std::vector<uint32_t> const & runtime_args(const CoreCoord &logical_core);
 
     std::map<std::string, std::string> defines() const { return defines_; }
 

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -51,7 +51,7 @@ class Kernel {
 
     void update_runtime_arg( const CoreCoord &logical_core, size_t idx, uint32_t value);
 
-    std::vector<uint32_t> const & runtime_args(const CoreCoord &logical_core) const;
+    std::vector<uint32_t> & runtime_args(const CoreCoord &logical_core);
 
     std::map<std::string, std::string> defines() const { return defines_; }
 

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -49,11 +49,11 @@ class Kernel {
 
     std::vector<uint32_t> compile_time_args() const { return compile_time_args_; }
 
-    std::unordered_map<CoreCoord, std::vector<uint32_t>> const &runtime_args() const { return core_to_runtime_args_; }
+    const std::unordered_set<CoreCoord>& cores_with_runtime_args() const { return core_with_runtime_args_; }
 
     void update_runtime_arg( const CoreCoord &logical_core, size_t idx, uint32_t value);
 
-    std::vector<uint32_t> const & runtime_args(const CoreCoord &logical_core);
+    std::vector<uint32_t> const & runtime_args(const CoreCoord &logical_core) const;
 
     std::map<std::string, std::string> defines() const { return defines_; }
 
@@ -87,7 +87,8 @@ class Kernel {
     std::unordered_map<chip_id_t, std::vector<ll_api::memory>> binaries_;
     uint16_t binary_size16_;
     std::vector<uint32_t> compile_time_args_;
-    std::unordered_map<CoreCoord, std::vector<uint32_t>> core_to_runtime_args_;
+    std::vector< std::vector< std::vector<uint32_t>> > core_to_runtime_args_;
+    std::unordered_set<CoreCoord> core_with_runtime_args_;
     std::map<std::string, std::string> defines_;        // preprocessor defines. this is to be able to generate generic instances.
     std::set<CoreCoord> logical_cores_;
 

--- a/tt_metal/impl/kernels/kernel_types.hpp
+++ b/tt_metal/impl/kernels/kernel_types.hpp
@@ -13,7 +13,7 @@
 
 namespace tt::tt_metal {
 
-using KernelID = uintptr_t;
+using KernelID = std::uint16_t;
 
 enum class DataMovementProcessor {
     RISCV_0 = 0,  // BRISC

--- a/tt_metal/impl/program.cpp
+++ b/tt_metal/impl/program.cpp
@@ -405,6 +405,7 @@ void Program::invalidate_circular_buffer_allocation() {
 }
 
 void Program::allocate_circular_buffers() {
+    ZoneScoped;
     if (not this->circular_buffer_allocation_needed_) {
         return;
     }

--- a/tt_metal/impl/program.hpp
+++ b/tt_metal/impl/program.hpp
@@ -16,6 +16,7 @@
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include "hostdevcommon/common_values.hpp"
+#include "tt_metal/impl/kernels/kernel_types.hpp"
 
 // XXXX TODO(PGK): fix include paths so device can export interfaces
 #include "tt_metal/src/firmware/riscv/common/dev_msgs.h"
@@ -27,7 +28,7 @@ namespace tt_metal {
 // Fwd declares
 namespace detail{
     void ValidateCircularBufferRegion(const Program &program, const Device *device);
-    void AddKernel ( Program & program, Kernel * kernel);
+    KernelID AddKernel ( Program & program, Kernel * kernel);
     Kernel *GetKernel(const Program &program, KernelID kernel_id);
     std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program &program, CircularBufferID id);
 }
@@ -66,7 +67,7 @@ class Program {
 
     const uint64_t get_id() const { return this->id; }
 
-    std::vector<KernelID> kernel_ids() const { return kernel_ids_; }
+    size_t num_kernels() const { return kernels_.size(); }
 
     const std::vector<std::shared_ptr<CircularBuffer>> &circular_buffers() const { return circular_buffers_; }
 
@@ -130,8 +131,7 @@ class Program {
 
     uint64_t id; // Need to make non-const due to move constructor
     static std::atomic<uint64_t> program_counter;
-    std::vector<KernelID> kernel_ids_;
-    std::unordered_map<KernelID, Kernel *> kernel_by_id_;
+    std::vector<Kernel*> kernels_;
     CoreCoord grid_extent_;
 
     std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_;
@@ -152,11 +152,11 @@ class Program {
     friend std::shared_ptr<CircularBuffer> detail::GetCircularBuffer(const Program &program, CircularBufferID id);
     friend void detail::ValidateCircularBufferRegion(const Program &program, const Device *device);
 
-    friend void detail::AddKernel(Program &program, Kernel *kernel);
+    friend KernelID detail::AddKernel(Program &program, Kernel *kernel);
     friend Kernel *detail::GetKernel(const Program &program, KernelID kernel_id);
 
     friend uint32_t CreateSemaphore(Program &program, const std::variant<CoreRange,CoreRangeSet> &core_spec, uint32_t initial_value);
-    void add_kernel(Kernel *kernel);
+    KernelID add_kernel(Kernel *kernel);
     Kernel *get_kernel(KernelID kernel_id) const;
 
     CircularBufferID add_circular_buffer(const CoreRangeSet &core_range_set, const CircularBufferConfig &config);

--- a/tt_metal/tools/profiler/op_profiler.hpp
+++ b/tt_metal/tools/profiler/op_profiler.hpp
@@ -512,7 +512,7 @@ namespace op_profiler {
     static void append_math_fidelities (const Program& program)
     {
 #if defined(PROFILER)
-        for (const auto& kernel_id : program.kernel_ids()) {
+        for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
             Kernel * kernel = tt::tt_metal::detail::GetKernel(program, kernel_id);
             if (kernel->processor() == RISCV::COMPUTE) {
                 ComputeKernel * compute_kernel = static_cast<ComputeKernel*>(kernel);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -479,7 +479,7 @@ void UpdateRuntimeArg(const Program &program, KernelID kernel_id, const std::var
     );
 }
 
-const std::vector<uint32_t> & GetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreCoord &logical_core) {
+std::vector<uint32_t> & GetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreCoord &logical_core) {
     return detail::GetKernel(program, kernel_id)->runtime_args(logical_core);
 }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -320,8 +320,9 @@ namespace detail {
         for (auto kernel_id : program.kernel_ids()) {
             const auto kernel = detail::GetKernel(program, kernel_id);
             auto processor = kernel->processor();
-            for (const auto &[logical_core, rt_args] : kernel->runtime_args()) {
+            for (const auto &logical_core : kernel->cores_with_runtime_args()) {
                 auto worker_core = device->worker_core_from_logical_core(logical_core);
+                const auto & rt_args = kernel->runtime_args(logical_core);
                 tt::llrt::write_hex_vec_to_core(device_id, worker_core, rt_args, get_l1_arg_base_addr(processor));
             }
         }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -317,7 +317,7 @@ namespace detail {
             return l1_arg_base;
         };
 
-        for (auto kernel_id : program.kernel_ids()) {
+        for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
             const auto kernel = detail::GetKernel(program, kernel_id);
             auto processor = kernel->processor();
             for (const auto &logical_core : kernel->cores_with_runtime_args()) {
@@ -371,8 +371,7 @@ KernelID CreateKernel(Program &program, const std::string &file_name, const std:
                             else if constexpr (std::is_same_v<T, EthernetConfig>) {
                                 kernel = new EthernetKernel(file_name, core_ranges, cfg);
                             }
-                            detail::AddKernel(program, kernel);
-                            return kernel->id();
+                            return detail::AddKernel(program, kernel);
                         },
                         config
                     );


### PR DESCRIPTION
1. new host API `UpdateRuntimeArg` that allows updating a specific RT arg rather than requiring user to call `GetRuntimeArgs`/`SetRuntimeArgs` again
2. return `vector&` on `GetRuntimeArgs` to allow for in-place update of any arg
3. inlining, replacing underlying storage of rt args from `unordered_map` to flat array 

Before

```
2023-11-14 10:16:57.114 | INFO     | models.demos.resnet.tests.test_perf_resnet:run_perf_resnet:107 - resnet50 224x224_batchsize1 inference time: 0.009492635726928711
2023-11-14 10:17:18.202 | INFO     | models.demos.resnet.tests.test_perf_resnet:run_perf_resnet:107 - resnet50 224x224_batchsize2 inference time: 0.01331019401550293
2023-11-14 10:17:45.785 | INFO     | models.demos.resnet.tests.test_perf_resnet:run_perf_resnet:107 - resnet50 224x224_batchsize8 inference time: 0.015589237213134766
```

After
```
2023-11-14 10:22:33.706 | INFO     | models.demos.resnet.tests.test_perf_resnet:run_perf_resnet:107 - resnet50 224x224_batchsize1 inference time: 0.00938558578491211
2023-11-14 10:22:54.638 | INFO     | models.demos.resnet.tests.test_perf_resnet:run_perf_resnet:107 - resnet50 224x224_batchsize2 inference time: 0.012433052062988281
2023-11-14 10:23:22.163 | INFO     | models.demos.resnet.tests.test_perf_resnet:run_perf_resnet:107 - resnet50 224x224_batchsize8 inference time: 0.013422966003417969
```

