### PR TITLE
#3693: Pin black to 23.10.1 to pre-commit hooks, CI, and local python dev env

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -48,4 +48,4 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
-      - uses: psf/black@stable
+      - uses: psf/black@23.10.1

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==23.1.0
+black==23.10.1
 pre-commit==3.0.4
 build==0.10.0
 twine==4.0.2


### PR DESCRIPTION
… dev env