### PR TITLE
#3640: eltwise binary op perf optimzation

### DIFF
--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -366,6 +366,17 @@ class CoreRangeSet {
       return num_cores;
     }
 
+    CoreRange bounding_box() const{
+      size_t min_x = UINT32_MAX, min_y = UINT32_MAX, max_x = 0, max_y = 0;
+      for (const auto & cr : this->ranges()){
+        min_x = std::min( min_x, cr.start.x);
+        max_x = std::max( max_x, cr.end.x );
+        min_y = std::min ( min_y, cr.start.y );
+        max_y = std::max ( max_y, cr.end.y);
+      }
+      return {.start = {.x = min_x, .y = min_y}, .end ={ .x = max_x, .y = max_y} };
+    }
+
   private:
     std::set<CoreRange> ranges_;
 };


### PR DESCRIPTION
Before 

![Screenshot 2023-11-19 at 1 33 20 PM](https://github.com/tenstorrent-metal/tt-metal/assets/135061747/40db4ad8-4292-4405-83f9-e7f215e703cc)

After

![Screenshot 2023-11-19 at 1 33 43 PM](https://github.com/tenstorrent-metal/tt-metal/assets/135061747/05474526-7aa6-4351-a843-e624c2345600)

Thanks @tt-aho ! The remaining time is constructing and setting the RT args, need to create/copy less data in order to push it further

Total time savings is 1.73 ms -> 1.41 ms (see top of each screenshot)