### PR TITLE
#4347: Move VGG tensors to L1 

### DIFF
--- a/models/experimental/vgg/demo/cpu_demo.py
+++ b/models/experimental/vgg/demo/cpu_demo.py
@@ -20,6 +20,4 @@ def test_cpu_demo(imagenet_sample_input, imagenet_label_dict):
         torch_vgg.eval()
         torch_output = torch_vgg(image).unsqueeze(1).unsqueeze(1)
 
-        logger.info(
-            f"CPU's predicted Output: {class_labels[torch.argmax(torch_output).item()]}"
-        )
+        logger.info(f"CPU's predicted Output: {class_labels[torch.argmax(torch_output).item()]}")

--- a/models/experimental/vgg/reference/vgg.py
+++ b/models/experimental/vgg/reference/vgg.py
@@ -123,25 +123,13 @@ def make_layers(
                 conv_ind = len(layers) - 3
                 bn_ind = len(layers) - 2
 
-                conv2d.weight = nn.Parameter(
-                    state_dict[f"{base_address}.{conv_ind}.weight"]
-                )
-                conv2d.bias = nn.Parameter(
-                    state_dict[f"{base_address}.{conv_ind}.bias"]
-                )
+                conv2d.weight = nn.Parameter(state_dict[f"{base_address}.{conv_ind}.weight"])
+                conv2d.bias = nn.Parameter(state_dict[f"{base_address}.{conv_ind}.bias"])
 
-                layers[bn_ind].weight = nn.Parameter(
-                    state_dict[f"{base_address}.{bn_ind}.weight"]
-                )
-                layers[bn_ind].bias = nn.Parameter(
-                    state_dict[f"{base_address}.{bn_ind}.bias"]
-                )
-                layers[bn_ind].running_mean = nn.Parameter(
-                    state_dict[f"{base_address}.{bn_ind}.running_mean"]
-                )
-                layers[bn_ind].running_var = nn.Parameter(
-                    state_dict[f"{base_address}.{bn_ind}.running_var"]
-                )
+                layers[bn_ind].weight = nn.Parameter(state_dict[f"{base_address}.{bn_ind}.weight"])
+                layers[bn_ind].bias = nn.Parameter(state_dict[f"{base_address}.{bn_ind}.bias"])
+                layers[bn_ind].running_mean = nn.Parameter(state_dict[f"{base_address}.{bn_ind}.running_mean"])
+                layers[bn_ind].running_var = nn.Parameter(state_dict[f"{base_address}.{bn_ind}.running_var"])
                 layers[bn_ind].num_batches_tracked = nn.Parameter(
                     state_dict[f"{base_address}.{bn_ind}.num_batches_tracked"],
                     requires_grad=False,

--- a/models/experimental/vgg/tests/test_perf_vgg.py
+++ b/models/experimental/vgg/tests/test_perf_vgg.py
@@ -6,7 +6,6 @@ import torch
 import pytest
 
 from torchvision import models
-from datasets import load_dataset
 from loguru import logger
 
 
@@ -17,8 +16,6 @@ from models.utility_functions import (
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
     Profiler,
-    comp_pcc,
-    unpad_from_zero,
     torch_to_tt_tensor,
 )
 from models.perf.perf_utils import prep_perf_report
@@ -36,8 +33,7 @@ def run_perf_vgg(imagenet_sample_input, expected_inference_time, expected_compil
     comments = "16"
 
     image = imagenet_sample_input
-
-    tt_image = torch_to_tt_tensor(image, device)
+    tt_image = torch_to_tt_tensor(image, device=device)
 
     cache_path = "/mnt/MLPerf/tt_dnn-models/tt/VGG/vgg16/"
     tt_vgg = vgg16(device, disable_conv_on_tt_device=True, tt_cache_path=cache_path)

--- a/models/experimental/vgg/tests/test_torch_vgg16.py
+++ b/models/experimental/vgg/tests/test_torch_vgg16.py
@@ -9,7 +9,7 @@ from torchvision import models
 from loguru import logger
 
 from models.experimental.vgg.reference.vgg import vgg16
-from models.utility_functions import comp_allclose_and_pcc, comp_pcc
+from models.utility_functions import comp_pcc
 
 
 _batch_size = 1
@@ -22,7 +22,6 @@ def test_vgg16_inference(fuse_ops, imagenet_sample_input):
     batch_size = _batch_size
     with torch.no_grad():
         torch_vgg = models.vgg16(weights=models.VGG16_Weights.IMAGENET1K_V1)
-
         torch_vgg.eval()
 
         state_dict = torch_vgg.state_dict()

--- a/models/experimental/vgg/tests/test_torch_vgg16_bn.py
+++ b/models/experimental/vgg/tests/test_torch_vgg16_bn.py
@@ -9,7 +9,7 @@ from torchvision import models
 from loguru import logger
 
 from models.experimental.vgg.reference.vgg import vgg16_bn
-from models.utility_functions import comp_allclose_and_pcc, comp_pcc
+from models.utility_functions import comp_pcc
 
 
 _batch_size = 1
@@ -22,7 +22,6 @@ def test_vgg16_bn_inference(fuse_ops, imagenet_sample_input):
     batch_size = _batch_size
     with torch.no_grad():
         torch_vgg = models.vgg16_bn(weights=models.VGG16_BN_Weights.IMAGENET1K_V1)
-
         torch_vgg.eval()
 
         state_dict = torch_vgg.state_dict()
@@ -32,10 +31,7 @@ def test_vgg16_bn_inference(fuse_ops, imagenet_sample_input):
 
         if fuse_ops:
             indices = [0, 3, 7, 10, 14, 17, 20, 24, 27, 30, 34, 37, 40]
-            modules_to_fuse = [
-                [f"features.{ind}", f"features.{ind+1}", f"features.{ind+2}"]
-                for ind in indices
-            ]
+            modules_to_fuse = [[f"features.{ind}", f"features.{ind+1}", f"features.{ind+2}"] for ind in indices]
             tt_vgg = torch.ao.quantization.fuse_modules(tt_vgg, modules_to_fuse)
 
         torch_output = torch_vgg(image).unsqueeze(1).unsqueeze(1)

--- a/models/experimental/vgg/tests/test_vgg11.py
+++ b/models/experimental/vgg/tests/test_vgg11.py
@@ -31,13 +31,15 @@ def test_vgg11_inference(device, pcc, imagenet_sample_input, model_location_gene
     with torch.no_grad():
         torch_vgg = models.vgg11(weights=models.VGG11_Weights.IMAGENET1K_V1)
         torch_vgg.eval()
+        torch_output = torch_vgg(image).unsqueeze(1).unsqueeze(1)
+
+        cache_path = "/mnt/MLPerf/tt_dnn-models/tt/VGG/vgg11/"
 
         cache_path = "/mnt/MLPerf/tt_dnn-models/tt/VGG/vgg11/"
         # TODO: enable conv on tt device after adding fast dtx transform
         tt_vgg = vgg11(device, disable_conv_on_tt_device=True, tt_cache_path=cache_path, tt_dtype=dtype)
 
-        torch_output = torch_vgg(image).unsqueeze(1).unsqueeze(1)
-        tt_image = torch_to_tt_tensor(image, device)
+        tt_image = torch_to_tt_tensor(image, device=device)
 
         tt_output = tt_vgg(tt_image)
         tt_output = unpad_from_zero(tt_output, torch_output.shape)

--- a/models/experimental/vgg/tests/test_vgg16.py
+++ b/models/experimental/vgg/tests/test_vgg16.py
@@ -11,7 +11,8 @@ from loguru import logger
 from models.utility_functions import comp_allclose
 
 from models.experimental.vgg.tt.vgg import vgg16
-from models.utility_functions import comp_pcc, unpad_from_zero, torch_to_tt_tensor
+from models.utility_functions import comp_pcc, torch_to_tt_tensor, unpad_from_zero
+
 
 _batch_size = 1
 
@@ -35,9 +36,9 @@ def test_vgg16_inference(device, pcc, imagenet_sample_input, model_location_gene
 
         # TODO: enable conv on tt device after adding fast dtx transform
         cache_path = "/mnt/MLPerf/tt_dnn-models/tt/VGG/vgg16/"
-        tt_vgg = vgg16(device, disable_conv_on_tt_device=True, tt_cache_path=cache_path)
+        tt_vgg = vgg16(device, disable_conv_on_tt_device=True, tt_cache_path=cache_path, tt_dtype=dtype)
 
-        tt_image = torch_to_tt_tensor(image, device)
+        tt_image = torch_to_tt_tensor(image, device=device)
 
         tt_output = tt_vgg(tt_image)
         tt_output = unpad_from_zero(tt_output, torch_output.shape)


### PR DESCRIPTION
This PR contains:
- moved all intermediate tensors to L1 cache
- removed passing state_dict to TtVGG and its variants
- enabled support for batch_size > 1
