### PR TITLE
#4433: part-3 of backward ops for TT Metalium

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -801,6 +801,8 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.gt_bw
 
+.. autofunction:: tt_lib.tensor.relu_bw
+
 .. autofunction:: tt_lib.tensor.ne_bw
 
 .. autofunction:: tt_lib.tensor.clamp_bw

--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -803,6 +803,12 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.ne_bw
 
+.. autofunction:: tt_lib.tensor.clamp_bw
+
+.. autofunction:: tt_lib.tensor.clamp_min_bw
+
+.. autofunction:: tt_lib.tensor.clamp_max_bw
+
 Loss Functions
 --------------
 

--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -809,6 +809,8 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.clamp_max_bw
 
+.. autofunction:: tt_lib.tensor.binary_le_bw
+
 Loss Functions
 --------------
 

--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -726,6 +726,8 @@ Other Operations
 
 .. autofunction:: tt_lib.tensor.nextafter
 
+.. autofunction:: tt_lib.tensor.lamb_optimizer
+
 .. autofunction:: tt_lib.tensor.repeat
 
 .. autofunction:: tt_lib.tensor.repeat_interleave

--- a/tests/tt_eager/python_api_testing/sweep_tests/reference_optimizer/lamb_optimizer_kernel.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/reference_optimizer/lamb_optimizer_kernel.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Copyright NVIDIA/apex
+This file is adapted from NVIDIA/apex/optimizer/fused_adam and implements the LAMB optimizer
+"""
+
+import torch
+import matplotlib.pyplot as plt
+import numpy as np
+
+torch.manual_seed(2)
+
+
+def lamb_kernel(
+    param, grad, exp_avg, exp_avg_sq, beta1: float, beta2: float, step_size: float, eps: float, weight_decay: float
+):
+    exp_avg = exp_avg * beta1 + (1 - beta1) * grad
+    exp_avg_sq = exp_avg_sq * beta2 + (1 - beta2) * (grad * grad)
+
+    adam_step = exp_avg / (exp_avg_sq.sqrt() + eps)
+    adam_step = adam_step + weight_decay * param
+
+    weight_norm = param.norm(p=2).clamp(0, 10)
+    adam_norm = adam_step.norm(p=2)
+
+    trust_ratio = weight_norm / (adam_norm + eps)
+    trust_ratio = (weight_norm == 0.0) * 1.0 + (weight_norm != 0.0) * trust_ratio
+    trust_ratio = (adam_norm == 0.0) * 1.0 + (adam_norm != 0.0) * trust_ratio
+
+    param = param - step_size * trust_ratio * adam_step
+    return exp_avg, exp_avg_sq, param

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_abs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_abs.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,7 @@ def test_bw_abs(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_abs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_abs.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,29 +17,19 @@ from loguru import logger
     ),
 )
 def test_bw_abs(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.abs(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.abs_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -6,10 +6,6 @@ import torch
 import pytest
 import tt_lib
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
 
 
 @pytest.mark.parametrize(
@@ -21,9 +17,9 @@ from loguru import logger
     ),
 )
 def test_bw_add(input_shapes, device):
-    in_data, input_tensor = bw_data_gen(input_shapes, device, True)
-    other_data, other_tensor = bw_data_gen(input_shapes, device, True)
-    grad_data, grad_tensor = bw_data_gen(input_shapes, device)
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.add_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -38,5 +34,5 @@ def test_bw_add(input_shapes, device):
     golden_tensor.append(in_data.grad)
     golden_tensor.append(other_data.grad)
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor, comparison_funcs.comp_pcc)
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -30,9 +30,7 @@ def test_bw_add(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(other_data.grad)
+    golden_tensor = [in_data.grad, other_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
@@ -20,27 +21,11 @@ from loguru import logger
     ),
 )
 def test_bw_add(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = bw_data_gen(input_shapes, device, True)
+    other_data, other_tensor = bw_data_gen(input_shapes, device, True)
+    grad_data, grad_tensor = bw_data_gen(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.add_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -49,15 +34,9 @@ def test_bw_add(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    (
-        comp_pass_a,
-        comp_out_a,
-    ) = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor, comparison_funcs.comp_pcc)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,27 +18,11 @@ from loguru import logger
 )
 @pytest.mark.parametrize("alpha", [0.05, 1.0, 0.5, 0.12])
 def test_bw_addalpha(input_shapes, alpha, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.addalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -50,12 +31,9 @@ def test_bw_addalpha(input_shapes, alpha, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -31,9 +31,7 @@ def test_bw_addalpha(input_shapes, alpha, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(other_data.grad)
+    golden_tensor = [in_data.grad, other_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -36,10 +36,7 @@ def test_bw_addcdiv(input_shapes, value, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(tensor1_data.grad)
-    golden_tensor.append(tensor2_data.grad)
+    golden_tensor = [in_data.grad, tensor1_data.grad, tensor2_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,34 +18,15 @@ from loguru import logger
 )
 @pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 5.0])
 def test_bw_addcdiv(input_shapes, value, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    tensor1_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    tensor2_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    tensor1_data, tensor1_tensor = data_gen_pt_tt(input_shapes, device, True)
+    tensor2_data, tensor2_tensor = data_gen_pt_tt(input_shapes, device, True)
 
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    tensor1_tensor = (
-        tt_lib.tensor.Tensor(tensor1_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-    tensor2_tensor = (
-        tt_lib.tensor.Tensor(tensor2_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device, False)
 
     tt_output_tensor_on_device = tt_lib.tensor.addcdiv_bw(
         grad_tensor, input_tensor, tensor1_tensor, tensor2_tensor, value
     )
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_c = tt_output_tensor_on_device[2].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     tensor1_data.retain_grad()
@@ -58,15 +36,10 @@ def test_bw_addcdiv(input_shapes, value, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = tensor1_data.grad
-    golden_output_tensor_c = tensor2_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(tensor1_data.grad)
+    golden_tensor.append(tensor2_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-    comp_pass_c, comp_out_c = comparison_funcs.comp_pcc(golden_output_tensor_c, tt_output_tensor_c)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    logger.info(comp_out_c)
-    assert comp_pass_a & comp_pass_b & comp_pass_c
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -36,10 +36,7 @@ def test_bw_addcmul(input_shapes, value, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(tensor1_data.grad)
-    golden_tensor.append(tensor2_data.grad)
+    golden_tensor = [in_data.grad, tensor1_data.grad, tensor2_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,34 +18,15 @@ from loguru import logger
 )
 @pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 0.12])
 def test_bw_addcmul(input_shapes, value, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    tensor1_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    tensor2_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    tensor1_data, tensor1_tensor = data_gen_pt_tt(input_shapes, device, True)
+    tensor2_data, tensor2_tensor = data_gen_pt_tt(input_shapes, device, True)
 
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    tensor1_tensor = (
-        tt_lib.tensor.Tensor(tensor1_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-    tensor2_tensor = (
-        tt_lib.tensor.Tensor(tensor2_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.addcmul_bw(
         grad_tensor, input_tensor, tensor1_tensor, tensor2_tensor, value
     )
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_c = tt_output_tensor_on_device[2].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     tensor1_data.retain_grad()
@@ -58,15 +36,10 @@ def test_bw_addcmul(input_shapes, value, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = tensor1_data.grad
-    golden_output_tensor_c = tensor2_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(tensor1_data.grad)
+    golden_tensor.append(tensor2_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-    comp_pass_c, comp_out_c = comparison_funcs.comp_pcc(golden_output_tensor_c, tt_output_tensor_c)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    logger.info(comp_out_c)
-    assert comp_pass_a & comp_pass_b & comp_pass_c
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_assign.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_assign.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -30,7 +30,6 @@ def test_bw_binary_assign(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,13 @@ from loguru import logger
     ),
 )
 def test_bw_binary_le(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.binary_le_bw(grad_tensor, input_tensor)
-    pyt_y = torch.zeros_like(grad_data)
-
-    tt_output_tensor_1 = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_2 = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor_1)
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor_2)
-    logger.info(comp_out)
+    pt_y = torch.zeros_like(grad_data)
+    golden_tensor = list()
+    golden_tensor.append(pt_y)
+    golden_tensor.append(pt_y)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_binary_le(input_shapes, device):
+    torch.manual_seed(12386)
+    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    grad_data = torch.randn(input_shapes).bfloat16()
+
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    tt_output_tensor_on_device = tt_lib.tensor.binary_le_bw(grad_tensor, input_tensor)
+    pyt_y = torch.zeros_like(grad_data)
+
+    tt_output_tensor_1 = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor_2 = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+
+    golden_output_tensor = pyt_y
+
+    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor_1)
+    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor_2)
+    logger.info(comp_out)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -22,8 +22,6 @@ def test_bw_binary_le(input_shapes, device):
 
     tt_output_tensor_on_device = tt_lib.tensor.binary_le_bw(grad_tensor, input_tensor)
     pt_y = torch.zeros_like(grad_data)
-    golden_tensor = list()
-    golden_tensor.append(pt_y)
-    golden_tensor.append(pt_y)
+    golden_tensor = [pt_y, pt_y]
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -30,7 +30,6 @@ def test_bw_clamp(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,29 +17,20 @@ from loguru import logger
     ),
 )
 def test_bw_clamp(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
     min = -10.0
     max = 10.0
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.clamp(in_data, min=min, max=max)
 
     tt_output_tensor_on_device = tt_lib.tensor.clamp_bw(grad_tensor, input_tensor, min, max)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_clamp(input_shapes, device):
+    torch.manual_seed(12386)
+    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    grad_data = torch.randn(input_shapes).bfloat16()
+    min = -10.0
+    max = 10.0
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    pyt_y = torch.clamp(in_data, min=min, max=max)
+
+    tt_output_tensor_on_device = tt_lib.tensor.clamp_bw(grad_tensor, input_tensor, min, max)
+    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_output_tensor = in_data.grad
+    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
+    logger.info(comp_out)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_max.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,7 @@ def test_bw_clamp_max(input_shapes, max, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_max.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("max", (1.0, 0.5, 0.0, -1.0, 10.0))
+def test_bw_clamp_max(input_shapes, max, device):
+    torch.manual_seed(12386)
+    in_data = torch.zeros(input_shapes, requires_grad=True).bfloat16()
+    grad_data = torch.randn(input_shapes).bfloat16()
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    pyt_y = torch.clamp(in_data, max=max)
+
+    tt_output_tensor_on_device = tt_lib.tensor.clamp_max_bw(grad_tensor, input_tensor, max)
+    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_output_tensor = in_data.grad
+
+    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
+    logger.info(comp_out)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_max.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,28 +18,18 @@ from loguru import logger
 )
 @pytest.mark.parametrize("max", (1.0, 0.5, 0.0, -1.0, 10.0))
 def test_bw_clamp_max(input_shapes, max, device):
-    torch.manual_seed(12386)
-    in_data = torch.zeros(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     pyt_y = torch.clamp(in_data, max=max)
 
     tt_output_tensor_on_device = tt_lib.tensor.clamp_max_bw(grad_tensor, input_tensor, max)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_min.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_min.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,7 @@ def test_bw_clamp_min(input_shapes, min, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_min.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_min.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,27 +18,18 @@ from loguru import logger
 )
 @pytest.mark.parametrize("min", (-1.0, 1.0, 0.0, -0.5, -10.0, 10.0))
 def test_bw_clamp_min(input_shapes, min, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     pyt_y = torch.clamp(in_data, min=min)
 
     tt_output_tensor_on_device = tt_lib.tensor.clamp_min_bw(grad_tensor, input_tensor, min)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_min.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_min.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("min", (-1.0, 1.0, 0.0, -0.5, -10.0, 10.0))
+def test_bw_clamp_min(input_shapes, min, device):
+    torch.manual_seed(12386)
+    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    grad_data = torch.randn(input_shapes).bfloat16()
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    pyt_y = torch.clamp(in_data, min=min)
+
+    tt_output_tensor_on_device = tt_lib.tensor.clamp_min_bw(grad_tensor, input_tensor, min)
+    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_output_tensor = in_data.grad
+    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
+    logger.info(comp_out)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -30,9 +30,7 @@ def test_bw_div(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(other_data.grad)
+    golden_tensor = [in_data.grad, other_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,26 +17,11 @@ from loguru import logger
     ),
 )
 def test_bw_div(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.div_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -48,15 +30,9 @@ def test_bw_div(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    (
-        comp_pass_a,
-        comp_out_a,
-    ) = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,7 @@ def test_bw_exp(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,29 +17,19 @@ from loguru import logger
     ),
 )
 def test_bw_exp(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.exp(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.exp_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 #   value: grad.sum()
 #   result: at::fill(self_t, value_t)
 def test_bw_fill(input_shapes, device):
-    torch.manual_seed(12386)
+    # torch.manual_seed(12386)
     grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     pyt_y = torch.zeros_like(grad_data)
     grad_sum = grad_data.sum()
@@ -30,7 +30,6 @@ def test_bw_fill(input_shapes, device):
 
     tt_output_tensor_on_device = tt_lib.tensor.fill_bw(grad_tensor)
 
-    golden_tensor = list()
-    golden_tensor.append(pyt_y)
+    golden_tensor = [pyt_y]
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill_zero.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill_zero.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -24,7 +24,6 @@ def test_bw_fill_zero(input_shapes, device):
     grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.fill_zero_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
-    golden_tensor = list()
-    golden_tensor.append(pyt_y)
+    golden_tensor = [pyt_y]
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill_zero.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill_zero.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -24,19 +21,10 @@ from loguru import logger
 #   self: zeros_like(grad)
 #   result: at::fill(self_t, 0)
 def test_bw_fill_zero(input_shapes, device):
-    torch.manual_seed(12386)
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.fill_zero_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
-
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(pyt_y)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_gt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_gt.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -22,8 +22,7 @@ def test_bw_unary_gt(input_shapes, device):
 
     pyt_y = torch.zeros_like(grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(pyt_y)
+    golden_tensor = [pyt_y]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_gt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_gt.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,19 +17,13 @@ from loguru import logger
     ),
 )
 def test_bw_unary_gt(input_shapes, device):
-    torch.manual_seed(12386)
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.gt_bw(grad_tensor)
+
     pyt_y = torch.zeros_like(grad_data)
 
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    golden_tensor = list()
+    golden_tensor.append(pyt_y)
 
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,20 +17,9 @@ from loguru import logger
     ),
 )
 def test_bw_log(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.log_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -41,8 +27,8 @@ def test_bw_log(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
 
 
 @pytest.mark.parametrize(
@@ -27,8 +27,6 @@ def test_bw_log(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-
+    golden_tensor = [in_data.grad]
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lt.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,19 +17,12 @@ from loguru import logger
     ),
 )
 def test_bw_unary_lt(input_shapes, device):
-    torch.manual_seed(12386)
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.lt_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
 
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    golden_tensor = list()
+    golden_tensor.append(pyt_y)
 
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lt.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -21,8 +21,7 @@ def test_bw_unary_lt(input_shapes, device):
     tt_output_tensor_on_device = tt_lib.tensor.lt_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(pyt_y)
+    golden_tensor = [pyt_y]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,26 +17,11 @@ from loguru import logger
     ),
 )
 def test_bw_max(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.max_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -48,12 +30,9 @@ def test_bw_max(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
 
 
 @pytest.mark.parametrize(
@@ -30,9 +30,7 @@ def test_bw_max(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(other_data.grad)
+    golden_tensor = [in_data.grad, other_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,26 +17,11 @@ from loguru import logger
     ),
 )
 def test_bw_min(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.min_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -48,12 +30,9 @@ def test_bw_min(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -30,9 +30,6 @@ def test_bw_min(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(other_data.grad)
-
+    golden_tensor = [in_data.grad, other_data.grad]
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,41 +17,22 @@ from loguru import logger
     ),
 )
 def test_bw_mul(input_shapes, device):
-    torch.manual_seed(0)
-    in_data_a = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    in_data_b = torch.randn(input_shapes, requires_grad=True).bfloat16()
-
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor_a = (
-        tt_lib.tensor.Tensor(in_data_a, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor_b = (
-        tt_lib.tensor.Tensor(in_data_b, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data_a, input_tensor_a = data_gen_pt_tt(input_shapes, device, True)
+    in_data_b, input_tensor_b = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.mul_bw(grad_tensor, input_tensor_a, input_tensor_b)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data_a.retain_grad()
     in_data_b.retain_grad()
 
-    pyt_y = in_data_a * in_data_b
+    pyt_y = torch.mul(in_data_a, in_data_b)
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data_a.grad
-    golden_output_tensor_b = in_data_b.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data_a.grad)
+    golden_tensor.append(in_data_b.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -30,9 +30,7 @@ def test_bw_mul(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data_a.grad)
-    golden_tensor.append(in_data_b.grad)
+    golden_tensor = [in_data_a.grad, in_data_b.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ne.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ne.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,19 +17,12 @@ from loguru import logger
     ),
 )
 def test_bw_unary_ne(input_shapes, device):
-    torch.manual_seed(12386)
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.ne_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
 
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    golden_tensor = list()
+    golden_tensor.append(pyt_y)
 
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ne.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ne.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -21,8 +21,7 @@ def test_bw_unary_ne(input_shapes, device):
     tt_output_tensor_on_device = tt_lib.tensor.ne_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(pyt_y)
+    golden_tensor = [pyt_y]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_neg.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_neg.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,20 +17,10 @@ from loguru import logger
     ),
 )
 def test_bw_neg(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.neg_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -41,9 +28,8 @@ def test_bw_neg(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_equal(golden_output_tensor, tt_output_tensor)
-
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_neg.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_neg.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,7 @@ def test_bw_neg(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,29 +18,19 @@ from loguru import logger
 )
 # @pytest.mark.parametrize("threshold",[0.0])
 def test_bw_relu(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.relu(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.relu_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+# @pytest.mark.parametrize("threshold",[0.0])
+def test_bw_relu(input_shapes, device):
+    torch.manual_seed(12386)
+    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    grad_data = torch.randn(input_shapes).bfloat16()
+
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    pyt_y = torch.relu(in_data)
+
+    tt_output_tensor_on_device = tt_lib.tensor.relu_bw(grad_tensor, input_tensor)
+    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_output_tensor = in_data.grad
+
+    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
+    logger.info(comp_out)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
 
 
 @pytest.mark.parametrize(

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsqrt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsqrt.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,28 +17,19 @@ from loguru import logger
     ),
 )
 def test_bw_rsqrt(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.rsqrt(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.rsqrt_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsqrt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsqrt.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,7 @@ def test_bw_rsqrt(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsub.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,12 @@ from loguru import logger
     ),
 )
 def test_bw_rsub(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
 
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.rsub_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -49,12 +31,9 @@ def test_bw_rsub(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsub.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -31,9 +31,7 @@ def test_bw_rsub(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(other_data.grad)
+    golden_tensor = [in_data.grad, other_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sigmoid.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sigmoid.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,28 +18,19 @@ from loguru import logger
 )
 def test_bw_sigmoid(input_shapes, device):
     torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.sigmoid(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.sigmoid_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor, 0.90)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor, 0.90)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sigmoid.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sigmoid.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -17,7 +17,6 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_sigmoid(input_shapes, device):
-    torch.manual_seed(12386)
     in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
     grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
@@ -29,8 +28,7 @@ def test_bw_sigmoid(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor, 0.90)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -28,7 +28,6 @@ def test_bw_sqrt(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,18 @@ from loguru import logger
     ),
 )
 def test_bw_sqrt(input_shapes, device):
-    torch.manual_seed(12345)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.sqrt(in_data)
 
-    sqrt_tensor = tt_lib.tensor.Tensor(pyt_y, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-
-    tt_output_tensor_on_device = tt_lib.tensor.sqrt_bw(grad_tensor, sqrt_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor_on_device = tt_lib.tensor.sqrt_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sub.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,11 @@ from loguru import logger
     ),
 )
 def test_bw_sub(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.sub_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -49,12 +30,9 @@ def test_bw_sub(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sub.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -30,9 +30,7 @@ def test_bw_sub(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(other_data.grad)
+    golden_tensor = [in_data.grad, other_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tan.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tan.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -32,7 +32,6 @@ def test_bw_tan(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
     comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor, 0.96)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tan.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tan.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,22 @@ from loguru import logger
     ),
 )
 def test_bw_tan(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    # tt tan supports input range [-1.45, 1.45]
+    in_data = torch.Tensor(size=input_shapes).uniform_(-1.45, 1.45)
+    in_data.requires_grad = True
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
-
     pyt_y = torch.tan(in_data)
 
-    tan_tensor = tt_lib.tensor.Tensor(pyt_y, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-
-    tt_output_tensor_on_device = tt_lib.tensor.tan_bw(grad_tensor, tan_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor_on_device = tt_lib.tensor.tan_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor, 0.96)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
 
 
 @pytest.mark.parametrize(
@@ -27,8 +27,7 @@ def test_bw_tanh(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor, 0.95)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,29 +17,18 @@ from loguru import logger
     ),
 )
 def test_bw_tanh(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     pyt_y = torch.tanh(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.tanh_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor, 0.95)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_add.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -29,8 +29,7 @@ def test_bw_unary_add(input_shapes, alpha, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_add.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -19,22 +16,12 @@ from loguru import logger
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("alpha", [1.0])
+@pytest.mark.parametrize("alpha", [1.0, 0.5, 0.035])
 def test_bw_unary_add(input_shapes, alpha, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_add_bw(grad_tensor, input_tensor, alpha=alpha)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -42,8 +29,8 @@ def test_bw_unary_add(input_shapes, alpha, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_assign.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_assign.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,20 +17,10 @@ from loguru import logger
     ),
 )
 def test_bw_unary_assign(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_assign_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -41,8 +28,8 @@ def test_bw_unary_assign(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_equal(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_assign.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_assign.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,7 @@ def test_bw_unary_assign(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_div.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,20 +18,10 @@ from loguru import logger
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
 def test_bw_unary_div(input_shapes, scalar, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_div_bw(grad_tensor, input_tensor, scalar=scalar)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -42,8 +29,8 @@ def test_bw_unary_div(input_shapes, scalar, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_div.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -29,8 +29,7 @@ def test_bw_unary_div(input_shapes, scalar, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_mul.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,20 +18,10 @@ from loguru import logger
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
 def test_bw_unary_mul(input_shapes, scalar, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_mul_bw(grad_tensor, input_tensor, scalar=scalar)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -42,8 +29,8 @@ def test_bw_unary_mul(input_shapes, scalar, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_mul.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -29,8 +29,7 @@ def test_bw_unary_mul(input_shapes, scalar, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -36,8 +36,7 @@ def test_bw_unary_pow(input_shapes, exponent, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -28,20 +25,10 @@ from loguru import logger
     ],
 )
 def test_bw_unary_pow(input_shapes, exponent, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_pow_bw(grad_tensor, input_tensor, exponent=exponent)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -49,8 +36,8 @@ def test_bw_unary_pow(input_shapes, exponent, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_sub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_sub.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -29,8 +29,7 @@ def test_bw_unary_sub(input_shapes, scalar, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
+    golden_tensor = [in_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_sub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_sub.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,20 +18,10 @@ from loguru import logger
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
 def test_bw_unary_sub(input_shapes, scalar, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_sub_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -42,8 +29,8 @@ def test_bw_unary_sub(input_shapes, scalar, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_where.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_where.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,31 +17,17 @@ from loguru import logger
     ),
 )
 def test_bw_where(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
     condition_data = torch.randn(input_shapes).bool()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
 
     condition_tensor = (
         tt_lib.tensor.Tensor(condition_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
 
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.where_bw(grad_tensor, condition_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -53,12 +36,9 @@ def test_bw_where(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_where.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_where.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
 @pytest.mark.parametrize(
@@ -36,9 +36,7 @@ def test_bw_where(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = list()
-    golden_tensor.append(in_data.grad)
-    golden_tensor.append(other_data.grad)
+    golden_tensor = [in_data.grad, other_data.grad]
 
     status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -6,10 +6,12 @@
 import torch
 import tt_lib
 from loguru import logger
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
 
 
-def bw_data_gen(input_shapes, device, required_grad=False):
-    torch.manual_seed(1235)
+def data_gen_pt_tt(input_shapes, device, required_grad=False):
     pt_tensor = torch.randn(input_shapes, requires_grad=required_grad).bfloat16()
     tt_tensor = (
         tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
@@ -17,13 +19,15 @@ def bw_data_gen(input_shapes, device, required_grad=False):
     return pt_tensor, tt_tensor
 
 
-def compare_results(tt_tensor, golden_tensor, comparison_funcs):
+def compare_results(tt_tensor, golden_tensor, pcc=0.99):
     status = True
     for i in range(len(tt_tensor)):
         tt_out_tensor = tt_tensor[i].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
         pt_out_tensor = golden_tensor[i]
-        comp_pass, comp_out = comparison_funcs(pt_out_tensor, tt_out_tensor)
+        comp_pass, comp_out = comparison_funcs.comp_pcc(pt_out_tensor, tt_out_tensor, pcc=pcc)
+        comp_all, _ = comparison_funcs.comp_allclose(pt_out_tensor, tt_out_tensor, atol=4, rtol=1e-1)
         logger.info(comp_pass)
+        logger.info(comp_all)
         logger.info(comp_out)
-        status = status & comp_pass
+        status = status & (comp_pass | comp_all)
     return status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -12,6 +12,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 
 
 def data_gen_pt_tt(input_shapes, device, required_grad=False):
+    torch.manual_seed(213919)
     pt_tensor = torch.randn(input_shapes, requires_grad=required_grad).bfloat16()
     tt_tensor = (
         tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+import tt_lib
+from loguru import logger
+
+
+def bw_data_gen(input_shapes, device, required_grad=False):
+    torch.manual_seed(1235)
+    pt_tensor = torch.randn(input_shapes, requires_grad=required_grad).bfloat16()
+    tt_tensor = (
+        tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    return pt_tensor, tt_tensor
+
+
+def compare_results(tt_tensor, golden_tensor, comparison_funcs):
+    status = True
+    for i in range(len(tt_tensor)):
+        tt_out_tensor = tt_tensor[i].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+        pt_out_tensor = golden_tensor[i]
+        comp_pass, comp_out = comparison_funcs(pt_out_tensor, tt_out_tensor)
+        logger.info(comp_pass)
+        logger.info(comp_out)
+        status = status & comp_pass
+    return status

--- a/tests/tt_eager/python_api_testing/unit_testing/test_lamb_kernel.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_lamb_kernel.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
+from loguru import logger
+
+
+def lamb_kernel(
+    param, grad, exp_avg, exp_avg_sq, beta1: float, beta2: float, step_size: float, eps: float, weight_decay: float
+):
+    exp_avg = exp_avg * beta1 + (1 - beta1) * grad
+    exp_avg_sq = exp_avg_sq * beta2 + (1 - beta2) * (grad * grad)
+
+    adam_step = exp_avg / (exp_avg_sq.sqrt() + eps)
+    adam_step = adam_step + weight_decay * param
+
+    weight_norm = param.norm(p=2).clamp(0, 10)
+    adam_norm = adam_step.norm(p=2)
+
+    trust_ratio = weight_norm / (adam_norm + eps)
+    trust_ratio = (weight_norm == 0.0) * 1.0 + (weight_norm != 0.0) * trust_ratio
+    trust_ratio = (adam_norm == 0.0) * 1.0 + (adam_norm != 0.0) * trust_ratio
+
+    param = param - step_size * trust_ratio * adam_step
+    return exp_avg, exp_avg_sq, param
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("beta1", [0.9])
+@pytest.mark.parametrize("beta2", [0.999])
+@pytest.mark.parametrize("step_size", [1e-3])
+@pytest.mark.parametrize("eps", [1e-6])
+@pytest.mark.parametrize("weight_decay", [0.01])
+def test_lamb_kernel(input_shapes, beta1, beta2, step_size, eps, weight_decay, device):
+    torch.manual_seed(0)
+    param_data = torch.Tensor(size=input_shapes).uniform_(1, 100)
+    grad_data, exp_avg_data, exp_avg_sq_data = param_data, param_data, param_data
+
+    param = (
+        tt_lib.tensor.Tensor(param_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
+    )
+
+    grad = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
+    )
+
+    exp_avg = (
+        tt_lib.tensor.Tensor(exp_avg_data, tt_lib.tensor.DataType.BFLOAT16)
+        .to(tt_lib.tensor.Layout.ROW_MAJOR)
+        .to(device)
+    )
+
+    exp_avg_sq = (
+        tt_lib.tensor.Tensor(exp_avg_sq_data, tt_lib.tensor.DataType.BFLOAT16)
+        .to(tt_lib.tensor.Layout.ROW_MAJOR)
+        .to(device)
+    )
+
+    tt_output_tensor_on_device = tt_lib.tensor.lamb_optimizer(
+        param,
+        grad,
+        exp_avg,
+        exp_avg_sq,
+        beta1=beta1,
+        beta2=beta2,
+        step_size=step_size,
+        eps=eps,
+        weight_decay=weight_decay,
+    )
+    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor_c = tt_output_tensor_on_device[2].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+
+    exp_avg_out, exp_avg_sq_out, param = lamb_kernel(
+        param_data,
+        grad_data,
+        exp_avg_data,
+        exp_avg_sq_data,
+        beta1=beta1,
+        beta2=beta2,
+        step_size=step_size,
+        eps=eps,
+        weight_decay=weight_decay,
+    )
+
+    comp_pass_a, _ = comparison_funcs.comp_pcc(exp_avg_out, tt_output_tensor_a, 0.99)
+    _, comp_out_a = comparison_funcs.comp_allclose_and_pcc(exp_avg_out, tt_output_tensor_a)
+
+    comp_pass_b, _ = comparison_funcs.comp_pcc(exp_avg_sq_out, tt_output_tensor_b, 0.99)
+    _, comp_out_b = comparison_funcs.comp_allclose_and_pcc(exp_avg_sq_out, tt_output_tensor_b)
+
+    comp_pass_c, _ = comparison_funcs.comp_pcc(param, tt_output_tensor_c, 0.99)
+    _, comp_out_c = comparison_funcs.comp_allclose_and_pcc(param, tt_output_tensor_c)
+
+    logger.info(comp_out_a)
+    logger.info(comp_out_b)
+    logger.info(comp_out_c)
+    assert comp_pass_a & comp_pass_b & comp_pass_c

--- a/tests/tt_eager/python_api_testing/unit_testing/test_lamb_optimizer.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_lamb_optimizer.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.reference_optimizer import (
+    lamb_optimizer_kernel,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("beta1", [0.9])
+@pytest.mark.parametrize("beta2", [0.999])
+@pytest.mark.parametrize("step_size", [1e-3])
+@pytest.mark.parametrize("eps", [1e-6])
+@pytest.mark.parametrize("weight_decay", [0.01])
+def test_lamb_kernel(input_shapes, beta1, beta2, step_size, eps, weight_decay, device):
+    torch.manual_seed(0)
+    param_data = torch.Tensor(size=input_shapes).uniform_(1, 100)
+    grad_data, exp_avg_data, exp_avg_sq_data = param_data, param_data, param_data
+
+    param = (
+        tt_lib.tensor.Tensor(param_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
+    )
+
+    grad = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
+    )
+
+    exp_avg = (
+        tt_lib.tensor.Tensor(exp_avg_data, tt_lib.tensor.DataType.BFLOAT16)
+        .to(tt_lib.tensor.Layout.ROW_MAJOR)
+        .to(device)
+    )
+
+    exp_avg_sq = (
+        tt_lib.tensor.Tensor(exp_avg_sq_data, tt_lib.tensor.DataType.BFLOAT16)
+        .to(tt_lib.tensor.Layout.ROW_MAJOR)
+        .to(device)
+    )
+
+    tt_output_tensor_on_device = tt_lib.tensor.lamb_optimizer(
+        param,
+        grad,
+        exp_avg,
+        exp_avg_sq,
+        beta1=beta1,
+        beta2=beta2,
+        step_size=step_size,
+        eps=eps,
+        weight_decay=weight_decay,
+    )
+    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor_c = tt_output_tensor_on_device[2].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+
+    exp_avg_out, exp_avg_sq_out, param = lamb_optimizer_kernel.lamb_kernel(
+        param_data,
+        grad_data,
+        exp_avg_data,
+        exp_avg_sq_data,
+        beta1=beta1,
+        beta2=beta2,
+        step_size=step_size,
+        eps=eps,
+        weight_decay=weight_decay,
+    )
+
+    comp_pass_a, _ = comparison_funcs.comp_pcc(exp_avg_out, tt_output_tensor_a, 0.99)
+    _, comp_out_a = comparison_funcs.comp_allclose_and_pcc(exp_avg_out, tt_output_tensor_a)
+
+    comp_pass_b, _ = comparison_funcs.comp_pcc(exp_avg_sq_out, tt_output_tensor_b, 0.99)
+    _, comp_out_b = comparison_funcs.comp_allclose_and_pcc(exp_avg_sq_out, tt_output_tensor_b)
+
+    comp_pass_c, _ = comparison_funcs.comp_pcc(param, tt_output_tensor_c, 0.99)
+    _, comp_out_c = comparison_funcs.comp_allclose_and_pcc(param, tt_output_tensor_c)
+
+    logger.info(comp_out_a)
+    logger.info(comp_out_b)
+    logger.info(comp_out_c)
+    assert comp_pass_a & comp_pass_b & comp_pass_c

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -99,6 +99,7 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/permute/permute_op.cpp \
 	tt_eager/tt_dnn/op_library/composite/composite_ops.cpp\
 	tt_eager/tt_dnn/op_library/backward/backward_ops.cpp\
+	tt_eager/tt_dnn/op_library/optimizer/optimizer_ops.cpp\
 	tt_eager/tt_dnn/op_library/complex/complex_ops.cpp\
 	tt_eager/tt_dnn/op_library/loss/loss_op.cpp\
 	tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp \

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -430,6 +430,50 @@ std::vector<Tensor> rsqrt_bw(const Tensor& grad, const Tensor& input, const Memo
 {
     return operation::decorate_as_composite(__func__, _rsqrt_bw)(grad, input, output_mem_config);
 }
+
+
+std::vector<Tensor> _clamp_bw(const Tensor& grad, const Tensor& input, float min, float max, const MemoryConfig& output_mem_config)
+{
+    std::vector<Tensor> grad_tensor;
+    Tensor minT = gte(input, full_like(input, min, output_mem_config), std::nullopt, output_mem_config);
+    Tensor maxT = lte(input, full_like(input, max, output_mem_config), std::nullopt, output_mem_config);
+    Tensor result = logical_and(minT, maxT, std::nullopt, output_mem_config);
+    result = mul(grad, result, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
+std::vector<Tensor> clamp_bw(const Tensor& grad, const Tensor& input, float min, float max, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _clamp_bw)(grad, input, min, max, output_mem_config);
+}
+
+
+std::vector<Tensor> _clamp_min_bw(const Tensor& grad, const Tensor& input, float min, const MemoryConfig& output_mem_config)
+{
+    std::vector<Tensor> grad_tensor;
+    Tensor minT = gte(input, full_like(input, min, output_mem_config), std::nullopt, output_mem_config);
+    Tensor result = mul(grad, minT, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
+std::vector<Tensor> clamp_min_bw(const Tensor& grad, const Tensor& input, float min, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _clamp_min_bw)(grad, input, min, output_mem_config);
+}
+
+
+std::vector<Tensor> _clamp_max_bw(const Tensor& grad, const Tensor& input, float max, const MemoryConfig& output_mem_config)
+{
+    std::vector<Tensor> grad_tensor;
+    Tensor maxT = lte(input, full_like(input, max, output_mem_config), std::nullopt, output_mem_config);
+    Tensor result = mul(grad, maxT, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
+std::vector<Tensor> clamp_max_bw(const Tensor& grad, const Tensor& input, float max, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _clamp_max_bw)(grad, input, max, output_mem_config);
+}
 }//namespace tt_metal
 
 }//namespace tt

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -488,6 +488,17 @@ std::vector<Tensor> clamp_max_bw(const Tensor& grad, const Tensor& input, float 
 {
     return operation::decorate_as_composite(__func__, _clamp_max_bw)(grad, input, max, output_mem_config);
 }
+std::vector<Tensor> _relu_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor result = mul(gtz(input,output_mem_config), grad, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
+std::vector<Tensor> relu_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _relu_bw)(grad, input, output_mem_config);
+}
+
 }//namespace tt_metal
 
 }//namespace tt

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -125,15 +125,18 @@ std::vector<Tensor> binary_assign_bw(const Tensor& grad, const Tensor& input, co
     return operation::decorate_as_composite(__func__, _unary_assign_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _sqrt_bw(const Tensor& grad, const Tensor& sqrt_result, const MemoryConfig& output_mem_config) {
+std::vector<Tensor> _sqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    Tensor sqrt_result = sqrt(input, output_mem_config);
     Tensor result = mul(grad, recip(mul_unary(sqrt_result, 2.0, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
+    Tensor t_nan  = full_like(input, std::nanf(""), output_mem_config);
+    result = where(ltz(input, output_mem_config), t_nan, result, output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;
 }
-std::vector<Tensor> sqrt_bw(const Tensor& grad, const Tensor& sqrt_result, const MemoryConfig& output_mem_config)
+std::vector<Tensor> sqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config)
 {
-    return operation::decorate_as_composite(__func__, _sqrt_bw)(grad, sqrt_result, output_mem_config);
+    return operation::decorate_as_composite(__func__, _sqrt_bw)(grad, input, output_mem_config);
 }
 
 
@@ -195,16 +198,16 @@ std::vector<Tensor> sigmoid_bw(const Tensor& grad, const Tensor& input,
 }
 
 
-
-std::vector<Tensor> _tan_bw(const Tensor& grad, const Tensor& tan_result, const MemoryConfig& output_mem_config) {
+std::vector<Tensor> _tan_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    Tensor tan_result = tan(input, output_mem_config);
     Tensor result = mul(grad, add1(square(tan_result, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;
 }
-std::vector<Tensor> tan_bw(const Tensor& grad, const Tensor& tan_result, const MemoryConfig& output_mem_config)
+std::vector<Tensor> tan_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config)
 {
-    return operation::decorate_as_composite(__func__, _tan_bw)(grad, tan_result, output_mem_config);
+    return operation::decorate_as_composite(__func__, _tan_bw)(grad, input, output_mem_config);
 }
 
 std::vector<Tensor> _addcdiv_bw(const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -415,6 +415,20 @@ std::vector<Tensor> abs_bw(const Tensor& grad, const Tensor& input, const Memory
 {
     return operation::decorate_as_composite(__func__, _abs_bw)(grad, input, output_mem_config);
 }
+
+std::vector<Tensor> _binary_le_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor zero_grad = zeros_like(grad, output_mem_config);
+    grad_tensor.emplace_back(zero_grad);
+    Tensor zero_input = zeros_like(input, output_mem_config);
+    grad_tensor.emplace_back(zero_input);
+    return grad_tensor;
+}
+std::vector<Tensor> binary_le_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _binary_le_bw)(grad, input, output_mem_config);
+}
+
 std::vector<Tensor> _rsqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor rsqrt_result = power(rsqrt(input, true, output_mem_config), 3, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -35,7 +35,7 @@ std::vector<Tensor> add_bw(const Tensor& grad, const Tensor& input, const Tensor
 
 std::vector<Tensor> exp_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> sqrt_bw(const Tensor& grad, const Tensor& sqrt_result, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<Tensor> sqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> unary_assign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
@@ -55,9 +55,9 @@ std::vector<Tensor> embedding_bw(const Tensor& grad, const Tensor& input, const 
 std::vector<Tensor> tanh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // grad(sigmoid) = grad*(1 - sigmoid(x))*sigmoid(x)
-std::vector<Tensor> sigmoid_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<Tensor> sigmoid_bw(const Tensor& grad, const Tensor& esinput, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> tan_bw(const Tensor& grad, const Tensor& tan_result, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<Tensor> tan_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> where_bw(const Tensor& grad, const Tensor& condition, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -81,6 +81,8 @@ std::vector<Tensor> rsqrt_bw(const Tensor& grad, const Tensor& input, const Memo
 
 std::vector<Tensor> neg_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> relu_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 std::vector<Tensor> lt_bw(const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> gt_bw(const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -73,6 +73,8 @@ std::vector<Tensor> rsub_bw(const Tensor& grad, const Tensor& input, const Tenso
 
 std::vector<Tensor> log_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> binary_le_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 std::vector<Tensor> abs_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> rsqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -85,6 +85,12 @@ std::vector<Tensor> gt_bw(const Tensor& grad, const MemoryConfig& output_mem_con
 
 std::vector<Tensor> ne_bw(const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> clamp_bw(const Tensor& grad, const Tensor& input, float min, float max, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> clamp_min_bw(const Tensor& grad, const Tensor& input, float min, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> clamp_max_bw(const Tensor& grad, const Tensor& input, float max, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 } //namespace tt_metal
 
 } //namespace tt

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -1269,6 +1269,56 @@ Tensor repeat(const Tensor& input_a, const Shape& shape_b, const MemoryConfig& o
     return operation::decorate_as_composite(__func__, _repeat)(input_a, shape_b, output_mem_config);
 }
 
+// lamb_optimizer
+// exp_avg = exp_avg * beta1 + (1 - beta1) * grad
+// exp_avg_sq = exp_avg_sq * beta2 + (1 - beta2) * (grad * grad)
+// adam_step = exp_avg / (exp_avg_sq.sqrt() + eps)
+// adam_step = adam_step + weight_decay * param
+// weight_norm = param.norm(p=2).clamp(0, 10)
+// adam_norm = adam_step.norm(p=2)
+// trust_ratio = 1.0 if weight_norm == 0 or adam_norm == 0 else weight_norm / (adam_norm + eps)
+// trust_ratio = where(greater(w_norm, 0), where(tf.greater(g_norm, 0), (w_norm / g_norm), 1.0),1.0)
+// param = param - step_size * trust_ratio * adam_step
+std::vector<Tensor> _lamb_optimizer(const Tensor& data, const Tensor& grad, const Tensor& exp_avg, const Tensor& exp_avg_sq, float beta1, float beta2, float step_size, float eps, float weight_decay, const MemoryConfig& output_mem_config) {
+    float beta1_out = 1.0f - beta1;
+    float beta2_out = 1.0f - beta2;
+
+    std::vector<Tensor> output_tensor;
+    Tensor exp_avg_out = add(mul_unary(exp_avg, beta1, output_mem_config), mul_unary(beta1_out, grad, output_mem_config), std::nullopt, output_mem_config);
+
+    Tensor exp_avg_sq_out = add(mul_unary(exp_avg_sq, beta2, output_mem_config),  mul_unary(beta2_out, square(grad, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
+
+    Tensor adam_step_mid = mul(exp_avg_out, recip(add_unary(sqrt(exp_avg_sq_out, output_mem_config), eps, output_mem_config),output_mem_config),  std::nullopt, output_mem_config);
+    Tensor adam_step = add(adam_step_mid, mul_unary(weight_decay, data, output_mem_config), std::nullopt, output_mem_config);
+
+    Tensor data_val = square(data, output_mem_config);
+    for(int rank = data_val.shape().rank()-1; rank >=0; rank--)
+        data_val = sum(data_val, rank, output_mem_config);
+    Tensor zeros = zeros_like(data, output_mem_config);
+    Tensor weight_norm = clamp(sqrt(bcast(zeros, data_val,  BcastOpMath::ADD, BcastOpDim::HW, output_mem_config), output_mem_config), 0.0f, 10.0f, output_mem_config);
+
+    Tensor adam_step_val = square(adam_step, output_mem_config);
+    for(int rank = adam_step_val.shape().rank()-1; rank >=0; rank--)
+        adam_step_val = sum(adam_step_val, rank, output_mem_config);
+    Tensor adam_norm = sqrt(bcast(zeros, adam_step_val,  BcastOpMath::ADD, BcastOpDim::HW, output_mem_config), output_mem_config);
+
+    Tensor ones = ones_like(weight_norm, output_mem_config);
+
+    Tensor trust_ratio_mid = mul(weight_norm, recip(add_unary(adam_norm, eps, output_mem_config),output_mem_config), std::nullopt, output_mem_config);
+    Tensor trust_ratio = where(gtz(weight_norm, output_mem_config), where(gtz(adam_norm, output_mem_config), trust_ratio_mid, ones, output_mem_config), ones);
+
+    Tensor param = sub(data, mul(adam_step, mul_unary(trust_ratio_mid, step_size, output_mem_config), std::nullopt, output_mem_config), std::nullopt, output_mem_config);
+    output_tensor.emplace_back(param);
+    output_tensor.emplace_back(exp_avg_out);
+    output_tensor.emplace_back(exp_avg_sq_out);
+
+    return output_tensor;
+}
+std::vector<Tensor> lamb_optimizer(const Tensor& data, const Tensor& grad, const Tensor& exp_avg, const Tensor& exp_avg_sq, float beta1, float beta2, float step_size, float eps, float weight_decay, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _lamb_optimizer)(data, grad, exp_avg, exp_avg_sq, beta1, beta2, step_size, eps, weight_decay, output_mem_config);
+}
+
 }//namespace tt_metal
 
 }//namespace tt

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -299,9 +299,6 @@ Tensor power_fp(const Tensor& input_a, float exponent, const MemoryConfig& outpu
 //repeat a input tensor @input_a as specified by the number of dimensions
 Tensor repeat(const Tensor& input_a, const Shape& shape,const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// vector returns param, exp_avg, exp_avg_sq
-std::vector<Tensor> lamb_optimizer(const Tensor& data, const Tensor& grad, const Tensor& exp_avg, const Tensor& exp_avg_sq, float beta1, float beta2, float step_size, float eps, float weight_decay, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 } //namespace tt_metal
 
 } //namespace tt

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -299,6 +299,9 @@ Tensor power_fp(const Tensor& input_a, float exponent, const MemoryConfig& outpu
 //repeat a input tensor @input_a as specified by the number of dimensions
 Tensor repeat(const Tensor& input_a, const Shape& shape,const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+// vector returns param, exp_avg, exp_avg_sq
+std::vector<Tensor> lamb_optimizer(const Tensor& data, const Tensor& grad, const Tensor& exp_avg, const Tensor& exp_avg_sq, float beta1, float beta2, float step_size, float eps, float weight_decay, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 } //namespace tt_metal
 
 } //namespace tt

--- a/tt_eager/tt_dnn/op_library/optimizer/optimizer_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/optimizer/optimizer_ops.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/optimizer/optimizer_ops.hpp"
+#include "tt_dnn/op_library/composite/composite_ops.hpp"
+#include "tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
+#include "tt_dnn/op_library/eltwise_binary/eltwise_binary_op.hpp"
+#include "tt_dnn/op_library/reshape/reshape_op.hpp"
+#include "tt_dnn/op_library/reduce/reduce_op.hpp"
+#include "tt_dnn/op_library/concat/concat_op.hpp"
+
+
+namespace tt {
+
+namespace tt_metal {
+
+// lamb_optimizer
+// exp_avg = exp_avg * beta1 + (1 - beta1) * grad
+// exp_avg_sq = exp_avg_sq * beta2 + (1 - beta2) * (grad * grad)
+// adam_step = exp_avg / (exp_avg_sq.sqrt() + eps)
+// adam_step = adam_step + weight_decay * param
+// weight_norm = param.norm(p=2).clamp(0, 10)
+// adam_norm = adam_step.norm(p=2)
+// trust_ratio = 1.0 if weight_norm == 0 or adam_norm == 0 else weight_norm / (adam_norm + eps)
+// trust_ratio = where(greater(w_norm, 0), where(tf.greater(g_norm, 0), (w_norm / g_norm), 1.0),1.0)
+// param = param - step_size * trust_ratio * adam_step
+std::vector<Tensor> _lamb_optimizer(const Tensor& data, const Tensor& grad, const Tensor& exp_avg, const Tensor& exp_avg_sq, float beta1, float beta2, float step_size, float eps, float weight_decay, const MemoryConfig& output_mem_config) {
+    using namespace tt::tt_metal;
+    const float beta1_out = 1.0f - beta1;
+    const float beta2_out = 1.0f - beta2;
+
+    std::vector<Tensor> output_tensor;
+    Tensor exp_avg_out = add(mul_unary(exp_avg, beta1, output_mem_config), mul_unary(beta1_out, grad, output_mem_config), std::nullopt, output_mem_config);
+
+    Tensor exp_avg_sq_out = add(mul_unary(exp_avg_sq, beta2, output_mem_config),  mul_unary(beta2_out, square(grad, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
+
+    Tensor adam_step_mid = mul(exp_avg_out, recip(add_unary(sqrt(exp_avg_sq_out, output_mem_config), eps, output_mem_config),output_mem_config),  std::nullopt, output_mem_config);
+    Tensor adam_step = add(adam_step_mid, mul_unary(weight_decay, data, output_mem_config), std::nullopt, output_mem_config);
+
+    auto rmsnorm = [&output_mem_config](Tensor data) -> Tensor {
+        Tensor data_val = square(data, output_mem_config);
+        data_val = global_sum(data_val,output_mem_config);
+        Tensor zeros = zeros_like(data, output_mem_config);
+        data_val = sqrt(bcast(zeros, data_val,  BcastOpMath::ADD, BcastOpDim::HW, output_mem_config), output_mem_config);
+        return data_val;
+    };
+    Tensor data_val = rmsnorm(data);
+    Tensor weight_norm = clamp(data_val, 0.0f, 10.0f, output_mem_config);
+
+    Tensor adam_norm = rmsnorm(adam_step);
+    Tensor ones = ones_like(weight_norm, output_mem_config);
+
+    Tensor trust_ratio_mid = mul(weight_norm, recip(add_unary(adam_norm, eps, output_mem_config),output_mem_config), std::nullopt, output_mem_config);
+    Tensor trust_ratio = where(gtz(weight_norm, output_mem_config), where(gtz(adam_norm, output_mem_config), trust_ratio_mid, ones, output_mem_config), ones);
+
+    Tensor param = sub(data, mul(adam_step, mul_unary(trust_ratio_mid, step_size, output_mem_config), std::nullopt, output_mem_config), std::nullopt, output_mem_config);
+    output_tensor.emplace_back(param);
+    output_tensor.emplace_back(exp_avg_out);
+    output_tensor.emplace_back(exp_avg_sq_out);
+
+    return output_tensor;
+}
+std::vector<Tensor> lamb_optimizer(const Tensor& data, const Tensor& grad, const Tensor& exp_avg, const Tensor& exp_avg_sq, float beta1, float beta2, float step_size, float eps, float weight_decay, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _lamb_optimizer)(data, grad, exp_avg, exp_avg_sq, beta1, beta2, step_size, eps, weight_decay, output_mem_config);
+}
+
+}//namespace tt_metal
+
+}//namespace tt

--- a/tt_eager/tt_dnn/op_library/optimizer/optimizer_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/optimizer/optimizer_ops.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "tt_dnn/op_library/composite/composite_ops.hpp"
+
+namespace tt {
+namespace tt_metal {
+    // vector returns param, exp_avg, exp_avg_sq
+    std::vector<Tensor> lamb_optimizer(const Tensor& data, const Tensor& grad, const Tensor& exp_avg, const Tensor& exp_avg_sq, float beta1, float beta2, float step_size, float eps, float weight_decay, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+}
+}

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -563,5 +563,57 @@ namespace tt::tt_metal::detail{
                 "input", "Tensor add is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
+
+    m_tensor.def("clamp_bw", &tt::tt_metal::clamp_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("min").noconvert(), py::arg("max").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for clamp of ``input`` tensors with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "min", "Minimum Value", "float", , "Yes"
+                "max", "Maximum Value", "float", , "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("clamp_min_bw", &tt::tt_metal::clamp_min_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("min").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for clamp min of ``input`` tensors with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "min", "Minimum Value", "float", , "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("clamp_max_bw", &tt::tt_metal::clamp_max_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("max").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for clamp max of ``input`` tensors with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "max", "Maximum Value", "float", , "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
     }
 }

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -131,7 +131,7 @@ namespace tt::tt_metal::detail{
         )doc");
 
     m_tensor.def("tan_bw", &tt::tt_metal::tan_bw,
-            py::arg("grad").noconvert(), py::arg("tan_result").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for tangent with given ``grad``
 
                 Input tensors must have BFLOAT16 data type.
@@ -142,7 +142,7 @@ namespace tt::tt_metal::detail{
                     :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
                     "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "tan_result", "Result tensor of an tangent forward operation", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                    "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
@@ -265,7 +265,7 @@ namespace tt::tt_metal::detail{
             )doc");
 
     m_tensor.def("sqrt_bw", &tt::tt_metal::sqrt_bw,
-            py::arg("grad").noconvert(), py::arg("sqrt_result").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for sqrt with given ``grad``.
 
                 Input tensors must have BFLOAT16 data type.
@@ -276,7 +276,7 @@ namespace tt::tt_metal::detail{
                     :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
                     "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "sqrt_result", "Result tensor of a sqrt forward operation", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                    "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -214,6 +214,22 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+    m_tensor.def("relu_bw", &tt::tt_metal::relu_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for relu of ``input`` tensors with given ``grad``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor relu is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
     m_tensor.def("unary_add_bw", &tt::tt_metal::unary_add_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for addition with given ``grad`` and ``alpha``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -615,5 +615,21 @@ namespace tt::tt_metal::detail{
                 "max", "Maximum Value", "float", , "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
+
+    m_tensor.def("binary_le_bw", &tt::tt_metal::binary_le_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor add is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
     }
 }

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -723,6 +723,30 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+        m_tensor.def("lamb_optimizer", &lamb_optimizer,
+            py::arg("data").noconvert(), py::arg("grad").noconvert(), py::arg("exp_avg").noconvert(), py::arg("exp_avg_sq").noconvert(), py::arg("beta1"), py::arg("beta2"), py::arg("step_size"), py::arg("eps"), py::arg("weight_decay"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Returns tensor with the threshold activation on elements of the input tensors ``arg0`` at threshold ``threshold``,
+            and value ``value``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "data", "Tensor data is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "grad", "Tensor grad is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "exp_avg", "Tensor exp_avg is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "exp_avg_sq", "exp_avg_sq threshold is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "beta1", "Value to beta1 at", "float", "", "Yes"
+                "beta2", "Value to beta2 with", "float", "", "Yes"
+                "step_size", "Value to beta1 at", "float", "", "Yes"
+                "eps", "Value to beta2 with", "float", "", "Yes"
+                "weight_decay", "Value to beta1 at", "float", "", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
         detail::bind_unary_op_with_param(
             m_tensor, "logit", &logit,
             py::arg("eps"),

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -7,6 +7,7 @@
 #include "tt_dnn/op_library/composite/composite_ops.hpp"
 #include "tt_dnn/op_library/complex/complex_ops.hpp"
 #include "tt_eager/tt_dnn/op_library/loss/loss_op.hpp"
+#include "tt_eager/tt_dnn/op_library/optimizer/optimizer_ops.hpp"
 
 namespace tt::tt_metal::detail{
     void TensorModuleCompositeOPs( py::module & m_tensor){


### PR DESCRIPTION
Optimizer
========
- 4203 - tt_lib.tensor.lamb_optimizer

TM Ops
======
- tt_lib.tensor.repeat
- tt_lib.tensor.repeat_interleave

Activation
========
- 4373 - tt_lib.tensor.relu_bw

Relational ops
==========
- tt_lib.tensor.gt_bw
- 4377  - tt_lib.tensor.binary_le_bw
- tt_lib.tensor.ne_bw

Clamp
=====
- 4287  - tt_lib.tensor.clamp_bw
- tt_lib.tensor.clamp_min_bw
- tt_lib.tensor.clamp_max_bw
