### PR TITLE
#3638: Fix microbenchmarks runner targets

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         runner-info: [
-          {arch: grayskull, runs-on: ["perf-grayskull", "fw-date-2023-06-28", "self-reset"]},
-          # N150
-          {arch: wormhole_b0, runs-on: ["perf-wormhole_b0", "fw-date-2023-08-08", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "self-reset"]},
+          {arch: grayskull, runs-on: ["perf-grayskull", "self-reset"]},
+          # Do not run N150 on microbenchmarks for now as we do not have the machines for it
+          # {arch: wormhole_b0, runs-on: ["perf-wormhole_b0", "fw-date-2023-08-08", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "self-reset"]},
           # N300
-          {arch: wormhole_b0, runs-on: ["perf-wormhole_b0", "fw-date-2023-08-08", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "self-reset"]},
+          {arch: wormhole_b0, runs-on: ["perf-wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "self-reset"]},
         ]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}


### PR DESCRIPTION
Stop targeting FW for benchmarks pipeline because the FW dates…… were wrong + stop targeting N150 for microbenchmarks because we don't have any available for use right now