### PR TITLE
#2860: Init one UMD per MMIO device ID and the remote devices it controls

### DIFF
--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -330,7 +330,7 @@ namespace tt::tt_metal{
             // Create valid PCIe address ranges
             // This implementation assumes contiguous ranges and aggregates the ranges into one bounds check
             // TODO: consider checking multiple ranges to detect straddling transactions
-            uint64_t pcie_chan_base_addr = tt::Cluster::instance().get_pcie_base_addr_from_device();
+            uint64_t pcie_chan_base_addr = tt::Cluster::instance().get_pcie_base_addr_from_device(device->id());
             uint64_t pcie_chan_end_addr = pcie_chan_base_addr;
             for (int pcie_chan = 0; pcie_chan < tt::Cluster::instance().get_num_host_channels(device->id()); pcie_chan++) {
                 pcie_chan_end_addr += tt::Cluster::instance().get_host_channel_size(device->id(), pcie_chan);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -75,6 +75,7 @@ size_t Device::detect_num_pci_devices() {
 
 void Device::initialize_cluster() {
     ZoneScoped;
+    tt::Cluster::instance().initialize_device_driver(this->id_);
     this->clear_l1_state();
 #ifdef TT_METAL_VERSIM_DISABLED
     int ai_clk = tt::Cluster::instance().get_device_aiclk(this->id_);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -75,7 +75,6 @@ size_t Device::detect_num_pci_devices() {
 
 void Device::initialize_cluster() {
     ZoneScoped;
-    tt::Cluster::instance().initialize_device_driver(this->id_);
     this->clear_l1_state();
 #ifdef TT_METAL_VERSIM_DISABLED
     int ai_clk = tt::Cluster::instance().get_device_aiclk(this->id_);

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -46,7 +46,7 @@ class SystemMemoryWriter {
    public:
     SystemMemoryCQWriteInterface cq_write_interface;
     SystemMemoryWriter(Device* device) :
-        m_dma_buf_size(tt::Cluster::instance().get_m_dma_buf_size()),
+        m_dma_buf_size(tt::Cluster::instance().get_m_dma_buf_size(device->id())),
         hugepage_start((char*) tt::Cluster::instance().host_dma_address(0, device->id(), 0)),
         fast_write_callable(
             tt::Cluster::instance().get_fast_pcie_static_tlb_write_callable(device->id())) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -18,10 +18,6 @@
 #include "tt_metal/third_party/umd/device/util.hpp"
 #include "watcher.hpp"
 
-using std::cout;
-using std::endl;
-using std::to_string;
-
 #ifdef ARCH_GRAYSKULL
 static constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
 static constexpr unsigned int MEM_SMALL_READ_WRITE_TLB = DEVICE_DATA.TLB_BASE_INDEX_2M + 1;
@@ -35,7 +31,7 @@ static constexpr uint32_t DYNAMIC_TLB_BASE_INDEX = DEVICE_DATA.MEM_LARGE_READ_TL
 
 namespace tt {
 
-const Cluster &Cluster::instance() {
+Cluster &Cluster::instance() {
     static Cluster inst;
     return inst;
 }
@@ -59,55 +55,70 @@ Cluster::Cluster() {
             get_arch_str(detected_arch));
     }
     const std::string sdesc_file = get_soc_description_file(this->arch_, this->target_type_);
-    const std::string cluster_desc_path = (this->arch_ == tt::ARCH::WORMHOLE_B0) ? GetClusterDescYAML().string() : "";
+    this->cluster_desc_path_ = (this->arch_ == tt::ARCH::WORMHOLE_B0) ? GetClusterDescYAML().string() : "";
 #else
     this->target_type_ = TargetDevice::Versim;
-    std::vector<chip_id_t> physical_mmio_device_ids = {0};
     auto arch_env = getenv("ARCH_NAME");
     TT_FATAL(arch_env, "arch_env needs to be set for versim (ARCH_NAME=)");
     this->arch_ = tt::get_arch_from_string(arch_env);
     const std::string sdesc_file = get_soc_description_file(this->arch_, this->target_type_);
-    const std::string cluster_desc_path = "";
+    this->cluster_desc_path_ = "";
 #endif
 
-
-    if (cluster_desc_path == "") {
-        // All Grayskull devices are MMIO mapped so physical_mmio_device_ids correspond to all available devices
+    if (this->arch_ == tt::ARCH::GRAYSKULL) {
+        // Cannot use tt_SiliconDevice::detect_available_device_ids because that returns physical device IDs
+        std::set<chip_id_t> logical_mmio_device_ids;
         for (chip_id_t logical_mmio_device_id = 0; logical_mmio_device_id < physical_mmio_device_ids.size(); logical_mmio_device_id++) {
-            this->target_device_ids_.insert(logical_mmio_device_id);
+            logical_mmio_device_ids.insert(logical_mmio_device_id);
         }
-        this->cluster_desc_ = tt_ClusterDescriptor::create_for_grayskull_cluster(this->target_device_ids_);
+        this->cluster_desc_ = tt_ClusterDescriptor::create_for_grayskull_cluster(logical_mmio_device_ids);
     } else {
-        this->cluster_desc_ = tt_ClusterDescriptor::create_from_yaml(cluster_desc_path);
-        for (chip_id_t logical_device_id = 0; logical_device_id < this->cluster_desc_->get_number_of_chips();
-             logical_device_id++) {
-            this->target_device_ids_.insert(logical_device_id);
-        }
+        this->cluster_desc_ = tt_ClusterDescriptor::create_from_yaml(this->cluster_desc_path_);
     }
 
-    this->open_device(sdesc_file, cluster_desc_path);
+    // Map MMIO device id to all devices on the same card (including the MMIO device)
+    if (this->target_type_ == TargetDevice::Versim) {
+        std::set<chip_id_t> dummy_versim_card = {0};
+        this->devices_grouped_by_assoc_mmio_device_[0] = dummy_versim_card;
+        this->device_to_mmio_device_[0] = 0;
+    } else {
+        for (chip_id_t device_id : this->cluster_desc_->get_all_chips()) {
+            chip_id_t closest_mmio_device_id = this->cluster_desc_->get_closest_mmio_capable_chip(device_id);
+            std::set<chip_id_t> &device_ids = this->devices_grouped_by_assoc_mmio_device_[closest_mmio_device_id];
+            device_ids.insert(device_id);
+            this->device_to_mmio_device_[device_id] = closest_mmio_device_id;
+        }
+    }
+}
+
+void Cluster::initialize_device_driver(chip_id_t device_id) {
+    chip_id_t assoc_mmio_device_id = this->device_to_mmio_device_.at(device_id);
+    if (this->mmio_device_id_to_driver_.count(assoc_mmio_device_id) and this->mmio_device_id_to_driver_.at(assoc_mmio_device_id) != nullptr) {
+        TT_FATAL(this->target_device_ids_.find(device_id) != this->target_device_ids_.end(), "Expected UMD containing device {} to be initialized with group for MMIO device {}!", device_id, assoc_mmio_device_id);
+        // Already initialized UMD that includes the current device
+        return;
+    }
+
+    this->open_device(device_id);
 
     tt_device_params default_params;
     if (getenv("TT_METAL_VERSIM_DUMP_CORES")) {
         std::string dump_cores_string = getenv("TT_METAL_VERSIM_DUMP_CORES");
         default_params.vcd_dump_cores = tt::utils::strsplit(dump_cores_string, ',');
     }
-    this->start_device(default_params);
+    this->start_device(device_id, default_params);
 }
 
-std::unordered_map<chip_id_t, metal_SocDescriptor> get_metal_desc_from_tt_desc(
+void Cluster::get_metal_desc_from_tt_desc(
     const std::unordered_map<chip_id_t, tt_SocDescriptor> &input,
     const std::unordered_map<chip_id_t, uint32_t> &per_chip_id_harvesting_masks) {
-    std::unordered_map<chip_id_t, metal_SocDescriptor> rval = {};
     for (const auto it : input) {
         chip_id_t id = it.first;
-        rval.emplace(id, metal_SocDescriptor(it.second, per_chip_id_harvesting_masks.at(id)));
+        this->sdesc_per_chip_.emplace(id, metal_SocDescriptor(it.second, per_chip_id_harvesting_masks.at(id)));
     }
-    return rval;
 }
 
-void Cluster::open_device(
-    const std::string &sdesc_path, const std::string &ndesc_path, const bool &skip_driver_allocs) {
+void Cluster::open_device(chip_id_t device_id, const bool &skip_driver_allocs) {
 #ifdef ARCH_GRAYSKULL
     TT_FATAL(
         this->arch_ == tt::ARCH::GRAYSKULL,
@@ -121,7 +132,17 @@ void Cluster::open_device(
         get_string(this->arch_));
 #endif
     TT_FATAL(this->target_type_ == TargetDevice::Versim or this->target_type_ == TargetDevice::Silicon);
+    if (this->target_type_ == TargetDevice::Versim and device_id != 0) {
+        TT_FATAL("Versim can only target device 0");
+    }
 
+    chip_id_t assoc_mmio_device_id = this->device_to_mmio_device_.at(device_id);
+    std::set<chip_id_t> device_ids = this->devices_grouped_by_assoc_mmio_device_.at(assoc_mmio_device_id);
+    this->target_device_ids_.insert(device_ids.begin(), device_ids.end());
+
+    const std::string sdesc_path = get_soc_description_file(this->arch_, this->target_type_);
+
+    std::unique_ptr<tt_device> device_driver;
     if (this->target_type_ == TargetDevice::Silicon) {
         // This is the target/desired number of mem channels per arch/device. Silicon driver will attempt to open
         // this many hugepages as channels, and assert if workload uses more than available.
@@ -131,26 +152,29 @@ void Cluster::open_device(
         // This will remove harvested rows from the soc descriptor
         const bool perform_harvesting = true;
 
-        this->device_ = std::make_unique<tt_SiliconDevice>(
+        device_driver = std::make_unique<tt_SiliconDevice>(
             sdesc_path,
-            ndesc_path,
-            this->target_device_ids_,
+            this->cluster_desc_path_,
+            device_ids,
             num_host_mem_ch_per_mmio_device,
             dynamic_tlb_config,
             skip_driver_allocs,
             perform_harvesting);
 
-        this->device_->clean_system_resources();
-        this->device_->set_driver_host_address_params(host_address_params);
-        this->device_->set_driver_eth_interface_params(eth_interface_params);
-    } else if (this->target_type_ == TargetDevice::Versim) {
-        this->device_ = std::make_unique<tt_VersimDevice>(sdesc_path, ndesc_path);
-    }
-    this->device_->set_device_dram_address_params(dram_address_params);
-    this->device_->set_device_l1_address_params(l1_address_params);
+        device_driver->clean_system_resources();
+        device_driver->set_driver_host_address_params(host_address_params);
+        device_driver->set_driver_eth_interface_params(eth_interface_params);
 
-    this->sdesc_per_chip_ = get_metal_desc_from_tt_desc(
-        this->device_->get_virtual_soc_descriptors(), this->device_->get_harvesting_masks_for_soc_descriptors());
+        // Adding this check is a workaround for current UMD bug that only uses this getter to populate private metadata that is later expected to be populated by unrelated APIs
+        TT_FATAL(device_driver->get_target_mmio_device_ids().size() == 1);
+    } else if (this->target_type_ == TargetDevice::Versim) {
+        device_driver = std::make_unique<tt_VersimDevice>(sdesc_path, this->cluster_desc_path_);
+    }
+    device_driver->set_device_dram_address_params(dram_address_params);
+    device_driver->set_device_l1_address_params(l1_address_params);
+
+    this->get_metal_desc_from_tt_desc(device_driver->get_virtual_soc_descriptors(), device_driver->get_harvesting_masks_for_soc_descriptors());
+    this->mmio_device_id_to_driver_[assoc_mmio_device_id] = std::move(device_driver);
 }
 
 #ifdef ARCH_WORMHOLE
@@ -226,8 +250,8 @@ std::int32_t get_static_tlb_index(CoreCoord target) {
 }
 #endif
 
-void Cluster::configure_static_tlbs(const std::uint32_t &chip) {
-    auto sdesc = get_soc_desc(chip);
+void Cluster::configure_static_tlbs(chip_id_t mmio_device_id) {
+    auto sdesc = get_soc_desc(mmio_device_id);
     auto statically_mapped_cores = sdesc.workers;
     statically_mapped_cores.insert(
         statically_mapped_cores.end(), sdesc.ethernet_cores.begin(), sdesc.ethernet_cores.end());
@@ -236,61 +260,98 @@ void Cluster::configure_static_tlbs(const std::uint32_t &chip) {
     // Setup static TLBs for all worker cores
     for (auto &core : statically_mapped_cores) {
         auto tlb_index = get_static_tlb_index(core);
-        this->device_->configure_tlb(chip, core, tlb_index, address);
+        this->get_driver(mmio_device_id).configure_tlb(mmio_device_id, core, tlb_index, address);
     }
     // Setup static TLBs for MMIO mapped data space
     uint64_t peer_dram_offset = DEVICE_DATA.DRAM_CHANNEL_0_PEER2PEER_REGION_START;
     for (uint32_t tlb_id = DYNAMIC_TLB_BASE_INDEX; tlb_id < DYNAMIC_TLB_BASE_INDEX + DYNAMIC_TLB_COUNT; tlb_id++) {
-        this->device_->configure_tlb(
-            chip, CoreCoord(DEVICE_DATA.DRAM_CHANNEL_0_X, DEVICE_DATA.DRAM_CHANNEL_0_Y), tlb_id, peer_dram_offset);
+        this->get_driver(mmio_device_id).configure_tlb(
+            mmio_device_id, CoreCoord(DEVICE_DATA.DRAM_CHANNEL_0_X, DEVICE_DATA.DRAM_CHANNEL_0_Y), tlb_id, peer_dram_offset);
         // Align address space of 16MB TLB to 16MB boundary
         peer_dram_offset += DEVICE_DATA.DYNAMIC_TLB_16M_SIZE;
     }
-    this->device_->setup_core_to_tlb_map([](CoreCoord core) { return get_static_tlb_index(core); });
+    this->get_driver(mmio_device_id).setup_core_to_tlb_map([](CoreCoord core) { return get_static_tlb_index(core); });
 }
 
-void Cluster::start_device(const tt_device_params &device_params) {
+void Cluster::start_device(chip_id_t device_id, tt_device_params &device_params) {
+    chip_id_t mmio_device_id = this->device_to_mmio_device_.at(device_id);
+    device_params.init_device = true;
+
     TT_FATAL(this->sdesc_per_chip_.size(), "Descriptor must be loaded. Try open_device()");
-    TT_FATAL(this->device_ != nullptr, "Device not initialized, make sure compile is done before running!");
 
     if (this->target_type_ == TargetDevice::Silicon && device_params.init_device) {
-        for (auto &device_id : this->device_->get_target_mmio_device_ids()) {
-            configure_static_tlbs(device_id);
-        }
-        // tt::tlb_config::activate_static_tlbs(device);
+        configure_static_tlbs(mmio_device_id);
     }
 
-    this->device_->start_device(device_params);
+    this->mmio_device_id_to_driver_.at(mmio_device_id)->start_device(device_params);
 }
 
-void Cluster::close_device() {
+void Cluster::close_device_driver(chip_id_t device_id) {
     log_info(tt::LogDevice, "Closing device driver");
-    if (this->device_) {
-        this->device_->close_device();
-        this->device_.reset();
+
+    chip_id_t mmio_device_id = this->device_to_mmio_device_.at(device_id);
+    bool is_mmio_device = (device_id == mmio_device_id);
+
+    // There is one device driver per MMIO device.
+    // Driver needs to remain open if any remote device is still open
+    if (is_mmio_device) {
+        bool all_devices_on_card_closed = true;
+        for (const chip_id_t &device_id_on_card : this->devices_grouped_by_assoc_mmio_device_.at(mmio_device_id)) {
+            if (device_id_on_card == mmio_device_id) { continue; }
+            if (this->target_device_ids_.find(device_id_on_card) != this->target_device_ids_.end()) {
+                all_devices_on_card_closed = false;
+                break;
+            }
+        }
+
+        if (all_devices_on_card_closed) {
+            this->get_driver(mmio_device_id).close_device();
+            this->mmio_device_id_to_driver_.at(mmio_device_id).reset();
+        }
+    }
+
+    // For both MMIO and remote devices we remove it from sdesc map and target device IDs collection to indicate that device has been closed
+    this->sdesc_per_chip_.erase(device_id);
+    this->target_device_ids_.erase(device_id);
+}
+
+Cluster::~Cluster() {
+    for (chip_id_t device_id : this->target_device_ids_) {
+        this->close_device_driver(device_id);
     }
     this->sdesc_per_chip_.clear();
 }
 
-Cluster::~Cluster() { this->close_device(); }
+tt_device &Cluster::get_driver(chip_id_t device_id) const {
+    if (this->target_device_ids_.find(device_id) == this->target_device_ids_.end()) {
+        TT_FATAL("Cannot access driver for device ID {} before it is initialized! Call initialize_device_driver({}) first", device_id, device_id);
+    }
+    chip_id_t mmio_device_id = this->device_to_mmio_device_.at(device_id);
+    return *(this->mmio_device_id_to_driver_.at(mmio_device_id));
+}
+
+const metal_SocDescriptor &Cluster::get_soc_desc(chip_id_t chip) const {
+    if (this->sdesc_per_chip_.find(chip) == this->sdesc_per_chip_.end()) {
+        TT_FATAL("Cannot access soc descriptor for {} before device driver is initialized! Call initialize_device_driver({}) first", chip, chip);
+    }
+    return this->sdesc_per_chip_.at(chip);
+}
 
 uint32_t Cluster::get_harvested_rows(chip_id_t chip) const {
     if (this->target_type_ == TargetDevice::Versim) {
         return 0;
     } else {
-        return this->device_->harvested_rows_per_target.at(chip);
+        return this->get_driver(chip).harvested_rows_per_target.at(chip);
     }
 }
 
 // clean up bad system resource state that may be carried over
-void Cluster::clean_system_resources() const {
-    TT_FATAL(this->device_ != nullptr, "Device not initialized, make sure compile is done before running!");
-    this->device_->clean_system_resources();
+void Cluster::clean_system_resources(chip_id_t device_id) const {
+    this->get_driver(device_id).clean_system_resources();
 }
 
 void Cluster::verify_eth_fw() const {
-    const std::unordered_set<chip_id_t> &all_chips = this->device_->get_all_chips_in_cluster();
-    for (const chip_id_t &chip : all_chips) {
+    for (const chip_id_t &chip : this->target_device_ids_) {
         std::vector<uint32_t> fw_versions;
         for (const CoreCoord &eth_core : get_soc_desc(chip).ethernet_cores) {
             uint32_t val;
@@ -303,8 +364,10 @@ void Cluster::verify_eth_fw() const {
 
 int Cluster::get_device_aiclk(const chip_id_t &chip_id) const {
     if (this->target_device_ids_.find(chip_id) != this->target_device_ids_.end()) {
-        chip_id_t mmio_device_id = this->cluster_desc_->get_closest_mmio_capable_chip(chip_id);
-        return this->device_->get_clocks().at(mmio_device_id);
+        // get_clocks returns MMIO device ID -> clock frequency
+        // There is one driver per MMIO device, so we use that to index returned map
+        chip_id_t mmio_device_id = this->device_to_mmio_device_.at(chip_id);
+        return this->get_driver(chip_id).get_clocks().at(mmio_device_id);
     }
     TT_THROW("Cannot get frequency for device {} that is not initialized!", chip_id);
     return 0;
@@ -334,22 +397,22 @@ void Cluster::reset_debug_print_server_buffers() const {
     }
 }
 
-void Cluster::assert_risc_reset(const chip_id_t &chip) const { this->device_->assert_risc_reset(chip); }
+void Cluster::assert_risc_reset(const chip_id_t &chip) const {  this->get_driver(chip).assert_risc_reset(chip); }
 
 void Cluster::deassert_risc_reset_at_core(const tt_cxy_pair &physical_chip_coord) const {
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(physical_chip_coord.chip);
     tt_cxy_pair virtual_chip_coord = soc_desc.convert_to_umd_coordinates(physical_chip_coord);
-    this->device_->deassert_risc_reset_at_core(virtual_chip_coord);
+    this->get_driver(virtual_chip_coord.chip).deassert_risc_reset_at_core(virtual_chip_coord);
 }
 
 void Cluster::deassert_risc_reset(const chip_id_t &target_device_id, bool start_stagger) const {
     if (this->target_type_ == TargetDevice::Versim) {
         // Not running silicon multichip test
-        this->device_->deassert_risc_reset(*this->target_device_ids_.begin());
+        this->get_driver(target_device_id).deassert_risc_reset(*this->target_device_ids_.begin());
     } else if (this->target_type_ == TargetDevice::Silicon) {
         log_debug(tt::LogLLRuntime, "Stagger start : {}", start_stagger);
         TT_ASSERT(not start_stagger, "UMD currently does not support staggered deassert of RISC reset");
-        this->device_->deassert_risc_reset(target_device_id);
+        this->get_driver(target_device_id).deassert_risc_reset(target_device_id);
     }
 }
 
@@ -404,17 +467,17 @@ void Cluster::read_dram_vec(
 
 void Cluster::write_core(
     const void *mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access) const {
-    int chip_id = core.chip;
+    chip_id_t chip_id = core.chip;
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(chip_id);
     if (tt::llrt::OptionsG.get_watcher_enabled()) {
         tt::llrt::watcher_sanitize_host_noc_write(
             soc_desc, {core.x, core.y}, addr, sz_in_bytes);
     }
     tt_cxy_pair virtual_core = soc_desc.convert_to_umd_coordinates(core);
-    this->device_->write_to_device(mem_ptr, sz_in_bytes, virtual_core, addr, "LARGE_WRITE_TLB");
-    if (this->device_->get_target_remote_device_ids().find(virtual_core.chip) !=
-        this->device_->get_target_remote_device_ids().end()) {
-            this->device_->wait_for_non_mmio_flush();
+    this->get_driver(chip_id).write_to_device(mem_ptr, sz_in_bytes, virtual_core, addr, "LARGE_WRITE_TLB");
+    if (this->get_driver(chip_id).get_target_remote_device_ids().find(virtual_core.chip) !=
+        this->get_driver(chip_id).get_target_remote_device_ids().end()) {
+            this->get_driver(chip_id).wait_for_non_mmio_flush();
         }
 }
 
@@ -429,7 +492,7 @@ void Cluster::read_core(
     }
 
     tt_cxy_pair virtual_core = soc_desc.convert_to_umd_coordinates(core);
-    this->device_->read_from_device(mem_ptr, virtual_core, addr, size_in_bytes, "LARGE_READ_TLB");
+    this->get_driver(chip_id).read_from_device(mem_ptr, virtual_core, addr, size_in_bytes, "LARGE_READ_TLB");
 }
 
 void Cluster::read_core(
@@ -447,10 +510,10 @@ void Cluster::write_reg(const std::uint32_t *mem_ptr, tt_cxy_pair target, uint64
         tt::llrt::watcher_sanitize_host_noc_write(soc_desc, {target.x, target.y}, addr, size_in_bytes);
     }
     tt_cxy_pair virtual_target = soc_desc.convert_to_umd_coordinates(target);
-    this->device_->write_to_device(mem_ptr, size_in_bytes, virtual_target, addr, "REG_TLB");
-    if (this->device_->get_target_remote_device_ids().find(virtual_target.chip) !=
-        this->device_->get_target_remote_device_ids().end()) {
-        this->device_->wait_for_non_mmio_flush();
+    this->get_driver(chip_id).write_to_device(mem_ptr, size_in_bytes, virtual_target, addr, "REG_TLB");
+    if (this->get_driver(chip_id).get_target_remote_device_ids().find(virtual_target.chip) !=
+        this->get_driver(chip_id).get_target_remote_device_ids().end()) {
+        this->get_driver(chip_id).wait_for_non_mmio_flush();
     }
 }
 
@@ -463,18 +526,18 @@ void Cluster::read_reg(std::uint32_t *mem_ptr, tt_cxy_pair target, uint64_t addr
         tt::llrt::watcher_sanitize_host_noc_read(soc_desc, {target.x, target.y}, addr, size_in_bytes);
     }
     tt_cxy_pair virtual_target = soc_desc.convert_to_umd_coordinates(target);
-    this->device_->read_from_device(mem_ptr, virtual_target, addr, size_in_bytes, "REG_TLB");
+    this->get_driver(chip_id).read_from_device(mem_ptr, virtual_target, addr, size_in_bytes, "REG_TLB");
 }
 
 void Cluster::write_sysmem(const void* vec, uint32_t size_in_bytes, uint64_t addr, chip_id_t src_device_id) const {
     constexpr uint16_t channel = 0;
-    this->device_->write_to_sysmem(vec, size_in_bytes, addr, channel, src_device_id);
+    this->get_driver(src_device_id).write_to_sysmem(vec, size_in_bytes, addr, channel, src_device_id);
 }
 
 void Cluster::read_sysmem(void *vec, uint32_t size_in_bytes, uint64_t addr, chip_id_t src_device_id) const {
     // TODO: Uplift
     constexpr uint16_t channel = 0;
-    this->device_->read_from_sysmem(vec, addr, channel, size_in_bytes, src_device_id);
+    this->get_driver(src_device_id).read_from_sysmem(vec, addr, channel, size_in_bytes, src_device_id);
 }
 
 void Cluster::verify_sw_fw_versions(
@@ -504,7 +567,7 @@ void Cluster::dram_barrier(chip_id_t chip_id) const {
     for (uint32_t channel = 0; channel < this->get_soc_desc(chip_id).get_num_dram_channels(); channel++) {
         dram_channels.insert(channel);
     }
-    this->device_->dram_membar(chip_id, "LARGE_WRITE_TLB", dram_channels);
+    this->get_driver(chip_id).dram_membar(chip_id, "LARGE_WRITE_TLB", dram_channels);
 }
 
 // L1 barrier is used to implement host-to-device synchronization and should be used when all previous writes to L1 need
@@ -513,26 +576,26 @@ void Cluster::dram_barrier(chip_id_t chip_id) const {
 // binaries, metadata, and data to compute on are committed before launching kernels
 void Cluster::l1_barrier(chip_id_t chip_id) const {
     // Sets and resets L1 barrier of all tensix cores and ethernet cores
-    this->device_->l1_membar(chip_id, "LARGE_WRITE_TLB");
+    this->get_driver(chip_id).l1_membar(chip_id, "LARGE_WRITE_TLB");
 }
 
 uint32_t Cluster::get_num_host_channels(chip_id_t device_id) const {
     bool mmio_capable = this->cluster_desc_->is_chip_mmio_capable(device_id);
-    return mmio_capable ? this->device_->get_num_host_channels(device_id) : 0;
+    return mmio_capable ? this->get_driver(device_id).get_num_host_channels(device_id) : 0;
 }
 
 uint32_t Cluster::get_host_channel_size(chip_id_t device_id, uint32_t channel) const {
     TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(device_id));
-    return this->device_->get_host_channel_size(device_id, channel);
+    return this->get_driver(device_id).get_host_channel_size(device_id, channel);
 }
 
 void *Cluster::host_dma_address(uint64_t offset, chip_id_t src_device_id, uint16_t channel) const {
     TT_ASSERT(this->cluster_desc_->is_chip_mmio_capable(src_device_id));
-    return this->device_->host_dma_address(offset, src_device_id, channel);
+    return this->get_driver(src_device_id).host_dma_address(offset, src_device_id, channel);
 }
 
-uint64_t Cluster::get_pcie_base_addr_from_device() const {
-    return this->device_->get_pcie_base_addr_from_device();
+uint64_t Cluster::get_pcie_base_addr_from_device(chip_id_t chip_id) const {
+    return this->get_driver(chip_id).get_pcie_base_addr_from_device();
 }
 
 // Ethernet cluster api

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -41,18 +41,21 @@ class Cluster {
     Cluster(const Cluster &) = delete;
     Cluster(Cluster &&other) noexcept = delete;
 
-    static const Cluster &instance();
+    static Cluster &instance();
 
     size_t number_of_devices() const { return this->cluster_desc_->get_number_of_chips(); }
     size_t number_of_pci_devices() const { return this->cluster_desc_->get_chips_with_mmio().size(); }
 
     ARCH arch() const { return this->arch_; }
 
-    const metal_SocDescriptor &get_soc_desc(chip_id_t chip) const { return this->sdesc_per_chip_.at(chip); }
+    void initialize_device_driver(chip_id_t device_id);
+    void close_device_driver(chip_id_t device_id);
+
+    const metal_SocDescriptor &get_soc_desc(chip_id_t chip) const;
     uint32_t get_harvested_rows(chip_id_t chip) const;
 
     //! device driver and misc apis
-    void clean_system_resources() const;
+    void clean_system_resources(chip_id_t device_id) const;
 
     void verify_eth_fw() const;
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions) const;
@@ -73,19 +76,22 @@ class Cluster {
         vector<uint32_t>& data, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
 
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair& target) const {
-        tt_SiliconDevice* device = dynamic_cast<tt_SiliconDevice*>(this->device_.get());
+        chip_id_t mmio_device_id = device_to_mmio_device_.at(target.chip);
+        tt_SiliconDevice* device = dynamic_cast<tt_SiliconDevice*>(this->mmio_device_id_to_driver_.at(mmio_device_id).get());
         const metal_SocDescriptor &soc_desc = this->get_soc_desc(target.chip);
         tt_cxy_pair virtual_chip_coord = soc_desc.convert_to_umd_coordinates(target);
         return device->get_tlb_data_from_target(virtual_chip_coord);
     }
 
-    uint32_t get_m_dma_buf_size() const {
-        tt_SiliconDevice* device = dynamic_cast<tt_SiliconDevice*>(this->device_.get());
+    uint32_t get_m_dma_buf_size(chip_id_t chip_id) const {
+        chip_id_t mmio_device_id = device_to_mmio_device_.at(chip_id);
+        tt_SiliconDevice* device = dynamic_cast<tt_SiliconDevice*>(this->mmio_device_id_to_driver_.at(mmio_device_id).get());
         return device->get_m_dma_buf_size();
     }
 
     std::function<void(uint32_t, uint32_t, const uint8_t*, uint32_t)> get_fast_pcie_static_tlb_write_callable(int chip_id) const {
-        tt_SiliconDevice* device = dynamic_cast<tt_SiliconDevice*>(this->device_.get());
+        chip_id_t mmio_device_id = device_to_mmio_device_.at(chip_id);
+        tt_SiliconDevice* device = dynamic_cast<tt_SiliconDevice*>(this->mmio_device_id_to_driver_.at(mmio_device_id).get());
         return device->get_fast_pcie_static_tlb_write_callable(chip_id);
     }
 
@@ -109,7 +115,7 @@ class Cluster {
     uint32_t get_host_channel_size(chip_id_t device_id, uint32_t channel) const;
     // Returns address in host space
     void *host_dma_address(uint64_t offset, chip_id_t src_device_id, uint16_t channel) const;
-    uint64_t get_pcie_base_addr_from_device() const;
+    uint64_t get_pcie_base_addr_from_device(chip_id_t chip_id) const;
 
     // Ethernet cluster api
     // Returns set of connected chip ids
@@ -128,24 +134,33 @@ class Cluster {
     Cluster();
     ~Cluster();
 
-    void open_device(
-        const std::string &sdesc_path = "", const std::string &ndesc_path = "", const bool &skip_driver_allocs = false);
-    void start_device(const tt_device_params &device_params);
-    void close_device();
+    void open_device(chip_id_t device_id, const bool &skip_driver_allocs = false);
+    void start_device(chip_id_t device_id, tt_device_params &device_params);
 
+    tt_device &get_driver(chip_id_t device_id) const;
+    void get_metal_desc_from_tt_desc(const std::unordered_map<chip_id_t, tt_SocDescriptor> &input, const std::unordered_map<chip_id_t, uint32_t> &per_chip_id_harvesting_masks);
     tt_cxy_pair convert_physical_cxy_to_virtual(const tt_cxy_pair &physical_cxy) const;
-    void configure_static_tlbs(const std::uint32_t &chip);
+    void configure_static_tlbs(chip_id_t mmio_device_id);
 
     ARCH arch_;
     TargetDevice target_type_;
 
-    std::unique_ptr<tt_device> device_;
+    // There is one device driver per PCIe card. This map points id of the MMIO device points to the associated device driver
+    std::unordered_map<chip_id_t, std::unique_ptr<tt_device>> mmio_device_id_to_driver_;
+
     // Need to hold reference to cluster descriptor to detect total number of devices available in cluster
     // UMD static APIs `detect_available_device_ids` and `detect_number_of_chips` only returns number of MMIO mapped
     // devices
+    std::string cluster_desc_path_;
     std::unique_ptr<tt_ClusterDescriptor> cluster_desc_;
+    // There is an entry for every device that can be targeted (MMIO and remote)
     std::unordered_map<chip_id_t, metal_SocDescriptor> sdesc_per_chip_;
 
+    // Collections of devices that are grouped based on the associated MMIO device. MMIO device is included in the grouping
+    std::unordered_map<chip_id_t, std::set<chip_id_t>> devices_grouped_by_assoc_mmio_device_;
+    // Save mapping of device id to associated MMIO device id for fast lookup
+    std::unordered_map<chip_id_t, chip_id_t> device_to_mmio_device_;
+    // Holds collection of devices (MMIO and remote) that can be targeted
     std::set<chip_id_t> target_device_ids_;
 
     tt_device_dram_address_params dram_address_params = {


### PR DESCRIPTION
This helps enable #2943 and concurrent modes of execution support. (Commit taken from https://github.com/tenstorrent-metal/tt-metal/pull/3114/) 

Helps enable 1 HW CQ by setting `num_host_mem_ch_per_mmio_device` to be 1 (MMIO device) + num of remote devices controlled by MMIO device. 

Currently host mem channel = hugepage 

We could have multiple mmio devices with a diff number of remote devices so this change allows each mmio + remote device grouping to have diff number of hugepages

This will work for N300 but we can only have 4 host channels per mmio device. #4087 is opened to spec out how we can have multiple HW CQs for Galaxy. 