### PR TITLE
#0: enable test for wormhole, use eps from device

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_repeat_interleave.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_repeat_interleave.py
@@ -23,8 +23,6 @@ shapes = (
     [[1, 3, 32, 2048]],  # Multi core h
     [[4, 3, 40, 640]],  # Multi core h
 )
-if is_wormhole_b0():
-    shapes = (shapes[0],)
 
 
 @pytest.mark.parametrize("input_shapes", shapes)
@@ -50,7 +48,7 @@ def test_run_repeat_interleave_test(input_shapes, dim, repeat, device):
     )
 
 
-@pytest.mark.parametrize("input_shapes", ([[1, 1, 32, 32]], [[32, 32, 32, 32]]))
+@pytest.mark.parametrize("input_shapes", shapes[:-1])
 @pytest.mark.parametrize("repeat", ([1, 2, 3, 4], [1, 1, 1, 2], [1, 1, 2, 1], [1, 2, 1, 1], [2, 1, 1, 1]))
 def test_run_repeat_test(input_shapes, repeat, device):
     datagen_func = [

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -718,12 +718,7 @@ Tensor repeat_interleave(const Tensor& input_a, uint32_t repeat, int32_t dim, co
 
 //nextafter
 Tensor _nextafter(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {
-    float eps;
-    if (is_arch_whb0(input_a.device()->arch())) {
-        eps = 1.19209e-07f;
-    } else {
-        eps = 0.001953125f;
-    }
+    const float eps = input_a.device()->sfpu_eps();
     Tensor result(input_a);
     {
         Tensor eps_gt(input_a);


### PR DESCRIPTION
- enable test for wormhole in repeat interleave as well as repeat
- use eps from the device implementation instead of hard-coding in nextafter