### PR TITLE
#4549: Disable dprint tests on E300

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -93,6 +93,19 @@ protected:
             );
             return true;
         }
+
+        // Also skip all devices after device 0 for grayskull. This to match all other tests
+        // targetting device 0 by default (and to not cause issues with BMs that have E300s).
+        // TODO: when we can detect only supported devices, this check can be removed.
+        if (this->arch_ == tt::ARCH::GRAYSKULL && device_id > 0) {
+            log_info(
+                tt::LogTest,
+                "Skipping test on device {} due to unsupported E300",
+                device_id
+            );
+            return true;
+        }
+
         return false;
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
@@ -62,8 +62,7 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
     );
 }
 
-// See issue #4549
-TEST_F(DPrintFixture, DISABLED_TestPrintMuting) {
+TEST_F(DPrintFixture, TestPrintMuting) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
@@ -289,8 +289,7 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
     );
 }
 
-//See issue #4549
-TEST_F(DPrintFixture, DISABLED_TestPrintRaiseWait) {
+TEST_F(DPrintFixture, TestPrintRaiseWait) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }


### PR DESCRIPTION
Since we don't have a way yet to only detect available devices, just skip on all devices after device 0 for grayskull - this matches what the other GS tests do (only target devise 0). WH should be fine since both N150 and N300 are supported.

Tested locally on the BM that shows the issue and it appears to be fixed.