### PR TITLE
Add FP32 acc mode to Bmm

### DIFF
--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -366,7 +366,7 @@ operation::ProgramWithCallbacks Matmul::create_program(const std::vector<Tensor>
                 input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
                 this->bcast_batch,
                 input_tensor_a.device()->compute_with_storage_grid_size(),
-                MathFidelity::HiFi4,
+                MathFidelity::HiFi4, false, true,
                 2, 4, 2,
                 16, 16, false, false, std::nullopt
             );
@@ -376,7 +376,7 @@ operation::ProgramWithCallbacks Matmul::create_program(const std::vector<Tensor>
                 input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
                 this->bcast_batch,
                 input_tensor_a.device()->compute_with_storage_grid_size(),
-                MathFidelity::HiFi4,
+                MathFidelity::HiFi4, false, true,
                 config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
                 config.per_core_M, config.per_core_N, false, std::nullopt, true
             );
@@ -386,7 +386,7 @@ operation::ProgramWithCallbacks Matmul::create_program(const std::vector<Tensor>
                 input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
                 this->bcast_batch,
                 input_tensor_a.device()->compute_with_storage_grid_size(),
-                MathFidelity::HiFi4,
+                MathFidelity::HiFi4, false, true,
                 config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
                 config.per_core_M, config.per_core_N, false, std::nullopt, false
             );
@@ -884,6 +884,9 @@ operation::ProgramWithCallbacks Matmul::create_program(
 
     tt::tt_metal::DataType output_dtype = this->output_dtype;
     MathFidelity math_fidelity = this->math_fidelity;
+    bool fp32_dest_acc_en = this->fp32_dest_acc_en;
+    bool math_approx_mode = this->math_approx_mode;
+
     bool fuse_batch = true;
     bool broadcast_batch = input_tensor_b.shape()[0] * input_tensor_b.shape()[1] == 1;
 
@@ -902,7 +905,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
                             input_tensor_a, input_tensor_b, bias, output_tensor,
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
-                            MathFidelity::HiFi4,
+                            MathFidelity::HiFi4, fp32_dest_acc_en, math_approx_mode,
                             2, 4, 2,
                             16, 16, false, false, std::nullopt
                         );
@@ -911,7 +914,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
                             input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
-                            MathFidelity::HiFi4,
+                            MathFidelity::HiFi4, fp32_dest_acc_en, math_approx_mode,
                             2, 4, 2,
                             16, 16, false, std::nullopt, true
                         );
@@ -920,7 +923,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
                             input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
-                            MathFidelity::HiFi4,
+                            MathFidelity::HiFi4, fp32_dest_acc_en, math_approx_mode,
                             2, 4, 2,
                             16, 16, false, std::nullopt, false
                         );
@@ -940,7 +943,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
                     input_tensor_a, input_tensor_b, output_tensor,
                     broadcast_batch,
                     program_config.compute_with_storage_grid_size,
-                    output_dtype, math_fidelity,
+                    output_dtype, math_fidelity, fp32_dest_acc_en, math_approx_mode,
                     program_config.in0_block_w, program_config.out_subblock_h, program_config.out_subblock_w,
                     program_config.per_core_M, program_config.per_core_N, fuse_batch
                 );
@@ -950,7 +953,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
                     input_tensor_a, input_tensor_b, bias, output_tensor,
                     broadcast_batch,
                     program_config.compute_with_storage_grid_size,
-                    math_fidelity,
+                    math_fidelity, fp32_dest_acc_en, math_approx_mode,
                     program_config.in0_block_w, program_config.out_subblock_h, program_config.out_subblock_w,
                     program_config.per_core_M, program_config.per_core_N, fuse_batch, program_config.transpose_mcast, program_config.fused_activation
                 );
@@ -960,7 +963,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
                     input_tensor_a, input_tensor_b, bias, output_tensor,
                     broadcast_batch,
                     program_config.compute_with_storage_grid_size,
-                    math_fidelity,
+                    math_fidelity, fp32_dest_acc_en, math_approx_mode,
                     program_config.in0_block_w, program_config.out_subblock_h, program_config.out_subblock_w,
                     program_config.per_core_M, program_config.per_core_N, program_config.fuse_batch, program_config.fused_activation,
                     program_config.mcast_in0
@@ -1004,11 +1007,11 @@ MatmulParallelizationStrategy Matmul::get_parallelization_strategy(const std::ve
     );
 }
 
-Tensor matmul_1d(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, std::optional<MatmulMultiCoreReuseMultiCast1DProgramConfig> program_config, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype, const MathFidelity math_fidelity) {
+Tensor matmul_1d(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, std::optional<MatmulMultiCoreReuseMultiCast1DProgramConfig> program_config, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype, const MathFidelity math_fidelity, const bool fp32_dest_acc_en, const bool math_approx_mode) {
     if (!program_config.has_value()) {
         program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b);
     }
-    return operations::primary::matmul(input_tensor_a, input_tensor_b, bias, program_config.value(), mem_config, output_dtype, math_fidelity);
+    return operations::primary::matmul(input_tensor_a, input_tensor_b, bias, program_config.value(), mem_config, output_dtype, math_fidelity, fp32_dest_acc_en, math_approx_mode);
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
@@ -75,9 +75,9 @@ inline Tensor bmm    (const Tensor &input_tensor_a, const Tensor &input_tensor_b
     return operation::run_with_autoformat(Matmul{.bcast_batch=false, .output_mem_config=mem_config, .output_dtype=input_tensor_a.dtype()}, {input_tensor_a, input_tensor_b}, {std::nullopt}).at(0);
 }
 
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const std::optional<const Tensor> bias, Tensor &output_tensor, bool bcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0);
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const std::optional<const Tensor> bias, Tensor &output_tensor, bool bcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, bool transpose_mcast, std::optional<UnaryWithParam> fused_activation);
-operation::ProgramWithCallbacks bmm_multi_core_reuse_optimized(const Tensor& input_tensor_a, const Tensor& input_tensor_b, Tensor &output_tensor, bool bcast_batch, CoreCoord compute_with_storage_grid_size, tt::tt_metal::DataType output_dtype, MathFidelity math_fidelity, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch);
+operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const std::optional<const Tensor> bias, Tensor &output_tensor, bool bcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0);
+operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const std::optional<const Tensor> bias, Tensor &output_tensor, bool bcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, bool transpose_mcast, std::optional<UnaryWithParam> fused_activation);
+operation::ProgramWithCallbacks bmm_multi_core_reuse_optimized(const Tensor& input_tensor_a, const Tensor& input_tensor_b, Tensor &output_tensor, bool bcast_batch, CoreCoord compute_with_storage_grid_size, tt::tt_metal::DataType output_dtype, MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch);
 
 
 /**
@@ -289,6 +289,8 @@ struct Matmul {
     const MemoryConfig output_mem_config;
     const DataType output_dtype;
     const MathFidelity math_fidelity;
+    const bool fp32_dest_acc_en;
+    const bool math_approx_mode;
 
     void validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
@@ -318,9 +320,11 @@ inline Tensor matmul(
     const MatmulProgramConfig& program_config = MatmulDefaultProgramConfig{},
     const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<const DataType> output_dtype=std::nullopt,
-    const MathFidelity math_fidelity = MathFidelity::LoFi
+    const MathFidelity math_fidelity = MathFidelity::LoFi,
+    const bool fp32_dest_acc_en = false,
+    const bool math_approx_mode = true
 ) {
-    return operation::run(Matmul{program_config, mem_config, output_dtype.value_or(input_tensor_a.dtype()), math_fidelity}, {input_tensor_a, input_tensor_b}, {std::nullopt}).at(0);
+    return operation::run(Matmul{program_config, mem_config, output_dtype.value_or(input_tensor_a.dtype()), math_fidelity, fp32_dest_acc_en, math_approx_mode}, {input_tensor_a, input_tensor_b}, {std::nullopt}).at(0);
 }
 
 inline Tensor matmul(
@@ -329,12 +333,14 @@ inline Tensor matmul(
     const MatmulProgramConfig& program_config = MatmulDefaultProgramConfig{},
     const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<const DataType> output_dtype=std::nullopt,
-    const MathFidelity math_fidelity = MathFidelity::LoFi
+    const MathFidelity math_fidelity = MathFidelity::LoFi,
+    const bool fp32_dest_acc_en = false,
+    const bool math_approx_mode = true
 ) {
-    return operation::run(Matmul{program_config, mem_config, output_dtype.value_or(input_tensor_a.dtype()), math_fidelity}, {input_tensor_a, input_tensor_b}, {bias}).at(0);
+    return operation::run(Matmul{program_config, mem_config, output_dtype.value_or(input_tensor_a.dtype()), math_fidelity, fp32_dest_acc_en, math_approx_mode}, {input_tensor_a, input_tensor_b}, {bias}).at(0);
 }
 
-Tensor matmul_1d(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, std::optional<MatmulMultiCoreReuseMultiCast1DProgramConfig> program_config = std::nullopt, const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::optional<const DataType> output_dtype=std::nullopt, const MathFidelity math_fidelity = MathFidelity::LoFi);
+Tensor matmul_1d(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, std::optional<MatmulMultiCoreReuseMultiCast1DProgramConfig> program_config = std::nullopt, const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::optional<const DataType> output_dtype=std::nullopt, const MathFidelity math_fidelity = MathFidelity::LoFi, const bool fp32_dest_acc_en = false, const bool math_approx_mode = true);
 
 }  // namespace primary
 

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -24,7 +24,7 @@ using namespace tt_metal;
 
 operation::ProgramWithCallbacks create_program_mcast_in0(
     tt_metal::Device *device,
-    MathFidelity math_fidelity,
+    MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode,
     CoreCoord core_range,
     uint32_t B, uint32_t M, uint32_t N, uint32_t K,
     bool bcast_batch,
@@ -303,9 +303,9 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     };
 
     // Create compute kernel
-    bool fp32_dest_acc_en = false;
+    // bool fp32_dest_acc_en = false;
     // Gelu currently has better accuracy when run in approx mode
-    bool math_approx_mode = false;
+    // bool math_approx_mode = false;
     auto mm_kernel = tt_metal::CreateKernel(
         program,
         device->arch() == ARCH::GRAYSKULL ?  "tt_eager/tt_dnn/op_library/bmm/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp" : "tt_eager/tt_dnn/op_library/bmm/kernels/compute/bmm_large_block_zm_fused_bias_activation_matmul_tiles.cpp",
@@ -555,7 +555,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
 
 operation::ProgramWithCallbacks create_program_mcast_in1(
     tt_metal::Device *device,
-    MathFidelity math_fidelity,
+    MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode,
     CoreCoord core_range,
     uint32_t B, uint32_t M, uint32_t N, uint32_t K,
     bool bcast_batch,
@@ -830,9 +830,9 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     };
 
     // Create compute kernel
-    bool fp32_dest_acc_en = false;
+    // bool fp32_dest_acc_en = false;
     // Gelu currently has better accuracy when run in approx mode
-    bool math_approx_mode = false;
+    // bool math_approx_mode = false;
     auto mm_kernel = tt_metal::CreateKernel(
         program,
         device->arch() == ARCH::GRAYSKULL ?  "tt_eager/tt_dnn/op_library/bmm/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp" : "tt_eager/tt_dnn/op_library/bmm/kernels/compute/bmm_large_block_zm_fused_bias_activation_matmul_tiles.cpp",
@@ -1069,7 +1069,7 @@ namespace tt {
 namespace tt_metal {
 
 
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(const Tensor &a, const Tensor &b, const std::optional<const Tensor> bias, Tensor& output, bool bcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0) {
+operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(const Tensor &a, const Tensor &b, const std::optional<const Tensor> bias, Tensor& output, bool bcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0) {
 
     const auto& ashape = a.shape(), bshape = b.shape();
 
@@ -1152,7 +1152,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     if (mcast_in0) {
         return reuse_mcast_1d_optimized_helpers::create_program_mcast_in0(
             device,
-            math_fidelity,
+            math_fidelity, fp32_dest_acc_en, math_approx_mode,
             compute_with_storage_grid_size,
             B, Mt, Nt, Kt,
             bcast_batch,
@@ -1167,7 +1167,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     } else {
         return reuse_mcast_1d_optimized_helpers::create_program_mcast_in1(
             device,
-            math_fidelity,
+            math_fidelity, fp32_dest_acc_en, math_approx_mode,
             compute_with_storage_grid_size,
             B, Mt, Nt, Kt,
             bcast_batch,
@@ -1182,8 +1182,8 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     }
 }
 
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(const Tensor& a, const Tensor& b, const std::optional<const Tensor> bias, Tensor& output_tensor, bool broadcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0) {
-    return matmul_multi_core_reuse_mcast_1d_optimized_(a, b, bias, output_tensor, broadcast_batch, compute_with_storage_grid_size, math_fidelity, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N, fuse_batch, fused_activation, mcast_in0);
+operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(const Tensor& a, const Tensor& b, const std::optional<const Tensor> bias, Tensor& output_tensor, bool broadcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0) {
+    return matmul_multi_core_reuse_mcast_1d_optimized_(a, b, bias, output_tensor, broadcast_batch, compute_with_storage_grid_size, math_fidelity, fp32_dest_acc_en, math_approx_mode, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N, fuse_batch, fused_activation, mcast_in0);
 }
 
 }  // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -1113,6 +1113,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     TT_ASSERT(bshape[2] % TILE_HEIGHT == 0);
     TT_ASSERT(bshape[3] % TILE_WIDTH == 0);
 
+    if (fp32_dest_acc_en) {
+        TT_ASSERT(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     //                      Matmul Parameters Setup
     ////////////////////////////////////////////////////////////////////////////

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -854,6 +854,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     TT_ASSERT(bshape[2] % TILE_HEIGHT == 0);
     TT_ASSERT(bshape[3] % TILE_WIDTH == 0);
 
+    if (fp32_dest_acc_en) {
+        TT_ASSERT(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     //                      Matmul Parameters Setup
     ////////////////////////////////////////////////////////////////////////////

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -405,7 +405,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     };
 
     // Create compute kernel
-    bool fp32_dest_acc_en = false;
+    bool fp32_dest_acc_en = true;
     // Gelu currently has better accuracy when run in approx mode
     bool math_approx_mode = false;
     auto mm_kernel = tt_metal::CreateKernel(

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -23,7 +23,7 @@ using namespace tt_metal;
 
 operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     tt_metal::Device *device,
-    MathFidelity math_fidelity,
+    MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode,
     CoreCoord core_range,
     uint32_t B, uint32_t M, uint32_t N, uint32_t K,
     bool bcast_batch,
@@ -405,9 +405,9 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     };
 
     // Create compute kernel
-    bool fp32_dest_acc_en = true;
+    // bool fp32_dest_acc_en = true;
     // Gelu currently has better accuracy when run in approx mode
-    bool math_approx_mode = false;
+    // bool math_approx_mode = false;
     auto mm_kernel = tt_metal::CreateKernel(
         program,
         device->arch() == ARCH::GRAYSKULL ?  "tt_eager/tt_dnn/op_library/bmm/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp" : "tt_eager/tt_dnn/op_library/bmm/kernels/compute/bmm_large_block_zm_fused_bias_activation_matmul_tiles.cpp",
@@ -811,7 +811,7 @@ namespace tt {
 namespace tt_metal {
 
 
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(const Tensor &a, const Tensor &b, const std::optional<const Tensor> bias, Tensor& output, bool bcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, bool transpose_mcast, std::optional<UnaryWithParam> fused_activation) {
+operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(const Tensor &a, const Tensor &b, const std::optional<const Tensor> bias, Tensor& output, bool bcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, bool transpose_mcast, std::optional<UnaryWithParam> fused_activation) {
     const auto& ashape = a.shape(), bshape = b.shape();
 
     // CB dataformats
@@ -903,7 +903,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     if (core_range.x > 1 && core_range.y > 1) {
         return reuse_mcast_optimized_helpers::create_program_mcast_in0_in1(
             device,
-            math_fidelity,
+            math_fidelity, fp32_dest_acc_en, math_approx_mode,
             core_range,
             B, Mt, Nt, Kt,
             bcast_batch,
@@ -927,8 +927,8 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     return {};
 }
 
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized(const Tensor& a, const Tensor& b, const std::optional<const Tensor> bias, Tensor& output_tensor, bool broadcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, bool transpose_mcast, std::optional<UnaryWithParam> fused_activation) {
-     return matmul_multi_core_reuse_mcast_2d_optimized_(a, b, bias, output_tensor, broadcast_batch, compute_with_storage_grid_size, math_fidelity, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N, fuse_batch, transpose_mcast, fused_activation);
+operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized(const Tensor& a, const Tensor& b, const std::optional<const Tensor> bias, Tensor& output_tensor, bool broadcast_batch, CoreCoord compute_with_storage_grid_size, MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, bool transpose_mcast, std::optional<UnaryWithParam> fused_activation) {
+     return matmul_multi_core_reuse_mcast_2d_optimized_(a, b, bias, output_tensor, broadcast_batch, compute_with_storage_grid_size, math_fidelity, fp32_dest_acc_en, math_approx_mode, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N, fuse_batch, transpose_mcast, fused_activation);
 }
 
 }  // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
@@ -449,6 +449,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
             && "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
     }
 
+    if (fp32_dest_acc_en) {
+        TT_ASSERT(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     //                      Matmul Parameters Setup
     ////////////////////////////////////////////////////////////////////////////

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
@@ -21,7 +21,7 @@ using namespace tt;
 using namespace tt_metal;
 operation::ProgramWithCallbacks create_program(
     tt_metal::Device *device,
-    MathFidelity math_fidelity,
+    MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode,
     CoreCoord core_range,
     uint32_t B, uint32_t M, uint32_t N, uint32_t K,
     bool bcast_batch,
@@ -421,7 +421,7 @@ namespace tt {
 namespace tt_metal {
 
 
-operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor &a, const Tensor &b, Tensor& output, bool bcast_batch, CoreCoord compute_with_storage_grid_size, tt::tt_metal::DataType output_dtype, MathFidelity math_fidelity, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch) {
+operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor &a, const Tensor &b, Tensor& output, bool bcast_batch, CoreCoord compute_with_storage_grid_size, tt::tt_metal::DataType output_dtype, MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch) {
 
     // Pass in a and b shapes instead
 
@@ -482,7 +482,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     ////////////////////////////////////////////////////////////////////////////
     return reuse_optimized_helpers::create_program(
         device,
-        math_fidelity,
+        math_fidelity, fp32_dest_acc_en, math_approx_mode,
         core_range,
         B, Mt, Nt, Kt,
         bcast_batch,
@@ -496,7 +496,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
 
 // TODO: Get rid of no-op reshapes when we generalize
 // matmul_multi_core_reuse_optimized_bert_large not used
-operation::ProgramWithCallbacks bmm_multi_core_reuse_optimized(const Tensor& a, const Tensor& b,  Tensor& output, bool bcast_batch, CoreCoord compute_with_storage_grid_size, tt::tt_metal::DataType output_dtype, MathFidelity math_fidelity, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch) {
+operation::ProgramWithCallbacks bmm_multi_core_reuse_optimized(const Tensor& a, const Tensor& b,  Tensor& output, bool bcast_batch, CoreCoord compute_with_storage_grid_size, tt::tt_metal::DataType output_dtype, MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch) {
     /*
      * For pre-softmax and post-softmax bmm, do an additional no-op reshape by changing cshape and ashape
      * - pre-softmax: [9, 16, 384, 64] x [9, 16, 64, 384] = ([9, 16, 384, 384] -> [9, 1, 6144, 384])
@@ -504,7 +504,7 @@ operation::ProgramWithCallbacks bmm_multi_core_reuse_optimized(const Tensor& a, 
      * NOTE: Only need to pass in the right cshape and ashape for these no-op reshapes.
      * The actual bmm op works on [9, 16, 384, 64] x [9, 16, 64, 384] and [9, 16, 384, 384] x [9, 16, 384, 64].
     */
-    return matmul_multi_core_reuse_optimized_(a, b, output, bcast_batch, compute_with_storage_grid_size, output_dtype, math_fidelity, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N, fuse_batch);
+    return matmul_multi_core_reuse_optimized_(a, b, output, bcast_batch, compute_with_storage_grid_size, output_dtype, math_fidelity, fp32_dest_acc_en, math_approx_mode, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N, fuse_batch);
 }
 
 }  // namespace tt_metal

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -106,8 +106,10 @@ void py_module(py::module& m_primary) {
            const MatmulDefaultProgramConfig& program_config,
            const MemoryConfig& out_mem_config,
            std::optional<DataType> output_dtype,
-           const MathFidelity math_fidelity) {
-            return matmul(input_tensor_a, input_tensor_b, program_config, out_mem_config, output_dtype, math_fidelity);
+           const MathFidelity math_fidelity,
+           const bool fp32_dest_acc_en,
+           const bool math_approx_mode) {
+            return matmul(input_tensor_a, input_tensor_b, program_config, out_mem_config, output_dtype, math_fidelity, fp32_dest_acc_en, math_approx_mode);
         },
         py::arg("input_tensor_a").noconvert(),
         py::arg("input_tensor_b").noconvert(),
@@ -116,6 +118,8 @@ void py_module(py::module& m_primary) {
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_dtype").noconvert() = std::nullopt,
         py::arg("math_fidelity").noconvert() = MathFidelity::LoFi,
+        py::arg("fp32_dest_acc_en").noconvert() = false,
+        py::arg("math_approx_mode").noconvert() = true,
         R"doc(
             Perform a matrix multiplication ``input_tensor_a x input_tensor_b``.
 
@@ -136,8 +140,10 @@ void py_module(py::module& m_primary) {
            const MatmulMultiCoreReuseProgramConfig& program_config,
            const MemoryConfig& out_mem_config,
            std::optional<DataType> output_dtype,
-           const MathFidelity math_fidelity) {
-            return matmul(input_tensor_a, input_tensor_b, program_config, out_mem_config, output_dtype, math_fidelity);
+           const MathFidelity math_fidelity,
+           const bool fp32_dest_acc_en,
+           const bool math_approx_mode) {
+            return matmul(input_tensor_a, input_tensor_b, program_config, out_mem_config, output_dtype, math_fidelity, fp32_dest_acc_en, math_approx_mode);
         },
         py::arg("input_tensor_a").noconvert(),
         py::arg("input_tensor_b").noconvert(),
@@ -146,6 +152,8 @@ void py_module(py::module& m_primary) {
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_dtype").noconvert() = std::nullopt,
         py::arg("math_fidelity").noconvert() = MathFidelity::LoFi,
+        py::arg("fp32_dest_acc_en").noconvert() = false,
+        py::arg("math_approx_mode").noconvert() = true,
         R"doc(
             Perform a matrix multiplication ``input_tensor_a x input_tensor_b``.
 
@@ -167,9 +175,11 @@ void py_module(py::module& m_primary) {
            const MatmulDefaultProgramConfig& program_config,
            const MemoryConfig& out_mem_config,
            std::optional<DataType> output_dtype,
-           const MathFidelity math_fidelity) {
+           const MathFidelity math_fidelity,
+           const bool fp32_dest_acc_en,
+           const bool math_approx_mode) {
             return matmul(
-                input_tensor_a, input_tensor_b, bias, program_config, out_mem_config, output_dtype, math_fidelity);
+                input_tensor_a, input_tensor_b, bias, program_config, out_mem_config, output_dtype, math_fidelity, fp32_dest_acc_en, math_approx_mode);
         },
         py::arg("input_tensor_a").noconvert(),
         py::arg("input_tensor_b").noconvert(),
@@ -179,6 +189,8 @@ void py_module(py::module& m_primary) {
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_dtype").noconvert() = std::nullopt,
         py::arg("math_fidelity").noconvert() = MathFidelity::LoFi,
+        py::arg("fp32_dest_acc_en").noconvert() = false,
+        py::arg("math_approx_mode").noconvert() = true,
         R"doc(
             Perform a matrix multiplication ``input_tensor_a x input_tensor_b``.
 
@@ -201,9 +213,11 @@ void py_module(py::module& m_primary) {
            const MatmulMultiCoreReuseMultiCastProgramConfig& program_config,
            const MemoryConfig& out_mem_config,
            std::optional<DataType> output_dtype,
-           const MathFidelity math_fidelity) {
+           const MathFidelity math_fidelity,
+           const bool fp32_dest_acc_en,
+           const bool math_approx_mode) {
             return matmul(
-                input_tensor_a, input_tensor_b, bias, program_config, out_mem_config, output_dtype, math_fidelity);
+                input_tensor_a, input_tensor_b, bias, program_config, out_mem_config, output_dtype, math_fidelity, fp32_dest_acc_en, math_approx_mode);
         },
         py::arg("input_tensor_a").noconvert(),
         py::arg("input_tensor_b").noconvert(),
@@ -213,6 +227,8 @@ void py_module(py::module& m_primary) {
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_dtype").noconvert() = std::nullopt,
         py::arg("math_fidelity").noconvert() = MathFidelity::LoFi,
+        py::arg("fp32_dest_acc_en").noconvert() = false,
+        py::arg("math_approx_mode").noconvert() = true,
         R"doc(
             Perform a matrix multiplication ``input_tensor_a x input_tensor_b``.
 
@@ -235,9 +251,11 @@ void py_module(py::module& m_primary) {
            const MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
            const MemoryConfig& out_mem_config,
            std::optional<DataType> output_dtype,
-           const MathFidelity math_fidelity) {
+           const MathFidelity math_fidelity,
+           const bool fp32_dest_acc_en,
+           const bool math_approx_mode) {
             return matmul(
-                input_tensor_a, input_tensor_b, bias, program_config, out_mem_config, output_dtype, math_fidelity);
+                input_tensor_a, input_tensor_b, bias, program_config, out_mem_config, output_dtype, math_fidelity, fp32_dest_acc_en, math_approx_mode);
         },
         py::arg("input_tensor_a").noconvert(),
         py::arg("input_tensor_b").noconvert(),
@@ -247,6 +265,8 @@ void py_module(py::module& m_primary) {
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_dtype").noconvert() = std::nullopt,
         py::arg("math_fidelity").noconvert() = MathFidelity::LoFi,
+        py::arg("fp32_dest_acc_en").noconvert() = false,
+        py::arg("math_approx_mode").noconvert() = true,
         R"doc(
             Perform a matrix multiplication ``input_tensor_a x input_tensor_b``.
 
@@ -269,9 +289,11 @@ void py_module(py::module& m_primary) {
            const std::optional<MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_config,
            const MemoryConfig& out_mem_config,
            std::optional<DataType> output_dtype,
-           const MathFidelity math_fidelity) {
+           const MathFidelity math_fidelity,
+           const bool fp32_dest_acc_en,
+           const bool math_approx_mode) {
             return matmul_1d(
-                input_tensor_a, input_tensor_b, bias, program_config, out_mem_config, output_dtype, math_fidelity);
+                input_tensor_a, input_tensor_b, bias, program_config, out_mem_config, output_dtype, math_fidelity, fp32_dest_acc_en, math_approx_mode);
         },
         py::arg("input_tensor_a").noconvert(),
         py::arg("input_tensor_b").noconvert(),
@@ -281,6 +303,8 @@ void py_module(py::module& m_primary) {
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_dtype").noconvert() = std::nullopt,
         py::arg("math_fidelity").noconvert() = MathFidelity::LoFi,
+        py::arg("fp32_dest_acc_en").noconvert() = false,
+        py::arg("math_approx_mode").noconvert() = true,
         R"doc(
             Perform a matrix multiplication ``input_tensor_a x input_tensor_b``.
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h
@@ -17,16 +17,19 @@ using namespace ckernel;
 #include "chlkc_unpack_data_format.h"
 #include "chlkc_math_fidelity.h"
 #include "chlkc_math_approx_mode.h"
+#include "chlkc_dst_accum_mode.h"
 #include "chlkc_math.cpp"
 #endif
 
 #ifdef UCK_CHLKC_PACK
 #include "chlkc_pack_data_format.h"
+#include "chlkc_dst_accum_mode.h"
 #include "chlkc_pack.cpp"
 #endif
 
 #ifdef UCK_CHLKC_UNPACK
 #include "chlkc_unpack_data_format.h"
+#include "chlkc_dst_accum_mode.h"
 #include "chlkc_unpack.cpp"
 #endif
 

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -64,7 +64,11 @@ ALWI void mul_tiles_bcast_rows(uint32_t icb0, uint32_t icb1, uint32_t itile0, ui
  */
 ALWI void add_tiles_bcast_rows(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst)
 {
+    #ifdef ARCH_GRAYSKULL
     MATH(( llk_math_eltwise_binary<EltwiseBinaryType::ELWADD, BroadcastType::ROW, SyncHalf, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(icb0, icb1, idst) ));
+    #else
+    MATH(( llk_math_eltwise_binary<EltwiseBinaryType::ELWADD, BroadcastType::ROW, SyncHalf, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE, DST_ACCUM_MODE>(icb0, icb1, idst) ));
+    #endif
     UNPACK(( llk_unpack_AB<BroadcastType::ROW>(icb0, icb1, itile0, itile1) ));
 }
 

--- a/tt_metal/include/compute_kernel_api/pack.h
+++ b/tt_metal/include/compute_kernel_api/pack.h
@@ -42,7 +42,11 @@ namespace ckernel {
  */
 ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb)
 {
-    PACK((  llk_pack<false, SYNC, false >(ifrom_dst, icb)  ));
+    #ifdef ARCH_GRAYSKULL
+    PACK((  llk_pack<false, SYNC, false>(ifrom_dst, icb)  ));
+    #else
+    PACK((  llk_pack<false, SYNC, false, DST_ACCUM_MODE>(ifrom_dst, icb)  ));
+    #endif
 }
 
 /**

--- a/tt_metal/include/compute_kernel_api/tile_move_copy.h
+++ b/tt_metal/include/compute_kernel_api/tile_move_copy.h
@@ -114,7 +114,11 @@ ALWI void copy_tile_init()
 ALWI void copy_tile(uint32_t icb, uint32_t itile, uint32_t idst)
 {
     UNPACK(( llk_unpack_A<BroadcastType::NONE, false>(icb, itile)  ));
+    #ifdef ARCH_GRAYSKULL
     MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, SyncHalf>(idst)  ));
+    #else
+    MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, SyncHalf, DST_ACCUM_MODE>(idst)  ));
+    #endif
 }
 
 ALWI void copy_block_matmul_partials(uint32_t icb, uint32_t start_itile, uint32_t start_idst, uint32_t ntiles)

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -293,6 +293,22 @@ static void generate_data_format_descriptors(JitBuildOptions& options, const tt:
     emit_pack_data_formats(pack_data_format_descs, pack_src_formats_all_cbs, pack_dst_formats_all_cbs);
 }
 
+static void generate_dst_accum_mode_descriptor(JitBuildOptions& options) {
+    string dst_accum_format_descriptor = options.path + "chlkc_dst_accum_mode.h";
+
+    ofstream file_stream;
+
+    file_stream.open(dst_accum_format_descriptor);
+
+    if (options.fp32_dest_acc_en == 0) {
+        file_stream << "constexpr bool DST_ACCUM_MODE = false;" << endl;
+    } else {
+        file_stream << "constexpr bool DST_ACCUM_MODE = true;" << endl;
+    }
+
+    file_stream.close();
+}
+
 static void generate_math_fidelity_descriptor(JitBuildOptions& options) {
     string math_fidelity_descriptor = options.path + "chlkc_math_fidelity.h";
     // assuming all cores within a op have the same desc
@@ -329,9 +345,11 @@ void jit_build_genfiles_descriptors(const JitBuildEnv& env,
         std::thread td( [&]() { generate_data_format_descriptors(options, env.get_arch()); } );
         std::thread tm( [&]() { generate_math_fidelity_descriptor(options); } );
         std::thread ta( [&]() { generate_math_approx_mode_descriptor(options); } );
+        std::thread tf( [&]() { generate_dst_accum_mode_descriptor(options); } );
         td.join();
         tm.join();
         ta.join();
+        tf.join();
     } catch (std::runtime_error &ex) {
         std::cerr << "EXCEPTION FROM THREADING IN GENERATE_DESCRIPTORS: " << ex.what() << std::endl;
     }


### PR DESCRIPTION
1. add emit entry for fp32_acc_mode for hit compile
3. add pybindings for fp32_acc_mode and math_approx_mode
4. add kernel support (add template args for fp32_acc_mode)