### PR TITLE
#3934: Enable DPRINT on N300 Device 0

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -40,21 +40,6 @@ protected:
         // Send output to a file so the test can check after program is run.
         tt::llrt::OptionsG.set_dprint_file_name(dprint_file_name);
 
-        // DPrint currently not supported for N300, so skip these tests for
-        // now. Seeing some hanging in device setup with DPrint enabled on N300
-        // so skip before creating the device.
-        // TODO: remove this once N300 DPrint is working.
-        auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
-        auto num_devices = tt::tt_metal::GetNumAvailableDevices();
-        auto num_pci_devices = tt::tt_metal::GetNumPCIeDevices();
-        if (arch == tt::ARCH::WORMHOLE_B0 and
-            num_devices == 2 and
-            num_pci_devices == 1) {
-            tt::log_info(tt::LogTest, "DPrint tests skipped on N300 for now.");
-            test_skipped = true;
-            GTEST_SKIP();
-        }
-
         // Parent call, sets up the device
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -89,6 +89,6 @@ protected:
         }
 
         // Wait for the print server to catch up if needed.
-        tt_await_debug_print_server();
+        tt::DprintServerAwait();
     }
 };

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_invalid_print_core.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_invalid_print_core.cpp
@@ -13,17 +13,6 @@
 using namespace tt::tt_metal;
 
 TEST(DPrintErrorChecking, TestPrintInvalidCore) {
-    // Skip for N300 for now (issue #3934).
-    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
-    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
-    auto num_pci_devices = tt::tt_metal::GetNumPCIeDevices();
-    if (arch == tt::ARCH::WORMHOLE_B0 and
-        num_devices == 2 and
-        num_pci_devices == 1) {
-        tt::log_info(tt::LogTest, "DPrint tests skipped on N300 for now.");
-        GTEST_SKIP();
-    }
-
     // Set DPRINT enabled on a mix of invalid and valid cores. Previously this would hang during
     // device setup, but not the print server should simply ignore the invalid cores.
     tt::llrt::OptionsG.set_dprint_cores({{0, 0}, {1, 1}, {100, 100}}); // Only (1,1) is valid.

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
@@ -49,11 +49,11 @@ TEST_F(DPrintFixture, TestPrintMuting) {
     run_program(0);
 
     // Disable the printing and run the program again.
-    tt_set_debug_print_server_mute(true);
+    DprintServerSetMute(true);
     run_program(1);
 
     // Re-enable prints and run the program one more time.
-    tt_set_debug_print_server_mute(false);
+    DprintServerSetMute(false);
     run_program(2);
 
     // Check the print log against golden output.

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -30,6 +30,9 @@ using std::flush;
 using std::tuple;
 using std::set;
 
+using tt::tt_metal::Device;
+using namespace tt;
+
 #define CAST_U8P(p) reinterpret_cast<uint8_t*>(p)
 
 namespace {
@@ -66,63 +69,26 @@ struct DebugPrintServerContext {
     static DebugPrintServerContext* inst;
     static bool ProfilerIsRunning;
 
-    DebugPrintServerContext(
-        vector<int> chip_ids,
-        const vector<CoreCoord>& cores,
-        uint32_t hart_mask,
-        string file_name
-    ) {
-        TT_ASSERT(inst == nullptr);
-        inst = this;
+    // Constructor/destructor, reads dprint options from RTOptions.
+    DebugPrintServerContext();
+    ~DebugPrintServerContext();
 
-        // the stream is shared between threads
-        if (file_name != "") {
-            outfile_ = new std::ofstream(file_name);
-        }
-        stream_ = outfile_ ? outfile_ : &cout;
-
-        stop_print_server_ = false;
-        mute_print_server_ = false;
-        new_data_last_iter_ = false;
-        server_killed_due_to_hang_ = false;
-        print_server_thread_ = new std::thread(
-            [this, chip_ids, cores, hart_mask] { thread_poll(chip_ids, cores, hart_mask); }
-        );
-    }
-
-    ~DebugPrintServerContext() {
-        // Signal the print server thread to finish
-        stop_print_server_ = true;
-
-        // Wait for the thread to end, with a timeout
-        auto future = std::async(std::launch::async, &std::thread::join, print_server_thread_);
-        if (future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
-            TT_FATAL(false && "Timed out waiting on debug print thread to terminate.");
-        }
-        delete print_server_thread_;
-        print_server_thread_ = nullptr;
-
-        if (outfile_) {
-            outfile_->close();
-            delete outfile_;
-        }
-        inst = nullptr;
-    }
-
+    // Sets whether the print server is muted. Calling this function while a kernel is running may
+    // result in a loss of print data.
     void SetMute(bool mute_print_server) { mute_print_server_ = mute_print_server; }
 
-    void WaitForPrintsFinished() {
-        // Simply poll the flag every few ms to check whether new data is still being processed,
-        // or whether any cores are waiting for a signal to be raised.
-        // TODO(dma): once we have access to the device is there a way we can poll the device to
-        // check whether more print data is coming?
-        do {
-            // No need to await if the server was killed already due to a hang.
-            if (server_killed_due_to_hang_)
-                break;
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
-        } while (hart_waiting_on_signal_.size() > 0 || new_data_last_iter_);
-    }
+    // Waits for the prints erver to finish processing any current print data.
+    void WaitForPrintsFinished();
+
+    // Attaches a device to be monitored by the print server.
+    // This device should not already be attached.
+    void AttachDevice(Device* device);
+
+    // Detaches a device from being monitored by the print server.
+    // This device must have been attached previously.
+    void DetachDevice(Device* device);
+
+    int GetNumAttachedDevices() { return device_to_core_range_.size(); }
 
     bool print_hang_detected() { return server_killed_due_to_hang_; }
 
@@ -150,8 +116,21 @@ private:
     // signal.
     std::set<uint32_t> raised_signals_;
 
-    void thread_poll(const vector<int>& chip_ids, const vector<CoreCoord>& cores, uint32_t hart_mask);
-    bool peek_flush_one_hart_nonblocking(
+    // A map from Device -> Core Range, which is used to determine which cores on which devices
+    // to scan for print data. Also a lock for editing it.
+    std::map<Device*, vector<CoreCoord>> device_to_core_range_;
+    std::mutex device_to_core_range_lock_;
+
+    // Polls specified cores/harts on all attached devices and prints any new print data. This
+    // function is the main loop for the print server thread.
+    void PollPrintData(uint32_t hart_mask);
+
+    // Peeks a specified hart for any debug prints present in the buffer, printing the contents
+    // out to host-side stream. Returns true if some data was read out, and false if no new
+    // print data was present on the device. Note that if an unanswered WAIT is present, the print
+    // buffer on the device is only flushed  up to the WAIT, even if more print data is available
+    // after it.
+    bool PeekOneHartNonBlocking(
         int chip_id,
         const CoreCoord& core,
         int hart_index,
@@ -159,7 +138,7 @@ private:
     );
 };
 
-static void print_tile_slice(ostream& stream, uint8_t* ptr, int hart_id) {
+static void PrintTileSlice(ostream& stream, uint8_t* ptr, int hart_id) {
     // Since MATH RISCV doesn't have access to CBs, we can't print tiles from it. If the user still
     // tries to do this print a relevant message.
     if ((1 << hart_id) == DPRINT_RISCV_TR1) {
@@ -206,25 +185,145 @@ static void print_tile_slice(ostream& stream, uint8_t* ptr, int hart_id) {
         }
     }
     stream << endl << "  ptr=" << ts->ptr_ << ")" << endl;
-}
+} // PrintTileSlice
 
 // Checks if our magic value was cleared by the device code
 // The assumption is that if our magic number was cleared,
 // it means there is a write in the queue and wpos/rpos are now valid
 // Note that this is not a bulletproof way to bootstrap the print server (TODO(AP))
-bool check_init_magic_cleared(int chip_id, const CoreCoord& core, int hart_id) {
+bool CheckInitMagicCleared(int chip_id, const CoreCoord& core, int hart_id) {
     // compute the buffer address for the requested hart
     uint32_t base_addr = PRINT_BUFFER_NC + hart_id*PRINT_BUFFER_SIZE;
 
     vector<uint32_t> initbuf = { DEBUG_PRINT_SERVER_STARTING_MAGIC };
     auto result = tt::llrt::read_hex_vec_from_core(chip_id, core, base_addr, 4);
     return (result[0] != initbuf[0]);
-} // check_init_magic_cleared
+} // CheckInitMagicCleared
 
-// Peeks a specified hart for any debug prints present in the buffer and flushes it, printing the
-// contents out to host-side stream. Returns true if some data was read out, and false if no new
-// print data was present on the device.
-bool DebugPrintServerContext::peek_flush_one_hart_nonblocking(
+DebugPrintServerContext::DebugPrintServerContext() {
+    TT_ASSERT(inst == nullptr);
+    inst = this;
+
+    // Read hart mask + log file from rtoptions
+    uint32_t hart_mask = tt::llrt::OptionsG.get_dprint_riscv_mask();
+    string file_name = tt::llrt::OptionsG.get_dprint_file_name();
+
+    // Set the output stream according to RTOptions, either a file name or stdout if none specified.
+    if (file_name != "") {
+        outfile_ = new std::ofstream(file_name);
+    }
+    stream_ = outfile_ ? outfile_ : &cout;
+
+    stop_print_server_ = false;
+    mute_print_server_ = false;
+    new_data_last_iter_ = false;
+    server_killed_due_to_hang_ = false;
+
+    // Spin off the thread that runs the print server.
+    print_server_thread_ = new std::thread(
+        [this, hart_mask] { PollPrintData(hart_mask); }
+    );
+} // DebugPrintServerContext
+
+DebugPrintServerContext::~DebugPrintServerContext() {
+    // Signal the print server thread to finish
+    stop_print_server_ = true;
+
+    // Wait for the thread to end, with a timeout
+    auto future = std::async(std::launch::async, &std::thread::join, print_server_thread_);
+    if (future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
+        TT_FATAL(false && "Timed out waiting on debug print thread to terminate.");
+    }
+    delete print_server_thread_;
+    print_server_thread_ = nullptr;
+
+    if (outfile_) {
+        outfile_->close();
+        delete outfile_;
+    }
+    inst = nullptr;
+} // ~DebugPrintServerContext
+
+void DebugPrintServerContext::WaitForPrintsFinished() {
+    // Simply poll the flag every few ms to check whether new data is still being processed,
+    // or whether any cores are waiting for a signal to be raised.
+    // TODO(dma): once we have access to the device is there a way we can poll the device to
+    // check whether more print data is coming?
+    do {
+        // No need to await if the server was killed already due to a hang.
+        if (server_killed_due_to_hang_)
+            break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    } while (hart_waiting_on_signal_.size() > 0 || new_data_last_iter_);
+} // WaitForPrintsFinished
+
+void DebugPrintServerContext::AttachDevice(Device* device) {
+    chip_id_t device_id = device->id();
+    tt::Cluster::instance().reset_debug_print_server_buffers(device_id);
+
+    // A set of all valid worker cores, used for checking the user input. Note that the core coords
+    // here are physical, which matches the user input for configuring the print server.
+    set<CoreCoord> all_worker_cores;
+    CoreCoord logical_grid_size = device->logical_grid_size();
+    for (uint32_t x = 0; x < logical_grid_size.x; x++) {
+        for (uint32_t y = 0; y < logical_grid_size.y; y++) {
+            CoreCoord logical_coord(x, y);
+            CoreCoord worker_core = device->worker_core_from_logical_core(logical_coord);
+            all_worker_cores.insert(worker_core);
+        }
+    }
+
+    // Core range depends on whether dprint_all_cores flag is set.
+    vector<CoreCoord> print_cores_sanitized;
+    if (tt::llrt::OptionsG.get_dprint_all_cores()) {
+        // Print from all worker cores, cores returned here are guaranteed to be valid.
+        print_cores_sanitized = vector<CoreCoord>(all_worker_cores.begin(), all_worker_cores.end());
+    } else {
+        // Only print from the cores specified by the user.
+        vector<CoreCoord> print_cores = tt::llrt::OptionsG.get_dprint_cores();
+
+        // We should also validate that the cores the user specified are valid worker cores.
+        for (auto core : print_cores) {
+            if (all_worker_cores.count(core) > 0) {
+                print_cores_sanitized.push_back(core);
+            } else {
+                log_warning(
+                    tt::LogMetal,
+                    "TT_METAL_DPRINT_CORES included worker core ({}, {}), which is not a valid coordinate. This coordinate will be ignored by the dprint server.",
+                    core.x,
+                    core.y
+                );
+            }
+        }
+    }
+
+    // Go through all cores on this new device and write init magic to set up DPRINT.
+    uint32_t hart_mask = tt::llrt::OptionsG.get_dprint_riscv_mask();
+    for (auto core : print_cores_sanitized) {
+        for (int hart_index = 0; hart_index < DPRINT_NRISCVS; hart_index++) {
+            if (hart_mask & (1<<hart_index)) {
+                write_init_magic(device_id, core, hart_index);
+            }
+        }
+    }
+
+    // Save this device + core range to the print server
+    device_to_core_range_lock_.lock();
+    TT_ASSERT(device_to_core_range_.count(device) == 0, "Device {} added to DPRINT server more than once!", device_id);
+    device_to_core_range_[device] = print_cores_sanitized;
+    device_to_core_range_lock_.unlock();
+    log_info(tt::LogMetal, "DPRINT Server attached device {}", device_id);
+} // AttachDevice
+
+void DebugPrintServerContext::DetachDevice(Device* device) {
+    device_to_core_range_lock_.lock();
+    TT_ASSERT(device_to_core_range_.count(device) > 0, "Device {} not present in DPRINT server but tried removing it!", device->id());
+    device_to_core_range_.erase(device);
+    device_to_core_range_lock_.unlock();
+    log_info(tt::LogMetal, "DPRINT Server dettached device {}", device->id());
+} // DetachDevice
+
+bool DebugPrintServerContext::PeekOneHartNonBlocking(
     int chip_id,
     const CoreCoord& core,
     int hart_id,
@@ -322,7 +421,7 @@ bool DebugPrintServerContext::peek_flush_one_hart_nonblocking(
                     TT_ASSERT(sz == strlen(cptr)+1);
                 break;
                 case DEBUG_PRINT_TYPEID_TILESLICE:
-                    print_tile_slice(stream, ptr, hart_id);
+                    PrintTileSlice(stream, ptr, hart_id);
                 break;
 
                 case DEBUG_PRINT_TYPEID_ENDL:
@@ -434,26 +533,11 @@ bool DebugPrintServerContext::peek_flush_one_hart_nonblocking(
 
     // Return false to signal that no print data was ready this time.
     return false;
-} // peek_one_hart_once_nonblocking
+} // PeekOneHartNonBlocking
 
-void DebugPrintServerContext::thread_poll(
-    const vector<int>& chip_ids,
-    const vector<CoreCoord>& cores,
-    uint32_t hart_mask
-) {
+void DebugPrintServerContext::PollPrintData(uint32_t hart_mask) {
     // Give the print server thread a reasonable name.
     pthread_setname_np(pthread_self(), "TT_DPRINT_SERVER");
-
-    // First, go through all cores and write init magic to set up dprint.
-    for (auto chip: chip_ids) {
-        for (auto core: cores) {
-            for (int hart_index = 0; hart_index < DPRINT_NRISCVS; hart_index++) {
-                if (hart_mask & (1<<hart_index)) {
-                    write_init_magic(chip, core, hart_index);
-                }
-            }
-        }
-    }
 
     // Main print loop, go through all chips/cores/harts on the device and poll for any print data
     // written.
@@ -465,17 +549,24 @@ void DebugPrintServerContext::thread_poll(
                 break;
         }
 
+        // Make a copy of the device->core map, so that it can be modified while polling.
+        std::map<Device*, vector<CoreCoord>> device_to_core_range_copy;
+        device_to_core_range_lock_.lock();
+        device_to_core_range_copy = device_to_core_range_;
+        device_to_core_range_lock_.unlock();
+
         // Flag for whether any new print data was found in this round of polling.
         bool new_data_this_iter = false;
-        for (auto chip: chip_ids) {
-            for (auto core: cores) {
+        for (auto& device_and_cores : device_to_core_range_copy) {
+            chip_id_t chip_id = device_and_cores.first->id();
+            for (auto core: device_and_cores.second) {
                 for (int hart_index = 0; hart_index < DPRINT_NRISCVS; hart_index++) {
                     if (hart_mask & (1<<hart_index)) {
-                        if (!check_init_magic_cleared(chip, core, hart_index))
+                        if (!CheckInitMagicCleared(chip_id, core, hart_index))
                             continue;
 
-                        new_data_this_iter |= peek_flush_one_hart_nonblocking(
-                            chip,
+                        new_data_this_iter |= PeekOneHartNonBlocking(
+                            chip_id,
                             core,
                             hart_index,
                             new_data_this_iter
@@ -495,39 +586,65 @@ void DebugPrintServerContext::thread_poll(
         if (!new_data_last_iter_)
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-}
+} // PollPrintData
 
 DebugPrintServerContext* DebugPrintServerContext::inst = nullptr;
 bool DebugPrintServerContext::ProfilerIsRunning = false;
 
 } // anon namespace
 
-void tt_stop_debug_print_server()
-{
-    // this can be called multiple times since we register it with atexit to make explicit call to stop optional
-    if (DebugPrintServerContext::inst != nullptr) {
-        delete DebugPrintServerContext::inst;
-        DebugPrintServerContext::inst = nullptr;
+// Implementation for functions available from dprint_server.hpp.
+namespace tt {
+
+void DprintServerAttach(Device* device) {
+    // Skip if DPRINT not enabled, and make sure profiler is not running.
+    if (!tt::llrt::OptionsG.get_dprint_enabled())
+        return;
+    TT_FATAL(
+       DebugPrintServerContext::ProfilerIsRunning == false,
+       "Device side profiler is running, cannot start print server"
+    );
+
+    // Skip if RTOptions doesn't enable DPRINT for this device
+    vector<chip_id_t> chip_ids = tt::llrt::OptionsG.get_dprint_chip_ids();
+    if (std::find(chip_ids.begin(), chip_ids.end(), device->id()) == chip_ids.end())
+        return;
+
+    // If no server ir running, create one
+    if (!DprintServerIsRunning())
+        DebugPrintServerContext* ctx = new DebugPrintServerContext();
+
+    // Add this device to the server
+    DebugPrintServerContext::inst->AttachDevice(device);
+}
+
+void DprintServerDetach(Device* device) {
+    if (DprintServerIsRunning()) {
+        DebugPrintServerContext::inst->DetachDevice(device);
+
+        // Check if there's no devices left attached to the server, and close it if so.
+        if (DebugPrintServerContext::inst->GetNumAttachedDevices() == 0) {
+            delete DebugPrintServerContext::inst;
+            DebugPrintServerContext::inst = nullptr;
+        }
     }
 }
 
-void tt_set_profiler_state_for_debug_print(bool profile_device)
-{
+void DprintServerSetProfilerState(bool profile_device) {
     DebugPrintServerContext::ProfilerIsRunning = profile_device;
 }
 
-bool tt_is_print_server_running()
-{
+bool DprintServerIsRunning() {
     return DebugPrintServerContext::inst != nullptr;
 }
 
-void tt_set_debug_print_server_mute(bool mute_print_server) {
-    if (DebugPrintServerContext::inst != nullptr)
+void DprintServerSetMute(bool mute_print_server) {
+    if (DprintServerIsRunning())
         DebugPrintServerContext::inst->SetMute(mute_print_server);
 }
 
-void tt_await_debug_print_server() {
-    if (DebugPrintServerContext::inst != nullptr) {
+void DprintServerAwait() {
+    if (DprintServerIsRunning()) {
         // Call the wait function for the print server, with a timeout
         auto future = std::async(
             std::launch::async,
@@ -540,70 +657,8 @@ void tt_await_debug_print_server() {
     }
 }
 
-bool tt_print_hang_detected() {
+bool DPrintServerHangDetected() {
     return (DebugPrintServerContext::inst != nullptr)
         && (DebugPrintServerContext::inst->print_hang_detected());
 }
-
-// The print server is not valid without alive Cluster and tt_device
-void tt_start_debug_print_server(
-    std::function<CoreCoord ()>get_grid_size,
-    std::function<CoreCoord (CoreCoord)>worker_from_logical
-) {
-    if (tt::llrt::OptionsG.get_dprint_enabled()) {
-        TT_FATAL(DebugPrintServerContext::inst == nullptr, "Multiple print servers not allowed");
-        TT_FATAL(DebugPrintServerContext::ProfilerIsRunning == false, "Device side profiler is running, cannot start print server");
-
-        tt::Cluster::instance().reset_debug_print_server_buffers();
-
-        // A set of all valid worker cores, used for checking the user input.
-        auto compare_coords = [](const CoreCoord& a, const CoreCoord& b){
-            if (a.x < b.x)
-                return true;
-            else if (a.x == b.x)
-                return (a.y < b.y);
-            else
-                return false;
-        };
-        set<CoreCoord, decltype(compare_coords)> all_worker_cores(compare_coords);
-        CoreCoord logical_grid_size = get_grid_size();
-        for (uint32_t x = 0; x < logical_grid_size.x; x++) {
-            for (uint32_t y = 0; y < logical_grid_size.y; y++) {
-                CoreCoord logical_coord(x, y);
-                CoreCoord worker_core = worker_from_logical(logical_coord);
-                all_worker_cores.insert(worker_core);
-            }
-        }
-
-        // Core range depends on whether dprint_all_cores flag is set.
-        vector<CoreCoord> print_cores_sanitized;
-        if (tt::llrt::OptionsG.get_dprint_all_cores()) {
-            // Print from all worker cores, cores returned here are guaranteed to be valid.
-            print_cores_sanitized = vector<CoreCoord>(all_worker_cores.begin(), all_worker_cores.end());
-        } else {
-            // Only print from the cores specified by the user.
-            vector<CoreCoord> print_cores = tt::llrt::OptionsG.get_dprint_cores();
-
-            // We should also validate that the cores the user specified are valid worker cores.
-            for (auto core : print_cores) {
-                if (all_worker_cores.count(core) > 0) {
-                    print_cores_sanitized.push_back(core);
-                } else {
-                    log_warning(
-                        tt::LogDevice,
-                        "TT_METAL_DPRINT_CORES included worker core ({}, {}), which is not a valid coordinate. This coordinate will be ignored by the dprint server.",
-                        core.x,
-                        core.y
-                    );
-                }
-            }
-        }
-
-        DebugPrintServerContext* ctx = new DebugPrintServerContext(
-            tt::llrt::OptionsG.get_dprint_chip_ids(),
-            print_cores_sanitized,
-            tt::llrt::OptionsG.get_dprint_riscv_mask(),
-            tt::llrt::OptionsG.get_dprint_file_name()
-        );
-    }
-}
+} // namespace tt

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -11,6 +11,8 @@
 #include "tt_metal/common/core_coord.h"
 #include "tt_metal/impl/device/device.hpp"
 
+namespace tt {
+
 enum DebugPrintHartFlags : unsigned int {
     DPRINT_RISCV_NC  = 1,
     DPRINT_RISCV_TR0 = 2,
@@ -22,46 +24,38 @@ enum DebugPrintHartFlags : unsigned int {
 constexpr int DPRINT_NRISCVS = 5;
 
 /*
-@brief Starts the print server thread - will poll all specified chip/cores/harts of a device for any print data accumulated in thread-local buffers.
+@brief Attaches a device to be monitored by the print server. If no devices were present on the
+    print server, also initializes the print server and launches the thread it runs on.
 
-thread_mask in this API is using flags from DebugPrintHartFlags to enable per-thread debug server listening.
-This call will launch a host thread for each core in cores array and each hart specified by the mask.
-
-Note that this call only works correctly after open_device and start_device calls. (TODO(AP): add runtime checks)
-
-@param filename If filename is null, by default all prints will go to std::cout.
-                If filename is specified, the output will go to that newly created file (used for testing).
-@param cores    A vector of NOC coordinates of cores for the print server to poll.
-                If a given core is not in this list, then it's DPRINT output will not show up on the host.
-                Note that these are not logical worker coordinates.
-                NOC coordinates start at {1,1} and have gaps, logical start at {0,0}.
+@param device Pointer to the device to attach to the print server. The cores/harts to be monitored
+    on this device are determined by the environment variables read out in RTOptions.
 
 This call is not thread safe, and there is only one instance of print server supported at a time.
-
 */
-void tt_start_debug_print_server(
-    std::function<CoreCoord ()>get_grid_size,
-    std::function<CoreCoord (CoreCoord)>worker_from_logical
-);
+void DprintServerAttach(tt::tt_metal::Device* device);
 
 /*
-@brief Stops the print server thread. This call is optional.
+@brief Detach a device so it is no longer monitored by the print server. If no devices are present
+    after detatching, also stops the print server.
+
+@param device Pointer to device to detatch, will throw if trying to detatch a device that is not
+    currently attached to the server.
 
 Note that this api call is not thread safe at the moment.
 */
-void tt_stop_debug_print_server();
+void DprintServerDetach(tt::tt_metal::Device* device);
 
 /**
 @brief Set device side profiler state.
 
 @param profile_device true if profiling, false if not profiling
 */
-void tt_set_profiler_state_for_debug_print(bool profile_device);
+void DprintServerSetProfilerState(bool profile_device);
 
 /**
 @brief Return if the instance debug print server is running or not.
 */
-bool tt_is_print_server_running();
+bool DprintServerIsRunning();
 
 /**
 @brief Set whether the debug print server should be muted.
@@ -72,15 +66,15 @@ while a kernel is running may result in loss of print data.
 
 @param mute_print_server true to mute the print server, false to unmute
 */
-void tt_set_debug_print_server_mute(bool mute_print_server);
+void DprintServerSetMute(bool mute_print_server);
 
 /**
 @brief Wait until the debug print server is not currently processing data.
 
 Note that this function does not actually check whether the device will continue producing print
-data, it only checks whether the print server is currently processing print data.
+data, it only checks whether the print server to finish with any data it is currently processing.
 */
-void tt_await_debug_print_server();
+void DprintServerAwait();
 
 /**
 @brief Check whether a print hang has been detected by the print server.
@@ -90,4 +84,6 @@ print command and (2) no new print data coming through. An invalid WAIT command 
 buffer filling up afterwards can cause the core to spin forever. In this case this function will
 return true and the print server will be terminated.
 */
-bool tt_print_hang_detected();
+bool DPrintServerHangDetected();
+
+} // namespace tt

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -271,10 +271,7 @@ bool Device::initialize(const std::vector<uint32_t>& l1_bank_remap) {
         this->build_firmware();
     }
 
-    tt_start_debug_print_server(
-        [&, this]() { return this->logical_grid_size(); },
-        [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); }
-    );
+    DprintServerAttach(this);
     llrt::watcher_init(this->id(),
                        [&, this]() { return this->logical_grid_size(); },
                        [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); }
@@ -321,7 +318,7 @@ bool Device::close() {
     }
     this->deallocate_buffers();
     llrt::watcher_detach(this);
-    tt_stop_debug_print_server();
+    DprintServerDetach(this);
 
     // Assert worker cores
     CoreCoord grid_size = this->logical_grid_size();

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1023,7 +1023,7 @@ void CommandQueue::finish() {
 
         // There's also a case where the device can be hung due to an unanswered DPRINT WAIT and
         // a full print buffer. Poll the print server for this case and throw if it happens.
-        if (tt_print_hang_detected()) {
+        if (DPrintServerHangDetected()) {
             TT_THROW("Command Queue could not finish: device hang due to unanswered DPRINT WAIT.");
         }
     } while (finish != 1);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -568,7 +568,7 @@ void Program::compile( Device * device )
     detail::ProfileTTMetalScope profile_this = detail::ProfileTTMetalScope("CompileProgram");
     bool profile_kernel = getDeviceProfilerState();
     std::vector<std::future<void>> events;
-    tt_set_profiler_state_for_debug_print(profile_kernel);
+    DprintServerSetProfilerState(profile_kernel);
 
     // compile all kernels in parallel
     for (Kernel * kernel : kernels_) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -363,28 +363,26 @@ int Cluster::get_device_aiclk(const chip_id_t &chip_id) const {
     return 0;
 }
 
-void Cluster::reset_debug_print_server_buffers() const {
-    for (const auto &[device_id, mmio_device_id] : this->device_to_mmio_device_) {
-        auto workers = get_soc_desc(device_id).workers;
-        for (const CoreCoord &core : workers)
-            for (int hart_id = 0; hart_id < 5; hart_id++) {  // TODO(AP): must match DPRINT_NHARTS, magic
-                // compute the buffer address for the requested hart
-                uint32_t base_addr = PRINT_BUFFER_NC + hart_id * PRINT_BUFFER_SIZE;
+void Cluster::reset_debug_print_server_buffers(const chip_id_t& device_id) const {
+    auto workers = get_soc_desc(device_id).workers;
+    for (const CoreCoord &core : workers)
+        for (int hart_id = 0; hart_id < 5; hart_id++) {  // TODO(AP): must match DPRINT_NHARTS, magic
+            // compute the buffer address for the requested hart
+            uint32_t base_addr = PRINT_BUFFER_NC + hart_id * PRINT_BUFFER_SIZE;
 
-                // The way this works is we first initialize all dprint buffers
-                // for all cores and all harts to this magic number.
-                // This way the device DPRINT will know that this core hasn't been initialized
-                // from tt_start_debug_print_server
-                // If we didn't have this mechanism them DPRINT in the kernel would have no way of knowing
-                // Whether the host is polling it's buffer and flushing it.
-                // If kernel code (in debug_print.h) detects that this magic value is present
-                // Then it simply skips the print entirely. It prevents the kernel code
-                // from hanging in a stall waiting for the host to flush the buffer
-                // and removes the requirement that the host must listen on device's buffer.
-                vector<uint32_t> initbuf = {uint32_t(DEBUG_PRINT_SERVER_DISABLED_MAGIC)};
-                write_core(initbuf.data(), initbuf.size() * sizeof(uint32_t), {uint32_t(device_id), core}, base_addr);
-            }
-    }
+            // The way this works is we first initialize all dprint buffers
+            // for all cores and all harts to this magic number.
+            // This way the device DPRINT will know that this core hasn't been initialized
+            // from tt_start_debug_print_server
+            // If we didn't have this mechanism them DPRINT in the kernel would have no way of knowing
+            // Whether the host is polling it's buffer and flushing it.
+            // If kernel code (in debug_print.h) detects that this magic value is present
+            // Then it simply skips the print entirely. It prevents the kernel code
+            // from hanging in a stall waiting for the host to flush the buffer
+            // and removes the requirement that the host must listen on device's buffer.
+            vector<uint32_t> initbuf = {uint32_t(DEBUG_PRINT_SERVER_DISABLED_MAGIC)};
+            write_core(initbuf.data(), initbuf.size() * sizeof(uint32_t), {uint32_t(device_id), core}, base_addr);
+        }
 }
 
 void Cluster::deassert_risc_reset_at_core(const tt_cxy_pair &physical_chip_coord) const {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -363,28 +363,6 @@ int Cluster::get_device_aiclk(const chip_id_t &chip_id) const {
     return 0;
 }
 
-void Cluster::reset_debug_print_server_buffers(const chip_id_t& device_id) const {
-    auto workers = get_soc_desc(device_id).workers;
-    for (const CoreCoord &core : workers)
-        for (int hart_id = 0; hart_id < 5; hart_id++) {  // TODO(AP): must match DPRINT_NHARTS, magic
-            // compute the buffer address for the requested hart
-            uint32_t base_addr = PRINT_BUFFER_NC + hart_id * PRINT_BUFFER_SIZE;
-
-            // The way this works is we first initialize all dprint buffers
-            // for all cores and all harts to this magic number.
-            // This way the device DPRINT will know that this core hasn't been initialized
-            // from tt_start_debug_print_server
-            // If we didn't have this mechanism them DPRINT in the kernel would have no way of knowing
-            // Whether the host is polling it's buffer and flushing it.
-            // If kernel code (in debug_print.h) detects that this magic value is present
-            // Then it simply skips the print entirely. It prevents the kernel code
-            // from hanging in a stall waiting for the host to flush the buffer
-            // and removes the requirement that the host must listen on device's buffer.
-            vector<uint32_t> initbuf = {uint32_t(DEBUG_PRINT_SERVER_DISABLED_MAGIC)};
-            write_core(initbuf.data(), initbuf.size() * sizeof(uint32_t), {uint32_t(device_id), core}, base_addr);
-        }
-}
-
 void Cluster::deassert_risc_reset_at_core(const tt_cxy_pair &physical_chip_coord) const {
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(physical_chip_coord.chip);
     tt_cxy_pair virtual_chip_coord = soc_desc.convert_to_umd_coordinates(physical_chip_coord);

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -97,11 +97,6 @@ class Cluster {
 
     int get_device_aiclk(const chip_id_t &chip_id) const;
 
-    // will write a value for each core+hart's debug buffer, indicating that by default
-    // any prints will be ignored unless specifically enabled for that core+hart
-    // (using tt_start_debug_print_server)
-    void reset_debug_print_server_buffers(const chip_id_t& device_id) const;
-
     void dram_barrier(chip_id_t chip_id) const;
     void l1_barrier(chip_id_t chip_id) const;
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -100,7 +100,7 @@ class Cluster {
     // will write a value for each core+hart's debug buffer, indicating that by default
     // any prints will be ignored unless specifically enabled for that core+hart
     // (using tt_start_debug_print_server)
-    void reset_debug_print_server_buffers() const;
+    void reset_debug_print_server_buffers(const chip_id_t& device_id) const;
 
     void dram_barrier(chip_id_t chip_id) const;
     void l1_barrier(chip_id_t chip_id) const;

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -37,7 +37,7 @@ void DumpDeviceProfileResults(Device *device, const vector<CoreCoord> &logical_c
             Finish(GetCommandQueue(device));
         }
 
-        TT_FATAL(tt_is_print_server_running() == false, "Debug print server is running, cannot dump device profiler data");
+        TT_FATAL(DprintServerIsRunning() == false, "Debug print server is running, cannot dump device profiler data");
         auto worker_cores_used_in_program =\
             device->worker_cores_from_logical_cores(logical_cores);
         auto device_id = device->id();


### PR DESCRIPTION
Changes /fixes to the DPRINT server + tests to enable running on n300 device 0. Multi-device will be left for a separate PR.

Also some general refactoring/cleanup in the print server.