### PR TITLE
Npetrovic/embed fix

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/common.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/common.py
@@ -346,11 +346,11 @@ def shapes_and_datagen(shape_dict, datagen_dict, test_args_gen, test_tt_dtypes, 
 
             def _gen_embeddings_shapes(shape):
                 batch_size = shape[0]
-                num_rows = shape[1]
-                num_embeddings = shape[2]
-                embedding_dim = shape[3]
+                num_rows = shape[3]
+                num_embeddings = shape[1]
+                embedding_dim = shape[2]
 
-                input_rows_shape = [batch_size, 1, num_rows, 1]
+                input_rows_shape = [batch_size, 1, 1, num_rows]
                 weights_shape = [1, 1, num_embeddings, embedding_dim]
 
                 return [input_rows_shape, weights_shape]

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1050,15 +1050,16 @@ def embeddings(x, y, *args, **kwargs):
     x_shape = x.shape
     y_shape = y.shape
 
+    batch_size = x_shape[0]
+    num_rows = x_shape[3]
+
+    num_embeddings = y_shape[2]
+    embedding_dim = y_shape[3]
+
     x_ref = x.detach().clone()
     y_ref = y.detach().clone()
 
-    x_ref = torch.clamp(x_ref, min=0, max=y.shape[-2] - 1)
-
-    batch_size = x_shape[0]
-    num_rows = x_shape[2]
-    num_embeddings = y_shape[2]
-    embedding_dim = y_shape[3]
+    x_ref = torch.clamp(x_ref, min=0, max=y.shape[-3] - 1)
 
     z = torch.nn.functional.embedding(
         x_ref.reshape((batch_size, num_rows)),

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_embeddings_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_embeddings_test.yaml
@@ -2,9 +2,9 @@
 test-list:
   - embeddings:
       shape:
-        start-shape: [1, 1, 512, 2048]
-        end-shape: [1, 1, 2048, 4096]
-        interval: [1, 1, 32, 32]
+        start-shape: [1, 32, 512, 2048]
+        end-shape: [1, 512, 2048, 4096]
+        interval: [1, 32, 32, 32]
         num-shapes: 2
         num-samples: 64
         method: embeddings

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_embeddings_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_embeddings_test.yaml
@@ -2,9 +2,9 @@
 test-list:
   - embeddings:
       shape:
-        start-shape: [1, 32, 512, 2048]
-        end-shape: [1, 512, 2048, 4096]
-        interval: [1, 32, 32, 32]
+        start-shape: [1, 1, 512, 2048]
+        end-shape: [1, 1, 2048, 4096]
+        interval: [1, 1, 32, 32]
         num-shapes: 2
         num-samples: 64
         method: embeddings

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2178,7 +2178,7 @@ def embeddings(x, y, *args, device, dtype, layout, input_mem_config, output_mem_
 
     t1 = ttl.tensor.Tensor(y, dtype[1]).to(device, input_mem_config[1])
 
-    t2 = ttl.tensor.embeddings(t0, t1, False, False, output_mem_config=output_mem_config)
+    t2 = ttl.tensor.embeddings(t0, t1, False, output_mem_config=output_mem_config)
 
     tt_data = t2.cpu().to_torch()
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2168,12 +2168,14 @@ def embeddings(x, y, *args, device, dtype, layout, input_mem_config, output_mem_
     y_shape = y.shape
 
     batch_size = x_shape[0]
-    num_rows = x_shape[2]
+    num_rows = x_shape[3]
+
+    num_embeddings = y_shape[2]
     embedding_dim = y_shape[3]
 
     x_ref = x.detach().clone()
 
-    t0 = torch.clamp(x_ref, min=0, max=y.shape[-2] - 1)
+    t0 = torch.clamp(x_ref, min=0, max=y.shape[-3] - 1)
     t0 = ttl.tensor.Tensor(t0, dtype[0]).to(device, input_mem_config[0])
 
     t1 = ttl.tensor.Tensor(y, dtype[1]).to(device, input_mem_config[1])


### PR DESCRIPTION
Sweep tests-related code was modified, as operation's arguments were modified and it was breaking. Therefore, the following aspects were affected: tt_lib_ops, pytorch_ops and common.py.