### PR TITLE
#4214: Add dprint testing for multi-device

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
@@ -18,10 +18,7 @@ const std::string golden_output =
 R"(Printing int from arg: 0
 Printing int from arg: 2)";
 
-TEST_F(DPrintFixture, TestPrintMuting) {
-    // Device already set up by gtest fixture.
-    Device *device = this->device_;
-
+static void RunTest(DPrintFixture* fixture, Device* device) {
     // Set up program
     Program program = Program();
 
@@ -42,7 +39,7 @@ TEST_F(DPrintFixture, TestPrintMuting) {
             core,
             {test_number}
         );
-        RunProgram(program);
+        fixture->RunProgram(device, program);
     };
 
     // Run the program, prints should be enabled.
@@ -63,4 +60,10 @@ TEST_F(DPrintFixture, TestPrintMuting) {
             golden_output
         )
     );
+}
+
+TEST_F(DPrintFixture, TestPrintMuting) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(RunTest, device);
+    }
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_all_harts.cpp
@@ -144,10 +144,7 @@ TILE: (
 
   ptr=122880))";
 
-TEST_F(DPrintFixture, TestPrintFromAllHarts) {
-    // Device already set up by gtest fixture.
-    Device *device = this->device_;
-
+static void RunTest(DPrintFixture* fixture, Device* device) {
     // Set up program and command queue
     constexpr CoreCoord core = {0, 0}; // Print on first core only
     Program program = Program();
@@ -183,7 +180,7 @@ TEST_F(DPrintFixture, TestPrintFromAllHarts) {
     );
 
     // Run the program
-    RunProgram(program);
+    fixture->RunProgram(device, program);
 
     // Check that the expected print messages are in the log file
     EXPECT_TRUE(
@@ -192,4 +189,10 @@ TEST_F(DPrintFixture, TestPrintFromAllHarts) {
             golden_output
         )
     );
+}
+
+TEST_F(DPrintFixture, TestPrintFromAllHarts) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(RunTest, device);
+    }
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
@@ -215,10 +215,8 @@ TestConstCharStrNC{4,4}
 ----------
 TestStrBR{4,4}
 +++++++++++++++)";
-TEST_F(DPrintFixture, TestPrintRaiseWait) {
-    // Device already set up by gtest fixture.
-    Device *device = this->device_;
 
+static void RunTest(DPrintFixture* fixture, Device* device) {
     // Set up program and command queue
     Program program = Program();
 
@@ -280,7 +278,7 @@ TEST_F(DPrintFixture, TestPrintRaiseWait) {
 
 
     // Run the program
-    RunProgram(program);
+    fixture->RunProgram(device, program);
 
     // Check the print log against golden output.
     EXPECT_TRUE(
@@ -289,4 +287,10 @@ TEST_F(DPrintFixture, TestPrintRaiseWait) {
             golden_output
         )
     );
+}
+
+TEST_F(DPrintFixture, TestPrintRaiseWait) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(RunTest, device);
+    }
 }

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -86,4 +86,14 @@ return true and the print server will be terminated.
 */
 bool DPrintServerHangDetected();
 
+/**
+@brief Clears the print server log file.
+*/
+void DPrintServerClearLogFile();
+
+/**
+@brief Clears any RAISE signals in the print server, so they can be used again in a later run.
+*/
+void DPrintServerClearSignals();
+
 } // namespace tt

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -30,6 +30,7 @@ class RunTimeOptions {
     std::vector<CoreCoord> dprint_cores;
     bool dprint_all_cores;
     std::vector<int> dprint_chip_ids;
+    bool dprint_all_chips;
     uint32_t dprint_riscv_mask;
     std::string dprint_file_name;
 
@@ -76,6 +77,11 @@ public:
     inline void set_dprint_chip_ids(std::vector<int> chip_ids) {
         dprint_chip_ids = chip_ids;
     }
+    // An alternative to setting cores by range, a flag to enable all.
+    inline void set_dprint_all_chips(bool all_chips) {
+        dprint_all_chips = all_chips;
+    }
+    inline bool get_dprint_all_chips() { return dprint_all_chips; }
     inline uint32_t get_dprint_riscv_mask() { return dprint_riscv_mask; }
     inline void set_dprint_riscv_mask(uint32_t riscv_mask) {
         dprint_riscv_mask = riscv_mask;


### PR DESCRIPTION
Mostly testing changes, with some additional dprint server features to clear the print log.

Passing CI: https://github.com/tenstorrent-metal/tt-metal/actions/runs/7295561688