### PR TITLE
Supports eltwise binary op that receives output tensor as function input

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -549,6 +549,10 @@ op_map = {
         "tt_lib_op": tt_lib_ops.eltwise_mul,
         "pytorch_op": pytorch_ops.mul,
     },
+    "eltwise-mul_out": {
+        "tt_lib_op": tt_lib_ops.eltwise_mul_out,
+        "pytorch_op": pytorch_ops.mul_out,
+    },
     "eltwise-min": {
         "tt_lib_op": tt_lib_ops.eltwise_min,
         "pytorch_op": pytorch_ops.min,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_binary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_binary.py
@@ -76,6 +76,42 @@ class TestEltwiseBinary:
             test_args,
         )
 
+    @pytest.mark.parametrize("fn_kind", ["mul_out"])
+    @pytest.mark.parametrize("in0_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+    @pytest.mark.parametrize("in1_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+    def test_run_eltwise_binary_out_ops(
+        self,
+        input_shapes,
+        fn_kind,
+        in0_dtype,
+        in1_dtype,
+        input_mem_config,
+        output_mem_config,
+        device,
+        function_level_defaults,
+    ):
+        input_shapes = input_shapes[:] + [input_shapes[0]]
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+        ] * len(input_shapes)
+        test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+        test_args.update(
+            {
+                "dtype": [in0_dtype, in1_dtype, in0_dtype],
+                "input_mem_config": [input_mem_config, input_mem_config],
+                "output_mem_config": output_mem_config,
+            }
+        )
+        comparison_func = comparison_funcs.comp_pcc
+        run_single_pytorch_test(
+            f"eltwise-{fn_kind}",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
     @pytest.mark.parametrize(
         "fn_kind",
         [

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -796,6 +796,10 @@ def mul(x, y, *args, **kwargs):
     return torch.mul(x, y)
 
 
+def mul_out(x, y, z, *args, **kwargs):
+    return torch.mul(x, y, out=z)
+
+
 def matmul(x, y, *args, **kwargs):
     return torch.matmul(x, y)
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1898,10 +1898,34 @@ def make_binary_op(ttl_tensor_binop):
 
     return binary_op
 
+def make_binary_op_out(ttl_tensor_binop):
+    @setup_host_and_device
+    def binary_op(
+        x,
+        y,
+        z,
+        *args,
+        device,
+        dtype,
+        layout,
+        input_mem_config,
+        output_mem_config,
+        **kwargs,
+    ):
+        t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+        t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+        t2 = setup_tt_tensor(z, device, layout[2], output_mem_config, dtype[2])
+        ttl_tensor_binop(t0, t1, t2)
+
+        return tt2torch_tensor(t2)
+
+    return binary_op
+
 
 eltwise_add = make_binary_op(ttl.tensor.add)
 eltwise_sub = make_binary_op(ttl.tensor.sub)
 eltwise_mul = make_binary_op(ttl.tensor.mul)
+eltwise_mul_out = make_binary_op_out(ttl.tensor.mul_out)
 eltwise_bias_gelu = make_binary_op(ttl.tensor.bias_gelu)
 eltwise_squared_difference = make_binary_op(ttl.tensor.squared_difference)
 eltwise_hypot = make_binary_op(ttl.tensor.hypot)

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
@@ -143,17 +143,26 @@ void EltwiseBinary::validate(const std::vector<Tensor>& input_tensors) const {
     }
 }
 
-std::vector<Shape> EltwiseBinary::compute_output_shapes(
-    const std::vector<Tensor>& input_tensors) const {
+std::vector<Shape> EltwiseBinary::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    if (input_tensors.size() == 3) {
+        const auto& output_tensor = input_tensors.at(2);
+        return {output_tensor.shape()};
+    }
+
     const auto& input_tensor = input_tensors.at(0);
     return {input_tensor.shape()};
 }
 
-std::vector<Tensor> EltwiseBinary::create_output_tensors(
-    const std::vector<Tensor>& input_tensors) const {
+std::vector<Tensor> EltwiseBinary::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    if (input_tensors.size() == 3) {
+        const auto& output_tensor = input_tensors.at(2);
+        return {output_tensor};
+    }
+
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     if (this->output_mem_config.is_sharded()) {
+
         ShardSpec shard_spec{.shard_grid=CoreRangeSet({}), .shard_shape={0, 0}};
         if (input_tensor_a.memory_config().is_sharded()) {
             shard_spec = input_tensor_a.shard_spec().value();

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.hpp
@@ -61,6 +61,16 @@ struct make_eltwise_binary {
      }
  };
 
+template <BinaryOpType binary_op_type>
+struct make_eltwise_binary_out {
+     Tensor operator()(const Tensor& input_tensor_a, const Tensor& input_tensor_b, Tensor& output_tensor, std::optional<std::vector<UnaryWithParam>> fused_activations = std::nullopt) const {
+         TT_ASSERT(input_tensor_a.shape() == input_tensor_b.shape(), "Input shapes must be the same!");
+         TT_ASSERT(input_tensor_a.shape() == output_tensor.shape(), "Input and output shapes must be the same!");
+         return operation::run_with_autoformat(EltwiseBinary{binary_op_type, fused_activations, output_tensor.memory_config()}, {input_tensor_a, input_tensor_b, output_tensor}).at(0);
+     }
+ };
+
+
 inline Tensor add_without_autoformat(const Tensor& input_tensor_a, const Tensor& input_tensor_b, std::optional<std::vector<UnaryWithParam>> fused_activations = std::nullopt, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     TT_ASSERT(input_tensor_a.shape() == input_tensor_b.shape(), "Input shapes must be the same!");
     return operation::run_without_autoformat(EltwiseBinary{BinaryOpType::ADD, fused_activations, output_mem_config}, {input_tensor_a, input_tensor_b}).at(0);
@@ -70,6 +80,7 @@ inline Tensor add_without_autoformat(const Tensor& input_tensor_a, const Tensor&
  constexpr auto add = make_eltwise_binary<BinaryOpType::ADD>{};
  constexpr auto sub = make_eltwise_binary<BinaryOpType::SUB>{};
  constexpr auto mul = make_eltwise_binary<BinaryOpType::MUL>{};
+ constexpr auto mul_out = make_eltwise_binary_out<BinaryOpType::MUL>{};
  constexpr auto squared_difference = make_eltwise_binary<BinaryOpType::SQUARED_DIFFERENCE>{};
  constexpr auto bias_gelu = make_eltwise_binary<BinaryOpType::BIAS_GELU>{};
  constexpr auto logaddexp = make_eltwise_binary<BinaryOpType::LOGADDEXP>{};

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_impl.hpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_impl.hpp
@@ -67,6 +67,47 @@ void bind_binary_op(py::module_ &module, std::string op_name, Func &&f, std::str
     }
 }
 
+template <bool fused_activations = true, bool mem_config_arg = false, typename Func>
+void bind_binary_op_out(py::module_ &module, std::string op_name, Func &&f, std::string op_desc) {
+    std::vector<std::string> arg_name = {"input", "other", "output"};
+    op_desc = fmt::format(op_desc, arg_name[0], arg_name[1], arg_name[2]);
+
+    std::string docstring = fmt::format(R"doc(
+        {0}
+
+        Both input tensors must be of equal shape.
+
+        .. csv-table::
+            :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+            "{2}", "First tensor to {1}", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+            "{3}", "Second tensor to {1}", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+            "{4}", "Output tensor to {1}", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes")doc",
+        op_desc, op_name, arg_name[0], arg_name[1], arg_name[2]
+    );
+    if constexpr (fused_activations) {
+        const std::string fused_activations_name = "fused_activations";
+        const std::optional<std::vector<UnaryWithParam>> default_fused_activations = std::nullopt;
+        docstring += fmt::format(R"doc(
+            "{0}", "Fused activations after binary computation", "List of FusibleActivation with optional param", "Default is None", "No")doc",
+            fused_activations_name
+        );
+        bind_op_with_mem_config<mem_config_arg>(module, op_name, f, docstring,
+            py::arg(arg_name[0].c_str()).noconvert(),
+            py::arg(arg_name[1].c_str()).noconvert(),
+            py::arg(arg_name[2].c_str()).noconvert(),
+            py::arg(fused_activations_name.c_str()) = default_fused_activations
+        );
+
+    } else {
+        bind_op_with_mem_config<mem_config_arg>(module, op_name, f, docstring,
+            py::arg(arg_name[0].c_str()).noconvert(),
+            py::arg(arg_name[1].c_str()).noconvert(),
+            py::arg(arg_name[2].c_str()).noconvert()
+        );
+    }
+}
+
 //TODO @tt-aho: Update to handle variable number of params
 template <bool mem_config_arg = true, typename Func>
 void bind_unary_op(py::module_ &module, std::string op_name, Func &&f, std::string op_desc) {

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -17,7 +17,7 @@ namespace tt::tt_metal::detail {
         detail::bind_binary_op(m_tensor, "add", add, R"doc(Perform an eltwise-binary add (``{0} + {1}``) on two tensors.)doc");
         detail::bind_binary_op(m_tensor, "sub", sub, R"doc(Perform an eltwise-binary sub (``{0} - {1}``) on two tensors.)doc");
         detail::bind_binary_op(m_tensor, "mul", mul, R"doc(Perform an eltwise-binary mul (``{0} * {1}``) on two tensors.)doc");
-        detail::bind_binary_op_out(m_tensor, "mul_out", mul_out, R"doc(Perform an eltwise-binary mul (``{0} * {1}``) on two tensors.)doc");
+        detail::bind_binary_op_out(m_tensor, "mul_out", mul_out, R"doc(Perform an eltwise-binary mul (``{2} = {0} * {1}``) on two tensors.)doc");
         detail::bind_binary_op(m_tensor, "squared_difference", squared_difference, R"doc(Perform an eltwise-binary squared_difference (``{0} - {1}``)^2 on two tensors.)doc");
         detail::bind_binary_op(m_tensor, "logical_and", logical_and, R"doc(Performs the element-wise logical AND of the given input tensors ``{0}`` && ``{1}``, Zeros are treated as False and nonzeros are treated as True.)doc");
         detail::bind_binary_op(m_tensor, "bias_gelu", bias_gelu, R"doc(Perform an eltwise-binary bias_gelu (``{0} + {1}``) on two tensors.)doc");

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -17,6 +17,7 @@ namespace tt::tt_metal::detail {
         detail::bind_binary_op(m_tensor, "add", add, R"doc(Perform an eltwise-binary add (``{0} + {1}``) on two tensors.)doc");
         detail::bind_binary_op(m_tensor, "sub", sub, R"doc(Perform an eltwise-binary sub (``{0} - {1}``) on two tensors.)doc");
         detail::bind_binary_op(m_tensor, "mul", mul, R"doc(Perform an eltwise-binary mul (``{0} * {1}``) on two tensors.)doc");
+        detail::bind_binary_op_out(m_tensor, "mul_out", mul_out, R"doc(Perform an eltwise-binary mul (``{0} * {1}``) on two tensors.)doc");
         detail::bind_binary_op(m_tensor, "squared_difference", squared_difference, R"doc(Perform an eltwise-binary squared_difference (``{0} - {1}``)^2 on two tensors.)doc");
         detail::bind_binary_op(m_tensor, "logical_and", logical_and, R"doc(Performs the element-wise logical AND of the given input tensors ``{0}`` && ``{1}``, Zeros are treated as False and nonzeros are treated as True.)doc");
         detail::bind_binary_op(m_tensor, "bias_gelu", bias_gelu, R"doc(Perform an eltwise-binary bias_gelu (``{0} + {1}``) on two tensors.)doc");


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

moreh requires tril, which takes an output tensor as input.
ex) `tril(const Tensor& input, Tensor& output, int diagonal)`

```C++
// current
Tensor _tril(const Tensor& input_a, int32_t diag, const MemoryConfig& output_mem_config) {
  Tensor index_l = tt::numpy::index_tril<bfloat16>(input_a.shape(), diag, DataType::BFLOAT16);
  return mul(input_a,index_l,std::nullopt,output_mem_config);
}

// moreh's desired implementation
Tensor _tril(const Tensor& input_a, Tensor& output, int32_t diag) {
  Tensor index_l = tt::numpy::index_tril<bfloat16>(input_a.shape(), diag, DataType::BFLOAT16);
  return mul_out(input_a,index_l,output);
}
```
Since tril is implemented as eltwise binary mul, moreh tril can also be easily implemented by creating `mul_out` that can receive the output tensor.


**Describe the solution you'd like**
A clear and concise description of what you want to happen.

Create `mul_out(input_a, input_b, output)` .