### PR TITLE
#0: update profiling for unary ops

### DIFF
--- a/scripts/profiler/profile_unary.py
+++ b/scripts/profiler/profile_unary.py
@@ -127,10 +127,11 @@ def run_eltwise_unary_ops(
         }
     )
 
-    if fn_kind in ["gelu", "rsqrt", "erf", "erfc"]:
+    if fn_kind in ["gelu", "rsqrt", "erf", "erfc", "exp"]:
         test_args.update(
             {
                 "fast_and_appx": True,
+                "fast_and_approx": True,
             }
         )
 

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -212,28 +212,36 @@ bool run_sfpu_test(string sfpu_name) {
     return pass;
 }
 
-int main(int argc, char **argv) {
+bool run_unit_test(std::string op_name) {
+    log_info(LogTest, "Running {}", op_name);
 
+    bool pass_ = run_sfpu_test(op_name);
+
+    if (pass_) {
+        log_info(LogTest, "{} test passed", op_name);
+    } else {
+        log_info(LogTest, "{} test failed", op_name);
+    }
+    return pass_;
+}
+
+int main(int argc, char **argv) {
     auto slow_dispatch_mode = getenv("TT_METAL_SLOW_DISPATCH_MODE");
     TT_FATAL(slow_dispatch_mode, "This test only supports TT_METAL_SLOW_DISPATCH_MODE");
 
     bool pass = true;
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Initial Runtime Args Parse
-    ////////////////////////////////////////////////////////////////////////////
+
     update_sfpu_op_to_hlk_op();
-    for (const auto& [op_name, _]: sfpu_op_to_hlk_op_name) {
-        log_info(LogTest, "Running {}", op_name);
 
-        bool pass_ = run_sfpu_test(op_name);
 
-        if (pass_) {
-            log_info(LogTest, "{} test passed", op_name);
-        } else {
-            log_info(LogTest, "{} test failed", op_name);
+    if ( argc == 1 ) {
+        for (const auto& [op_name, _]: sfpu_op_to_hlk_op_name) {
+            pass &= run_unit_test(op_name);
         }
-
-        pass &= pass_;
+    } else {
+        for(uint32_t idx = 1; idx < argc; idx++) {
+            pass &= run_unit_test(argv[idx]);
+        }
     }
 
     if (pass) {

--- a/tt_metal/hw/ckernels/grayskull/common/inc/ckernel_sfpu.h
+++ b/tt_metal/hw/ckernels/grayskull/common/inc/ckernel_sfpu.h
@@ -181,7 +181,8 @@ inline void calculate_asin()
 }
 
 
-#define PI_2 (1.570796326794)
+
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_acos()
 {
@@ -191,7 +192,7 @@ inline void calculate_acos()
     {
         vFloat v = dst_reg[0];
         v = sfpu_asine_maclaurin_series<APPROXIMATION_MODE>(v);
-        v = PI_2 - v;
+        v = (1.570796326794) - v;
         dst_reg[0] = v;
         dst_reg++;
     }


### PR DESCRIPTION
update profiling for unary ops:
- double include PI_2 fix
- test_sfpu unittest to take arguments from CLI
-  update profiler test_sfpu to accept arguments of sfpu ops at CLI