### PR TITLE
#308: Add a new test for coverage of previous issue with dprinting float consts from ncrisc

### DIFF
--- a/docs/source/tools/kernel_print.rst
+++ b/docs/source/tools/kernel_print.rst
@@ -44,7 +44,7 @@ To display the kernel debug prints on the host:
 
 .. code-block::
 
-    export TT_METAL_DPRINT_CORES=1,1     # required, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2)
+    export TT_METAL_DPRINT_CORES=1,1     # required, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all
     export TT_METAL_DPRINT_CHIPS=0       # optional, comma separated list of chip
     export TT_METAL_DPRINT_RISCVS=BR     # optional, default is all RISCs.  Use a subset of BR,NC,TR0,TR1,TR2
     export TT_METAL_DPRINT_FILE=log.txt  # optional, default is to print to the screen

--- a/tests/tt_metal/tt_metal/test_kernels/misc/dprint_raise_wait_brisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/dprint_raise_wait_brisc.cpp
@@ -1,0 +1,31 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/dprint.h"
+
+/*
+ * A test for the WAIT and RAISE DPrint features.
+*/
+
+void kernel_main() {
+    uint32_t x               = get_arg_val<uint32_t>(0);
+    uint32_t y               = get_arg_val<uint32_t>(1);
+    uint32_t multicore       = get_arg_val<uint32_t>(2);
+    uint32_t num_chars       = get_arg_val<uint32_t>(3);
+
+    // Wait for this core's ncrisc to raise a signal before printing to ensure ordering.
+    DPRINT << WAIT{x*5 + y*1000};
+    // Do some test printing
+    DPRINT << "TestStr";
+    DPRINT << 'B' << 'R' << '{' << x << ',' << y << '}' << ENDL();
+    for (uint32_t num = 0; num < num_chars; num++)
+        DPRINT << '+';
+    DPRINT << ENDL();
+
+    // Raise the signal for the next core's ncrisc to start printing.
+    if (multicore)
+        DPRINT << RAISE{x + y*20 + 20000};
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/dprint_raise_wait_ncrisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/dprint_raise_wait_ncrisc.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/dprint.h"
+
+/*
+ * A test for the WAIT and RAISE DPrint features.
+*/
+
+void kernel_main() {
+    uint32_t x               = get_arg_val<uint32_t>(0);
+    uint32_t y               = get_arg_val<uint32_t>(1);
+    uint32_t num_cols        = get_arg_val<uint32_t>(2);
+    uint32_t multicore       = get_arg_val<uint32_t>(3);
+    uint32_t test_width      = get_arg_val<uint32_t>(4);
+    uint32_t test_width_num  = get_arg_val<uint32_t>(5);
+    uint32_t num_chars       = get_arg_val<uint32_t>(6);
+
+    // Wait for the dprint raise from the brisc on the preceeding core, but not
+    // for core {0, 0}.
+    if (multicore > 0 && x + y != 0) {
+        uint32_t wait_x = x - 1;
+        uint32_t wait_y = y;
+        if (x == 0) {
+            // Account for wrapping
+            wait_x = num_cols - 1;
+            wait_y = y - 1;
+        }
+        // Now wait on previous core's brisc to raise a signal
+        DPRINT << WAIT{wait_x + wait_y * 20 + 20000};
+    }
+
+    // Do some test printing
+    // Use a string of size 17 here (non-multiple of 4) due to previous bug
+    // with .rodata alignment for non-multiple of 4 strings.
+    DPRINT << "TestConstCharStr";
+    DPRINT << 'N' << 'C' << '{' << x << ',' << y << '}' << ENDL();
+    DPRINT << SETW(test_width, false) << test_width_num << ENDL();
+    DPRINT << SETP(4) << 0.123456f << ENDL();
+    DPRINT << FIXP() << F32(0.12f) << ENDL();
+    DPRINT << BF16(0x3dfb) << ENDL(); // 0.12255859375
+    for (uint32_t num = 0; num < num_chars; num++)
+        DPRINT << '-';
+    DPRINT << ENDL();
+
+    // Raise the signal for this core's brisc to start printing.
+    DPRINT << RAISE{x*5 + y*1000};
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -46,7 +46,7 @@ protected:
         // The core range (physical) needs to be set >= the set of all cores
         // used by all tests using this fixture. TODO: update with a way to
         // just set all physical cores to have printing enabled.
-        tt::llrt::OptionsG.set_dprint_core_range({1, 1}, {5, 5});
+        tt::llrt::OptionsG.set_dprint_all_cores(true);
         // Send output to a file so the test can check after program is run.
         tt::llrt::OptionsG.set_dprint_file_name(dprint_file_name);
 
@@ -79,6 +79,7 @@ protected:
 
         // Reset DPrint settings
         tt::llrt::OptionsG.set_dprint_cores({});
+        tt::llrt::OptionsG.set_dprint_all_cores(false);
         tt::llrt::OptionsG.set_dprint_file_name("");
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -43,9 +43,11 @@ public:
     inline static const string dprint_file_name = "gtest_dprint_log.txt";
 protected:
     void SetUp() override {
-        // Set DPrint options: For now print from the first core only, and send
-        // output to a file to the test can check after the program is run.
-        tt::llrt::OptionsG.set_dprint_core_range({{1, 1}});
+        // The core range (physical) needs to be set >= the set of all cores
+        // used by all tests using this fixture. TODO: update with a way to
+        // just set all physical cores to have printing enabled.
+        tt::llrt::OptionsG.set_dprint_core_range({1, 1}, {5, 5});
+        // Send output to a file so the test can check after program is run.
         tt::llrt::OptionsG.set_dprint_file_name(dprint_file_name);
 
         // DPrint currently not supported for N300, so skip these tests for
@@ -76,7 +78,7 @@ protected:
         }
 
         // Reset DPrint settings
-        tt::llrt::OptionsG.set_dprint_core_range({});
+        tt::llrt::OptionsG.set_dprint_cores({});
         tt::llrt::OptionsG.set_dprint_file_name("");
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_raise_wait.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "command_queue_fixture.hpp"
+#include "gtest/gtest.h"
+#include "test_utils.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+// A test for DPrint RAISE/WAIT between cores and riscs.
+////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+TEST_F(CommandQueueWithDPrintFixture, TestPrintRaiseWait) {
+    // This test is a fast dispatch test.
+    if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
+        TT_THROW("Test not supported w/ slow dispatch, exiting");
+    }
+try{
+    // Device already set up by gtest fixture.
+    Device *device = this->device_;
+
+    // Set up program and command queue
+    CommandQueue& cq = *tt::tt_metal::detail::GLOBAL_CQ;
+    Program program = Program();
+
+    // Test runs on a 5x5 grid
+    CoreCoord xy_start = {0, 0};
+    CoreCoord xy_end = {4, 4};
+
+    // Two kernels - one for brisc and one for ncrisc. Nothing for triscs in
+    // this test.
+    KernelID brisc_kernel_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/dprint_raise_wait_brisc.cpp",
+        CoreRange{
+            .start = xy_start,
+            .end = xy_end
+        },
+        DataMovementConfig {
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default
+        }
+    );
+    KernelID ncrisc_kernel_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/dprint_raise_wait_ncrisc.cpp",
+        CoreRange{
+            .start = xy_start,
+            .end = xy_end
+        },
+        DataMovementConfig {
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default
+        }
+    );
+
+    // Write runtime args
+    uint32_t multi_core = 1;
+    for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
+        for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
+            const std::vector<uint32_t> brisc_rt_args = {
+                x, y, multi_core, 15
+            };
+            SetRuntimeArgs(
+                program,
+                brisc_kernel_id,
+                CoreCoord{x, y},
+                brisc_rt_args
+            );
+            const std::vector<uint32_t> ncrisc_rt_args = {
+                x, y, (uint32_t) xy_end.x+1, multi_core, 4, 2, 10
+            };
+            SetRuntimeArgs(
+                program,
+                ncrisc_kernel_id,
+                CoreCoord{x, y},
+                ncrisc_rt_args
+            );
+        }
+    }
+
+
+    // Run the program
+    EnqueueProgram(cq, program, false);
+    Finish(cq);
+
+    // Since the program takes almost no time to run, wait a bit for the print
+    // server to catch up.
+    std::this_thread::sleep_for (std::chrono::seconds(1));
+
+    // Check the print log against golden output.
+    EXPECT_TRUE(
+        FilesAreIdentical(
+            CommandQueueWithDPrintFixture::dprint_file_name,
+            "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_raise_wait_golden.txt"
+        )
+    );
+} catch (std::exception& e) {
+    TT_THROW("Exception: {}", e.what());
+}
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_raise_wait_golden.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_raise_wait_golden.txt
@@ -1,0 +1,200 @@
+TestConstCharStrNC{0,0}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{0,0}
++++++++++++++++
+TestConstCharStrNC{1,0}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{1,0}
++++++++++++++++
+TestConstCharStrNC{2,0}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{2,0}
++++++++++++++++
+TestConstCharStrNC{3,0}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{3,0}
++++++++++++++++
+TestConstCharStrNC{4,0}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{4,0}
++++++++++++++++
+TestConstCharStrNC{0,1}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{0,1}
++++++++++++++++
+TestConstCharStrNC{1,1}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{1,1}
++++++++++++++++
+TestConstCharStrNC{2,1}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{2,1}
++++++++++++++++
+TestConstCharStrNC{3,1}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{3,1}
++++++++++++++++
+TestConstCharStrNC{4,1}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{4,1}
++++++++++++++++
+TestConstCharStrNC{0,2}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{0,2}
++++++++++++++++
+TestConstCharStrNC{1,2}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{1,2}
++++++++++++++++
+TestConstCharStrNC{2,2}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{2,2}
++++++++++++++++
+TestConstCharStrNC{3,2}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{3,2}
++++++++++++++++
+TestConstCharStrNC{4,2}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{4,2}
++++++++++++++++
+TestConstCharStrNC{0,3}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{0,3}
++++++++++++++++
+TestConstCharStrNC{1,3}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{1,3}
++++++++++++++++
+TestConstCharStrNC{2,3}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{2,3}
++++++++++++++++
+TestConstCharStrNC{3,3}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{3,3}
++++++++++++++++
+TestConstCharStrNC{4,3}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{4,3}
++++++++++++++++
+TestConstCharStrNC{0,4}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{0,4}
++++++++++++++++
+TestConstCharStrNC{1,4}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{1,4}
++++++++++++++++
+TestConstCharStrNC{2,4}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{2,4}
++++++++++++++++
+TestConstCharStrNC{3,4}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{3,4}
++++++++++++++++
+TestConstCharStrNC{4,4}
+   2
+0.1235
+0.1200
+0.1226
+----------
+TestStrBR{4,4}
++++++++++++++++

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -251,7 +251,10 @@ bool Device::initialize(const std::vector<uint32_t>& l1_bank_remap) {
         this->initialize_build();
     }
 
-    tt_start_debug_print_server();
+    tt_start_debug_print_server(
+        [&, this]() { return this->logical_grid_size(); },
+        [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); }
+    );
     llrt::watcher_init(this->id(),
                        [&, this]() { return this->logical_grid_size(); },
                        [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -97,7 +97,7 @@ void RunTimeOptions::ParseDPrintCoreRange(const char* env_var) {
     }
 
     // Set the core range, whether or not dprint is enabled depends on whether this is empty.
-    dprint_core_range = cores;
+    dprint_cores = cores;
 }
 
 void RunTimeOptions::ParseDPrintChipIds(const char* env_var) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -54,6 +54,12 @@ void RunTimeOptions::ParseDPrintEnv() {
 void RunTimeOptions::ParseDPrintCoreRange(const char* env_var) {
     char *str = std::getenv(env_var);
     vector<CoreCoord> cores;
+
+    // Check if "all" is specified, rather than a range of cores.
+    if (str == "all") {
+        dprint_all_cores = true;
+        return;
+    }
     if (str != nullptr) {
         if (isdigit(str[0])) {
             // Assume this is a single core

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -24,7 +24,7 @@ class RunTimeOptions {
     int watcher_interval_ms;
     bool watcher_dump_all;
 
-    std::vector<CoreCoord> dprint_core_range;
+    std::vector<CoreCoord> dprint_cores;
     std::vector<int> dprint_chip_ids;
     uint32_t dprint_riscv_mask;
     std::string dprint_file_name;
@@ -38,12 +38,22 @@ public:
 
     // Info from DPrint environment variables, setters included so that user can
     // override with a SW call.
-    inline bool get_dprint_enabled() { return dprint_core_range.size() != 0; }
-    inline std::vector<CoreCoord>& get_dprint_core_range() {
-        return dprint_core_range;
+    inline bool get_dprint_enabled() { return dprint_cores.size() != 0; }
+    // Note: dprint cores are physical
+    inline std::vector<CoreCoord>& get_dprint_cores() {
+        return dprint_cores;
     }
-    inline void set_dprint_core_range(std::vector<CoreCoord> core_range) {
-        dprint_core_range = core_range;
+    inline void set_dprint_cores(std::vector<CoreCoord> cores) {
+        dprint_cores = cores;
+    }
+    // Note: core range is inclusive
+    inline void set_dprint_core_range(CoreCoord start, CoreCoord end) {
+        dprint_cores.clear();
+        for (uint32_t x = start.x; x <= end.x; x++) {
+            for (uint32_t y = start.y; y <= end.y; y++) {
+                dprint_cores.push_back({x, y});
+            }
+        }
     }
     inline std::vector<int>& get_dprint_chip_ids() { return dprint_chip_ids; }
     inline void set_dprint_chip_ids(std::vector<int> chip_ids) {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -25,6 +25,7 @@ class RunTimeOptions {
     bool watcher_dump_all;
 
     std::vector<CoreCoord> dprint_cores;
+    bool dprint_all_cores;
     std::vector<int> dprint_chip_ids;
     uint32_t dprint_riscv_mask;
     std::string dprint_file_name;
@@ -38,7 +39,9 @@ public:
 
     // Info from DPrint environment variables, setters included so that user can
     // override with a SW call.
-    inline bool get_dprint_enabled() { return dprint_cores.size() != 0; }
+    inline bool get_dprint_enabled() {
+        return dprint_cores.size() != 0 || dprint_all_cores;
+    }
     // Note: dprint cores are physical
     inline std::vector<CoreCoord>& get_dprint_cores() {
         return dprint_cores;
@@ -46,6 +49,11 @@ public:
     inline void set_dprint_cores(std::vector<CoreCoord> cores) {
         dprint_cores = cores;
     }
+    // An alternative to setting cores by range, a flag to enable all.
+    inline void set_dprint_all_cores(bool all_cores) {
+        dprint_all_cores = all_cores;
+    }
+    inline bool get_dprint_all_cores() { return dprint_all_cores; }
     // Note: core range is inclusive
     inline void set_dprint_core_range(CoreCoord start, CoreCoord end) {
         dprint_cores.clear();

--- a/tt_metal/llrt/tt_debug_print_server.cpp
+++ b/tt_metal/llrt/tt_debug_print_server.cpp
@@ -476,7 +476,7 @@ void tt_start_debug_print_server()
 
         DebugPrintServerContext* ctx = new DebugPrintServerContext(
             tt::llrt::OptionsG.get_dprint_chip_ids(),
-            tt::llrt::OptionsG.get_dprint_core_range(),
+            tt::llrt::OptionsG.get_dprint_cores(),
             tt::llrt::OptionsG.get_dprint_riscv_mask(),
             tt::llrt::OptionsG.get_dprint_file_name()
         );

--- a/tt_metal/llrt/tt_debug_print_server.hpp
+++ b/tt_metal/llrt/tt_debug_print_server.hpp
@@ -41,7 +41,10 @@ Note that this call only works correctly after open_device and start_device call
 This call is not thread safe, and there is only one instance of print server supported at a time.
 
 */
-void tt_start_debug_print_server();
+void tt_start_debug_print_server(
+    std::function<CoreCoord ()>get_grid_size,
+    std::function<CoreCoord (CoreCoord)>worker_from_logical
+);
 
 /*
 @brief Stops the print server thread. This call is optional.


### PR DESCRIPTION
The original issue used a test that has been long since removed, so I've re-created the dprint/raise/wait pattern as a new gtest. Issue appears to be resolved, so just check in the test.

Also includes a change to allow TT_METAL_DPRINT_CORES=all, which enables printing on all logical cores. Added this because on WH it's non-trivial to figure out which logical cores map to worker cores (since the TT_METAL_DPRINT_CORES uses worker core coordinates).

Passing CI (with new test added): https://github.com/tenstorrent-metal/tt-metal/actions/runs/6884301671