### PR TITLE
Doc update for EnqueueReadBuffer

### DIFF
--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -262,12 +262,12 @@ std::vector<uint32_t>& GetRuntimeArgs(const Program &program, KernelID kernel_id
  *
  * Return value: void
  *
- * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
- * | buffer       | The device buffer we are reading from                                  | Buffer &                      |                                    | Yes      |
- * | dst          | The vector where the results that are read will be stored              | vector<uint32_t> &                 |                                    | Yes      |
- * | blocking     | Whether or not this is a blocking operation                            | bool                          |                                    | Yes      |
+ * | Argument     | Description                                                            | Type                          | Valid Range                            | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|----------------------------------------|----------|
+ * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                        | Yes      |
+ * | buffer       | The device buffer we are reading from                                  | Buffer &                      |                                        | Yes      |
+ * | dst          | The vector where the results that are read will be stored              | vector<uint32_t> &            |                                        | Yes      |
+ * | blocking     | Whether or not this is a blocking operation                            | bool                          | Only blocking mode supported currently | Yes      |
  */
 void EnqueueReadBuffer(CommandQueue& cq, Buffer& buffer, std::vector<uint32_t>& dst, bool blocking);
 
@@ -276,12 +276,12 @@ void EnqueueReadBuffer(CommandQueue& cq, Buffer& buffer, std::vector<uint32_t>& 
  *
  * Return value: void
  *
- * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
- * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
- * | buffer       | The device buffer we are reading from                                  | Buffer &                      |                                    | Yes      |
- * | dst          | The memory where the result will be stored                             | void*                         |                                    | Yes      |
- * | blocking     | Whether or not this is a blocking operation                            | bool                          |                                    | Yes      |
+ * | Argument     | Description                                                            | Type                          | Valid Range                            | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|----------------------------------------|----------|
+ * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                        | Yes      |
+ * | buffer       | The device buffer we are reading from                                  | Buffer &                      |                                        | Yes      |
+ * | dst          | The memory where the result will be stored                             | void*                         |                                        | Yes      |
+ * | blocking     | Whether or not this is a blocking operation                            | bool                          | Only blocking mode supported currently | Yes      |
  */
 void EnqueueReadBuffer(CommandQueue& cq, Buffer& buffer, void* dst, bool blocking);
 


### PR DESCRIPTION
Update documentation to warn users that only blocking mode of EnqueueReadBuffer is supported

@DrJessop already errors out if user requests non-blocking mode