### PR TITLE
document compute_kernel_api/matmul.h, compute_kernel_api/pack.h, and compute_kernel_api/bcasth.h

### DIFF
--- a/docs/source/tt_metal/apis/kernel_apis/compute/add_tiles_bcast.rst
+++ b/docs/source/tt_metal/apis/kernel_apis/compute/add_tiles_bcast.rst
@@ -3,4 +3,5 @@ add_tiles_bcast
 
 .. doxygenfunction:: add_bcast_cols_init_short()
 .. doxygenfunction:: add_bcast_rows_init_short()
+.. doxygenfunction:: add_bcast_rows_init_short_post_matmul()
 .. doxygenfunction:: add_tiles_bcast(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)

--- a/docs/source/tt_metal/apis/kernel_apis/compute/compute.rst
+++ b/docs/source/tt_metal/apis/kernel_apis/compute/compute.rst
@@ -20,6 +20,7 @@ Compute APIs
   mul_tiles_bcast
 
   matmul_tiles
+  matmul_block
   exp_tile
   exp2_tile
   expm1_tile

--- a/docs/source/tt_metal/apis/kernel_apis/compute/matmul_block.rst
+++ b/docs/source/tt_metal/apis/kernel_apis/compute/matmul_block.rst
@@ -1,0 +1,7 @@
+matmul_block
+============
+
+.. doxygenfunction:: mm_block_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t out_cb_id = 16)
+.. doxygenfunction:: mm_block_init_short(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, const std::uint32_t transpose=0)
+.. doxygenfunction:: mm_block_init_short_with_dt(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t cbid=2)
+.. doxygenfunction:: matmul_block(uint32_t c_in0, uint32_t c_in1, uint32_t itile0, uint32_t itile1, uint32_t idst, bool transpose, uint32_t ct_dim, uint32_t rt_dim, uint32_t kt_dim)

--- a/docs/source/tt_metal/apis/kernel_apis/compute/matmul_tiles.rst
+++ b/docs/source/tt_metal/apis/kernel_apis/compute/matmul_tiles.rst
@@ -1,4 +1,7 @@
 matmul_tiles
 ============
 
+.. doxygenfunction:: mm_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t out_cb_id = 16, const uint32_t transpose=0)
+.. doxygenfunction:: mm_init_short_with_dt(uint32_t cbid, const uint32_t transpose=0)
+.. doxygenfunction:: mm_init_short(const std::uint32_t transpose=0)
 .. doxygenfunction:: matmul_tiles(uint32_t c_in0, uint32_t c_in1, uint32_t itile0, uint32_t itile1, uint32_t idst, bool transpose)

--- a/docs/source/tt_metal/apis/kernel_apis/compute/pack_tile.rst
+++ b/docs/source/tt_metal/apis/kernel_apis/compute/pack_tile.rst
@@ -2,3 +2,4 @@ pack_tile
 =========
 
 .. doxygenfunction:: pack_tile(uint32_t idst, uint32_t cbid)
+.. doxygenfunction:: matmul_pack_tile(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles)

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -221,6 +221,11 @@ ALWI void add_bcast_rows_init_short()
     #endif
 }
 
+/**
+ * This function reconfigures the compute engine from ColMajor mode to RowMajor mode. It performs
+ * a switch-from-matmul_block tile hw reconfiguration step needed for add_bcast_rows to be executed correctly.
+ * Required to be called before add_tiles_bcast if using row as broadcast type
+ */
 ALWI void add_bcast_rows_init_short_post_matmul()
 {
     // math

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -100,7 +100,7 @@ ALWI void mm_init_short_with_dt(uint32_t cbid, const uint32_t transpose=0) {
 }
 
 /**
- * A shor version of initialization for matmul_tiles operation.
+ * A short version of initialization for matmul_tiles operation.
  * Configure the unpacker and math engine to matmul mode.
  *
  * Return value: None
@@ -156,7 +156,7 @@ ALWI void mm_block_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t
 
 /**
  * Performs block-sized matrix multiplication *C=A\*B* between the blocks in two
- * specified input CBs and writes the result to DST. The DST register buffer
+ * different input CBs and writes the result to DST. The DST register buffer
  * must be in acquired state via *acquire_dst* call. This call is blocking and
  * is only available on the compute engine.
  *
@@ -182,7 +182,7 @@ ALWI void matmul_block(uint32_t c_in0, uint32_t c_in1, uint32_t itile0, uint32_t
 }
 
 /**
- * A shor version of initialization for matmul_block operation.
+ * A short version of initialization for matmul_block operation.
  * It is used to reconfigure srcA of the compute engine back to matmul mode.
  *
  * Return value: None
@@ -206,7 +206,7 @@ ALWI void mm_block_init_short_with_dt(uint32_t in0_cb_id = 0, uint32_t in1_cb_id
 }
 
 /**
- * A shor version of initialization for matmul_block operation.
+ * A short version of initialization for matmul_block operation.
  * Configure the unpacker and math engine to matmul mode.
  *
  * Return value: None

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -77,7 +77,7 @@ ALWI void matmul_tiles(uint32_t c_in0, uint32_t c_in1, uint32_t itile0, uint32_t
 }
 
 /**
- * A shor version of initialization for matmul_tiles operation.
+ * A short version of matmul_tiles initialization.
  * It is used to reconfigure srcA of the compute engine back to matmul mode.
  *
  * Return value: None
@@ -100,7 +100,7 @@ ALWI void mm_init_short_with_dt(uint32_t cbid, const uint32_t transpose=0) {
 }
 
 /**
- * A short version of initialization for matmul_tiles operation.
+ * A short version of matmul_tiles initialization.
  * Configure the unpacker and math engine to matmul mode.
  *
  * Return value: None
@@ -182,7 +182,7 @@ ALWI void matmul_block(uint32_t c_in0, uint32_t c_in1, uint32_t itile0, uint32_t
 }
 
 /**
- * A short version of initialization for matmul_block operation.
+ * A short version of matmul_block initialization.
  * It is used to reconfigure srcA of the compute engine back to matmul mode.
  *
  * Return value: None
@@ -206,7 +206,7 @@ ALWI void mm_block_init_short_with_dt(uint32_t in0_cb_id = 0, uint32_t in1_cb_id
 }
 
 /**
- * A short version of initialization for matmul_block operation.
+ * A short version of matmul_block initialization.
  * Configure the unpacker and math engine to matmul mode.
  *
  * Return value: None

--- a/tt_metal/include/compute_kernel_api/pack.h
+++ b/tt_metal/include/compute_kernel_api/pack.h
@@ -45,6 +45,35 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb)
     PACK((  llk_pack<false, SYNC, false >(ifrom_dst, icb)  ));
 }
 
+/**
+ * Copies a block of tiles from the DST register buffer at a start index to a
+ * specified CB at a given start index. cb_reserve_back(n) had to be called first
+ * to reserve at least some number n>0 of tiles in the output CB. The out_tile_index = 0
+ * then references the first tile in the reserved section of the CB, up to index n-1 that
+ * will then be visible to the consumer in the same order after a cb_push_back call.
+ * The DST register buffer must be in acquired state via *acquire_dst* call.
+ * This call is blocking and is only available on the compute engine.
+ *
+ * Each subsequent pack call will increment the write pointer in the cb by ntiles size.
+ * The pointer is then again set to a valid position with space for n
+ * reserved tiles by another cb_reserve_back call.
+ *
+ * Operates in tandem with functions cb_reserve_back and cb_push_back.
+ *
+ * A typical use case is first the producer ensures that there is a number of
+ * tiles available in the buffer via cb_reserve_back, then the producer uses
+ * the matmul_pack_tile call to copy a block of tiles from the DST slots to the slots in
+ * reserved space and finally cb_push_back is called to announce visibility of
+ * the reserved section of the circular buffer to the consumer.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                       | Type     | Valid Range                                         | Required |
+ * |----------------|---------------------------------------------------|----------|-----------------------------------------------------|----------|
+ * | ifrom_dst      | The index of the tile in the DST register         | uint32_t | Must be less than the size of the DST register (16) | True     |
+ * | icb            | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                             | True     |
+ * | ntiles         | The number of tiles to copy from DST to CB        | uint32_t | Must be less than the size of the CB                | True     |
+ */
 ALWI void matmul_pack_tile(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles)
 {
     #ifdef ARCH_GRAYSKULL


### PR DESCRIPTION
add documentations for the following functions

- mm_block_init
- mm_block_init_short
- mm_block_init_short_with_dt
- matmul_block

- mm_init
- mm_init_short_with_dt
- mm_init_short

- matmul_pack_tile

- add_bcast_rows_init_short_post_matmul