### PR TITLE
#3568: Move weigths dtype from bfloat16 to bfp8 in mistral model

### DIFF
--- a/models/experimental/mistral/tests/test_mistral_attention.py
+++ b/models/experimental/mistral/tests/test_mistral_attention.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import torch
+import tt_lib
 import pytest
 from loguru import logger
 import json
@@ -29,11 +30,22 @@ from models.utility_functions import (
     (True, False),
 )
 @pytest.mark.parametrize(
+    "dtype",
+    (tt_lib.tensor.DataType.BFLOAT16, tt_lib.tensor.DataType.BFLOAT8_B),
+)
+@pytest.mark.parametrize(
     "pcc",
     ((0.9793647197892646),),
 )
 def test_mistral_attention_inference(
-    pcc, model_location_generator, device, reset_seeds, empty_ondevice, rotary_embedding_ondevice, softmax_ondevice
+    pcc,
+    model_location_generator,
+    device,
+    reset_seeds,
+    empty_ondevice,
+    rotary_embedding_ondevice,
+    softmax_ondevice,
+    dtype,
 ):
     mistral_path = model_location_generator("mistral-7B-v0.1", model_subdir="Mistral")
     state_dict = torch.load(mistral_path / "consolidated.00.pth")
@@ -49,6 +61,7 @@ def test_mistral_attention_inference(
     model_args.FALLBACK_ROTARY_EMBEDDING = rotary_embedding_ondevice
     model_args.FALLBACK_SOFTMAX = softmax_ondevice
     model_args.FALLBACK_EMPTY = empty_ondevice
+    model_args.WEIGHTS_DTYPE = dtype
     tt_model = TtAttention(
         args=model_args,
         state_dict=state_dict,

--- a/models/experimental/mistral/tests/test_mistral_rms_norm.py
+++ b/models/experimental/mistral/tests/test_mistral_rms_norm.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import torch
+import tt_lib
 import pytest
 from loguru import logger
 import json

--- a/models/experimental/mistral/tests/test_mistral_transformer.py
+++ b/models/experimental/mistral/tests/test_mistral_transformer.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import torch
+import tt_lib
 import pytest
 from loguru import logger
 import json
@@ -18,10 +19,14 @@ from models.utility_functions import (
 
 
 @pytest.mark.parametrize(
+    "dtype",
+    (tt_lib.tensor.DataType.BFLOAT16, tt_lib.tensor.DataType.BFLOAT8_B),
+)
+@pytest.mark.parametrize(
     "pcc",
     ((0.99),),
 )
-def test_mistral_transformer_inference(pcc, model_location_generator, device, reset_seeds):
+def test_mistral_transformer_inference(pcc, model_location_generator, device, dtype, reset_seeds):
     prompts = [
         "This is a sample text for single layer execution ",
     ]
@@ -35,6 +40,7 @@ def test_mistral_transformer_inference(pcc, model_location_generator, device, re
 
     model_args.max_batch_size = 1
     model_args.n_layers = 32
+    model_args.WEIGHTS_DTYPE = dtype
     reference_model = Transformer(args=model_args)
     reference_model.load_state_dict(state_dict)
 

--- a/models/experimental/mistral/tests/test_mistral_transformer_block.py
+++ b/models/experimental/mistral/tests/test_mistral_transformer_block.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import torch
+import tt_lib
 import pytest
 from loguru import logger
 import json
@@ -17,10 +18,14 @@ from models.utility_functions import (
 
 
 @pytest.mark.parametrize(
+    "dtype",
+    (tt_lib.tensor.DataType.BFLOAT16, tt_lib.tensor.DataType.BFLOAT8_B),
+)
+@pytest.mark.parametrize(
     "pcc",
     ((0.99),),
 )
-def test_mistral_transformer_block_inference(pcc, model_location_generator, device, reset_seeds):
+def test_mistral_transformer_block_inference(pcc, model_location_generator, device, dtype, reset_seeds):
     mistral_path = model_location_generator("mistral-7B-v0.1", model_subdir="Mistral")
     state_dict = torch.load(mistral_path / "consolidated.00.pth")
     base_address = f""
@@ -30,6 +35,7 @@ def test_mistral_transformer_block_inference(pcc, model_location_generator, devi
     state_dict = {k[9:]: v for k, v in state_dict.items() if (k.startswith("layers.0."))}
 
     model_args.max_batch_size = 1
+    model_args.WEIGHTS_DTYPE = dtype
     reference_model = TransformerBlock(args=model_args)
     reference_model.load_state_dict(state_dict)
 

--- a/models/experimental/mistral/tt/mistral_attention.py
+++ b/models/experimental/mistral/tt/mistral_attention.py
@@ -35,7 +35,13 @@ class TtAttention(nn.Module):
 
         self.scale = self.args.head_dim**-0.5
 
-        self.wq_weights = torch_to_tt_tensor_rm(self.state_dict[f"{base_address}wq.weight"], self.device)
+        wq_weights = self.state_dict[f"{base_address}wq.weight"]
+        self.wq_weights = tt_lib.tensor.Tensor(
+            wq_weights.unsqueeze(0).unsqueeze(0).reshape(-1).tolist(),
+            wq_weights.unsqueeze(0).unsqueeze(0).shape,
+            self.args.WEIGHTS_DTYPE,
+            tt_lib.tensor.Layout.ROW_MAJOR,
+        )
         self.wq = TtLinear(
             args.dim,
             args.n_heads * args.head_dim,
@@ -43,7 +49,13 @@ class TtAttention(nn.Module):
             device=self.device,
         )
 
-        self.wk_weights = torch_to_tt_tensor_rm(self.state_dict[f"{base_address}wk.weight"], self.device)
+        wk_weights = self.state_dict[f"{base_address}wk.weight"]
+        self.wk_weights = tt_lib.tensor.Tensor(
+            wk_weights.unsqueeze(0).unsqueeze(0).reshape(-1).tolist(),
+            wk_weights.unsqueeze(0).unsqueeze(0).shape,
+            self.args.WEIGHTS_DTYPE,
+            tt_lib.tensor.Layout.ROW_MAJOR,
+        )
         self.wk = TtLinear(
             args.dim,
             args.n_kv_heads * args.head_dim,
@@ -51,7 +63,13 @@ class TtAttention(nn.Module):
             device=self.device,
         )
 
-        self.wv_weights = torch_to_tt_tensor_rm(self.state_dict[f"{base_address}wv.weight"], self.device)
+        wv_weights = self.state_dict[f"{base_address}wv.weight"]
+        self.wv_weights = tt_lib.tensor.Tensor(
+            wv_weights.unsqueeze(0).unsqueeze(0).reshape(-1).tolist(),
+            wv_weights.unsqueeze(0).unsqueeze(0).shape,
+            self.args.WEIGHTS_DTYPE,
+            tt_lib.tensor.Layout.ROW_MAJOR,
+        )
         self.wv = TtLinear(
             args.dim,
             args.n_kv_heads * args.head_dim,
@@ -59,7 +77,13 @@ class TtAttention(nn.Module):
             device=self.device,
         )
 
-        self.wo_weights = torch_to_tt_tensor_rm(self.state_dict[f"{base_address}wo.weight"], self.device)
+        wo_weights = state_dict[f"{base_address}wo.weight"]
+        self.wo_weights = tt_lib.tensor.Tensor(
+            wo_weights.unsqueeze(0).unsqueeze(0).reshape(-1).tolist(),
+            wo_weights.unsqueeze(0).unsqueeze(0).shape,
+            self.args.WEIGHTS_DTYPE,
+            tt_lib.tensor.Layout.ROW_MAJOR,
+        )
         self.wo = TtLinear(
             args.n_heads * args.head_dim,
             args.dim,

--- a/models/experimental/mistral/tt/mistral_configuration.py
+++ b/models/experimental/mistral/tt/mistral_configuration.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
+import tt_lib
 
 
 @dataclass
@@ -20,3 +21,4 @@ class TtModelArgs:
     FALLBACK_SOFTMAX: bool = False
     FALLBACK_ROTARY_EMBEDDING: bool = False
     FALLBACK_EMPTY: bool = False
+    WEIGHTS_DTYPE = tt_lib.tensor.DataType.BFLOAT16

--- a/models/experimental/mistral/tt/mistral_feed_forward.py
+++ b/models/experimental/mistral/tt/mistral_feed_forward.py
@@ -19,8 +19,13 @@ class TtFeedForward(nn.Module):
     ):
         super().__init__()
         self.device = device
-        self.w1_weights = torch_to_tt_tensor_rm(
-            state_dict[f"{base_address}w1.weight"], self.device, put_on_device=False
+
+        w1_weights = state_dict[f"{base_address}w1.weight"]
+        self.w1_weights = tt_lib.tensor.Tensor(
+            w1_weights.unsqueeze(0).unsqueeze(0).reshape(-1).tolist(),
+            w1_weights.unsqueeze(0).unsqueeze(0).shape,
+            args.WEIGHTS_DTYPE,
+            tt_lib.tensor.Layout.ROW_MAJOR,
         )
         self.w1 = TtLinear(
             args.dim,
@@ -28,8 +33,13 @@ class TtFeedForward(nn.Module):
             self.w1_weights,
             device=self.device,
         )
-        self.w2_weights = torch_to_tt_tensor_rm(
-            state_dict[f"{base_address}w2.weight"], self.device, put_on_device=False
+
+        w2_weights = state_dict[f"{base_address}w2.weight"]
+        self.w2_weights = tt_lib.tensor.Tensor(
+            w2_weights.unsqueeze(0).unsqueeze(0).reshape(-1).tolist(),
+            w2_weights.unsqueeze(0).unsqueeze(0).shape,
+            args.WEIGHTS_DTYPE,
+            tt_lib.tensor.Layout.ROW_MAJOR,
         )
         self.w2 = TtLinear(
             args.hidden_dim,
@@ -37,8 +47,13 @@ class TtFeedForward(nn.Module):
             self.w2_weights,
             device=self.device,
         )
-        self.w3_weights = torch_to_tt_tensor_rm(
-            state_dict[f"{base_address}w3.weight"], self.device, put_on_device=False
+
+        w3_weights = state_dict[f"{base_address}w3.weight"]
+        self.w3_weights = tt_lib.tensor.Tensor(
+            w3_weights.unsqueeze(0).unsqueeze(0).reshape(-1).tolist(),
+            w3_weights.unsqueeze(0).unsqueeze(0).shape,
+            args.WEIGHTS_DTYPE,
+            tt_lib.tensor.Layout.ROW_MAJOR,
         )
         self.w3 = TtLinear(
             args.dim,

--- a/models/experimental/mistral/tt/mistral_rms_norm.py
+++ b/models/experimental/mistral/tt/mistral_rms_norm.py
@@ -18,7 +18,15 @@ class TtRMSNorm(nn.Module):
         super().__init__()
         self.eps = eps
         self.device = device
-        self.weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}weight"], self.device)
+        weight = state_dict[f"{base_address}weight"]
+
+        # converting to bfp8 reduces PCC
+        self.weight = tt_lib.tensor.Tensor(
+            weight.unsqueeze(0).unsqueeze(0).unsqueeze(0).reshape(-1).tolist(),
+            weight.unsqueeze(0).unsqueeze(0).unsqueeze(0).shape,
+            tt_lib.tensor.DataType.BFLOAT16,
+            tt_lib.tensor.Layout.ROW_MAJOR,
+        )
 
     def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
         return tt_lib.tensor.rmsnorm(x, self.eps, self.weight)

--- a/models/experimental/mistral/tt/mistral_transformer.py
+++ b/models/experimental/mistral/tt/mistral_transformer.py
@@ -49,7 +49,13 @@ class TtTransformer(nn.Module):
             ]
         )
         self.norm = TtRMSNorm(args.dim, base_address=f"norm.", state_dict=state_dict, device=device, eps=args.norm_eps)
-        self.output_weight = torch_to_tt_tensor_rm(state_dict["output.weight"], self.device)
+        output_weight = state_dict["output.weight"]
+        self.output_weight = tt_lib.tensor.Tensor(
+            output_weight.unsqueeze(0).unsqueeze(0).reshape(-1).tolist(),
+            output_weight.unsqueeze(0).unsqueeze(0).shape,
+            args.WEIGHTS_DTYPE,
+            tt_lib.tensor.Layout.ROW_MAJOR,
+        )
         self.output = TtLinear(
             args.dim,
             args.vocab_size,


### PR DESCRIPTION
This PR contains implementation of mistral model after changing weights dtype from BFLOAT16 to BFLOAT8_B