### PR TITLE
#3830: Fix CB failures in perf pipelines

### DIFF
--- a/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv/optimized_conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv/optimized_conv_op.cpp
@@ -68,8 +68,8 @@ tuple<CircularBufferID, CircularBufferID> create_CBs(tt_metal::Program &program,
 		.set_page_size(act_cb, act_tile_size);
     auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
 
-    auto cb_sharded_act = 0;
-    auto cb_sharded_act_mcast_receiver = 0;
+    CircularBufferID cb_sharded_act = 0;
+    CircularBufferID cb_sharded_act_mcast_receiver = 0;
     if (input.is_sharded()) {
         uint32_t num_bytes_for_df = datum_size(act_df);
         auto shard_shape = input.shard_spec().value().shard_shape;

--- a/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded.cpp
@@ -64,7 +64,7 @@ tuple<CircularBufferID, CircularBufferID> create_CBs_for_sharded_input(
     uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
     uint32_t out_tile_size = tt_metal::detail::TileSize(out_df);
 
-    auto cb_sharded_act = 0;
+    CircularBufferID cb_sharded_act = 0;
     if (input.memory_config().is_sharded()) {
         uint32_t num_bytes_for_df = datum_size(act_df);
         auto shard_shape = input.shard_spec().value().shard_shape;

--- a/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.hpp
+++ b/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.hpp
@@ -104,6 +104,8 @@ struct OptimizedConv {
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const;
 
     static constexpr auto attribute_names = std::make_tuple(
+        "parallelization_config",
+        "block_config",
         "conv_params",
         "output_channels",
         "untilize_out",
@@ -112,9 +114,12 @@ struct OptimizedConv {
         "math_fidelity",
         "extra_padding_for_32B_alignment",
         "output_mem_config",
-        "output_dtype");
+        "output_dtype",
+        "input_tensor_shape");
     const auto attribute_values() const {
         return std::make_tuple(
+            std::cref(this->parallelization_config),
+            std::cref(this->block_config),
             std::cref(this->conv_params),
             std::cref(this->output_channels),
             std::cref(this->untilize_out),
@@ -123,7 +128,8 @@ struct OptimizedConv {
             std::cref(this->math_fidelity),
             std::cref(this->extra_padding_for_32B_alignment),
             std::cref(this->output_mem_config),
-            std::cref(this->output_dtype));
+            std::cref(this->output_dtype),
+            std::cref(this->input_tensor_shape));
     }
 };
 


### PR DESCRIPTION
- Add missing optimized conv attributes to hash calculation
- Add CircularBufferID type for sharded buffers