### PR TITLE
Refactor backward tests

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_abs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_abs.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,29 +17,19 @@ from loguru import logger
     ),
 )
 def test_bw_abs(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.abs(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.abs_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -6,10 +6,6 @@ import torch
 import pytest
 import tt_lib
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
 
 
 @pytest.mark.parametrize(
@@ -21,9 +17,9 @@ from loguru import logger
     ),
 )
 def test_bw_add(input_shapes, device):
-    in_data, input_tensor = bw_data_gen(input_shapes, device, True)
-    other_data, other_tensor = bw_data_gen(input_shapes, device, True)
-    grad_data, grad_tensor = bw_data_gen(input_shapes, device)
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.add_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -38,5 +34,5 @@ def test_bw_add(input_shapes, device):
     golden_tensor.append(in_data.grad)
     golden_tensor.append(other_data.grad)
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor, comparison_funcs.comp_pcc)
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
@@ -20,27 +21,11 @@ from loguru import logger
     ),
 )
 def test_bw_add(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = bw_data_gen(input_shapes, device, True)
+    other_data, other_tensor = bw_data_gen(input_shapes, device, True)
+    grad_data, grad_tensor = bw_data_gen(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.add_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -49,15 +34,9 @@ def test_bw_add(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    (
-        comp_pass_a,
-        comp_out_a,
-    ) = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor, comparison_funcs.comp_pcc)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,27 +18,11 @@ from loguru import logger
 )
 @pytest.mark.parametrize("alpha", [0.05, 1.0, 0.5, 0.12])
 def test_bw_addalpha(input_shapes, alpha, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.addalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -50,12 +31,9 @@ def test_bw_addalpha(input_shapes, alpha, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,34 +18,15 @@ from loguru import logger
 )
 @pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 5.0])
 def test_bw_addcdiv(input_shapes, value, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    tensor1_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    tensor2_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    tensor1_data, tensor1_tensor = data_gen_pt_tt(input_shapes, device, True)
+    tensor2_data, tensor2_tensor = data_gen_pt_tt(input_shapes, device, True)
 
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    tensor1_tensor = (
-        tt_lib.tensor.Tensor(tensor1_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-    tensor2_tensor = (
-        tt_lib.tensor.Tensor(tensor2_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device, False)
 
     tt_output_tensor_on_device = tt_lib.tensor.addcdiv_bw(
         grad_tensor, input_tensor, tensor1_tensor, tensor2_tensor, value
     )
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_c = tt_output_tensor_on_device[2].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     tensor1_data.retain_grad()
@@ -58,15 +36,10 @@ def test_bw_addcdiv(input_shapes, value, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = tensor1_data.grad
-    golden_output_tensor_c = tensor2_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(tensor1_data.grad)
+    golden_tensor.append(tensor2_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-    comp_pass_c, comp_out_c = comparison_funcs.comp_pcc(golden_output_tensor_c, tt_output_tensor_c)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    logger.info(comp_out_c)
-    assert comp_pass_a & comp_pass_b & comp_pass_c
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,34 +18,15 @@ from loguru import logger
 )
 @pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 0.12])
 def test_bw_addcmul(input_shapes, value, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    tensor1_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    tensor2_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    tensor1_data, tensor1_tensor = data_gen_pt_tt(input_shapes, device, True)
+    tensor2_data, tensor2_tensor = data_gen_pt_tt(input_shapes, device, True)
 
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    tensor1_tensor = (
-        tt_lib.tensor.Tensor(tensor1_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-    tensor2_tensor = (
-        tt_lib.tensor.Tensor(tensor2_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.addcmul_bw(
         grad_tensor, input_tensor, tensor1_tensor, tensor2_tensor, value
     )
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_c = tt_output_tensor_on_device[2].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     tensor1_data.retain_grad()
@@ -58,15 +36,10 @@ def test_bw_addcmul(input_shapes, value, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = tensor1_data.grad
-    golden_output_tensor_c = tensor2_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(tensor1_data.grad)
+    golden_tensor.append(tensor2_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-    comp_pass_c, comp_out_c = comparison_funcs.comp_pcc(golden_output_tensor_c, tt_output_tensor_c)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    logger.info(comp_out_c)
-    assert comp_pass_a & comp_pass_b & comp_pass_c
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,13 @@ from loguru import logger
     ),
 )
 def test_bw_binary_le(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.binary_le_bw(grad_tensor, input_tensor)
-    pyt_y = torch.zeros_like(grad_data)
-
-    tt_output_tensor_1 = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_2 = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor_1)
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor_2)
-    logger.info(comp_out)
+    pt_y = torch.zeros_like(grad_data)
+    golden_tensor = list()
+    golden_tensor.append(pt_y)
+    golden_tensor.append(pt_y)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,29 +17,20 @@ from loguru import logger
     ),
 )
 def test_bw_clamp(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
     min = -10.0
     max = 10.0
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.clamp(in_data, min=min, max=max)
 
     tt_output_tensor_on_device = tt_lib.tensor.clamp_bw(grad_tensor, input_tensor, min, max)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_max.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,28 +18,18 @@ from loguru import logger
 )
 @pytest.mark.parametrize("max", (1.0, 0.5, 0.0, -1.0, 10.0))
 def test_bw_clamp_max(input_shapes, max, device):
-    torch.manual_seed(12386)
-    in_data = torch.zeros(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     pyt_y = torch.clamp(in_data, max=max)
 
     tt_output_tensor_on_device = tt_lib.tensor.clamp_max_bw(grad_tensor, input_tensor, max)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_min.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_clamp_min.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,27 +18,18 @@ from loguru import logger
 )
 @pytest.mark.parametrize("min", (-1.0, 1.0, 0.0, -0.5, -10.0, 10.0))
 def test_bw_clamp_min(input_shapes, min, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     pyt_y = torch.clamp(in_data, min=min)
 
     tt_output_tensor_on_device = tt_lib.tensor.clamp_min_bw(grad_tensor, input_tensor, min)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,26 +17,11 @@ from loguru import logger
     ),
 )
 def test_bw_div(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.div_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -48,15 +30,9 @@ def test_bw_div(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    (
-        comp_pass_a,
-        comp_out_a,
-    ) = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,29 +17,19 @@ from loguru import logger
     ),
 )
 def test_bw_exp(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.exp(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.exp_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill_zero.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill_zero.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -24,19 +21,10 @@ from loguru import logger
 #   self: zeros_like(grad)
 #   result: at::fill(self_t, 0)
 def test_bw_fill_zero(input_shapes, device):
-    torch.manual_seed(12386)
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.fill_zero_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
-
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(pyt_y)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_gt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_gt.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,19 +17,13 @@ from loguru import logger
     ),
 )
 def test_bw_unary_gt(input_shapes, device):
-    torch.manual_seed(12386)
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.gt_bw(grad_tensor)
+
     pyt_y = torch.zeros_like(grad_data)
 
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    golden_tensor = list()
+    golden_tensor.append(pyt_y)
 
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,20 +17,9 @@ from loguru import logger
     ),
 )
 def test_bw_log(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.log_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -41,8 +27,8 @@ def test_bw_log(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lt.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,19 +17,12 @@ from loguru import logger
     ),
 )
 def test_bw_unary_lt(input_shapes, device):
-    torch.manual_seed(12386)
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.lt_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
 
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    golden_tensor = list()
+    golden_tensor.append(pyt_y)
 
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,26 +17,11 @@ from loguru import logger
     ),
 )
 def test_bw_max(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.max_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -48,12 +30,9 @@ def test_bw_max(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,26 +17,11 @@ from loguru import logger
     ),
 )
 def test_bw_min(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.min_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -48,12 +30,9 @@ def test_bw_min(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,41 +17,22 @@ from loguru import logger
     ),
 )
 def test_bw_mul(input_shapes, device):
-    torch.manual_seed(0)
-    in_data_a = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    in_data_b = torch.randn(input_shapes, requires_grad=True).bfloat16()
-
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor_a = (
-        tt_lib.tensor.Tensor(in_data_a, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor_b = (
-        tt_lib.tensor.Tensor(in_data_b, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data_a, input_tensor_a = data_gen_pt_tt(input_shapes, device, True)
+    in_data_b, input_tensor_b = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.mul_bw(grad_tensor, input_tensor_a, input_tensor_b)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data_a.retain_grad()
     in_data_b.retain_grad()
 
-    pyt_y = in_data_a * in_data_b
+    pyt_y = torch.mul(in_data_a, in_data_b)
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data_a.grad
-    golden_output_tensor_b = in_data_b.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data_a.grad)
+    golden_tensor.append(in_data_b.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ne.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ne.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,19 +17,12 @@ from loguru import logger
     ),
 )
 def test_bw_unary_ne(input_shapes, device):
-    torch.manual_seed(12386)
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     tt_output_tensor_on_device = tt_lib.tensor.ne_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
 
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    golden_tensor = list()
+    golden_tensor.append(pyt_y)
 
-    golden_output_tensor = pyt_y
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_neg.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_neg.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,20 +17,10 @@ from loguru import logger
     ),
 )
 def test_bw_neg(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.neg_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -41,9 +28,8 @@ def test_bw_neg(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_equal(golden_output_tensor, tt_output_tensor)
-
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,29 +18,19 @@ from loguru import logger
 )
 # @pytest.mark.parametrize("threshold",[0.0])
 def test_bw_relu(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.relu(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.relu_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsqrt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsqrt.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,28 +17,19 @@ from loguru import logger
     ),
 )
 def test_bw_rsqrt(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.rsqrt(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.rsqrt_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsub.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,12 @@ from loguru import logger
     ),
 )
 def test_bw_rsub(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
 
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.rsub_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -49,12 +31,9 @@ def test_bw_rsub(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sigmoid.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sigmoid.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,28 +18,19 @@ from loguru import logger
 )
 def test_bw_sigmoid(input_shapes, device):
     torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.sigmoid(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.sigmoid_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor, 0.90)
-    logger.info(comp_out)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor, 0.90)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,18 @@ from loguru import logger
     ),
 )
 def test_bw_sqrt(input_shapes, device):
-    torch.manual_seed(12345)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     pyt_y = torch.sqrt(in_data)
 
-    sqrt_tensor = tt_lib.tensor.Tensor(pyt_y, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-
-    tt_output_tensor_on_device = tt_lib.tensor.sqrt_bw(grad_tensor, sqrt_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor_on_device = tt_lib.tensor.sqrt_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sub.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,11 @@ from loguru import logger
     ),
 )
 def test_bw_sub(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.sub_bw(grad_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -49,12 +30,9 @@ def test_bw_sub(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tan.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tan.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,27 +17,22 @@ from loguru import logger
     ),
 )
 def test_bw_tan(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    # tt tan supports input range [-1.45, 1.45]
+    in_data = torch.Tensor(size=input_shapes).uniform_(-1.45, 1.45)
+    in_data.requires_grad = True
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
-
     pyt_y = torch.tan(in_data)
 
-    tan_tensor = tt_lib.tensor.Tensor(pyt_y, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-
-    tt_output_tensor_on_device = tt_lib.tensor.tan_bw(grad_tensor, tan_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor_on_device = tt_lib.tensor.tan_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
-
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor, 0.96)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,29 +17,18 @@ from loguru import logger
     ),
 )
 def test_bw_tanh(input_shapes, device):
-    torch.manual_seed(12386)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     pyt_y = torch.tanh(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.tanh_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor, 0.95)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_add.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -19,22 +16,12 @@ from loguru import logger
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("alpha", [1.0])
+@pytest.mark.parametrize("alpha", [1.0, 0.5, 0.035])
 def test_bw_unary_add(input_shapes, alpha, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_add_bw(grad_tensor, input_tensor, alpha=alpha)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -42,8 +29,8 @@ def test_bw_unary_add(input_shapes, alpha, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_assign.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_assign.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,20 +17,10 @@ from loguru import logger
     ),
 )
 def test_bw_unary_assign(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_assign_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -41,8 +28,8 @@ def test_bw_unary_assign(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_equal(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_div.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,20 +18,10 @@ from loguru import logger
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
 def test_bw_unary_div(input_shapes, scalar, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_div_bw(grad_tensor, input_tensor, scalar=scalar)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -42,8 +29,8 @@ def test_bw_unary_div(input_shapes, scalar, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_mul.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,20 +18,10 @@ from loguru import logger
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
 def test_bw_unary_mul(input_shapes, scalar, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_mul_bw(grad_tensor, input_tensor, scalar=scalar)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -42,8 +29,8 @@ def test_bw_unary_mul(input_shapes, scalar, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -28,20 +25,10 @@ from loguru import logger
     ],
 )
 def test_bw_unary_pow(input_shapes, exponent, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_pow_bw(grad_tensor, input_tensor, exponent=exponent)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -49,8 +36,8 @@ def test_bw_unary_pow(input_shapes, exponent, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_sub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_sub.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -21,20 +18,10 @@ from loguru import logger
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
 def test_bw_unary_sub(input_shapes, scalar, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_sub_bw(grad_tensor, input_tensor)
-    tt_output_tensor = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
 
@@ -42,8 +29,8 @@ def test_bw_unary_sub(input_shapes, scalar, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor = in_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
 
-    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_output_tensor, tt_output_tensor)
-    logger.info(comp_out)
-    assert comp_pass
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_where.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_where.py
@@ -5,10 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.sweep_tests import (
-    comparison_funcs,
-)
-from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import *
 
 
 @pytest.mark.parametrize(
@@ -20,31 +17,17 @@ from loguru import logger
     ),
 )
 def test_bw_where(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    other_data = torch.randn(input_shapes, requires_grad=True).bfloat16()
-    grad_data = torch.randn(input_shapes).bfloat16()
     condition_data = torch.randn(input_shapes).bool()
-
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
 
     condition_tensor = (
         tt_lib.tensor.Tensor(condition_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
 
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-
-    other_tensor = (
-        tt_lib.tensor.Tensor(other_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.where_bw(grad_tensor, condition_tensor, input_tensor, other_tensor)
-    tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_output_tensor_b = tt_output_tensor_on_device[1].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -53,12 +36,9 @@ def test_bw_where(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_output_tensor_a = in_data.grad
-    golden_output_tensor_b = other_data.grad
+    golden_tensor = list()
+    golden_tensor.append(in_data.grad)
+    golden_tensor.append(other_data.grad)
 
-    comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
-    comp_pass_b, comp_out_b = comparison_funcs.comp_pcc(golden_output_tensor_b, tt_output_tensor_b)
-
-    logger.info(comp_out_a)
-    logger.info(comp_out_b)
-    assert comp_pass_a & comp_pass_b
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -6,10 +6,12 @@
 import torch
 import tt_lib
 from loguru import logger
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
 
 
-def bw_data_gen(input_shapes, device, required_grad=False):
-    torch.manual_seed(1235)
+def data_gen_pt_tt(input_shapes, device, required_grad=False):
     pt_tensor = torch.randn(input_shapes, requires_grad=required_grad).bfloat16()
     tt_tensor = (
         tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
@@ -17,13 +19,15 @@ def bw_data_gen(input_shapes, device, required_grad=False):
     return pt_tensor, tt_tensor
 
 
-def compare_results(tt_tensor, golden_tensor, comparison_funcs):
+def compare_results(tt_tensor, golden_tensor, pcc=0.99):
     status = True
     for i in range(len(tt_tensor)):
         tt_out_tensor = tt_tensor[i].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
         pt_out_tensor = golden_tensor[i]
-        comp_pass, comp_out = comparison_funcs(pt_out_tensor, tt_out_tensor)
+        comp_pass, comp_out = comparison_funcs.comp_pcc(pt_out_tensor, tt_out_tensor, pcc=pcc)
+        comp_all, _ = comparison_funcs.comp_allclose(pt_out_tensor, tt_out_tensor, atol=4, rtol=1e-1)
         logger.info(comp_pass)
+        logger.info(comp_all)
         logger.info(comp_out)
-        status = status & comp_pass
+        status = status & (comp_pass | comp_all)
     return status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+import tt_lib
+from loguru import logger
+
+
+def bw_data_gen(input_shapes, device, required_grad=False):
+    torch.manual_seed(1235)
+    pt_tensor = torch.randn(input_shapes, requires_grad=required_grad).bfloat16()
+    tt_tensor = (
+        tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    return pt_tensor, tt_tensor
+
+
+def compare_results(tt_tensor, golden_tensor, comparison_funcs):
+    status = True
+    for i in range(len(tt_tensor)):
+        tt_out_tensor = tt_tensor[i].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+        pt_out_tensor = golden_tensor[i]
+        comp_pass, comp_out = comparison_funcs(pt_out_tensor, tt_out_tensor)
+        logger.info(comp_pass)
+        logger.info(comp_out)
+        status = status & comp_pass
+    return status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -125,15 +125,18 @@ std::vector<Tensor> binary_assign_bw(const Tensor& grad, const Tensor& input, co
     return operation::decorate_as_composite(__func__, _unary_assign_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _sqrt_bw(const Tensor& grad, const Tensor& sqrt_result, const MemoryConfig& output_mem_config) {
+std::vector<Tensor> _sqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    Tensor sqrt_result = sqrt(input, output_mem_config);
     Tensor result = mul(grad, recip(mul_unary(sqrt_result, 2.0, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
+    Tensor t_nan  = full_like(input, std::nanf(""), output_mem_config);
+    result = where(ltz(input, output_mem_config), t_nan, result, output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;
 }
-std::vector<Tensor> sqrt_bw(const Tensor& grad, const Tensor& sqrt_result, const MemoryConfig& output_mem_config)
+std::vector<Tensor> sqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config)
 {
-    return operation::decorate_as_composite(__func__, _sqrt_bw)(grad, sqrt_result, output_mem_config);
+    return operation::decorate_as_composite(__func__, _sqrt_bw)(grad, input, output_mem_config);
 }
 
 
@@ -195,16 +198,16 @@ std::vector<Tensor> sigmoid_bw(const Tensor& grad, const Tensor& input,
 }
 
 
-
-std::vector<Tensor> _tan_bw(const Tensor& grad, const Tensor& tan_result, const MemoryConfig& output_mem_config) {
+std::vector<Tensor> _tan_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    Tensor tan_result = tan(input, output_mem_config);
     Tensor result = mul(grad, add1(square(tan_result, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;
 }
-std::vector<Tensor> tan_bw(const Tensor& grad, const Tensor& tan_result, const MemoryConfig& output_mem_config)
+std::vector<Tensor> tan_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config)
 {
-    return operation::decorate_as_composite(__func__, _tan_bw)(grad, tan_result, output_mem_config);
+    return operation::decorate_as_composite(__func__, _tan_bw)(grad, input, output_mem_config);
 }
 
 std::vector<Tensor> _addcdiv_bw(const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -35,7 +35,7 @@ std::vector<Tensor> add_bw(const Tensor& grad, const Tensor& input, const Tensor
 
 std::vector<Tensor> exp_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> sqrt_bw(const Tensor& grad, const Tensor& sqrt_result, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<Tensor> sqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> unary_assign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
@@ -55,9 +55,9 @@ std::vector<Tensor> embedding_bw(const Tensor& grad, const Tensor& input, const 
 std::vector<Tensor> tanh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // grad(sigmoid) = grad*(1 - sigmoid(x))*sigmoid(x)
-std::vector<Tensor> sigmoid_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<Tensor> sigmoid_bw(const Tensor& grad, const Tensor& esinput, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> tan_bw(const Tensor& grad, const Tensor& tan_result, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<Tensor> tan_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> where_bw(const Tensor& grad, const Tensor& condition, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -131,7 +131,7 @@ namespace tt::tt_metal::detail{
         )doc");
 
     m_tensor.def("tan_bw", &tt::tt_metal::tan_bw,
-            py::arg("grad").noconvert(), py::arg("tan_result").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for tangent with given ``grad``
 
                 Input tensors must have BFLOAT16 data type.
@@ -142,7 +142,7 @@ namespace tt::tt_metal::detail{
                     :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
                     "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "tan_result", "Result tensor of an tangent forward operation", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                    "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
@@ -265,7 +265,7 @@ namespace tt::tt_metal::detail{
             )doc");
 
     m_tensor.def("sqrt_bw", &tt::tt_metal::sqrt_bw,
-            py::arg("grad").noconvert(), py::arg("sqrt_result").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for sqrt with given ``grad``.
 
                 Input tensors must have BFLOAT16 data type.
@@ -276,7 +276,7 @@ namespace tt::tt_metal::detail{
                     :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
                     "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "sqrt_result", "Result tensor of a sqrt forward operation", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                    "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 


### PR DESCRIPTION
- Created a module to generate data and compare results
- compare_results modules calculate all close also since few ops are failing due to small differences across all elements hence use rtol and atol param to pass those tests (e.g div variants, fill, log ) 