### PR TITLE
Opt LN_sharded and SMX_sharded

### DIFF
--- a/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
@@ -171,7 +171,7 @@ def test_perf_virtual_machine(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_inference_time, expected_compile_time, inference_iterations",
-    ([0.0375, 10, 10],),
+    ([0.0364, 10, 10],),
 )
 def test_perf_bare_metal(
     use_program_cache,

--- a/tt_eager/tt_dnn/op_library/layernorm/kernels/compute/layernorm.cpp
+++ b/tt_eager/tt_dnn/op_library/layernorm/kernels/compute/layernorm.cpp
@@ -99,8 +99,6 @@ void MAIN {
     }
     unpack_reconfig_data_format(tt::CB::c_intermed0, tt::CB::c_intermed0);
     cb_wait_front(cb_in, num_tiles_per_block);
-
-    // UNPACK(( DPRINT  << TSLICE(cb_in, 0, SliceRange::h0_w0_32()) << ENDL() ));
     #endif
 
     // E[x],
@@ -176,6 +174,7 @@ void MAIN {
 
     // (x - E[x])^2, cb_mm2 <-- cb_xmm
     mul_tiles_init();
+    index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -194,6 +193,7 @@ void MAIN {
             cb_push_back(cb_xmm2, subblock_w);
             index_subblock_w_offset += subblock_w;
         }
+        index_h_offset += block_w;
     }
     cb_wait_front(cb_xmm2, num_tiles_per_block);
 
@@ -260,7 +260,7 @@ void MAIN {
             pack_tile(dst0, cb_ex2pe);
             cb_push_back(cb_ex2pe, 1);
             tile_regs_release();
-            cb_wait_front(cb_ex2pe, 1);
+            cb_wait_front(cb_ex2pe, 1+i);
         }
 
     }

--- a/tt_eager/tt_dnn/op_library/layernorm/kernels/compute/layernorm.cpp
+++ b/tt_eager/tt_dnn/op_library/layernorm/kernels/compute/layernorm.cpp
@@ -260,7 +260,6 @@ void MAIN {
             pack_tile(dst0, cb_ex2pe);
             cb_push_back(cb_ex2pe, 1);
             tile_regs_release();
-            cb_wait_front(cb_ex2pe, 1+i);
         }
 
     }

--- a/tt_eager/tt_dnn/op_library/softmax/kernels/compute/softmax.cpp
+++ b/tt_eager/tt_dnn/op_library/softmax/kernels/compute/softmax.cpp
@@ -64,7 +64,7 @@ void MAIN {
         unpack_reconfig_data_format(cb_scale_mask, cb_fused_attn);
 
         // fused attn
-        cb_wait_front(cb_scale_mask, block_w);
+        // cb_wait_front(cb_scale_mask, block_w);
         cb_wait_front(cb_fused_attn, block_w);
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -111,7 +111,7 @@ void MAIN {
         // sum(exp(x))
         ACQ();
         reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
-        cb_wait_front(cb_exps, block_w);
+        // cb_wait_front(cb_exps, block_w);
         cb_wait_front(cb_bcast_scaler, 1);
         cb_reserve_back(cb_recipsumexps, 1);
         for (uint32_t w = 0; w < block_w; w++) {

--- a/tt_eager/tt_dnn/op_library/transformer_tms/compute/transpose_wh_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/compute/transpose_wh_sharded.cpp
@@ -31,7 +31,6 @@ void MAIN {
 
         cb_push_back(cb_out1, 1);
         cb_pop_front(cb_im0, 1);
-        cb_wait_front(cb_out1, 1);
 
 
     }


### PR DESCRIPTION
1. for SMX, remove wait_front to avoid unpacker packer sync
2. for LN, finished compute for one block in one run before switching to another compute section.