### PR TITLE
Update test sweeps for the system memory input buffer

### DIFF
--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_geglu.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_geglu.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import tt_lib as ttl
+
+from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import activation_geglu as tt_activation_geglu
+from tests.tt_eager.python_api_testing.sweep_tests.common import set_slow_dispatch_mode
+
+
+def run_geglu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+    torch.manual_seed(data_seed)
+
+    if in_mem_config == "SYSTEM_MEMORY":
+        in_mem_config = None
+
+    x = torch.Tensor(size=input_shape).uniform_(-100, 100)
+    x_ref = x.detach().clone()
+
+    # get ref result
+    ref_value = pytorch_ops.activation_geglu(x_ref)
+
+    tt_result = tt_activation_geglu(
+        x=x,
+        device=device,
+        dtype=[dtype],
+        layout=[dlayout],
+        input_mem_config=[in_mem_config],
+        output_mem_config=out_mem_config,
+    )
+
+    # compare tt and golden outputs
+    success, pcc_value = comp_pcc(ref_value, tt_result)
+    logger.debug(pcc_value)
+
+    assert success
+
+
+test_sweep_args = [
+    (
+        (1, 1, 88, 128),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.ROW_MAJOR,
+        "SYSTEM_MEMORY",
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        11033139,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
+    (test_sweep_args),
+)
+def test_geglu(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+    run_geglu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_glu.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_glu.py
@@ -10,11 +10,11 @@ import tt_lib as ttl
 
 from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
-from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import permute as tt_permute
+from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import activation_glu as tt_activation_glu
 from tests.tt_eager.python_api_testing.sweep_tests.common import set_slow_dispatch_mode
 
 
-def run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed, device):
+def run_glu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
     torch.manual_seed(data_seed)
     # prev_dispatch_mode = set_slow_dispatch_mode("1")
 
@@ -25,11 +25,10 @@ def run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config
     x_ref = x.detach().clone()
 
     # get ref result
-    ref_value = pytorch_ops.permute(x_ref, permute_dims=permute_dims)
+    ref_value = pytorch_ops.activation_glu(x_ref)
 
-    tt_result = tt_permute(
+    tt_result = tt_activation_glu(
         x=x,
-        permute_dims=permute_dims,
         device=device,
         dtype=[dtype],
         layout=[dlayout],
@@ -46,29 +45,19 @@ def run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config
 
 test_sweep_args = [
     (
-        (3, 4, 98, 124),
+        (1, 1, 88, 128),
         ttl.tensor.DataType.BFLOAT16,
         ttl.tensor.Layout.ROW_MAJOR,
         "SYSTEM_MEMORY",
         (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
-        (1, 2, 3, 0),
-        18244914,
-    ),
-    (
-        (2, 3, 82, 126),
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.Layout.ROW_MAJOR,
-        "SYSTEM_MEMORY",
-        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
-        (0, 1, 2, 3),
-        4054436,
+        11033139,
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed",
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_permute(input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed, device):
-    run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed, device)
+def test_glu(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+    run_glu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_permute.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_permute.py
@@ -46,15 +46,6 @@ def run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config
 
 test_sweep_args = [
     (
-        (3, 4, 98, 124),
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.Layout.ROW_MAJOR,
-        "SYSTEM_MEMORY",
-        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
-        (1, 2, 3, 0),
-        18244914,
-    ),
-    (
         (2, 3, 82, 126),
         ttl.tensor.DataType.BFLOAT16,
         ttl.tensor.Layout.ROW_MAJOR,

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_permute.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_permute.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import tt_lib as ttl
+
+from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import permute as tt_permute
+from tests.tt_eager.python_api_testing.sweep_tests.common import set_slow_dispatch_mode
+
+
+def run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed, device):
+    torch.manual_seed(data_seed)
+    # prev_dispatch_mode = set_slow_dispatch_mode("1")
+
+    if in_mem_config == "SYSTEM_MEMORY":
+        in_mem_config = None
+
+    x = torch.Tensor(size=input_shape).uniform_(-100, 100)
+    x_ref = x.detach().clone()
+
+    # get ref result
+    ref_value = pytorch_ops.permute(x_ref, permute_dims=permute_dims)
+
+    tt_result = tt_permute(
+        x=x,
+        permute_dims=permute_dims,
+        device=device,
+        dtype=[dtype],
+        layout=[dlayout],
+        input_mem_config=[in_mem_config],
+        output_mem_config=out_mem_config,
+    )
+
+    # compare tt and golden outputs
+    success, pcc_value = comp_pcc(ref_value, tt_result)
+    logger.debug(pcc_value)
+
+    assert success
+
+
+# permute,"[[3, 4, 98, 124]]","{'dtype': [<DataType.BFLOAT16: 0>], 'layout': [<Layout.ROW_MAJOR: 0>], 'input_mem_config': [None], 'output_mem_config': tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM), 'permute_dims': (1, 2, 3, 0)}",18244914,"(('TT_METAL_SLOW_DISPATCH_MODE', ''),)",error,Unexpected index,fail
+# permute,"[[2, 3, 82, 126]]","{'dtype': [<DataType.BFLOAT16: 0>], 'layout': [<Layout.ROW_MAJOR: 0>], 'input_mem_config': [None], 'output_mem_config': tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM), 'permute_dims': (0, 1, 2, 3)}",4054436,"(('TT_METAL_SLOW_DISPATCH_MODE', ''),)",error,Unexpected index,fail
+# permute,"[[2, 6, 6, 2]]","{'dtype': [<DataType.BFLOAT16: 0>], 'layout': [<Layout.ROW_MAJOR: 0>], 'input_mem_config': [None], 'output_mem_config': tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM), 'permute_dims': (1, 3, 0, 2)}",13369045,"(('TT_METAL_SLOW_DISPATCH_MODE', ''),)",error,Unexpected index,fail
+# permute,"[[3, 5, 92, 52]]","{'dtype': [<DataType.BFLOAT16: 0>], 'layout': [<Layout.ROW_MAJOR: 0>], 'input_mem_config': [None], 'output_mem_config': tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM), 'permute_dims': (3, 0, 1, 2)}",3423616,"(('TT_METAL_SLOW_DISPATCH_MODE', ''),)",error,Unexpected index,fail
+
+test_sweep_args = [
+    (
+        (3, 4, 98, 124),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.ROW_MAJOR,
+        "SYSTEM_MEMORY",
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        (1, 2, 3, 0),
+        18244914,
+    ),
+    (
+        (2, 3, 82, 126),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.ROW_MAJOR,
+        "SYSTEM_MEMORY",
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        (0, 1, 2, 3),
+        4054436,
+    ),
+    (
+        (2, 6, 6, 2),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.ROW_MAJOR,
+        "SYSTEM_MEMORY",
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        (1, 3, 0, 2),
+        13369045,
+    ),
+    (
+        (3, 5, 92, 52),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.ROW_MAJOR,
+        "SYSTEM_MEMORY",
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        (3, 0, 1, 2),
+        3423616,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed",
+    (test_sweep_args),
+)
+def test_permute(input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed, device):
+    run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed, device)

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_reglu.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_reglu.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import tt_lib as ttl
+
+from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.tt_eager.python_api_testing.sweep_tests import tt_lib_ops
+from tests.tt_eager.python_api_testing.sweep_tests.common import set_slow_dispatch_mode
+
+
+def run_reglu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, dispatch_mode, device):
+    torch.manual_seed(data_seed)
+    prev_dispatch_mode = set_slow_dispatch_mode(dispatch_mode)
+
+    x = torch.Tensor(size=input_shape).uniform_(-100, 100)
+    x_ref = x.detach().clone()
+
+    ref_value = pytorch_ops.activation_reglu(x_ref)
+
+    tt_result = tt_lib_ops.activation_reglu(
+        x=x,
+        device=device,
+        dtype=dtype,
+        layout=dlayout,
+        input_mem_config=in_mem_config,
+        output_mem_config=out_mem_config,
+    )
+
+    # compare tt and golden outputs
+    success, pcc_value = comp_pcc(ref_value, tt_result)
+    logger.debug(pcc_value)
+
+    set_slow_dispatch_mode(prev_dispatch_mode)
+
+    assert success
+
+
+test_sweep_args = [
+    (
+        (1, 1, 96, 64),
+        [ttl.tensor.DataType.BFLOAT16],
+        [ttl.tensor.Layout.TILE],
+        [None],
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        4689090,
+        "",
+    ),
+    (
+        (1, 1, 64, 128),
+        [ttl.tensor.DataType.BFLOAT16],
+        [ttl.tensor.Layout.TILE],
+        [None],
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        19118259,
+        "",
+    ),
+    (
+        (1, 1, 128, 64),
+        [ttl.tensor.DataType.BFLOAT16],
+        [ttl.tensor.Layout.TILE],
+        [None],
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        12497748,
+        "1",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, dispatch_mode",
+    (test_sweep_args),
+)
+def test_reglu(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, dispatch_mode, device):
+    run_reglu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, dispatch_mode, device)

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_repeat_interleave.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_repeat_interleave.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import tt_lib as ttl
+import numpy as np
+from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.tt_eager.python_api_testing.sweep_tests import tt_lib_ops
+from tests.tt_eager.python_api_testing.sweep_tests.common import set_slow_dispatch_mode
+
+
+def run_repeat_interleave_tests(
+    input_shape, dtype, dlayout, in_mem_config, out_mem_config, repeat, dim, data_seed, dispatch_mode, device
+):
+    torch.manual_seed(data_seed)
+    prev_dispatch_mode = set_slow_dispatch_mode(dispatch_mode)
+
+    x = torch.Tensor(size=input_shape).uniform_(-100, 100).to(torch.bfloat16)
+    x_ref = x.detach().clone()
+
+    ref_value = pytorch_ops.repeat_interleave(
+        x=x_ref,
+        repeat=repeat,
+        dim=dim,
+    )
+
+    tt_result = tt_lib_ops.repeat_interleave(
+        x=x,
+        repeat=repeat,
+        dim=dim,
+        device=device,
+        dtype=dtype,
+        layout=dlayout,
+        input_mem_config=in_mem_config,
+        output_mem_config=out_mem_config,
+    )
+
+    # compare tt and golden outputs
+    success, pcc_value = comp_pcc(ref_value, tt_result)
+    logger.debug(pcc_value)
+
+    set_slow_dispatch_mode(prev_dispatch_mode)
+
+    assert success
+
+
+test_sweep_args = [
+    (
+        (4, 11, 96, 64),
+        [ttl.tensor.DataType.BFLOAT16],
+        [ttl.tensor.Layout.TILE],
+        [None],
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        1,
+        0,
+        15366393,
+        "1",
+    ),
+    (
+        (6, 2, 96, 192),
+        [ttl.tensor.DataType.BFLOAT16],
+        [ttl.tensor.Layout.TILE],
+        [None],
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        1,
+        2,
+        9424875,
+        "1",
+    ),
+    (
+        (1, 1, 128, 64),
+        [ttl.tensor.DataType.BFLOAT16],
+        [ttl.tensor.Layout.ROW_MAJOR],
+        [None],
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        1,
+        2,
+        2738700,
+        "1",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, repeat, dim, data_seed, dispatch_mode",
+    (test_sweep_args),
+)
+def test_repeat_interleave(
+    input_shape, dtype, dlayout, in_mem_config, out_mem_config, repeat, dim, data_seed, dispatch_mode, device
+):
+    run_repeat_interleave_tests(
+        input_shape, dtype, dlayout, in_mem_config, out_mem_config, repeat, dim, data_seed, dispatch_mode, device
+    )

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_split_last_dim_two_chunks_tiled.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_split_last_dim_two_chunks_tiled.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import tt_lib as ttl
+
+from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import (
+    split_last_dim_two_chunks_tiled as tt_split_last_dim_two_chunks_tiled,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.common import set_slow_dispatch_mode
+
+
+def run_geglu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+    torch.manual_seed(data_seed)
+
+    if in_mem_config == "SYSTEM_MEMORY":
+        in_mem_config = None
+
+    x = torch.Tensor(size=input_shape).uniform_(-100, 100)
+    x_ref = x.detach().clone()
+
+    # get ref result
+    ref_value = pytorch_ops.split_last_dim_two_chunks_tiled(x_ref)
+
+    tt_result = tt_split_last_dim_two_chunks_tiled(
+        x=x,
+        device=device,
+        dtype=[dtype],
+        layout=[dlayout],
+        input_mem_config=[in_mem_config],
+        output_mem_config=out_mem_config,
+    )
+
+    # compare tt and golden outputs
+    success, pcc_value = comp_pcc(ref_value, tt_result)
+    logger.debug(pcc_value)
+
+    assert success
+
+
+test_sweep_args = [
+    (
+        (1, 1, 88, 128),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.ROW_MAJOR,
+        "SYSTEM_MEMORY",
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        11033139,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
+    (test_sweep_args),
+)
+def test_geglu(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+    run_geglu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_sum_0.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_sum_0.py
@@ -70,6 +70,7 @@ test_sweep_args = [
 ]
 
 
+# unit test which reproduce low PCC error
 @pytest.mark.parametrize(
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_sum_0.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_sum_0.py
@@ -67,14 +67,6 @@ test_sweep_args = [
         ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
         13587334,
     ),
-    (
-        (1, 4, 50, 48),
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.Layout.ROW_MAJOR,
-        "SYSTEM_MEMORY",
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        3514701,
-    ),
 ]
 
 

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_sum_0.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_sum_0.py
@@ -18,6 +18,9 @@ def run_sum_0_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, 
     torch.manual_seed(data_seed)
     prev_dispatch_mode = set_slow_dispatch_mode("")
 
+    if in_mem_config == "SYSTEM_MEMORY":
+        in_mem_config = None
+
     x = torch.Tensor(size=input_shape).uniform_(0, 100).to(torch.bfloat16)
     ref_value = pytorch_ops.sum(x, dim=0)
 
@@ -64,6 +67,14 @@ test_sweep_args = [
         ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
         13587334,
     ),
+    (
+        (1, 4, 50, 48),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.ROW_MAJOR,
+        "SYSTEM_MEMORY",
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        3514701,
+    ),
 ]
 
 
@@ -73,9 +84,3 @@ test_sweep_args = [
 )
 def test_sum_0_test(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
     run_sum_0_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)
-
-
-# def test_sum_0_test(device):
-#     for (input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed) in test_sweep_args:
-#         os.environ["TT_METAL_SLOW_DISPATCH_MODE"] = "1"
-#         run_sum_0_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_swiglu.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_swiglu.py
@@ -10,11 +10,11 @@ import tt_lib as ttl
 
 from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
-from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import permute as tt_permute
+from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import activation_swiglu as tt_activation_swiglu
 from tests.tt_eager.python_api_testing.sweep_tests.common import set_slow_dispatch_mode
 
 
-def run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed, device):
+def run_swiglu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
     torch.manual_seed(data_seed)
     # prev_dispatch_mode = set_slow_dispatch_mode("1")
 
@@ -25,11 +25,10 @@ def run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config
     x_ref = x.detach().clone()
 
     # get ref result
-    ref_value = pytorch_ops.permute(x_ref, permute_dims=permute_dims)
+    ref_value = pytorch_ops.activation_swiglu(x_ref)
 
-    tt_result = tt_permute(
+    tt_result = tt_activation_swiglu(
         x=x,
-        permute_dims=permute_dims,
         device=device,
         dtype=[dtype],
         layout=[dlayout],
@@ -46,29 +45,20 @@ def run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config
 
 test_sweep_args = [
     (
-        (3, 4, 98, 124),
+        (1, 1, 88, 128),
         ttl.tensor.DataType.BFLOAT16,
         ttl.tensor.Layout.ROW_MAJOR,
         "SYSTEM_MEMORY",
         (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
-        (1, 2, 3, 0),
-        18244914,
-    ),
-    (
-        (2, 3, 82, 126),
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.Layout.ROW_MAJOR,
-        "SYSTEM_MEMORY",
-        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
-        (0, 1, 2, 3),
-        4054436,
+        True,
+        11033139,
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed",
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-def test_permute(input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed, device):
-    run_permute_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, permute_dims, data_seed, device)
+def test_swiglu(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+    run_swiglu_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_swiglu.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_swiglu.py
@@ -50,7 +50,6 @@ test_sweep_args = [
         ttl.tensor.Layout.ROW_MAJOR,
         "SYSTEM_MEMORY",
         (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
-        True,
         11033139,
     ),
 ]

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_tilize.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_tilize.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import tt_lib as ttl
+
+from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import tilize as tt_tilize
+from tests.tt_eager.python_api_testing.sweep_tests.common import set_slow_dispatch_mode
+
+
+def run_tilize_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, use_multicore, data_seed, device):
+    torch.manual_seed(data_seed)
+    # prev_dispatch_mode = set_slow_dispatch_mode("1")
+
+    if in_mem_config == "SYSTEM_MEMORY":
+        in_mem_config = None
+
+    x = torch.Tensor(size=input_shape).uniform_(-100, 100)
+    x_ref = x.detach().clone()
+
+    # get ref result
+    ref_value = pytorch_ops.tilize(x_ref)
+
+    tt_result = tt_tilize(
+        x=x,
+        use_multicore=use_multicore,
+        device=device,
+        dtype=[dtype],
+        layout=[dlayout],
+        input_mem_config=[in_mem_config],
+        output_mem_config=out_mem_config,
+    )
+
+    # compare tt and golden outputs
+    success, pcc_value = comp_pcc(ref_value, tt_result)
+    logger.debug(pcc_value)
+
+    assert success
+
+
+# tilize,"[[7, 14, 32, 160]]","{'dtype': [<DataType.BFLOAT16: 0>], 'layout': [<Layout.TILE: 1>], 'input_mem_config': [None], 'output_mem_config': tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM), 'use_multicore': True}",9456908,"(('TT_METAL_SLOW_DISPATCH_MODE', ''),)",error,Unexpected index,fail
+# tilize,"[[7, 14, 32, 160]]","{'dtype': [<DataType.BFLOAT16: 0>], 'layout': [<Layout.TILE: 1>], 'input_mem_config': [None], 'output_mem_config': tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM), 'use_multicore': False}",4689090,"(('TT_METAL_SLOW_DISPATCH_MODE', ''),)",error,Unexpected index,fail
+
+test_sweep_args = [
+    (
+        (7, 14, 32, 160),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.TILE,
+        "SYSTEM_MEMORY",
+        (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)),
+        True,
+        9456908,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, use_multicore, data_seed",
+    (test_sweep_args),
+)
+def test_tilize(input_shape, dtype, dlayout, in_mem_config, out_mem_config, use_multicore, data_seed, device):
+    run_tilize_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, use_multicore, data_seed, device)

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_tilize.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_tilize.py
@@ -11,12 +11,10 @@ import tt_lib as ttl
 from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import tilize as tt_tilize
-from tests.tt_eager.python_api_testing.sweep_tests.common import set_slow_dispatch_mode
 
 
 def run_tilize_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, use_multicore, data_seed, device):
     torch.manual_seed(data_seed)
-    # prev_dispatch_mode = set_slow_dispatch_mode("1")
 
     if in_mem_config == "SYSTEM_MEMORY":
         in_mem_config = None
@@ -43,9 +41,6 @@ def run_tilize_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config,
 
     assert success
 
-
-# tilize,"[[7, 14, 32, 160]]","{'dtype': [<DataType.BFLOAT16: 0>], 'layout': [<Layout.TILE: 1>], 'input_mem_config': [None], 'output_mem_config': tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM), 'use_multicore': True}",9456908,"(('TT_METAL_SLOW_DISPATCH_MODE', ''),)",error,Unexpected index,fail
-# tilize,"[[7, 14, 32, 160]]","{'dtype': [<DataType.BFLOAT16: 0>], 'layout': [<Layout.TILE: 1>], 'input_mem_config': [None], 'output_mem_config': tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM), 'use_multicore': False}",4689090,"(('TT_METAL_SLOW_DISPATCH_MODE', ''),)",error,Unexpected index,fail
 
 test_sweep_args = [
     (

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_glu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_glu_test.yaml
@@ -19,7 +19,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -45,7 +45,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_reglu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_reglu_test.yaml
@@ -19,7 +19,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -45,7 +45,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_swiglu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_swiglu_test.yaml
@@ -19,7 +19,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -45,7 +45,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_groupnorm_noweights_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_groupnorm_noweights_test.yaml
@@ -24,5 +24,5 @@ test-list:
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_rmsnorm_noweights_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_rmsnorm_noweights_test.yaml
@@ -24,7 +24,7 @@ test-list:
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
   - rmsnorm-noweights:
       shape:
@@ -50,5 +50,5 @@ test-list:
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_rmsnorm_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_rmsnorm_test.yaml
@@ -25,7 +25,7 @@ test-list:
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]
   - rmsnorm:
       shape:
@@ -52,5 +52,5 @@ test-list:
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
-        buffer-type: ["DRAM", "L1"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
         out-buffer-type: ["DRAM"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_sum_0_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_sum_0_test.yaml
@@ -3,7 +3,7 @@ test-list:
   - sum-0:
       shape:
         start-shape: [1, 1, 32, 32]
-        end-shape: [6, 12, 256, 256]
+        end-shape: [3, 6, 128, 128]
         interval: [1, 1, 32, 32]
         num-shapes: 1
         num-samples: 64
@@ -29,7 +29,7 @@ test-list:
   - sum-0:
       shape:
         start-shape: [1, 1, 2, 2]
-        end-shape: [6, 12, 256, 256]
+        end-shape: [3, 6, 128, 128]
         interval: [1, 1, 2, 2]
         num-shapes: 1
         num-samples: 64

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_glu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_glu_test.yaml
@@ -16,7 +16,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -42,7 +42,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_reglu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_reglu_test.yaml
@@ -16,7 +16,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -42,7 +42,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_swiglu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_swiglu_test.yaml
@@ -16,7 +16,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -42,7 +42,7 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_fast_and_approx_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_0_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_0_test.yaml
@@ -9,10 +9,10 @@ test-list:
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
-        function: gen_checkerboard
+        function: gen_rand
         dtype: bfloat16
         args:
-          low: 0
+          low: -100
           high: 100
       comparison:
         function: comp_pcc
@@ -35,10 +35,10 @@ test-list:
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
-        function: gen_checkerboard
+        function: gen_rand
         dtype: bfloat16
         args:
-          low: 0
+          low: -100
           high: 100
       comparison:
         function: comp_pcc

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_1_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_1_test.yaml
@@ -9,10 +9,10 @@ test-list:
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
-        function: gen_checkerboard
+        function: gen_rand
         dtype: bfloat16
         args:
-          low: 0
+          low: -100
           high: 100
       comparison:
         function: comp_pcc
@@ -35,10 +35,10 @@ test-list:
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
-        function: gen_checkerboard
+        function: gen_rand
         dtype: bfloat16
         args:
-          low: 0
+          low: -100
           high: 100
       comparison:
         function: comp_pcc

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_2_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_2_test.yaml
@@ -9,16 +9,13 @@ test-list:
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
-        function: gen_checkerboard
+        function: gen_rand
         dtype: bfloat16
         args:
-          low: 0
+          low: -100
           high: 100
       comparison:
-        function: comp_allclose
-        args:
-          rtol: 0
-          atol: 0.1
+        function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: sum_2_sweep.csv
       env:
@@ -38,16 +35,13 @@ test-list:
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
-        function: gen_checkerboard
+        function: gen_rand
         dtype: bfloat16
         args:
-          low: 0
+          low: -100
           high: 100
       comparison:
-        function: comp_allclose
-        args:
-          rtol: 0
-          atol: 0.1
+        function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: sum_2_sweep.csv
       env:

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_3_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_sum_3_test.yaml
@@ -9,10 +9,10 @@ test-list:
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
-        function: gen_checkerboard
+        function: gen_rand
         dtype: bfloat16
         args:
-          low: 0
+          low: -100
           high: 100
       comparison:
         function: comp_pcc
@@ -35,10 +35,10 @@ test-list:
         num-samples: 64
         args-sampling-strategy: "all"
       datagen:
-        function: gen_checkerboard
+        function: gen_rand
         dtype: bfloat16
         args:
-          low: 0
+          low: -100
           high: 100
       comparison:
         function: comp_pcc


### PR DESCRIPTION
Update some test sweep yaml files for system memory input buffer. Some operations now support system memory as an input buffer type. In this PR, we have also added the unit tests for the operations which throw "unexpected index" error.