### PR TITLE
#4096: Fix issue with DPRINT server closing too early for some WAITs

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/test_utils.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/test_utils.hpp
@@ -80,8 +80,9 @@ inline bool FilesMatchesString(string file_name, const string& expected) {
 
     // Go through line-by-line
     string line_a, line_b;
-    int line_num = 1;
+    int line_num = 0;
     while (getline(file, line_a) && getline(expect_stream, line_b)) {
+        line_num++;
         if (line_a != line_b) {
             tt::log_info(
                 tt::LogTest,
@@ -93,23 +94,24 @@ inline bool FilesMatchesString(string file_name, const string& expected) {
             );
             return false;
         }
-        line_num++;
     }
 
     // Make sure that there's no lines left over in either stream
     if (getline(file, line_a)) {
         tt::log_info(
             tt::LogTest,
-            "Test Error: file {} has more lines than expected.",
-            file_name
+            "Test Error: file {} has more lines than expected (>{}).",
+            file_name,
+            line_num
         );
         return false;
     }
     if (getline(expect_stream, line_b)) {
         tt::log_info(
             tt::LogTest,
-            "Test Error: file {} has less lines than expected.",
-            file_name
+            "Test Error: file {} has less lines than expected ({}).",
+            file_name,
+            line_num
         );
         return false;
     }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/dprint/test_raise_wait.cpp
@@ -217,9 +217,6 @@ TestConstCharStrNC{4,4}
 TestStrBR{4,4}
 +++++++++++++++)";
 TEST_F(CommandQueueWithDPrintFixture, TestPrintRaiseWait) {
-    // Disable for now, see https://github.com/tenstorrent-metal/tt-metal/issues/4096
-    GTEST_SKIP();
-
     // Device already set up by gtest fixture.
     Device *device = this->device_;
 


### PR DESCRIPTION
Issue here was that for some tests with lots of RAISE/WAITs, the DPRINT server would sometimes close before capturing all prints. Solution here is to adjust the exit condition to account for existing WAITs. This works fine as long as all WAITs are valid, and handling for any invalid WAITs is handled in issue #4073.