### PR TITLE
#0: add split by 2 on last dim 3 or the one before last dim 3

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_split_any_dim_two_chunks_tiled.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_split_any_dim_two_chunks_tiled.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+import sys
+from loguru import logger
+import random
+import numpy as np
+
+
+import tt_lib as ttl
+
+from models.utility_functions import (
+    comp_pcc,
+)
+import torch
+import sys
+import numpy
+import pytest
+import os
+
+
+@pytest.mark.parametrize(
+    "in_mem_config",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["in_DRAM", "in_L1"],
+)
+@pytest.mark.parametrize(
+    "out_mem_config",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dim", (2,))  # 0, 1 ),
+@pytest.mark.parametrize(
+    "refshape",
+    (
+        [1, 2, 64, 128],
+        [1, 2, 1024, 128],
+        [1, 2, 256, 2560],
+        [1, 2, 1024, 2560],
+        [1, 2, 256, 5120],
+        [1, 2, 64, 10240],
+    ),
+    ids=[
+        "1x2x64x64",
+        "1x2x64x128",
+        "1x2x256x2560",
+        "1x2x1024x2560",
+        "1x2x256x5120",
+        "1x2x64x10240",
+    ],
+)
+def test_split_tiled_w(dim, refshape, in_mem_config, out_mem_config, device, dtype=ttl.tensor.DataType.BFLOAT16):
+    profile_location = "splitTwoChunks/"
+    os.system(f"rm -rf {profile_location}")
+
+    ttl.profiler.set_profiler_location(profile_location)
+    _shape = refshape
+    assert _shape[0] == 1
+    num_splits = 2
+    torch.manual_seed(1234)
+
+    tile_size = 32
+    W = _shape[0]  # *(random.choice([1,2]))
+    Z = _shape[1]
+    Y = _shape[2]
+    X = _shape[3]
+
+    assert dim in [0, 1, 2, 3]
+
+    if dim == 0:
+        W, Y = Y, W
+    elif dim == 1:
+        Z, Y = Y, Z
+    elif dim in [2, 3]:
+        Y, X = X, Y
+
+    if Y % 32 != 0:
+        Y = 64
+
+    if dim == 3:
+        chunk_shape = [W, Z, Y, X // 2]
+    elif dim == 2:
+        chunk_shape = [W, Z, Y // 2, X]
+    elif dim == 1:
+        chunk_shape = [W, Z // 2, Y, X]
+    elif dim == 0:
+        chunk_shape = [W // 2, Z, Y, X]
+
+    a_shape = [W, Z, Y, X]
+    logger.info(f"Split tensor of size: {str(a_shape)}")
+
+    dtype_torch = torch.bfloat16
+
+    A = torch.arange(W * Z * Y * X, dtype=dtype_torch).reshape(a_shape)
+    assert list(A.size()) == a_shape
+
+    tiled = (a_shape[dim] % tile_size == 0) and (a_shape[3] % tile_size == 0)
+
+    if tiled:
+        a_t = (
+            ttl.tensor.Tensor(
+                A.flatten().tolist(),
+                a_shape,
+                dtype,
+                ttl.tensor.Layout.ROW_MAJOR,
+            )
+            .to(ttl.tensor.Layout.TILE)
+            .to(device, in_mem_config)
+        )
+    else:
+        assert False
+        a_t = ttl.tensor.Tensor(
+            A.flatten().tolist(),
+            a_shape,
+            dtype,
+            ttl.tensor.Layout.ROW_MAJOR,
+        ).to(device)
+
+    ttl.profiler.start_profiling("Run")
+    dev_buffers = ttl.tensor.split_dim_two_chunks_tiled(a_t, dim, out_mem_config)
+    ttl.profiler.stop_profiling("Run")
+
+    # Check memory of inputs and outputs
+    logger.debug(f"in0 is on: {a_t.memory_config().buffer_type}")
+
+    pyt_buff_list = []
+
+    assert len(dev_buffers) == num_splits
+    for index, buff in enumerate(dev_buffers):
+        logger.debug(f"buff{index} is on: {buff.memory_config().buffer_type}")
+        assert buff.shape() == chunk_shape
+        tt_host_rm_buff = buff.cpu().to(ttl.tensor.Layout.ROW_MAJOR)
+        pyt_got_back_rm_buff = tt_host_rm_buff.to_torch()
+        pyt_buff_list.append(pyt_got_back_rm_buff)
+
+    golden_buffers = torch.chunk(A, num_splits, dim=dim)
+    assert len(pyt_buff_list) == len(golden_buffers)
+
+    for index, pyt_buff in enumerate(pyt_buff_list):
+        golden_buff = golden_buffers[index]
+        passing_pcc, output_pcc = comp_pcc(pyt_buff, golden_buff, 1.0)
+        logger.info(f"Out passing={passing_pcc}")
+        logger.info(f"Output pcc={output_pcc}")
+        assert passing_pcc

--- a/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.cpp
+++ b/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.cpp
@@ -3,20 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.hpp"
-#include "tt_dnn/op_library/work_split.hpp"
-#include "tt_dnn/op_library/auto_format.hpp"
-#include "tt_dnn/op_library/reshape/reshape_op.hpp"
-
-#include "common/constants.hpp"
-#include "tt_metal/host_api.hpp"
-#include "tt_metal/detail/util.hpp"
 
 #include <iostream>
 
+#include "common/constants.hpp"
+#include "tt_dnn/op_library/auto_format.hpp"
+#include "tt_dnn/op_library/reshape/reshape_op.hpp"
+#include "tt_dnn/op_library/transpose/transpose_op.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
 using namespace tt::constants;
 using namespace tt::tt_metal;
-
-
 
 namespace tt {
 
@@ -40,53 +39,51 @@ void setup_runtime(
     uint32_t start_core_x = 0;
     uint32_t start_core_y = 0;
 
-    if(num_cores_c > 1){
-        TT_ASSERT(num_cores_c %2 == 0, "Must be even number of cores");
+    if (num_cores_c > 1) {
+        TT_ASSERT(num_cores_c % 2 == 0, "Must be even number of cores");
     }
     uint32_t idc_outer_limit = 1;
     uint32_t idc_inner_limit = num_cores_c;
 
-
     for (int id_r_outer = 0; id_r_outer < z; id_r_outer++) {
-        for(int id_r_inner = 0; id_r_inner < num_cores_x; id_r_inner++){
-            uint32_t id_r = id_r_outer*num_cores_x + id_r_inner;
+        for (int id_r_inner = 0; id_r_inner < num_cores_x; id_r_inner++) {
+            uint32_t id_r = id_r_outer * num_cores_x + id_r_inner;
 
-            uint32_t id_r_reader = id_r_outer*num_tiles_per_z + id_r_inner*per_core_tiles_y*num_cores_c*per_core_tiles_x;
-            uint32_t id_r_writer = id_r_reader/2;
-            if(num_cores_c > 1){
+            uint32_t id_r_reader =
+                id_r_outer * num_tiles_per_z + id_r_inner * per_core_tiles_y * num_cores_c * per_core_tiles_x;
+            uint32_t id_r_writer = id_r_reader / 2;
+            if (num_cores_c > 1) {
                 idc_outer_limit = 2;
-                idc_inner_limit = num_cores_c/2;
+                idc_inner_limit = num_cores_c / 2;
             }
-            for(int id_c_outer = 0; id_c_outer < idc_outer_limit; id_c_outer++){
+            for (int id_c_outer = 0; id_c_outer < idc_outer_limit; id_c_outer++) {
                 for (int id_c_inner = 0; id_c_inner < idc_inner_limit; id_c_inner++) {
-                    uint32_t id_c = id_c_outer*idc_inner_limit + id_c_inner;
+                    uint32_t id_c = id_c_outer * idc_inner_limit + id_c_inner;
                     CoreCoord core = {(std::size_t)start_core_x + id_r, (std::size_t)start_core_y + id_c};
 
-                    uint32_t reader_core_id = id_c*per_core_tiles_y;
+                    uint32_t reader_core_id = id_c * per_core_tiles_y;
                     reader_core_id += id_r_reader;
-
 
                     std::vector<uint32_t> reader_runtime_args = {
                         (std::uint32_t)reader_core_id,
                         (std::uint32_t)(in0_buffer->address()),  // in0_tensor_addr
-                        (std::uint32_t) 0 //split on last dim
+                        (std::uint32_t)0                         // split on last dim
                     };
                     bool out0_only = false;
                     bool out1_only = false;
-                    if(num_cores_c > 1){
+                    if (num_cores_c > 1) {
                         out0_only = (id_c_outer == 0);
                         out1_only = (id_c_outer == 1);
                     }
 
-                    uint32_t writer_core_id = id_c_inner*per_core_tiles_y + (id_r_writer);
+                    uint32_t writer_core_id = id_c_inner * per_core_tiles_y + (id_r_writer);
 
                     std::vector<uint32_t> writer_runtime_args = {
                         writer_core_id,
                         (std::uint32_t)out0_buffer->address(),  // first base addr
                         (std::uint32_t)out1_buffer->address(),  // second base addr
-                        (std::uint32_t) out0_only,
-                        (std::uint32_t) out1_only
-                    };
+                        (std::uint32_t)out0_only,
+                        (std::uint32_t)out1_only};
                     tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
                     tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
                 }
@@ -145,8 +142,8 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
         get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_dim_3, num_cores_y_limit, /*request_even=*/true);
 
     // parallelize x
-    auto [num_cores_x, per_core_tiles_x] = get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_dim_2,
-                                                                                        num_cores_x_limit/ num_cores_z);
+    auto [num_cores_x, per_core_tiles_x] =
+        get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_dim_2, num_cores_x_limit / num_cores_z);
 
     uint32_t per_core_tiles = per_core_tiles_x * per_core_tiles_y * (z / num_cores_z);
 
@@ -170,32 +167,30 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
     uint32_t z_stride_read = num_tiles_per_z;
     uint32_t y_stride_read = per_core_tiles_y * num_cores_y;
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        // interleaved accessor args
-        (std::uint32_t)tile_dtype_is_bfloat16,
-        // by default in dram
-        (std::uint32_t)in0_is_dram,
+    std::vector<uint32_t> reader_compile_time_args = {// interleaved accessor args
+                                                      (std::uint32_t)tile_dtype_is_bfloat16,
+                                                      // by default in dram
+                                                      (std::uint32_t)in0_is_dram,
 
-        // READER COMPILE TIME ARGS
-        (std::uint32_t)(z / num_cores_z),
-        (std::uint32_t) per_core_tiles_x,  // out_num_tiles_per_tensor
-        (std::uint32_t) per_core_tiles_y,  // out_num_tiles_per_tensor
-        (std::uint32_t)z_stride_read,
-        (std::uint32_t)y_stride_read};
+                                                      // READER COMPILE TIME ARGS
+                                                      (std::uint32_t)(z / num_cores_z),
+                                                      (std::uint32_t)per_core_tiles_x,  // out_num_tiles_per_tensor
+                                                      (std::uint32_t)per_core_tiles_y,  // out_num_tiles_per_tensor
+                                                      (std::uint32_t)z_stride_read,
+                                                      (std::uint32_t)y_stride_read};
 
     uint32_t z_stride_write = num_tiles_per_z / num_chunks;
-    uint32_t y_stride_write = per_core_tiles_y * (num_cores_c/num_chunks);
-    std::vector<uint32_t> writer_compile_time_args = {
-        // interleaved accessor args
-        (std::uint32_t)tile_dtype_is_bfloat16,
-        (std::uint32_t)out_is_dram,
+    uint32_t y_stride_write = per_core_tiles_y * (num_cores_c / num_chunks);
+    std::vector<uint32_t> writer_compile_time_args = {// interleaved accessor args
+                                                      (std::uint32_t)tile_dtype_is_bfloat16,
+                                                      (std::uint32_t)out_is_dram,
 
-        (std::uint32_t) per_core_tiles_x,  // out_num_tiles_per_tensor
-        (std::uint32_t) per_core_tiles_y,  // out_num_tiles_per_tensor
+                                                      (std::uint32_t)per_core_tiles_x,  // out_num_tiles_per_tensor
+                                                      (std::uint32_t)per_core_tiles_y,  // out_num_tiles_per_tensor
 
-        (std::uint32_t)(z / num_cores_z),
-        (std::uint32_t)z_stride_write,
-        (std::uint32_t)y_stride_write
+                                                      (std::uint32_t)(z / num_cores_z),
+                                                      (std::uint32_t)z_stride_write,
+                                                      (std::uint32_t)y_stride_write
 
     };
 
@@ -203,13 +198,19 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
         program,
         "tt_eager/tt_dnn/kernels/dataflow/reader_tm_tile_layout_split_two_chunks.cpp",
         all_cores,
-        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default, .compile_args = reader_compile_time_args});
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt_metal::NOC::RISCV_1_default,
+            .compile_args = reader_compile_time_args});
 
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
         "tt_eager/tt_dnn/kernels/dataflow/writer_tm_tile_layout_split_two_chunks.cpp",
         all_cores,
-        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default, .compile_args = writer_compile_time_args});
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = writer_compile_time_args});
 
     // Dummy compute kernel
     std::vector<uint32_t> compute_args = {0};  // dummy
@@ -219,12 +220,17 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
         program,
         "tt_metal/kernels/compute/blank.cpp",
         all_cores,
-        tt_metal::ComputeConfig{.math_fidelity = MathFidelity::HiFi4, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode, .compile_args = compute_args});
+        tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_args});
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;
-    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-		.set_page_size(src0_cb_index, single_tile_size);
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, single_tile_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     setup_runtime(
@@ -245,7 +251,9 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
 
     auto override_runtime_args_callback =
         [reader_kernel_id, writer_kernel_id, num_cores_r, num_cores_c, start_core_x, start_core_y](
-            const Program &program, const std::vector<Buffer *> &input_buffers, const std::vector<Buffer *> &output_buffers) {
+            const Program &program,
+            const std::vector<Buffer *> &input_buffers,
+            const std::vector<Buffer *> &output_buffers) {
             auto src_dram_buffer = input_buffers.at(0);
 
             auto dst_0_dram_buffer = output_buffers.at(0);
@@ -283,25 +291,24 @@ operation::ProgramWithCallbacks SplitLastDimTwoChunksTiled::create_program(
 std::vector<Tensor> impl_split_last_dim_two_chunks_tiled(const Tensor &input_tensor, const MemoryConfig &mem_config);
 
 std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor &input_tensor, const MemoryConfig &mem_config) {
-  const auto shape = input_tensor.shape();
-  const bool pre_post_reshape = shape[0] > 1;
+    const auto shape = input_tensor.shape();
+    const bool pre_post_reshape = shape[0] > 1;
 
-  if ( !pre_post_reshape ) {
-     return impl_split_last_dim_two_chunks_tiled( input_tensor, mem_config );
-  }
+    if (!pre_post_reshape) {
+        return impl_split_last_dim_two_chunks_tiled(input_tensor, mem_config);
+    }
 
-  const int W = 1, Z = shape[0]*shape[1], Y = shape[2], X = shape[3];
-  const Tensor& reshaped_tensor = reshape(input_tensor, 1, -1, Y, X,mem_config);
+    const int W = 1, Z = shape[0] * shape[1], Y = shape[2], X = shape[3];
+    const Tensor &reshaped_tensor = reshape(input_tensor, 1, -1, Y, X, mem_config);
 
-  auto part_reshaped = impl_split_last_dim_two_chunks_tiled( reshaped_tensor, mem_config );
+    auto part_reshaped = impl_split_last_dim_two_chunks_tiled(reshaped_tensor, mem_config);
 
-  std::vector<Tensor> results;
-  for(auto& part : part_reshaped) {
-    results.push_back( reshape( part, -1, shape[1], Y, X/2, mem_config ) );
-  }
-  return results;
+    std::vector<Tensor> results;
+    results.reserve(part_reshaped.size());
+    for (auto &part : part_reshaped) results.emplace_back(reshape(part, -1, shape[1], Y, X / 2, mem_config));
+
+    return results;
 }
-
 
 std::vector<Tensor> impl_split_last_dim_two_chunks_tiled(const Tensor &input_tensor, const MemoryConfig &mem_config) {
     SplitLastDimTwoChunksTiled op(mem_config);
@@ -325,13 +332,30 @@ std::vector<Tensor> impl_split_last_dim_two_chunks_tiled(const Tensor &input_ten
     } else {
         auto device = input_tensor.device();
         auto output_shape = op.compute_output_shapes({input_tensor}).at(0);
-        const auto padded_tensor = AutoFormat::format_input_tensor(input_tensor, device, padded_input_shape, 0.0, Layout::TILE);
+        const auto padded_tensor =
+            AutoFormat::format_input_tensor(input_tensor, device, padded_input_shape, 0.0, Layout::TILE);
         auto output_tensors = operation::run(op, {padded_tensor});
         for (auto &output_tensor : output_tensors) {
             output_tensor = AutoFormat::format_output_tensor(output_tensor, output_shape, device, Layout::TILE);
         }
         return output_tensors;
     }
+}
+
+std::vector<Tensor> split_dim_two_chunks_tiled(
+    const Tensor &input_tensor, uint dim /* = 3 */, const MemoryConfig &mem_config /* = default */) {
+    TT_ASSERT(dim == 3 || dim == 2, "split is possible along dim 2 or 3 only");
+    if (dim == 3) {
+        return split_last_dim_two_chunks_tiled(input_tensor, mem_config);
+    }
+    Tensor ref_input_tensor = transpose(input_tensor, dim, 3, mem_config);
+    auto transposed_result = split_last_dim_two_chunks_tiled(ref_input_tensor, mem_config);
+    std::vector<Tensor> results;
+    results.reserve(transposed_result.size());
+    for (Tensor &t : transposed_result) {
+        results.emplace_back(transpose(t, dim, 3, mem_config));
+    }
+    return results;
 }
 
 }  // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.hpp
+++ b/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.hpp
@@ -17,13 +17,16 @@ namespace tt_metal {
 struct SplitLastDimTwoChunksTiled : public SplitTiled {
     // setting dim = 3 (last dim)
     // num_chunks = 2
-    SplitLastDimTwoChunksTiled(const MemoryConfig& mem_config) : SplitTiled{3, 2, mem_config} { ; }
+    SplitLastDimTwoChunksTiled(const MemoryConfig &mem_config) : SplitTiled{3, 2, mem_config} { ; }
     operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor> &input_tensors,
-        std::vector<Tensor> &output_tensors) const;
+        const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
 };
 
-std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor &a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<Tensor> split_last_dim_two_chunks_tiled(
+    const Tensor &a, const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> split_dim_two_chunks_tiled(
+    const Tensor &a, uint dim = 3, const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 }  // namespace tt_metal
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -444,6 +444,18 @@ void TensorModule(py::module &m_tensor) {
             "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
 
     )doc");
+
+    m_tensor.def("split_dim_two_chunks_tiled", &split_dim_two_chunks_tiled, py::arg("input").noconvert(), py::arg("dim").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+        Splits a tensor's last or penultimate dimension in two equal sized chunks. This assumes the last dim is tile sized and penultimate dimension is also tile sized.
+
+        .. csv-table::
+            :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+            "input", "Input tensor", "Tensor", "Tensor of shape [W0, Z0, Y0, X0]", "Yes"
+            "dim", "Dimension", "integer", "Dimension to split over can only be 2 or 3", "Yes"
+            "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+    )doc");
+
     m_tensor.def("convert_conv_weight_tensor_to_tiled_layout", &convert_conv_weight_tensor_to_tiled_layout,
         py::arg("conv_weight_tensor").noconvert(), py::arg("in1_block_h"), py::arg("in1_block_w"), py::arg("output_dtype").noconvert() = std::nullopt, R"doc(
         Converts convolution weights to 2d matrix tiled layout on host


### PR DESCRIPTION
#0: add split along any specified dim
  - add support for split along dim=2 Y in (i.e. W, Z, Y, X)
  - this enables split along dim Y, in addition to previously exisiting along X.