### PR TITLE
#4053: Add chmod ugo+x step in ansible scripts for copying over script assets

### DIFF
--- a/infra/machine_setup/playbooks/0-install-deps.yaml
+++ b/infra/machine_setup/playbooks/0-install-deps.yaml
@@ -40,6 +40,13 @@
       ansible.builtin.copy:
         src: ../scripts/
         dest: "/opt/tt_metal_infra/scripts/"
+    - name: Make all script files in scripts/ci executable because perms may not txfr
+      become: yes
+      ansible.builtin.file:
+        path: /opt/tt_metal_infra/scripts/ci
+        state: directory
+        mode: ugo+x
+        recurse: yes
     - name: Copy assets
       become: yes
       ansible.builtin.copy:


### PR DESCRIPTION
because permissions don't transfer and I don't think relying on later scripts to turn it on is convenient as we want to be able to update just the scripts and not have to reinstall resets