### PR TITLE
#3824: cache weight tensors for mistral

### DIFF
--- a/models/experimental/mistral/demo/gs_demo.py
+++ b/models/experimental/mistral/demo/gs_demo.py
@@ -35,11 +35,13 @@ def test_gs_demo_single_input_inference(batch_size, model_location_generator, de
     model_args.max_batch_size = batch_size
     model_args.n_layers = 32
 
+    tt_cache_path = "/mnt/MLPerf/tt_dnn-models/tt/Mistral/"
     tt_model = TtTransformer(
         args=model_args,
         state_dict=state_dict,
         device=device,
         base_address=base_address,
+        tt_cache_path=tt_cache_path,
     )
 
     tt_output = generate(

--- a/models/experimental/mistral/tests/test_mistral_attention.py
+++ b/models/experimental/mistral/tests/test_mistral_attention.py
@@ -54,7 +54,7 @@ def test_mistral_attention_inference(
 ):
     mistral_path = model_location_generator("mistral-7B-v0.1", model_subdir="Mistral")
     state_dict = torch.load(mistral_path / "consolidated.00.pth")
-    base_address = f""
+    base_address = f"layers.0.attention."
     with open(mistral_path / "params.json", "r") as f:
         model_args = TtModelArgs(**json.loads(f.read()))
     if True:
@@ -68,11 +68,12 @@ def test_mistral_attention_inference(
     model_args.FALLBACK_EMPTY = empty_ondevice
     model_args.FALLBACK_SCATTER = scatter_ondevice
     model_args.WEIGHTS_DTYPE = dtype
+    tt_cache_path = "/mnt/MLPerf/tt_dnn-models/tt/Mistral/"
     tt_model = TtAttention(
         args=model_args,
-        state_dict=state_dict,
         device=device,
         base_address=base_address,
+        tt_cache_path=tt_cache_path,
     )
     input = torch.randn(1, 11, 4096)
     empty_tensor = torch.zeros((11, 64))

--- a/models/experimental/mistral/tests/test_mistral_feed_forward.py
+++ b/models/experimental/mistral/tests/test_mistral_feed_forward.py
@@ -27,7 +27,7 @@ from models.utility_functions import (
 def test_mistral_feed_forward_inference(pcc, model_location_generator, device, dtype, reset_seeds):
     mistral_path = model_location_generator("mistral-7B-v0.1", model_subdir="Mistral")
     state_dict = torch.load(mistral_path / "consolidated.00.pth")
-    base_address = f""
+    base_address = f"layers.0.feed_forward."
     with open(mistral_path / "params.json", "r") as f:
         model_args = TtModelArgs(**json.loads(f.read()))
 
@@ -37,11 +37,13 @@ def test_mistral_feed_forward_inference(pcc, model_location_generator, device, d
     reference_model = FeedForward(args=model_args)
     reference_model.load_state_dict(state_dict)
 
+    tt_cache_path = "/mnt/MLPerf/tt_dnn-models/tt/Mistral/"
+
     tt_model = TtFeedForward(
         args=model_args,
-        state_dict=state_dict,
         device=device,
         base_address=base_address,
+        tt_cache_path=tt_cache_path,
     )
     input = torch.rand(1, 11, 4096)
     reference_output = reference_model(input)

--- a/models/experimental/mistral/tests/test_mistral_rms_norm.py
+++ b/models/experimental/mistral/tests/test_mistral_rms_norm.py
@@ -23,7 +23,7 @@ from models.utility_functions import (
 def test_mistral_rms_norm_inference(pcc, model_location_generator, device, reset_seeds):
     mistral_path = model_location_generator("mistral-7B-v0.1", model_subdir="Mistral")
     state_dict = torch.load(mistral_path / "consolidated.00.pth")
-    base_address = f""
+    base_address = f"layers.0.attention_norm."
     with open(mistral_path / "params.json", "r") as f:
         model_args = TtModelArgs(**json.loads(f.read()))
 
@@ -34,11 +34,11 @@ def test_mistral_rms_norm_inference(pcc, model_location_generator, device, reset
     reference_model = RMSNorm(dim=dim)
     reference_model.load_state_dict(state_dict)
 
+    tt_cache_path = "/mnt/MLPerf/tt_dnn-models/tt/Mistral/"
     tt_model = TtRMSNorm(
         dim=dim,
-        state_dict=state_dict,
-        device=device,
         base_address=base_address,
+        tt_cache_path=tt_cache_path,
     )
     input = torch.rand(1, 11, 4096)
     reference_output = reference_model(input)

--- a/models/experimental/mistral/tests/test_mistral_transformer.py
+++ b/models/experimental/mistral/tests/test_mistral_transformer.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import tt_lib
 import torch
 import tt_lib
 import pytest
@@ -38,17 +39,21 @@ def test_mistral_transformer_inference(pcc, model_location_generator, device, dt
     with open(mistral_path / "params.json", "r") as f:
         model_args = TtModelArgs(**json.loads(f.read()))
 
+    model_args.WEIGHTS_DTYPE = dtype
     model_args.max_batch_size = 1
     model_args.n_layers = 32
     model_args.WEIGHTS_DTYPE = dtype
     reference_model = Transformer(args=model_args)
     reference_model.load_state_dict(state_dict)
 
+    tt_cache_path = "/mnt/MLPerf/tt_dnn-models/tt/Mistral/"
+
     tt_model = TtTransformer(
         args=model_args,
         state_dict=state_dict,
         device=device,
         base_address=base_address,
+        tt_cache_path=tt_cache_path,
     )
 
     encoded_prompts = [tokenizer.encode(prompt) for prompt in prompts]

--- a/models/experimental/mistral/tests/test_mistral_transformer_block.py
+++ b/models/experimental/mistral/tests/test_mistral_transformer_block.py
@@ -28,7 +28,7 @@ from models.utility_functions import (
 def test_mistral_transformer_block_inference(pcc, model_location_generator, device, dtype, reset_seeds):
     mistral_path = model_location_generator("mistral-7B-v0.1", model_subdir="Mistral")
     state_dict = torch.load(mistral_path / "consolidated.00.pth")
-    base_address = f""
+    base_address = f"layers.0."
     with open(mistral_path / "params.json", "r") as f:
         model_args = TtModelArgs(**json.loads(f.read()))
 
@@ -39,11 +39,13 @@ def test_mistral_transformer_block_inference(pcc, model_location_generator, devi
     reference_model = TransformerBlock(args=model_args)
     reference_model.load_state_dict(state_dict)
 
+    tt_cache_path = "/mnt/MLPerf/tt_dnn-models/tt/Mistral/"
+
     tt_model = TtTransformerBlock(
         args=model_args,
-        state_dict=state_dict,
         device=device,
         base_address=base_address,
+        tt_cache_path=tt_cache_path,
     )
 
     input = torch.randn(1, 11, 4096)

--- a/models/experimental/mistral/tests/test_perf_mistral.py
+++ b/models/experimental/mistral/tests/test_perf_mistral.py
@@ -55,11 +55,13 @@ def run_perf_mistral(expected_inference_time, expected_compile_time, device, mod
         Path(mistral_path), n_layers=32, max_batch_size=max_batch_size, is_whole_model=True
     )
 
+    tt_cache_path = "/mnt/MLPerf/tt_dnn-models/tt/Mistral/"
     tt_model = TtTransformer(
         args=model_args,
         state_dict=state_dict,
         device=device,
         base_address=base_address,
+        tt_cache_path=tt_cache_path,
     )
 
     with torch.no_grad():

--- a/models/experimental/mistral/tt/mistral_feed_forward.py
+++ b/models/experimental/mistral/tt/mistral_feed_forward.py
@@ -15,18 +15,14 @@ class TtFeedForward(nn.Module):
         args: TtModelArgs,
         base_address=None,
         device=None,
-        state_dict=None,
+        tt_cache_path=None,
     ):
         super().__init__()
         self.device = device
+        self.args = args
 
-        w1_weights = state_dict[f"{base_address}w1.weight"]
-        ref_w1_weights = w1_weights.unsqueeze(0).unsqueeze(0)
-        self.w1_weights = tt_lib.tensor.Tensor(
-            ref_w1_weights.reshape(-1).tolist(),
-            ref_w1_weights.shape,
-            args.WEIGHTS_DTYPE,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+        self.w1_weights = tt_lib.tensor.load_tensor(
+            tt_cache_path + base_address + "w1.weight" + str(self.args.WEIGHTS_DTYPE) + ".bin"
         )
         self.w1 = TtLinear(
             args.dim,
@@ -35,13 +31,8 @@ class TtFeedForward(nn.Module):
             device=self.device,
         )
 
-        w2_weights = state_dict[f"{base_address}w2.weight"]
-        ref_w2_weights = w2_weights.unsqueeze(0).unsqueeze(0)
-        self.w2_weights = tt_lib.tensor.Tensor(
-            ref_w2_weights.reshape(-1).tolist(),
-            ref_w2_weights.shape,
-            args.WEIGHTS_DTYPE,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+        self.w2_weights = tt_lib.tensor.load_tensor(
+            tt_cache_path + base_address + "w2.weight" + str(self.args.WEIGHTS_DTYPE) + ".bin"
         )
         self.w2 = TtLinear(
             args.hidden_dim,
@@ -50,13 +41,8 @@ class TtFeedForward(nn.Module):
             device=self.device,
         )
 
-        w3_weights = state_dict[f"{base_address}w3.weight"]
-        ref_w3_weights = w3_weights.unsqueeze(0).unsqueeze(0)
-        self.w3_weights = tt_lib.tensor.Tensor(
-            ref_w3_weights.reshape(-1).tolist(),
-            ref_w3_weights.shape,
-            args.WEIGHTS_DTYPE,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+        self.w3_weights = tt_lib.tensor.load_tensor(
+            tt_cache_path + base_address + "w3.weight" + str(self.args.WEIGHTS_DTYPE) + ".bin"
         )
         self.w3 = TtLinear(
             args.dim,

--- a/models/experimental/mistral/tt/mistral_rms_norm.py
+++ b/models/experimental/mistral/tt/mistral_rms_norm.py
@@ -11,23 +11,14 @@ class TtRMSNorm(nn.Module):
         self,
         dim: int,
         eps: float = 1e-6,
-        state_dict=None,
-        device=None,
         base_address=None,
+        tt_cache_path=None,
     ):
         super().__init__()
         self.eps = eps
-        self.device = device
-        weight = state_dict[f"{base_address}weight"]
 
-        # converting to bfp8 reduces PCC
-        ref_weight = weight.unsqueeze(0).unsqueeze(0).unsqueeze(0)
-        self.weight = tt_lib.tensor.Tensor(
-            ref_weight.reshape(-1).tolist(),
-            ref_weight.shape,
-            tt_lib.tensor.DataType.BFLOAT16,
-            tt_lib.tensor.Layout.ROW_MAJOR,
-        )
+        # bfp8 reduces PCC for so using weights in bfloat16
+        self.weight = tt_lib.tensor.load_tensor(tt_cache_path + base_address + "weightDataType.BFLOAT16.bin")
 
     def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
         return tt_lib.tensor.rmsnorm(x, self.eps, self.weight)

--- a/models/experimental/mistral/tt/mistral_transformer_block.py
+++ b/models/experimental/mistral/tt/mistral_transformer_block.py
@@ -15,25 +15,27 @@ class TtTransformerBlock(nn.Module):
     def __init__(
         self,
         args: TtModelArgs,
-        state_dict=None,
         device=None,
         base_address=None,
+        tt_cache_path=None,
     ):
         super().__init__()
         self.n_heads = args.n_heads
         self.dim = args.dim
         self.device = device
-        self.attention = TtAttention(args, f"{base_address}attention.", device, state_dict)
-        self.feed_forward = TtFeedForward(args, f"{base_address}feed_forward.", device, state_dict)
+        self.attention = TtAttention(args, f"{base_address}attention.", device, tt_cache_path=tt_cache_path)
+        self.feed_forward = TtFeedForward(args, f"{base_address}feed_forward.", device, tt_cache_path=tt_cache_path)
         self.attention_norm = TtRMSNorm(
             args.dim,
             base_address=f"{base_address}attention_norm.",
-            state_dict=state_dict,
-            device=device,
             eps=args.norm_eps,
+            tt_cache_path=tt_cache_path,
         )
         self.ffn_norm = TtRMSNorm(
-            args.dim, base_address=f"{base_address}ffn_norm.", state_dict=state_dict, device=device, eps=args.norm_eps
+            args.dim,
+            base_address=f"{base_address}ffn_norm.",
+            eps=args.norm_eps,
+            tt_cache_path=tt_cache_path,
         )
         self.args = args
 


### PR DESCRIPTION
This PR contains storing weight tensors for mistral in weka in TILE layout.