### PR TITLE
#0: Fix scatter op

### DIFF
--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -12,7 +12,7 @@
 #include "tt_numpy/functions.hpp"
 #include "tt_eager/tensor/tensor_utils.hpp"
 #include "tt_dnn/op_library/math.hpp"
-#include "tt_dnn/op_library/copy/copy_op.hpp"
+#include "tt_eager/tt_dnn/op_library/pad/pad_op.hpp"
 
 namespace tt {
 
@@ -951,10 +951,10 @@ Tensor hypot(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& o
 }
 
 Tensor _scatter(const Tensor &input_a, const Tensor &input_b, const MemoryConfig& output_mem_config) {
-    Tensor temp = assign(input_b, output_mem_config);
-    Tensor pre = assign(input_a,temp, output_mem_config);
-    Tensor result = where(eqz(temp, output_mem_config), input_b, temp, output_mem_config);
-    return result;
+    const Shape start_index = {0, 0, 0, 0};
+    Tensor index = pad( ones_like(input_a , output_mem_config), input_b.shape(), start_index, 0);
+    Tensor temp_a = pad( input_a, input_b.shape(), start_index, 0);
+    return where(index, temp_a, input_b, output_mem_config);
 }
 Tensor scatter(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config)
 {

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -762,7 +762,7 @@ namespace tt::tt_metal::detail{
         detail::bind_binary_op<false, true, false>(m_tensor, "max", &tt::tt_metal::max, R"doc(Perform an eltwise-binary max on two tensors.)doc");
         detail::bind_binary_op<false, true, false>(m_tensor, "min", &tt::tt_metal::min, R"doc(Perform an eltwise-binary min on two tensors.)doc");
         detail::bind_binary_op<false, true, false>(m_tensor, "hypot", &hypot, R"doc(Returns tensor with the hypot activation on elements of the input tensors ``{0}`` and ``{1}``.)doc");
-        detail::bind_binary_op<false, true, false>(m_tensor, "scatter", &tt::tt_metal::scatter, R"doc(Returns tensor with the scatter op on elements of the input tensors ``{0}`` and ``{1}``.)doc");
+        detail::bind_binary_op<false, true, false>(m_tensor, "scatter", &tt::tt_metal::scatter, R"doc(Performs scatter operation on elements of the input tensors ``{0}`` and ``{1}``,specifically to copy channel data.)doc");
         detail::bind_binary_op<false, true, false>(m_tensor, "xlogy", &xlogy, R"doc(Performs eltwise-binary xlogy (``{0} * log( {1} )``) on two tensors.)doc");
         detail::bind_binary_op<false, true, false>(m_tensor, "atan2", &atan2, R"doc(Returns tensor with the atan2 activation on elements of the input tensors ``{0}`` and ``{1}``.)doc");
         detail::bind_binary_op<false, true, false>(m_tensor, "nextafter", &nextafter, R"doc(Returns the next floating-point value after input towards other of the input tensors ``{0}`` and ``{1}``.)doc");


### PR DESCRIPTION
The implemented scatter operation from [PR](https://github.com/tenstorrent-metal/tt-metal/pull/3787) does not work as expected if the src tensor has 0 in it

This change will fix the issue