### PR TITLE
#4055: non-deterministic test_pow_fractional PCC error with watcher enabled

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_pow_fractional.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_pow_fractional.py
@@ -13,6 +13,7 @@ from models.utility_functions import skip_for_wormhole_b0
 
 @skip_for_wormhole_b0()
 def test_pow_fractional_composite(device):
+    torch.manual_seed(577215)
     N = 1
     C = 2
     H = 32


### PR DESCRIPTION
- issue due to random normal variate running into the bfloat16 accuracy and amplifying as failure
- solution is to seed it manually