### PR TITLE
Issue 4073: Fix for host-side hanging when an invalid DPRINT WAIT command is running on the device.

### DIFF
--- a/docs/source/tools/kernel_print.rst
+++ b/docs/source/tools/kernel_print.rst
@@ -27,7 +27,7 @@ Note that the core coordinates are currently physical NOC coordinates (not logic
 To generate kernel debug prints on the device, include the ``debug/dprint.h`` header and use the APIs defined there.
 And example with the different features available is shown below:
 
-.. code-block::
+.. code-block:: c++
 
     #include "debug/dprint.h"  // required in all kernels using DPRINT
 
@@ -64,7 +64,7 @@ to the current CB read or write pointer. This means that for printing a tile rea
 ``DPRINT`` call has to occur between the ``cb_wait_front`` and ``cb_pop_front`` calls. For printing a tile from the
 back of the CB, the ``DPRINT`` call has to occur between the ``cb_reserve_back`` and ``cb_push_back`` calls.
 
-.. code-block::
+.. code-block:: sh
 
     #include "debug/dprint.h"  // required in all kernels using DPRINT
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/print_hang.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/print_hang.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "debug/dprint.h"
+#include "debug/dprint_test_common.h"
+
+/*
+ * Test kernel that wait for a signal that never raises.
+*/
+
+void kernel_main() {
+    DPRINT << WAIT{1};
+    print_test_data();
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_print_hanging.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "command_queue_fixture.hpp"
+#include "common/bfloat16.hpp"
+#include "impl/debug/dprint_server.hpp"
+#include "gtest/gtest.h"
+#include "test_utils.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// A test for checking that we can handle an invalid WAIT command.
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+const std::string golden_output =
+R"(DPRINT server timed out on core (1,1) riscv 4, waiting on a RAISE signal: 1
+)";
+
+TEST_F(CommandQueueWithDPrintFixture, TestPrintHanging) {
+    // Device already set up by gtest fixture.
+    Device *device = this->device_;
+
+    // Set up program and command queue
+    CommandQueue& cq = *tt::tt_metal::detail::GLOBAL_CQ;
+    Program program = Program();
+
+    // Run a kernel that just waits on a signal that never comes (BRISC only).
+    constexpr CoreCoord core = {0, 0}; // Print on first core only
+    KernelHandle brisc_print_kernel_id = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/print_hang.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}
+    );
+
+    // Run the program
+    EnqueueProgram(cq, program, false);
+    Finish(cq);
+    tt_await_debug_print_server();
+
+    // Check the print log against golden output.
+    EXPECT_TRUE(
+        FilesMatchesString(
+            CommandQueueWithDPrintFixture::dprint_file_name,
+            golden_output
+        )
+    );
+}

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -81,3 +81,13 @@ Note that this function does not actually check whether the device will continue
 data, it only checks whether the print server is currently processing print data.
 */
 void tt_await_debug_print_server();
+
+/**
+@brief Check whether a print hang has been detected by the print server.
+
+The print server tries to determine if a core is stalled due to the combination of (1) a WAIT
+print command and (2) no new print data coming through. An invalid WAIT command and the print
+buffer filling up afterwards can cause the core to spin forever. In this case this function will
+return true and the print server will be terminated.
+*/
+bool tt_print_hang_detected();

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -879,9 +879,9 @@ void CommandQueue::finish() {
         tt::Cluster::instance().read_sysmem(&finish, 4, HOST_CQ_FINISH_PTR, 0);
 
         // There's also a case where the device can be hung due to an unanswered DPRINT WAIT and
-        // a full print buffer. Poll the print server for this case and finish if it happens.
+        // a full print buffer. Poll the print server for this case and throw if it happens.
         if (tt_print_hang_detected()) {
-            break;
+            TT_THROW("Command Queue could not finish: device hang due to unanswered DPRINT WAIT.");
         }
     } while (finish != 1);
 


### PR DESCRIPTION
The issue here was that when an invalid WAIT is followed by more prints than fit in the print buffer, the core will spin forever waiting for space in the print buffer. However, since the WAIT is never satisfied we get a deadlock where the host will also spin forever waiting for the core to finish.

Typically this isn't something we'd expect to have happen (since DPRINT RAISE/WAIT is only for ordering prints), but it's possible that a user could write bad RAISE/WAITs so we shouldn't hang at least.

Changes here are for trying to detect this deadlock from the print server, and give a warning and exit cleanly if it happens.

Passing CI: https://github.com/tenstorrent-metal/tt-metal/actions/runs/7053409465