### PR TITLE
#4211: Assert that hugepages number is greater than or equal to required, rather than equal to

### DIFF
--- a/infra/machine_setup/scripts/setup_hugepages.py
+++ b/infra/machine_setup/scripts/setup_hugepages.py
@@ -273,7 +273,7 @@ def is_proc_cmdline_set():
             size = parse_scaled_value(v)
             seen_hugepagesz = size == HUGEPAGE_SIZE
         elif k == "hugepages":
-            seen_hugepages = int(v) == num_tt_devices
+            seen_hugepages = int(v) >= num_tt_devices
         elif k == "iommu":
             seen_iommu = v == "pt"
 


### PR DESCRIPTION
so we don't error out when the machine has more HP than required