### PR TITLE
#4549: disable failing DPRINT tests

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
@@ -62,7 +62,8 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
     );
 }
 
-TEST_F(DPrintFixture, TestPrintMuting) {
+// See issue #4549
+TEST_F(DPrintFixture, DISABLED_TestPrintMuting) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
@@ -289,7 +289,8 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
     );
 }
 
-TEST_F(DPrintFixture, TestPrintRaiseWait) {
+//See issue #4549
+TEST_F(DPrintFixture, DISABLED_TestPrintRaiseWait) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }


### PR DESCRIPTION
These tests are failing on BM only for some reason