### PR TITLE
#4352: Develop Bert-tiny model using ttnn

### DIFF
--- a/models/experimental/bert_tiny/bert_tiny_helper_funcs.py
+++ b/models/experimental/bert_tiny/bert_tiny_helper_funcs.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+import tt_lib
+import ttnn
+from typing import Optional
+
+
+def Linear(
+    weight: tt_lib.tensor.Tensor,
+    bias: Optional[tt_lib.tensor.Tensor] = None,
+    device=None,
+    output_mem_config=tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    ),
+):
+    weight_T = ttnn.permute(weight, (1, 0))
+
+    def linear_(activation):
+        output = ttnn.matmul(activation, weight_T)
+        if bias is not None:
+            output_plus_bias = ttnn.add(
+                output,
+                bias,
+                alpha=1,
+            )
+            return output_plus_bias
+        return output
+
+    return linear_

--- a/models/experimental/bert_tiny/tests/test_bert_intermediate.py
+++ b/models/experimental/bert_tiny/tests/test_bert_intermediate.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from loguru import logger
+import ttnn
+import tt_lib
+from models.experimental.bert_tiny.tt.bert_intermediate import TtBertintermediate
+from transformers import BertForQuestionAnswering
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+
+
+@pytest.mark.parametrize(
+    "pcc",
+    ((0.99),),
+)
+def test_bert_intermediate_inference(
+    pcc,
+    model_location_generator,
+    device,
+    reset_seeds,
+):
+    model_name = str(model_location_generator("mrm8488/bert-tiny-finetuned-squadv2", model_subdir="Bert"))
+    hugging_face_reference_model = BertForQuestionAnswering.from_pretrained(model_name, torchscript=False)
+
+    state_dict = hugging_face_reference_model.state_dict()
+    encoder_idx = 0
+
+    output_mem_config = tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    )
+    tt_intermediate_model = TtBertintermediate(
+        hugging_face_reference_model.config,
+        encoder_idx,
+        state_dict,
+        device,
+        mem_config=output_mem_config,
+    )
+    pytorch_intermediate_model = hugging_face_reference_model.bert.encoder.layer[encoder_idx].intermediate
+
+    input = (torch.rand(1, 1, 128, hugging_face_reference_model.config.hidden_size) * 2) - 1
+    pytorch_out = pytorch_intermediate_model(input).squeeze(0)
+
+    tt_input = ttnn.to_device(ttnn.from_torch(input.squeeze(1), dtype=ttnn.bfloat16), device=device)
+    tt_output = tt_intermediate_model(tt_input)
+    tt_output = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
+    tt_output = ttnn.from_device(tt_output)
+    tt_output = ttnn.to_torch(tt_output)
+
+    passing, pcc_message = comp_pcc(pytorch_out, tt_output, pcc)
+
+    logger.info(comp_allclose(pytorch_out, tt_output))
+    logger.info(pcc_message)
+
+    if passing:
+        logger.info("Bert-tiny_Intermediate Passed!")
+    else:
+        logger.warning("Bert-tiny_Intermediate Failed!")
+
+    assert passing, f"Bert-tiny_Intermediate output does not meet PCC requirement {pcc}."

--- a/models/experimental/bert_tiny/tests/test_bert_output.py
+++ b/models/experimental/bert_tiny/tests/test_bert_output.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from loguru import logger
+import ttnn
+import tt_lib
+
+from models.experimental.bert_tiny.tt.bert_output import TtBertoutput
+from transformers import BertForQuestionAnswering
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+
+
+@pytest.mark.parametrize(
+    "pcc",
+    ((0.99),),
+)
+def test_bert_output_inference(
+    pcc,
+    model_location_generator,
+    device,
+    reset_seeds,
+):
+    model_name = str(model_location_generator("mrm8488/bert-tiny-finetuned-squadv2", model_subdir="Bert"))
+    hugging_face_reference_model = BertForQuestionAnswering.from_pretrained(model_name, torchscript=False)
+
+    state_dict = hugging_face_reference_model.state_dict()
+    encoder_idx = 0
+    output_mem_config = tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    )
+    tt_ouptut_model = TtBertoutput(
+        hugging_face_reference_model.config,
+        encoder_idx,
+        base_address="attention.output",
+        state_dict=state_dict,
+        device=device,
+        mem_config=output_mem_config,
+    )
+    pytorch_output_model = hugging_face_reference_model.bert.encoder.layer[encoder_idx].attention.output
+    hidden_state = (torch.rand(1, 1, 128, hugging_face_reference_model.config.hidden_size) * 2) - 1
+    input = (torch.rand(1, 1, 128, hugging_face_reference_model.config.hidden_size) * 2) - 1
+    pytorch_out = pytorch_output_model(hidden_state, input)
+
+    tt_hidden_state = ttnn.to_device(ttnn.from_torch(hidden_state, dtype=ttnn.bfloat16), device=device)
+    tt_input = ttnn.to_device(ttnn.from_torch(input, dtype=ttnn.bfloat16), device=device)
+    tt_output = tt_ouptut_model(tt_hidden_state, tt_input)
+    tt_output = ttnn.from_device(tt_output)
+    tt_output = ttnn.to_torch(tt_output).squeeze(0)
+
+    passing, pcc_message = comp_pcc(pytorch_out, tt_output, pcc)
+
+    logger.info(comp_allclose(pytorch_out, tt_output))
+    logger.info(pcc_message)
+
+    if passing:
+        logger.info("Bert_Output Passed!")
+    else:
+        logger.warning("Bert_Output Failed!")
+
+    assert passing, f"Bert_Output output does not meet PCC requirement {pcc}."

--- a/models/experimental/bert_tiny/tests/test_bert_self_attention.py
+++ b/models/experimental/bert_tiny/tests/test_bert_self_attention.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from loguru import logger
+import ttnn
+import tt_lib
+
+from models.experimental.bert_tiny.tt.bert_self_attention import TtBertselfattention
+from transformers import BertForQuestionAnswering
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+
+
+@pytest.mark.parametrize(
+    "pcc",
+    ((0.99),),
+)
+def test_bert_self_attention_inference(
+    pcc,
+    model_location_generator,
+    device,
+    reset_seeds,
+):
+    model_name = str(model_location_generator("mrm8488/bert-tiny-finetuned-squadv2", model_subdir="Bert"))
+    hugging_face_reference_model = BertForQuestionAnswering.from_pretrained(model_name, torchscript=False)
+
+    state_dict = hugging_face_reference_model.state_dict()
+    encoder_idx = 0
+    output_mem_config = tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    )
+    tt_attention_model = TtBertselfattention(
+        hugging_face_reference_model.config, encoder_idx, state_dict, device, output_mem_config
+    )
+    pytorch_attention_model = hugging_face_reference_model.bert.encoder.layer[encoder_idx].attention.self
+    input = (torch.rand(1, 1, 128, hugging_face_reference_model.config.hidden_size) * 2) - 1
+    pytorch_out = pytorch_attention_model(input.squeeze(1))[0]
+
+    tt_input = ttnn.to_device(ttnn.from_torch(input.squeeze(1), dtype=ttnn.bfloat16), device=device)
+    tt_output = tt_attention_model(tt_input)
+    tt_output = ttnn.from_device(tt_output)
+    tt_output = ttnn.to_torch(tt_output).squeeze(0)
+
+    passing, pcc_message = comp_pcc(pytorch_out, tt_output, pcc)
+
+    logger.info(comp_allclose(pytorch_out, tt_output))
+    logger.info(pcc_message)
+
+    if passing:
+        logger.info("Bert_Self_Attention Passed!")
+    else:
+        logger.warning("Bert_Self_Attention Failed!")
+
+    assert passing, f"Bert_Self_Attention output does not meet PCC requirement {pcc}."

--- a/models/experimental/bert_tiny/tt/bert_intermediate.py
+++ b/models/experimental/bert_tiny/tt/bert_intermediate.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import tt_lib
+import ttnn
+import torch.nn as nn
+from typing import Optional
+from models.experimental.bert_tiny.bert_tiny_helper_funcs import Linear as TtLinear
+
+
+class TtBertintermediate(nn.Module):
+    def __init__(
+        self,
+        config,
+        encoder_idx: int,
+        state_dict=None,
+        device=None,
+        mem_config=None,
+    ):
+        super().__init__()
+
+        self.config = config
+        self.device = device
+
+        self.output_mem_config = mem_config
+
+        self.weight = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.intermediate.dense.weight"], dtype=ttnn.bfloat16
+            ),
+            device=self.device,
+        )
+
+        self.bias = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.intermediate.dense.bias"], dtype=ttnn.bfloat16
+            ),
+            memory_config=self.output_mem_config,
+            device=self.device,
+        )
+
+        self.dense = TtLinear(
+            self.weight,
+            self.bias,
+            device=self.device,
+            output_mem_config=self.output_mem_config,
+        )
+
+    def forward(self, activation: Optional[ttnn.Tensor] = None):
+        out = self.dense(activation)
+        return ttnn.gelu(out, memory_config=self.output_mem_config)

--- a/models/experimental/bert_tiny/tt/bert_output.py
+++ b/models/experimental/bert_tiny/tt/bert_output.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import tt_lib
+import ttnn
+import torch.nn as nn
+from typing import Optional
+from models.experimental.bert_tiny.bert_tiny_helper_funcs import Linear as TtLinear
+from models.utility_functions import tt_to_torch_tensor, torch_to_tt_tensor_rm
+
+
+class TtBertoutput(nn.Module):
+    def __init__(
+        self,
+        config,
+        encoder_idx: int,
+        base_address=None,
+        state_dict=None,
+        device=None,
+        mem_config=None,
+    ):
+        super().__init__()
+
+        self.config = config
+        self.device = device
+        self.base_address = base_address
+
+        self.output_mem_config = mem_config
+
+        self.weight = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.{self.base_address}.dense.weight"], dtype=ttnn.bfloat16
+            ),
+            device=self.device,
+        )
+
+        self.bias = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.{self.base_address}.dense.bias"], dtype=ttnn.bfloat16
+            ),
+            memory_config=self.output_mem_config,
+            device=self.device,
+        )
+
+        self.output = TtLinear(
+            self.weight,
+            self.bias,
+            device=self.device,
+            output_mem_config=self.output_mem_config,
+        )
+
+        self.beta = torch_to_tt_tensor_rm(
+            state_dict[f"bert.encoder.layer.{encoder_idx}.{self.base_address}.LayerNorm.bias"],
+            device=self.device,
+            put_on_device=False,
+        )
+        self.gamma = torch_to_tt_tensor_rm(
+            state_dict[f"bert.encoder.layer.{encoder_idx}.{self.base_address}.LayerNorm.weight"],
+            device=self.device,
+            put_on_device=False,
+        )
+        self.ln = tt_lib.tensor.layernorm
+
+    def forward(self, hidden_state: Optional[ttnn.Tensor] = None, input: Optional[ttnn.Tensor] = None):
+        out = self.output(hidden_state)
+        out = out + input
+        out = ttnn.to_layout(out, layout=ttnn.ROW_MAJOR_LAYOUT)
+        out = ttnn.from_device(out)
+        out = ttnn.to_torch(out)
+        out = torch_to_tt_tensor_rm(out, self.device, put_on_device=False)
+        ln_out = self.ln(out, eps=1e-12, gamma=self.gamma, beta=self.beta)
+        ln_out = tt_to_torch_tensor(ln_out)
+        return ttnn.to_device(ttnn.from_torch(ln_out, dtype=ttnn.bfloat16), device=self.device)

--- a/models/experimental/bert_tiny/tt/bert_self_attention.py
+++ b/models/experimental/bert_tiny/tt/bert_self_attention.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import tt_lib
+import ttnn
+import math
+import torch
+from typing import Optional
+from tt_lib.fallback_ops import fallback_ops
+from models.utility_functions import tt_to_torch_tensor, torch_to_tt_tensor
+from models.experimental.bert_tiny.bert_tiny_helper_funcs import Linear as TtLinear
+
+
+def mha(
+    query_weight,
+    query_bias,
+    key_weight,
+    key_bias,
+    value_weight,
+    value_bias,
+    hidden_dim,
+    num_heads,
+    device,
+    out_mem_config,
+):
+    Q_projection = TtLinear(
+        query_weight,
+        query_bias,
+        device=device,
+        output_mem_config=out_mem_config,
+    )
+
+    K_projection = TtLinear(
+        key_weight,
+        key_bias,
+        device=device,
+        output_mem_config=out_mem_config,
+    )
+
+    V_projection = TtLinear(
+        value_weight,
+        value_bias,
+        device=device,
+        output_mem_config=out_mem_config,
+    )
+    reciprocal_of_sqrt_hidden_dim_tensor = ttnn.to_device(
+        ttnn.from_torch(
+            torch.tensor([1 / math.sqrt(hidden_dim // num_heads)] + [0 for _ in range(32 * 32 - 1)]),
+            dtype=ttnn.bfloat16,
+        ),
+        memory_config=out_mem_config,
+        device=device,
+    )
+    reciprocal_of_sqrt_hidden_dim_tensor = ttnn.reshape(reciprocal_of_sqrt_hidden_dim_tensor, (1, 1, 32, 32))
+
+    def make_attetntion_heads(x: ttnn.Tensor):
+        if num_heads == 1:
+            return x
+
+        x = ttnn.to_torch(ttnn.from_device(ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT)))
+        x = torch_to_tt_tensor(x, device)
+
+        # Reshape expects the expected output shape to be in TILE layout
+        # Input shape : [1, 1, 128, 128]
+        # Expected output shape: [1, 128, 2, 64]
+        reshape_unt = fallback_ops.reshape(x, x.shape()[0], x.shape()[2], num_heads, x.shape()[3] // num_heads)
+        # Permute expects input to be in TILE layout
+        # Input shape: [1, 128, 2, 64]
+        transposed = tt_lib.tensor.permute(reshape_unt, [0, 2, 1, 3])
+
+        transposed = tt_to_torch_tensor(transposed)
+        transposed = ttnn.from_torch(transposed, dtype=ttnn.bfloat16)
+        transposed = ttnn.to_device(ttnn.to_layout(transposed, layout=ttnn.TILE_LAYOUT), device=device)
+
+        return transposed
+
+    def unmake_attention_heads(x: ttnn.Tensor):
+        if num_heads == 1:
+            return x
+        else:
+            ctx = ttnn.permute(x, (0, 2, 1, 3))
+            ushape = ctx.shape
+            reshaped = ttnn.reshape(ctx, (ushape[0], 1, ushape[1], ushape[2] * ushape[3]))
+            return reshaped
+
+    def multiply_by_sqrt_hidden_dim(x: ttnn.Tensor, reciprocal_of_sqrt_hidden_dim_tensor: ttnn.Tensor):
+        x = ttnn.to_torch(ttnn.from_device(ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT)))
+        x = torch_to_tt_tensor(x, device)
+
+        reciprocal_of_sqrt_hidden_dim_tensor = ttnn.to_torch(ttnn.from_device(reciprocal_of_sqrt_hidden_dim_tensor))
+        reciprocal_of_sqrt_hidden_dim_tensor = torch_to_tt_tensor(reciprocal_of_sqrt_hidden_dim_tensor, device)
+
+        return tt_lib.tensor.bcast(
+            x,
+            reciprocal_of_sqrt_hidden_dim_tensor,
+            tt_lib.tensor.BcastOpMath.MUL,
+            tt_lib.tensor.BcastOpDim.HW,
+            output_mem_config=out_mem_config,
+        )
+
+    def mha_(activation: ttnn.Tensor, attention_mask: ttnn.Tensor):
+        Q = Q_projection(activation)
+        K = K_projection(activation)
+        V = V_projection(activation)
+        Q_heads = make_attetntion_heads(Q)
+        K_heads = make_attetntion_heads(K)
+        V_heads = make_attetntion_heads(V)
+
+        K_T_heads = ttnn.permute(K_heads, (0, 1, -1, -2))
+        qkt = ttnn.matmul(Q_heads, K_T_heads)
+
+        (
+            N,
+            C,
+            H,
+            W,
+        ) = qkt.shape
+
+        attention_score_input = multiply_by_sqrt_hidden_dim(qkt, reciprocal_of_sqrt_hidden_dim_tensor)
+        attention_score_input = tt_to_torch_tensor(attention_score_input)
+        attention_score_input = ttnn.to_layout(
+            ttnn.from_torch(attention_score_input, dtype=ttnn.bfloat16), layout=ttnn.TILE_LAYOUT
+        )
+
+        if attention_mask is not None:
+            attention_score_input = ttnn.to_device(attention_score_input, device)
+            attention_score_input = ttnn.add(attention_score_input, attention_mask)
+        attention_scores = ttnn.reshape(ttnn.softmax(attention_score_input, -1), (N, C, H, W))
+        weighted_activation = ttnn.matmul(attention_scores, V_heads)
+        return unmake_attention_heads(
+            weighted_activation
+        )  # [N, num heads, seq len, hid size / num heads] -> [N, seq len, hid size]
+
+    return mha_
+
+
+class TtBertselfattention(nn.Module):
+    def __init__(self, config, encoder_idx: int, state_dict=None, device=None, mem_config=None):
+        super().__init__()
+        self.config = config
+
+        self.device = device
+
+        self.output_mem_config = mem_config
+
+        self.query_weight = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.attention.self.query.weight"], dtype=ttnn.bfloat16
+            ),
+            device=self.device,
+        )
+
+        self.query_bias = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.attention.self.query.bias"], dtype=ttnn.bfloat16
+            ),
+            memory_config=self.output_mem_config,
+            device=self.device,
+        )
+
+        self.key_weight = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.attention.self.key.weight"], dtype=ttnn.bfloat16
+            ),
+            memory_config=self.output_mem_config,
+            device=self.device,
+        )
+
+        self.key_bias = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.attention.self.key.bias"], dtype=ttnn.bfloat16
+            ),
+            memory_config=self.output_mem_config,
+            device=self.device,
+        )
+        self.value_weight = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.attention.self.value.weight"], dtype=ttnn.bfloat16
+            ),
+            memory_config=self.output_mem_config,
+            device=self.device,
+        )
+
+        self.value_bias = ttnn.to_device(
+            ttnn.from_torch(
+                state_dict[f"bert.encoder.layer.{encoder_idx}.attention.self.value.bias"], dtype=ttnn.bfloat16
+            ),
+            memory_config=self.output_mem_config,
+            device=self.device,
+        )
+
+        hidden_dim = self.query_weight.shape[-1]
+
+        parameters = [
+            self.query_weight,
+            self.query_bias,
+            self.key_weight,
+            self.key_bias,
+            self.value_weight,
+            self.value_bias,
+        ]
+
+        self.mha = mha(*parameters, hidden_dim, config.num_attention_heads, device, self.output_mem_config)
+
+    def forward(self, activation: Optional[ttnn.Tensor] = None, attention_mask: Optional[ttnn.Tensor] = None):
+        result = self.mha(activation, attention_mask)
+        return result


### PR DESCRIPTION
This PR has the following:

- TT implementation of Bert-tiny submodules: Self_attention, Intermediate, Output using ttnn APIs