### PR TITLE
#3990: Remove DPRINT SETW sticky bit

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/dprint_raise_wait_ncrisc.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/dprint_raise_wait_ncrisc.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
     // with .rodata alignment for non-multiple of 4 strings.
     DPRINT << "TestConstCharStr";
     DPRINT << 'N' << 'C' << '{' << x << ',' << y << '}' << ENDL();
-    DPRINT << SETW(test_width, false) << test_width_num << ENDL();
+    DPRINT << SETW(test_width) << test_width_num << ENDL();
     DPRINT << SETPRECISION(4) << 0.123456f << ENDL();
     DPRINT << FIXED() << F32(0.12f) << ENDL();
     DPRINT << BF16(0x3dfb) << ENDL(); // 0.12255859375

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/test_utils.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/test_utils.hpp
@@ -108,7 +108,7 @@ inline bool FilesMatchesString(string file_name, const string& expected) {
     if (getline(expect_stream, line_b)) {
         tt::log_info(
             tt::LogTest,
-            "Test Error: file {} has less lines than expectes.",
+            "Test Error: file {} has less lines than expected.",
             file_name
         );
         return false;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_mute_print_server.cpp
@@ -19,12 +19,6 @@ R"(Printing int from arg: 0
 Printing int from arg: 2)";
 
 TEST_F(CommandQueueWithDPrintFixture, TestPrintMuting) {
-    bool pass = true;
-
-    if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
-        TT_THROW("Test not supported w/ slow dispatch, exiting");
-    }
-
     // Device already set up by gtest fixture.
     Device *device = this->device_;
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_print_all_harts.cpp
@@ -23,11 +23,10 @@ Basic Types:
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
+3.14159
 3.141590118
-SETW (sticky):
-    123456    123456
-SETW (non-sticky):
-    123456123456
+SETW:
+    123456123456  ab
 HEX/OCT/DEC:
 1e240361100123456
 SLICE:
@@ -44,11 +43,10 @@ Basic Types:
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
+3.14159
 3.141590118
-SETW (sticky):
-    123456    123456
-SETW (non-sticky):
-    123456123456
+SETW:
+    123456123456  ab
 HEX/OCT/DEC:
 1e240361100123456
 SLICE:
@@ -65,11 +63,10 @@ Basic Types:
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
+3.14159
 3.141590118
-SETW (sticky):
-    123456    123456
-SETW (non-sticky):
-    123456123456
+SETW:
+    123456123456  ab
 HEX/OCT/DEC:
 1e240361100123456
 SLICE:
@@ -79,11 +76,10 @@ Basic Types:
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
+3.14159
 3.141590118
-SETW (sticky):
-    123456    123456
-SETW (non-sticky):
-    123456123456
+SETW:
+    123456123456  ab
 HEX/OCT/DEC:
 1e240361100123456
 SLICE:
@@ -100,11 +96,10 @@ Basic Types:
 SETPRECISION/FIXED/DEFAULTFLOAT:
 3.1416
 3.14159012
+3.14159
 3.141590118
-SETW (sticky):
-    123456    123456
-SETW (non-sticky):
-    123456123456
+SETW:
+    123456123456  ab
 HEX/OCT/DEC:
 1e240361100123456
 SLICE:
@@ -117,12 +112,6 @@ TILE: (
   ptr=122880))";
 
 TEST_F(CommandQueueWithDPrintFixture, TestPrintFromAllHarts) {
-    bool pass = true;
-
-    if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
-        TT_THROW("Test not supported w/ slow dispatch, exiting");
-    }
-
     // Device already set up by gtest fixture.
     Device *device = this->device_;
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_raise_wait.cpp
@@ -217,11 +217,6 @@ TestConstCharStrNC{4,4}
 TestStrBR{4,4}
 +++++++++++++++)";
 TEST_F(CommandQueueWithDPrintFixture, TestPrintRaiseWait) {
-    // This test is a fast dispatch test.
-    if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
-        TT_THROW("Test not supported w/ slow dispatch, exiting");
-    }
-try{
     // Device already set up by gtest fixture.
     Device *device = this->device_;
 
@@ -300,7 +295,4 @@ try{
             golden_output
         )
     );
-} catch (std::exception& e) {
-    TT_THROW("Exception: {}", e.what());
-}
 }

--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -74,10 +74,7 @@ struct DEFAULTFLOAT { char tmp; } ATTR_PACK; // Analog of cout << std::defaultfl
 struct HEX  { char tmp; } ATTR_PACK; // Analog of cout << std::hex
 struct OCT  { char tmp; } ATTR_PACK; // Analog of cout << std::oct
 struct DEC  { char tmp; } ATTR_PACK; // Analog of cout << std::dec
-struct SETW {
-    char w;
-    SETW(char wa, bool sticky = true) { w = wa; if (sticky) w |= 0b10000000; }
-} ATTR_PACK; // Analog of cout << std::setw(), defaults to sticky TODO(AP): 2 chars didn't work
+struct SETW { char w; SETW(char w) : w(w) {} } ATTR_PACK; // Analog of cout << std::setw()
 
 // These primitives are intended for ordering debug prints
 // A possible use here is to synchronize debug print order between cores/harts

--- a/tt_metal/hw/inc/debug/dprint_test_common.h
+++ b/tt_metal/hw/inc/debug/dprint_test_common.h
@@ -13,12 +13,10 @@ inline void print_test_data() {
     DPRINT << SETPRECISION(5) << my_float << ENDL();
     DPRINT << SETPRECISION(9) << my_float << ENDL();
     DPRINT << FIXED();
-    // See issue #3990, disable this line for now until it's fixed.
-    // DPRINT << SETPRECISION(5) << my_float << ENDL();
+    DPRINT << SETPRECISION(5) << my_float << ENDL();
     DPRINT << SETPRECISION(9) << my_float << ENDL();
     DPRINT << DEFAULTFLOAT();
-    DPRINT << "SETW (sticky):\n" << SETW(10) << my_int << my_int << ENDL();
-    DPRINT << "SETW (non-sticky):\n" << SETW(10, false) << my_int << my_int << ENDL();
+    DPRINT << "SETW:\n" << SETW(10) << my_int << my_int << SETW(4) << "ab" << ENDL();
     DPRINT << "HEX/OCT/DEC:\n" << HEX() << my_int << OCT() << my_int << DEC() << my_int << ENDL();
     DPRINT << "SLICE:\n";
 // See issue #3970, disable TSLICE printing for math for now.

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -201,7 +201,6 @@ bool DebugPrintServerContext::peek_flush_one_hart_nonblocking(int chip_id, const
     uint32_t wpos = from_dev[0], rpos = from_dev[1];
     uint32_t counter = 0;
     uint32_t sigval = 0;
-    uint32_t sticky_setw = 0; // std::setw is not sticky by default, we have to implement it manually
     char val = 0;
     ostream& stream = (mute_print_server_)? null_stream : *stream_;
     if (rpos < wpos) {
@@ -251,8 +250,7 @@ bool DebugPrintServerContext::peek_flush_one_hart_nonblocking(int chip_id, const
                 break;
                 case DEBUG_PRINT_TYPEID_SETW:
                     val = CAST_U8P(ptr)[0];
-                    stream << setw(val & 0b01111111); // low 7 bits are setw value
-                    sticky_setw  = (val & 0b10000000) ? (val&0b01111111) : 0; // top bit is sticky flag
+                    stream << setw(val);
                     TT_ASSERT(sz == 1);
                 break;
                 case DEBUG_PRINT_TYPEID_SETPRECISION:
@@ -280,17 +278,14 @@ bool DebugPrintServerContext::peek_flush_one_hart_nonblocking(int chip_id, const
                     TT_ASSERT(sz == 1);
                 break;
                 case DEBUG_PRINT_TYPEID_UINT32:
-                    if (sticky_setw) stream << setw(sticky_setw);
                     stream << *reinterpret_cast<uint32_t*>(ptr);
                     TT_ASSERT(sz == 4);
                 break;
                 case DEBUG_PRINT_TYPEID_FLOAT32:
-                    if (sticky_setw) stream << setw(sticky_setw);
                     stream << *reinterpret_cast<float*>(ptr);
                     TT_ASSERT(sz == 4);
                 break;
                 case DEBUG_PRINT_TYPEID_BFLOAT16:
-                    if (sticky_setw) stream << setw(sticky_setw);
                     stream << bfloat16_to_float(*reinterpret_cast<uint16_t*>(ptr));
                     TT_ASSERT(sz == 2);
                 break;
@@ -320,7 +315,6 @@ bool DebugPrintServerContext::peek_flush_one_hart_nonblocking(int chip_id, const
                     }
                 break;
                 case DEBUG_PRINT_TYPEID_INT32:
-                    if (sticky_setw) stream << setw(sticky_setw);
                     stream << *reinterpret_cast<int32_t*>(ptr);
                     TT_ASSERT(sz == 4);
                 break;


### PR DESCRIPTION
This sticky bit feature isn't present in std::setw and has some issues with the SETPRECISION macro, so just remove it.

Also a bit of cleanup in the DPRINT gtests.