### PR TITLE
DPRINT test fixes

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -58,16 +58,15 @@ protected:
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
         auto num_devices = tt::tt_metal::GetNumAvailableDevices();
         auto num_pci_devices = tt::tt_metal::GetNumPCIeDevices();
+        // An extra flag for if we have remote devices, as some tests are disabled for fast
+        // dispatch + remote devices.
+        this->has_remote_devices_ = num_devices > num_pci_devices;
         for (unsigned int id = 0; id < num_devices; id++) {
             if (SkipTest(id))
                 continue;
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
-
-        // An extra flag for if we have remote devices, as some tests are disabled for fast
-        // dispatch + remote devices.
-        this->has_remote_devices_ = num_devices > num_pci_devices;
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_hanging.cpp
@@ -58,7 +58,6 @@ TEST_F(DPrintFixture, TestPrintHanging) {
     if (this->slow_dispatch_)
         GTEST_SKIP();
 
-    for (Device* device : this->devices_) {
-        this->RunTestOnDevice(RunTest, device);
-    }
+    // Since the dprint server gets killed from a timeout, only run on one device.
+    this->RunTestOnDevice(RunTest, this->devices_[0]);
 }


### PR DESCRIPTION
Two issues, two commits: 
- For machines that have multiple devices, only run the hanging test on the first device since it takes down the print server
- Fix a usage of an uninitialized flag in the dprint test fixture