### PR TITLE
remove UpdateRuntimeArg

### DIFF
--- a/docs/source/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -6,5 +6,3 @@ Runtime Arguments
 .. doxygenfunction:: SetRuntimeArgs(const Program &program, KernelID kernel, const std::vector< CoreCoord > & core_spec, const std::vector< std::vector<uint32_t> > &runtime_args)
 
 .. doxygenfunction:: GetRuntimeArgs
-
-.. doxygenfunction:: UpdateRuntimeArg

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -230,22 +230,6 @@ void SetRuntimeArgs(const Program &program, KernelID kernel, const std::variant<
  */
 void SetRuntimeArgs(const Program &program, KernelID kernel, const std::vector< CoreCoord > & core_spec, const std::vector< std::vector<uint32_t> > &runtime_args);
 
-
-/**
- * Update a single runtime arg of a kernel, yielding performance benefits in certain situations. This API can only be called after SetRuntimeArgs has been called on a kernel.
- *
- * Return value: void
- *
- * | Argument     | Description                                                            | Type                                                   | Valid Range                                                         | Required |
- * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------|----------|
- * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
- * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelID (uint64_t)                                    |                                                                     | Yes      |
- * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::variant<CoreCoord,CoreRange,CoreRangeSet> & | Any logical Tensix core coordinate(s) on which the kernel is placed | Yes      |
- * | offset       | Offset into original vector of runtime args                            | size_t                                                 | Within the bounds of the original runtime arg vector                | Yes      |
- * | value        | The runtime args to be written                                         | uint32_t                                               |                                                                     | Yes      |
- */
-void UpdateRuntimeArg(const Program &program, KernelID kernel, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, size_t offset, uint32_t value);
-
 /**
  * Get the runtime args for a kernel.
  *

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -81,20 +81,6 @@ inline void SetRuntimeArgs(const Program &program, KernelID kernel_id, const Cor
     }
 }
 
-inline void UpdateRuntimeArg(const Program &program, KernelID kernel_id, const CoreCoord &c, size_t offset, uint32_t value)
-{
-    detail::GetKernel(program, kernel_id)->update_runtime_arg(c, offset, value);
-}
-
-inline void UpdateRuntimeArg(const Program &program, KernelID kernel_id, const CoreRange &core_range, size_t offset, uint32_t value)
-{
-    for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-        for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
-            UpdateRuntimeArg(program, kernel_id, CoreCoord(x,y), offset, value);
-        }
-    }
-}
-
 }  // namespace
 
 namespace detail {
@@ -483,26 +469,6 @@ void SetRuntimeArgs(const Program &program, KernelID kernel, const std::vector< 
     Kernel * k = detail::GetKernel(program, kernel);
     for (size_t i = 0; i < core_spec.size(); i++)
         k->set_runtime_args(core_spec[i], runtime_args[i]);
-}
-
-
-void UpdateRuntimeArg(const Program &program, KernelID kernel_id, const std::variant<CoreCoord,CoreRange,CoreRangeSet> &core_spec, size_t offset, uint32_t value) {
-    ZoneScoped;
-    std::visit(
-        [&](auto&& core_spec)
-        {
-            using T = std::decay_t<decltype(core_spec)>;
-            if constexpr (std::is_same_v<T, CoreRange> || std::is_same_v<T, CoreCoord> ) {
-                UpdateRuntimeArg(program, kernel_id, core_spec, offset, value);
-            }
-            else if constexpr (std::is_same_v<T, CoreRangeSet>) {
-                for (const auto& core_range : core_spec.ranges()) {
-                    UpdateRuntimeArg(program, kernel_id, core_range, offset, value);
-                }
-            }
-        },
-        core_spec
-    );
 }
 
 std::vector<uint32_t> & GetRuntimeArgs(const Program &program, KernelID kernel_id, const CoreCoord &logical_core) {


### PR DESCRIPTION
Its use has been superceded by:

1) `GetRuntimeArgs`returning a reference and updating in-place
2) new `SetRuntimeArgs` variant that allows for batch update a set of `CoreCoord`'s RT args in 1 call