### PR TITLE
#3894: Add backward unary pow

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -752,3 +752,5 @@ Backward Operations
 .. autofunction:: tt_lib.tensor.add_bw
 
 .. autofunction:: tt_lib.tensor.exp_bw
+
+.. autofunction:: tt_lib.tensor.unary_pow_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/test_backward_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_backward_ops.py
@@ -39,7 +39,7 @@ class TestBackwardOps:
 
         in_data.retain_grad()
 
-        pyt_y = torch.mul(in_data, torch.tensor(scalar))
+        pyt_y = in_data * torch.tensor(scalar)
 
         pyt_y.backward(gradient=grad_data)
 
@@ -195,8 +195,15 @@ class TestBackwardOps:
         logger.info(comp_out)
         assert comp_pass
 
-    @pytest.mark.parametrize("alpha", [1.0])
-    def test_bw_unary_add(self, input_shapes, alpha, device):
+    @pytest.mark.parametrize(
+        "exponent",
+        [
+            0.0,
+            1.0,
+            2.0,
+        ],
+    )
+    def test_bw_unary_pow(self, input_shapes, exponent, device):
         torch.manual_seed(0)
         in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
         grad_data = torch.randn(input_shapes).bfloat16()
@@ -209,12 +216,12 @@ class TestBackwardOps:
             tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
         )
 
-        tt_output_tensor_on_device = tt_lib.tensor.unary_add_bw(grad_tensor, input_tensor, alpha=alpha)
+        tt_output_tensor_on_device = tt_lib.tensor.unary_pow_bw(grad_tensor, input_tensor, exponent=exponent)
         tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
         in_data.retain_grad()
 
-        pyt_y = torch.add(in_data, torch.tensor(alpha))
+        pyt_y = torch.pow(in_data, exponent)
 
         pyt_y.backward(gradient=grad_data)
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -41,6 +41,19 @@ std::vector<Tensor> unary_mul_bw(const Tensor& grad, const Tensor& input, float 
     return operation::decorate_as_composite(__func__, _unary_mul_bw)(grad, input, scalar, output_mem_config);
 }
 
+std::vector<Tensor> _unary_pow_bw(const Tensor& grad, const Tensor& input, float exponent, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor power_input = power(input, exponent - 1, output_mem_config);
+
+    Tensor result = mul_unary(power_input, exponent, output_mem_config);
+    Tensor final_result = mul(result, grad, std::nullopt, output_mem_config);
+    grad_tensor.push_back(final_result);
+    return grad_tensor;
+}
+std::vector<Tensor> unary_pow_bw(const Tensor& grad, const Tensor& input, float exponent, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _unary_pow_bw)(grad, input, exponent, output_mem_config);
+}
 
 std::vector<Tensor> _unary_add_bw(const Tensor& grad, const Tensor& input, float alpha, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -24,6 +24,8 @@ std::vector<Tensor> unary_mul_bw(const Tensor& grad, const Tensor& input, float 
 
 std::vector<Tensor> unary_add_bw(const Tensor& grad, const Tensor& input, float alpha, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> unary_pow_bw(const Tensor& grad, const Tensor& input, float exponent, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 std::vector<Tensor> mul_bw(const Tensor& grad, const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> add_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -78,6 +78,14 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
+    m_tensor.def("unary_pow_bw", &tt::tt_metal::unary_pow_bw,
+        py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("exponent") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for power with given ``grad`` and ``exponent`` where exponent value is greater than 1.
+
+                "exponent", "Exponent value", "integer", "default to 1", "Yes"
+            )doc");
+
+
     m_tensor.def("mul_bw", &tt::tt_metal::mul_bw,
             py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for multiplication of two input tensors with given ``grad``


### PR DESCRIPTION
Added support fro unary power where input is tensor and exponent value is of scalar.
As power op supported for integer values exponent is supported for int values