### PR TITLE
#4453: Support for lazy execution mode of command queue

### DIFF
--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -125,6 +125,11 @@ void DeviceModule(py::module &m_device) {
     m_device.def("Synchronize", &detail::Synchronize, R"doc(
         Wait for all kernels on TT device to complete.
     )doc");
+    m_device.def("SetLazyCommandQueueMode", &detail::SetLazyCommandQueueMode, R"doc(
+        If set to true, the host does not notify the device that there are commands available other than
+        the FinishCommand. Once set to false, all subsequent commands will immediately notify the device
+        that the write pointer has been updated.
+    )doc");
     m_device.def("DeallocateBuffers", &detail::DeallocateBuffers, R"doc(
         Deallocate all buffers associated with Device handle
     )doc");

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -298,6 +298,12 @@ namespace tt::tt_metal{
             }
         }
 
+        inline void SetLazyCommandQueueMode(bool lazy)
+        {
+            DispatchStateCheck(true);
+            LAZY_COMMAND_QUEUE_MODE = lazy;
+        }
+
         inline void DeallocateBuffers(Device * device)
         {
             device->deallocate_buffers();

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -404,7 +404,7 @@ void EnqueueReadBufferCommand::process() {
 
     this->manager.issue_queue_reserve_back(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND);
     this->manager.cq_write(cmd.get_desc().data(), DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, write_ptr);
-    this->manager.issue_queue_push_back(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND);
+    this->manager.issue_queue_push_back(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, LAZY_COMMAND_QUEUE_MODE);
 }
 
 EnqueueCommandType EnqueueReadBufferCommand::type() { return this->type_; }
@@ -531,7 +531,7 @@ void EnqueueWriteBufferCommand::process() {
         this->manager.cq_write((char*)this->src + unpadded_src_offset, data_size_in_bytes, system_memory_temporary_storage_address);
     }
 
-    this->manager.issue_queue_push_back(cmd_size);
+    this->manager.issue_queue_push_back(cmd_size, LAZY_COMMAND_QUEUE_MODE);
 }
 
 EnqueueCommandType EnqueueWriteBufferCommand::type() { return this->type_; }
@@ -689,7 +689,7 @@ void EnqueueProgramCommand::process() {
         }
     }
 
-    this->manager.issue_queue_push_back(cmd_size);
+    this->manager.issue_queue_push_back(cmd_size, LAZY_COMMAND_QUEUE_MODE);
 }
 
 EnqueueCommandType EnqueueProgramCommand::type() { return this->type_; }
@@ -710,7 +710,7 @@ void FinishCommand::process() {
 
     this->manager.issue_queue_reserve_back(cmd_size);
     this->manager.cq_write(cmd.get_desc().data(), DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, write_ptr);
-    this->manager.issue_queue_push_back(cmd_size);
+    this->manager.issue_queue_push_back(cmd_size, false);
 }
 
 EnqueueCommandType FinishCommand::type() { return this->type_; }
@@ -740,7 +740,7 @@ void EnqueueWrapCommand::process() {
 
     this->manager.issue_queue_reserve_back(wrap_packet_size_bytes);
     this->manager.cq_write(command_vector.data(), command_vector.size() * sizeof(uint32_t), write_ptr);
-    this->manager.issue_queue_push_back(wrap_packet_size_bytes);
+    this->manager.issue_queue_push_back(wrap_packet_size_bytes, LAZY_COMMAND_QUEUE_MODE);
     if (this->wrap_region == DeviceCommand::WrapRegion::COMPLETION) {
         // Wrap the read pointers for completion queue because device will start writing data at head of completion queue and there are no more reads to be done at current completion queue write pointer
         // If we don't wrap the read then the subsequent read buffer command may attempt to read past the total command queue size

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -220,4 +220,6 @@ class CommandQueue {
     friend CommandQueue &detail::GetCommandQueue(Device *device);
 };
 
+inline bool LAZY_COMMAND_QUEUE_MODE = false;
+
 } // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -155,7 +155,7 @@ class SystemMemoryManager {
         tt_driver_atomics::sfence();
     }
 
-    void issue_queue_push_back(uint32_t push_size_B) {
+    void issue_queue_push_back(uint32_t push_size_B, bool lazy) {
         // All data needs to be 32B aligned
         uint32_t push_size_16B =
             (((push_size_B - 1) | 31) + 1) >> 4;  // Terse way to find next multiple of 32 in 16B words
@@ -170,7 +170,9 @@ class SystemMemoryManager {
         }
 
         // Notify dispatch core
-        this->send_issue_queue_write_ptr();
+        if (not lazy) {
+            this->send_issue_queue_write_ptr();
+        }
     }
 
     void completion_queue_wait_front() {


### PR DESCRIPTION
Under this mode, only finish notifies the device that the write pointer was updated. This mode can be turned on and off at runtime. By default, it's not enabled.