### PR TITLE
#0: Ignore /device, not device/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,7 @@ tests/end_to_end_tests/env
 
 # Exclude files that should not be here
 tt_metal/device/
-device/
+/device/
 src/firmware/riscv/targets/erisc/src/api/
 src/firmware/riscv/targets/erisc/src/eth_routing.cpp
 src/firmware/riscv/targets/erisc/src/eth_routing_v2.cpp


### PR DESCRIPTION
 because we have detail/……impl folders for device but still don't want to import trash from the olden days