### PR TITLE
#3486: Caching enqueue program commands

### DIFF
--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -16,6 +16,10 @@ DeviceCommand::DeviceCommand() {
                                                                       DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION;
 }
 
+uint32_t& DeviceCommand::operator[](uint32_t idx) {
+    return this->desc[idx];
+}
+
 void DeviceCommand::wrap() { this->desc[this->wrap_idx] = 1; }
 
 void DeviceCommand::finish() { this->desc[this->finish_idx] = 1; }
@@ -81,10 +85,14 @@ void DeviceCommand::add_buffer_transfer_instruction(
     this->buffer_transfer_idx += DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION;
 
     this->desc[this->num_buffer_transfers_idx]++;
-    tt::log_assert(
+    TT_ASSERT(
         this->desc[this->num_buffer_transfers_idx] <= DeviceCommand::NUM_POSSIBLE_BUFFER_TRANSFERS,
         "Surpassing the limit of {} on possible buffer transfers in a single command",
         DeviceCommand::NUM_POSSIBLE_BUFFER_TRANSFERS);
+}
+
+void DeviceCommand::write_at_index(uint32_t index, uint32_t value) {
+    this->desc[index] = value;
 }
 
 void DeviceCommand::write_program_entry(const uint32_t value) {

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -53,6 +53,8 @@ class DeviceCommand {
     static constexpr uint32_t data_size_idx = 16;
     static constexpr uint32_t producer_consumer_transfer_num_pages_idx = 17;
 
+    uint32_t& operator[](uint32_t idx);
+
     void wrap();
 
     void finish();
@@ -90,6 +92,8 @@ class DeviceCommand {
         const uint32_t padded_page_size,
         const uint32_t src_buf_type,
         const uint32_t dst_buf_type);
+
+    void write_at_index(uint32_t index, uint32_t value);
 
     void write_program_entry(const uint32_t val);
 


### PR DESCRIPTION
Support for caching enqueue program commands and just updating the runtime src on subsequent cached calls. This is purely a host-side optimization, no implementation of DRAM caching here.

It appears as if it degrades BERT performance by 3.5%.