### PR TITLE
Add Causal Mask support for Softmax

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_softmax.py
@@ -19,87 +19,92 @@ from models.utility_functions import skip_for_wormhole_b0
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
 
 
-@skip_for_wormhole_b0()
-@pytest.mark.parametrize("inplace", [True, False])
-def test_softmax(device, inplace):
-    torch.manual_seed(0)
-    sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
+# @skip_for_wormhole_b0()
+# @pytest.mark.parametrize("inplace", [True, False])
+# def test_softmax(device, inplace):
+#     torch.manual_seed(0)
+#     sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
 
-    input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
+#     input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
 
-    for input_shape in input_shapes:
-        input_tensor = torch.randn(input_shape).bfloat16()
+#     for input_shape in input_shapes:
+#         input_tensor = torch.randn(input_shape).bfloat16()
 
-        tt_input_tensor = (
-            ttl.tensor.Tensor(input_tensor, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
-        )
-        tt_output_tensor_on_device = sm_op(tt_input_tensor)
-        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+#         tt_input_tensor = (
+#             ttl.tensor.Tensor(input_tensor, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+#         )
+#         tt_output_tensor_on_device = sm_op(tt_input_tensor)
+#         tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
-        golden_output_tensor = torch.softmax(input_tensor, dim=-1)
-        print_diff_argmax(tt_output_tensor, golden_output_tensor)
+#         golden_output_tensor = torch.softmax(input_tensor, dim=-1)
+#         print_diff_argmax(tt_output_tensor, golden_output_tensor)
 
-        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-        assert allclose, f"FAILED: {output}"
+#         allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+#         assert allclose, f"FAILED: {output}"
 
 
-@skip_for_wormhole_b0()
-@pytest.mark.parametrize("inplace", [True, False])
-def test_softmax_with_program_cache(device, use_program_cache, inplace):
-    torch.manual_seed(0)
-    sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
+# @skip_for_wormhole_b0()
+# @pytest.mark.parametrize("inplace", [True, False])
+# def test_softmax_with_program_cache(device, use_program_cache, inplace):
+#     torch.manual_seed(0)
+#     sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
 
-    input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
+#     input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
 
-    for input_shape in input_shapes:
-        input_tensor = torch.randn(input_shape).bfloat16()
+#     for input_shape in input_shapes:
+#         input_tensor = torch.randn(input_shape).bfloat16()
 
-        tt_input_tensor = (
-            ttl.tensor.Tensor(input_tensor, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
-        )
-        tt_output_tensor_on_device = sm_op(tt_input_tensor)
-        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+#         tt_input_tensor = (
+#             ttl.tensor.Tensor(input_tensor, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+#         )
+#         tt_output_tensor_on_device = sm_op(tt_input_tensor)
+#         tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
-        golden_output_tensor = torch.softmax(input_tensor, dim=-1)
-        print_diff_argmax(tt_output_tensor, golden_output_tensor)
+#         golden_output_tensor = torch.softmax(input_tensor, dim=-1)
+#         print_diff_argmax(tt_output_tensor, golden_output_tensor)
 
-        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-        assert allclose, f"FAILED: {output}"
+#         allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+#         assert allclose, f"FAILED: {output}"
+
+
+# @skip_for_wormhole_b0()
+# @pytest.mark.parametrize(
+#     "cb_dtype",
+#     (ttl.tensor.DataType.BFLOAT16,),
+#     ids=["BFLOAT16"],
+# )
+# @pytest.mark.parametrize(
+#     "in_dtype",
+#     (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
+#     ids=["BFLOAT16", "BFLOAT8_B"],
+# )
+# @pytest.mark.parametrize("inplace", [True, False])
+# def test_softmax_mix_precision(device, inplace, in_dtype, cb_dtype):
+#     torch.manual_seed(0)
+#     sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
+
+#     input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
+
+#     for input_shape in input_shapes:
+#         input_tensor = torch.randn(input_shape).bfloat16()
+
+#         tt_input_tensor = ttl.tensor.Tensor(input_tensor, in_dtype).to(ttl.tensor.Layout.TILE).to(device)
+#         tt_output_tensor_on_device = sm_op(tt_input_tensor)
+#         tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+
+#         golden_output_tensor = torch.softmax(input_tensor, dim=-1)
+#         print_diff_argmax(tt_output_tensor, golden_output_tensor)
+
+#         allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+#         assert allclose, f"FAILED: {output}"
 
 
 @skip_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "cb_dtype",
-    (ttl.tensor.DataType.BFLOAT16,),
-    ids=["BFLOAT16"],
+    "seq_len",
+    [64, 384],
+    ids=["64", "384"],
 )
-@pytest.mark.parametrize(
-    "in_dtype",
-    (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
-    ids=["BFLOAT16", "BFLOAT8_B"],
-)
-@pytest.mark.parametrize("inplace", [True, False])
-def test_softmax_mix_precision(device, inplace, in_dtype, cb_dtype):
-    torch.manual_seed(0)
-    sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
-
-    input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
-
-    for input_shape in input_shapes:
-        input_tensor = torch.randn(input_shape).bfloat16()
-
-        tt_input_tensor = ttl.tensor.Tensor(input_tensor, in_dtype).to(ttl.tensor.Layout.TILE).to(device)
-        tt_output_tensor_on_device = sm_op(tt_input_tensor)
-        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-
-        golden_output_tensor = torch.softmax(input_tensor, dim=-1)
-        print_diff_argmax(tt_output_tensor, golden_output_tensor)
-
-        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-        assert allclose, f"FAILED: {output}"
-
-
-@skip_for_wormhole_b0()
 @pytest.mark.parametrize(
     "casual_mask",
     [True, False],
@@ -120,14 +125,14 @@ def test_softmax_mix_precision(device, inplace, in_dtype, cb_dtype):
     ),
     ids=["BFLOAT16", "BFLOAT8_B"],
 )
-def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, casual_mask):
+def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, casual_mask, seq_len):
     torch.manual_seed(0)
     fuse_head = 2
 
     grid_size = (12, 8)
     batch = grid_size[0]
     num_cores_r = grid_size[1]
-    input_shape = (batch, 1, num_cores_r * fuse_head * 384, 384)
+    input_shape = (batch, 1, num_cores_r * fuse_head * seq_len, seq_len)
     M = input_shape[2]
     K = input_shape[3] * batch
 
@@ -137,25 +142,25 @@ def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, casual_mas
     scale = 1 / math.sqrt(hidden_dim // num_heads)
 
     if casual_mask == False:
-        attention_mask = torch.rand(batch, 1, 32, 384)
+        attention_mask = torch.rand(batch, 1, 32, seq_len)
         attention_mask = (attention_mask > 0.5).float()
         attention_mask32 = tilize_to_list(pad_weight(attention_mask))
         attention_mask_t = ttl.tensor.Tensor(
             attention_mask32,
-            [batch, 1, 32, 384],
+            [batch, 1, 32, seq_len],
             ttl.tensor.DataType.BFLOAT16,
             ttl.tensor.Layout.TILE,
             device,
             ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
         )
     else:
-        # attention_mask = torch.zeros(batch, 1, 384, 384)
-        attention_mask = torch.rand(batch, 1, 384, 384)
+        # attention_mask = torch.zeros(batch, 1, seq_len, seq_len)
+        attention_mask = torch.rand(batch, 1, seq_len, seq_len)
         attention_mask = (attention_mask > 0.5).float()
         attention_mask32 = tilize_to_list(pad_weight(attention_mask))
         attention_mask_t = ttl.tensor.Tensor(
             attention_mask32,
-            [batch, 1, 384, 384],
+            [batch, 1, seq_len, seq_len],
             ttl.tensor.DataType.BFLOAT16,
             ttl.tensor.Layout.TILE,
             device,
@@ -165,14 +170,16 @@ def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, casual_mas
     input_tensor = torch.randn(input_shape).bfloat16().float()
     in1_t = torch2tt_tensor(input_tensor, device, tt_memory_config=in0_mem_config, tt_dtype=in_dtype)
 
-    tt_output = ttl.operations.primary.transformers.scale_mask_softmax_in_place(in1_t, scale, attention_mask_t)
+    tt_output = ttl.operations.primary.transformers.scale_mask_softmax_in_place(
+        in1_t, scale, attention_mask_t, is_causal_mask=casual_mask
+    )
 
     tt_output_tensor = tt_output.cpu().to_torch().float()
     tt_output_tensor = torch.Tensor(tt_output_tensor).reshape(input_shape)
     tt_output_tensor = untilize(tt_output_tensor)
 
     if casual_mask == False:
-        attention_mask = attention_mask.reshape(batch, 1, 32, 384)[:, :, 0, :]
+        attention_mask = attention_mask.reshape(batch, 1, 32, seq_len)[:, :, 0, :]
     else:
         attention_mask = attention_mask.repeat(1, 1, num_cores_r * fuse_head, 1)
 
@@ -188,65 +195,65 @@ def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, casual_mas
         assert allclose, f"FAILED: {output}"
 
 
-@skip_for_wormhole_b0()
-@pytest.mark.parametrize(
-    "in0_mem_config",
-    (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),),
-    ids=[
-        "in0_DRAM",
-    ],
-)
-@pytest.mark.parametrize(
-    "in_dtype",
-    (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
-    ids=["BFLOAT16", "BFLOAT8_B"],
-)
-def test_scale_mask_softmax(device, in_dtype, in0_mem_config):
-    torch.manual_seed(0)
-    fuse_head = 2
+# @skip_for_wormhole_b0()
+# @pytest.mark.parametrize(
+#     "in0_mem_config",
+#     (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),),
+#     ids=[
+#         "in0_DRAM",
+#     ],
+# )
+# @pytest.mark.parametrize(
+#     "in_dtype",
+#     (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
+#     ids=["BFLOAT16", "BFLOAT8_B"],
+# )
+# def test_scale_mask_softmax(device, in_dtype, in0_mem_config):
+#     torch.manual_seed(0)
+#     fuse_head = 2
 
-    grid_size = (12, 8)
-    batch = grid_size[0]
-    num_cores_r = grid_size[1]
-    input_shape = (batch, 1, num_cores_r * fuse_head * 384, 384)
-    M = input_shape[2]
-    K = input_shape[3] * batch
+#     grid_size = (12, 8)
+#     batch = grid_size[0]
+#     num_cores_r = grid_size[1]
+#     input_shape = (batch, 1, num_cores_r * fuse_head * 384, 384)
+#     M = input_shape[2]
+#     K = input_shape[3] * batch
 
-    hidden_dim = 1024
-    num_heads = 16
-    scale = 1 / math.sqrt(hidden_dim // num_heads)
-    attention_mask = torch.rand(batch, 1, 32, 384)
-    attention_mask = (attention_mask > 0.5).float()
-    attention_mask32 = tilize_to_list(pad_weight(attention_mask))
-    attention_mask_t = ttl.tensor.Tensor(
-        attention_mask32,
-        [batch, 1, 32, 384],
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.Layout.TILE,
-        device,
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
-    )
+#     hidden_dim = 1024
+#     num_heads = 16
+#     scale = 1 / math.sqrt(hidden_dim // num_heads)
+#     attention_mask = torch.rand(batch, 1, 32, 384)
+#     attention_mask = (attention_mask > 0.5).float()
+#     attention_mask32 = tilize_to_list(pad_weight(attention_mask))
+#     attention_mask_t = ttl.tensor.Tensor(
+#         attention_mask32,
+#         [batch, 1, 32, 384],
+#         ttl.tensor.DataType.BFLOAT16,
+#         ttl.tensor.Layout.TILE,
+#         device,
+#         ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+#     )
 
-    input_tensor = torch.randn(input_shape).bfloat16().float()
-    in1_t = torch2tt_tensor(input_tensor, device, tt_memory_config=in0_mem_config, tt_dtype=in_dtype)
+#     input_tensor = torch.randn(input_shape).bfloat16().float()
+#     in1_t = torch2tt_tensor(input_tensor, device, tt_memory_config=in0_mem_config, tt_dtype=in_dtype)
 
-    tt_output = ttl.tensor.scale_mask_softmax(in1_t, scale, attention_mask_t)
+#     tt_output = ttl.tensor.scale_mask_softmax(in1_t, scale, attention_mask_t)
 
-    tt_output_tensor = tt_output.cpu().to_torch().float()
-    tt_output_tensor = torch.Tensor(tt_output_tensor).reshape(input_shape)
-    tt_output_tensor = untilize(tt_output_tensor)
+#     tt_output_tensor = tt_output.cpu().to_torch().float()
+#     tt_output_tensor = torch.Tensor(tt_output_tensor).reshape(input_shape)
+#     tt_output_tensor = untilize(tt_output_tensor)
 
-    attention_mask = attention_mask.reshape(batch, 1, 32, 384)
+#     attention_mask = attention_mask.reshape(batch, 1, 32, 384)
 
-    attention_mask_ref = attention_mask[:, :, 0, :]
+#     attention_mask_ref = attention_mask[:, :, 0, :]
 
-    for i in range(batch):
-        golden_output_tensor = input_tensor[i] * scale + attention_mask_ref[i]
-        golden_output_tensor = torch.softmax(golden_output_tensor, dim=-1)
+#     for i in range(batch):
+#         golden_output_tensor = input_tensor[i] * scale + attention_mask_ref[i]
+#         golden_output_tensor = torch.softmax(golden_output_tensor, dim=-1)
 
-        allclose, output = comp_pcc(
-            tt_output_tensor[i],
-            golden_output_tensor,
-        )
-        logger.info(output)
-        assert allclose, f"FAILED: {output}"
+#         allclose, output = comp_pcc(
+#             tt_output_tensor[i],
+#             golden_output_tensor,
+#         )
+#         logger.info(output)
+#         assert allclose, f"FAILED: {output}"

--- a/tests/tt_eager/python_api_testing/unit_testing/test_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_softmax.py
@@ -19,84 +19,84 @@ from models.utility_functions import skip_for_wormhole_b0
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
 
 
-# @skip_for_wormhole_b0()
-# @pytest.mark.parametrize("inplace", [True, False])
-# def test_softmax(device, inplace):
-#     torch.manual_seed(0)
-#     sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("inplace", [True, False])
+def test_softmax(device, inplace):
+    torch.manual_seed(0)
+    sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
 
-#     input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
+    input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
 
-#     for input_shape in input_shapes:
-#         input_tensor = torch.randn(input_shape).bfloat16()
+    for input_shape in input_shapes:
+        input_tensor = torch.randn(input_shape).bfloat16()
 
-#         tt_input_tensor = (
-#             ttl.tensor.Tensor(input_tensor, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
-#         )
-#         tt_output_tensor_on_device = sm_op(tt_input_tensor)
-#         tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        tt_input_tensor = (
+            ttl.tensor.Tensor(input_tensor, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+        )
+        tt_output_tensor_on_device = sm_op(tt_input_tensor)
+        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
-#         golden_output_tensor = torch.softmax(input_tensor, dim=-1)
-#         print_diff_argmax(tt_output_tensor, golden_output_tensor)
+        golden_output_tensor = torch.softmax(input_tensor, dim=-1)
+        print_diff_argmax(tt_output_tensor, golden_output_tensor)
 
-#         allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-#         assert allclose, f"FAILED: {output}"
-
-
-# @skip_for_wormhole_b0()
-# @pytest.mark.parametrize("inplace", [True, False])
-# def test_softmax_with_program_cache(device, use_program_cache, inplace):
-#     torch.manual_seed(0)
-#     sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
-
-#     input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
-
-#     for input_shape in input_shapes:
-#         input_tensor = torch.randn(input_shape).bfloat16()
-
-#         tt_input_tensor = (
-#             ttl.tensor.Tensor(input_tensor, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
-#         )
-#         tt_output_tensor_on_device = sm_op(tt_input_tensor)
-#         tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-
-#         golden_output_tensor = torch.softmax(input_tensor, dim=-1)
-#         print_diff_argmax(tt_output_tensor, golden_output_tensor)
-
-#         allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-#         assert allclose, f"FAILED: {output}"
+        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+        assert allclose, f"FAILED: {output}"
 
 
-# @skip_for_wormhole_b0()
-# @pytest.mark.parametrize(
-#     "cb_dtype",
-#     (ttl.tensor.DataType.BFLOAT16,),
-#     ids=["BFLOAT16"],
-# )
-# @pytest.mark.parametrize(
-#     "in_dtype",
-#     (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
-#     ids=["BFLOAT16", "BFLOAT8_B"],
-# )
-# @pytest.mark.parametrize("inplace", [True, False])
-# def test_softmax_mix_precision(device, inplace, in_dtype, cb_dtype):
-#     torch.manual_seed(0)
-#     sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("inplace", [True, False])
+def test_softmax_with_program_cache(device, use_program_cache, inplace):
+    torch.manual_seed(0)
+    sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
 
-#     input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
+    input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
 
-#     for input_shape in input_shapes:
-#         input_tensor = torch.randn(input_shape).bfloat16()
+    for input_shape in input_shapes:
+        input_tensor = torch.randn(input_shape).bfloat16()
 
-#         tt_input_tensor = ttl.tensor.Tensor(input_tensor, in_dtype).to(ttl.tensor.Layout.TILE).to(device)
-#         tt_output_tensor_on_device = sm_op(tt_input_tensor)
-#         tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        tt_input_tensor = (
+            ttl.tensor.Tensor(input_tensor, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+        )
+        tt_output_tensor_on_device = sm_op(tt_input_tensor)
+        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
-#         golden_output_tensor = torch.softmax(input_tensor, dim=-1)
-#         print_diff_argmax(tt_output_tensor, golden_output_tensor)
+        golden_output_tensor = torch.softmax(input_tensor, dim=-1)
+        print_diff_argmax(tt_output_tensor, golden_output_tensor)
 
-#         allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-#         assert allclose, f"FAILED: {output}"
+        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+        assert allclose, f"FAILED: {output}"
+
+
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "cb_dtype",
+    (ttl.tensor.DataType.BFLOAT16,),
+    ids=["BFLOAT16"],
+)
+@pytest.mark.parametrize(
+    "in_dtype",
+    (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
+    ids=["BFLOAT16", "BFLOAT8_B"],
+)
+@pytest.mark.parametrize("inplace", [True, False])
+def test_softmax_mix_precision(device, inplace, in_dtype, cb_dtype):
+    torch.manual_seed(0)
+    sm_op = ttl.operations.primary.softmax_in_place if inplace else ttl.tensor.softmax
+
+    input_shapes = [(3, 64, 128, 96), (1, 64, 32, 32)]
+
+    for input_shape in input_shapes:
+        input_tensor = torch.randn(input_shape).bfloat16()
+
+        tt_input_tensor = ttl.tensor.Tensor(input_tensor, in_dtype).to(ttl.tensor.Layout.TILE).to(device)
+        tt_output_tensor_on_device = sm_op(tt_input_tensor)
+        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+
+        golden_output_tensor = torch.softmax(input_tensor, dim=-1)
+        print_diff_argmax(tt_output_tensor, golden_output_tensor)
+
+        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+        assert allclose, f"FAILED: {output}"
 
 
 @skip_for_wormhole_b0()
@@ -195,65 +195,65 @@ def test_scale_mask_softmax_inplace(device, in_dtype, in0_mem_config, casual_mas
         assert allclose, f"FAILED: {output}"
 
 
-# @skip_for_wormhole_b0()
-# @pytest.mark.parametrize(
-#     "in0_mem_config",
-#     (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),),
-#     ids=[
-#         "in0_DRAM",
-#     ],
-# )
-# @pytest.mark.parametrize(
-#     "in_dtype",
-#     (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
-#     ids=["BFLOAT16", "BFLOAT8_B"],
-# )
-# def test_scale_mask_softmax(device, in_dtype, in0_mem_config):
-#     torch.manual_seed(0)
-#     fuse_head = 2
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "in0_mem_config",
+    (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),),
+    ids=[
+        "in0_DRAM",
+    ],
+)
+@pytest.mark.parametrize(
+    "in_dtype",
+    (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
+    ids=["BFLOAT16", "BFLOAT8_B"],
+)
+def test_scale_mask_softmax(device, in_dtype, in0_mem_config):
+    torch.manual_seed(0)
+    fuse_head = 2
 
-#     grid_size = (12, 8)
-#     batch = grid_size[0]
-#     num_cores_r = grid_size[1]
-#     input_shape = (batch, 1, num_cores_r * fuse_head * 384, 384)
-#     M = input_shape[2]
-#     K = input_shape[3] * batch
+    grid_size = (12, 8)
+    batch = grid_size[0]
+    num_cores_r = grid_size[1]
+    input_shape = (batch, 1, num_cores_r * fuse_head * 384, 384)
+    M = input_shape[2]
+    K = input_shape[3] * batch
 
-#     hidden_dim = 1024
-#     num_heads = 16
-#     scale = 1 / math.sqrt(hidden_dim // num_heads)
-#     attention_mask = torch.rand(batch, 1, 32, 384)
-#     attention_mask = (attention_mask > 0.5).float()
-#     attention_mask32 = tilize_to_list(pad_weight(attention_mask))
-#     attention_mask_t = ttl.tensor.Tensor(
-#         attention_mask32,
-#         [batch, 1, 32, 384],
-#         ttl.tensor.DataType.BFLOAT16,
-#         ttl.tensor.Layout.TILE,
-#         device,
-#         ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
-#     )
+    hidden_dim = 1024
+    num_heads = 16
+    scale = 1 / math.sqrt(hidden_dim // num_heads)
+    attention_mask = torch.rand(batch, 1, 32, 384)
+    attention_mask = (attention_mask > 0.5).float()
+    attention_mask32 = tilize_to_list(pad_weight(attention_mask))
+    attention_mask_t = ttl.tensor.Tensor(
+        attention_mask32,
+        [batch, 1, 32, 384],
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.TILE,
+        device,
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    )
 
-#     input_tensor = torch.randn(input_shape).bfloat16().float()
-#     in1_t = torch2tt_tensor(input_tensor, device, tt_memory_config=in0_mem_config, tt_dtype=in_dtype)
+    input_tensor = torch.randn(input_shape).bfloat16().float()
+    in1_t = torch2tt_tensor(input_tensor, device, tt_memory_config=in0_mem_config, tt_dtype=in_dtype)
 
-#     tt_output = ttl.tensor.scale_mask_softmax(in1_t, scale, attention_mask_t)
+    tt_output = ttl.tensor.scale_mask_softmax(in1_t, scale, attention_mask_t)
 
-#     tt_output_tensor = tt_output.cpu().to_torch().float()
-#     tt_output_tensor = torch.Tensor(tt_output_tensor).reshape(input_shape)
-#     tt_output_tensor = untilize(tt_output_tensor)
+    tt_output_tensor = tt_output.cpu().to_torch().float()
+    tt_output_tensor = torch.Tensor(tt_output_tensor).reshape(input_shape)
+    tt_output_tensor = untilize(tt_output_tensor)
 
-#     attention_mask = attention_mask.reshape(batch, 1, 32, 384)
+    attention_mask = attention_mask.reshape(batch, 1, 32, 384)
 
-#     attention_mask_ref = attention_mask[:, :, 0, :]
+    attention_mask_ref = attention_mask[:, :, 0, :]
 
-#     for i in range(batch):
-#         golden_output_tensor = input_tensor[i] * scale + attention_mask_ref[i]
-#         golden_output_tensor = torch.softmax(golden_output_tensor, dim=-1)
+    for i in range(batch):
+        golden_output_tensor = input_tensor[i] * scale + attention_mask_ref[i]
+        golden_output_tensor = torch.softmax(golden_output_tensor, dim=-1)
 
-#         allclose, output = comp_pcc(
-#             tt_output_tensor[i],
-#             golden_output_tensor,
-#         )
-#         logger.info(output)
-#         assert allclose, f"FAILED: {output}"
+        allclose, output = comp_pcc(
+            tt_output_tensor[i],
+            golden_output_tensor,
+        )
+        logger.info(output)
+        assert allclose, f"FAILED: {output}"

--- a/tests/tt_eager/python_api_testing/unit_testing/test_softmax_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_softmax_sharded.py
@@ -65,15 +65,6 @@ def test_softmax(device, in_dtype, cb_dtype, in0_mem_config, casual_mask):
         attention_mask = torch.rand(batch, 1, 1, 384)
         attention_mask = (attention_mask > 0.5).float()
         attention_mask = attention_mask.reshape(batch, 1, -1, 32)
-        # attention_mask32 = tilize_to_list(pad_weight(attention_mask))
-        # attention_mask_t = ttl.tensor.Tensor(
-        #     attention_mask32,
-        #     [batch, 1, 32, 384],
-        #     ttl.tensor.DataType.BFLOAT16,
-        #     ttl.tensor.Layout.TILE,
-        #     device,
-        #     ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
-        # )
         attention_mask_t = ttl.tensor.Tensor(
             attention_mask,
             ttl.tensor.DataType.BFLOAT16,

--- a/tests/tt_eager/python_api_testing/unit_testing/test_softmax_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_softmax_sharded.py
@@ -110,7 +110,9 @@ def test_softmax(device, in_dtype, cb_dtype, in0_mem_config, casual_mask):
         im_data_format=cb_dtype,
     )
 
-    tt_output_sharded = sm_op(in1_t_shard, scale, attention_mask_t, program_config=program_config)
+    tt_output_sharded = sm_op(
+        in1_t_shard, scale, attention_mask_t, program_config=program_config, is_causal_mask=casual_mask
+    )
 
     tt_output = ttl.tensor.sharded_to_interleaved(tt_output_sharded, in0_mem_config)
     tt_output_tensor = tt_output.cpu().to_torch().float()

--- a/tests/tt_eager/python_api_testing/unit_testing/test_softmax_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_softmax_sharded.py
@@ -21,6 +21,11 @@ from models.utility_functions import skip_for_wormhole_b0
 
 @skip_for_wormhole_b0()
 @pytest.mark.parametrize(
+    "casual_mask",
+    [True, False],
+    ids=["causal", "no-causal"],
+)
+@pytest.mark.parametrize(
     "cb_dtype",
     (ttl.tensor.DataType.BFLOAT16,),
     ids=["BFLOAT16"],
@@ -37,7 +42,7 @@ from models.utility_functions import skip_for_wormhole_b0
     (ttl.tensor.DataType.BFLOAT8_B,),
     ids=["BFLOAT8_B"],
 )
-def test_softmax(device, in_dtype, cb_dtype, in0_mem_config):
+def test_softmax(device, in_dtype, cb_dtype, in0_mem_config, casual_mask):
     torch.manual_seed(0)
     sm_op = ttl.operations.primary.transformers.scale_mask_softmax_in_place
 
@@ -54,19 +59,37 @@ def test_softmax(device, in_dtype, cb_dtype, in0_mem_config):
     num_heads = 16
     # scale = 1.0
     scale = 1 / math.sqrt(hidden_dim // num_heads)
-    # attention_mask = torch.zeros(1, 1, 1, 384 * batch)
-    attention_mask = torch.rand(batch, 1, 1, 384)
-    attention_mask = (attention_mask > 0.5).float()
-    attention_mask = attention_mask.reshape(batch, 1, 12, 32)
-    attention_mask32 = tilize_to_list(pad_weight(attention_mask))
-    attention_mask_t = ttl.tensor.Tensor(
-        attention_mask32,
-        [batch, 1, 32, 32],
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.Layout.TILE,
-        device,
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
-    )
+
+    if casual_mask == False:
+        # attention_mask = torch.zeros(1, 1, 1, 384 * batch)
+        attention_mask = torch.rand(batch, 1, 1, 384)
+        attention_mask = (attention_mask > 0.5).float()
+        attention_mask = attention_mask.reshape(batch, 1, -1, 32)
+        # attention_mask32 = tilize_to_list(pad_weight(attention_mask))
+        # attention_mask_t = ttl.tensor.Tensor(
+        #     attention_mask32,
+        #     [batch, 1, 32, 384],
+        #     ttl.tensor.DataType.BFLOAT16,
+        #     ttl.tensor.Layout.TILE,
+        #     device,
+        #     ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        # )
+        attention_mask_t = ttl.tensor.Tensor(
+            attention_mask,
+            ttl.tensor.DataType.BFLOAT16,
+        ).to(device, ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1))
+    else:
+        attention_mask = torch.rand(batch, 1, 384, 384)
+        attention_mask = (attention_mask > 0.5).float()
+        attention_mask32 = tilize_to_list(pad_weight(attention_mask))
+        attention_mask_t = ttl.tensor.Tensor(
+            attention_mask32,
+            [batch, 1, 384, 384],
+            ttl.tensor.DataType.BFLOAT16,
+            ttl.tensor.Layout.TILE,
+            device,
+            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        )
 
     input_tensor = torch.randn(input_shape).bfloat16().float()
     in1_t = torch2tt_tensor(input_tensor, device, tt_memory_config=in0_mem_config, tt_dtype=in_dtype)
@@ -94,7 +117,10 @@ def test_softmax(device, in_dtype, cb_dtype, in0_mem_config):
     tt_output_tensor = torch.Tensor(tt_output_tensor).reshape(input_shape)
     tt_output_tensor = untilize(tt_output_tensor)
 
-    attention_mask = attention_mask.reshape(batch, 1, 1, 384)
+    if casual_mask == False:
+        attention_mask = attention_mask.reshape(batch, 1, 1, 384)
+    else:
+        attention_mask = attention_mask.repeat(1, 1, 16, 1)
 
     for i in range(batch):
         golden_output_tensor = input_tensor[i] * scale + attention_mask[i]

--- a/tt_eager/tt_dnn/op_library/softmax/kernels/compute/softmax.cpp
+++ b/tt_eager/tt_dnn/op_library/softmax/kernels/compute/softmax.cpp
@@ -64,7 +64,30 @@ void MAIN {
         unpack_reconfig_data_format(cb_scale_mask, cb_fused_attn);
 
         // fused attn
-        // cb_wait_front(cb_scale_mask, block_w);
+        #if CAUSAL_MASK
+        cb_wait_front(cb_scale_mask, block_w);
+        cb_wait_front(cb_fused_attn, block_w);
+        index_subblock_w_offset = 0;
+        for (uint32_t j = 0; j < num_subblocks_w; j++) {
+            ACQ();
+            add_tiles_init();
+            for (uint32_t w = 0; w < subblock_w; w++) {
+                index = w + index_subblock_w_offset;
+                add_tiles(cb_scale_mask, cb_fused_attn, index, index, w);
+            }
+            cb_reserve_back(cb_exps, subblock_w);
+            exp_tile_init(true);
+            for (uint32_t w = 0; w < subblock_w; w++) {
+                exp_tile(w,true);
+                pack_tile(w, cb_exps);
+            }
+            cb_push_back(cb_exps, subblock_w);
+            REL();
+            index_subblock_w_offset += subblock_w;
+        }
+        cb_pop_front(cb_scale_mask, block_w);
+        cb_pop_front(cb_fused_attn, block_w);
+        #else
         cb_wait_front(cb_fused_attn, block_w);
         index_subblock_w_offset = 0;
         for (uint32_t j = 0; j < num_subblocks_w; j++) {
@@ -85,6 +108,8 @@ void MAIN {
             index_subblock_w_offset += subblock_w;
         }
         cb_pop_front(cb_scale_mask, block_w);
+        #endif // CAUSAL_MASK
+
         #else
         unpack_reconfig_data_format(cb_in0, cb_in0);
         pack_reconfig_data_format(cb_exps);
@@ -109,7 +134,7 @@ void MAIN {
         }
         cb_pop_front(cb_in0, block_w);
         unpack_reconfig_data_format(cb_exps, cb_bcast_scaler);
-        #endif
+        #endif // FUSED_SCALE_MASK
 
         // sum(exp(x))
         ACQ();

--- a/tt_eager/tt_dnn/op_library/softmax/softmax_op.hpp
+++ b/tt_eager/tt_dnn/op_library/softmax/softmax_op.hpp
@@ -47,6 +47,7 @@ struct Softmax {
     const bool inplace;
     const MemoryConfig output_mem_config;
     const tt::operations::primary::transformers::SoftmaxProgramConfig program_config;
+    const bool is_causal_mask;
 
     void validate(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -72,7 +73,7 @@ namespace transformers {
 // tmp2 = bcast_add_w->h(tmp1, mask) ; shape of attn mask is [1,N,32,W]
 // y = softmax(tmp2)              ; r=result
 // If scale == 0.0f then just y = softmax(x) is computed
-Tensor scale_mask_softmax_in_place(Tensor& input_tensor, std::optional<float> scale = std::nullopt, std::optional<const Tensor> mask = std::nullopt, const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{});
+Tensor scale_mask_softmax_in_place(Tensor& input_tensor, std::optional<float> scale = std::nullopt, std::optional<const Tensor> mask = std::nullopt, const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{}, const bool is_causal_mask = false);
 }  // namespace transformers
 
 }  // namespace primary
@@ -82,7 +83,7 @@ namespace tt_metal {
 Tensor softmax(const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 namespace transformers {
-Tensor scale_mask_softmax(const Tensor& input_tensor, std::optional<float> scale, std::optional<const Tensor> mask, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor scale_mask_softmax(const Tensor& input_tensor, std::optional<float> scale, std::optional<const Tensor> mask, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, const bool is_causal_mask = false);
 }  // namespace transformers
 }  // namespace tt_metal
 

--- a/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
@@ -72,6 +72,7 @@ void py_module(py::module& m_transformers) {
         py::arg("scale").noconvert() = std::nullopt,
         py::arg("mask").noconvert() = std::nullopt,
         py::arg("program_config").noconvert() = SoftmaxDefaultProgramConfig{},
+        py::arg("is_causal_mask").noconvert() = false,
         "Performs a fused scale->attention_mask->softmax operation. Returns a reference to the input tensor modified in place."
         );
 }

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -296,6 +296,7 @@ namespace tt::tt_metal::detail {
             py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
             "Performs a softmax operation on the last tensor dimension.");
 
+        // softmax with scale and mask, regular mask has a dim of (batch, 1, 1, seq_len), causal mask has a dim of (batch, 1, seq_len, seq_len)
         m_tensor.def("scale_mask_softmax", &transformers::scale_mask_softmax,
         py::arg("input").noconvert(), py::arg("scale"), py::arg("mask").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("is_causal_mask").noconvert() = false,
         "Performs a fused scale->attention_mask->softmax operation.");

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -297,7 +297,7 @@ namespace tt::tt_metal::detail {
             "Performs a softmax operation on the last tensor dimension.");
 
         m_tensor.def("scale_mask_softmax", &transformers::scale_mask_softmax,
-        py::arg("input").noconvert(), py::arg("scale"), py::arg("mask").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("input").noconvert(), py::arg("scale"), py::arg("mask").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("is_causal_mask").noconvert() = false,
         "Performs a fused scale->attention_mask->softmax operation.");
 
     }


### PR DESCRIPTION
add causal mask for `scale_mask_softmax_in_place` and `scale_mask_softmax`, supports both sharded and interleaved

to use causal mask instead of mask, add one extra arg `is_causal_mask=True` when calling the softmax function