### PR TITLE
#4231: improve unary add, sub, mul and div implementation in SFPU. Add complex polar operator

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -641,7 +641,9 @@ Complex Operations (Type 2)
 ---------------------------
 Type 2 Complex representation allows for more flexible storage than earlier one while providing same set of
 operations; specifically this storage allows for compute without the cost of split-concat implict in
-the Type 1 contiguous representations.
+the Type 1 contiguous representations. One additional function is following,
+
+.. autofunction:: tt_lib.tensor.polar
 
 Other Operations
 ----------------

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_composite.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_composite.py
@@ -26,6 +26,7 @@ reference_pcc = defaultdict(lambda: 0.999)
 reference_pcc["silu"] = 0.9714
 reference_pcc["swish"] = reference_pcc["silu"]
 reference_pcc["softplus"] = 0.9984
+reference_pcc["softsign"] = reference_pcc["softplus"]
 
 
 def custom_compare(*args, **kwargs):

--- a/tt_eager/tt_dnn/op_library/complex/complex_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/complex/complex_ops.cpp
@@ -178,6 +178,19 @@ ComplexTensor complex_sub(const ComplexTensor& input_a, const ComplexTensor& inp
              sub(input_a[1],input_b[1],{},output_mem_config) });
 }
 
+ComplexTensor polar(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {
+
+    Tensor c = cos(input_b,output_mem_config);
+    Tensor r = mul(input_a,c,{},output_mem_config);
+    c.deallocate();
+
+    Tensor s = sin(input_b,output_mem_config);
+    Tensor i = mul(input_a,s,{},output_mem_config);
+    s.deallocate();
+
+    return ComplexTensor({r,i});
+}
+
 }//namespace tt_metal
 
 }//namespace tt

--- a/tt_eager/tt_dnn/op_library/complex/complex_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/complex/complex_ops.hpp
@@ -88,6 +88,9 @@ ComplexTensor complex_mul(const ComplexTensor& input_a, const ComplexTensor& inp
 ComplexTensor complex_div(const ComplexTensor& input_a, const ComplexTensor& input_b,  const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 ComplexTensor complex_recip(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+//polar operator: return a complex value tensor
+ComplexTensor polar(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 } //namespace tt_metal
 
 } //namespace tt

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -74,7 +74,14 @@ Tensor bias_gelu_unary(const Tensor& a, float bias, const MemoryConfig& output_m
 // Function: softsign
 // Ref: https://pytorch.org/docs/stable/generated/torch.nn.Softsign.html
 Tensor _softsign(const Tensor& a, const MemoryConfig& output_mem_config) {
-    return mul(a, recip(add1(abs(a, output_mem_config), output_mem_config), output_mem_config), std::nullopt, output_mem_config);
+    Tensor recip_a = unary_chain(a,{
+        UnaryWithParam{.op_type = UnaryOpType::ABS},
+        UnaryWithParam{.op_type = UnaryOpType::ADD_UNARY,
+                        .param = 1.0f},
+        UnaryWithParam{.op_type = UnaryOpType::RECIP}
+    },output_mem_config);
+
+    return mul(a, recip_a, std::nullopt, output_mem_config);
 }
 Tensor softsign(const Tensor& a, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _softsign)(a, output_mem_config);
@@ -371,9 +378,8 @@ Tensor mac(const Tensor& a, const Tensor& b, const Tensor& c, const MemoryConfig
 }
 
 Tensor _mac_overload(const Tensor& a, float b, float c, const MemoryConfig& output_mem_config) {
-    Tensor t_b = mk_scalar(b);
-    Tensor t_c = mk_scalar(c);
-    return  mac(a, t_b, t_c, output_mem_config);
+  const Tensor ab = tt::tt_metal::mul_unary(b,a,output_mem_config);
+  return tt::tt_metal::add_unary(ab,c,output_mem_config);
 }
 Tensor mac(const Tensor& input_a, float b, float c, const MemoryConfig& output_mem_config )
 {

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -24,15 +24,6 @@ using binary_tensor_op_t = Tensor (const Tensor& a, const Tensor& b);
 //Note: inline doesn't allow pybind to work well so we keep few function not inlined.
 
 template<typename T>
-Tensor mk_scalar(T value) {
-    assert(std::is_scalar<T>::value && "T should be scalar");
-    std::array<unsigned int,4> shape = {1,1,1,1};
-    auto buffer = owned_buffer::create(std::vector{bfloat16(value)});
-    Tensor scalar = Tensor(OwnedStorage{buffer}, shape, DataType::BFLOAT16, Layout::ROW_MAJOR);
-    return scalar;
-}
-
-template<typename T>
 Tensor mk_tiled_scalar(T value) {
     assert(std::is_scalar<T>::value && "T should be scalar");
     std::array<unsigned int,4> shape = {1, 1, TILE_HEIGHT, TILE_WIDTH};

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -67,13 +67,22 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string,std::string>
         case UnaryOpType::LEAKY_RELU:
             defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1";
             break;
+        case UnaryOpType::ADD_UNARY:
+        case UnaryOpType::SUB_UNARY:
+        case UnaryOpType::MUL_UNARY:
+        case UnaryOpType::DIV_UNARY:
+            defines["SFPU_OP_BINOP_WITH_SCALAR_INCLUDE"] = "1";
+            break;
         case UnaryOpType::IDENTITY:
             defines["SFPU_OP_IDENTITY_INCLUDE"] = "1";
             break;
         case UnaryOpType::RDIV:
+            defines["SFPU_OP_RECIP_INCLUDE"] = "1";
+            defines["SFPU_OP_BINOP_WITH_SCALAR_INCLUDE"] = "1";
             break;
         case UnaryOpType::RSUB:
             defines["SFPU_OP_REVERSE_FAMILY_INCLUDE"] = "1";
+	    break;
         case UnaryOpType::ISINF:
         case UnaryOpType::ISNAN:
         case UnaryOpType::ISNEGINF:
@@ -117,8 +126,12 @@ std::pair<string, string> get_op_init_and_func_parameterized(UnaryOpType op_type
         case UnaryOpType::EXP: op_init_and_name = {"exp_tile_init({1});", fmt::format("exp_tile({0}, {1}u);", idst, std::to_string((uint32_t)param0))}; break;
         case UnaryOpType::ERF: op_init_and_name = {"erf_tile_init({1});", fmt::format("erf_tile({0}, {1}u);", idst, std::to_string((uint32_t)param0))}; break;
         case UnaryOpType::ERFC: op_init_and_name = {"erfc_tile_init({1});", fmt::format("erfc_tile({0}, {1}u);", idst, std::to_string((uint32_t)param0))}; break;
-        case UnaryOpType::RDIV: op_init_and_name = {}; break;
+        case UnaryOpType::RDIV: op_init_and_name = {"recip_tile_init();", fmt::format("recip_tile({}); mul_unary_tile({},{}u);",idst, idst,Converter::to_hex(param0))}; break;
         case UnaryOpType::RSUB: op_init_and_name = {"rsub_tile_init();", fmt::format("rsub_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
+        case UnaryOpType::SUB_UNARY: op_init_and_name = {"binop_with_scalar_tile_init();", fmt::format("sub_unary_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
+        case UnaryOpType::ADD_UNARY: op_init_and_name = {"binop_with_scalar_tile_init();", fmt::format("add_unary_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
+        case UnaryOpType::MUL_UNARY: op_init_and_name = {"binop_with_scalar_tile_init();", fmt::format("mul_unary_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
+        case UnaryOpType::DIV_UNARY: op_init_and_name = {"binop_with_scalar_tile_init();", fmt::format("div_unary_tile({}, {}u);", idst, Converter::to_hex(1.0f/param0))}; break;
         default:
         TT_ASSERT( false && "unexpected parameterized type");
     };
@@ -301,54 +314,6 @@ const operation::Hash EltwiseUnary::compute_program_hash(const std::vector<Tenso
         }
     }
     return hash;
-}
-
-//unary op version tie
-template<BcastOpMath OP>
-Tensor tie_binop_to_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
-  Tensor t_value = mk_tiled_scalar(value);
-  return bcast(input_tensor, t_value, OP, BcastOpDim::HW);
-}
-
-Tensor div_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
-    return tie_binop_to_unary<BcastOpMath::MUL>(input_tensor, 1.0f/value, output_mem_config);
-}
-
-Tensor div_unary(float value,const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-    Tensor inv = recip(input_tensor,output_mem_config);
-    return tie_binop_to_unary<BcastOpMath::MUL>(inv, value, output_mem_config);
-}
-
-//same as div_unary(value,tensor)
-Tensor rdiv(const Tensor& input_tensor,float value, const MemoryConfig& output_mem_config) {
-    return div_unary(value,input_tensor,output_mem_config);
-}
-
-
-
-Tensor mul_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
-    return tie_binop_to_unary<BcastOpMath::MUL>(input_tensor, value, output_mem_config);
-}
-
-Tensor sub_unary(const Tensor& input_tensor,float value, const MemoryConfig& output_mem_config) {
-    return tie_binop_to_unary<BcastOpMath::SUB>(input_tensor, value, output_mem_config);
-}
-
-Tensor sub_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-  return add_unary(value, neg(input_tensor, output_mem_config), output_mem_config);
-}
-
-Tensor add_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
-    return tie_binop_to_unary<BcastOpMath::ADD>(input_tensor, value, output_mem_config);
-}
-
-// symmetric
-Tensor add_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-    return add_unary(input_tensor, value, output_mem_config);
-}
-
-Tensor mul_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-    return mul_unary(input_tensor, value, output_mem_config);
 }
 
 }  // namespace tt_metal

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -771,6 +771,9 @@ namespace tt::tt_metal::detail{
             py::arg("input_a"), py::arg("input_b"),
             py::arg("output_mem_config").noconvert() = std::nullopt,R"doc(Perform an eltwise-binary subtraction ``input_a - input_b`` on two complex tensors.)doc");
 
+        m_tensor.def("polar", py::overload_cast<const Tensor&,const Tensor&, const MemoryConfig&>(&tt::tt_metal::polar),
+	    py::arg("input_a"), py::arg("input_b"),
+            py::arg("output_mem_config").noconvert() = std::nullopt,R"doc(Perform an polar to Cartesian transformation of the input_a (r), input_b(theta) into x + i*y generating a type-2 complex tensor.)doc");
 
         detail::bind_binary_op<false, true, false>(m_tensor, "logical_xor", &logical_xor, R"doc(Performs eltwise-binary logical_xor (``{0} ^ {1}``) on two tensors.)doc");
         detail::bind_binary_op<false, true, false>(m_tensor, "max", &tt::tt_metal::max, R"doc(Perform an eltwise-binary max on two tensors.)doc");

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -199,7 +199,23 @@ namespace tt::tt_metal::detail {
         detail::bind_unary_op(m_tensor, "rad2deg", &rad2deg, R"doc(Returns tensor with the rad2deg conversion of elements of the input tensor ``{0}``.)doc");
 
 
-        m_tensor.def("mul_unary", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&mul_unary),
+        m_tensor.def("mul_unary", [](float a, const Tensor& b, const MemoryConfig& c) -> Tensor { return mul_unary(a,b,c); },
+            py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Perform an eltwise-binary mul on one tensor and one scalar.
+
+            Both inputs, the tensor and scalar, must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "scalar", "Scalar", "float", "", "Yes"
+                "input", "Tensor to mul", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
+        )doc");
+        m_tensor.def("mul_unary", [](const Tensor& a,float b,  const MemoryConfig& c) -> Tensor { return mul_unary(a,b,c); },
             py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Perform an eltwise-binary mul on one tensor and one scalar.
 
@@ -216,7 +232,7 @@ namespace tt::tt_metal::detail {
 
         )doc");
 
-        m_tensor.def("div_unary", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&div_unary),
+        m_tensor.def("div_unary", [](float a, const Tensor& b, const MemoryConfig& c) -> Tensor { return div_unary(a,b,c); },
             py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Perform an eltwise-binary div on one tensor and one scalar.
 
@@ -232,8 +248,40 @@ namespace tt::tt_metal::detail {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
 
         )doc");
+        m_tensor.def("div_unary", [](const Tensor& a,float b,  const MemoryConfig& c) -> Tensor { return div_unary(a,b,c); },
+            py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Perform an eltwise-binary div on one tensor and one scalar.
 
-        m_tensor.def("sub_unary", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&sub_unary),
+            Both inputs, the tensor and scalar, must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor to div", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "scalar", "Scalar", "float", "", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
+        )doc");
+
+        m_tensor.def("sub_unary", [](float a, const Tensor& b, const MemoryConfig& c) -> Tensor { return sub_unary(a,b,c); },
+            py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Perform an eltwise-binary sub on one tensor and one scalar.
+
+            Both inputs, the tensor and scalar, must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "scalar", "Scalar", "float", "", "Yes"
+                "input", "Tensor to sub", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
+        )doc");
+        m_tensor.def("sub_unary", [](const Tensor& a,float b,  const MemoryConfig& c) -> Tensor { return sub_unary(a,b,c); },
             py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Perform an eltwise-binary sub on one tensor and one scalar.
 
@@ -250,7 +298,7 @@ namespace tt::tt_metal::detail {
 
         )doc");
 
-        m_tensor.def("add_unary", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&add_unary),
+        m_tensor.def("add_unary", [](float a, const Tensor& b, const MemoryConfig& c) -> Tensor { return add_unary(a,b,c); },
             py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Perform an eltwise-binary add on one tensor and one scalar.
 
@@ -264,32 +312,25 @@ namespace tt::tt_metal::detail {
                 "scalar", "Scalar", "float", "", "Yes"
                 "input", "Tensor to add", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
+        )doc");
+        m_tensor.def("add_unary", [](const Tensor& a,float b,  const MemoryConfig& c) -> Tensor { return add_unary(a,b,c); },
+            py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Perform an eltwise-binary mul on one tensor and one scalar.
+
+            Both inputs, the tensor and scalar, must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor to add", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "scalar", "Scalar", "float", "", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
         )doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "sub_unary", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&sub_unary),
-            py::arg("scalar"),
-            R"doc(Perform an eltwise-binary sub on one tensor ``{0}`` and one scalar ``{1}``.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "mul_unary", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&mul_unary),
-            py::arg("scalar"),
-            R"doc(Perform an eltwise-binary mul on one tensor ``{0}`` and one scalar ``{1}``.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "div_unary", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&div_unary),
-            py::arg("scalar"),
-            R"doc(Perform an eltwise-binary div on one tensor ``{0}`` and one scalar ``{1}``.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "add_unary", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&add_unary),
-            py::arg("scalar"),
-            R"doc(Perform an eltwise-binary add on one tensor ``{0}`` and one scalar ``{1}``.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
 
         // softmax
         m_tensor.def("softmax", &softmax,

--- a/tt_metal/hw/ckernels/grayskull/common/inc/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/grayskull/common/inc/ckernel_sfpu_binop_with_unary.h
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <limits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_converter.h"
+#include "noc_nonblocking_api.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+enum { ADD = 0, SUB = 1, MUL = 2, DIV = 3, RSUB = 4 };
+
+template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
+void calculate_binop_with_scalar(uint32_t param) {
+    const vFloat parameter = Converter::to_float(param);
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat val = dst_reg[0];
+        vFloat result = 0.0f;
+
+        if constexpr (BINOP_MODE == ADD) {
+            result = val + parameter;
+        } else if constexpr (BINOP_MODE == SUB) {
+            result = val - parameter;
+        } else if constexpr (BINOP_MODE == MUL) {
+            result = val * parameter;
+        } else if constexpr (BINOP_MODE == DIV) {
+            // parameter is inverted from host side and passed down
+            result = val * parameter;
+        } else if constexpr (BINOP_MODE == RSUB) {
+            result = parameter - val;
+        }
+        dst_reg[0] = result;
+        dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_add(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_sub(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_mul(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_div(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_rsub(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(param);
+    return;
+}
+
+template <bool APPROXIMATION_MODE>
+void calculate_binop_with_scalar_init() {}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/grayskull/llk_lib/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/grayskull/llk_lib/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_sfpu_binop_with_unary.h"
+#include "llk_math_eltwise_unary_sfpu_1_param.h"
+#include "llk_math_eltwise_unary_sfpu_common_includes.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE, int binop_mode, DstSync Dst = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(uint dst_index, uint32_t param1, int vector_mode = Dim::RC) {
+    llk_math_eltwise_unary_sfpu_1_param<APPROXIMATE, Dst>(
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 4>,
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 4>,
+        dst_index,
+        vector_mode,
+        param1);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
+    llk_math_eltwise_unary_sfpu_init<APPROXIMATE>(sfpu::calculate_binop_with_scalar_init<APPROXIMATE>);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/common/inc/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/common/inc/ckernel_sfpu_binop_with_unary.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <limits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_converter.h"
+#include "noc_nonblocking_api.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+enum {
+    ADD = 0,
+    SUB = 1,
+    MUL = 2,
+    DIV = 3,
+    RSUB = 4,
+};  // BINOP_MODE
+
+template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
+void calculate_binop_with_scalar(uint32_t param) {
+    const vFloat parameter = Converter::to_float(param);
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat val = dst_reg[0];
+        vFloat result = 0.0f;
+
+        if constexpr (BINOP_MODE == ADD) {
+            result = val + parameter;
+        } else if constexpr (BINOP_MODE == SUB) {
+            result = val - parameter;
+        } else if constexpr (BINOP_MODE == MUL) {
+            result = val * parameter;
+        } else if constexpr (BINOP_MODE == DIV) {
+            // inversion is carried out on host side and passed down
+            result = val * parameter;
+        } else if constexpr (BINOP_MODE == RSUB) {
+            result = parameter - val;
+        }
+
+        dst_reg[0] = result;
+        dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_add(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_sub(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_mul(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_div(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_rsub(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(param);
+    return;
+}
+
+template <bool APPROXIMATION_MODE>
+void calculate_binop_with_scalar_init() {}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_sfpu_binop_with_unary.h"
+#include "llk_math_eltwise_unary_sfpu_1_param.h"
+#include "llk_math_eltwise_unary_sfpu_common_includes.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE, int binop_mode, DstSync Dst = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(uint dst_index, uint32_t param1, int vector_mode = Dim::RC) {
+    llk_math_eltwise_unary_sfpu_1_param<APPROXIMATE, Dst>(
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>,
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>,
+        dst_index,
+        vector_mode,
+        param1);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
+    llk_math_eltwise_unary_sfpu_init<APPROXIMATE>(sfpu::calculate_binop_with_scalar_init<APPROXIMATE>);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_identity.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/llk_lib/llk_math_eltwise_unary_sfpu_identity.h
@@ -4,11 +4,10 @@
 
 #pragma once
 
-
+#include "ckernel_sfpu_identity.h"
+#include "llk_math_eltwise_unary_sfpu_0_param.h"
 #include "llk_math_eltwise_unary_sfpu_common_includes.h"
 #include "llk_math_eltwise_unary_sfpu_init.h"
-#include "llk_math_eltwise_unary_sfpu_0_param.h"
-#include "ckernel_sfpu_identity.h"
 
 namespace ckernel {
 
@@ -16,13 +15,12 @@ namespace ckernel {
 
 template <bool APPROXIMATE, DstSync Dst = DstSync::SyncFull>
 inline void llk_math_eltwise_unary_sfpu_identity(uint dst_index, int vector_mode = Dim::RC) {
-
-	constexpr bool zero_negative = true;
     constexpr int first_iterations = 1;
-    llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE, Dst>
-      (ckernel::sfpu::calculate_identity<APPROXIMATE,8>,
-       ckernel::sfpu::calculate_identity<APPROXIMATE,8>,
-                                dst_index, vector_mode);
+    llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE, Dst>(
+        ckernel::sfpu::calculate_identity<APPROXIMATE, 8>,
+        ckernel::sfpu::calculate_identity<APPROXIMATE, 8>,
+        dst_index,
+        vector_mode);
 }
 
 template <bool APPROXIMATE>
@@ -30,4 +28,4 @@ inline void llk_math_eltwise_unary_sfpu_identity_init() {
     llk_math_eltwise_unary_sfpu_init<APPROXIMATE>(sfpu::identity_init<APPROXIMATE>);
 }
 
-}
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/binop_with_scalar.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/binop_with_scalar.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_binop_with_scalar.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+/**
+ * Performs a simple elementwise binop with scalar operation on the input: y = binop(x,scalar)
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | tile_index     | The index of the tile in DST register buffer to perform requested operation| uint32_t | Must be less than the size of the DST register buffer | True     |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | mode           | 0, 1, 2, 3, and 4                                                          | uint32_t | 0, 1, 2, 3, 4 corresponding to add, mul, sub, div,    | True     |
+ * |                |                                                                            |          | and rsub                                              |          |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | param1         | fp32 value scalar encoded as uint32                                        | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ */
+enum { ADD_UNARY = 0, SUB_UNARY = 1, MUL_UNARY = 2, DIV_UNARY = 3, RSUB_UNARY = 4 };
+ALWI void add_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, ADD_UNARY, SyncHalf>(idst, param1)));
+}
+
+ALWI void sub_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, SUB_UNARY, SyncHalf>(idst, param1)));
+}
+
+ALWI void mul_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, MUL_UNARY, SyncHalf>(idst, param1)));
+}
+
+ALWI void div_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, DIV_UNARY, SyncHalf>(idst, param1)));
+}
+
+ALWI void rsub_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, RSUB_UNARY, SyncHalf>(idst, param1)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void binop_with_scalar_tile_init() { MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -64,6 +64,10 @@
 #include "compute_kernel_api/eltwise_unary/identity.h"
 #endif
 
+#if SFPU_OP_BINOP_WITH_SCALAR_INCLUDE
+#include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
+#endif
+
 #if SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
 #include "compute_kernel_api.h"
 #endif


### PR DESCRIPTION
#0: remove cruft and fine-tune the unary ops to improve performance and cut down kernel launches

#0: move add, sub, div, mul binops with scalar tied in as full featured unary op on sfpu
    remove RDIV from the unary kernel since it has poor accuracy
#0: remove rdiv from the eltwise_binop_unary_with_param code for GS like in WH

#4231: add polar hooks and python binding
     : polar operator for mistral
     : add doc for polar
     : polar test

#0: update soft sign implementation to be faster

#0: softsign test added and some profiling result for refactoring
<img width="466" alt="image" src="https://github.com/tenstorrent-metal/tt-metal/assets/135061812/35390720-79d9-4d48-9c10-bda36c4e1ef9">
