### PR TITLE
#2220: Redo use new UMD apis to get PCIe address ranges

### DIFF
--- a/tt_metal/build_kernels_for_riscv/build_kernels_for_riscv.hpp
+++ b/tt_metal/build_kernels_for_riscv/build_kernels_for_riscv.hpp
@@ -117,7 +117,6 @@ void generate_bank_to_noc_coord_descriptor(
 
 void generate_noc_addr_ranges_header(
     build_kernel_for_riscv_options_t* build_kernel_for_riscv_options,
-    tt::ARCH arch,
     string out_dir_path,
     uint64_t pcie_addr_base,
     uint64_t pcie_addr_size,

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -517,14 +517,17 @@ void Cluster::l1_barrier(chip_id_t chip_id) const {
 }
 
 uint32_t Cluster::get_num_host_channels(chip_id_t device_id) const {
-    return this->device_->get_num_host_channels(device_id);
+    bool mmio_capable = this->cluster_desc_->is_chip_mmio_capable(device_id);
+    return mmio_capable ? this->device_->get_num_host_channels(device_id) : 0;
 }
 
 uint32_t Cluster::get_host_channel_size(chip_id_t device_id, uint32_t channel) const {
+    TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(device_id));
     return this->device_->get_host_channel_size(device_id, channel);
 }
 
 void *Cluster::host_dma_address(uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
+    TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));
     return this->device_->host_dma_address(offset, src_device_id, channel);
 }
 


### PR DESCRIPTION
Fix get_num_host_channels to work w/ non mmio devices

This re-reverts commit 5ed288f4c4bd704ac7322f82a71bd21c524bf315.