### PR TITLE
#3747: type-1 complex tensors complex_mul and div not supported for batch_size>1 

### DIFF
--- a/tt_eager/tt_dnn/op_library/complex/complex_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/complex/complex_ops.cpp
@@ -14,7 +14,10 @@ namespace tt {
 
 namespace tt_metal {
 
-#define CHECK_FOR_COMPLEX(input) TT_ASSERT( utility::is_complex_shape(input), "works for complex shape only")
+#define CHECK_FOR_COMPLEX(input) do {\
+  TT_ASSERT( utility::is_complex_shape(input), "works for complex shape only"); \
+  /* TT_ASSERT( input.shape()[0] == 1, "tensor should have batch size 1"); */ \
+  } while(0);
 
 Tensor mk_complex(const Tensor& input_r, const Tensor& input_i, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> inputs = {input_r,input_i};


### PR DESCRIPTION
- use reshape pre/post type-1 complex split-concat to accomodate restriction on split-2-last-dim not taking batch-size > 1, workaround
- enable  split-2-last-dim to take batch-size > 1
- add tests for type-2 complex for bs > 1 to ensure support