### PR TITLE
Pytest timeout plugin to allows setting a per test time limit

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+timeout = 600
 minversion = 7.2
 addopts = --import-mode=importlib -vvvs -rA
 empty_parameter_set_mark = skip

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -17,6 +17,7 @@ yamllint==1.32.0
 
 # testing
 pytest==7.2.2
+pytest-timeout==2.2.0
 jsbeautifier==1.14.7
 datasets==2.9.0
 torchvision==0.14.1+cpu


### PR DESCRIPTION
Currently have set time limit to 10 minutes per test (see pytest.ini)

Measuring locally on my dev machine, the longest individual pytest is currently ~88s in our post commit suite.