### PR TITLE
#4314: removed sharded specific api in buffer and return shard spec i…

### DIFF
--- a/tests/tt_eager/tensors/test_sharded_loopback.cpp
+++ b/tests/tt_eager/tensors/test_sharded_loopback.cpp
@@ -41,12 +41,12 @@ class test_config {
             return shape;
         }
         ShardSpec get_shard_spec(){
-            ShardSpec shard_spec = {.shard_grid = CoreRangeSet(
+            ShardSpec shard_spec = {.grid = CoreRangeSet(
                                                      {CoreRange(
                                                          CoreCoord(0, 0), CoreCoord(0, num_cores_height*num_cores_width - 1))
                                                      }),
-                                     .shard_shape = {page_height * num_pages_per_core_height, num_pages_per_core_width * page_width},
-                                     .shard_orientation = ShardOrientation::ROW_MAJOR
+                                     .shape = {page_height * num_pages_per_core_height, num_pages_per_core_width * page_width},
+                                     .orientation = ShardOrientation::ROW_MAJOR
                                                      };
             return shard_spec;
         }
@@ -151,12 +151,12 @@ int main(int argc, char **argv) {
 
         {
             Shape shape = {1, 1, 2304, 256};
-            ShardSpec shard_spec = {.shard_grid = CoreRangeSet(
+            ShardSpec shard_spec = {.grid = CoreRangeSet(
                                                      {CoreRange(
                                                          CoreCoord(0, 0), CoreCoord(7, 7))
                                                      }),
-                                     .shard_shape = {72, 128},
-                                     .shard_orientation = ShardOrientation::ROW_MAJOR
+                                     .shape = {72, 128},
+                                     .orientation = ShardOrientation::ROW_MAJOR
                                                      };
             Layout layout = Layout::ROW_MAJOR;
             MemoryConfig mem_config = {.memory_layout=TensorMemoryLayout::BLOCK_SHARDED,
@@ -169,12 +169,12 @@ int main(int argc, char **argv) {
 
         {
             Shape shape = {1, 1, 800, 512};
-            ShardSpec shard_spec = {.shard_grid = CoreRangeSet(
+            ShardSpec shard_spec = {.grid = CoreRangeSet(
                                                      {CoreRange(
                                                          CoreCoord(0, 0), CoreCoord(8, 7))
                                                      }),
-                                     .shard_shape = {96, 64},
-                                     .shard_orientation = ShardOrientation::ROW_MAJOR
+                                     .shape = {96, 64},
+                                     .orientation = ShardOrientation::ROW_MAJOR
                                                      };
             Layout layout = Layout::TILE;
             MemoryConfig mem_config = {.memory_layout=TensorMemoryLayout::BLOCK_SHARDED,
@@ -187,12 +187,12 @@ int main(int argc, char **argv) {
 
         {
             Shape shape = {1, 1, 800, 512};
-            ShardSpec shard_spec = {.shard_grid = CoreRangeSet(
+            ShardSpec shard_spec = {.grid = CoreRangeSet(
                                                      {CoreRange(
                                                          CoreCoord(0, 0), CoreCoord(8, 7))
                                                      }),
-                                     .shard_shape = {96, 64},
-                                     .shard_orientation = ShardOrientation::ROW_MAJOR
+                                     .shape = {96, 64},
+                                     .orientation = ShardOrientation::ROW_MAJOR
                                                      };
             Layout layout = Layout::TILE;
             MemoryConfig mem_config = {.memory_layout=TensorMemoryLayout::BLOCK_SHARDED,

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -257,12 +257,11 @@ std::vector<uint32_t> Tensor::host_page_ordering(){
     auto cores = buffer()->all_cores();
     auto shard_size = buffer()->shard_spec().size();
     auto num_pages = cores.size() * shard_size;
-    auto dp_map = buffer()->dev_page_to_host_page_mapping();
 
     std::vector<uint32_t> ret_vec;
     ret_vec.reserve(num_pages);
     for(int page_id = 0; page_id <num_pages ; page_id++){
-        ret_vec.push_back(dp_map[page_id]);
+        ret_vec.push_back(buffer()->get_mapped_page_id(page_id));
     }
     return ret_vec;
 }

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -255,7 +255,7 @@ bool Tensor::is_allocated() const {
 
 std::vector<uint32_t> Tensor::host_page_ordering(){
     auto cores = buffer()->all_cores();
-    auto shard_size = buffer()->shard_size();
+    auto shard_size = buffer()->shard_spec().size();
     auto num_pages = cores.size() * shard_size;
     auto dp_map = buffer()->dev_page_to_host_page_mapping();
 
@@ -324,8 +324,7 @@ Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layo
     ZoneScoped;
     TT_ASSERT(memory_config.is_sharded());
     TT_ASSERT(memory_config.buffer_type == BufferType::L1);
-    auto& shard_grid = shard_spec.shard_grid;
-    auto& shard_shape = shard_spec.shard_shape;
+    auto& shard_shape = shard_spec.shape;
 
     uint32_t num_cores = shard_spec.num_cores();
 
@@ -354,7 +353,7 @@ Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layo
     }
 
     auto element_size = tensor_impl::element_size_bytes_wrapper(data_type);
-    auto page_shape = tensor_impl::get_sharded_page_shape(layout, shape, data_type, shard_spec.num_cores(), shard_spec.shard_shape);
+    auto page_shape = tensor_impl::get_sharded_page_shape(layout, shape, data_type, shard_spec.num_cores(), shard_spec.shape);
     std::array<uint32_t,2> tensor2d_size = {shape[0]*shape[1] * shape[2]/page_shape[0],
                                                 shape[3]/page_shape[1]
                                             };

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -458,7 +458,7 @@ inline DeviceBuffer initialize_data_on_device(const BufferType<T>& data_to_write
 
     std::optional<ShardSpecBuffer> shard_spec_buffer = std::nullopt;
     if(shard_spec.has_value()){
-        auto page_shape = get_sharded_page_shape(layout, shape, data_type, shard_spec.value().num_cores(), shard_spec.value().shard_shape);
+        auto page_shape = get_sharded_page_shape(layout, shape, data_type, shard_spec.value().num_cores(), shard_spec.value().shape);
         std::array<uint32_t, 2> tensor2d_size = {shape[0]*shape[1] * shape[2]/ page_shape[0],
                                                 shape[3]/page_shape[1]
                                             };
@@ -872,7 +872,7 @@ template <typename T>
 Tensor extract_shard(const Tensor & tensor, const uint32_t & core_id){
 
     auto buffer= tensor.buffer();
-    auto buffer_shard_shape = buffer->shard_shape();
+    auto buffer_shard_shape = buffer->shard_spec().shape;
     std::array <uint32_t, 4> shard_shape_array = {1,1,buffer_shard_shape[0],buffer_shard_shape[1]};
     Shape shard_shape(shard_shape_array);
     std::vector<uint32_t> device_data;

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -872,7 +872,7 @@ template <typename T>
 Tensor extract_shard(const Tensor & tensor, const uint32_t & core_id){
 
     auto buffer= tensor.buffer();
-    auto buffer_shard_shape = buffer->shard_spec().shape;
+    auto buffer_shard_shape = buffer->shard_spec().shape();
     std::array <uint32_t, 4> shard_shape_array = {1,1,buffer_shard_shape[0],buffer_shard_shape[1]};
     Shape shard_shape(shard_shape_array);
     std::vector<uint32_t> device_data;

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -629,20 +629,20 @@ void Matmul::validate(
                         if (this->output_mem_config.is_sharded()) {
                             TT_FATAL(input_tensor_a.memory_config() == this->output_mem_config);
                         }
-                        TT_FATAL(input_tensor_a.shard_spec().value().shard_orientation == ShardOrientation::ROW_MAJOR);
+                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
                         uint32_t M = (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.shape()[-1] : input_tensor_a.shape()[-2]) / TILE_HEIGHT;
                         uint32_t N = input_tensor_b.shape()[-1] / TILE_WIDTH;
                         uint32_t K = input_tensor_a.shape()[-1] / TILE_WIDTH;
                         uint32_t per_core_M = program_config.per_core_M;
                         uint32_t per_core_N = program_config.per_core_N;
-                        auto shard_shape = input_tensor_a.shard_spec().value().shard_shape;
+                        auto shard_shape = input_tensor_a.shard_spec().value().shape;
 
                         // No padding
                         TT_FATAL(M == per_core_M);
                         TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
                         TT_FATAL(K % program_config.in0_block_w == 0);
-                        TT_FATAL(K / program_config.in0_block_w == input_tensor_a.shard_spec().value().shard_grid.num_cores());
-                        TT_FATAL(N / per_core_N == input_tensor_a.shard_spec().value().shard_grid.num_cores());
+                        TT_FATAL(K / program_config.in0_block_w == input_tensor_a.shard_spec().value().grid.num_cores());
+                        TT_FATAL(N / per_core_N == input_tensor_a.shard_spec().value().grid.num_cores());
                     }
                     if (this->output_mem_config.is_sharded()) {
                         TT_FATAL(program_config.mcast_in0 == true);
@@ -665,11 +665,11 @@ void Matmul::validate(
                         if (this->output_mem_config.is_sharded()) {
                             TT_FATAL(input_tensor_a.memory_config() == this->output_mem_config);
                         }
-                        TT_FATAL(input_tensor_a.shard_spec().value().shard_orientation == ShardOrientation::ROW_MAJOR);
+                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
                         uint32_t M = (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.shape()[-1] : input_tensor_a.shape()[-2]) / TILE_HEIGHT;
                         uint32_t K = input_tensor_a.shape()[-1] / TILE_WIDTH;
                         uint32_t per_core_M = program_config.per_core_M;
-                        auto shard_shape = input_tensor_a.shard_spec().value().shard_shape;
+                        auto shard_shape = input_tensor_a.shard_spec().value().shape;
 
                         // No padding
                         TT_FATAL(M % per_core_M == 0);
@@ -696,9 +696,9 @@ void Matmul::validate(
             ) {
                 if (input_tensor_a.memory_config().is_sharded()) {
                     if (program_config.transpose_mcast) {
-                        TT_FATAL(input_tensor_a.shard_spec().value().shard_orientation == ShardOrientation::COL_MAJOR);
+                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR);
                     } else {
-                        TT_FATAL(input_tensor_a.shard_spec().value().shard_orientation == ShardOrientation::ROW_MAJOR);
+                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
                     }
                     TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
                     if (this->output_mem_config.is_sharded()) {
@@ -709,7 +709,7 @@ void Matmul::validate(
                     uint32_t K = input_tensor_a.shape()[-1] / TILE_WIDTH;
                     uint32_t N = input_tensor_b.shape()[-1] / TILE_WIDTH;
                     uint32_t per_core_M = program_config.per_core_M;
-                    auto shard_shape = input_tensor_a.shard_spec().value().shard_shape;
+                    auto shard_shape = input_tensor_a.shard_spec().value().shape;
 
                     TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
                     TT_FATAL((shard_shape[1] / TILE_WIDTH) % program_config.in0_block_w == 0);
@@ -737,7 +737,7 @@ void Matmul::validate(
                 TT_ASSERT(N == per_core_N);
                 if (input_tensor_a.is_sharded()) {
                     TT_FATAL(input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
-                    auto in0_shard_shape = input_tensor_a.shard_spec().value().shard_shape;
+                    auto in0_shard_shape = input_tensor_a.shard_spec().value().shape;
 
                     TT_FATAL(K == in0_shard_shape[1]);
                     TT_FATAL(in0_shard_shape[1] == program_config.in0_block_w * TILE_WIDTH);
@@ -745,7 +745,7 @@ void Matmul::validate(
 
                     if (input_tensor_b.is_sharded()) {
                         TT_FATAL(input_tensor_a.memory_config() == input_tensor_b.memory_config());
-                        TT_FATAL(input_tensor_a.shard_spec().value().shard_orientation == input_tensor_b.shard_spec().value().shard_orientation);
+                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == input_tensor_b.shard_spec().value().orientation);
                     }
                     if (this->output_mem_config.is_sharded()) {
                         TT_FATAL(input_tensor_a.memory_config() == this->output_mem_config);
@@ -755,7 +755,7 @@ void Matmul::validate(
                     bool broadcast_batch = input_tensor_b.shape()[0] * input_tensor_b.shape()[1] == 1;
                     TT_FATAL(!broadcast_batch);
                     TT_FATAL(input_tensor_b.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
-                    auto in1_shard_shape = input_tensor_b.shard_spec().value().shard_shape;
+                    auto in1_shard_shape = input_tensor_b.shard_spec().value().shape;
                     TT_FATAL(in1_shard_shape[1] == input_tensor_b.shape()[-1]);
                     TT_FATAL(per_core_N * TILE_HEIGHT == in1_shard_shape[1]);
                     TT_FATAL(in1_shard_shape[0] % K == 0);
@@ -814,7 +814,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
                     uint32_t num_cores = num_blocks_x * num_blocks_y;
                     CoreRangeSet all_cores = num_cores_to_corerange_set(num_cores, program_config.compute_with_storage_grid_size, true);
-                    ShardSpec shard_spec = ShardSpec{.shard_grid=all_cores, .shard_shape={per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, .shard_orientation=ShardOrientation::ROW_MAJOR};
+                    ShardSpec shard_spec = ShardSpec{.grid=all_cores, .shape={per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, .orientation=ShardOrientation::ROW_MAJOR};
                     return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), this->output_dtype, Layout::TILE, input_tensor_a.device(), this->output_mem_config, shard_spec)};
                 } else if constexpr (
                     std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>
@@ -837,7 +837,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                         all_cores = CoreRangeSet({CoreRange{.start={0, 0}, .end={num_blocks_x - 1, num_blocks_y - 1}}});
                         shard_orientation = ShardOrientation::ROW_MAJOR;
                     }
-                    ShardSpec shard_spec = ShardSpec{.shard_grid=all_cores, .shard_shape={per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, .shard_orientation=shard_orientation};
+                    ShardSpec shard_spec = ShardSpec{.grid=all_cores, .shape={per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, .orientation=shard_orientation};
                     return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), this->output_dtype, Layout::TILE, input_tensor_a.device(), this->output_mem_config, shard_spec)};
                 } else if constexpr (
                     std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>
@@ -853,13 +853,13 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                     uint32_t num_cores = num_blocks_x * num_blocks_y;
                     ShardOrientation shard_orientation = ShardOrientation::COL_MAJOR;
                     if (input_tensor_a.is_sharded()) {
-                        shard_orientation = input_tensor_a.shard_spec().value().shard_orientation;
+                        shard_orientation = input_tensor_a.shard_spec().value().orientation;
                     } else if (input_tensor_b.is_sharded()) {
-                        shard_orientation = input_tensor_b.shard_spec().value().shard_orientation;
+                        shard_orientation = input_tensor_b.shard_spec().value().orientation;
                     }
 
                     CoreRangeSet all_cores = num_cores_to_corerange_set(num_cores, program_config.compute_with_storage_grid_size, shard_orientation==ShardOrientation::ROW_MAJOR);
-                    ShardSpec shard_spec = ShardSpec{.shard_grid=all_cores, .shard_shape={per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, .shard_orientation=shard_orientation};
+                    ShardSpec shard_spec = ShardSpec{.grid=all_cores, .shape={per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, .orientation=shard_orientation};
                     return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), this->output_dtype, Layout::TILE, input_tensor_a.device(), this->output_mem_config, shard_spec)};
                 } else {
                     TT_ASSERT(false, "Unsupported op for output sharding");

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
@@ -97,7 +97,7 @@ operation::ProgramWithCallbacks create_program(
     CoreRangeSet all_cores({}), core_group_1({}), core_group_2({});
 
     if(shard_spec.has_value()) {
-        all_cores = shard_spec.value().shard_grid;
+        all_cores = shard_spec.value().grid;
         num_cores = all_cores.num_cores();
         core_group_1 = all_cores;
         num_blocks_per_core_group_1 = num_output_blocks_total / num_cores * batch_scale_factor;
@@ -317,7 +317,7 @@ operation::ProgramWithCallbacks create_program(
     };
     bool row_major = false;
     if (shard_spec.has_value()) {
-        row_major = shard_spec.value().shard_orientation == ShardOrientation::ROW_MAJOR;
+        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
     }
     const auto cores = grid_to_cores(num_cores, core_range.x, core_range.y, row_major);
 

--- a/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv/optimized_conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv/optimized_conv_op.cpp
@@ -72,7 +72,7 @@ tuple<CBHandle, CBHandle> create_CBs(tt_metal::Program &program,
     CBHandle cb_sharded_act_mcast_receiver = 0;
     if (input.is_sharded()) {
         uint32_t num_bytes_for_df = datum_size(act_df);
-        auto shard_shape = input.shard_spec().value().shard_shape;
+        auto shard_shape = input.shard_spec().value().shape;
         CircularBufferConfig cb_sharded_act_config = CircularBufferConfig(shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{sharded_act_cb, act_df}})
 		    .set_page_size(sharded_act_cb, shard_shape[1] * num_bytes_for_df);
         // incoming data is the input cb instead of raw l1/dram addr
@@ -876,7 +876,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_(const Tensor& a, cons
             uint32_t last_partial_left_aligned_row_width = sharding_config.last_partial_left_aligned_row_width;
 
             if (weight_width_sliced) {
-                auto shard_shape = a.shard_spec().value().shard_shape;
+                auto shard_shape = a.shard_spec().value().shape;
                 uint32_t shard_size_bytes = shard_shape[0] * shard_shape[1] * a.element_size();
                 CoreCoord bottom_core = {(std::size_t) core_x_i, (std::size_t) num_cores_y - 1};
                 auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);

--- a/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded.cpp
@@ -67,7 +67,7 @@ tuple<CBHandle, CBHandle> create_CBs_for_sharded_input(
     CBHandle cb_sharded_act = 0;
     if (input.memory_config().is_sharded()) {
         uint32_t num_bytes_for_df = datum_size(act_df);
-        auto shard_shape = input.shard_spec().value().shard_shape;
+        auto shard_shape = input.shard_spec().value().shape;
         // 2D-sys-conv already has uint16_t indicies, TODO: do the same for 1D-sys-conv
         TT_ASSERT(shard_shape[0] <= (1<<16), "Shard height must be less than 2^16, read pattern indicies are uint16_t");
         CircularBufferConfig cb_sharded_act_config = CircularBufferConfig(shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{sharded_act_cb, act_df}})
@@ -908,7 +908,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_(const Tensor&
             uint32_t last_partial_left_aligned_row_width = sharding_config.last_partial_left_aligned_row_width;
 
             if (weight_width_sliced) {
-                auto shard_shape = a.shard_spec().value().shard_shape;
+                auto shard_shape = a.shard_spec().value().shape;
                 uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
                 CoreCoord bottom_core = {(std::size_t) core_x_i, (std::size_t) num_cores_y - 1};
                 auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);

--- a/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -68,7 +68,7 @@ tuple<CBHandle, CBHandle> create_CBs_for_sharded_input_v2(
     CBHandle cb_sharded_act = 0;
     if (input.memory_config().is_sharded()) {
         uint32_t num_bytes_for_df = datum_size(act_df);
-        auto shard_shape = input.shard_spec().value().shard_shape;
+        auto shard_shape = input.shard_spec().value().shape;
         // 2D-sys-conv already has uint16_t indicies, TODO: do the same for 1D-sys-conv
         TT_ASSERT(shard_shape[0] <= (1<<16), "Shard height must be less than 2^16, read pattern indicies are uint16_t");
         CircularBufferConfig cb_sharded_act_config = CircularBufferConfig(shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{sharded_act_cb, act_df}})
@@ -912,7 +912,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(const Tens
             uint32_t last_partial_left_aligned_row_width = sharding_config.last_partial_left_aligned_row_width;
 
             if (weight_width_sliced) {
-                auto shard_shape = a.shard_spec().value().shard_shape;
+                auto shard_shape = a.shard_spec().value().shape;
                 uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
                 CoreCoord bottom_core = {(std::size_t) core_x_i, (std::size_t) num_cores_y - 1};
                 auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);

--- a/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
@@ -161,7 +161,7 @@ std::vector<Tensor> OptimizedConv::create_output_tensors(const std::vector<Tenso
             CoreRangeSet shard_grid = num_cores_to_corerange_set(num_cores, this->parallelization_config.grid_size, true);
 
             std::array<uint32_t, 2> shard_shape = {this->parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT, output_shape[-1]};
-            auto shard_spec = ShardSpec{.shard_grid=shard_grid, .shard_shape=shard_shape, .shard_orientation=ShardOrientation::ROW_MAJOR};
+            auto shard_spec = ShardSpec{.grid=shard_grid, .shape=shard_shape, .orientation=ShardOrientation::ROW_MAJOR};
             return {create_sharded_device_tensor(output_shape, this->output_dtype, output_layout, input_tensor.device(), this->output_mem_config, shard_spec)};
         } else {
             auto [act_matrix_shape, act_matrix_shape_unpadded] = optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(this->input_tensor_shape, conv_params, this->block_config.out_block_h_ntiles, extra_padding_for_32B_alignment);
@@ -174,7 +174,7 @@ std::vector<Tensor> OptimizedConv::create_output_tensors(const std::vector<Tenso
             uint32_t total_active_num_cores = total_active_num_cores_per_weight_slice * num_weight_slices_width;
             CoreRangeSet shard_grid = num_cores_to_corerange_set(total_active_num_cores, this->parallelization_config.grid_size, true);
             std::array<uint32_t, 2> shard_shape = {this->parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT, this->parallelization_config.per_core_weight_matrix_width_ntiles * TILE_WIDTH};
-            auto shard_spec = ShardSpec{.shard_grid=shard_grid, .shard_shape=shard_shape, .shard_orientation=ShardOrientation::COL_MAJOR};
+            auto shard_spec = ShardSpec{.grid=shard_grid, .shape=shard_shape, .orientation=ShardOrientation::COL_MAJOR};
             return {create_sharded_device_tensor(output_shape, this->output_dtype, output_layout, input_tensor.device(), this->output_mem_config, shard_spec)};
         }
 

--- a/tt_eager/tt_dnn/op_library/downsample/downsample_op.cpp
+++ b/tt_eager/tt_dnn/op_library/downsample/downsample_op.cpp
@@ -62,12 +62,12 @@ std::vector<Shape> Downsample::compute_output_shapes(const std::vector<Tensor> &
 std::vector<Tensor> Downsample::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     auto output_shape = this->compute_output_shapes(input_tensors).at(0);
-    auto [num_cores_height_sliced, num_cores_width_sliced] = get_num_cores_height_width_sliced(input_tensor.shard_spec().value().shard_grid,
+    auto [num_cores_height_sliced, num_cores_width_sliced] = get_num_cores_height_width_sliced(input_tensor.shard_spec().value().grid,
                                             input_tensor.memory_config().memory_layout,
-                                            input_tensor.shard_spec().value().shard_orientation);
+                                            input_tensor.shard_spec().value().orientation);
     uint32_t output_shard_height = round_up(output_shape[2], num_cores_height_sliced * TILE_HEIGHT) / num_cores_height_sliced;
     uint32_t output_shard_width = round_up(output_shape[3], num_cores_width_sliced * TILE_WIDTH) / num_cores_width_sliced;
-    return {create_sharded_device_tensor(output_shape, this->output_dtype, Layout::TILE, input_tensor.device(), input_tensor.memory_config(), ShardSpec{input_tensor.shard_spec().value().shard_grid, std::array<uint32_t, 2>{{output_shard_height, output_shard_width}}, input_tensor.shard_spec().value().shard_orientation})};
+    return {create_sharded_device_tensor(output_shape, this->output_dtype, Layout::TILE, input_tensor.device(), input_tensor.memory_config(), ShardSpec{input_tensor.shard_spec().value().grid, std::array<uint32_t, 2>{{output_shard_height, output_shard_width}}, input_tensor.shard_spec().value().orientation})};
 }
 
 operation::ProgramWithCallbacks Downsample::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
@@ -385,13 +385,13 @@ operation::ProgramWithCallbacks downsample_single_core(const Tensor &a, std::arr
 
 
     uint32_t ncores_x_full_grid = device->compute_with_storage_grid_size().x;
-    auto [num_cores_height_sliced, num_cores_width_sliced] = get_num_cores_height_width_sliced(a.shard_spec().value().shard_grid,
+    auto [num_cores_height_sliced, num_cores_width_sliced] = get_num_cores_height_width_sliced(a.shard_spec().value().grid,
                                         a.memory_config().memory_layout,
-                                        a.shard_spec().value().shard_orientation);
+                                        a.shard_spec().value().orientation);
     uint32_t num_cores = num_cores_height_sliced * num_cores_width_sliced;
-    auto all_cores = a.shard_spec().value().shard_grid;
+    auto all_cores = a.shard_spec().value().grid;
     auto memory_layout = a.memory_config().memory_layout;
-    TT_ASSERT(all_cores == output.shard_spec().value().shard_grid);
+    TT_ASSERT(all_cores == output.shard_spec().value().grid);
     TT_ASSERT(memory_layout == output.memory_config().memory_layout);
     TT_ASSERT(memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
     if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
@@ -414,10 +414,10 @@ operation::ProgramWithCallbacks downsample_single_core(const Tensor &a, std::arr
     uint32_t output_height_unpadded = img_batch_size * std::ceil((double) (img_height * img_width) / (double) (img_stride_h * img_stride_w));
     TT_ASSERT(output_height >= output_height_unpadded);
 
-    uint32_t input_shard_height = a.shard_spec().value().shard_shape[0];
+    uint32_t input_shard_height = a.shard_spec().value().shape[0];
     TT_ASSERT(input_shard_height * num_cores_height_sliced >= input_height); // last core shard size may be padded
     uint32_t input_height_padded = input_shard_height * num_cores_height_sliced;
-    uint32_t input_shard_width = a.shard_spec().value().shard_shape[1];
+    uint32_t input_shard_width = a.shard_spec().value().shape[1];
     TT_ASSERT(input_shard_width * num_cores_width_sliced == input_width);
 
     uint32_t input_height_padding = input_height_padded - input_height_unpadded;
@@ -425,8 +425,8 @@ operation::ProgramWithCallbacks downsample_single_core(const Tensor &a, std::arr
     uint32_t last_core_input_shard_height_unpadded = input_shard_height - input_height_padding;
 
 
-    uint32_t output_shard_height = output.shard_spec().value().shard_shape[0];
-    uint32_t output_shard_width = output.shard_spec().value().shard_shape[1];
+    uint32_t output_shard_height = output.shard_spec().value().shape[0];
+    uint32_t output_shard_width = output.shard_spec().value().shape[1];
 
     TT_ASSERT(output_shard_width == input_shard_width);
     TT_ASSERT(output_shard_height * num_cores_height_sliced >= output_height); // last core shard size may be padded

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
@@ -119,7 +119,7 @@ void EltwiseBinary::validate(const std::vector<Tensor>& input_tensors) const {
         if (input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
             // If we aren't height sharded, we require all sharding schemes to match until we add blocked reader/writers for width and block sharding
             TT_FATAL((input_tensor_b.memory_config().is_sharded()));
-            TT_FATAL(input_tensor_a.shard_spec().value().shard_grid.ranges().size() == 1);
+            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1);
         }
         if (input_tensor_b.memory_config().is_sharded()) {
             TT_FATAL(input_tensor_a.memory_config() == input_tensor_b.memory_config());
@@ -168,7 +168,7 @@ std::vector<Tensor> EltwiseBinary::create_output_tensors(
         return {};
     }
     if (this->output_mem_config.is_sharded()) {
-        ShardSpec shard_spec{.shard_grid=CoreRangeSet({}), .shard_shape={0, 0}};
+        ShardSpec shard_spec{.grid=CoreRangeSet({}), .shape={0, 0}};
         if (input_tensor_a.memory_config().is_sharded()) {
             shard_spec = input_tensor_a.shard_spec().value();
         } else if (input_tensor_b.memory_config().is_sharded()) {
@@ -178,9 +178,9 @@ std::vector<Tensor> EltwiseBinary::create_output_tensors(
             auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
             uint32_t num_grid_cores = core_grid.x * core_grid.y;
             uint32_t target_num_cores = num_blocks < num_grid_cores ? num_blocks : num_grid_cores;
-            shard_spec.shard_grid = num_cores_to_corerange_set(target_num_cores, input_tensor_a.device()->compute_with_storage_grid_size(), true);
-            shard_spec.shard_shape = {num_blocks / target_num_cores * TILE_HEIGHT, input_tensor_a.shape()[-1]};
-            shard_spec.shard_orientation = ShardOrientation::ROW_MAJOR;
+            shard_spec.grid = num_cores_to_corerange_set(target_num_cores, input_tensor_a.device()->compute_with_storage_grid_size(), true);
+            shard_spec.shape = {num_blocks / target_num_cores * TILE_HEIGHT, input_tensor_a.shape()[-1]};
+            shard_spec.orientation = ShardOrientation::ROW_MAJOR;
         }
         return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), this->output_dtype, Layout::TILE, input_tensor_a.device(), this->output_mem_config, shard_spec)};
     }

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/multi_core/eltwise_binary_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/multi_core/eltwise_binary_op_multi_core.cpp
@@ -58,7 +58,7 @@ operation::ProgramWithCallbacks eltwise_binary_multi_core(const Tensor &a, const
 
     uint32_t max_block_size = 1, num_tiles_per_shard = 0;
     if (shard_spec.has_value()) {
-        num_tiles_per_shard = shard_spec.value().shard_shape[0] * shard_spec.value().shard_shape[1] / TILE_HW;
+        num_tiles_per_shard = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
         max_block_size = find_max_block_size(num_tiles_per_shard);
     }
 
@@ -208,23 +208,23 @@ operation::ProgramWithCallbacks eltwise_binary_multi_core(const Tensor &a, const
         vector<CoreCoord> cores;
 
         if (shard_spec.has_value()) {
-            all_cores = shard_spec.value().shard_grid;
+            all_cores = shard_spec.value().grid;
             num_cores = all_cores.num_cores();
             core_group_1 = all_cores;
             core_group_2 = CoreRangeSet({});
-            num_tiles_per_core_group_1 = shard_spec.value().shard_shape[0] * shard_spec.value().shard_shape[1] / TILE_HW;
+            num_tiles_per_core_group_1 = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
             num_tiles_per_core_group_2 = 0;
             block_size_per_core_group_1 = find_max_block_size(num_tiles_per_core_group_1);
             max_block_size = block_size_per_core_group_1;
 
             block_cnt_per_core_group_1 = num_tiles_per_core_group_1 / block_size_per_core_group_1;
             block_cnt_per_core_group_2 = num_tiles_per_core_group_2 / block_size_per_core_group_2;
-            row_major = shard_spec.value().shard_orientation == ShardOrientation::ROW_MAJOR;
+            row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
             if (block_sharded) {
-                block_height = shard_spec.value().shard_shape[0] / TILE_HEIGHT;
-                block_width = shard_spec.value().shard_shape[1] / TILE_WIDTH;
+                block_height = shard_spec.value().shape[0] / TILE_HEIGHT;
+                block_width = shard_spec.value().shape[1] / TILE_WIDTH;
                 block_size = block_width * block_height;
-                end_core = (*shard_spec.value().shard_grid.ranges().begin()).end;
+                end_core = (*shard_spec.value().grid.ranges().begin()).end;
                 output_width = output.shape()[-1] / TILE_WIDTH;
                 uint32_t output_height = output.volume() / output.shape()[-1] / TILE_HEIGHT;
                 last_unpadded_block_height = block_height -  (round_up(output_height, block_height) - output_height);

--- a/tt_eager/tt_dnn/op_library/move/move_op.hpp
+++ b/tt_eager/tt_dnn/op_library/move/move_op.hpp
@@ -126,8 +126,8 @@ inline Tensor move_sharded(Tensor& input_tensor, std::optional<MemoryConfig>& me
         return input_tensor;
     }
     auto shard_spec = input_tensor.shard_spec().value();
-    auto shard_shape = shard_spec.shard_shape;
-    auto shard_grid = shard_spec.shard_grid;
+    auto shard_shape = shard_spec.shape;
+    auto shard_grid = shard_spec.grid;
     auto input_shape = input_tensor.shape();
     auto input_dtype = input_tensor.dtype();
     auto input_layout = input_tensor.layout();

--- a/tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core_sharded.cpp
@@ -24,12 +24,12 @@ operation::ProgramWithCallbacks move_multi_core_sharded(const Tensor &input, Ten
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
     auto shard_spec = input.shard_spec().value();
-    auto shard_shape = shard_spec.shard_shape;
-    auto shard_grid = shard_spec.shard_grid;
+    auto shard_shape = shard_spec.shape;
+    auto shard_grid = shard_spec.grid;
     auto input_shape = input.shape();
     auto input_dtype = input.dtype();
     auto input_layout = input.layout();
-    TT_FATAL(input_layout == output.layout() && input_dtype == output.dtype() && shard_shape == output.shard_spec().value().shard_shape && input_shape == output.shape());
+    TT_FATAL(input_layout == output.layout() && input_dtype == output.dtype() && shard_shape == output.shard_spec().value().shape && input_shape == output.shape());
     const uint32_t src_cb_sharded = CB::c_in0;
     const uint32_t dst_cb_sharded = CB::c_in1;
     uint32_t tile_size_bytes = tile_size(cb_data_format);

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads.cpp
@@ -49,11 +49,11 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads(const Tensor &a, Ten
     uint32_t num_cores = 0, num_blocks_per_core_group_1 = 0, num_blocks_per_core_group_2 = 0;
     CoreRangeSet all_cores = CoreRangeSet({}), core_group_1 = CoreRangeSet({}), core_group_2 = CoreRangeSet({});
     if (in_sharded) {
-        all_cores = a.shard_spec().value().shard_grid;
+        all_cores = a.shard_spec().value().grid;
         num_cores = all_cores.num_cores();
         core_group_1 = all_cores;
-        num_blocks_per_core_group_1 = a.shard_spec().value().shard_shape[0] / a.shape()[-2];
-        per_tensor_tiles = a.shard_spec().value().shard_shape[0] * a.shard_spec().value().shard_shape[1] / TILE_HW;
+        num_blocks_per_core_group_1 = a.shard_spec().value().shape[0] / a.shape()[-2];
+        per_tensor_tiles = a.shard_spec().value().shape[0] * a.shard_spec().value().shape[1] / TILE_HW;
     } else {
         std::tie(num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2) = split_work_to_cores(compute_with_storage_grid_size, num_blocks);
     }

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -32,9 +32,9 @@ void NlpTM::validate(const std::vector<Tensor>& input_tensors) const {
             if (input_tensor.is_sharded()) {
                 TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
                 auto shard_spec = input_tensor.shard_spec().value();
-                TT_FATAL(shard_spec.shard_shape[1] == input_tensor.shape()[-1]);
-                TT_FATAL(shard_spec.shard_shape[0] % input_tensor.shape()[-2] == 0);
-                TT_FATAL(input_tensor.shape()[1] % (shard_spec.shard_shape[0] / input_tensor.shape()[-2]) == 0);
+                TT_FATAL(shard_spec.shape[1] == input_tensor.shape()[-1]);
+                TT_FATAL(shard_spec.shape[0] % input_tensor.shape()[-2] == 0);
+                TT_FATAL(input_tensor.shape()[1] % (shard_spec.shape[0] / input_tensor.shape()[-2]) == 0);
                 TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
             } else {
                 TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
@@ -68,8 +68,8 @@ std::vector<Tensor> NlpTM::create_output_tensors(const std::vector<Tensor>& inpu
         if (this->nlp_tm_op_type == NlpTMOpType::CONCAT_HEADS) {
             ShardSpec shard_spec = input_tensor.shard_spec().value();
             uint32_t num_cores = shard_spec.num_cores();
-            uint32_t heads_per_shard = shard_spec.shard_shape[0] / input_tensor.shape()[-2];
-            shard_spec.shard_shape = {shard_spec.shard_shape[0] / heads_per_shard, shard_spec.shard_shape[1] * heads_per_shard};
+            uint32_t heads_per_shard = shard_spec.shape[0] / input_tensor.shape()[-2];
+            shard_spec.shape = {shard_spec.shape[0] / heads_per_shard, shard_spec.shape[1] * heads_per_shard};
             return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), input_tensor.dtype(), Layout::TILE, input_tensor.device(), this->output_mem_config, shard_spec)};
         } else {
             TT_ASSERT(false);

--- a/tt_eager/tt_dnn/op_library/reduce/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/tt_eager/tt_dnn/op_library/reduce/multi_core_h/reduce_op_multi_core_h.cpp
@@ -50,11 +50,11 @@ operation::ProgramWithCallbacks reduce_multi_core_h(const Tensor &a, Tensor& out
 
     // Current sharding only supports width, and that input and output are sharded
     if (in_sharded) {
-        all_cores = a.shard_spec().value().shard_grid;
+        all_cores = a.shard_spec().value().grid;
         num_cores = all_cores.num_cores();
         core_group_1 = all_cores;
         core_group_2 = CoreRangeSet({});
-        num_cols_per_core_group_1 = NC * (a.shard_spec().value().shard_shape[1] / TILE_WIDTH);
+        num_cols_per_core_group_1 = NC * (a.shard_spec().value().shape[1] / TILE_WIDTH);
         num_cols_per_core_group_2 = 0;
     }
     string compute_kernel_name = reduce_op_utils::dim_to_kernel_name(reduce_dim, reduce_op);

--- a/tt_eager/tt_dnn/op_library/reduce/reduce_op.cpp
+++ b/tt_eager/tt_dnn/op_library/reduce/reduce_op.cpp
@@ -101,7 +101,7 @@ std::vector<Tensor> Reduce::create_output_tensors(const std::vector<Tensor> &inp
     if(this->output_mem_config.is_sharded()){
         auto output_shape = this->compute_output_shapes(input_tensors).at(0);
         auto shard_spec = input_tensor.shard_spec().value();
-        shard_spec.shard_shape[0] = tt_metal::compute_volume(output_shape) / output_shape[-1];
+        shard_spec.shape[0] = tt_metal::compute_volume(output_shape) / output_shape[-1];
         return {create_sharded_device_tensor(output_shape, this->output_dtype, Layout::TILE, input_tensor.device(), this->output_mem_config, shard_spec)};
     } else {
         return operation::generic_create_output_tensors(*this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);

--- a/tt_eager/tt_dnn/op_library/sharded/sharded_op.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/sharded_op.cpp
@@ -23,9 +23,9 @@ void Sharded::validate(const std::vector<Tensor>& input_tensors) const {
     } else if (this->sharded_op_type == ShardedOpType::ShardedToInterleaved) {
         TT_FATAL(input_tensor.memory_config().is_sharded());
         if (input_tensor.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
-            if (input_tensor.shape()[-1] % this->shard_spec.shard_shape[1] != 0 ||
-                ((input_tensor.volume() / input_tensor.shape()[-1]) % this->shard_spec.shard_shape[0]) != 0) {
-                TT_FATAL(input_tensor.shard_spec().value().shard_grid.ranges().size() == 1);
+            if (input_tensor.shape()[-1] % this->shard_spec.shape[1] != 0 ||
+                ((input_tensor.volume() / input_tensor.shape()[-1]) % this->shard_spec.shape[0]) != 0) {
+                TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1);
             }
         }
     }

--- a/tt_eager/tt_dnn/op_library/tilize/tilize_multi_core/tilize_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/tilize/tilize_multi_core/tilize_op_multi_core.cpp
@@ -380,9 +380,9 @@ operation::ProgramWithCallbacks tilize_multi_core_sharded(const Tensor &input, T
     tt_metal::Device *device = input.device();
 
     auto shard_spec = input.shard_spec().value();
-    uint32_t num_tiles_per_shard = shard_spec.shard_shape[0] * shard_spec.shard_shape[1] / TILE_HW;
-    uint32_t num_tiles_per_row = shard_spec.shard_shape[1] / TILE_WIDTH;
-    auto all_cores = shard_spec.shard_grid;
+    uint32_t num_tiles_per_shard = shard_spec.shape[0] * shard_spec.shape[1] / TILE_HW;
+    uint32_t num_tiles_per_row = shard_spec.shape[1] / TILE_WIDTH;
+    auto all_cores = shard_spec.grid;
     uint32_t num_cores_x = device->compute_with_storage_grid_size().x;
     uint32_t num_cores = all_cores.num_cores();
 
@@ -505,17 +505,17 @@ operation::ProgramWithCallbacks tilize_with_val_padding_multi_core(const Tensor 
     auto input_shard_spec = a.shard_spec().value();
     auto output_shard_spec = output.shard_spec().value();
 
-    auto all_cores = output_shard_spec.shard_grid;
+    auto all_cores = output_shard_spec.grid;
 
     uint32_t num_batches = output.volume() / (output.shape()[-2] * output.shape()[-1]);
 
-    uint32_t num_input_rows = input_shard_spec.shard_shape[0];
-    uint32_t input_shard_width_bytes = input_shard_spec.shard_shape[1] * a.element_size();
+    uint32_t num_input_rows = input_shard_spec.shape[0];
+    uint32_t input_shard_width_bytes = input_shard_spec.shape[1] * a.element_size();
     uint32_t input_shard_size_bytes = num_input_rows * input_shard_width_bytes;
-    uint32_t ntiles_per_core = output_shard_spec.shard_shape[0] * output_shard_spec.shard_shape[1] / TILE_HW;
+    uint32_t ntiles_per_core = output_shard_spec.shape[0] * output_shard_spec.shape[1] / TILE_HW;
     uint32_t ntiles_per_batch = ntiles_per_core / num_batches;
-    uint32_t ntiles_per_block = output_shard_spec.shard_shape[1] / TILE_WIDTH;
-    uint32_t nblocks_per_core = output_shard_spec.shard_shape[0] / TILE_HEIGHT;
+    uint32_t ntiles_per_block = output_shard_spec.shape[1] / TILE_WIDTH;
+    uint32_t nblocks_per_core = output_shard_spec.shape[0] / TILE_HEIGHT;
     uint32_t num_padded_rows = output.shape()[-2] - a.shape()[-2];
 
     uint32_t src0_cb_index = CB::c_in1;

--- a/tt_eager/tt_dnn/op_library/tilize/tilize_op.cpp
+++ b/tt_eager/tt_dnn/op_library/tilize/tilize_op.cpp
@@ -43,7 +43,7 @@ void Tilize::validate(const std::vector<Tensor> &input_tensors) const {
         TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
         TT_FATAL(this->output_mem_config == input_tensor_a.memory_config());
         TT_FATAL(this->use_multicore == true);
-        TT_FATAL(input_tensor_a.shard_spec().value().shard_orientation == ShardOrientation::ROW_MAJOR);
+        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
     } else {
         TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
         TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
@@ -142,7 +142,7 @@ std::vector<Tensor> TilizeWithValPadding::create_output_tensors(const std::vecto
     if (input_tensor_a.memory_config().is_sharded()) {
         auto output_shape = this->compute_output_shapes(input_tensors).at(0);
         auto shard_spec = input_tensor_a.shard_spec().value();
-        shard_spec.shard_shape[0] = tt_metal::compute_volume(output_shape) / output_shape[-1];
+        shard_spec.shape[0] = tt_metal::compute_volume(output_shape) / output_shape[-1];
         return {create_sharded_device_tensor(output_shape, this->output_dtype, Layout::TILE, input_tensor_a.device(), this->output_mem_config, shard_spec)};
     } else {
         return operation::generic_create_output_tensors(*this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);

--- a/tt_eager/tt_dnn/op_library/untilize/untilize_op.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/untilize_op.cpp
@@ -33,7 +33,7 @@ void Untilize::validate(const std::vector<Tensor> &input_tensors) const {
             TT_FATAL(this->output_mem_config == input_tensor_a.memory_config());
         }
         if (input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
-            TT_FATAL(input_tensor_a.shard_spec().value().shard_grid.ranges().size() == 1);
+            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1);
         }
         TT_FATAL(this->use_multicore == true);
     } else if (this->output_mem_config.is_sharded()) {
@@ -70,7 +70,7 @@ std::vector<Tensor> Untilize::create_output_tensors(const std::vector<Tensor> &i
             auto shard_grid = num_cores_to_corerange_set(num_cores, input_tensor.device()->compute_with_storage_grid_size(), true);
             uint32_t fused_height = input_tensor.volume() / input_tensor.shape()[-1];
             std::array<uint32_t, 2> shard_shape = {fused_height / num_cores, input_tensor.shape()[-1]};
-            ShardSpec shard_spec{.shard_grid=shard_grid, .shard_shape=shard_shape, .shard_orientation=ShardOrientation::ROW_MAJOR};
+            ShardSpec shard_spec{.grid=shard_grid, .shape=shard_shape, .orientation=ShardOrientation::ROW_MAJOR};
             return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), output_dtype, Layout::ROW_MAJOR, input_tensor.device(), this->output_mem_config, shard_spec)};
         }
     } else {
@@ -136,13 +136,13 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor> &input_tensors) c
 
     if (input_tensor_a.memory_config().is_sharded()) {
         if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-            TT_FATAL(input_tensor_a.shard_spec().value().shard_grid.ranges().size() == 1);
+            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1);
             TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
             TT_FATAL(input_tensor_a.volume() / (input_tensor_a.shape()[-2] * input_tensor_a.shape()[-1]) == 1, "Can only write unbatched output interleaved");
         } else if(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
             auto output_shape = this->compute_output_shapes(input_tensors).at(0);
             // Minor host code changes required to remove this restriction
-            TT_FATAL(input_tensor_a.shard_spec().value().shard_grid.ranges().size() == 1);
+            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1);
             for (uint32_t i = 0; i < output_shape.rank() - 2; i++) {
                 TT_FATAL(input_tensor_a.shape()[i] == output_shape[i]);
             }
@@ -152,7 +152,7 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor> &input_tensors) c
             } else {
                 TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
                 TT_FATAL(input_tensor_a.volume() / (input_tensor_a.shape()[-2] * input_tensor_a.shape()[-1]) == 1, "Can only write unbatched output interleaved");
-                TT_FATAL(input_tensor_a.shape()[-1] - output_shape[-1] < input_tensor_a.shard_spec().value().shard_shape[1]);
+                TT_FATAL(input_tensor_a.shape()[-1] - output_shape[-1] < input_tensor_a.shard_spec().value().shape[1]);
             }
         } else {
             TT_FATAL(false, "Unsupported sharding scheme");
@@ -181,7 +181,7 @@ std::vector<Tensor> UntilizeWithUnpadding::create_output_tensors(const std::vect
         uint32_t num_cores = input_tensor_a.shard_spec().value().num_cores();
         std::array<uint32_t, 2> shard_shape = {fused_height, output_shape[-1] / num_cores};
         ShardSpec shard_spec = input_tensor_a.shard_spec().value();
-        shard_spec.shard_shape = shard_shape;
+        shard_spec.shape = shard_shape;
         return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), output_dtype, Layout::ROW_MAJOR, input_tensor_a.device(), this->output_mem_config, shard_spec)};
     } else {
         return operation::generic_create_output_tensors(*this, input_tensors, output_dtype, Layout::ROW_MAJOR, this->output_mem_config);

--- a/tt_eager/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
@@ -153,13 +153,13 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s2(const Tensor& i
     untilize_with_halo_helpers::init_neighbor_core_xy_mapping(grid_size);
 
     int32_t ncores_x = grid_size.x;     // distributing data to cores row-wise
-    CoreRangeSet all_cores = input.shard_spec().value().shard_grid;
+    CoreRangeSet all_cores = input.shard_spec().value().grid;
     int32_t ncores = 0;
     for (const auto& core_range : all_cores.ranges()) {
         ncores += core_range.size();
     }
     CoreRangeSet core_range_cliff = CoreRangeSet({});
-    uint32_t nblocks_per_core = input.shard_spec().value().shard_shape[0] / TILE_HEIGHT;
+    uint32_t nblocks_per_core = input.shard_spec().value().shape[0] / TILE_HEIGHT;
     uint32_t nblocks_per_core_cliff = 0;
 
     uint32_t in_hw = pc.in_h * pc.in_w;
@@ -173,7 +173,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s2(const Tensor& i
     int32_t halo_out_nsticks = (pc.in_w + 2 * pc.pad_w) * pc.pad_h + pc.window_w / 2;   // output sticks from the writer
 
     if (1) {
-        log_debug(LogOp, "shard_shape: {},{}", input.shard_spec().value().shard_shape[0], input.shard_spec().value().shard_shape[1]);
+        log_debug(LogOp, "shard_shape: {},{}", input.shard_spec().value().shape[0], input.shard_spec().value().shape[1]);
         log_debug(LogOp, "ncores: {}", ncores);
         log_debug(LogOp, "ncores_x: {}", ncores_x);
         log_debug(LogOp, "nblocks_per_core: {}", nblocks_per_core);
@@ -773,7 +773,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s1(const Tensor& a
 
     int32_t ncores_x = grid_size.x;
     int32_t ncores_y = grid_size.y;
-    CoreRangeSet all_cores = a.shard_spec().value().shard_grid;
+    CoreRangeSet all_cores = a.shard_spec().value().grid;
     int32_t ncores = all_cores.num_cores();
     int32_t ncores_col = 1;
     if (a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
@@ -789,7 +789,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s1(const Tensor& a
     uint32_t nblocks = ceil((float) ntiles / ntiles_per_block);
     uint32_t block_size_nbytes = input_shape[3] * output.element_size();
 
-    auto shard_shape = a.shard_spec().value().shard_shape;
+    auto shard_shape = a.shard_spec().value().shape;
 
     if (a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         ntiles = input_shape[0] * input_shape[1] * shard_shape[0] * shard_shape[1];
@@ -798,9 +798,9 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s1(const Tensor& a
         block_size_nbytes = shard_shape[1] * output.element_size();
         auto core_range = *(all_cores.ranges().begin());
         int32_t ncores_y = core_range.end.y - core_range.start.y + 1;
-        TT_ASSERT(a.shard_spec().value().shard_shape[1] * ncores_y == input_shape[3], "Input shape in W should be same as shard width * num cores along each row!");
+        TT_ASSERT(a.shard_spec().value().shape[1] * ncores_y == input_shape[3], "Input shape in W should be same as shard width * num cores along each row!");
     } else {
-        TT_ASSERT(a.shard_spec().value().shard_shape[1] == input_shape[3], "Input shape in W should be same as shard width!");
+        TT_ASSERT(a.shard_spec().value().shape[1] == input_shape[3], "Input shape in W should be same as shard width!");
     }
 
     // TODO: hard coded for now. need to pass these args in.
@@ -836,7 +836,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s1(const Tensor& a
         log_debug(LogOp, "pad_w: {}", pad_w);
         log_debug(LogOp, "window_h: {}", window_h);
         log_debug(LogOp, "window_w: {}", window_w);
-        log_debug(LogOp, "shard_shape: {},{}", a.shard_spec().value().shard_shape[0], a.shard_spec().value().shard_shape[1]);
+        log_debug(LogOp, "shard_shape: {},{}", a.shard_spec().value().shape[0], a.shard_spec().value().shape[1]);
         log_debug(LogOp, "ncores: {}", ncores);
         log_debug(LogOp, "ncores_col: {}", ncores_col);
         log_debug(LogOp, "ncores_x: {}", ncores_x);
@@ -1317,10 +1317,10 @@ std::vector<Shape> UntilizeWithHalo::compute_output_shapes(const std::vector<Ten
     uint32_t nbatch = input_shape[0];
 
     // get ncores from shard shape and input shape
-    auto shard_shape = input.shard_spec().value().shard_shape;
+    auto shard_shape = input.shard_spec().value().shape;
     uint32_t ncores = in_nhw / shard_shape[0];
     if (input.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        auto core_range = *(input.shard_spec().value().shard_grid.ranges().begin());
+        auto core_range = *(input.shard_spec().value().grid.ranges().begin());
         ncores = core_range.end.x - core_range.start.x + 1;
     }
 
@@ -1351,12 +1351,12 @@ std::vector<Tensor> UntilizeWithHalo::create_output_tensors(const std::vector<Te
     DataType output_dtype = input_tensor.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.dtype();
     auto shard_spec = input_tensor.shard_spec().value();
     auto output_shape = this->compute_output_shapes(input_tensors).at(0);
-    uint32_t ncores = input_tensor.shape()[0] * input_tensor.shape()[2] / shard_spec.shard_shape[0];
+    uint32_t ncores = input_tensor.shape()[0] * input_tensor.shape()[2] / shard_spec.shape[0];
     if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        auto core_range = *(input_tensor.shard_spec().value().shard_grid.ranges().begin());
+        auto core_range = *(input_tensor.shard_spec().value().grid.ranges().begin());
         ncores = core_range.end.x - core_range.start.x + 1;
     }
-    shard_spec.shard_shape[0] = output_shape[0] * div_up(output_shape[2], ncores);
+    shard_spec.shape[0] = output_shape[0] * div_up(output_shape[2], ncores);
     shard_spec.halo = true;
     // log_debug(LogOp, "derived ncores: {}", ncores);
     return {create_sharded_device_tensor(output_shape, output_dtype, Layout::ROW_MAJOR, input_tensor.device(), this->output_mem_config, shard_spec)};
@@ -1389,7 +1389,7 @@ Tensor untilize_with_halo(const Tensor &input_tensor_a, const uint32_t pad_val, 
     uint32_t dilation_h = 1;
     uint32_t dilation_w = 1;
 
-    CoreRangeSet all_cores = input_tensor_a.shard_spec().value().shard_grid;
+    CoreRangeSet all_cores = input_tensor_a.shard_spec().value().grid;
     uint32_t ncores = all_cores.num_cores();
 
     // TODO: Uplift to support different num of sticks per core
@@ -1398,11 +1398,11 @@ Tensor untilize_with_halo(const Tensor &input_tensor_a, const uint32_t pad_val, 
     uint32_t halo_out_nsticks = (in_w + window_w / 2 + 2 * pad_w);  // left or right halo
 
     if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        TT_ASSERT(input_tensor_a.shard_spec().value().shard_orientation == ShardOrientation::COL_MAJOR);
+        TT_ASSERT(input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR);
         TT_ASSERT(all_cores.ranges().size() == 1);
         auto core_range = *(all_cores.ranges().begin());
         ncores = core_range.end.x - core_range.start.x + 1;
-        in_nsticks_per_core = input_tensor_a.shard_spec().value().shard_shape[0];
+        in_nsticks_per_core = input_tensor_a.shard_spec().value().shape[0];
     }
 
     auto input_shape = input_tensor_a.shape();

--- a/tt_eager/tt_dnn/op_library/untilize/untilize_with_halo_op_v2.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/untilize_with_halo_op_v2.cpp
@@ -134,7 +134,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     uint32_t ncores_x = grid_size.x;
     uint32_t ncores_y = grid_size.y;
 
-    CoreRangeSet all_cores = input_tensor.shard_spec().value().shard_grid;
+    CoreRangeSet all_cores = input_tensor.shard_spec().value().grid;
     uint32_t ncores = all_cores.num_cores();
     uint32_t ncores_c = 1;
     if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
@@ -145,7 +145,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     log_debug(LogOp, "ncores_c: {}", ncores_c);
     TT_ASSERT(ncores_nhw == ncores);
 
-    auto shard_shape = input_tensor.shard_spec().value().shard_shape;
+    auto shard_shape = input_tensor.shard_spec().value().shape;
     uint32_t ntiles_per_block = shard_shape[1] / TILE_WIDTH;
     uint32_t nblocks_per_core = shard_shape[0] / TILE_HEIGHT;
     uint32_t input_npages = ntiles_per_block * nblocks_per_core;
@@ -639,13 +639,13 @@ std::vector<Tensor> UntilizeWithHaloV2::create_output_tensors(const std::vector<
     auto output_shape = this->compute_output_shapes(input_tensors).at(0);
 
     if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        auto core_range = *(shard_spec.shard_grid.ranges().begin());
+        auto core_range = *(shard_spec.grid.ranges().begin());
         TT_FATAL(ncores_nhw_ == core_range.end.x - core_range.start.x + 1);
     } else {
-        TT_FATAL(ncores_nhw_ == shard_spec.shard_grid.num_cores());
+        TT_FATAL(ncores_nhw_ == shard_spec.grid.num_cores());
     }
     auto out_shard_spec = shard_spec;
-    out_shard_spec.shard_shape[0] = output_shape[0] * div_up(output_shape[2], ncores_nhw_);
+    out_shard_spec.shape[0] = output_shape[0] * div_up(output_shape[2], ncores_nhw_);
     out_shard_spec.halo = true;
     // log_debug(LogOp, "OUTPUT SHARD SPEC: {}", out_shard_spec);
     return {create_sharded_device_tensor(output_shape, output_dtype, Layout::ROW_MAJOR, input_tensor.device(), out_mem_config_, out_shard_spec)};

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -101,14 +101,15 @@ inline std::vector< std::vector<uint32_t> > core_to_host_pages(
 std::string Buffer::get_shard_info() const {
     std::string ret_str = "Shard info for buffer \n";
 
+    auto sspec = shard_spec();
     ret_str += "Page Size " + std::to_string(page_size_) + "\n";
 
-    auto t2d_size = tensor2d_size();
+    auto t2d_size = sspec.tensor2d_shape;
     ret_str += "Tensor2D Size: ("  + std::to_string(t2d_size[0]) + ", " + std::to_string(t2d_size[1]) + ")\n";
-    auto s_shape = shard_shape();
+    auto s_shape = sspec.shape;
     ret_str += "Shard Shape: ("  + std::to_string(s_shape[0]) +  ", " + std::to_string(s_shape[1]) + ")\n"; ;
 
-    auto p_shape = page_shape();
+    auto p_shape = sspec.page_shape;
     ret_str += "Page Shape: ("  + std::to_string(p_shape[0]) +  ", " + std::to_string(p_shape[1]) + ")\n"; ;
 
 
@@ -125,7 +126,7 @@ std::string Buffer::get_shard_info() const {
         core_index++;
     }
     ret_str += "Dev page mappings:\n";;
-    uint32_t num_pages = all_cores_.size() * shard_size();
+    uint32_t num_pages = all_cores_.size() * sspec.size();
     for(uint32_t dev_page_id = 0; dev_page_id < num_pages; dev_page_id ++){
         ret_str += "Dev page: " + std::to_string(dev_page_id) +
             " mapped to core " + all_cores_[dev_page_to_core_mapping_[dev_page_id]].str() +
@@ -155,18 +156,18 @@ Buffer::Buffer(Device *device, uint64_t size, uint64_t page_size, const BufferTy
     TT_FATAL(this->device_ != nullptr and this->device_->allocator_ != nullptr);
     validate_buffer_size_and_page_size(size, page_size, buffer_type, buffer_layout, shard_parameters);
     if(is_sharded(buffer_layout)){
-        auto row_major = shard_parameters.value().shard_orientation == ShardOrientation::ROW_MAJOR;
-        all_cores_ = corerange_to_cores(shard_parameters.value().shard_grid, this->num_cores(), row_major);
+        auto row_major = shard_parameters.value().orientation == ShardOrientation::ROW_MAJOR;
+        all_cores_ = corerange_to_cores(shard_parameters.value().grid, this->num_cores(), row_major);
         TT_ASSERT(this->num_cores() == all_cores_.size());
         uint32_t core_id = 0;
         for(auto core: all_cores_){
             this->core_to_core_id_.insert({core, core_id });
             core_id++;
         }
-        core_host_page_indices_ = core_to_host_pages(shard_size(), this->num_cores(), buffer_layout, page_shape(), shard_shape(), tensor2d_size());
+        core_host_page_indices_ = core_to_host_pages(shard_spec().size(), this->num_cores(), buffer_layout, shard_spec().page_shape, shard_spec().shape, shard_spec().tensor2d_shape);
         core_bank_indices_.reserve(this->num_cores());
 
-        auto total_dev_pages = this->num_cores() * shard_size();
+        auto total_dev_pages = this->num_cores() * shard_spec().size();
         dev_page_to_host_page_mapping_ = std::vector<uint32_t>(total_dev_pages);
         dev_page_to_core_mapping_ = std::vector<uint32_t>(total_dev_pages);
         for(auto core : all_cores_){
@@ -293,7 +294,7 @@ uint64_t Buffer::page_address(uint32_t bank_id, uint32_t page_index) const {
 
     int pages_offset_within_bank = (int)page_index / num_banks;
     if( is_sharded(this->buffer_layout_)){
-        pages_offset_within_bank = page_index % shard_size();
+        pages_offset_within_bank = page_index % shard_spec().size();
     }
     auto offset = (round_up(this->page_size_, ADDRESS_ALIGNMENT) * pages_offset_within_bank);
     return base_page_address + offset;
@@ -322,21 +323,21 @@ Buffer::~Buffer() {
 
 tt::stl::reflection::Attributes ShardSpec::attributes() const {
     return {
-        {"shard_grid", this->shard_grid.str()},
-        {"shard_shape", this->shard_shape},
-        {"shard_orientation", this->shard_orientation},
+        {"shard_grid", this->grid.str()},
+        {"shard_shape", this->shape},
+        {"shard_orientation", this->orientation},
         {"halo", this->halo},
     };
 }
 
 bool operator==(const ShardSpec& spec_a, const ShardSpec& spec_b) {
-    if (spec_a.shard_shape != spec_b.shard_shape) {
+    if (spec_a.shape != spec_b.shape) {
         return false;
     }
-    if (spec_a.shard_grid != spec_b.shard_grid) {
+    if (spec_a.grid != spec_b.grid) {
         return false;
     }
-    if (spec_a.shard_orientation != spec_b.shard_orientation) {
+    if (spec_a.orientation != spec_b.orientation) {
         return false;
     }
     return true;

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -62,7 +62,8 @@ struct ShardSpec {
 };
 
 
-struct ShardSpecBuffer:  ShardSpec {
+struct ShardSpecBuffer {
+    ShardSpec tensor_shard_spec;
     std::array<uint32_t, 2> page_shape;
     std::array<uint32_t, 2 > tensor2d_shape;
     ShardSpecBuffer(const CoreRangeSet & core_sets_,
@@ -71,7 +72,7 @@ struct ShardSpecBuffer:  ShardSpec {
                 const bool & halo_,
                 const std::array<uint32_t, 2> & page_shape,
                 const std::array<uint32_t, 2> & tensor2d_shape
-                ): ShardSpec(core_sets_, shard_shape_, shard_orientation_, halo_)
+                ): tensor_shard_spec(core_sets_, shard_shape_, shard_orientation_, halo_)
                 {
                     this->page_shape = page_shape;
                     this->tensor2d_shape = tensor2d_shape;
@@ -80,14 +81,26 @@ struct ShardSpecBuffer:  ShardSpec {
             const ShardSpec & shard_spec,
             const std::array<uint32_t, 2> & page_shape,
             const std::array<uint32_t, 2> & tensor2d_shape
-            ): ShardSpec(shard_spec)
+            ): tensor_shard_spec(shard_spec)
             {
                 this->page_shape = page_shape;
                 this-> tensor2d_shape = tensor2d_shape;
             }
+    CoreRangeSet grid() {
+        return tensor_shard_spec.grid;
+    }
+    std::array<uint32_t, 2>  shape() {
+        return tensor_shard_spec.shape;
+    }
+    ShardOrientation orientation() {
+        return tensor_shard_spec.orientation;
+    }
+    bool halo() {
+        return tensor_shard_spec.halo;
+    }
     uint32_t size(){
-        auto width_in_pages = this->shape[0] / this->page_shape[0];
-        auto height_in_pages = this->shape[1] / this->page_shape[1];
+        auto width_in_pages = tensor_shard_spec.shape[0] / page_shape[0];
+        auto height_in_pages = tensor_shard_spec.shape[1] / page_shape[1];
         return width_in_pages * height_in_pages;
 
     }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -326,7 +326,7 @@ const DeviceCommand EnqueueReadBufferCommand::assemble_device_command(uint32_t d
 
     if (is_sharded(this->buffer.buffer_layout())) {
         uint32_t num_cores = this->buffer.num_cores();
-        uint32_t shard_size = this->buffer.shard_size();
+        uint32_t shard_size = this->buffer.shard_spec().size();
         //TODO: for now all shards are same size of pages
         vector<uint32_t> num_pages_in_shards(num_cores, shard_size);
         vector<uint32_t> core_id_x;
@@ -435,7 +435,7 @@ const DeviceCommand EnqueueWriteBufferCommand::assemble_device_command(uint32_t 
     uint32_t src_page_index = 0;
     if (is_sharded(this->buffer.buffer_layout())) {
         uint32_t num_cores = this->buffer.num_cores();
-        uint32_t shard_size = this->buffer.shard_size();
+        uint32_t shard_size = this->buffer.shard_spec().size();
         //TODO: for now all shards are same size of pages
         vector<uint32_t> num_pages_in_shards(num_cores, shard_size);
         vector<uint32_t> core_id_x;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -79,6 +79,10 @@ class EnqueueReadBufferCommand : public Command {
     uint32_t pages_to_read;
     static constexpr EnqueueCommandType type_ = EnqueueCommandType::ENQUEUE_READ_BUFFER;
 
+    const DeviceCommand assemble_device_command_postamble(const DeviceCommand & input_cmd,
+                                    uint32_t padded_page_size,
+                                    uint32_t num_pages);
+
    public:
     Buffer& buffer;
     uint32_t read_buffer_addr;
@@ -91,6 +95,7 @@ class EnqueueReadBufferCommand : public Command {
         std::optional<uint32_t> pages_to_read = std::nullopt);
 
     const DeviceCommand assemble_device_command(uint32_t dst);
+    const DeviceCommand assemble_device_command_sharded(uint32_t dst);
 
     void process();
 
@@ -107,6 +112,10 @@ class EnqueueWriteBufferCommand : public Command {
     uint32_t dst_page_index;
     uint32_t pages_to_write;
     static constexpr EnqueueCommandType type_ = EnqueueCommandType::ENQUEUE_WRITE_BUFFER;
+
+    const DeviceCommand assemble_device_command_postamble(const DeviceCommand & input_cmd,
+                                    uint32_t padded_page_size,
+                                    uint32_t num_pages);
    public:
     EnqueueWriteBufferCommand(
         Device* device,
@@ -117,6 +126,7 @@ class EnqueueWriteBufferCommand : public Command {
         std::optional<uint32_t> pages_to_write = std::nullopt);
 
     const DeviceCommand assemble_device_command(uint32_t src_address);
+    const DeviceCommand assemble_device_command_sharded(uint32_t src_address);
 
     void process();
 

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -69,6 +69,38 @@ void DeviceCommand::set_producer_consumer_transfer_num_pages(const uint32_t prod
     this->desc[this->producer_consumer_transfer_num_pages_idx] = producer_consumer_transfer_num_pages;
 }
 
+void DeviceCommand::add_buffer_transfer_instruction_preamble(
+    const uint32_t src,
+    const uint32_t dst,
+    const uint32_t num_pages,
+    const uint32_t padded_page_size,
+    const uint32_t src_buf_type,
+    const uint32_t dst_buf_type,
+    const uint32_t src_page_index,
+    const uint32_t dst_page_index
+)
+{
+    this->desc[this->buffer_transfer_idx] = src;
+    this->desc[this->buffer_transfer_idx + 1] = dst;
+    this->desc[this->buffer_transfer_idx + 2] = num_pages;
+    this->desc[this->buffer_transfer_idx + 3] = padded_page_size;
+    this->desc[this->buffer_transfer_idx + 4] = src_buf_type;
+    this->desc[this->buffer_transfer_idx + 5] = dst_buf_type;
+    this->desc[this->buffer_transfer_idx + 6] = src_page_index;
+    this->desc[this->buffer_transfer_idx + 7] = dst_page_index;
+
+}
+
+void DeviceCommand::add_buffer_transfer_instruction_postamble(){
+    this->buffer_transfer_idx += DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION;
+
+    this->desc[this->num_buffer_transfers_idx]++;
+    TT_ASSERT(
+        this->desc[this->num_buffer_transfers_idx] <= DeviceCommand::NUM_POSSIBLE_BUFFER_TRANSFERS,
+        "Surpassing the limit of {} on possible buffer transfers in a single command",
+        DeviceCommand::NUM_POSSIBLE_BUFFER_TRANSFERS);
+}
+
 void DeviceCommand::add_buffer_transfer_instruction(
     const uint32_t src,
     const uint32_t dst,
@@ -78,21 +110,13 @@ void DeviceCommand::add_buffer_transfer_instruction(
     const uint32_t dst_buf_type,
     const uint32_t src_page_index,
     const uint32_t dst_page_index) {
-    this->desc[this->buffer_transfer_idx] = src;
-    this->desc[this->buffer_transfer_idx + 1] = dst;
-    this->desc[this->buffer_transfer_idx + 2] = num_pages;
-    this->desc[this->buffer_transfer_idx + 3] = padded_page_size;
-    this->desc[this->buffer_transfer_idx + 4] = src_buf_type;
-    this->desc[this->buffer_transfer_idx + 5] = dst_buf_type;
-    this->desc[this->buffer_transfer_idx + 6] = src_page_index;
-    this->desc[this->buffer_transfer_idx + 7] = dst_page_index;
-    this->buffer_transfer_idx += DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION;
 
-    this->desc[this->num_buffer_transfers_idx]++;
-    TT_ASSERT(
-        this->desc[this->num_buffer_transfers_idx] <= DeviceCommand::NUM_POSSIBLE_BUFFER_TRANSFERS,
-        "Surpassing the limit of {} on possible buffer transfers in a single command",
-        DeviceCommand::NUM_POSSIBLE_BUFFER_TRANSFERS);
+    this->add_buffer_transfer_instruction_preamble(src, dst, num_pages, padded_page_size,
+                                        src_buf_type, dst_buf_type,
+                                        src_page_index, dst_page_index
+                                        );
+    this->add_buffer_transfer_instruction_postamble();
+
 }
 
 
@@ -111,31 +135,25 @@ void DeviceCommand::add_buffer_transfer_instruction_sharded(
     ) {
 
 
+    this->add_buffer_transfer_instruction_preamble(src, dst, num_pages, padded_page_size,
+                                        src_buf_type, dst_buf_type,
+                                        src_page_index, dst_page_index
+                                        );
+
+
+    // Shard specific portion of instruction
     TT_ASSERT(core_id_x.size() == core_id_y.size());
     TT_ASSERT(core_id_x.size() == num_pages_in_shard.size());
     uint32_t num_shards = core_id_x.size();
-
-    uint32_t idx_offset = 0;
-    this->desc[this->buffer_transfer_idx + idx_offset++] = src;
-    this->desc[this->buffer_transfer_idx + idx_offset++] = dst;
-    this->desc[this->buffer_transfer_idx + idx_offset++] = num_pages;
-    this->desc[this->buffer_transfer_idx + idx_offset++] = padded_page_size;
-    this->desc[this->buffer_transfer_idx + idx_offset++] = src_buf_type;
-    this->desc[this->buffer_transfer_idx + idx_offset++] = dst_buf_type;
-    this->desc[this->buffer_transfer_idx + idx_offset++] = src_page_index;
-    this->desc[this->buffer_transfer_idx + idx_offset++] = dst_page_index;
+    uint32_t idx_offset = COMMAND_PTR_SHARD_IDX;
     for (auto shard_id = 0; shard_id < num_shards; shard_id++) {
         this->desc[this->buffer_transfer_idx + idx_offset++] = num_pages_in_shard[shard_id];
         this->desc[this->buffer_transfer_idx + idx_offset++] = core_id_x[shard_id];
         this->desc[this->buffer_transfer_idx + idx_offset++] = core_id_y[shard_id];
     }
-    this->buffer_transfer_idx += DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION;
 
-    this->desc[this->num_buffer_transfers_idx]++;
-    TT_ASSERT(
-        this->desc[this->num_buffer_transfers_idx] <= DeviceCommand::NUM_POSSIBLE_BUFFER_TRANSFERS,
-        "Surpassing the limit of {} on possible buffer transfers in a single command",
-        DeviceCommand::NUM_POSSIBLE_BUFFER_TRANSFERS);
+
+    this->add_buffer_transfer_instruction_postamble();
 }
 
 void DeviceCommand::write_program_entry(const uint32_t value) {

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -134,4 +134,15 @@ class DeviceCommand {
     std::array<uint32_t, DeviceCommand::NUM_ENTRIES_IN_DEVICE_COMMAND> desc;
     uint32_t buffer_transfer_idx;
     uint32_t program_transfer_idx;
+    void add_buffer_transfer_instruction_preamble(
+        const uint32_t src,
+        const uint32_t dst,
+        const uint32_t num_pages,
+        const uint32_t padded_page_size,
+        const uint32_t src_buf_type,
+        const uint32_t dst_buf_type,
+        const uint32_t src_page_index,
+        const uint32_t dst_page_index
+        );
+    void add_buffer_transfer_instruction_postamble();
 };

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -124,18 +124,15 @@ namespace detail {
         #ifdef DEBUG_PRINT_SHARD
             std::cout << "Writing to Device Sharded " << std::endl;
         #endif
-        auto cores = buffer.all_cores();
-        auto core_bank_ids = buffer.core_bank_indices();
         auto core_host_page_ids = buffer.core_host_page_indices();
 
 
         int dev_page_index = 0;
-        for(int core_index = 0; core_index < cores.size(); core_index++){
-            auto core = cores[core_index];
-            auto bank_id = core_bank_ids[core_index];
+        for(int core_index = 0; core_index < buffer.num_cores(); core_index++){
+            auto bank_id = buffer.get_bank_id_from_page_id(dev_page_index);
             auto host_page_ids = core_host_page_ids[core_index];
             for(auto host_page_id: host_page_ids){
-                auto absolute_address = buffer.page_address(bank_id, dev_page_index);
+                auto absolute_address = buffer.page_address(dev_page_index);
                 auto data_index = host_page_id * num_entries_per_page;
                 std::vector<uint32_t> page;
                 page.insert(
@@ -268,7 +265,7 @@ namespace detail {
                                   const uint32_t & dev_page_id,
                                   const uint32_t & bank_id
     ){
-        auto absolute_address = dev_buffer.page_address(bank_id, dev_page_id);
+        auto absolute_address = dev_buffer.page_address(dev_page_id);
         auto noc_coordinates = dev_buffer.noc_coordinates(bank_id);
 
         uint32_t num_entries_per_page = page_size/sizeof(uint32_t);
@@ -291,18 +288,9 @@ namespace detail {
             std::cout << "Reading From Device Height Sharded " << std::endl;
         #endif
 
-        auto cores = buffer.all_cores();
-        auto core_bank_ids = buffer.core_bank_indices();
-        auto core_dev_page_ids = buffer.core_host_page_indices();
-        auto host_page_ids = buffer.dev_page_to_host_page_mapping();
 
         int output_page_index = 0;
-
-        auto total_pages = cores.size() * buffer.shard_spec().size();
-        auto dev_page_to_core_mapping = buffer.dev_page_to_core_mapping();
-
-
-
+        auto total_pages = buffer.num_pages();
         uint32_t page_size = buffer.page_size();
         uint32_t bytes_per_page_entry = sizeof(uint32_t);
         uint32_t num_entries_per_page = page_size / bytes_per_page_entry;
@@ -311,10 +299,8 @@ namespace detail {
 
 
         for(int dev_page_id=0; dev_page_id<total_pages; dev_page_id++){
-            auto core_index = dev_page_to_core_mapping[dev_page_id];
-            auto core = cores[core_index];
-            auto bank_id = core_bank_ids[core_index];
-            auto host_page_id = host_page_ids[dev_page_id];
+            auto bank_id = buffer.get_bank_id_from_page_id(dev_page_id);
+            auto host_page_id = buffer.get_mapped_page_id(dev_page_id);
             if(!shard_order){
                 read_pages_to_host_helper(
                     device,
@@ -337,9 +323,6 @@ namespace detail {
                     bank_id
                 );
             }
-            #ifdef DEBUG_PRINT_SHARD
-                print_page(dev_page_id, core, host_page_id, noc_coordinates, absolute_address, bank_id,  page);
-            #endif
         }
 
     }
@@ -396,13 +379,9 @@ namespace detail {
 
         auto page_ids = buffer.dev_pages_in_shard(core_id);
 
-        auto core_bank_ids = buffer.core_bank_indices();
-        auto dev_page_to_core_mapping = buffer.dev_page_to_core_mapping();
-
         uint32_t host_page_id = 0;
         for(auto dev_page_id: page_ids){
-            auto core_index = dev_page_to_core_mapping[dev_page_id];
-            auto bank_id = core_bank_ids[core_index];
+            auto bank_id = buffer.get_bank_id_from_page_id(dev_page_id);
             read_pages_to_host_helper(
                 device,
                 buffer,

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -298,7 +298,7 @@ namespace detail {
 
         int output_page_index = 0;
 
-        auto total_pages = cores.size() * buffer.shard_size();
+        auto total_pages = cores.size() * buffer.shard_spec().size();
         auto dev_page_to_core_mapping = buffer.dev_page_to_core_mapping();
 
 
@@ -391,7 +391,7 @@ namespace detail {
         host_buffer.clear();  // overwrite the data
 
         uint32_t num_entries_per_page = buffer.page_size() / sizeof(uint32_t);
-        uint32_t num_entries_per_shard = num_entries_per_page * buffer.shard_size();
+        uint32_t num_entries_per_shard = num_entries_per_page * buffer.shard_spec().size();
         host_buffer = std::vector<uint32_t>(num_entries_per_shard);
 
         auto page_ids = buffer.dev_pages_in_shard(core_id);


### PR DESCRIPTION
This PR is the first of 2 PRs refactoring the sharded buffer and sharded buffer spec.

The sharded spec is used within the tensor and the buffer, but only the buffer had lower level information (page shape, tensor2d shape), this has been refactored to be two different structs (using inheritance).

Secondly this PR lays some of the groundwork for separating the sharded buffer into a separate class. Higher-level APIs that use members within the shard spec now first call the shard spec and then call the specific member. This will be easier to migrate to a different class once they are split up .

Thirdly, changed member variable names in shard spec, it's redundant for every member variable to start with "shard_". 

The splitting up will be done in a subsequent PR