### PR TITLE
#3960: add support for multichip tracy profiler and ethernet profile dump

### DIFF
--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -117,12 +117,12 @@ namespace tt::tt_metal{
          *
          * Return value: void
          *
-         * | Argument      | Description                                       | Type                      | Valid Range               | Required |
-         * |---------------|---------------------------------------------------|---------------------------|---------------------------|----------|
-         * | device        | The device holding the program being profiled.    | Device *                  |                           | True     |
-         * | core_coords   | The logical core coordinates being profiled.      | const vector<CoreCoord> & |                           | True     |
+         * | Argument      | Description                                       | Type                                                         | Valid Range               | Required |
+         * |---------------|---------------------------------------------------|--------------------------------------------------------------|---------------------------|----------|
+         * | device        | The device holding the program being profiled.    | Device *                                                     |                           | True     |
+         * | core_coords   | The logical core coordinates being profiled.      | const std::unordered_map<CoreType, std::vector<CoreCoord>> & |                           | True     |
          * */
-        void DumpDeviceProfileResults(Device *device, const vector<CoreCoord>& logical_cores);
+        void DumpDeviceProfileResults(Device *device,const std::unordered_map<CoreType, std::vector<CoreCoord>> &logical_cores);
 
         /**
          * Set the directory for all CSV logs produced by the profiler instance in the tt-metal module

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -9,6 +9,7 @@
 #include "noc_nonblocking_api.h"
 #include "noc_parameters.h"
 #include "risc_attribs.h"
+#include "tools/profiler/kernel_profiler.hpp"
 #include "tt_eth_api.h"
 
 #ifdef __cplusplus
@@ -21,6 +22,9 @@ void ApplicationHandler(void) __attribute__((__section__(".init")));
 }
 #endif
 
+namespace kernel_profiler {
+uint32_t wIndex __attribute__((used));
+}
 uint8_t my_x[NUM_NOCS] __attribute__((used));
 uint8_t my_y[NUM_NOCS] __attribute__((used));
 
@@ -36,6 +40,8 @@ void __attribute__((section("code_l1"))) risc_init() {
     }
 }
 void __attribute__((section("erisc_l1_code"))) ApplicationHandler(void) {
+    kernel_profiler::init_profiler();
+    kernel_profiler::mark_time(CC_MAIN_START);
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
     risc_init();
@@ -54,4 +60,5 @@ void __attribute__((section("erisc_l1_code"))) ApplicationHandler(void) {
         }
     }
     disable_erisc_app();
+    kernel_profiler::mark_time(CC_MAIN_END);
 }

--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -35,6 +35,8 @@ void __attribute__((section("erisc_l1_code"))) kernel_launch() {
     }
     ncrisc_noc_full_sync();
 
+    kernel_profiler::mark_time(CC_KERNEL_MAIN_START);
     kernel_main();
+    kernel_profiler::mark_time(CC_KERNEL_MAIN_END);
     erisc_info->num_bytes = 0;
 }

--- a/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
@@ -25,6 +25,7 @@ struct address_map {
   static constexpr std::int32_t ERISC_L1_UNRESERVED_BASE = 0;
   static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = 0;
   static constexpr std::uint32_t FW_VERSION_ADDR = 0;
+  static constexpr std::int32_t PRINT_BUFFER_ER = 0;
 
   static constexpr std::int32_t ERISC_BARRIER_BASE = 0;
   static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -565,7 +565,8 @@ void Program::compile( Device * device )
         "dependent on information that is set during device initialization.",
         this->get_id());
 
-    detail::ProfileTTMetalScope profile_this = detail::ProfileTTMetalScope("CompileProgram");
+    detail::ProfileTTMetalScope profile_this =
+        detail::ProfileTTMetalScope(std::string("CompileProgram ") + std::to_string(device->id()));
     bool profile_kernel = getDeviceProfilerState();
     std::vector<std::future<void>> events;
     DprintServerSetProfilerState(profile_kernel);

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -47,6 +47,10 @@ namespace kernel_profiler{
         buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PRINT_BUFFER_T2);
         buffer [BUFFER_END_INDEX] = wIndex;
         buffer [DROPPED_MARKER_COUNTER] = 0;
+#elif defined(COMPILE_FOR_ERISC)
+        buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(eth_l1_mem::address_map::PRINT_BUFFER_ER);
+        buffer[BUFFER_END_INDEX] = wIndex;
+        buffer[DROPPED_MARKER_COUNTER] = 0;
 #endif
 #endif //PROFILE_KERNEL
     }
@@ -54,7 +58,7 @@ namespace kernel_profiler{
     inline __attribute__((always_inline)) void mark_time(uint32_t timer_id)
     {
 #if defined(PROFILE_KERNEL)
-#if defined(COMPILE_FOR_NCRISC) | defined(COMPILE_FOR_BRISC)
+#if defined(COMPILE_FOR_NCRISC) | defined(COMPILE_FOR_BRISC) | defined(COMPILE_FOR_ERISC)
         uint32_t time_L = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
         uint32_t time_H = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_H);
 #else

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -102,8 +102,11 @@ class Profiler {
         //Change the output dir of the profile logs
         void setOutputDir(const std::string& new_output_dir);
 
-        //Traverse all cores on the device and dump the device profile results
-        void dumpDeviceResults(int device_id, const vector<CoreCoord> &worker_cores);
+        // Traverse all tensix cores on the device and dump the device profile results
+        void dumpTensixDeviceResults(int device_id, const vector<CoreCoord>& worker_cores);
+
+        // Traverse all ethernet cores on the device and dump the device profile results
+        void dumpEthernetDeviceResults(int device_id, const vector<CoreCoord>& eth_cores);
 };
 
 }  // namespace tt_metal

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -15,10 +15,7 @@ namespace tt_metal {
 
 void DumpDeviceProfileResults(Device *device, const Program &program) {
     const auto &all_logical_cores = program.logical_cores();
-    if (all_logical_cores.find(CoreType::WORKER) != all_logical_cores.end()) {
-        detail::DumpDeviceProfileResults(device, program.logical_cores().at(CoreType::WORKER));
-    }
-    // TODO: add support for ethernet core device dumps
+    detail::DumpDeviceProfileResults(device, program.logical_cores());
 }
 
 
@@ -26,7 +23,8 @@ namespace detail {
 
 static Profiler tt_metal_profiler = Profiler();
 
-void DumpDeviceProfileResults(Device *device, const vector<CoreCoord> &logical_cores) {
+void DumpDeviceProfileResults(
+    Device *device, const std::unordered_map<CoreType, std::vector<CoreCoord>> &logical_cores) {
 #if defined(PROFILER)
     ZoneScoped;
     if (getDeviceProfilerState())
@@ -38,15 +36,21 @@ void DumpDeviceProfileResults(Device *device, const vector<CoreCoord> &logical_c
         }
 
         TT_FATAL(DprintServerIsRunning() == false, "Debug print server is running, cannot dump device profiler data");
-        auto worker_cores_used_in_program =\
-            device->worker_cores_from_logical_cores(logical_cores);
         auto device_id = device->id();
         tt_metal_profiler.setDeviceArchitecture(device->arch());
-        tt_metal_profiler.dumpDeviceResults(device_id, worker_cores_used_in_program);
+        if (logical_cores.find(CoreType::WORKER) != logical_cores.end()) {
+            auto worker_cores_used_in_program =
+                device->worker_cores_from_logical_cores(logical_cores.at(CoreType::WORKER));
+            tt_metal_profiler.dumpTensixDeviceResults(device_id, worker_cores_used_in_program);
+        }
+        if (logical_cores.find(CoreType::ETH) != logical_cores.end()) {
+            auto ethernet_cores_used_in_program =
+                device->ethernet_cores_from_logical_cores(logical_cores.at(CoreType::ETH));
+            tt_metal_profiler.dumpEthernetDeviceResults(device_id, ethernet_cores_used_in_program);
+        }
     }
 #endif
 }
-
 
 void SetProfilerDir(std::string output_dir){
 #if defined(PROFILER)

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -197,7 +197,8 @@ namespace detail {
 
     void WriteToDevice(const Buffer &buffer, const std::vector<uint32_t> &host_buffer) {
         ZoneScoped;
-        detail::ProfileTTMetalScope profile_this = detail::ProfileTTMetalScope("WriteToDevice");
+        detail::ProfileTTMetalScope profile_this =
+            detail::ProfileTTMetalScope(std::string("WriteToDevice ") + std::to_string(buffer.device()->id()));
         if(buffer.buffer_layout() == TensorMemoryLayout::INTERLEAVED || buffer.buffer_layout() == TensorMemoryLayout::SINGLE_BANK){
             WriteToDeviceInterleavedContiguous(buffer, host_buffer);
         }
@@ -346,7 +347,8 @@ namespace detail {
 
     void ReadFromDevice(const Buffer &buffer, std::vector<uint32_t> &host_buffer,  bool shard_order) {
         ZoneScoped;
-        detail::ProfileTTMetalScope profile_this = detail::ProfileTTMetalScope("ReadFromDevice");
+        detail::ProfileTTMetalScope profile_this =
+            detail::ProfileTTMetalScope(std::string("ReadFromDevice ") + std::to_string(buffer.device()->id()));
 
         host_buffer.clear();  // overwrite the data
         if(buffer.buffer_layout() == TensorMemoryLayout::INTERLEAVED
@@ -421,7 +423,8 @@ namespace detail {
         {//Profiler scope start
         ZoneScoped;
         detail::DispatchStateCheck( false );
-        detail::ProfileTTMetalScope profile_this = detail::ProfileTTMetalScope("LaunchProgram");
+        detail::ProfileTTMetalScope profile_this =
+            detail::ProfileTTMetalScope(std::string("LaunchProgram ") + std::to_string(device->id()));
         detail::CompileProgram(device, program);
         detail::WriteRuntimeArgsToDevice(device, program);
         detail::ConfigureDeviceWithProgram(device, program);
@@ -454,7 +457,8 @@ namespace detail {
         ZoneScoped;
         bool pass = true;
         detail::DispatchStateCheck( false );
-        detail::ProfileTTMetalScope profile_this = detail::ProfileTTMetalScope("ConfigureDeviceWithProgram");
+        detail::ProfileTTMetalScope profile_this =
+            detail::ProfileTTMetalScope(std::string("ConfigureDeviceWithProgram ") + std::to_string(device->id()));
 
         auto device_id = device->id();
 


### PR DESCRIPTION
I'm trying to enable tracy profiler dump for remote devices, as well as ethernet cores. I'm still collecting data for some tests to make sure things make sense.