### PR TITLE
#4176: uplift umd plus tt_metal changes

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -64,7 +64,6 @@ void Device::initialize_cluster() {
     int ai_clk = tt::Cluster::instance().get_device_aiclk(this->id_);
     log_info(tt::LogMetal, "AI CLK for device {} is:   {} MHz", this->id_, ai_clk);
 #endif
-    tt::Cluster::instance().assert_risc_reset(this->id_);
 }
 
 void Device::initialize_allocator(const std::vector<uint32_t>& l1_bank_remap) {
@@ -288,7 +287,20 @@ bool Device::close() {
     this->deallocate_buffers();
     llrt::watcher_detach(this);
     tt_stop_debug_print_server();
-    tt::Cluster::instance().assert_risc_reset(id_);
+
+    // Assert worker cores
+    CoreCoord grid_size = this->logical_grid_size();
+    for (uint32_t y = 0; y < grid_size.y; y++) {
+        for (uint32_t x = 0; x < grid_size.x; x++) {
+            CoreCoord logical_core(x, y);
+            CoreCoord worker_core = this->worker_core_from_logical_core(logical_core);
+
+            if (this->storage_only_cores_.find(logical_core) == this->storage_only_cores_.end()) {
+                tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->id(), worker_core));
+            }
+        }
+    }
+
     this->clear_l1_state();
     tt::Cluster::instance().l1_barrier(id_);
     allocator::clear(*this->allocator_);

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -52,14 +52,11 @@ class Cluster {
     uint32_t get_harvested_rows(chip_id_t chip) const;
 
     //! device driver and misc apis
-    void clean_system_resources(chip_id_t device_id) const;
-
     void verify_eth_fw() const;
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions) const;
 
-    void assert_risc_reset(const chip_id_t &chip) const;
     void deassert_risc_reset_at_core(const tt_cxy_pair &physical_chip_coord) const;
-    void deassert_risc_reset(const chip_id_t &target_device_id, bool start_stagger = false) const;
+    void assert_risc_reset_at_core(const tt_cxy_pair &physical_chip_coord) const;
 
     void write_dram_vec(vector<uint32_t> &vec, tt_target_dram dram, uint64_t addr, bool small_access = false) const;
     void read_dram_vec(
@@ -134,6 +131,7 @@ class Cluster {
     void detect_arch_and_target();
     void generate_cluster_descriptor();
     void initialize_device_drivers();
+    void assert_risc_reset();
     void open_driver(chip_id_t mmio_device_id, const std::set<chip_id_t> &controlled_device_ids, const bool &skip_driver_allocs = false);
     void start_driver(chip_id_t mmio_device_id, tt_device_params &device_params) const;
 
@@ -174,7 +172,8 @@ class Cluster {
         (uint32_t)MEM_TRISC2_SIZE,
         (uint32_t)MEM_TRISC0_BASE,
         (uint32_t)GET_MAILBOX_ADDRESS_HOST(l1_barrier),
-        (uint32_t)eth_l1_mem::address_map::ERISC_BARRIER_BASE
+        (uint32_t)eth_l1_mem::address_map::ERISC_BARRIER_BASE,
+        (uint32_t)eth_l1_mem::address_map::FW_VERSION_ADDR,
     };
 
     tt_driver_host_address_params host_address_params = {


### PR DESCRIPTION
- move assert to cluster level, assert used worker cores on device close
- move clean system api call to bool
- new create-eth-map binary
- removed a bunch of hardcoded zero in umd