### PR TITLE
Add test-sweeps for new operations

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
@@ -1629,3 +1629,30 @@ def gen_power_fp_args(
         dtype,
     ):
         yield input_info
+
+
+def gen_isclose_args(
+    input_shapes,
+    dtypes,
+    layouts,
+    mem_configs,
+    rtol_low=1e-7,
+    rtol_high=1e-5,
+    atol_low=1e-9,
+    atol_high=1e-7,
+    dtype=torch.bfloat16,
+):
+    for input_info in gen_dtype_layout_device(input_shapes, dtypes, layouts, mem_configs):
+        if input_info is not None:
+            if dtype.is_floating_point:
+                rtol = torch.tensor(1, dtype=dtype).uniform_(rtol_low, rtol_low).item()
+            else:
+                rtol = torch.tensor(1, dtype=dtype).random_(rtol_low, rtol_low).item()
+
+            if dtype.is_floating_point:
+                atol = torch.tensor(1, dtype=dtype).uniform_(atol_low, atol_low).item()
+            else:
+                atol = torch.tensor(1, dtype=dtype).random_(atol_low, atol_low).item()
+
+            input_info.update({"rtol": rtol, "atol": atol, "equal_nan": False})
+            yield input_info

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/broken_wormhole/pytorch_empty_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/broken_wormhole/pytorch_empty_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-empty:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_empty_sweep.csv
+  - eltwise-empty:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_empty_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_clone_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_clone_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - clone:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM"]
+      output-file: clone_sweep.csv
+  - clone:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM"]
+      output-file: clone_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_copy_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_copy_test.yaml
@@ -1,0 +1,154 @@
+---
+test-list:
+  - copy:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 32
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: copy_sweep.csv
+  - copy:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 32
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1"]
+          - input-2:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: copy_sweep.csv
+  - copy:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 32
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: copy_sweep.csv
+  - copy:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 32
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
+          - input-2:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: copy_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_assign_binary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_assign_binary_test.yaml
@@ -1,0 +1,78 @@
+---
+test-list:
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_assign_binary_sweep.csv
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_assign_binary_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_assign_unary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_assign_unary_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_assign_unary_sweep.csv
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_assign_unary_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_erfinv_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_erfinv_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_erfinv_sweep.csv
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_erfinv_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_i0_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_i0_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-i0:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -10
+          high: 10
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_i0_sweep.csv
+  - eltwise-i0:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -10
+          high: 10
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_i0_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_isclose_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_isclose_test.yaml
@@ -1,0 +1,78 @@
+---
+test-list:
+  - eltwise-isclose:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_isclose_args
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_isclose_sweep.csv
+  - eltwise-isclose:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_isclose_args
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_isclose_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_tril_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_tril_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-tril:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_tril_sweep.csv
+  - eltwise-tril:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_tril_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_triu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_triu_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-triu:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_triu_sweep.csv
+  - eltwise-triu:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_triu_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_empty_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_empty_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-empty:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_empty_sweep.csv
+  - eltwise-empty:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_empty_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_clone_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_clone_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - clone:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM"]
+      output-file: clone_sweep.csv
+  - clone:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM"]
+      output-file: clone_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_copy_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_copy_test.yaml
@@ -1,0 +1,154 @@
+---
+test-list:
+  - copy:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 32
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: copy_sweep.csv
+  - copy:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 32
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1"]
+          - input-2:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: copy_sweep.csv
+  - copy:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 32
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: copy_sweep.csv
+  - copy:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 32
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
+          - input-2:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: copy_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_assign_binary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_assign_binary_test.yaml
@@ -1,0 +1,78 @@
+---
+test-list:
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_assign_binary_sweep.csv
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_assign_binary_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_assign_unary_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_assign_unary_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_assign_unary_sweep.csv
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_assign_unary_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_erfinv_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_erfinv_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_erfinv_sweep.csv
+  - eltwise-erfinv:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_erfinv_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_i0_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_i0_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-i0:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -10
+          high: 10
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_i0_sweep.csv
+  - eltwise-i0:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -10
+          high: 10
+        dtype: bfloat16
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_i0_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_isclose_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_isclose_test.yaml
@@ -1,0 +1,78 @@
+---
+test-list:
+  - eltwise-isclose:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_isclose_args
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["TILE"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_isclose_sweep.csv
+  - eltwise-isclose:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        - input_1:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+        - input_2:
+          function: gen_rand
+          dtype: bfloat16
+          args:
+            low: -100
+            high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_isclose_args
+      args:
+        inputs:
+          - input-1:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+          - input-2:
+            data-layout: ["ROW_MAJOR"]
+            data-type: ["BFLOAT16"]
+            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_isclose_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_tril_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_tril_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-tril:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_tril_sweep.csv
+  - eltwise-tril:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_tril_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_triu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_triu_test.yaml
@@ -1,0 +1,52 @@
+---
+test-list:
+  - eltwise-triu:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_triu_sweep.csv
+  - eltwise-triu:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+        dtype: bfloat16
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: eltwise_triu_sweep.csv


### PR DESCRIPTION
In this MR new yaml files are added for both, GS and WH. Added operations are:

- erfinv
- assign unary
- assign binary
- isclose
- i0
- empty
- copy
- clone
- tril
- triu
