### PR TITLE
#2470: revert SHAID ca63a16373de942f

### DIFF
--- a/tests/tt_eager/ops/test_reduce_op.cpp
+++ b/tests/tt_eager/ops/test_reduce_op.cpp
@@ -99,8 +99,9 @@ int main () {
     auto some_tensor = tt::numpy::random::uniform(bfloat16(0.0f), bfloat16(0.0f), {1, 1, 32, 32}).to(Layout::TILE).to(device);
 
     run_reduce_ops();
+
     TT_FATAL(
-        tt::tt_metal::program_cache::num_entries() >= 5,
+        tt::tt_metal::program_cache::num_entries() == 6,
         "There are {} entries",
         tt::tt_metal::program_cache::num_entries());
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_reduce.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_reduce.py
@@ -49,6 +49,7 @@ shapes2 = (
 )
 
 
+@pytest.mark.skipif(is_wormhole_b0(), reason="poor PCC")
 @pytest.mark.parametrize("input_shapes", shapes2)
 @pytest.mark.parametrize("minmax", ["min", "max"])
 def test_run_reduce_max_w_test(input_shapes, minmax, device, function_level_defaults):

--- a/tt_eager/tt_dnn/op_library/reduce/reduce_op.hpp
+++ b/tt_eager/tt_dnn/op_library/reduce/reduce_op.hpp
@@ -50,7 +50,6 @@ struct Reduce {
 };
 
 Tensor reduce(const Tensor &input_tensor, ReduceOpMath reduce_math, ReduceOpDim reduce_dim, float scaler = 1.0f, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, const std::optional<DataType>& output_dtype=std::nullopt);
-Tensor max(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 Tensor sum(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 Tensor mean(const Tensor& input_tensor, uint aggregate_dims=2, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 Tensor mean_hw(const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);


### PR DESCRIPTION
Revert "2470: reduce sum, max for dim=[N,C,H,W][2] will need transpose-compute-transpose on the WH B0 architecture today"

This reverts commit ca63a16373de942f22d96ea9fccc0cba2b06d29f.