### PR TITLE
#3103: profile the SFPU operators

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -729,3 +729,5 @@ Other Operations
 .. autofunction:: tt_lib.tensor.repeat_interleave
 
 .. autofunction:: tt_lib.tensor.power_fp
+
+.. autofunction:: tt_lib.tensor.identity

--- a/docs/source/ttnn/ttnn.rst.bck
+++ b/docs/source/ttnn/ttnn.rst.bck
@@ -1,9 +1,0 @@
-TTNN
-====
-
-.. toctree::
-   :maxdepth: 1
-
-   operations
-   tutorials
-   dependencies/index.rst

--- a/scripts/profiler/sfpu_profiler_process.py
+++ b/scripts/profiler/sfpu_profiler_process.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pandas as pd
+import sys
+import os
+import subprocess
+import copy
+from pprint import pprint
+import argparse
+
+# ASSUME: repo is compiled for the profiling
+# ASSUME: test_sfpu is compiled
+results = {}
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(prog="sfpu_profiler_process.py", description="run SFPU profiler")
+    all_operations = [
+        "abs",
+        "exponential",
+        "gelu",
+        "identity",
+        "log",
+        "log10",
+        "log2",
+        "reciprocal",
+        "relu",
+        "sigmoid",
+        "sign",
+        "sqrt",
+        "square",
+        "tanh",
+    ]
+    parser.add_argument("operations", nargs="+", default=all_operations, help=", ".join(all_operations))
+    parser.add_argument("--use-L1", action="store_true", default=False)
+    return parser
+
+
+def get_args():
+    parser = make_parser()
+    return parser.parse_args()
+
+
+def run(args, home, function):
+    testpath = os.path.join(home, "build", "test", "tt_eager", "ops", "test_sfpu")
+    assert os.path.exists(testpath)
+    env = copy.deepcopy(os.environ)
+    env["TT_METAL_SLOW_DISPATCH_MODE"] = "1"
+    env["TT_METAL_DEVICE_PROFILER"] = "1"
+    env["TT_METAL_ENV"] = "dev"
+    testcmd = " ".join([testpath, function, args.use_L1 and "--use-L1" or "--use-DRAM", "--tile-factor", "1"])
+    subprocess.run(testcmd, shell=True, env=env)
+    return
+
+
+def postproc(home):
+    def get_cycles(df):
+        cycles = (
+            df[df[" timer_id"] == 9998][" time[cycles since reset]"].to_numpy()
+            - df[df[" timer_id"] == 9997][" time[cycles since reset]"].to_numpy()
+        )[1]
+        return cycles
+
+    filepath = os.path.join(home, "generated", "profiler", ".logs", "profile_log_device.csv")
+    df = pd.read_csv(filepath, header=1)
+    print(f"the number of cycles (TRISC_1) = {get_cycles(df)}")
+    return get_cycles(df)
+
+
+def main():
+    args = get_args()
+
+    def run_function(function):
+        home = os.environ["TT_METAL_HOME"]
+        run(args, home, function)
+        cycles = postproc(home)
+        results[function] = cycles
+
+    list(map(run_function, args.operations))
+    pprint(["*" * 40, "result", "*" * 40])
+    print(pd.DataFrame.from_dict(results, orient="index", columns=["TRISC_1 Cycles"]))
+    print("*" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tests_common/sfpu_helper/sfpu_helper.hpp
+++ b/tests/tests_common/sfpu_helper/sfpu_helper.hpp
@@ -70,6 +70,10 @@ float ref_abs(float x) {
     return std::abs(x);
 }
 
+float ref_identity(float x) {
+    return x;
+}
+
 vector<uint32_t> sfpu(const vector<uint32_t> &src, std::function<float(float)> sfpu_func) {
     vector<uint32_t> dst;
 
@@ -157,7 +161,8 @@ static std::vector<string> sfpu_op =
      "tanh",
      "sign",
      "abs",
-     "square"
+     "square",
+     "identity"
     };
 
 const map<string, std::function<float(float)>> sfpu_op_to_function = {
@@ -173,7 +178,8 @@ const map<string, std::function<float(float)>> sfpu_op_to_function = {
     {"tanh",        ref_tanh},
     {"sign",        ref_sign},
     {"abs",         ref_abs},
-    {"square",      ref_square}
+    {"square",      ref_square},
+    {"identity",    ref_identity}
 };
 
 const map<string, std::function<vector<uint32_t>(uint32_t num_bytes, int seed)>> sfpu_op_to_init_func = {
@@ -189,7 +195,8 @@ const map<string, std::function<vector<uint32_t>(uint32_t num_bytes, int seed)>>
     {"tanh",        create_random_vector_of_bfloat16_1_1},
     {"sign",        create_random_vector_of_bfloat16_1_1},
     {"abs",         create_random_vector_of_bfloat16_1_1},
-    {"square",      create_random_vector_of_bfloat16_1_1}
+    {"square",      create_random_vector_of_bfloat16_1_1},
+    {"identity",      create_random_vector_of_bfloat16_1_1}
 };
 
 const map<string, std::function<bool(float a, float b)>> sfpu_op_to_comparison_function = {
@@ -205,5 +212,6 @@ const map<string, std::function<bool(float a, float b)>> sfpu_op_to_comparison_f
     {"tanh", is_close_rtol_0p175_atol_0p1},
     {"sign", is_close_rtol_0p175_atol_0p1},
     {"abs",  is_close_rtol_0p175_atol_0p1},
-    {"square", is_close_rtol_0p175_atol_0p1}
+    {"square", is_close_rtol_0p175_atol_0p1},
+    {"identity", is_close_rtol_0p175_atol_0p1}
 };

--- a/tests/tt_eager/ops/kernel/eltwise_sfpu.cpp
+++ b/tests/tt_eager/ops/kernel/eltwise_sfpu.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+
+namespace NAMESPACE {
+void MAIN {
+           uint32_t per_core_block_cnt = 1; // get_compile_time_arg_val(0);
+           uint32_t per_core_block_dim = 1; //get_compile_time_arg_val(1);
+
+
+
+           init_sfpu(tt::CB::c_in0);
+           uint32_t block_index = 0;
+           cb_reserve_back(tt::CB::c_out0, per_core_block_dim);
+           uint32_t tile_index = 0;
+           acquire_dst(tt::DstMode::Half);
+
+           // Pop tile after tile, copy to DST and pack
+           cb_wait_front(tt::CB::c_in0, 1);
+
+           copy_tile(tt::CB::c_in0, 0, 0);
+
+           kernel_profiler::mark_time(9997);
+
+           for(int i=0; i < 1024; i++) {
+#ifdef SFPU_OP_CHAIN_0
+           SFPU_OP_CHAIN_0
+#endif
+           }
+           kernel_profiler::mark_time(9998);
+
+           pack_tile(0, tt::CB::c_out0);
+
+           cb_pop_front(tt::CB::c_in0, 1);
+
+           release_dst(tt::DstMode::Half);
+
+           cb_push_back(tt::CB::c_out0, per_core_block_dim);
+
+}
+}

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -73,7 +73,7 @@ bool run_sfpu_test(string sfpu_name,int tile_factor=1,bool use_DRAM=true) {
         CoreCoord core = {0, 0};
 
         uint32_t single_tile_size = 2 * 1024;
-        uint32_t num_tiles = 2048*tile_factor;
+        uint32_t num_tiles = 1*tile_factor;
         uint32_t dram_buffer_size = single_tile_size * num_tiles; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
         uint32_t page_size = single_tile_size;
@@ -127,7 +127,8 @@ bool run_sfpu_test(string sfpu_name,int tile_factor=1,bool use_DRAM=true) {
                                                 uint(num_tiles),
                                                 1,
         };
-        string hlk_kernel_name = "tt_metal/kernels/compute/eltwise_sfpu.cpp";
+        string hlk_kernel_name = "tests/tt_eager/ops/kernel/eltwise_sfpu.cpp";
+
         // defines macro expands per SFPU ops
         std::map<string, string> hlk_op_name = sfpu_op_to_hlk_op_name.at(sfpu_name);
         auto eltwise_unary_kernel = tt_metal::CreateKernel(


### PR DESCRIPTION
#3103: microkernel profiling automation for unary ops
#0: profile the SFPU operators
#0: update help strings
#0: update SFPU Identity operator help text, docs

```
python3 scripts/profiler/sfpu_profiler_process.py  --help usage: sfpu_profiler_process.py [-h] [--use-L1] operations [operations ...]

run SFPU profiler

positional arguments:
  operations  abs, exponential, gelu, identity, log, log10, log2, reciprocal, relu, sigmoid, sign,
              sqrt, square, tanh

optional arguments:
  -h, --help  show this help message and exit
  --use-L1
```