### PR TITLE
Add batch 20 for resnet-50

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Build tt-metal CPP tests
         run: make tests
       - name: Run pre/post regression tests
-        timeout-minutes: 120
+        timeout-minutes: 100
         run: |
           source build/python_env/bin/activate
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type post_commit --dispatch-mode slow

--- a/models/demos/resnet/tests/test_demo.py
+++ b/models/demos/resnet/tests/test_demo.py
@@ -44,6 +44,7 @@ def test_demo_sample(
     (
         (8, 400),
         (16, 200),
+        (20, 250),
     ),
 )
 def test_demo_imagenet(batch_size, iterations, imagenet_label_dict, model_location_generator, device):

--- a/models/demos/resnet/tests/test_metal_resnet50.py
+++ b/models/demos/resnet/tests/test_metal_resnet50.py
@@ -97,10 +97,27 @@ golden_pcc = {
             tt_lib.tensor.DataType.BFLOAT8_B,
         ): 0.884609,  # Max ATOL Delta: 6.455164909362793, Max RTOL Delta: inf, PCC: 0.8846098380419435
     },
+    20: {
+        (
+            tt_lib.tensor.MathFidelity.HiFi4,
+            tt_lib.tensor.DataType.BFLOAT8_B,
+            tt_lib.tensor.DataType.BFLOAT8_B,
+        ): 0.978099,  # Max ATOL Delta: 1.955164909362793, Max RTOL Delta: inf, PCC: 0.9780993165966628
+        (
+            tt_lib.tensor.MathFidelity.HiFi2,
+            tt_lib.tensor.DataType.BFLOAT8_B,
+            tt_lib.tensor.DataType.BFLOAT8_B,
+        ): 0.944435,  # Max ATOL Delta: 4.705164909362793, Max RTOL Delta: inf, PCC: 0.9444350983635021
+        (
+            tt_lib.tensor.MathFidelity.LoFi,
+            tt_lib.tensor.DataType.BFLOAT8_B,
+            tt_lib.tensor.DataType.BFLOAT8_B,
+        ): 0.884609,  # Max ATOL Delta: 6.455164909362793, Max RTOL Delta: inf, PCC: 0.8846098380419433
+    },
 }
 
 
-@pytest.mark.parametrize("batch_size", [1, 2, 8, 16], ids=["batch_1", "batch_2", "batch_8", "batch_16"])
+@pytest.mark.parametrize("batch_size", [1, 2, 8, 16, 20], ids=["batch_1", "batch_2", "batch_8", "batch_16", "batch_20"])
 @pytest.mark.parametrize(
     "weights_dtype",
     [tt_lib.tensor.DataType.BFLOAT16, tt_lib.tensor.DataType.BFLOAT8_B],

--- a/models/demos/resnet/tests/test_perf_accuracy_resnet.py
+++ b/models/demos/resnet/tests/test_perf_accuracy_resnet.py
@@ -163,7 +163,7 @@ def run_perf_resnet(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time, iterations",
-    ((16, 0.225, 33, 160),),
+    ((16, 0.015, 33, 160), (20, 0.015, 33, 160)),
 )
 def test_perf_bare_metal(
     use_program_cache,
@@ -193,7 +193,7 @@ def test_perf_bare_metal(
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time, iterations",
-    ((16, 0.3, 36, 50),),
+    ((16, 0.015, 36, 50), (20, 0.015, 36, 50)),
 )
 def test_perf_virtual_machine(
     use_program_cache,

--- a/models/demos/resnet/tests/test_perf_device_resnet.py
+++ b/models/demos/resnet/tests/test_perf_device_resnet.py
@@ -12,8 +12,10 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
     [
         [8, "HiFi4-activations_BFLOAT16-weights_BFLOAT16-batch_8", 2600],
         [16, "HiFi2-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16", 5010],
+        [20, "HiFi2-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20", 5400],
         [8, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_8", 3930],
         [16, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16", 5660],
+        [20, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20", 6100],
     ],
 )
 def test_perf_device_bare_metal(batch_size, test, expected_perf):

--- a/models/demos/resnet/tests/test_perf_resnet.py
+++ b/models/demos/resnet/tests/test_perf_resnet.py
@@ -112,10 +112,11 @@ def run_perf_resnet(
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
     (
-        (1, 0.02, 28),
-        (2, 0.017, 28),
-        (8, 0.020, 28),
-        (16, 0.020, 28),
+        (1, 0.015, 28),
+        (2, 0.015, 28),
+        (8, 0.015, 28),
+        (16, 0.015, 28),
+        (20, 0.015, 28),
     ),
 )
 def test_perf_bare_metal(
@@ -142,10 +143,11 @@ def test_perf_bare_metal(
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
     (
-        (1, 0.099, 36),
-        (2, 0.099, 36),
-        (8, 0.099, 36),
-        (16, 0.099, 36),
+        (1, 0.015, 36),
+        (2, 0.015, 36),
+        (8, 0.015, 36),
+        (16, 0.015, 36),
+        (20, 0.015, 36),
     ),
 )
 def test_perf_virtual_machine(

--- a/models/demos/resnet/tt/metalResnetBlock50.py
+++ b/models/demos/resnet/tt/metalResnetBlock50.py
@@ -55,6 +55,17 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
+    20: tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(8, 4),
+        in0_block_w=2,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=1,
+        per_core_N=1,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+    ),
 }
 
 
@@ -702,6 +713,175 @@ hardcoded_matmul_config_conv = {
             fused_activation=None,
         ),
     },
+    20: {
+        (62720, 64, 64): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(12, 9),
+            in0_block_w=2,
+            out_subblock_h=4,
+            out_subblock_w=2,
+            per_core_M=20,
+            per_core_N=2,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        ),
+        (62720, 64, 256): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(12, 9),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=8,
+            per_core_M=20,
+            per_core_N=8,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        ),
+        (62720, 256, 64): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(12, 9),
+            in0_block_w=8,
+            out_subblock_h=4,
+            out_subblock_w=2,
+            per_core_M=20,
+            per_core_N=2,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        ),
+        (62720, 256, 128): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(12, 9),
+            in0_block_w=8,
+            out_subblock_h=2,
+            out_subblock_w=4,
+            per_core_M=20,
+            per_core_N=4,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        ),
+        (15680, 128, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(12, 9),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=8,
+            per_core_M=5,
+            per_core_N=16,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        ),
+        (15680, 256, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(12, 9),
+            in0_block_w=8,
+            out_subblock_h=1,
+            out_subblock_w=8,
+            per_core_M=5,
+            per_core_N=16,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        ),
+        (15680, 512, 128): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(12, 9),
+            in0_block_w=16,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=5,
+            per_core_N=4,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        ),
+        (15680, 512, 256): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(12, 8),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=41,
+            per_core_N=1,
+            transpose_mcast=True,
+            fused_activation=None,
+        ),
+        (3936, 256, 1024): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(12, 8),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=11,
+            per_core_N=4,
+            transpose_mcast=True,
+            fused_activation=None,
+        ),
+        (3936, 1024, 256): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(12, 8),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=1,
+            per_core_M=11,
+            per_core_N=1,
+            transpose_mcast=True,
+            fused_activation=None,
+        ),
+        (3936, 1024, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(12, 8),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=2,
+            per_core_M=11,
+            per_core_N=2,
+            transpose_mcast=True,
+            fused_activation=None,
+        ),
+        (3936, 512, 1024): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(12, 8),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=11,
+            per_core_N=4,
+            transpose_mcast=True,
+            fused_activation=None,
+        ),
+        (3936, 1024, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(12, 8),
+            in0_block_w=4,
+            out_subblock_h=4,
+            out_subblock_w=2,
+            per_core_M=12,
+            per_core_N=2,
+            transpose_mcast=True,
+            fused_activation=None,
+        ),
+        (992, 512, 2048): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(11, 8),
+            in0_block_w=2,
+            out_subblock_h=1,
+            out_subblock_w=8,
+            per_core_M=3,
+            per_core_N=8,
+            transpose_mcast=True,
+            fused_activation=None,
+        ),
+        (992, 1024, 2048): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(11, 8),
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=8,
+            per_core_M=3,
+            per_core_N=8,
+            transpose_mcast=True,
+            fused_activation=None,
+        ),
+        (992, 2048, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=(11, 8),
+            in0_block_w=8,
+            out_subblock_h=3,
+            out_subblock_w=2,
+            per_core_M=3,
+            per_core_N=2,
+            transpose_mcast=True,
+            fused_activation=None,
+        ),
+    },
 }
 
 hardcoded_conv_blocking_and_parallelization_config = {
@@ -740,6 +920,13 @@ hardcoded_conv_blocking_and_parallelization_config = {
         (12544, 128): [128 * 3, 128, 128, 64, 128, 128, (12, 9), 128, 128, 98],
         (3136, 256): [256, 288, 32, 96, 32, 288, (11, 8), 288, 32, 11],
         (800, 512): [512, 96, 64, 96, 64, 96, (9, 8), 96, 64, 9],
+    },
+    20: {
+        (250880, 64): [16 * 4, 1280, 64, 128, 64, 2560, (12, 9), 2560, 64, 98],
+        (62720, 64): [64 * 3, 320, 64, 64, 64, 640, (12, 9), 640, 64, 98],  # try actblock h = 320, subblock h = 64
+        (15680, 128): [128 * 3, 160, 128, 32, 128, 160, (12, 9), 160, 128, 98],
+        (3936, 256): [256, 352, 32, 32, 32, 352, (12, 8), 352, 32, 12],
+        (992, 512): [512, 96, 64, 96, 64, 96, (11, 8), 96, 64, 11],
     },
 }
 
@@ -1017,16 +1204,20 @@ class Bottleneck:
         # conv1 is 1x1 conv
         # logger.info("Running conv1")
         out = self.conv1(x)
-        # logger.info("conv1 output shape - ", self.conv1_output_shape)
-        # logger.info("Running ds or nop")
-        ds_out = self.downsample_or_noop(x)
-        if self.deallocate:
-            x.deallocate()
-        # Relu after conv1 is fused with the 1x1 conv (matmul)
-        # out = self.relu(out, self.memory_config)
-        # logger.info("Running untilize op")
+
+        if not (self.module_input_shape[1] == 56 and self.module_input_shape[3] == 64):
+            ds_out = self.downsample_or_noop(x)
+            if self.deallocate:
+                x.deallocate()
+
         if self.conv_halo:
             out = self.tt_py_untilize_with_halo_op(out)
+            if self.deallocate and (
+                self.module_input_shape[0] == 20
+                and self.module_input_shape[1] == 56
+                and self.module_input_shape[3] == 256
+            ):
+                out = tt_lib.tensor.move_sharded(out)
         else:
             out = format_tensor(out, tt_lib.tensor.Layout.ROW_MAJOR, self.device, self.memory_config)
             out = out.reshape(
@@ -1038,12 +1229,17 @@ class Bottleneck:
 
         # logger.info("Running conv2")
         out = self.conv2(out)
-        # out = self.relu(out, self.memory_config)  ## fused with conv2
         # conv3 is 1x1 conv
         # logger.info("Running conv3")
         out = self.conv3(out)
 
+        if self.module_input_shape[1] == 56 and self.module_input_shape[3] == 64:
+            ds_out = self.downsample_or_noop(x)
+            if self.deallocate:
+                x.deallocate()
+
         fused_activations = [tt_lib.tensor.FusibleActivation.RELU]
+
         # logger.info("Running eltwise add")
         out = tt_lib.tensor.add_without_autoformat(
             out,
@@ -1053,7 +1249,9 @@ class Bottleneck:
             self.model_config["ACTIVATIONS_DTYPE"],
             self.out_in_place,
         )
-        # out = self.relu(out, self.memory_config)
+        if self.module_input_shape[0] == 20 and self.module_input_shape[1] == 56 and self.module_input_shape[3] == 64:
+            out = tt_lib.tensor.move_sharded(out)
+
         return out
 
 
@@ -1173,12 +1371,18 @@ class ResNet(nn.Module):
             per_core_act_h_ntiles = 64
             self.layer_3_grid_size = (11, 8)
             self.layer_4_grid_size = (9, 8)
+        elif batch_size == 20:
+            act_block_h_datums = 2560
+            grid_size = (12, 9)
+            per_core_act_h_ntiles = 80
+            self.layer_3_grid_size = (12, 8)
+            self.layer_4_grid_size = (11, 8)
+
+        self.first_conv_num_cores_nhw = 98
         if sharded:
             self.folded_conv1_params = [self.inplanes, 16, 4, 4, 1, 1, 0, 0, 1, groups]
             first_conv_output_padded_nhw_size = _nearest_y(112 * 112 * batch_size, 98 * 32)
             first_conv_output_channels = 64
-            self.first_conv_num_cores_nhw = 98
-            self.first_conv_grid_size = (12, 9)
             assert (
                 first_conv_output_padded_nhw_size,
                 first_conv_output_channels,
@@ -1232,6 +1436,7 @@ class ResNet(nn.Module):
             self.tt_py_untilize_with_halo_op_before_first_conv = TTPyUntilizeWithHalo(
                 self.device, sliding_window_op_params
             )
+            self.first_conv_op_params = sliding_window_op_params
         else:
             self.conv1 = resnet50_first_conv(
                 conv1_weight.reshape(-1).tolist(),
@@ -1660,11 +1865,6 @@ class ResNet(nn.Module):
         return x
 
     def forward(self, x: tt_lib.tensor) -> tt_lib.tensor:
-        # extra_padding_for_32B_alignment = 25
-        # x = torch.nn.functional.pad(x, (3, 4 + extra_padding_for_32B_alignment, 3, 3, 0, 1))
-        # x = torch.permute(x, (0, 2, 3, 1))
-
-        # x = tt_lib.tensor.Tensor(x, tt_lib.tensor.DataType.BFLOAT16)
         if self.sharded:
             untilize_with_halo_input_shard_height = (int)(x.shape()[2] / self.first_conv_num_cores_nhw)
 
@@ -1692,9 +1892,9 @@ class ResNet(nn.Module):
             mem_config = tt_lib.tensor.MemoryConfig(
                 tt_lib.tensor.TensorMemoryLayout.HEIGHT_SHARDED, tt_lib.tensor.BufferType.L1
             )
-
             x = x.to(self.device, mem_config, shard_spec)
             x = self.tt_py_untilize_with_halo_op_before_first_conv(x)
+
         else:
             original_A_cl_host_shape = x.shape()
             x = x.reshape(x.shape()[0], x.shape()[1], 1, x.shape()[2] * x.shape()[3])
@@ -1707,8 +1907,12 @@ class ResNet(nn.Module):
                 original_A_cl_host_shape[2],
                 original_A_cl_host_shape[3],
             )
+
         x = self.conv1(x)
         # Relu is fused with conv1
+
+        if self.batch_size == 20:
+            x = tt_lib.tensor.move_sharded(x)
 
         if self.sharded:
             x = self.maxpool_untilize_with_halo(x)
@@ -1734,6 +1938,8 @@ class ResNet(nn.Module):
             output_dtype=self.model_config["ACTIVATIONS_DTYPE"],
             use_multicore=True,
         )
+        if self.batch_size == 20:
+            x = tt_lib.tensor.move_sharded(x)
 
         x = self.layer1_module1(x)
         x = self.layer1_module2(x)
@@ -1772,7 +1978,6 @@ class ResNet(nn.Module):
                 tt_lib.tensor.TensorMemoryLayout.BLOCK_SHARDED,
                 tt_lib.tensor.ShardOrientation.COL_MAJOR,
             )
-
         x = self.layer4_module1(x)
         x = self.layer4_module2(x)
         x = self.layer4_module3(x)

--- a/tests/tt_eager/python_api_testing/unit_testing/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_move_sharded.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from loguru import logger
+
+
+from models.utility_functions import skip_for_wormhole_b0
+import tt_lib as ttl
+from models.utility_functions import (
+    comp_pcc,
+)
+import torch
+
+shapes = [
+    [1, 1, 25088, 64],
+]
+
+
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("shape", shapes)
+def test_move_op(shape, device):
+    run_move_op(shape, device)
+
+
+def run_move_op(shape, device):
+    """
+    For non_overlap, multi-core is run for num_tiles > 1.
+    """
+    torch.manual_seed(1234)
+    height_sharded_mem_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=ttl.tensor.BufferType.L1,
+    )
+    dtype = ttl.tensor.DataType.BFLOAT16
+    layout = ttl.tensor.Layout.ROW_MAJOR
+    shard_orientation = ttl.tensor.ShardOrientation.ROW_MAJOR
+    shard_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(11, 7),
+            ),
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 8),
+                ttl.tensor.CoreCoord(1, 8),
+            ),
+        }
+    )
+    assert shape[0] == 1 and shape[1] == 1
+    assert shape[2] % 98 == 0 and shape[3] % 32 == 0
+    shard_shape = [(int)(shape[2] / 98), shape[3]]
+    shard_spec = ttl.tensor.ShardSpec(
+        shard_grid,
+        shard_shape,
+        shard_orientation,
+        False,
+    )
+    # make dummy shape half of shape, so we will test move sharded with overlap
+    dummy_shape = [shape[0], shape[1], (int)(shape[2] / 2), shape[3]]
+    dummy_shard_shape = [(int)(dummy_shape[2] / 98), dummy_shape[3]]
+    dummy_shard_spec = ttl.tensor.ShardSpec(
+        shard_grid,
+        dummy_shard_shape,
+        shard_orientation,
+        False,
+    )
+    dummy_tensor = torch.zeros(dummy_shape)
+    tt_dummy_tensor = ttl.tensor.Tensor(dummy_tensor, dtype)
+    tt_dummy_tensor = tt_dummy_tensor.to(device, height_sharded_mem_config, dummy_shard_spec)
+    logger.info(f"shape={shape}")
+    input_volume = shape[2] * shape[3]
+    tensor = []
+    for val in range(1, input_volume + 1):
+        tensor.append(val)
+    torch_tensor = torch.tensor(tensor).reshape(shape)
+    tt_tensor = ttl.tensor.Tensor(torch_tensor, dtype)
+    tt_tensor = tt_tensor.to(device, height_sharded_mem_config, shard_spec)
+
+    # Free up dummy tensor from memory to make available to move
+    tt_dummy_tensor.deallocate()
+
+    output = ttl.tensor.move_sharded(tt_tensor, height_sharded_mem_config)
+
+    tt_host_rm = output.cpu().to(ttl.tensor.Layout.ROW_MAJOR)
+    pyt_got_back_rm = tt_host_rm.to_torch()
+
+    passing_pcc, output_pcc = comp_pcc(pyt_got_back_rm, torch_tensor, 0.99)
+    logger.info(f"Passing={passing_pcc}")
+    logger.info(f"Output pcc={output_pcc}")
+
+    assert passing_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/test_resnet50_untilize_with_halo_and_conv_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_resnet50_untilize_with_halo_and_conv_v2.py
@@ -468,6 +468,11 @@ def test_resnet50_conv(
     if C == 16:
         pytest.skip("These tests are hanging in interleaved_to_sharded after rebase. Issue: #4336")
 
+    if math_fidelity != tt_lib.tensor.MathFidelity.LoFi:
+        pytest.skip(
+            "By default, only run tests with LoFi math for pipelines. For local unit testing, enable the other variants by uncommenting the skip here!"
+        )
+
     if (
         activations_dtype == tt_lib.tensor.DataType.BFLOAT16
         and N == 20

--- a/tests/tt_eager/python_api_testing/unit_testing/test_untilize_with_halo_and_max_pool_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_untilize_with_halo_and_max_pool_v2.py
@@ -39,6 +39,7 @@ def volume(shape):
             [4, 64, 112, 112],
             [8, 64, 112, 112],
             [16, 64, 112, 112],
+            [20, 64, 112, 112],
         )
     ),
 )
@@ -141,7 +142,14 @@ def test_run_max_pool(
     elif out_nhw == 2048 or out_nhw == 4096 or out_nhw == 8192 or out_nhw == 16384 or out_nhw == 32768:
         ncores_nhw = 64
         grid_size = (8, 8)
-    elif out_nhw == 3136 or out_nhw == 6272 or out_nhw == 12544 or out_nhw == 25088 or out_nhw == 50176:
+    elif (
+        out_nhw == 3136
+        or out_nhw == 6272
+        or out_nhw == 12544
+        or out_nhw == 25088
+        or out_nhw == 50176
+        or out_nhw == 62720
+    ):
         if is_wormhole_b0():
             pytest.skip("Unsupported grid size for WH")
         ncores_nhw = 98

--- a/tests/tt_eager/python_api_testing/unit_testing/test_untilize_with_halo_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_untilize_with_halo_v2.py
@@ -278,9 +278,8 @@ def test_generate_all_configs_and_references(
     ]
 
     if (
-        (input_channels == 128 and stride_h == 2 and batch_size == 20)  # Hangs
-        # These ones weren't hanging on bliu/issue-4319 but are now after rebase
-        or (input_channels == 16 and skip_untilize == True)
+        # These ones weren't hanging on bliu/issue-4386 but are now after rebase
+        (input_channels == 16 and skip_untilize == True)
         or (input_channels == 256 and skip_untilize == True)
         or (input_channels == 512 and skip_untilize == True and not ((stride_h == 2) and batch_size == 8))
     ):
@@ -388,7 +387,7 @@ def test_generate_all_configs_and_references(
 
     if input_c < 32 and not skip_untilize:
         ## for input_c < 32, always need to pad when not skipping untilize, so skip
-        pytest.skip()
+        pytest.skip("Skipping first conv tests when untilize is skipped.")
 
     memory_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
 

--- a/tt_eager/tensor/tensor_impl.cpp
+++ b/tt_eager/tensor/tensor_impl.cpp
@@ -95,29 +95,8 @@ std::array<uint32_t, 2> get_sharded_page_shape(Layout layout, const Shape& shape
     //Physical limitation in FD for now
     switch (layout) {
         case Layout::ROW_MAJOR: {
-            if( valid_page_shape({shard_shape[0], shard_shape[1]}, size_of_element)
-                && enough_work_for_sharding(shape, shard_shape, {H,W}, num_shards)
-                ){
-                page_shape ={ shard_shape[0], shard_shape[1]};
-            }
-            //else if(valid_page_shape({H,W/num_shards}, size_of_element)
-            //    && enough_work_for_sharding(shape, shard_shape, {H,W/num_shards}, num_shards)
-            //    && (W % num_shards == 0)
-            //){
-            //    page_shape = {H, W/num_shards};
-            //}
-            //else if(valid_page_shape({H/num_shards,W/num_shards}, size_of_element)
-            //    && enough_work_for_sharding(shape, shard_shape, {H/num_shards,W}, num_shards)
-            //    && (H % num_shards == 0)
-            //){
-            //    page_shape ={ H/num_shards, W};
-            //}
-            else if( valid_page_shape({1, shard_shape[1]}, size_of_element)){
-                page_shape = {1, shard_shape[1]};
-            }
-            else {
-                TT_ASSERT(false && "Unsupported  row major size");
-            }
+            //TODO: Explore valid page shapes other than 1,W
+            page_shape = {1, shard_shape[1]};
         }
         break;
         case Layout::TILE: {;}

--- a/tt_eager/tt_dnn/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp
+++ b/tt_eager/tt_dnn/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t i = 0;
+    uint32_t total_size_bytes = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t num_chunks = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t chunk_size_bytes = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t remainder_chunk_size_bytes = get_arg_val<uint32_t>(i); i+=1;
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t dst_cb_id = get_compile_time_arg_val(1);
+
+    uint32_t src_cb_base_addr = get_write_ptr(src_cb_id); // TODO change to read
+    uint32_t dst_cb_base_addr = get_write_ptr(dst_cb_id);
+
+    // Copy from top of src cb to top of dst cb (backwards)
+    uint32_t src_cb_addr = src_cb_base_addr + total_size_bytes;
+    uint32_t dst_cb_addr = dst_cb_base_addr + total_size_bytes;
+    for (uint32_t i = 0; i<num_chunks; i += 1) {
+        src_cb_addr -= chunk_size_bytes;
+        dst_cb_addr -= chunk_size_bytes;
+        noc_async_read(get_noc_addr(src_cb_addr), dst_cb_addr, chunk_size_bytes);
+        noc_async_read_barrier();
+    }
+    if(remainder_chunk_size_bytes > 0) {
+        src_cb_addr -= remainder_chunk_size_bytes;
+        dst_cb_addr -= remainder_chunk_size_bytes;
+        noc_async_read(get_noc_addr(src_cb_addr), dst_cb_addr, remainder_chunk_size_bytes);
+        noc_async_read_barrier();
+    }
+}

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -11,6 +11,7 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/move/single_core/move_op_single_core.cpp \
 	tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core.cpp \
 	tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core_overlap.cpp \
+	tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core_sharded.cpp \
 	tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp \
 	tt_eager/tt_dnn/op_library/eltwise_binary/single_core/eltwise_binary_op_single_core.cpp \
 	tt_eager/tt_dnn/op_library/eltwise_binary/multi_core/eltwise_binary_op_multi_core.cpp \

--- a/tt_eager/tt_dnn/op_library/downsample/downsample_op.cpp
+++ b/tt_eager/tt_dnn/op_library/downsample/downsample_op.cpp
@@ -465,7 +465,7 @@ operation::ProgramWithCallbacks downsample_single_core(const Tensor &a, std::arr
     auto halo_prev_input_cb = tt_metal::CreateCircularBuffer(program, core_range, halo_prev_input_cb_config);
 
     uint32_t halo_next_input_cb_index = CB::c_in2;
-    uint32_t halo_next_input_cb_max_rows_of_tiles = 12; // TODO: Remove hardcoding
+    uint32_t halo_next_input_cb_max_rows_of_tiles = 33; // TODO: Remove hardcoding
     uint32_t num_halo_next_cb_input_tiles = num_input_tiles_in_row  * halo_next_input_cb_max_rows_of_tiles;
     tt_metal::CircularBufferConfig halo_next_input_cb_config = tt_metal::CircularBufferConfig(num_halo_next_cb_input_tiles * input_single_tile_size, {{halo_next_input_cb_index, input_cb_data_format}})
 		.set_page_size(halo_next_input_cb_index, input_single_tile_size);

--- a/tt_eager/tt_dnn/op_library/move/move_op.cpp
+++ b/tt_eager/tt_dnn/op_library/move/move_op.cpp
@@ -55,6 +55,8 @@ operation::ProgramWithCallbacks Move::create_program(const std::vector<Tensor>& 
             return move_multi_core(input_tensor, output_tensor);
         case MoveOpParallelizationStrategy::MULTI_CORE_OVERLAP:
             return move_multi_core_with_overlap(input_tensor, output_tensor);
+        case MoveOpParallelizationStrategy::MULTI_CORE_SHARDED:
+            return move_multi_core_sharded(input_tensor, output_tensor);
         case MoveOpParallelizationStrategy::SINGLE_CORE:
         default:
             return move_single_core(input_tensor, output_tensor);

--- a/tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core_sharded.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+
+#include "tt_dnn/op_library/move/move_op.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_dnn/op_library/math.hpp"
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/common/constants.hpp"
+
+using namespace tt::constants;
+
+namespace tt {
+
+namespace tt_metal {
+
+// Sharded buffers are mapped to CBs. Move from top of src CB to dst CB
+operation::ProgramWithCallbacks move_multi_core_sharded(const Tensor &input, Tensor &output) {
+    tt_metal::Program program{};
+
+    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    auto shard_spec = input.shard_spec().value();
+    auto shard_shape = shard_spec.shard_shape;
+    auto shard_grid = shard_spec.shard_grid;
+    auto input_shape = input.shape();
+    auto input_dtype = input.dtype();
+    auto input_layout = input.layout();
+    TT_FATAL(input_layout == output.layout() && input_dtype == output.dtype() && shard_shape == output.shard_spec().value().shard_shape && input_shape == output.shape());
+    const uint32_t src_cb_sharded = CB::c_in0;
+    const uint32_t dst_cb_sharded = CB::c_in1;
+    uint32_t tile_size_bytes = tile_size(cb_data_format);
+    uint32_t shard_shape_num_tiles = div_up(shard_shape[0] * shard_shape[1], TILE_HEIGHT * TILE_WIDTH);
+    uint32_t total_size_bytes = 0;
+    uint32_t page_size_bytes = 0;
+    if ((shard_shape[0] * shard_shape[1]) % (TILE_HEIGHT * TILE_WIDTH) == 0) {
+        uint32_t tile_size_bytes = tile_size(cb_data_format);
+        total_size_bytes = shard_shape_num_tiles * tile_size_bytes;
+        page_size_bytes = tile_size_bytes;
+    } else {
+        uint32_t datum_size_bytes =  datum_size(cb_data_format);
+        total_size_bytes = shard_shape[0] * shard_shape[1] * datum_size_bytes;
+        page_size_bytes = shard_shape[1] *  datum_size_bytes;
+    }
+    CircularBufferConfig src_cb_sharded_config = CircularBufferConfig(total_size_bytes, {{src_cb_sharded, cb_data_format}})
+		    .set_page_size(src_cb_sharded, page_size_bytes);
+    src_cb_sharded_config.set_globally_allocated_address(*input.buffer());
+    auto src_sharded_cb = tt_metal::CreateCircularBuffer(program, shard_grid, src_cb_sharded_config);
+
+    CircularBufferConfig dst_cb_sharded_config = CircularBufferConfig(total_size_bytes, {{dst_cb_sharded, cb_data_format}})
+		    .set_page_size(dst_cb_sharded, page_size_bytes);
+    dst_cb_sharded_config.set_globally_allocated_address(*output.buffer());
+    auto dst_sharded_cb = tt_metal::CreateCircularBuffer(program, shard_grid, dst_cb_sharded_config);
+
+    auto input_buffer_address = input.buffer()->address();
+    auto output_buffer_address = output.buffer()->address();
+    TT_FATAL(output_buffer_address > input_buffer_address, "Expected output buffer to be allocated at a higher address than input buffer");
+    uint32_t move_chunk_size_bytes = output_buffer_address - input_buffer_address;
+    TT_FATAL(move_chunk_size_bytes % 32 == 0, "Expected chunk size bytes to move to be 32 byte aligned.");
+    uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
+    uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
+
+    std::vector<uint32_t> reader_compile_time_args = {src_cb_sharded, dst_cb_sharded};
+    KernelHandle kernel_id = CreateKernel(
+        program,
+        "tt_eager/tt_dnn/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp",
+        shard_grid,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::NOC_1,
+            .compile_args = reader_compile_time_args}
+    );
+    std::vector<uint32_t> runtime_args = {total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes};
+    SetRuntimeArgs(program, kernel_id, shard_grid, runtime_args);
+
+    auto override_runtime_args_callback = [shard_grid=shard_grid, kernel_id=kernel_id, src_sharded_cb=src_sharded_cb, dst_sharded_cb=dst_sharded_cb, total_size_bytes=total_size_bytes](
+        const void* operation,
+        Program& program,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        const std::vector<Tensor>& output_tensors
+    ) {
+        auto src_buffer = input_tensors.at(0).buffer();
+        auto dst_buffer = output_tensors.at(0).buffer();
+        UpdateDynamicCircularBufferAddress(program, src_sharded_cb, *src_buffer);
+        UpdateDynamicCircularBufferAddress(program, dst_sharded_cb, *dst_buffer);
+        auto input_buffer_address = src_buffer->address();
+        auto output_buffer_address = dst_buffer->address();
+        uint32_t move_chunk_size_bytes = output_buffer_address - input_buffer_address;
+        uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
+        uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
+        std::vector<uint32_t> runtime_args = {total_size_bytes, num_chunks, move_chunk_size_bytes, remainder_chunk_size_bytes};
+        SetRuntimeArgs(program, kernel_id, shard_grid, runtime_args);
+    };
+
+    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_args_callback};
+}
+
+}  // namespace tt_metal
+
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/pool/max_pool_multi_core.cpp
@@ -143,6 +143,7 @@ uint32_t get_num_cores(CoreCoord grid_size, uint32_t out_nhw) {
         case 12544: // nbatch = 4
         case 25088: // nbatch = 8
         case 50176: // nbatch = 16
+        case 62720: // nbatch = 20
             ncores = 98;
             break;
         case 784:   // test case

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
@@ -449,6 +449,20 @@ namespace tt::tt_metal::detail{
             +----------+----------------------------+----------------------------+---------------------------------+----------+
         )doc");
 
+        m_tensor.def("move_sharded", &move_sharded,
+            py::arg().noconvert(), py::arg("output_mem_config").noconvert() = std::nullopt, R"doc(
+            Moves the elements of the sharded input tensor ``arg0`` to a location in local L1.
+
+            +----------+----------------------------+----------------------------+---------------------------------+----------+
+            | Argument | Description                | Data type                  | Valid range                     | Required |
+            +==========+============================+============================+=================================+==========+
+            | arg0     | Tensor to move             | Tensor                     | Tensor of shape [W, Z, Y, X]    | Yes      |
+            +----------+----------------------------+----------------------------+---------------------------------+----------+
+            | arg1     | MemoryConfig of tensor of  | tt_lib.tensor.MemoryConfig | Default is same as input tensor | No       |
+            |          | TT accelerator device      |                            |                                 |          |
+            +----------+----------------------------+----------------------------+---------------------------------+----------+
+        )doc");
+
         m_tensor.def("transpose", &transpose,
         py::arg("input").noconvert(), py::arg("dim0"), py::arg("dim1"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
         Returns a tensor that is a transposed version of input tensor with shape ``[W, Z, Y, X]``, where dimensions ``arg1`` and ``arg2`` are swapped.


### PR DESCRIPTION
- Add batch 20 variant of resnet 50
- Add batch 20 model to perf, perf_accuracy, demo, and device perf scripts for resnet-50
- Only run one math fidelity variant for conv unit tests in pipelines