### PR TITLE
new SetRuntimeArgs API for updating a set of args with 1 call

### DIFF
--- a/docs/source/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -3,6 +3,8 @@ Runtime Arguments
 
 .. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelID kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &logical_core, const std::vector<uint32_t> &runtime_args)
 
+.. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelID kernel, const std::vector< CoreCoord > & core_spec, const std::vector< std::vector<uint32_t> > &runtime_args)
+
 .. doxygenfunction:: GetRuntimeArgs
 
 .. doxygenfunction:: UpdateRuntimeArg

--- a/tt_eager/tt_dnn/op_library/work_split.hpp
+++ b/tt_eager/tt_dnn/op_library/work_split.hpp
@@ -155,6 +155,7 @@ inline std::set<CoreRange> num_cores_to_corerange_set(uint32_t target_num_cores,
 // If it can be evenly divided, the second CoreRangeSet is the same as the first, and the last is empty
 // The last 2 args are the units of work for the two core grids
 inline std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(CoreCoord grid_size, uint32_t units_to_divide, bool row_wise = false) {
+    ZoneScoped;
 	uint32_t num_cores_x = grid_size.x, num_cores_y = grid_size.y;
 	auto target_num_cores = std::min(units_to_divide, num_cores_x * num_cores_y);
 	CoreRangeSet all_cores(num_cores_to_corerange_set(target_num_cores, grid_size, row_wise));
@@ -233,6 +234,7 @@ inline std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, 
 }
 
 inline std::vector<CoreCoord> grid_to_cores(uint32_t num_cores, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise=false) {
+    ZoneScoped;
     std::vector<CoreCoord> cores;
     cores.reserve(num_cores);
     TT_ASSERT(num_cores <= grid_size_x * grid_size_y);

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -216,6 +216,20 @@ void DeallocateBuffer(Buffer &buffer);
  */
 void SetRuntimeArgs(const Program &program, KernelID kernel, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::vector<uint32_t> &runtime_args);
 
+/**
+ * Set multiple runtime arguments of a kernel at once during runtime, each mapping to a specific core. The runtime args for each core may be unique.
+ *
+ * Return value: void
+ *
+ * | Argument     | Description                                                            | Type                                                   | Valid Range                                                                | Required |
+ * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|----------------------------------------------------------------------------|----------|
+ * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                            | Yes      |
+ * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelID (uint64_t)                                    |                                                                            | Yes      |
+ * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::vector<CoreCoord> &                         | Any set of logical Tensix core coordinates on which the kernel is placed   | Yes      |
+ * | runtime_args | The runtime args to be written                                         | const std::vector< vector<uint32_t> > &                | outer vector size must be equal to size of core_spec vector                | Yes      |
+ */
+void SetRuntimeArgs(const Program &program, KernelID kernel, const std::vector< CoreCoord > & core_spec, const std::vector< std::vector<uint32_t> > &runtime_args);
+
 
 /**
  * Update a single runtime arg of a kernel, yielding performance benefits in certain situations. This API can only be called after SetRuntimeArgs has been called on a kernel.

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -475,8 +475,17 @@ void SetRuntimeArgs(const Program &program, KernelID kernel_id, const std::varia
         },
         core_spec
     );
-
 }
+
+void SetRuntimeArgs(const Program &program, KernelID kernel, const std::vector< CoreCoord > & core_spec, const std::vector< std::vector<uint32_t> > &runtime_args)
+{
+    ZoneScoped;
+    TT_FATAL( core_spec.size() == runtime_args.size(), "Mistmatch between number of cores {} and number of runtime args {} getting updated", core_spec.size(), runtime_args.size());
+    Kernel * k = detail::GetKernel(program, kernel);
+    for (size_t i = 0; i < core_spec.size(); i++)
+        k->set_runtime_args(core_spec[i], runtime_args[i]);
+}
+
 
 void UpdateRuntimeArg(const Program &program, KernelID kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &core_spec, size_t offset, uint32_t value) {
     ZoneScoped;


### PR DESCRIPTION
This API is used to optimize for situations where a large set of Cores need their runtime args updated at once. Eltwise binary OP ran faster with this new API.

Before (1st OP)

![eltwise_binary_1_before](https://github.com/tenstorrent-metal/tt-metal/assets/135061747/5ab685c6-b5f7-426e-b989-3cbe82083480)

After (1st OP)

![eltwise_binary_1_after](https://github.com/tenstorrent-metal/tt-metal/assets/135061747/d81eceb9-85da-4df1-a1f4-576be3f33467)

Before (2nd OP)

![eltwise_binary_2_before](https://github.com/tenstorrent-metal/tt-metal/assets/135061747/a56cd766-a03d-4705-ad07-99a6f6f83cb9)

After (2nd OP)

![eltwise_binary_2_after](https://github.com/tenstorrent-metal/tt-metal/assets/135061747/b6a26118-f0b5-4f2c-97b8-2ac2e14cd8e1)

