### PR TITLE
#4181: Add bfloat8_b dtype fix for tests that should support bfloat8_b

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_bmm_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_bmm_test.yaml
@@ -35,6 +35,38 @@ test-list:
   - bmm:
       shape:
         start-shape:
+          - [1, 1, 32, 32]
+          - [1, 1, 32, 32]
+        end-shape:
+          - [6, 12, 256, 256]
+          - [6, 12, 256, 256]
+        interval: [1, 1, 32, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+        method: matmul
+        bcast-batch: False
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: bmm_sweep.csv
+  - bmm:
+      shape:
+        start-shape:
           - [1, 1, 1, 2]
           - [1, 1, 1, 2]
         end-shape:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_add_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_add_test.yaml
@@ -31,11 +31,11 @@ test-list:
         inputs:
           - input-1:
             data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
+            data-type: ["BFLOAT16", "BFLOAT8_B"]
             buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
           - input-2:
             data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
+            data-type: ["BFLOAT16", "BFLOAT8_B"]
             buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_add_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_lerp_ternary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_lerp_ternary_test.yaml
@@ -22,7 +22,7 @@ test-list:
       output-file: eltwise_lerp_ternary_sweep.csv
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
   - eltwise-lerp_ternary:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_mul_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_mul_test.yaml
@@ -22,7 +22,7 @@ test-list:
       args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
       output-file: eltwise_mul_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_squared_difference_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_squared_difference_test.yaml
@@ -23,7 +23,7 @@ test-list:
       output-file: eltwise_squared_difference_sweep.csv
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
   - eltwise-squared_difference:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_sub_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_sub_test.yaml
@@ -23,7 +23,7 @@ test-list:
       output-file: eltwise_sub_sweep.csv
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
   - eltwise-sub:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_xlogy_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_xlogy_test.yaml
@@ -11,20 +11,33 @@ test-list:
         TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
         # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
-        function: gen_rand
-        dtype: bfloat16
-        args:
-          low: 0.001
-          high: 100
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: 0.001
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: 0.001
+            high: 100
       comparison:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
-      output-file: eltwise_xlogy_sweep.csv
       args:
-        data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16", "BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
+      output-file: eltwise_xlogy_sweep.csv
   - eltwise-xlogy:
       shape:
         start-shape: [1, 1, 2, 2]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_tilize_with_zero_padding_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_tilize_with_zero_padding_test.yaml
@@ -23,6 +23,6 @@ test-list:
       output-file: tilize_with_zero_padding_sweep.csv
       args:
         data-layout: ["ROW_MAJOR"]
-        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_transpose_cn_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_transpose_cn_test.yaml
@@ -18,7 +18,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_pcc
+        function: comp_equal
       args-gen: gen_dtype_layout_device
       output-file: transpose_cn_sweep.csv
       args:
@@ -70,7 +70,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_pcc
+        function: comp_equal
       args-gen: gen_dtype_layout_device
       output-file: transpose_cn_sweep.csv
       args:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_transpose_cn_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_transpose_cn_test.yaml
@@ -18,7 +18,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: transpose_cn_sweep.csv
       args:
@@ -44,7 +44,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: transpose_cn_sweep.csv
       args:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_transpose_wh_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_transpose_wh_test.yaml
@@ -18,7 +18,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_pcc
+        function: comp_equal
       args-gen: gen_dtype_layout_device
       output-file: transpose_wh_sweep.csv
       args:
@@ -70,7 +70,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_pcc
+        function: comp_equal
       args-gen: gen_dtype_layout_device
       output-file: transpose_wh_sweep.csv
       args:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_transpose_wh_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_transpose_wh_test.yaml
@@ -18,7 +18,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: transpose_wh_sweep.csv
       args:
@@ -44,7 +44,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: transpose_wh_sweep.csv
       args:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_unpad_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_unpad_test.yaml
@@ -18,7 +18,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_pcc
       args-gen: gen_unpad_args
       output-file: unpad_sweep.csv
       args:
@@ -44,7 +44,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_pcc
       args-gen: gen_unpad_args
       output-file: unpad_sweep.csv
       args:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_unpad_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_unpad_test.yaml
@@ -18,7 +18,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_pcc
+        function: comp_equal
       args-gen: gen_unpad_args
       output-file: unpad_sweep.csv
       args:
@@ -70,7 +70,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_pcc
+        function: comp_equal
       args-gen: gen_unpad_args
       output-file: unpad_sweep.csv
       args:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_untilize_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_untilize_test.yaml
@@ -19,7 +19,7 @@ test-list:
           high: 100
       args-gen: gen_dtype_layout_device
       comparison:
-        function: comp_pcc
+        function: comp_equal
       output-file: untilize_sweep.csv
       args:
         data-layout: ["TILE"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_untilize_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_untilize_test.yaml
@@ -3,32 +3,6 @@ test-list:
   - untilize:
       shape:
         start-shape: [1, 1, 32, 32]
-        end-shape: [12, 24, 512, 512]
-        interval: [1, 1, 32, 32]
-        num-shapes: 1
-        num-samples: 128
-        args-sampling-strategy: "all"
-      env:
-        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
-      datagen:
-        function: gen_rand
-        dtype: bfloat16
-        args:
-          low: -100
-          high: 100
-      args-gen: gen_dtype_layout_device
-      comparison:
-        function: comp_pcc
-      output-file: untilize_sweep.csv
-      args:
-        data-layout: ["TILE"]
-        data-type: ["BFLOAT16", "BFLOAT8_B"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
-  - untilize:
-      shape:
-        start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-shapes: 1
@@ -48,7 +22,7 @@ test-list:
         function: comp_pcc
       output-file: untilize_sweep.csv
       args:
-        data-layout: ["ROW_MAJOR"]
+        data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_untilize_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_untilize_test.yaml
@@ -19,10 +19,36 @@ test-list:
           high: 100
       args-gen: gen_dtype_layout_device
       comparison:
-        function: comp_equal
+        function: comp_pcc
       output-file: untilize_sweep.csv
       args:
-        data-layout: ["ROW_MAJOR", "TILE"]
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+  - untilize:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      args-gen: gen_dtype_layout_device
+      comparison:
+        function: comp_pcc
+      output-file: untilize_sweep.csv
+      args:
+        data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_bmm_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_bmm_test.yaml
@@ -35,6 +35,38 @@ test-list:
   - bmm:
       shape:
         start-shape:
+          - [1, 1, 32, 32]
+          - [1, 1, 32, 32]
+        end-shape:
+          - [6, 12, 256, 256]
+          - [6, 12, 256, 256]
+        interval: [1, 1, 32, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+        method: matmul
+        bcast-batch: False
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: bmm_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - bmm:
+      shape:
+        start-shape:
           - [1, 1, 1, 2]
           - [1, 1, 1, 2]
         end-shape:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_add_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_add_test.yaml
@@ -21,11 +21,11 @@ test-list:
         inputs:
           - input-1:
             data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
+            data-type: ["BFLOAT16", "BFLOAT8_B"]
             buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
           - input-2:
             data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
+            data-type: ["BFLOAT16", "BFLOAT8_B"]
             buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_add_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_lerp_ternary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_lerp_ternary_test.yaml
@@ -22,7 +22,7 @@ test-list:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
   - eltwise-lerp_ternary:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_mul_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_mul_test.yaml
@@ -19,7 +19,7 @@ test-list:
       args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
       output-file: eltwise_mul_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_squared_difference_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_squared_difference_test.yaml
@@ -23,7 +23,7 @@ test-list:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
   - eltwise-squared_difference:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_sub_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_sub_test.yaml
@@ -23,7 +23,7 @@ test-list:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
   - eltwise-sub:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_xlogy_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_xlogy_test.yaml
@@ -8,11 +8,18 @@ test-list:
         num-shapes: 2
         num-samples: 64
       datagen:
-        function: gen_rand
-        dtype: bfloat16
-        args:
-          low: 0.001
-          high: 100
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: 0.001
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: 0.001
+            high: 100
       comparison:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
@@ -21,9 +28,15 @@ test-list:
         TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
         # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
-        data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16", "BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
   - eltwise-xlogy:
       shape:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_matmul_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_matmul_test.yaml
@@ -80,6 +80,7 @@ test-list:
         bcast-batch: True
       datagen:
         function: gen_rand
+        dtype: bfloat16
         args:
           low: -100
           high: 100

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_3_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_3_test.yaml
@@ -24,7 +24,7 @@ test-list:
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM"]
   - sum-3:
       shape:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_tilize_with_zero_padding_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_tilize_with_zero_padding_test.yaml
@@ -23,6 +23,6 @@ test-list:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
-        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_untilize_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_untilize_test.yaml
@@ -16,39 +16,13 @@ test-list:
           high: 100
       args-gen: gen_dtype_layout_device
       comparison:
-        function: comp_pcc
+        function: comp_equal
       output-file: untilize_sweep.csv
       env:
         TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
         # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16", "BFLOAT8_B"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
-  - untilize:
-      shape:
-        start-shape: [1, 1, 32, 32]
-        end-shape: [12, 24, 512, 512]
-        interval: [1, 1, 32, 32]
-        num-shapes: 1
-        num-samples: 128
-        args-sampling-strategy: "all"
-      datagen:
-        function: gen_rand
-        dtype: bfloat16
-        args:
-          low: -100
-          high: 100
-      args-gen: gen_dtype_layout_device
-      comparison:
-        function: comp_pcc
-      output-file: untilize_sweep.csv
-      env:
-        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
-      args:
-        data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_untilize_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_untilize_test.yaml
@@ -22,7 +22,33 @@ test-list:
         TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
         # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
-        data-layout: ["ROW_MAJOR", "TILE"]
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+  - untilize:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      args-gen: gen_dtype_layout_device
+      comparison:
+        function: comp_pcc
+      output-file: untilize_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      args:
+        data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]


### PR DESCRIPTION
Add bfloat8_b type in test sweeps that support bfloat8. Fix additional failing sweeps.