### PR TITLE
Revert "#2220: Use new UMD apis to get PCIe address ranges"

### DIFF
--- a/tt_metal/build_kernels_for_riscv/build_kernels_for_riscv.cpp
+++ b/tt_metal/build_kernels_for_riscv/build_kernels_for_riscv.cpp
@@ -1189,21 +1189,34 @@ void generate_bank_to_noc_coord_descriptor(
     file_stream_nc.close();
 }
 
-static string generate_noc_core_xy_range_define(const std::vector<CoreCoord>& cores) {
+static string generate_noc_core_xy_range_define(const std::vector<CoreCoord>& cores,
+                                                uint32_t expected_x_flag = 0) {
     stringstream ss;
 
-    string end_of_line = " \\\n    ( \\";
+    ss << " \\\n    ( \\" << endl;
+    if (expected_x_flag != 0) {
+        ss << "     ((x) & " << expected_x_flag << ") && ( \\";
+    } else {
+        ss << "     ( \\";
+    }
+
+    string end_of_line = "";
     for (const auto& core : cores) {
         ss << end_of_line << endl;
-        ss << "    ((x) == NOC_X((uint32_t)" << core.x << ") && (y) == NOC_Y((uint32_t)" << core.y << "))";
+        if (expected_x_flag != 0) {
+            ss << "      (((x) & " << std::hex << "0x" << ~expected_x_flag << std::dec << ") == NOC_X((uint32_t)" << core.x << ") && (y) == NOC_Y((uint32_t)" << core.y << "))";
+        } else {
+            ss << "      ((x) == NOC_X((uint32_t)" << core.x << ") && (y) == NOC_Y((uint32_t)" << core.y << "))";
+        }
         end_of_line = " || \\";
     }
-    ss << ")" << endl;
+    ss << "))" << endl;
 
     return ss.str();
 }
 
 static string generate_noc_addr_ranges_string(
+    tt::ARCH arch,
     uint64_t pcie_addr_base,
     uint64_t pcie_addr_size,
     uint64_t dram_addr_base,
@@ -1243,8 +1256,16 @@ static string generate_noc_addr_ranges_string(
     ss << "#define NOC_DRAM_ADDR_END (NOC_DRAM_ADDR_BASE + NOC_DRAM_ADDR_SIZE)" << endl;
     ss << endl;
 
+    // On WH, PCIE core has a bit ORed into the x coord
+    uint32_t expected_x_flag = 0;
+    if (arch == tt::ARCH::WORMHOLE_B0) {
+        expected_x_flag = 0x8;
+    } else if (arch != tt::ARCH::GRAYSKULL) {
+        TT_ASSERT(0, "Invalid arch");
+    }
+
     ss << "#define NOC_PCIE_XY_P(x, y)";
-    ss << generate_noc_core_xy_range_define(pcie_cores);
+    ss << generate_noc_core_xy_range_define(pcie_cores, expected_x_flag);
     ss << endl;
 
     ss << "#define NOC_DRAM_XY_P(x, y)";
@@ -1297,6 +1318,7 @@ static string generate_noc_addr_ranges_string(
 
 void generate_noc_addr_ranges_header(
     build_kernel_for_riscv_options_t* build_kernel_for_riscv_options,
+    tt::ARCH arch,
     string out_dir_path,
     uint64_t pcie_addr_base,
     uint64_t pcie_addr_size,
@@ -1309,7 +1331,8 @@ void generate_noc_addr_ranges_header(
     const std::vector<uint32_t>& harvested_rows,
     const vector<CoreCoord>& dispatch_cores) {
 
-    string output_string = generate_noc_addr_ranges_string(pcie_addr_base, pcie_addr_size, dram_addr_base, dram_addr_size,
+    string output_string = generate_noc_addr_ranges_string(arch,
+                                                           pcie_addr_base, pcie_addr_size, dram_addr_base, dram_addr_size,
                                                            pcie_cores, dram_cores, ethernet_cores, grid_size, harvested_rows, dispatch_cores);
 
     string full_path = build_kernel_for_riscv_options->outpath;

--- a/tt_metal/build_kernels_for_riscv/build_kernels_for_riscv.hpp
+++ b/tt_metal/build_kernels_for_riscv/build_kernels_for_riscv.hpp
@@ -119,6 +119,7 @@ void generate_bank_to_noc_coord_descriptor(
 
 void generate_noc_addr_ranges_header(
     build_kernel_for_riscv_options_t* build_kernel_for_riscv_options,
+    tt::ARCH arch,
     string out_dir_path,
     uint64_t pcie_addr_base,
     uint64_t pcie_addr_size,

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -99,6 +99,7 @@ namespace tt::tt_metal{
         bool ConfigureDeviceWithProgram(Device *device, Program &program);
 
 
+
         /**
          * Read device side profiler data and dump results into device side CSV log
          *
@@ -329,20 +330,12 @@ namespace tt::tt_metal{
             CoreCoord producer_logical_core = *dispatch_cores++;
             CoreCoord consumer_logical_core = *dispatch_cores;
 
-            // Create valid PCIe address ranges
-            // This implementation assumes contiguous ranges and aggregates the ranges into one bounds check
-            // TODO: consider checking multiple ranges to detect straddling transactions
-            uint64_t pcie_chan_base_addr = tt::Cluster::instance().get_pcie_base_addr_from_device();
-            uint64_t pcie_chan_end_addr = pcie_chan_base_addr;
-            for (int pcie_chan = 0; pcie_chan < tt::Cluster::instance().get_num_host_channels(device->id()); pcie_chan++) {
-                pcie_chan_end_addr += tt::Cluster::instance().get_host_channel_size(device->id(), pcie_chan);
-            }
-
             generate_noc_addr_ranges_header(
                 build_options,
+                device->arch(),
                 op_path_suffix,
-                pcie_chan_base_addr,
-                pcie_chan_end_addr - pcie_chan_base_addr,
+                0,
+                (uint64_t)4 * 1024 * 1024 * 1024,
                 0,
                 soc_d.dram_core_size,
                 soc_d.get_pcie_cores(),


### PR DESCRIPTION
This reverts commit 6b27683bdd23aeb72ff6cbb43ac159d5f69624ec.