### PR TITLE
SW CQ

### DIFF
--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueProgram.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueProgram.rst
@@ -1,4 +1,4 @@
 EnqueueProgram
 ==============
 
-void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking, optional<reference_wrapper<Trace>> trace);
+void EnqueueProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program> > program, bool blocking, std::optional<std::reference_wrapper<Trace>> trace);

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadBuffer
 ==================
 
-.. doxygenfunction:: EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, vector<uint32_t>& dst, bool blocking)
-.. doxygenfunction:: EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, void* dst, bool blocking)
+.. doxygenfunction:: EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& dst, bool blocking)
+.. doxygenfunction:: EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteBuffer
 ==================
 
-.. doxygenfunction:: EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, vector<uint32_t>& src, bool blocking)
-.. doxygenfunction:: EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, const void* src, bool blocking)
+.. doxygenfunction:: EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& src, bool blocking)
+.. doxygenfunction:: EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, const void* src, bool blocking)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
         int device_id = 0;
         tt_metal::Device *device = tt_metal::CreateDevice(device_id);
 
-        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        CommandQueue& cq = device->command_queue();
 
         tt_metal::Program program = tt_metal::CreateProgram();
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
         int device_id = 0;
         tt_metal::Device *device = tt_metal::CreateDevice(device_id);
 
-        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        CommandQueue& cq = device->command_queue();
 
         tt_metal::Program program = tt_metal::CreateProgram();
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/matmul/matmul_global_l1.cpp
@@ -1213,8 +1213,8 @@ int main(int argc, char** argv) {
 
     // took from run_operation.cpp
     auto start = std::chrono::high_resolution_clock::now();
-    EnqueueProgram(::detail::GetCommandQueue(device), program, false);
-    Finish(::detail::GetCommandQueue(device));
+    EnqueueProgram(device->command_queue(), program, false);
+    Finish(device->command_queue());
     auto end = std::chrono::high_resolution_clock::now();
     duration = end - start;
     tt_metal::DumpDeviceProfileResults(device, program);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/matmul/matmul_local_l1.cpp
@@ -381,8 +381,8 @@ int main(int argc, char **argv) {
     std::chrono::duration<double, std::nano> duration;
     // took from run_operation.cpp
     auto start = std::chrono::high_resolution_clock::now();
-    EnqueueProgram(::detail::GetCommandQueue(device), program, false);
-    Finish(::detail::GetCommandQueue(device));
+    EnqueueProgram(device->command_queue(), program, false);
+    Finish(device->command_queue());
     auto end = std::chrono::high_resolution_clock::now();
     duration = end - start;
     tt_metal::DumpDeviceProfileResults(device, program);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_read_global_l1.cpp
@@ -272,8 +272,8 @@ int main(int argc, char **argv) {
 
     log_info(LogTest, "Running {} core test", num_cores_r * num_cores_c);
     auto begin = std::chrono::steady_clock::now();
-    EnqueueProgram(::detail::GetCommandQueue(device), program, false);
-    Finish(::detail::GetCommandQueue(device));
+    EnqueueProgram(device->command_queue(), program, false);
+    Finish(device->command_queue());
     auto end = std::chrono::steady_clock::now();
     auto elapsed_us = duration_cast<microseconds>(end - begin).count();
     auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) /

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_read_local_l1.cpp
@@ -225,8 +225,8 @@ int main(int argc, char **argv) {
 
     log_info(LogTest, "Running {} core test", num_cores_r * num_cores_c);
     auto begin = std::chrono::steady_clock::now();
-    EnqueueProgram(::detail::GetCommandQueue(device), program, false);
-    Finish(::detail::GetCommandQueue(device));
+    EnqueueProgram(device->command_queue(), program, false);
+    Finish(device->command_queue());
     auto end = std::chrono::steady_clock::now();
     auto elapsed_us = duration_cast<microseconds>(end - begin).count();
     auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) /

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/pcie/test_enqueue_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/pcie/test_enqueue_rw_buffer.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
     // Device Setup
     int device_id = 0;
     tt_metal::Device* device = tt_metal::CreateDevice(device_id);
-    CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+    CommandQueue& cq = device->command_queue();
 
     // Application Setup
     uint32_t single_tile_size = 2 * 1024;

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
     tt_metal::Device* device = tt_metal::CreateDevice(device_id);
 
 
-    CommandQueue& cq = detail::GetCommandQueue(device);
+    CommandQueue& cq = device->command_queue();
 
     Program programs[] = {tt_metal::CreateProgram(), tt_metal::CreateProgram(), tt_metal::CreateProgram()};
 

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -148,7 +148,7 @@ int main(int argc, char** argv) {
             std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(
                 dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-            EnqueueWriteBuffer(cq, src0_dram_buffer, src0_vec, false);
+            EnqueueWriteBuffer(cq, std::ref(src0_dram_buffer), src0_vec, false);
 
             std::vector<uint32_t> src1_vec;
             if (eltwise_op == EltwiseOp::MUL)
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
             else
                 src1_vec = create_constant_vector_of_bfloat16(dram_buffer_size, 0.0f);
 
-            EnqueueWriteBuffer(cq, src1_dram_buffer, src1_vec, false);
+            EnqueueWriteBuffer(cq, std::ref(src1_dram_buffer), src1_vec, false);
 
             vector<uint32_t> reader_args = {
                 dram_buffer_src0_addr,

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
@@ -316,7 +316,7 @@ bool move_tiles_to_dram(
         }
     }
 
-    EnqueueWriteBuffer(cq, buffer, tiles, false);
+    EnqueueWriteBuffer(cq, std::ref(buffer), tiles, false);
     return pass;
 }
 

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
@@ -397,7 +397,7 @@ int main(int argc, char **argv) {
             per_core_N);
 
 
-        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        CommandQueue& cq = device->command_queue();
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application

--- a/tests/tt_metal/tt_metal/tt_dispatch/test_enqueue_program.cpp
+++ b/tests/tt_metal/tt_metal/tt_dispatch/test_enqueue_program.cpp
@@ -95,7 +95,7 @@ void test_enqueue_program(std::function<tt_metal::Program(tt_metal::Device *devi
 
     vector<uint32_t> out_vec;
     {
-        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        CommandQueue& cq = device->command_queue();
 
         // Enqueue program inputs
         Buffer buf(device, NUM_TILES * 2048, 2048, BufferType::DRAM);

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -16,7 +16,7 @@ public:
         if (this->slow_dispatch_) {
             tt::tt_metal::detail::LaunchProgram(device, program);
         } else {
-            CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+            CommandQueue& cq = device->command_queue();
             EnqueueProgram(cq, program, false);
             Finish(cq);
         }
@@ -25,7 +25,7 @@ public:
         if (this->slow_dispatch_) {
             tt::tt_metal::detail::WriteToBuffer(in_buffer, src_vec);
         } else {
-            CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+            CommandQueue& cq = device->command_queue();
             EnqueueWriteBuffer(cq, in_buffer, src_vec, false);
         }
     }
@@ -33,7 +33,7 @@ public:
         if (this->slow_dispatch_) {
             tt::tt_metal::detail::ReadFromBuffer(out_buffer, dst_vec);
         } else {
-            CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+            CommandQueue& cq = device->command_queue();
             EnqueueReadBuffer(cq, out_buffer, dst_vec, true);
         }
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/matmul/matmul_utils.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/matmul/matmul_utils.hpp
@@ -134,7 +134,7 @@ inline bool move_tiles_to_dram(tt_metal::Device *device, std::vector<uint32_t> t
     int tile_size_bytes = 32 * 32 * 2;
     int start_index = 0;
     int tile_id = 0;
-    CommandQueue& cq = tt_metal::detail::GetCommandQueue(device);
+    CommandQueue& cq = device->command_queue();
     vector<uint32_t> tiles;
     for (int i = 0; i < tiles_r; i++) {
         for (int j = 0; j < tiles_c; j++) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/matmul/test_matmul_multi_core_X_dram.cpp
@@ -408,7 +408,7 @@ bool matmul_multi_core_multi_dram(CommonFixture *fixture, tt_metal::Device *devi
         );
 
 
-    // CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+    // CommandQueue& cq = device->command_queue();
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Application

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_CommandQueue.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_CommandQueue.cpp
@@ -20,7 +20,7 @@ namespace host_tests {
 namespace multi_device_tests {
 TEST_F(CommandQueueMultiDeviceFixture, TestAccessCommandQueue) {
     for (unsigned int device_id = 0; device_id < num_devices_; device_id++) {
-        EXPECT_NO_THROW(detail::GetCommandQueue(devices_[device_id]));
+        EXPECT_NO_THROW(devices_[device_id]->command_queue());
     }
 }
 
@@ -32,9 +32,9 @@ TEST(FastDispatchHostSuite, TestCannotAccessCommandQueueForClosedDevice) {
     }
     const unsigned int device_id = 0;
     Device* device = CreateDevice(device_id);
-    EXPECT_NO_THROW(detail::GetCommandQueue(device));
+    EXPECT_NO_THROW(device->command_queue());
     CloseDevice(device);
-    EXPECT_ANY_THROW(detail::GetCommandQueue(device));
+    EXPECT_ANY_THROW(device->command_queue());
 }
 
 TEST_F(CommandQueueMultiDeviceFixture, TestDirectedLoopbackToUniqueHugepage) {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -298,8 +298,8 @@ TEST_F(CommandQueueFixture, TestArbiterDoesNotHang) {
     auto dummy_reader_kernel = CreateKernel(
         program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/arbiter_hang.cpp", cr_set, DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-    EnqueueProgram(::detail::GetCommandQueue(device_), program, false);
-    Finish(::detail::GetCommandQueue(device_));
+    EnqueueProgram(*this->cmd_queue_, program, false);
+    Finish(*this->cmd_queue_);
 }
 
 }
@@ -314,7 +314,7 @@ TEST_F(CommandQueueFixture, TestSingleCbConfigCorrectlySentSingleCore) {
 
     DummyProgramMultiCBConfig config = {.cr_set = cr_set, .cb_config_vector = {cb_config} };
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestMultiCbSeqConfigCorrectlySentSingleCore) {
@@ -329,7 +329,7 @@ TEST_F(CommandQueueFixture, TestMultiCbSeqConfigCorrectlySentSingleCore) {
 
     DummyProgramMultiCBConfig config = {.cr_set = cr_set, .cb_config_vector = {cb_config_0, cb_config_1, cb_config_2, cb_config_3}};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestMultiCbRandomConfigCorrectlySentSingleCore) {
@@ -344,7 +344,7 @@ TEST_F(CommandQueueFixture, TestMultiCbRandomConfigCorrectlySentSingleCore) {
 
     DummyProgramMultiCBConfig config = {.cr_set = cr_set, .cb_config_vector = {cb_config_0, cb_config_1, cb_config_2, cb_config_3}};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestMultiCBSharedAddressSpaceSentSingleCore) {
@@ -370,9 +370,9 @@ TEST_F(CommandQueueFixture, TestMultiCBSharedAddressSpaceSentSingleCore) {
     auto cb = CreateCircularBuffer(program, cr_set, cb_config);
 
     local_test_functions::initialize_dummy_kernels(program, cr_set);
-    EnqueueProgram(tt::tt_metal::detail::GetCommandQueue(device_), program, false);
+    EnqueueProgram(*this->cmd_queue_, program, false);
 
-    Finish(tt::tt_metal::detail::GetCommandQueue(device_));
+    Finish(*this->cmd_queue_);
     vector<uint32_t> cb_config_vector;
     uint32_t cb_config_buffer_size = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
@@ -406,7 +406,7 @@ TEST_F(CommandQueueFixture, TestSingleCbConfigCorrectlyUpdateSizeSentSingleCore)
 
     DummyProgramMultiCBConfig config = {.cr_set = cr_set, .cb_config_vector = {cb_config}};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestSingleSemaphoreConfigCorrectlySentSingleCore) {
@@ -415,7 +415,7 @@ TEST_F(CommandQueueFixture, TestSingleSemaphoreConfigCorrectlySentSingleCore) {
 
     DummyProgramConfig config = {.cr_set = cr_set, .num_sems = 1};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_sems(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_sems(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestAutoInsertedBlankBriscKernelInDeviceDispatchMode) {
@@ -429,8 +429,8 @@ TEST_F(CommandQueueFixture, TestAutoInsertedBlankBriscKernelInDeviceDispatchMode
         program, "tt_metal/kernels/dataflow/blank.cpp", cr_set,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-    EnqueueProgram(tt::tt_metal::detail::GetCommandQueue(device_), program, false);
-    Finish(tt::tt_metal::detail::GetCommandQueue(device_));
+    EnqueueProgram(*this->cmd_queue_, program, false);
+    Finish(*this->cmd_queue_);
 }
 
 TEST_F(CommandQueueFixture, ComputeRuntimeArgs) {
@@ -449,8 +449,8 @@ TEST_F(CommandQueueFixture, ComputeRuntimeArgs) {
 
     std::vector<uint32_t> initial_runtime_args = {101, 202};
     SetRuntimeArgs(program, 0, cr_set, initial_runtime_args);
-    EnqueueProgram(tt::tt_metal::detail::GetCommandQueue(device_), program, false);
-    Finish(tt::tt_metal::detail::GetCommandQueue(device_));
+    EnqueueProgram(*this->cmd_queue_, program, false);
+    Finish(*this->cmd_queue_);
 
     std::vector<uint32_t> increments = {87, 216};
     std::vector<uint32_t> written_args;
@@ -468,7 +468,7 @@ TEST_F(CommandQueueFixture, TestRuntimeArgsCorrectlySentSingleCore) {
     CoreRangeSet cr_set({cr});
 
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), dummy_program_config);
+    local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(this->device_, *this->cmd_queue_, dummy_program_config);
 }
 
 }  // end namespace single_core_tests
@@ -489,7 +489,7 @@ TEST_F(CommandQueueFixture, TestAllCbConfigsCorrectlySentMultiCore) {
     DummyProgramMultiCBConfig config = {
         .cr_set = cr_set, .cb_config_vector = cb_config_vector};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestAllCbConfigsCorrectlySentUpdateSizeMultiCore) {
@@ -506,7 +506,7 @@ TEST_F(CommandQueueFixture, TestAllCbConfigsCorrectlySentUpdateSizeMultiCore) {
     DummyProgramMultiCBConfig config = {
         .cr_set = cr_set, .cb_config_vector = cb_config_vector  };
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, *this->cmd_queue_, config));
 }
 
 
@@ -525,7 +525,7 @@ TEST_F(CommandQueueFixture, TestMultiCbConfigsCorrectlySentUpdateSizeMultiCore) 
     DummyProgramMultiCBConfig config = {
         .cr_set = cr_set, .cb_config_vector = cb_config_vector  };
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestAllSemConfigsCorrectlySentMultiCore) {
@@ -536,7 +536,7 @@ TEST_F(CommandQueueFixture, TestAllSemConfigsCorrectlySentMultiCore) {
 
     DummyProgramConfig config = {.cr_set = cr_set, .num_sems = NUM_SEMAPHORES};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_sems(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_sems(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestAllRuntimeArgsCorrectlySentMultiCore) {
@@ -546,7 +546,7 @@ TEST_F(CommandQueueFixture, TestAllRuntimeArgsCorrectlySentMultiCore) {
     CoreRangeSet cr_set({cr});
 
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), dummy_program_config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(this->device_, *this->cmd_queue_, dummy_program_config));
 }
 
 }  // end namespace multicore_tests

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -298,8 +298,8 @@ TEST_F(CommandQueueFixture, TestArbiterDoesNotHang) {
     auto dummy_reader_kernel = CreateKernel(
         program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/arbiter_hang.cpp", cr_set, DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-    EnqueueProgram(*this->cmd_queue_, program, false);
-    Finish(*this->cmd_queue_);
+    EnqueueProgram(*this->cmd_queue, program, false);
+    Finish(*this->cmd_queue);
 }
 
 }
@@ -314,7 +314,7 @@ TEST_F(CommandQueueFixture, TestSingleCbConfigCorrectlySentSingleCore) {
 
     DummyProgramMultiCBConfig config = {.cr_set = cr_set, .cb_config_vector = {cb_config} };
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestMultiCbSeqConfigCorrectlySentSingleCore) {
@@ -329,7 +329,7 @@ TEST_F(CommandQueueFixture, TestMultiCbSeqConfigCorrectlySentSingleCore) {
 
     DummyProgramMultiCBConfig config = {.cr_set = cr_set, .cb_config_vector = {cb_config_0, cb_config_1, cb_config_2, cb_config_3}};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestMultiCbRandomConfigCorrectlySentSingleCore) {
@@ -344,7 +344,7 @@ TEST_F(CommandQueueFixture, TestMultiCbRandomConfigCorrectlySentSingleCore) {
 
     DummyProgramMultiCBConfig config = {.cr_set = cr_set, .cb_config_vector = {cb_config_0, cb_config_1, cb_config_2, cb_config_3}};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestMultiCBSharedAddressSpaceSentSingleCore) {
@@ -370,9 +370,9 @@ TEST_F(CommandQueueFixture, TestMultiCBSharedAddressSpaceSentSingleCore) {
     auto cb = CreateCircularBuffer(program, cr_set, cb_config);
 
     local_test_functions::initialize_dummy_kernels(program, cr_set);
-    EnqueueProgram(*this->cmd_queue_, program, false);
+    EnqueueProgram(*this->cmd_queue, program, false);
 
-    Finish(*this->cmd_queue_);
+    Finish(*this->cmd_queue);
     vector<uint32_t> cb_config_vector;
     uint32_t cb_config_buffer_size = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
@@ -406,7 +406,7 @@ TEST_F(CommandQueueFixture, TestSingleCbConfigCorrectlyUpdateSizeSentSingleCore)
 
     DummyProgramMultiCBConfig config = {.cr_set = cr_set, .cb_config_vector = {cb_config}};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestSingleSemaphoreConfigCorrectlySentSingleCore) {
@@ -415,7 +415,7 @@ TEST_F(CommandQueueFixture, TestSingleSemaphoreConfigCorrectlySentSingleCore) {
 
     DummyProgramConfig config = {.cr_set = cr_set, .num_sems = 1};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_sems(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_sems(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestAutoInsertedBlankBriscKernelInDeviceDispatchMode) {
@@ -429,8 +429,8 @@ TEST_F(CommandQueueFixture, TestAutoInsertedBlankBriscKernelInDeviceDispatchMode
         program, "tt_metal/kernels/dataflow/blank.cpp", cr_set,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-    EnqueueProgram(*this->cmd_queue_, program, false);
-    Finish(*this->cmd_queue_);
+    EnqueueProgram(*this->cmd_queue, program, false);
+    Finish(*this->cmd_queue);
 }
 
 TEST_F(CommandQueueFixture, ComputeRuntimeArgs) {
@@ -449,8 +449,8 @@ TEST_F(CommandQueueFixture, ComputeRuntimeArgs) {
 
     std::vector<uint32_t> initial_runtime_args = {101, 202};
     SetRuntimeArgs(program, 0, cr_set, initial_runtime_args);
-    EnqueueProgram(*this->cmd_queue_, program, false);
-    Finish(*this->cmd_queue_);
+    EnqueueProgram(*this->cmd_queue, program, false);
+    Finish(*this->cmd_queue);
 
     std::vector<uint32_t> increments = {87, 216};
     std::vector<uint32_t> written_args;
@@ -468,7 +468,7 @@ TEST_F(CommandQueueFixture, TestRuntimeArgsCorrectlySentSingleCore) {
     CoreRangeSet cr_set({cr});
 
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(this->device_, *this->cmd_queue_, dummy_program_config);
+    local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(this->device_, *this->cmd_queue, dummy_program_config);
 }
 
 }  // end namespace single_core_tests
@@ -489,7 +489,7 @@ TEST_F(CommandQueueFixture, TestAllCbConfigsCorrectlySentMultiCore) {
     DummyProgramMultiCBConfig config = {
         .cr_set = cr_set, .cb_config_vector = cb_config_vector};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestAllCbConfigsCorrectlySentUpdateSizeMultiCore) {
@@ -506,7 +506,7 @@ TEST_F(CommandQueueFixture, TestAllCbConfigsCorrectlySentUpdateSizeMultiCore) {
     DummyProgramMultiCBConfig config = {
         .cr_set = cr_set, .cb_config_vector = cb_config_vector  };
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, *this->cmd_queue, config));
 }
 
 
@@ -525,7 +525,7 @@ TEST_F(CommandQueueFixture, TestMultiCbConfigsCorrectlySentUpdateSizeMultiCore) 
     DummyProgramMultiCBConfig config = {
         .cr_set = cr_set, .cb_config_vector = cb_config_vector  };
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_cbs_update_size(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestAllSemConfigsCorrectlySentMultiCore) {
@@ -536,7 +536,7 @@ TEST_F(CommandQueueFixture, TestAllSemConfigsCorrectlySentMultiCore) {
 
     DummyProgramConfig config = {.cr_set = cr_set, .num_sems = NUM_SEMAPHORES};
 
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_sems(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_sems(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestAllRuntimeArgsCorrectlySentMultiCore) {
@@ -546,7 +546,7 @@ TEST_F(CommandQueueFixture, TestAllRuntimeArgsCorrectlySentMultiCore) {
     CoreRangeSet cr_set({cr});
 
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(this->device_, *this->cmd_queue_, dummy_program_config));
+    EXPECT_TRUE(local_test_functions::test_dummy_EnqueueProgram_with_runtime_args(this->device_, *this->cmd_queue, dummy_program_config));
 }
 
 }  // end namespace multicore_tests

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueRestart.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueRestart.cpp
@@ -23,16 +23,16 @@ TEST_F(CommandQueueFixture, TestEnqueueRestart) {
         program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/arbiter_hang.cpp", cr_set, DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
     CommandQueue cq(this->device_, 0);
-
+    HWCommandQueue &hcq = detail::GetHWCommandQueue(this->device_, 0);
     uint32_t starting_issue_read_ptr;
     uint32_t starting_issue_write_ptr;
-    tt_cxy_pair physical_producer_core(this->device_->id(), this->device_->worker_core_from_logical_core(cq.issue_queue_reader_core));
+    tt_cxy_pair physical_producer_core(this->device_->id(), this->device_->worker_core_from_logical_core(hcq.issue_queue_reader_core));
     tt::Cluster::instance().read_core(&starting_issue_read_ptr, 4, physical_producer_core, CQ_ISSUE_READ_PTR, false);
     tt::Cluster::instance().read_core(&starting_issue_write_ptr, 4, physical_producer_core, CQ_ISSUE_WRITE_PTR, false);
 
     uint32_t starting_completion_read_ptr;
     uint32_t starting_completion_write_ptr;
-    tt_cxy_pair physical_consumer_core(this->device_->id(), this->device_->worker_core_from_logical_core(cq.completion_queue_writer_core));
+    tt_cxy_pair physical_consumer_core(this->device_->id(), this->device_->worker_core_from_logical_core(hcq.completion_queue_writer_core));
     tt::Cluster::instance().read_core(&starting_completion_read_ptr, 4, physical_consumer_core, CQ_COMPLETION_READ_PTR, false);
     tt::Cluster::instance().read_core(&starting_completion_write_ptr, 4, physical_consumer_core, CQ_COMPLETION_WRITE_PTR, false);
     EnqueueProgram(cq, program, false);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueRestart.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueRestart.cpp
@@ -23,7 +23,7 @@ TEST_F(CommandQueueFixture, TestEnqueueRestart) {
         program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/arbiter_hang.cpp", cr_set, DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
     CommandQueue cq(this->device_, 0);
-    HWCommandQueue &hcq = detail::GetHWCommandQueue(this->device_, 0);
+    HWCommandQueue &hcq = this->device_->hw_command_queue(0);
     uint32_t starting_issue_read_ptr;
     uint32_t starting_issue_write_ptr;
     tt_cxy_pair physical_producer_core(this->device_->id(), this->device_->worker_core_from_logical_core(hcq.issue_queue_reader_core));

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -99,13 +99,13 @@ vector<uint32_t> generate_arange_vector(uint32_t size_bytes) {
     }
     return src;
 }
-
 bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer(Device* device, CommandQueue& cq, const TestBufferConfig& config) {
     bool pass = true;
-    size_t buf_size = config.num_pages * config.page_size;
-    Buffer bufa(device, buf_size, config.page_size, config.buftype);
-    vector<uint32_t> src = generate_arange_vector(bufa.size());
     for (const bool use_void_star_api: {true, false}) {
+        size_t buf_size = config.num_pages * config.page_size;
+        Buffer bufa(device, buf_size, config.page_size, config.buftype);
+
+        vector<uint32_t> src = generate_arange_vector(bufa.size());
 
         if (use_void_star_api) {
             EnqueueWriteBuffer(cq, bufa, src.data(), false);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -506,18 +506,18 @@ TEST_F(CommandQueueFixture, TestNonblockingReads) {
 
     Buffer bufa(device_, 2048, 2048, buff_type);
     auto src_a = local_test_functions::generate_arange_vector(bufa.size());
-    EnqueueWriteBuffer(tt::tt_metal::detail::GetCommandQueue(device_), bufa, src_a, false);
+    EnqueueWriteBuffer(*this->cmd_queue, bufa, src_a, false);
 
     Buffer bufb(device_, 2048, 2048, buff_type);
     auto src_b = local_test_functions::generate_arange_vector(bufb.size());
-    EnqueueWriteBuffer(tt::tt_metal::detail::GetCommandQueue(device_), bufb, src_b, false);
+    EnqueueWriteBuffer(*this->cmd_queue, bufb, src_b, false);
 
     vector<uint32_t> result_a;
-    EnqueueReadBuffer(tt::tt_metal::detail::GetCommandQueue(device_), bufa, result_a, false);
+    EnqueueReadBuffer(*this->cmd_queue, bufa, result_a, false);
 
     vector<uint32_t> result_b;
-    EnqueueReadBuffer(tt::tt_metal::detail::GetCommandQueue(device_), bufb, result_b, false);
-    Finish(tt::tt_metal::detail::GetCommandQueue(device_));
+    EnqueueReadBuffer(*this->cmd_queue, bufb, result_b, false);
+    Finish(*this->cmd_queue);
 
     EXPECT_EQ(src_a, result_a);
     EXPECT_EQ(src_b, result_b);
@@ -531,7 +531,7 @@ TEST_F(CommandQueueFixture, WritesToRandomBufferTypeAndThenReadsBlocking) {
     BufferStressTestConfig config = {
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
     EXPECT_TRUE(
-        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer<true>(this->device_, tt::tt_metal::detail::GetCommandQueue(this->device_), config));
+        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer<true>(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, WritesToRandomBufferTypeAndThenReadsNonblocking) {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -101,12 +101,11 @@ vector<uint32_t> generate_arange_vector(uint32_t size_bytes) {
 }
 
 bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer(Device* device, CommandQueue& cq, const TestBufferConfig& config) {
+    bool pass = true;
+    size_t buf_size = config.num_pages * config.page_size;
+    Buffer bufa(device, buf_size, config.page_size, config.buftype);
+    vector<uint32_t> src = generate_arange_vector(bufa.size());
     for (const bool use_void_star_api: {true, false}) {
-
-        size_t buf_size = config.num_pages * config.page_size;
-        Buffer bufa(device, buf_size, config.page_size, config.buftype);
-
-        vector<uint32_t> src = generate_arange_vector(bufa.size());
 
         if (use_void_star_api) {
             EnqueueWriteBuffer(cq, bufa, src.data(), false);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -291,7 +291,7 @@ namespace dram_tests {
 
 TEST_F(CommandQueueFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, WriteOneTileToAllDramBanks) {
@@ -300,7 +300,7 @@ TEST_F(CommandQueueFixture, WriteOneTileToAllDramBanks) {
         .page_size = 2048,
         .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
@@ -310,7 +310,7 @@ TEST_F(CommandQueueFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
         .page_size = 2048,
         .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, Sending131072Pages) {
@@ -321,20 +321,20 @@ TEST_F(CommandQueueFixture, Sending131072Pages) {
         .page_size = 128,
         .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestNon32BAlignedPageSizeForDram) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestNon32BAlignedPageSizeForDram2) {
     // From stable diffusion read buffer
     TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestPageSizeTooLarge) {
@@ -344,7 +344,7 @@ TEST_F(CommandQueueFixture, TestPageSizeTooLarge) {
     // Should throw a host error due to the page size not fitting in the consumer CB
     TestBufferConfig config = {.num_pages = 1024, .page_size = 250880 * 2, .buftype = BufferType::DRAM};
 
-    EXPECT_ANY_THROW(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_ANY_THROW(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestWrapHostHugepageOnEnqueueReadBuffer) {
@@ -371,7 +371,7 @@ TEST_F(CommandQueueFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
 
     TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 // Test that command queue wraps when buffer available space in completion region is less than a page
@@ -392,23 +392,23 @@ TEST_F(CommandQueueFixture, TestWrapCompletionQOnInsufficientSpace) {
 
     Buffer buff_1(this->device_, first_buffer_size, large_page_size, BufferType::DRAM);
     auto src_1 = local_test_functions::generate_arange_vector(buff_1.size());
-    EnqueueWriteBuffer(*this->cmd_queue_, buff_1, src_1, false);
+    EnqueueWriteBuffer(*this->cmd_queue, buff_1, src_1, false);
     vector<uint32_t> result_1;
-    EnqueueReadBuffer(*this->cmd_queue_, buff_1, result_1, true);
+    EnqueueReadBuffer(*this->cmd_queue, buff_1, result_1, true);
     EXPECT_EQ(src_1, result_1);
 
     Buffer buff_2(this->device_, num_pages_second_buffer * small_page_size, small_page_size, BufferType::DRAM);
     auto src_2 = local_test_functions::generate_arange_vector(buff_2.size());
-    EnqueueWriteBuffer(*this->cmd_queue_, buff_2, src_2, false);
+    EnqueueWriteBuffer(*this->cmd_queue, buff_2, src_2, false);
     vector<uint32_t> result_2;
-    EnqueueReadBuffer(*this->cmd_queue_, buff_2, result_2, true);
+    EnqueueReadBuffer(*this->cmd_queue, buff_2, result_2, true);
     EXPECT_EQ(src_2, result_2);
 
     Buffer buff_3(this->device_, 32 * large_page_size, large_page_size, BufferType::DRAM);
     auto src_3 = local_test_functions::generate_arange_vector(buff_3.size());
-    EnqueueWriteBuffer(*this->cmd_queue_, buff_3, src_3, false);
+    EnqueueWriteBuffer(*this->cmd_queue, buff_3, src_3, false);
     vector<uint32_t> result_3;
-    EnqueueReadBuffer(*this->cmd_queue_, buff_3, result_3, true);
+    EnqueueReadBuffer(*this->cmd_queue, buff_3, result_3, true);
     EXPECT_EQ(src_3, result_3);
 }
 
@@ -430,16 +430,16 @@ TEST_F(CommandQueueFixture, TestWrapCompletionQOnInsufficientSpace2) {
     uint32_t num_pages_for_wrapping_buffer = (avail_space_for_wrapping_buffer / page_size) + 4;
 
     auto src_1 = local_test_functions::generate_arange_vector(buff_1.size());
-    EnqueueWriteBuffer(*this->cmd_queue_, buff_1, src_1, false);
+    EnqueueWriteBuffer(*this->cmd_queue, buff_1, src_1, false);
     vector<uint32_t> result_1;
-    EnqueueReadBuffer(*this->cmd_queue_, buff_1, result_1, true);
+    EnqueueReadBuffer(*this->cmd_queue, buff_1, result_1, true);
     EXPECT_EQ(src_1, result_1);
 
     Buffer wrap_buff(this->device_, num_pages_for_wrapping_buffer * page_size, page_size, BufferType::DRAM);
     auto src_2 = local_test_functions::generate_arange_vector(wrap_buff.size());
-    EnqueueWriteBuffer(*this->cmd_queue_, wrap_buff, src_2, false);
+    EnqueueWriteBuffer(*this->cmd_queue, wrap_buff, src_2, false);
     vector<uint32_t> result_2;
-    EnqueueReadBuffer(*this->cmd_queue_, wrap_buff, result_2, true);
+    EnqueueReadBuffer(*this->cmd_queue, wrap_buff, result_2, true);
     EXPECT_EQ(src_2, result_2);
 }
 
@@ -450,7 +450,7 @@ namespace l1_tests {
 
 TEST_F(CommandQueueFixture, WriteOneTileToL1Bank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, WriteOneTileToAllL1Banks) {
@@ -460,7 +460,7 @@ TEST_F(CommandQueueFixture, WriteOneTileToAllL1Banks) {
         .page_size = 2048,
         .buftype = BufferType::L1};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
@@ -470,13 +470,13 @@ TEST_F(CommandQueueFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
         .page_size = 2048,
         .buftype = BufferType::L1};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestNon32BAlignedPageSizeForL1) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, TestBackToBackNon32BAlignedPageSize) {
@@ -484,17 +484,17 @@ TEST_F(CommandQueueFixture, TestBackToBackNon32BAlignedPageSize) {
 
     Buffer bufa(device_, 125000, 100, buff_type);
     auto src_a = local_test_functions::generate_arange_vector(bufa.size());
-    EnqueueWriteBuffer(*this->cmd_queue_, bufa, src_a, false);
+    EnqueueWriteBuffer(*this->cmd_queue, bufa, src_a, false);
 
     Buffer bufb(device_, 152000, 152, buff_type);
     auto src_b = local_test_functions::generate_arange_vector(bufb.size());
-    EnqueueWriteBuffer(*this->cmd_queue_, bufb, src_b, false);
+    EnqueueWriteBuffer(*this->cmd_queue, bufb, src_b, false);
 
     vector<uint32_t> result_a;
-    EnqueueReadBuffer(*this->cmd_queue_, bufa, result_a, true);
+    EnqueueReadBuffer(*this->cmd_queue, bufa, result_a, true);
 
     vector<uint32_t> result_b;
-    EnqueueReadBuffer(*this->cmd_queue_, bufb, result_b, true);
+    EnqueueReadBuffer(*this->cmd_queue, bufb, result_b, true);
 
     EXPECT_EQ(src_a, result_a);
     EXPECT_EQ(src_b, result_b);
@@ -539,7 +539,7 @@ TEST_F(CommandQueueFixture, WritesToRandomBufferTypeAndThenReadsNonblocking) {
     BufferStressTestConfig config = {
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
     EXPECT_TRUE(
-        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer<false>(this->device_, tt::tt_metal::detail::GetCommandQueue(this->device_), config));
+        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer<false>(this->device_, *this->cmd_queue, config));
 }
 
 
@@ -549,7 +549,7 @@ TEST_F(CommandQueueFixture, ShardedBufferReadWrites) {
     config.num_iterations = 100;
 
     EXPECT_TRUE(
-        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(this->device_, tt::tt_metal::detail::GetCommandQueue(this->device_), config));
+        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(this->device_, *this->cmd_queue, config));
 }
 
 TEST_F(CommandQueueFixture, StressWrapTest) {
@@ -563,7 +563,7 @@ TEST_F(CommandQueueFixture, StressWrapTest) {
     BufferStressTestConfig config = {
         .page_size = 4096, .max_num_pages_per_buffer = 2000, .num_iterations = 10000, .num_unique_vectors = 20};
     EXPECT_TRUE(
-        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_wrap(this->device_, tt::tt_metal::detail::GetCommandQueue(this->device_), config));
+        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_wrap(this->device_, *this->cmd_queue, config));
 }
 
 }  // end namespace stress_tests

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -291,7 +291,7 @@ namespace dram_tests {
 
 TEST_F(CommandQueueFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, WriteOneTileToAllDramBanks) {
@@ -300,7 +300,7 @@ TEST_F(CommandQueueFixture, WriteOneTileToAllDramBanks) {
         .page_size = 2048,
         .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
@@ -310,7 +310,7 @@ TEST_F(CommandQueueFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
         .page_size = 2048,
         .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, Sending131072Pages) {
@@ -321,20 +321,20 @@ TEST_F(CommandQueueFixture, Sending131072Pages) {
         .page_size = 128,
         .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestNon32BAlignedPageSizeForDram) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestNon32BAlignedPageSizeForDram2) {
     // From stable diffusion read buffer
     TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestPageSizeTooLarge) {
@@ -344,7 +344,7 @@ TEST_F(CommandQueueFixture, TestPageSizeTooLarge) {
     // Should throw a host error due to the page size not fitting in the consumer CB
     TestBufferConfig config = {.num_pages = 1024, .page_size = 250880 * 2, .buftype = BufferType::DRAM};
 
-    EXPECT_ANY_THROW(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_ANY_THROW(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestWrapHostHugepageOnEnqueueReadBuffer) {
@@ -371,7 +371,7 @@ TEST_F(CommandQueueFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
 
     TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 // Test that command queue wraps when buffer available space in completion region is less than a page
@@ -392,23 +392,23 @@ TEST_F(CommandQueueFixture, TestWrapCompletionQOnInsufficientSpace) {
 
     Buffer buff_1(this->device_, first_buffer_size, large_page_size, BufferType::DRAM);
     auto src_1 = local_test_functions::generate_arange_vector(buff_1.size());
-    EnqueueWriteBuffer(tt::tt_metal::detail::GetCommandQueue(device_), buff_1, src_1, false);
+    EnqueueWriteBuffer(*this->cmd_queue_, buff_1, src_1, false);
     vector<uint32_t> result_1;
-    EnqueueReadBuffer(tt::tt_metal::detail::GetCommandQueue(device_), buff_1, result_1, true);
+    EnqueueReadBuffer(*this->cmd_queue_, buff_1, result_1, true);
     EXPECT_EQ(src_1, result_1);
 
     Buffer buff_2(this->device_, num_pages_second_buffer * small_page_size, small_page_size, BufferType::DRAM);
     auto src_2 = local_test_functions::generate_arange_vector(buff_2.size());
-    EnqueueWriteBuffer(tt::tt_metal::detail::GetCommandQueue(device_), buff_2, src_2, false);
+    EnqueueWriteBuffer(*this->cmd_queue_, buff_2, src_2, false);
     vector<uint32_t> result_2;
-    EnqueueReadBuffer(tt::tt_metal::detail::GetCommandQueue(device_), buff_2, result_2, true);
+    EnqueueReadBuffer(*this->cmd_queue_, buff_2, result_2, true);
     EXPECT_EQ(src_2, result_2);
 
     Buffer buff_3(this->device_, 32 * large_page_size, large_page_size, BufferType::DRAM);
     auto src_3 = local_test_functions::generate_arange_vector(buff_3.size());
-    EnqueueWriteBuffer(tt::tt_metal::detail::GetCommandQueue(device_), buff_3, src_3, false);
+    EnqueueWriteBuffer(*this->cmd_queue_, buff_3, src_3, false);
     vector<uint32_t> result_3;
-    EnqueueReadBuffer(tt::tt_metal::detail::GetCommandQueue(device_), buff_3, result_3, true);
+    EnqueueReadBuffer(*this->cmd_queue_, buff_3, result_3, true);
     EXPECT_EQ(src_3, result_3);
 }
 
@@ -430,16 +430,16 @@ TEST_F(CommandQueueFixture, TestWrapCompletionQOnInsufficientSpace2) {
     uint32_t num_pages_for_wrapping_buffer = (avail_space_for_wrapping_buffer / page_size) + 4;
 
     auto src_1 = local_test_functions::generate_arange_vector(buff_1.size());
-    EnqueueWriteBuffer(tt::tt_metal::detail::GetCommandQueue(device_), buff_1, src_1, false);
+    EnqueueWriteBuffer(*this->cmd_queue_, buff_1, src_1, false);
     vector<uint32_t> result_1;
-    EnqueueReadBuffer(tt::tt_metal::detail::GetCommandQueue(device_), buff_1, result_1, true);
+    EnqueueReadBuffer(*this->cmd_queue_, buff_1, result_1, true);
     EXPECT_EQ(src_1, result_1);
 
     Buffer wrap_buff(this->device_, num_pages_for_wrapping_buffer * page_size, page_size, BufferType::DRAM);
     auto src_2 = local_test_functions::generate_arange_vector(wrap_buff.size());
-    EnqueueWriteBuffer(tt::tt_metal::detail::GetCommandQueue(device_), wrap_buff, src_2, false);
+    EnqueueWriteBuffer(*this->cmd_queue_, wrap_buff, src_2, false);
     vector<uint32_t> result_2;
-    EnqueueReadBuffer(tt::tt_metal::detail::GetCommandQueue(device_), wrap_buff, result_2, true);
+    EnqueueReadBuffer(*this->cmd_queue_, wrap_buff, result_2, true);
     EXPECT_EQ(src_2, result_2);
 }
 
@@ -450,7 +450,7 @@ namespace l1_tests {
 
 TEST_F(CommandQueueFixture, WriteOneTileToL1Bank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, WriteOneTileToAllL1Banks) {
@@ -460,7 +460,7 @@ TEST_F(CommandQueueFixture, WriteOneTileToAllL1Banks) {
         .page_size = 2048,
         .buftype = BufferType::L1};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
@@ -470,13 +470,13 @@ TEST_F(CommandQueueFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
         .page_size = 2048,
         .buftype = BufferType::L1};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestNon32BAlignedPageSizeForL1) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
-    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, tt::tt_metal::detail::GetCommandQueue(device_), config));
+    EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue_, config));
 }
 
 TEST_F(CommandQueueFixture, TestBackToBackNon32BAlignedPageSize) {
@@ -484,17 +484,17 @@ TEST_F(CommandQueueFixture, TestBackToBackNon32BAlignedPageSize) {
 
     Buffer bufa(device_, 125000, 100, buff_type);
     auto src_a = local_test_functions::generate_arange_vector(bufa.size());
-    EnqueueWriteBuffer(tt::tt_metal::detail::GetCommandQueue(device_), bufa, src_a, false);
+    EnqueueWriteBuffer(*this->cmd_queue_, bufa, src_a, false);
 
     Buffer bufb(device_, 152000, 152, buff_type);
     auto src_b = local_test_functions::generate_arange_vector(bufb.size());
-    EnqueueWriteBuffer(tt::tt_metal::detail::GetCommandQueue(device_), bufb, src_b, false);
+    EnqueueWriteBuffer(*this->cmd_queue_, bufb, src_b, false);
 
     vector<uint32_t> result_a;
-    EnqueueReadBuffer(tt::tt_metal::detail::GetCommandQueue(device_), bufa, result_a, true);
+    EnqueueReadBuffer(*this->cmd_queue_, bufa, result_a, true);
 
     vector<uint32_t> result_b;
-    EnqueueReadBuffer(tt::tt_metal::detail::GetCommandQueue(device_), bufb, result_b, true);
+    EnqueueReadBuffer(*this->cmd_queue_, bufb, result_b, true);
 
     EXPECT_EQ(src_a, result_a);
     EXPECT_EQ(src_b, result_b);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
@@ -15,16 +15,15 @@ TEST_F(CommandQueueFixture, TestEventsWrittenToCompletionQueueInOrder) {
     size_t num_buffers = 100;
     uint32_t page_size = 2048;
     vector<uint32_t> page(page_size / sizeof(uint32_t));
-    CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(this->device_);
-    uint32_t completion_queue_base = this->device_->manager->get_completion_queue_read_ptr(0);
+    uint32_t completion_queue_base = this->device_->sysmem_manager().get_completion_queue_read_ptr(0);
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
     constexpr uint32_t completion_queue_event_alignment = 32;
     for (size_t i = 0; i < num_buffers; i++) {
         Buffer buf(this->device_, page_size, page_size, BufferType::DRAM);
-        EnqueueWriteBuffer(cq, buf, page, false);
+        EnqueueWriteBuffer(*this->cmd_queue, buf, page, false);
     }
-    Finish(cq);
+    Finish(*this->cmd_queue);
 
     // Read completion queue and ensure we see events 0-99 inclusive in order
     uint32_t event;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_remote_dispatch_tunneling.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_remote_dispatch_tunneling.cpp
@@ -26,7 +26,7 @@ TEST_F(CommandQueueMultiDeviceFixture, TestCommandReachesRemoteDevice) {
             continue;
         }
 
-        CommandQueue &remote_cq = detail::GetCommandQueue(device);
+        CommandQueue &remote_cq = device->command_queue();
 
         chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
         uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -15,7 +15,7 @@ class CommandQueueFixture : public ::testing::Test {
     tt::ARCH arch_;
     Device* device_;
     uint32_t pcie_id;
-    std::unique_ptr<CommandQueue> cmd_queue_;
+    std::unique_ptr<CommandQueue> cmd_queue;
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
@@ -26,7 +26,7 @@ class CommandQueueFixture : public ::testing::Test {
 
         const int device_id = 0;
         this->device_ = tt::tt_metal::CreateDevice(device_id);
-        this->cmd_queue_ = std::make_unique<CommandQueue> ( device_, 0);
+        this->cmd_queue = std::make_unique<CommandQueue> ( device_, 0);
         this->pcie_id = 0;
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -15,7 +15,7 @@ class CommandQueueFixture : public ::testing::Test {
     tt::ARCH arch_;
     Device* device_;
     uint32_t pcie_id;
-
+    std::unique_ptr<CommandQueue> cmd_queue_;
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
@@ -26,7 +26,7 @@ class CommandQueueFixture : public ::testing::Test {
 
         const int device_id = 0;
         this->device_ = tt::tt_metal::CreateDevice(device_id);
-
+        this->cmd_queue_ = std::make_unique<CommandQueue> ( device_, 0);
         this->pcie_id = 0;
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/compute/sfpu/sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/compute/sfpu/sfpu_compute.cpp
@@ -113,11 +113,11 @@ struct SfpuConfig {
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_sfpu_all_same_buffer(tt_metal::Device* device, const SfpuConfig& test_config) {
+bool run_sfpu_all_same_buffer(CommandQueue & cq, const SfpuConfig& test_config) {
     const size_t byte_size = test_config.num_tiles * test_config.tile_byte_size;
     tt_metal::Program program = tt_metal::CreateProgram();
     tt::tt_metal::InterleavedBufferConfig dram_config{
-                    .device= device,
+                    .device= cq.device(),
                     .size = byte_size,
                     .page_size = byte_size,
                     .buffer_type = tt::tt_metal::BufferType::DRAM
@@ -207,7 +207,7 @@ bool run_sfpu_all_same_buffer(tt_metal::Device* device, const SfpuConfig& test_c
                 .defines = sfpu_defines});
 
         int chip_id = 0;
-        CoresInCoreRangeGenerator cores_in_core_range(core_range, device->logical_grid_size());
+        CoresInCoreRangeGenerator cores_in_core_range(core_range, cq.device()->logical_grid_size());
 
         bool terminate;
 
@@ -223,7 +223,6 @@ bool run_sfpu_all_same_buffer(tt_metal::Device* device, const SfpuConfig& test_c
     }
 
     std::vector<uint32_t> dest_buffer_data;
-    CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
     EnqueueWriteBuffer(cq, input_dram_buffer, packed_input, false);
 
     EnqueueProgram(cq, program, false);
@@ -257,7 +256,7 @@ TEST_P(SingleCoreSingleDeviceSfpuParameterizedFixture, SfpuCompute) {
             .sfpu_op = sfpu_op,
             .approx_mode = false};
         log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-        EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     }
 }
 
@@ -305,7 +304,7 @@ TEST_P(SingleCoreSingleDeviceSfpuParameterizedApproxFixture, SfpuCompute) {
             .sfpu_op = sfpu_op,
             .approx_mode = true};
         log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-        EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     }
 }
 INSTANTIATE_TEST_CASE_P(
@@ -350,21 +349,21 @@ TEST_F(CommandQueueFixture, DISABLED_MultiContinguousCoreSingleTileSfpuApproxCom
 
     test_config.num_tiles = 1;
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
 }
 
 TEST_F(CommandQueueFixture, DISABLED_MultiContinguousCoreMultiTileSfpuApproxCompute) {
@@ -389,21 +388,21 @@ TEST_F(CommandQueueFixture, DISABLED_MultiContinguousCoreMultiTileSfpuApproxComp
     test_config.num_tiles = 4;
 
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
 }
 TEST_F(CommandQueueFixture, DISABLED_AllCoreSingleTileSfpuApproxCompute) {
     unit_tests::compute::sfpu::SfpuConfig test_config = {
@@ -428,21 +427,21 @@ TEST_F(CommandQueueFixture, DISABLED_AllCoreSingleTileSfpuApproxCompute) {
 
     test_config.num_tiles = 1;
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
 }
 TEST_F(CommandQueueFixture, DISABLED_AllCoreMultiTileSfpuApproxCompute) {
     unit_tests::compute::sfpu::SfpuConfig test_config = {
@@ -466,19 +465,19 @@ TEST_F(CommandQueueFixture, DISABLED_AllCoreMultiTileSfpuApproxCompute) {
     test_config.cores = core_set;
     test_config.num_tiles = 4;
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(device_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
 }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/compute/sfpu/sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/compute/sfpu/sfpu_compute.cpp
@@ -256,7 +256,7 @@ TEST_P(SingleCoreSingleDeviceSfpuParameterizedFixture, SfpuCompute) {
             .sfpu_op = sfpu_op,
             .approx_mode = false};
         log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-        EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     }
 }
 
@@ -304,7 +304,7 @@ TEST_P(SingleCoreSingleDeviceSfpuParameterizedApproxFixture, SfpuCompute) {
             .sfpu_op = sfpu_op,
             .approx_mode = true};
         log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-        EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     }
 }
 INSTANTIATE_TEST_CASE_P(
@@ -349,21 +349,21 @@ TEST_F(CommandQueueFixture, DISABLED_MultiContinguousCoreSingleTileSfpuApproxCom
 
     test_config.num_tiles = 1;
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
 }
 
 TEST_F(CommandQueueFixture, DISABLED_MultiContinguousCoreMultiTileSfpuApproxCompute) {
@@ -388,21 +388,21 @@ TEST_F(CommandQueueFixture, DISABLED_MultiContinguousCoreMultiTileSfpuApproxComp
     test_config.num_tiles = 4;
 
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
 }
 TEST_F(CommandQueueFixture, DISABLED_AllCoreSingleTileSfpuApproxCompute) {
     unit_tests::compute::sfpu::SfpuConfig test_config = {
@@ -427,21 +427,21 @@ TEST_F(CommandQueueFixture, DISABLED_AllCoreSingleTileSfpuApproxCompute) {
 
     test_config.num_tiles = 1;
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
 }
 TEST_F(CommandQueueFixture, DISABLED_AllCoreMultiTileSfpuApproxCompute) {
     unit_tests::compute::sfpu::SfpuConfig test_config = {
@@ -465,19 +465,19 @@ TEST_F(CommandQueueFixture, DISABLED_AllCoreMultiTileSfpuApproxCompute) {
     test_config.cores = core_set;
     test_config.num_tiles = 4;
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue_, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
 }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_EnqueueProgram.cpp
@@ -64,7 +64,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args(Device* device, const CoreCoord
     tt::tt_metal::SetRuntimeArgs(program, dummy_kernel0, eth_core_coord, dummy_kernel0_args);
 
     tt::tt_metal::detail::CompileProgram(device, program);
-    auto& cq = tt::tt_metal::detail::GetCommandQueue(device);
+    auto& cq = device->command_queue();
     EnqueueProgram(cq, program, false);
     Finish(cq);
 
@@ -136,7 +136,7 @@ bool reader_kernel_no_send(
             (uint32_t)eth_l1_byte_address,
         });
 
-    auto& cq = tt::tt_metal::detail::GetCommandQueue(device);
+    auto& cq = device->command_queue();
     tt::tt_metal::detail::CompileProgram(device, program);
     EnqueueProgram(cq, program, false);
     Finish(cq);
@@ -206,7 +206,7 @@ bool writer_kernel_no_receive(
             (uint32_t)eth_l1_byte_address,
         });
 
-    auto& cq = tt::tt_metal::detail::GetCommandQueue(device);
+    auto& cq = device->command_queue();
     tt::tt_metal::detail::CompileProgram(device, program);
     EnqueueProgram(cq, program, false);
     Finish(cq);
@@ -304,15 +304,12 @@ bool eth_direct_sender_receiver_kernels(
     ////////////////////////////////////////////////////////////////////////////
 
     tt::tt_metal::detail::CompileProgram(sender_device, sender_program);
-    auto& sender_cq = tt::tt_metal::detail::GetCommandQueue(sender_device);
-
     tt::tt_metal::detail::CompileProgram(receiver_device, receiver_program);
-    auto& receiver_cq = tt::tt_metal::detail::GetCommandQueue(receiver_device);
 
-    EnqueueProgram(sender_cq, sender_program, false);
-    EnqueueProgram(receiver_cq, receiver_program, false);
-    Finish(sender_cq);
-    Finish(receiver_cq);
+    EnqueueProgram(sender_device->command_queue(), sender_program, false);
+    EnqueueProgram(receiver_device->command_queue(), receiver_program, false);
+    Finish(sender_device->command_queue());
+    Finish(receiver_device->command_queue());
 
     auto readback_vec = llrt::read_hex_vec_from_core(
         receiver_device->id(),
@@ -424,15 +421,12 @@ bool chip_to_chip_dram_buffer_transfer(
     ////////////////////////////////////////////////////////////////////////////
 
     tt::tt_metal::detail::CompileProgram(sender_device, sender_program);
-    auto& sender_cq = tt::tt_metal::detail::GetCommandQueue(sender_device);
-
     tt::tt_metal::detail::CompileProgram(receiver_device, receiver_program);
-    auto& receiver_cq = tt::tt_metal::detail::GetCommandQueue(receiver_device);
 
-    EnqueueProgram(sender_cq, sender_program, false);
-    EnqueueProgram(receiver_cq, receiver_program, false);
-    Finish(sender_cq);
-    Finish(receiver_cq);
+    EnqueueProgram(sender_device->command_queue(), sender_program, false);
+    EnqueueProgram(receiver_device->command_queue(), receiver_program, false);
+    Finish(sender_device->command_queue());
+    Finish(receiver_device->command_queue());
 
     std::vector<uint32_t> dest_dram_data;
     tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_dram_data);
@@ -545,15 +539,12 @@ bool chip_to_chip_interleaved_buffer_transfer(
     ////////////////////////////////////////////////////////////////////////////
 
     tt::tt_metal::detail::CompileProgram(sender_device, sender_program);
-    auto& sender_cq = tt::tt_metal::detail::GetCommandQueue(sender_device);
-
     tt::tt_metal::detail::CompileProgram(receiver_device, receiver_program);
-    auto& receiver_cq = tt::tt_metal::detail::GetCommandQueue(receiver_device);
 
-    EnqueueProgram(sender_cq, sender_program, false);
-    EnqueueProgram(receiver_cq, receiver_program, false);
-    Finish(sender_cq);
-    Finish(receiver_cq);
+    EnqueueProgram(sender_device->command_queue(), sender_program, false);
+    EnqueueProgram(receiver_device->command_queue(), receiver_program, false);
+    Finish(sender_device->command_queue());
+    Finish(receiver_device->command_queue());
 
     std::vector<uint32_t> dest_buffer_data;
     tt_metal::detail::ReadFromBuffer(output_buffer, dest_buffer_data);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_ring_gather_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_ring_gather_EnqueueProgram.cpp
@@ -280,7 +280,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
     for (uint32_t i = 0; i < sender_receivers.size(); ++i) {
         const auto& device = std::get<0>(sender_receivers[i]);
         tt::tt_metal::detail::CompileProgram(device, programs.at(device->id()));
-        auto& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        auto& cq = device->command_queue();
 
         EnqueueProgram(cq, programs.at(device->id()), false);
         cqs.emplace_back(cq);
@@ -427,7 +427,7 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
     for (uint32_t i = 0; i < sender_receivers.size(); ++i) {
         const auto& device = std::get<0>(sender_receivers[i]);
         tt::tt_metal::detail::CompileProgram(device, programs.at(device->id()));
-        auto& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        auto& cq = device->command_queue();
 
         EnqueueProgram(cq, programs.at(device->id()), false);
         cqs.emplace_back(cq);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
@@ -30,7 +30,7 @@ struct PipelineRowConfig {
 };
 
 void create_and_run_row_pipeline(tt_metal::Device* device, const PipelineRowConfig& test_config) {
-    CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+    CommandQueue& cq = device->command_queue();
 
     tt_metal::Program program = tt_metal::CreateProgram();
 

--- a/tests/tt_metal/tt_metal/unit_tests_frequent/tests/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_frequent/tests/run_many_times.cpp
@@ -70,7 +70,7 @@ void RunTest(Device *device) {
         tt::tt_metal::detail::LaunchProgram(device, program);
     } else {
         // Fast Dispatch uses the command queue
-        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        CommandQueue& cq = device->command_queue();
         EnqueueProgram(cq, program, false);
         Finish(cq);
     }

--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -91,6 +91,8 @@ class Tensor {
 
      // TODO(arakhmati): clean up the methods below
      Buffer *buffer() const { return std::get<DeviceStorage>(this->storage_).buffer.get(); }
+     DeviceBuffer device_buffer() const { return std::get<DeviceStorage>(this->storage_).buffer; }
+
      Device *device() const { return this->buffer()->device(); }
      const MemoryConfig memory_config() const {
          return std::visit(

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -428,7 +428,7 @@ inline void read_data_from_device_buffer_slow_dispatch(const Tensor& tensor, vec
 }
 
 template <typename T, template <typename> typename BufferType>
-inline void write_data_to_device_buffer(const BufferType<T>& host_buffer, Buffer& device_buffer) {
+inline void write_data_to_device_buffer(const BufferType<T>& host_buffer, DeviceBuffer device_buffer) {
     ZoneScoped;
     // TODO(arakhmati): can we use generators in this function to go from `data_to_write` to `uint32_data`?
     // And effectively get rid of any additional allocation
@@ -938,10 +938,10 @@ void memcpy(Tensor& dst, const Tensor& src) {
 
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
         EnqueueReadBuffer(
-            src.device()->command_queue(), *src.buffer(), get_raw_host_data_ptr(dst), true);
+            src.device()->command_queue(), src.device_buffer(), get_raw_host_data_ptr(dst), true);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
         EnqueueWriteBuffer(
-            dst.device()->command_queue(), *dst.buffer(), get_raw_host_data_ptr(src), false);
+            dst.device()->command_queue(), dst.device_buffer(), get_raw_host_data_ptr(src), false);
     } else {
         TT_THROW("Unsupported memcpy");
     }

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -433,8 +433,7 @@ inline void write_data_to_device_buffer(const BufferType<T>& host_buffer, Buffer
     // TODO(arakhmati): can we use generators in this function to go from `data_to_write` to `uint32_data`?
     // And effectively get rid of any additional allocation
 
-    EnqueueWriteBuffer(
-        tt::tt_metal::detail::GetCommandQueue(device_buffer.device(), false), device_buffer, host_buffer.data(), false);
+    EnqueueWriteBuffer( device_buffer.device()->command_queue(), device_buffer, host_buffer.data(), false);
 
 }
 
@@ -939,10 +938,10 @@ void memcpy(Tensor& dst, const Tensor& src) {
 
     if (is_cpu_tensor(dst) && is_device_tensor(src)) {
         EnqueueReadBuffer(
-            tt::tt_metal::detail::GetCommandQueue(src.device(), false), *src.buffer(), get_raw_host_data_ptr(dst), true);
+            src.device()->command_queue(), *src.buffer(), get_raw_host_data_ptr(dst), true);
     } else if (is_device_tensor(dst) && is_cpu_tensor(src)) {
         EnqueueWriteBuffer(
-            tt::tt_metal::detail::GetCommandQueue(dst.device(), false), *dst.buffer(), get_raw_host_data_ptr(src), false);
+            dst.device()->command_queue(), *dst.buffer(), get_raw_host_data_ptr(src), false);
     } else {
         TT_THROW("Unsupported memcpy");
     }

--- a/tt_eager/tt_dnn/op_library/move/move_op.cpp
+++ b/tt_eager/tt_dnn/op_library/move/move_op.cpp
@@ -12,6 +12,9 @@ namespace move_op_utils {
 using namespace tt::tt_metal;
 
 bool can_deallocate(const Tensor &input_tensor) {
+    if (input_tensor.device())
+        tt::tt_metal::Finish(input_tensor.device()->command_queue());
+
     return std::visit(
         [](auto&& storage)
         {

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -228,12 +228,13 @@ std::vector<Tensor> run_device_operation(
             }
 
             if (USE_FAST_DISPATCH) {
+                CommandQueue cq ( device, 0);
 #ifndef TTNN_ENABLE_LOGGING
-                EnqueueProgram(tt::tt_metal::detail::GetCommandQueue(device), program, false);
+                EnqueueProgram(cq, program, false);
 #else
                 const auto start{std::chrono::steady_clock::now()};
-                EnqueueProgram(tt::tt_metal::detail::GetCommandQueue(device), program, false);
-                Finish(tt::tt_metal::detail::GetCommandQueue(device));
+                EnqueueProgram(cq, program, false);
+                Finish(cq);
                 const auto end{std::chrono::steady_clock::now()};
                 const auto elapsed_seconds = static_cast<std::size_t>((end - start).count());
                 tt::log_info(

--- a/tt_eager/tt_numpy/functions.hpp
+++ b/tt_eager/tt_numpy/functions.hpp
@@ -351,15 +351,15 @@ static Tensor manual_insertion(const Tensor& input_tensor, const Shape& shape, D
 			  const MemoryConfig& output_mem_config = MemoryConfig{.memory_layout=tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) {
     TT_ASSERT(input_tensor.layout() == Layout::ROW_MAJOR);
     TT_ASSERT(shape[0] * shape[1] * shape[2] * shape[3] == input_tensor.volume(), "Required shape volume must match old shape volume");
-    auto device_buffer = input_tensor.buffer();
+    auto device_buffer = input_tensor.device_buffer();
     uint32_t size_in_bytes = device_buffer->size();
     vector<T> data_vec;
     const char *TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
         data_vec.resize(size_in_bytes / sizeof(T));
-        tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(input_tensor, data_vec.data(), true);
+        tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(input_tensor.device()->command_queue(), device_buffer, data_vec.data(), true);
     } else {
-        tt::tt_metal::tensor_impl::read_data_from_device_buffer_slow_dispatch<T>(input_tensor, data_vec);
+        tt::tt_metal::tensor_impl::read_data_from_device_buffer<T>(device_buffer, data_vec);
     }
     auto owned_buffer = owned_buffer::create<T>(std::move(data_vec));
     auto output = Tensor(OwnedStorage{owned_buffer}, shape, data_type, Layout::ROW_MAJOR).to(layout);

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -277,15 +277,12 @@ namespace tt::tt_metal{
         inline CommandQueue &GetCommandQueue(Device *device, bool init_cq)
         {
             detail::DispatchStateCheck(true);
-            // For now there is only one SW CommandQueue per device
             static std::vector<std::unique_ptr<CommandQueue>> command_queues( GetNumAvailableDevices() );
-            chip_id_t id = device->id();
-            TT_FATAL(id < command_queues.size(), "Invalid device {} detected", id);
-            TT_FATAL(device->is_initialized(), "Cannot access command queue for closed device {}", id);
             static std::mutex cq_creation_mutex;
             if (init_cq) {
                 std::lock_guard<std::mutex> lock(cq_creation_mutex);
-                command_queues[device->id()] = std::make_unique<CommandQueue>(device, 0);
+                if ( command_queues[device->id()] == nullptr)
+                    command_queues[device->id()] = std::make_unique<CommandQueue>( device, 0);
             }
             return *(command_queues[id]);
         }

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -281,7 +281,7 @@ namespace tt::tt_metal{
             static std::mutex cq_creation_mutex;
             if (init_cq) {
                 std::lock_guard<std::mutex> lock(cq_creation_mutex);
-                if ( command_queues[device->id()] == nullptr)
+                if ( command_queues[device->id()] == nullptr || command_queues[device->id()]->device() != device)
                     command_queues[device->id()] = std::make_unique<CommandQueue>( device, 0);
             }
             return *(command_queues[id]);

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -274,40 +274,10 @@ namespace tt::tt_metal{
             return true;
         }
 
-        inline CommandQueue &GetCommandQueue(Device *device, bool init_cq)
-        {
-            detail::DispatchStateCheck(true);
-            static std::vector<std::unique_ptr<CommandQueue>> command_queues( GetNumAvailableDevices() );
-            static std::mutex cq_creation_mutex;
-            if (init_cq) {
-                std::lock_guard<std::mutex> lock(cq_creation_mutex);
-                if ( command_queues[device->id()] == nullptr || command_queues[device->id()]->device() != device)
-                    command_queues[device->id()] = std::make_unique<CommandQueue>( device, 0);
-            }
-            return *(command_queues[id]);
-        }
-
-        inline HWCommandQueue &GetHWCommandQueue(Device *device, uint32_t cmd_queue_channel)
-        {
-            detail::DispatchStateCheck(true);
-            // For now there is only one SW HWCommandQueue per device
-            static std::vector<std::unique_ptr<HWCommandQueue>> command_queues( GetNumAvailableDevices() );
-            chip_id_t id = device->id();
-            TT_FATAL(id < command_queues.size(), "Invalid device {} detected", id);
-            TT_FATAL(device->is_initialized(), "Cannot access command queue for closed device {}", id);
-            static std::mutex cq_creation_mutex;
-            {
-                std::lock_guard<std::mutex> lock(cq_creation_mutex);
-                if ( command_queues[device->id()] == nullptr || command_queues[device->id()]->device != device )
-                    command_queues[device->id()] = std::make_unique<HWCommandQueue>(device, cmd_queue_channel);
-            }
-            return *(command_queues[id]);
-        }
-
         inline void Synchronize(Device *device)
         {
             if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
-                Finish(GetCommandQueue(device, false));
+                Finish(device->command_queue());
             }
         }
 

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -81,6 +81,7 @@ namespace tt::tt_metal{
         // Launches all kernels on cores specified with kernels in the program.
         // All kernels on a given Tensix core must be launched.
         void LaunchProgram(Device *device, Program &program);
+        void LaunchProgram(Device *device, std::shared_ptr<Program> program);
 
         /**
          *  Compiles all kernels within the program, and generates binaries that are written to `$TT_METAL_HOME/built/<device>/kernels/<kernel name>/<kernel hash>`

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -382,15 +382,15 @@ void EnqueueTrace(Trace& trace, bool blocking);
  * */
 void DumpDeviceProfileResults(Device *device, const Program &program);
 
-namespace experimental
-{
-    struct Event{
-        uint32_t id;
-        uint32_t cq_id;
-    };
+// namespace experimental
+// {
+//     struct Event{
+//         uint32_t id;
+//         uint32_t cq_id;
+//     };
 
-    void RecordEvent (Event & e);
-}
+//     void RecordEvent (Event & e);
+// }
 
 }  // namespace tt_metal
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -265,7 +265,7 @@ std::vector<uint32_t>& GetRuntimeArgs(const Program &program, KernelHandle kerne
  * | dst          | The vector where the results that are read will be stored              | vector<uint32_t> &                  |                                        | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                                | Only blocking mode supported currently | Yes      |
  */
-void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, vector<uint32_t>& dst, bool blocking);
+void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& dst, bool blocking);
 
 /**
  * Reads a buffer from the device
@@ -279,7 +279,7 @@ void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buf
  * | dst          | The memory where the result will be stored                             | void*                               |                                        | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                                | Only blocking mode supported currently | Yes      |
  */
-void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, void* dst, bool blocking);
+void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking);
 
 /**
  * Writes a buffer to the device
@@ -293,7 +293,7 @@ void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buf
  * | src          | The vector we are writing to the device                                | vector<uint32_t> &                  |                                    | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                                |                                    | Yes      |
  */
-void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, vector<uint32_t>& src, bool blocking);
+void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& src, bool blocking);
 
 /**
  * Writes a buffer to the device
@@ -307,7 +307,7 @@ void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Bu
  * | src          | The memory we are writing to the device                                | const void*                         |                                    | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                                |                                    | Yes      |
  */
-void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, const void* src, bool blocking);
+void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, const void* src, bool blocking);
 
 /**
  * Writes a program to the device and launches it

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <variant>
 #include <vector>
+#include <future>
 #include "common/core_coord.h"
 #include "tt_metal/impl/program/program.hpp"
 #include "tt_metal/impl/buffers/buffer.hpp"
@@ -128,7 +129,7 @@ CBHandle CreateCircularBuffer(Program &program, const std::variant<CoreCoord, Co
  * | Argument  | Description                                                    | Type                         | Valid Range | Required |
  * |-----------|----------------------------------------------------------------|------------------------------|-------------|----------|
  * | program   | The program containing the circular buffer                     | Program &                    |             | Yes      |
- * | cb_handle | ID of the circular buffer, returned by `CreateCircularBuffers` | CBHandle (uintptr_t) |             | Yes      |
+ * | cb_handle | ID of the circular buffer, returned by `CreateCircularBuffers` | CBHandle (uintptr_t) |       |    Yes      |
 */
 const CircularBufferConfig &GetCircularBufferConfig(Program &program, CBHandle cb_handle);
 
@@ -140,7 +141,7 @@ const CircularBufferConfig &GetCircularBufferConfig(Program &program, CBHandle c
  * | Argument   | Description                                                    | Type                         | Valid Range | Required |
  * |------------|----------------------------------------------------------------|------------------------------|-------------|----------|
  * | program    | The program containing the circular buffer                     | Program &                    |             | Yes      |
- * | cb_handle  | ID of the circular buffer, returned by `CreateCircularBuffers` | CBHandle (uintptr_t) |             | Yes      |
+ * | cb_handle  | ID of the circular buffer, returned by `CreateCircularBuffers` | CBHandle (uintptr_t) |       | Yes         |          |
  * | total_size | New size of the circular buffer in bytes                       | uint32_t                     |             | Yes      |
 */
 void UpdateCircularBufferTotalSize(Program &program, CBHandle cb_handle, uint32_t total_size);
@@ -167,7 +168,7 @@ void UpdateCircularBufferPageSize(Program &program, CBHandle cb_handle, uint8_t 
  * | Argument  | Description                                                                              | Type                         | Valid Range | Required |
  * |-----------|------------------------------------------------------------------------------------------|------------------------------|-------------|----------|
  * | program   | The program containing the circular buffer                                               | Program &                    |             | Yes      |
- * | cb_handle | ID of the circular buffer, returned by `CreateCircularBuffers`                           | CBHandle (uintptr_t) |             | Yes      |
+ * | cb_handle | ID of the circular buffer, returned by `CreateCircularBuffers`                           | CBHandle (uintptr_t) |       | Yes         |          |
  * | buffer    | Dynamically allocated L1 buffer that shares address space of circular buffer `cb_handle` | const Buffer &               | L1 buffer   | Yes      |
  */
 void UpdateDynamicCircularBufferAddress(Program &program, CBHandle cb_handle, const Buffer &buffer);
@@ -219,7 +220,7 @@ void DeallocateBuffer(Buffer &buffer);
  * | Argument     | Description                                                            | Type                                                   | Valid Range                                                         | Required |
  * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------|----------|
  * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
- * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)                                    |                                                                     | Yes      |
+ * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)                                |                                                                     | Yes      |
  * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::variant<CoreCoord,CoreRange,CoreRangeSet> & | Any logical Tensix core coordinate(s) on which the kernel is placed | Yes      |
  * | runtime_args | The runtime args to be written                                         | const std::vector<uint32_t> &                          |                                                                     | Yes      |
  */
@@ -315,7 +316,7 @@ void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Bu
  *
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
+ * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &              |                                    | Yes      |
  * | program      | The program that will be executed on the device that cq is bound to    | Program &                     |                                    | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                          |                                    | Yes      |
  * | trace        | The trace object which represents the history of previously issued     | optional<reference_wrapper<Trace>>                       |                                    | Yes      |
@@ -330,7 +331,7 @@ void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking, std::opti
  *
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
+ * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &              |                                    | Yes      |
  */
 void Finish(CommandQueue& cq);
 
@@ -381,6 +382,15 @@ void EnqueueTrace(Trace& trace, bool blocking);
  * */
 void DumpDeviceProfileResults(Device *device, const Program &program);
 
+namespace experimental
+{
+    struct Event{
+        uint32_t id;
+        uint32_t cq_id;
+    };
+
+    void RecordEvent (Event & e);
+}
 
 }  // namespace tt_metal
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -322,7 +322,7 @@ void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Bu
  * | trace        | The trace object which represents the history of previously issued     | optional<reference_wrapper<Trace>>                       |                                    | Yes      |
  * |              | commands                                                               |                               |                                    |          |
  */
-void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking, std::optional<std::reference_wrapper<Trace>> trace = {});
+void EnqueueProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program> > program, bool blocking, std::optional<std::reference_wrapper<Trace>> trace = {});
 
 /**
  * Blocks until all previously dispatched commands on the device have completed

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -796,11 +796,13 @@ const string Device::build_kernel_target_path(JitBuildProcessorType t, int i, co
 
 HWCommandQueue& Device::hw_command_queue(size_t cq_id) {
     TT_ASSERT( cq_id < hw_command_queues_.size(), "cq_id {} is out of range", cq_id );
+    TT_FATAL(this->is_initialized(), "Device has not been initialized, did you forget to call InitializeDevice?");
     return *hw_command_queues_[cq_id];
 }
 
 CommandQueue& Device::command_queue(size_t cq_id) {
     TT_ASSERT( cq_id < sw_command_queues_.size(), "cq_id {} is out of range", cq_id );
+    TT_FATAL(this->is_initialized(), "Device has not been initialized, did you forget to call InitializeDevice?");
     return *sw_command_queues_[cq_id];
 }
 }  // namespace tt_metal

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -61,9 +61,7 @@ Device::Device(chip_id_t device_id, const uint8_t num_hw_cqs, const std::vector<
 {
     ZoneScoped;
     TT_ASSERT(num_hw_cqs > 0 and num_hw_cqs < 3, "num_hw_cqs can be between 1 and 2");
-
     this->initialize(l1_bank_remap);
-    tt::tt_metal::detail::GetCommandQueue(this, true); // Needed to initialize a new command queue
 }
 
 void Device::initialize_cluster() {

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -68,11 +68,11 @@ class Device {
     ~Device();
 
     // TODO: Add copy/move semantics
-    Device(const Device &other): num_hw_cqs_(other.num_hw_cqs_) { }
-    Device& operator=(const Device &other) { return *this; }
+    Device(const Device &other) = delete;
+    Device& operator=(const Device &other) = delete;
 
-    Device(Device &&other): num_hw_cqs_(other.num_hw_cqs_) { }
-    Device& operator=(Device &&other) { return *this; }
+    Device(Device &&other) = default;
+    Device& operator=(Device &&other) = default;
 
     tt::ARCH arch() const;
 

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -34,6 +34,8 @@ namespace detail {
 struct ProgramDeleter {
     void operator()(Program* p);
 };
+
+
 }
 
 using on_close_device_callback = std::function<void ()>;

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -23,7 +23,7 @@ enum class BufferType;
 class Buffer;
 class Program;
 class JitBuildEnv;
-class CommandQueue;
+class HWCommandQueue;
 
 namespace detail {
 // TODO(agrebenisan): Need device to hold onto command queue programs,
@@ -207,6 +207,11 @@ class Device {
     JitBuildEnv build_env_;
     JitBuildStateSet firmware_build_states_;
     JitBuildStateSet kernel_build_states_;
+
+    // SystemMemoryManager is the interface to the hardware command queue
+    std::unique_ptr<SystemMemoryManager> sysmem_manager;
+    // Allows access to sysmem_writer
+    friend class HWCommandQueue;
 
     std::set<CoreCoord> compute_cores_;
     std::set<CoreCoord> storage_only_cores_;

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1108,8 +1108,8 @@ void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buf
                 device->hw_command_queue(cq_id).enqueue_read_buffer(b, dst, blocking);
             }, f );
         }
-        f.wait();
-        if (t.has_value()) t.value().get().reset();
+        f.get();
+        // if (t.has_value()) t.value().get().reset();
 
     }, buffer);
 }
@@ -1132,8 +1132,8 @@ void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Bu
             }, f );
 
        }
-       f.wait();
-       if (t.has_value()) t.value().get().reset();
+       f.get();
+    //    if (t.has_value()) t.value().get().reset();
     }, buffer);
 }
 
@@ -1162,8 +1162,8 @@ void EnqueueProgram(CommandQueue& cq, std::variant < std::reference_wrapper<Prog
                     device->hw_command_queue(cq_id).enqueue_program(*program, trace, blocking);
                 }, f );
             }
-            f.wait();
-            if (t.has_value()) t.value().get().reset();
+            f.get();
+            // if (t.has_value()) t.value().get().reset();
         }, program);
 }
 
@@ -1173,7 +1173,7 @@ void Finish(CommandQueue& cq) {
     cq.submit( [device = cq.device(), cq_id = cq.id()] {
         device->hw_command_queue(cq_id).finish();
     }, f);
-    f.wait();
+    f.get();
     cq.reset();
 }
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1174,6 +1174,7 @@ void Finish(CommandQueue& cq) {
         device->hw_command_queue(cq_id).finish();
     }, f);
     f.wait();
+    cq.reset();
 }
 
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1101,7 +1101,7 @@ void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buf
     TT_FATAL(blocking, "Non-blocking EnqueueReadBuffer not yet supported");
     std::visit ( [&cq, dst, blocking](auto&& b) {
         using T = std::decay_t<decltype(b)>;
-        std::future<void> f;
+        std::shared_future<void> f;
         std::optional<std::reference_wrapper<tf::AsyncTask>> t;
         if constexpr (std::is_same_v<T, std::reference_wrapper<Buffer>> || std::is_same_v<T, std::shared_ptr<Buffer> > ) {
             t = cq.submit( [device = cq.device(), cq_id = cq.id(), b, dst, blocking] {
@@ -1119,7 +1119,7 @@ void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Bu
     detail::DispatchStateCheck(true);
     std::visit ( [&cq, src, blocking](auto&& b) {
         using T = std::decay_t<decltype(b)>;
-        std::future<void> f;
+        std::shared_future<void> f;
         std::optional<std::reference_wrapper<tf::AsyncTask>> t;
         if constexpr (std::is_same_v<T, std::reference_wrapper<Buffer>> ) {
             t = cq.submit( [device = cq.device(), cq_id = cq.id(), b, src, blocking] {
@@ -1143,7 +1143,7 @@ void EnqueueProgram(CommandQueue& cq, std::variant < std::reference_wrapper<Prog
     detail::DispatchStateCheck(true);
     std::visit ( [&cq, blocking, trace](auto&& program) {
             using T = std::decay_t<decltype(program)>;
-            std::future<void> f;
+            std::shared_future<void> f;
             std::optional<std::reference_wrapper<tf::AsyncTask>> t;
             if constexpr (std::is_same_v<T, std::reference_wrapper<Program>>) {
                 t = cq.submit( [device = cq.device(), cq_id = cq.id(), program, blocking, trace] {
@@ -1169,7 +1169,7 @@ void EnqueueProgram(CommandQueue& cq, std::variant < std::reference_wrapper<Prog
 
 void Finish(CommandQueue& cq) {
     detail::DispatchStateCheck(true);
-    std::future<void> f;
+    std::shared_future<void> f;
     cq.submit( [device = cq.device(), cq_id = cq.id()] {
         device->hw_command_queue(cq_id).finish();
     }, f);
@@ -1219,7 +1219,7 @@ namespace detail {
 void EnqueueRestart(CommandQueue& cq) {
     ZoneScoped;
     detail::DispatchStateCheck(true);
-    std::future<void> f;
+    std::shared_future<void> f;
     auto& t = cq.submit( [device = cq.device(), cq_id = cq.id()] {
         device->hw_command_queue(cq_id).restart();
     }, f);

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -461,7 +461,7 @@ class CommandQueue
         ~CommandQueue() {}
 
         template < class F >
-        auto& submit ( F && func, std::reference_wrapper< std::future< void > > event ){
+        auto& submit ( F && func, std::reference_wrapper< std::shared_future< void > > event ){
             std::lock_guard<std::mutex> lk(mutex_);
             std::tie(last_, event.get()) = last_.has_value() ? detail::GetExecutor().dependent_async ( func, last_.value()) : detail::GetExecutor().dependent_async ( func );
             return last_.value();

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -463,11 +463,17 @@ class CommandQueue
         template < class F >
         tf::AsyncTask& submit ( F && func, std::reference_wrapper< std::shared_future< void > > event ){
             std::lock_guard<std::mutex> lk(mutex_);
-            std::tie(last_, event.get()) = last_.empty() ? detail::GetExecutor().dependent_async ( func ) : detail::GetExecutor().dependent_async ( func, last_);
+            std::tie(last_, event.get()) = last_.empty() ? detail::GetExecutor().dependent_async ( std::forward<F>(func) ) : detail::GetExecutor().dependent_async ( std::forward<F>(func), last_);
             return last_;
         }
 
         //WARNING: Exceptions thrown by sub-tasks are retieved via future; the silent versions don't return a future object, and therefore exceptions are lost
+        template < class F >
+        void submit ( F && func){
+            std::lock_guard<std::mutex> lk(mutex_);
+            last_ = last_.empty() ? detail::GetExecutor().silent_dependent_async(std::forward<F>(func) ) : detail::GetExecutor().silent_dependent_async( std::forward<F>(func), last_ );
+        }
+
         // template < class F >
         // auto& submit ( F && func){
         //     std::lock_guard<std::mutex> lk(mutex_);

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -467,12 +467,13 @@ class CommandQueue
             return last_.value();
         }
 
-        template < class F >
-        auto& submit ( F && func){
-            std::lock_guard<std::mutex> lk(mutex_);
-            last_ = last_.has_value() ? detail::GetExecutor().silent_dependent_async((func), last_.value()) : detail::GetExecutor().silent_dependent_async( func );
-            return last_.value();
-        }
+        //WARNING: Exceptions thrown by sub-tasks are retieved via future; the silent versions don't return a future object, and therefore exceptions are lost
+        // template < class F >
+        // auto& submit ( F && func){
+        //     std::lock_guard<std::mutex> lk(mutex_);
+        //     last_ = last_.has_value() ? detail::GetExecutor().silent_dependent_async((func), last_.value()) : detail::GetExecutor().silent_dependent_async( func );
+        //     return last_.value();
+        // }
 
         Device* device() const {
             return device_;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -437,20 +437,14 @@ class HWCommandQueue {
     void restart();
     void launch(launch_msg_t& msg);
 
-    friend HWCommandQueue & detail::GetHWCommandQueue(Device *device, uint32_t cmd_queue_channel);
+    SystemMemoryManager& sysmem_manager() { return this->sysmem_manager_; }
 
-    // Trace APIs
-    friend void EndTrace(Trace& trace);
-    friend void EnqueueTrace(Trace& trace, bool blocking);
-    friend class Trace;
-
+    uint32_t cq_id() const { return this->id; }
    private:
     uint32_t id;
     uint32_t size_B;
-
-    SystemMemoryManager& manager;
-
     Device* device;
+    SystemMemoryManager& sysmem_manager_;
 
 };
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -481,6 +481,11 @@ class CommandQueue
             return id_;
         }
 
+        void reset() {
+            std::lock_guard<std::mutex> lk(mutex_);
+            if (last_.has_value()) last_.value().reset();
+        }
+
     private:
         std::mutex mutex_;
         std::optional<tf::AsyncTask> last_;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -461,10 +461,10 @@ class CommandQueue
         ~CommandQueue() {}
 
         template < class F >
-        auto& submit ( F && func, std::reference_wrapper< std::shared_future< void > > event ){
+        tf::AsyncTask& submit ( F && func, std::reference_wrapper< std::shared_future< void > > event ){
             std::lock_guard<std::mutex> lk(mutex_);
-            std::tie(last_, event.get()) = last_.has_value() ? detail::GetExecutor().dependent_async ( func, last_.value()) : detail::GetExecutor().dependent_async ( func );
-            return last_.value();
+            std::tie(last_, event.get()) = last_.empty() ? detail::GetExecutor().dependent_async ( func ) : detail::GetExecutor().dependent_async ( func, last_);
+            return last_;
         }
 
         //WARNING: Exceptions thrown by sub-tasks are retieved via future; the silent versions don't return a future object, and therefore exceptions are lost
@@ -489,7 +489,7 @@ class CommandQueue
 
     private:
         std::mutex mutex_;
-        std::optional<tf::AsyncTask> last_;
+        tf::AsyncTask last_;
         uint32_t id_;
         Device * device_;
 };

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -17,6 +17,9 @@
 #include "tt_metal/common/tt_backend_api_types.hpp"
 #include "tt_metal/impl/program/program.hpp"
 #include "noc/noc_parameters.h"
+#include "third_party/taskflow/taskflow/taskflow.hpp"
+#include "common/executor.hpp"
+#include "tt_metal/host_api.hpp"
 
 namespace tt::tt_metal {
 
@@ -311,18 +314,18 @@ class Trace {
           uint32_t num_data_bytes;
       };
       bool trace_complete;
-      CommandQueue& command_queue;
+      HWCommandQueue& command_queue;
       vector<TraceNode> history;
       uint32_t num_data_bytes;
       void create_replay();
 
     friend class EnqueueProgramCommand;
-    friend Trace BeginTrace(CommandQueue& cq);
+    friend Trace BeginTrace(HWCommandQueue& cq);
     friend void EndTrace(Trace& trace);
     friend void EnqueueTrace(Trace& trace, bool blocking);
 
     public:
-      Trace(CommandQueue& command_queue);
+      Trace(HWCommandQueue& command_queue);
       void record(const TraceNode& trace_node);
 };
 
@@ -400,12 +403,12 @@ typedef thread_safe_map<IssuedReadData, issued_read_mutex> IssuedReadMap;
 }
 
 
-class CommandQueue {
+class HWCommandQueue {
    public:
+    HWCommandQueue(Device* device, uint32_t id);
 
-    CommandQueue(Device* device, uint32_t id);
+    ~HWCommandQueue();
 
-    ~CommandQueue();
     CoreCoord issue_queue_reader_core;
     CoreCoord completion_queue_writer_core;
 
@@ -453,7 +456,52 @@ class CommandQueue {
     friend void EnqueueTrace(Trace& trace, bool blocking);
     friend class Device;
     friend class Trace;
+   private:
+    uint32_t id;
+    uint32_t size_B;
+
+    SystemMemoryManager& manager;
+
+    Device* device;    
+
 };
+
+class CommandQueue
+{
+    public:
+        CommandQueue () = delete;
+        CommandQueue ( Device * device, uint32_t command_queue_channel) : device_(device), command_queue_channel_(command_queue_channel)
+        {
+        }
+
+        ~CommandQueue() {}
+
+        template < class F >
+        void submit ( F && func, std::reference_wrapper< std::future< void > > event ){
+            std::lock_guard<std::mutex> lk(mutex_);
+            std::tie(last_, event.get()) = last_.has_value() ? detail::GetExecutor().dependent_async ( func, last_.value()) : detail::GetExecutor().dependent_async ( func );
+        }
+
+        template < class F >
+        void submit ( F && func){
+            std::lock_guard<std::mutex> lk(mutex_);
+            last_ = last_.has_value() ? detail::GetExecutor().silent_dependent_async((func), last_.value()) : detail::GetExecutor().silent_dependent_async( func );
+        }
+
+        Device* device() const {
+            return device_;
+        }
+        uint32_t command_queue_channel() const{
+            return command_queue_channel_;
+        }
+
+    private:
+        std::mutex mutex_;
+        std::optional<tf::AsyncTask> last_;
+        uint32_t command_queue_channel_;
+        Device * device_;
+};
+
 
 inline bool LAZY_COMMAND_QUEUE_MODE = false;
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -437,18 +437,9 @@ class HWCommandQueue {
     void restart();
     void launch(launch_msg_t& msg);
 
-    friend void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, vector<uint32_t>& dst, bool blocking);
-    friend void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, vector<uint32_t>& src, bool blocking);
-    friend void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, void* dst, bool blocking);
-    friend void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, const void* src, bool blocking);
-    friend void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking, std::optional<std::reference_wrapper<Trace>> trace);
-    friend void Finish(CommandQueue& cq);
-    friend void ClearProgramCache(CommandQueue& cq);
-
     friend HWCommandQueue & detail::GetHWCommandQueue(Device *device, uint32_t cmd_queue_channel);
 
     // Trace APIs
-    friend Trace BeginTrace(CommandQueue& command_queue);
     friend void EndTrace(Trace& trace);
     friend void EnqueueTrace(Trace& trace, bool blocking);
     friend class Trace;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -461,15 +461,17 @@ class CommandQueue
         ~CommandQueue() {}
 
         template < class F >
-        void submit ( F && func, std::reference_wrapper< std::future< void > > event ){
+        auto& submit ( F && func, std::reference_wrapper< std::future< void > > event ){
             std::lock_guard<std::mutex> lk(mutex_);
             std::tie(last_, event.get()) = last_.has_value() ? detail::GetExecutor().dependent_async ( func, last_.value()) : detail::GetExecutor().dependent_async ( func );
+            return last_.value();
         }
 
         template < class F >
-        void submit ( F && func){
+        auto& submit ( F && func){
             std::lock_guard<std::mutex> lk(mutex_);
             last_ = last_.has_value() ? detail::GetExecutor().silent_dependent_async((func), last_.value()) : detail::GetExecutor().silent_dependent_async( func );
+            return last_.value();
         }
 
         Device* device() const {

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -483,7 +483,7 @@ class CommandQueue
 
         void reset() {
             std::lock_guard<std::mutex> lk(mutex_);
-            if (last_.has_value()) last_.value().reset();
+            last_.reset();
         }
 
     private:

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -419,17 +419,17 @@ class HWCommandQueue {
     detail::IssuedReadMap issued_reads;
     detail::thread_safe_map<uint32_t, detail::completion_wrap_mutex> issued_completion_wraps;
 
-    void enqueue_write_buffer(std::shared_ptr<const Buffer> buffer, const void* src, bool blocking);
 
-    void enqueue_write_buffer(const Buffer& buffer, const void* src, bool blocking);
 
     Device* device;
 
     void copy_into_user_space(uint32_t event, uint32_t read_ptr, chip_id_t mmio_device_id, uint16_t channel);
     void read_completion_queue();
     void enqueue_command(Command& command, bool blocking);
+    void enqueue_read_buffer(std::shared_ptr<Buffer> buffer, void* dst, bool blocking);
     void enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking);
-    void enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking);
+    void enqueue_write_buffer(std::shared_ptr<const Buffer> buffer, const void* src, bool blocking);
+    void enqueue_write_buffer(const Buffer& buffer, const void* src, bool blocking);
     void enqueue_program(Program& program, std::optional<std::reference_wrapper<Trace>> trace, bool blocking);
     void finish();
     void issue_wrap();

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -181,7 +181,7 @@ class Program {
 
     void update_kernel_groups();
 
-    friend class CommandQueue;
+    friend class HWCommandQueue;
     friend class EnqueueProgramCommand;
 };
 

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
         /*
         * Setup program to execute along with its buffers and kernels to use
         */
-        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        CommandQueue& cq = device->command_queue();
 
         Program program = CreateProgram();
 

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
         /*
         * Setup program to execute along with its buffers and kernels to use
         */
-        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        CommandQueue& cq = device->command_queue();
 
         Program program = CreateProgram();
 

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
         /*
         * Setup program and command queue to execute along with its buffers and kernels to use
         */
-        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        CommandQueue& cq = device->command_queue();
         Program program = CreateProgram();
 
         constexpr CoreCoord core = {0, 0};

--- a/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
@@ -53,7 +53,7 @@ void matmul_multi_core(vector<bfloat16>& a, vector<bfloat16>& b, vector<bfloat16
     /*
     * Setup program to execute along with its buffers and kernels to use
     */
-    CommandQueue& cq = tt_metal::detail::GetCommandQueue(device);
+    CommandQueue& cq = device->command_queue();
     Program program{};
 
     /*

--- a/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -52,7 +52,7 @@ void matmul_multicore_reuse(vector<bfloat16>& a, vector<bfloat16>& b, vector<bfl
     * Setup program to execute along with its buffers and kernels to use
     * Core range is just single core
     */
-    CommandQueue& cq = tt_metal::detail::GetCommandQueue(device);
+    CommandQueue& cq = device->command_queue();
     Program program{};
 
     tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;

--- a/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -53,7 +53,7 @@ void matmul_multicore_reuse_mcast(vector<bfloat16>& a, vector<bfloat16>& b, vect
     * Setup program to execute along with its buffers and kernels to use
     * Core range is just single core
     */
-    CommandQueue& cq = tt_metal::detail::GetCommandQueue(device);
+    CommandQueue& cq = device->command_queue();
     Program program{};
 
     tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;

--- a/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
@@ -52,7 +52,7 @@ void matmul_single_core(vector<bfloat16>& a, vector<bfloat16>& b, vector<bfloat1
     * Setup program to execute along with its buffers and kernels to use
     * Core range is just single core
     */
-    CommandQueue& cq = tt_metal::detail::GetCommandQueue(device);
+    CommandQueue& cq = device->command_queue();
     Program program{};
     CoreRange core = {.start={0, 0}, .end={0, 0}};
 

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -42,8 +42,8 @@ bool RunCustomCycle(tt_metal::Device *device, int loop_count, string run_name = 
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines}
     );
 
-    EnqueueProgram(tt_metal::detail::GetCommandQueue(device), program, false);
-    Finish(tt_metal::detail::GetCommandQueue(device));
+    EnqueueProgram(device->command_queue(), program, false);
+    Finish(device->command_queue());
     tt_metal::DumpDeviceProfileResults(device, program);
 
     return pass;

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -42,8 +42,8 @@ bool RunCustomCycle(tt_metal::Device *device, int loop_count, string run_name = 
         tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines}
     );
 
-    EnqueueProgram(tt_metal::detail::GetCommandQueue(device), program, false);
-    Finish(tt_metal::detail::GetCommandQueue(device));
+    EnqueueProgram(device->command_queue(), program, false);
+    Finish(device->command_queue());
     tt_metal::DumpDeviceProfileResults(device, program);
 
     return pass;

--- a/tt_metal/tools/profiler/op_profiler.hpp
+++ b/tt_metal/tools/profiler/op_profiler.hpp
@@ -538,6 +538,11 @@ namespace op_profiler {
 #endif
     }
 
+    static void dump_device_profiler_results (Device * device, std::shared_ptr<Program> program)
+    {
+        dump_device_profiler_results(device, *program);
+    }
+
     class OpProfileScope
     {
         private:

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -32,7 +32,7 @@ void DumpDeviceProfileResults(
         ProfileTTMetalScope profile_this = ProfileTTMetalScope("DumpDeviceProfileResults");
         //TODO: (MO) This global is temporary need to update once the new interface is in
         if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
-            Finish(GetCommandQueue(device));
+            Finish(device->command_queue());
         }
 
         TT_FATAL(DprintServerIsRunning() == false, "Debug print server is running, cannot dump device profiler data");

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -431,6 +431,10 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
 
     }
 
+    void LaunchProgram(Device *device, std::shared_ptr<Program> program){
+        LaunchProgram(device, *program);
+    }
+
     void LaunchProgram(Device *device, Program &program) {
         {//Profiler scope start
         ZoneScoped;


### PR DESCRIPTION
This PR introduces software queues into metal. The main change is that the user now sees a true software CQ that maps to a hw CQ that is now owned by the device. It is currently a 1:1 mapping. A few changes that were needed to make it happen:

- [ ] accept `std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> >` instead of `Buffer&` across multiple APIs; true async behavior will lead to more dangling pointer / reference situations and `std::shared_ptr<Buffer>` will be there as an option to avoid these situtations
- [ ] multiple race condition fixes in different testcases
- [ ] Taskflow upgrade that throws exceptions from worker threads when `get` on future objects is called
- [ ] old `CommandQueue` is now renamed to `HWCommandQueue`; users should now interact with `CommandQueue`, which feeds to a corresponding `HWCommandQueue` under the hood
- [ ] Removal of global `GetCommandQueue` function; `Device` now owns default `CommandQueue` and `HWCommandQueue` objects
- [ ] Disable `Device` copy semantics and use default move semantics