### PR TITLE
#3649: Missing l1 barrier between sending dispatch kernels/data and sending go signals resulted in a semaphore state race

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -662,6 +662,8 @@ void send_dispatch_kernel_to_device(Device* device) {
     tt::tt_metal::detail::WriteToDeviceL1(device, producer_logical_core, CQ_READ_PTR, fifo_addr_vector);
     tt::tt_metal::detail::WriteToDeviceL1(device, producer_logical_core, CQ_WRITE_PTR, fifo_addr_vector);
 
+    tt::Cluster::instance().l1_barrier(device->id());
+
     launch_msg_t msg = dispatch_program.kernels_on_core(producer_logical_core)->launch_msg;
 
     // TODO(pkeller): Should use LaunchProgram once we have a mechanism to avoid running all RISCs


### PR DESCRIPTION
Fixes a race where the semaphore states are not fully set prior to sending GO signals.