### PR TITLE
#3745: Fix python env install error msgs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@ third_party/ @tt-rkim @TT-billteng @kkwong10
 MANIFEST.in @tt-rkim
 setup.py @tt-rkim
 pyproject.toml @tt-rkim
+requirements*.txt @tt-rkim
 
 Makefile @tt-rkim
 /module.mk @tt-rkim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
   "setuptools==68.0.0",
   "setuptools-scm==7.1.0",
+  "wheel",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tt_eager/tt_lib/module.mk
+++ b/tt_eager/tt_lib/module.mk
@@ -3,4 +3,5 @@ include tt_eager/tt_lib/csrc/module.mk
 tt_eager/tt_lib: tt_lib/csrc
 
 tt_eager/tt_lib/dev_install: tt_lib/csrc/setup_local_so
+	echo "Installing editable dev version of tt_eager packages..."
 	bash -c "source $(PYTHON_ENV)/bin/activate && pip install -e ."

--- a/tt_metal/python_env/module.mk
+++ b/tt_metal/python_env/module.mk
@@ -13,11 +13,14 @@ python_env/clean:
 $(PYTHON_ENV)/.installed:
 	python3.8 -m venv $(PYTHON_ENV)
 	bash -c "source $(PYTHON_ENV)/bin/activate && python -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu"
+	echo "Installing python env build backend requirements..."
+	bash -c "source $(PYTHON_ENV)/bin/activate && python -m pip install setuptools wheel"
 	touch $@
 
 $(PYTHON_ENV)/%: $(PYTHON_ENV)/.installed
 	bash -c "source $(PYTHON_ENV)/bin/activate"
 
 $(PYTHON_ENV)/.installed-dev: tt_eager/tt_lib/dev_install python_env tt_metal/python_env/requirements-dev.txt
+	echo "Installing dev environment packages..."
 	bash -c "source $(PYTHON_ENV)/bin/activate && python -m pip install -r tt_metal/python_env/requirements-dev.txt"
 	touch $@

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -1,5 +1,13 @@
-black==23.10.1
+# As this is a development environment, some build backend dependencies may
+# not be available during environment installation. We recommend setuptools
+# and wheel before installing this requirements.txt file.
+
+# During dep resolution, black may install platformdirs >=4.0.0, which is
+# a breaking dependency for virtualenv installed by pre-commit. virtualenv
+# requires <4.0.0 platformdirs, so we're pinning platformdirs here
+platformdirs<4.0.0
 pre-commit==3.0.4
+black==23.10.1
 build==0.10.0
 twine==4.0.2
 yamllint==1.32.0
@@ -26,6 +34,10 @@ accelerate==0.19.0
 ftfy==6.1.1
 gitpython==3.1.32
 einops==0.6.1
+# Pin to this because evaluate 0.4.0 will download the latest multiprocess as a
+# transitive dep, which uses dill >=0.3.7, however many packages require
+# dill < 0.3.7
+multiprocess==0.70.14
 evaluate==0.4.0
 bert-score==0.3.12
 fsspec==2023.9.2 # Temporary pin to 2023.9.2: https://github.com/tenstorrent-metal/tt-metal/issues/3314


### PR DESCRIPTION
- Add wheel as a package-level build dep so that an installing environment has wheel available for things like pyyaml
- Install setuptools and wheel in the Python dev environment at time of venv creation so later dependencies have it to install their wheels etc.
- Pin platformdirs and multiprocess so we fix platformdirs and dill dependency issues. A deeper explanation is available in the requirements.txt comments