### PR TITLE
Mistral Deallocate

### DIFF
--- a/models/experimental/mistral/tt/mistral_attention.py
+++ b/models/experimental/mistral/tt/mistral_attention.py
@@ -265,13 +265,22 @@ def apply_rotary_emb_type2(
     freq_img = torch_to_tt_tensor_rm(freqs_cis.imag, device)
     freqs_cis = tt_lib.tensor.complex_tensor(freq_real, freq_img)
 
+    freq_real.deallocate()
+    freq_img.deallocate()
+
     xq_real = torch_to_tt_tensor_rm(t_xq[..., :, :, ::2], device)
     xq_img = torch_to_tt_tensor_rm(t_xq[..., :, :, 1::2], device)
     xq = tt_lib.tensor.complex_tensor(xq_real, xq_img)
 
+    xq_real.deallocate()
+    xq_img.deallocate()
+
     xk_real = torch_to_tt_tensor_rm(t_xk[..., :, :, ::2], device)
     xk_img = torch_to_tt_tensor_rm(t_xk[..., :, :, 1::2], device)
     xk = tt_lib.tensor.complex_tensor(xk_real, xk_img)
+
+    xk_real.deallocate()
+    xk_img.deallocate()
 
     BCH = tt_lib.tensor.BcastOpDim.H
     BCMUL = tt_lib.tensor.BcastOpMath.MUL
@@ -300,6 +309,8 @@ def apply_rotary_emb_type2(
     xk_out = tt_lib.tensor.concat([xk_out.real, xk_out.imag], -1)
     xq, xk = tt_to_torch_tensor(xq_out).to(torch.float32), tt_to_torch_tensor(xk_out).to(torch.float32)
 
+    xq_out.deallocate()
+    xk_out.deallocate()
     # FIXME: move this operation to on-device - should be easy.
     shapes = xq.shape
     dindex = shapes[3] // 2

--- a/models/experimental/mistral/tt/mistral_transformer.py
+++ b/models/experimental/mistral/tt/mistral_transformer.py
@@ -75,6 +75,7 @@ class TtTransformer(nn.Module):
             diagonal = 0
 
             mask = tt_lib.tensor.tril(tensor, diagonal)
+            tensor.deallocate()
             # make the mask banded to account for sliding window
             diagonal = -self.args.sliding_window
             mask = tt_lib.tensor.triu(mask, diagonal)

--- a/models/experimental/mistral/tt/mistral_transformer_block.py
+++ b/models/experimental/mistral/tt/mistral_transformer_block.py
@@ -46,6 +46,8 @@ class TtTransformerBlock(nn.Module):
     ) -> tt_lib.tensor.Tensor:
         r = self.attention.forward(self.attention_norm(x), freqs_cis, positions, mask)
         h = tt_lib.tensor.add(x, r)
+        x.deallocate()
         r = self.feed_forward.forward(self.ffn_norm(h))
         out = tt_lib.tensor.add(h, r)
+        h.deallocate()
         return out


### PR DESCRIPTION
@muthutt Added the deallocate for the mistral code. With these changes there is no compromise in PCC and the text output as well
```

                  Metal | INFO     | AI CLK for device 0 is:   1202 MHz
           BuildKernels | INFO     | Skip generating erisc binaries for grayskull
2023-11-14 12:32:46.702 | INFO     | models.experimental.mistral.demo.gs_demo:test_gs_demo_single_input_inference:48 - Input Prompt
2023-11-14 12:32:46.703 | INFO     | models.experimental.mistral.demo.gs_demo:test_gs_demo_single_input_inference:49 - ['A man is sitting on a roof ']
2023-11-14 12:32:46.703 | INFO     | models.experimental.mistral.demo.gs_demo:test_gs_demo_single_input_inference:50 - Mistral Model output
2023-11-14 12:32:46.703 | INFO     | models.experimental.mistral.demo.gs_demo:test_gs_demo_single_input_inference:51 - ['A man is sitting on a roof 100 feet above']
PASSED                  Metal | INFO     | Closing device 0
                     Op | INFO     | Program Cache: disabled and cleared.


========================================================================= PASSES =========================================================================
================================================================ short test summary info =================================================================
PASSED models/experimental/mistral/demo/gs_demo.py::test_gs_demo_single_input_inference[1]
============================================================= 1 passed in 1410.60s (0:23:30) =============================================================
                 Device | INFO     | Closing device driver
```