### PR TITLE
#4456: Uplift NlpCreateHeads to support generic shapes

### DIFF
--- a/models/demos/falcon7b/tt/falcon_attention.py
+++ b/models/demos/falcon7b/tt/falcon_attention.py
@@ -238,7 +238,7 @@ class TtFalconAttention(nn.Module):
         ###########
         ### TMs ###
         ###########
-        query_layer, key_layer, value_layer = tt_lib.tensor.nlp_create_qkv_heads(
+        query_layer, key_layer, value_layer = tt_lib.tensor.nlp_create_qkv_heads_falcon7b(
             fused_query_key_value,
             output_mem_config=self.model_config["CREATE_QKV_HEADS_OUTPUT_MEMCFG"],
         )

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
@@ -100,12 +100,18 @@ def test_bert_large_concatenate_heads_test(device, batch, dtype, in0_mem_config,
 
 def test_bert_large_concatenate_heads_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
-        run_bert_large_concatenate_heads_test(device, 9, dtype, dram_mem_config, dram_mem_config)
+        run_bert_large_concatenate_heads_test(device, 9, dtype, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
-        run_bert_large_concatenate_heads_test(device, 9, dtype, dram_mem_config, dram_mem_config)
+        run_bert_large_concatenate_heads_test(device, 9, dtype, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
@@ -200,28 +200,34 @@ def test_bert_large_ff1_matmul_test(
 
 def test_bert_large_ff1_matmul_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
         run_bert_large_ff1_matmul_test(
             device,
             dtype,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
             fused_activation=None,
         )
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
         run_bert_large_ff1_matmul_test(
             device,
             dtype,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
             fused_activation=(ttl.tensor.FusibleActivation.GELU, True),
         )
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
@@ -149,26 +149,32 @@ def test_bert_large_ff2_matmul_test(
 
 def test_bert_large_ff2_matmul_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
         run_bert_large_ff2_matmul_test(
             device,
             dtype,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
         )
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
         run_bert_large_ff2_matmul_test(
             device,
             dtype,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
         )
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
@@ -149,26 +149,32 @@ def test_bert_large_fused_qkv_matmul_test(
 
 def test_bert_large_fused_qkv_matmul_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
         run_bert_large_fused_qkv_matmul_test(
             device,
             dtype,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
         )
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
         run_bert_large_fused_qkv_matmul_test(
             device,
             dtype,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
         )
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
@@ -116,12 +116,18 @@ def test_bert_large_post_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem
 
 def test_bert_large_post_softmax_bmm_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
-        run_bert_large_post_softmax_bmm_test(device, dtype, dram_mem_config, dram_mem_config, dram_mem_config)
+        run_bert_large_post_softmax_bmm_test(device, dtype, mem_config, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
-        run_bert_large_post_softmax_bmm_test(device, dtype, dram_mem_config, dram_mem_config, dram_mem_config)
+        run_bert_large_post_softmax_bmm_test(device, dtype, mem_config, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_pre_softmax_bmm.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_pre_softmax_bmm.py
@@ -109,12 +109,18 @@ def test_bert_large_pre_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_
 
 def test_bert_large_pre_softmax_bmm_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
-        run_bert_large_pre_softmax_bmm_test(device, dtype, dram_mem_config, dram_mem_config, dram_mem_config)
+        run_bert_large_pre_softmax_bmm_test(device, dtype, mem_config, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
-        run_bert_large_pre_softmax_bmm_test(device, dtype, dram_mem_config, dram_mem_config, dram_mem_config)
+        run_bert_large_pre_softmax_bmm_test(device, dtype, mem_config, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
@@ -148,26 +148,32 @@ def test_bert_large_selfout_matmul_test(
 
 def test_bert_large_selfout_matmul_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
         run_bert_large_selfout_matmul_test(
             device,
             dtype,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
         )
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
         run_bert_large_selfout_matmul_test(
             device,
             dtype,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
-            dram_mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
+            mem_config,
         )
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
@@ -122,12 +122,18 @@ def test_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_me
 
 def test_split_query_key_value_and_split_heads_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
-        run_split_query_key_value_and_split_heads_test(device, 9, dtype, dram_mem_config, dram_mem_config)
+        run_split_query_key_value_and_split_heads_test(device, 9, dtype, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
-        run_split_query_key_value_and_split_heads_test(device, 9, dtype, dram_mem_config, dram_mem_config)
+        run_split_query_key_value_and_split_heads_test(device, 9, dtype, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
@@ -122,12 +122,18 @@ def test_split_query_key_value_and_split_heads(device, batch, dtype, in0_mem_con
 
 def test_split_query_key_value_and_split_heads_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
-        run_split_query_key_value_and_split_heads_test(device, 9, dtype, dram_mem_config, dram_mem_config)
+        run_split_query_key_value_and_split_heads_test(device, 9, dtype, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
-        run_split_query_key_value_and_split_heads_test(device, 9, dtype, dram_mem_config, dram_mem_config)
+        run_split_query_key_value_and_split_heads_test(device, 9, dtype, mem_config, mem_config)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/tests/tt_eager/python_api_testing/unit_testing/test_move.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_move.py
@@ -91,18 +91,23 @@ def test_move_op(test_id, shape, layout, dtype, in0_mem_config, output_mem_confi
 
 
 def test_move_op_with_program_cache(use_program_cache, device):
-    in0_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
-    output_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     dtype = ttl.tensor.DataType.BFLOAT16
     layout = ttl.tensor.Layout.TILE
     shape = [1, 3, 320, 384]
 
     # Single core because of overlap
     for _ in range(2):
-        run_move_op(0, shape, layout, dtype, in0_mem_config, output_mem_config, device)
+        run_move_op(0, shape, layout, dtype, mem_config, mem_config, device)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     # Multi-core
     for _ in range(2):
-        run_move_op(1, shape, layout, dtype, in0_mem_config, output_mem_config, device)
+        run_move_op(1, shape, layout, dtype, mem_config, mem_config, device)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/tests/tt_eager/python_api_testing/unit_testing/test_nlp_concat_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_nlp_concat_heads.py
@@ -86,12 +86,18 @@ def test_nlp_concat_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem_co
 @skip_for_wormhole_b0()
 def test_nlp_concat_heads_with_program_cache(use_program_cache, device):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
-        run_nlp_concat_heads_test(1, 32, dtype, dram_mem_config, dram_mem_config, device)
+        run_nlp_concat_heads_test(1, 32, dtype, mem_config, mem_config, device)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
-        run_nlp_concat_heads_test(1, 32, dtype, dram_mem_config, dram_mem_config, device)
+        run_nlp_concat_heads_test(1, 32, dtype, mem_config, mem_config, device)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/tests/tt_eager/python_api_testing/unit_testing/test_nlp_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_nlp_create_qkv_heads.py
@@ -10,7 +10,12 @@ from models.utility_functions import tt2torch_tensor, comp_pcc
 import torch
 
 
-def run_nlp_create_qkv_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, device):
+"""
+Falcon-7B shapes + functionality
+"""
+
+
+def run_nlp_create_qkv_heads_falcon7b_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, device):
     torch.manual_seed(1234)
 
     in0_shape = [batch, 1, seq_len, 4672]
@@ -19,7 +24,7 @@ def run_nlp_create_qkv_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem
 
     in0_t = ttl.tensor.Tensor(A, dtype).to(ttl.tensor.Layout.TILE).to(device, in0_mem_config)
 
-    q, k, v = ttl.tensor.nlp_create_qkv_heads(in0_t, out_mem_config)
+    q, k, v = ttl.tensor.nlp_create_qkv_heads_falcon7b(in0_t, out_mem_config)
 
     # Check memory of inputs and outputs
     assert in0_t.memory_config().buffer_type == in0_mem_config.buffer_type
@@ -92,19 +97,187 @@ def run_nlp_create_qkv_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem
         "batch1_seq128",
     ],
 )
-def test_nlp_create_qkv_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, request, device):
-    ttl.profiler.set_profiler_location(f"nlp_create_qkv_heads_tm_{request.node.callspec.id}")
-    run_nlp_create_qkv_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, device)
+def test_nlp_create_qkv_heads_falcon7b_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, request, device):
+    ttl.profiler.set_profiler_location(f"nlp_create_qkv_heads_falcon7b_tm_{request.node.callspec.id}")
+    run_nlp_create_qkv_heads_falcon7b_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, device)
+
+
+def test_nlp_create_qkv_heads_falcon7b_with_program_cache(use_program_cache, device):
+    dtype = ttl.tensor.DataType.BFLOAT8_B
+    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    for _ in range(2):
+        run_nlp_create_qkv_heads_falcon7b_test(1, 32, dtype, dram_mem_config, dram_mem_config, device)
+
+    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    for _ in range(2):
+        run_nlp_create_qkv_heads_falcon7b_test(1, 32, dtype, dram_mem_config, dram_mem_config, device)
+
+    assert ttl.program_cache.num_entries() == 2
+
+
+"""
+Generic shapes + functionality
+"""
+
+
+def run_nlp_create_qkv_heads_test(
+    batch,
+    seq_len,
+    head_dim,
+    num_q_heads,
+    num_kv_heads,
+    transpose_k_heads,
+    read_from_input_tensor_kv,
+    dtype,
+    in_mem_config,
+    out_mem_config,
+    device,
+):
+    torch.manual_seed(1234)
+
+    if read_from_input_tensor_kv:
+        in0_shape = [batch, 1, seq_len, num_q_heads * head_dim]
+        in1_shape = [batch, 1, seq_len, 2 * num_kv_heads * head_dim]
+        A = torch.randn(in0_shape)
+        B = torch.randn(in1_shape)
+        in0_t = ttl.tensor.Tensor(A, dtype).to(ttl.tensor.Layout.TILE).to(device, in_mem_config)
+        in1_t = ttl.tensor.Tensor(B, dtype).to(ttl.tensor.Layout.TILE).to(device, in_mem_config)
+    else:
+        in0_shape = [batch, 1, seq_len, (num_q_heads + 2 * num_kv_heads) * head_dim]
+        A = torch.randn(in0_shape)
+        in0_t = ttl.tensor.Tensor(A, dtype).to(ttl.tensor.Layout.TILE).to(device, in_mem_config)
+
+    q, k, v = ttl.tensor.nlp_create_qkv_heads(
+        in0_t,
+        in1_t if read_from_input_tensor_kv else None,
+        num_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        transpose_k_heads=transpose_k_heads,
+        output_mem_config=out_mem_config,
+    )
+
+    # Check memory of inputs and outputs
+    assert in0_t.memory_config().buffer_type == in_mem_config.buffer_type
+    assert q.memory_config().buffer_type == out_mem_config.buffer_type
+    assert k.memory_config().buffer_type == out_mem_config.buffer_type
+    assert v.memory_config().buffer_type == out_mem_config.buffer_type
+    logger.debug(f"in0: {in0_t.memory_config().buffer_type} and {in0_t.dtype()}")
+    logger.debug(f"q: {q.memory_config().buffer_type} and {q.dtype()}")
+    logger.debug(f"k: {k.memory_config().buffer_type} and {k.dtype()}")
+    logger.debug(f"v: {v.memory_config().buffer_type} and {v.dtype()}")
+
+    assert list(q.shape()) == [batch, num_q_heads, seq_len, head_dim]
+    if transpose_k_heads:
+        assert list(k.shape()) == [batch, num_kv_heads, head_dim, seq_len]
+    else:
+        assert list(k.shape()) == [batch, num_kv_heads, seq_len, head_dim]
+    assert list(v.shape()) == [batch, num_kv_heads, seq_len, head_dim]
+
+    pyt_got_back_rm_q = tt2torch_tensor(q)
+    pyt_got_back_rm_k = tt2torch_tensor(k)
+    pyt_got_back_rm_v = tt2torch_tensor(v)
+
+    if read_from_input_tensor_kv:
+        ref_q = A
+        (ref_k, ref_v) = torch.split(B, [num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1)
+    else:
+        (ref_q, ref_k, ref_v) = torch.split(
+            A, [num_q_heads * head_dim, num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1
+        )
+
+    # Additional shuffling for Q, K, V heads
+    ref_q = torch.reshape(ref_q, [batch, seq_len, num_q_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    if transpose_k_heads:
+        ref_k = ref_k.transpose(-2, -1)
+
+    if dtype == ttl.tensor.DataType.BFLOAT8_B:
+        pcc = 0.99
+    else:
+        pcc = 1.0
+
+    passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, pcc)
+    logger.info(f"Q passing={passing_pcc_q}")
+    logger.info(f"Q output pcc={output_pcc_q}")
+    assert passing_pcc_q
+    passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, pcc)
+    logger.info(f"K passing={passing_pcc_k}")
+    logger.info(f"K output pcc={output_pcc_k}")
+    assert passing_pcc_k
+    passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, pcc)
+    logger.info(f"V passing={passing_pcc_v}")
+    logger.info(f"V output pcc={output_pcc_v}")
+    assert passing_pcc_v
+
+
+@pytest.mark.parametrize(
+    "out_mem_config",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize(
+    "in_mem_config",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["in_DRAM", "in_L1"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.BFLOAT16),
+    ids=["BFLOAT8_B", "BFLOAT16"],
+)
+@pytest.mark.parametrize(
+    "batch, seq_len, head_dim, num_q_heads, num_kv_heads, transpose_k_heads, read_from_input_tensor_kv",
+    (
+        (1, 128, 64, 71, 1, False, False),
+        (111, 64, 96, 5, 3, True, False),
+        (5, 1024, 64, 8, 8, True, True),
+    ),
+)
+def test_nlp_create_qkv_heads_test(
+    batch,
+    seq_len,
+    head_dim,
+    num_q_heads,
+    num_kv_heads,
+    transpose_k_heads,
+    read_from_input_tensor_kv,
+    dtype,
+    in_mem_config,
+    out_mem_config,
+    request,
+    device,
+):
+    run_nlp_create_qkv_heads_test(
+        batch,
+        seq_len,
+        head_dim,
+        num_q_heads,
+        num_kv_heads,
+        transpose_k_heads,
+        read_from_input_tensor_kv,
+        dtype,
+        in_mem_config,
+        out_mem_config,
+        device,
+    )
 
 
 def test_nlp_create_qkv_heads_with_program_cache(use_program_cache, device):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
-        run_nlp_create_qkv_heads_test(1, 32, dtype, dram_mem_config, dram_mem_config, device)
-
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
-    for _ in range(2):
-        run_nlp_create_qkv_heads_test(1, 32, dtype, dram_mem_config, dram_mem_config, device)
+        run_nlp_create_qkv_heads_test(5, 1024, 64, 4, 2, True, False, dtype, mem_config, mem_config, device)
+        # Same in0_shape to make sure cache misses if we have additional optional tensor works
+        run_nlp_create_qkv_heads_test(5, 1024, 64, 8, 8, True, True, dtype, mem_config, mem_config, device)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2

--- a/tests/tt_eager/python_api_testing/unit_testing/test_nlp_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_nlp_create_qkv_heads.py
@@ -104,13 +104,19 @@ def test_nlp_create_qkv_heads_falcon7b_test(batch, seq_len, dtype, in0_mem_confi
 
 def test_nlp_create_qkv_heads_falcon7b_with_program_cache(use_program_cache, device):
     dtype = ttl.tensor.DataType.BFLOAT8_B
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     for _ in range(2):
-        run_nlp_create_qkv_heads_falcon7b_test(1, 32, dtype, dram_mem_config, dram_mem_config, device)
+        run_nlp_create_qkv_heads_falcon7b_test(1, 32, dtype, mem_config, mem_config, device)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    dram_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
     for _ in range(2):
-        run_nlp_create_qkv_heads_falcon7b_test(1, 32, dtype, dram_mem_config, dram_mem_config, device)
+        run_nlp_create_qkv_heads_falcon7b_test(1, 32, dtype, mem_config, mem_config, device)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
     assert ttl.program_cache.num_entries() == 2
 

--- a/tt_eager/tt_dnn/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
+++ b/tt_eager/tt_dnn/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+
+void kernel_main() {
+    // READER RUNTIME ARGS
+    uint32_t in0_tensor_addr                     = get_arg_val<uint32_t>(0);
+    uint32_t in1_tensor_addr                     = get_arg_val<uint32_t>(1);
+    uint32_t num_blocks                          = get_arg_val<uint32_t>(2);
+    uint32_t in0_tensor_tile_id                  = get_arg_val<uint32_t>(3);
+    uint32_t in1_tensor_tile_id                  = get_arg_val<uint32_t>(4);
+
+    // COMPILE TIME ARGS
+    // interleaved accessor args
+    constexpr uint32_t in0_is_dram               = get_compile_time_arg_val(0);
+    constexpr uint32_t in1_is_dram               = get_compile_time_arg_val(1);
+    // READER COMPILE TIME ARGS
+    constexpr uint32_t q_num_tiles               = get_compile_time_arg_val(2);
+    constexpr uint32_t kv_num_tiles              = get_compile_time_arg_val(3);
+
+
+    constexpr uint32_t cb_id_qv = 1; // cb for Q, V heads
+    #ifdef TRANSPOSE_K_HEADS
+    constexpr uint32_t cb_id_k = 0; // cb for K heads (used by compute)
+    #else
+    constexpr uint32_t cb_id_k = 1; // cb for K heads (directly to writer)
+    #endif
+
+    constexpr uint32_t onetile = 1;
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_id_qv);
+    const DataFormat data_format = get_dataformat(cb_id_qv);
+
+    constexpr bool in0_is_dram_bool = in0_is_dram == 1;
+    const InterleavedAddrGenFast<in0_is_dram_bool> s0 = {
+        .bank_base_address = in0_tensor_addr,
+        .page_size = single_tile_size_bytes,
+        .data_format = data_format,
+    };
+
+    #ifdef READ_FROM_INPUT_TENSOR_KV
+    constexpr bool in1_is_dram_bool = in1_is_dram == 1;
+    const InterleavedAddrGenFast<in1_is_dram_bool> s1 = {
+        .bank_base_address = in1_tensor_addr,
+        .page_size = single_tile_size_bytes,
+        .data_format = data_format,
+    };
+    #endif
+
+
+    for (uint32_t block = 0; block < num_blocks; block++) {
+        // Q
+        for (uint32_t i = 0; i < q_num_tiles; i++) {
+            cb_reserve_back(cb_id_qv, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_qv);
+            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_qv, onetile);
+            in0_tensor_tile_id++;
+        }
+
+        // K
+        for (uint32_t i = 0; i < kv_num_tiles; i++) {
+            cb_reserve_back(cb_id_k, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_k);
+            #ifdef READ_FROM_INPUT_TENSOR_KV
+            noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr);
+            in1_tensor_tile_id++;
+            #else
+            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            in0_tensor_tile_id++;
+            #endif
+            noc_async_read_barrier();
+            cb_push_back(cb_id_k, onetile);
+        }
+
+        // V
+        for (uint32_t i = 0; i < kv_num_tiles; i++) {
+            cb_reserve_back(cb_id_qv, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_qv);
+            #ifdef READ_FROM_INPUT_TENSOR_KV
+            noc_async_read_tile(in1_tensor_tile_id, s1, l1_write_addr);
+            in1_tensor_tile_id++;
+            #else
+            noc_async_read_tile(in0_tensor_tile_id, s0, l1_write_addr);
+            in0_tensor_tile_id++;
+            #endif
+            noc_async_read_barrier();
+            cb_push_back(cb_id_qv, onetile);
+        }
+    }
+}

--- a/tt_eager/tt_dnn/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads.cpp
+++ b/tt_eager/tt_dnn/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads.cpp
@@ -15,22 +15,27 @@ void kernel_main() {
     uint32_t num_blocks                          = get_arg_val<uint32_t>(3);
     uint32_t q_out_h_dim                         = get_arg_val<uint32_t>(4);
     uint32_t q_out_tensor_tile_id                = get_arg_val<uint32_t>(5);
-    uint32_t kv_out_tensor_tile_id               = get_arg_val<uint32_t>(6);
+    uint32_t k_out_tensor_tile_id                = get_arg_val<uint32_t>(6);
+    uint32_t v_out_tensor_tile_id                = get_arg_val<uint32_t>(7);
 
     // COMPILE TIME ARGS
     // interleaved accessor args
     constexpr uint32_t out_is_dram               = get_compile_time_arg_val(0);
-    constexpr uint32_t q_num_tiles               = get_compile_time_arg_val(1);
-    constexpr uint32_t kv_num_tiles              = get_compile_time_arg_val(2);
-    constexpr uint32_t q_out_h_tiles             = get_compile_time_arg_val(3);
-    constexpr uint32_t q_out_w_tiles             = get_compile_time_arg_val(4);
-    constexpr uint32_t q_out_c                   = get_compile_time_arg_val(5);
-    constexpr uint32_t q_out_HtWt                = get_compile_time_arg_val(6);
+    constexpr uint32_t q_out_h_tiles             = get_compile_time_arg_val(1);
+    constexpr uint32_t q_out_w_tiles             = get_compile_time_arg_val(2);
+    constexpr uint32_t q_out_HtWt                = get_compile_time_arg_val(3);
+    constexpr uint32_t q_out_c                   = get_compile_time_arg_val(4);
+    constexpr uint32_t kv_out_c                  = get_compile_time_arg_val(5);
 
 
-    constexpr uint32_t cb_id_out0 = 0; // same as cb_id_in0
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_id_out0);
-    const DataFormat data_format = get_dataformat(cb_id_out0);
+    constexpr uint32_t cb_id_qv = 1; // cb for Q, V heads tiles
+    #ifdef TRANSPOSE_K_HEADS
+    constexpr uint32_t cb_id_k = 16; // cb for K heads (filled by compute)
+    #else
+    constexpr uint32_t cb_id_k = 1; // cb for K heads (directly from reader)
+    #endif
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_id_qv);
+    const DataFormat data_format = get_dataformat(cb_id_qv);
 
     constexpr bool out_is_dram_bool = out_is_dram == 1;
     const InterleavedAddrGenFast<out_is_dram_bool> sq = {
@@ -50,66 +55,101 @@ void kernel_main() {
     };
 
     constexpr uint32_t block_size = 1; // micro-block size for read/write; nothing to do with num_blocks
+    // TODO: This might negatively impact perf
+    constexpr uint32_t out_num_tiles_read = block_size; // always read and pop by micro-block size for generality
     uint32_t l1_read_addr;
-    uint32_t out_num_tiles_read;
     uint32_t q_out_tensor_current_tile_id; // need this to update q_out_tensor_tile_id
-    uint32_t out_tensor_current_tile_id;
+    uint32_t k_out_tensor_current_tile_id; // need this to update k_out_tensor_tile_id
+    uint32_t v_out_tensor_current_tile_id; // need this to update v_out_tensor_tile_id
     uint32_t out_tensor_current_tile_id_along_c;
 
     for (uint32_t block = 0; block < num_blocks; block++) {
-        l1_read_addr = get_read_ptr(cb_id_out0);
-        out_num_tiles_read = 0;
-
-        // q + create q head --> outputs: [B, num_heads, S, head_dim]
+        // q + create q head --> outputs: [B, num_q_heads, S, head_dim]
         out_tensor_current_tile_id_along_c = q_out_tensor_tile_id;
         for (uint32_t c_dim = 0; c_dim < q_out_c; c_dim++) {
             q_out_tensor_current_tile_id = out_tensor_current_tile_id_along_c;
             for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
-                out_num_tiles_read += block_size;
-                cb_wait_front(cb_id_out0, out_num_tiles_read);
-
+                cb_wait_front(cb_id_qv, out_num_tiles_read);
+                l1_read_addr = get_read_ptr(cb_id_qv);
                 noc_async_write_tile(q_out_tensor_current_tile_id, sq, l1_read_addr);
-                l1_read_addr += single_tile_size_bytes;
+
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_qv, out_num_tiles_read);
+
                 q_out_tensor_current_tile_id++;
             }
             out_tensor_current_tile_id_along_c += q_out_HtWt;
         }
 
-        // k
-        out_tensor_current_tile_id = kv_out_tensor_tile_id;
-        for (uint32_t i = 0; i < kv_num_tiles; i++) {
-            out_num_tiles_read += block_size;
-            cb_wait_front(cb_id_out0, out_num_tiles_read);
+        // k + create k head --> outputs: [B, num_kv_heads, S, head_dim]
+        #ifndef TRANSPOSE_K_HEADS
+        out_tensor_current_tile_id_along_c = k_out_tensor_tile_id;
+        #else
+        k_out_tensor_current_tile_id = k_out_tensor_tile_id;
+        #endif
+        for (uint32_t c_dim = 0; c_dim < kv_out_c; c_dim++) {
+            #ifndef TRANSPOSE_K_HEADS
+            k_out_tensor_current_tile_id = out_tensor_current_tile_id_along_c;
+            #endif
+            for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
+                cb_wait_front(cb_id_k, out_num_tiles_read);
+                l1_read_addr = get_read_ptr(cb_id_k);
+                noc_async_write_tile(k_out_tensor_current_tile_id, sk, l1_read_addr);
 
-            noc_async_write_tile(out_tensor_current_tile_id, sk, l1_read_addr);
-            l1_read_addr += single_tile_size_bytes;
-            out_tensor_current_tile_id++;
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_k, out_num_tiles_read);
+
+                #ifndef TRANSPOSE_K_HEADS
+                k_out_tensor_current_tile_id++;
+                #else
+                k_out_tensor_current_tile_id += q_out_h_tiles;
+                #endif
+            }
+            #ifndef TRANSPOSE_K_HEADS
+            out_tensor_current_tile_id_along_c += q_out_HtWt;
+            #endif
         }
 
-        // v
-        out_tensor_current_tile_id = kv_out_tensor_tile_id;
-        for (uint32_t i = 0; i < kv_num_tiles; i++) {
-            out_num_tiles_read += block_size;
-            cb_wait_front(cb_id_out0, out_num_tiles_read);
+        // v + create v head --> outputs: [B, num_kv_heads, S, head_dim]
+        out_tensor_current_tile_id_along_c = v_out_tensor_tile_id;
+        for (uint32_t c_dim = 0; c_dim < kv_out_c; c_dim++) {
+            v_out_tensor_current_tile_id = out_tensor_current_tile_id_along_c;
+            for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
+                cb_wait_front(cb_id_qv, out_num_tiles_read);
+                l1_read_addr = get_read_ptr(cb_id_qv);
+                noc_async_write_tile(v_out_tensor_current_tile_id, sv, l1_read_addr);
 
-            noc_async_write_tile(out_tensor_current_tile_id, sv, l1_read_addr);
-            l1_read_addr += single_tile_size_bytes;
-            out_tensor_current_tile_id++;
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_qv, out_num_tiles_read);
+
+                v_out_tensor_current_tile_id++;
+            }
+            out_tensor_current_tile_id_along_c += q_out_HtWt;
         }
 
         // Update out_tensor_tile_id for next h_dim or batch if we finish one CHtWt
         q_out_h_dim++;
         if (q_out_h_dim < q_out_h_tiles) {
             q_out_tensor_tile_id += q_out_w_tiles;
+            #ifndef TRANSPOSE_K_HEADS
+            k_out_tensor_tile_id += q_out_w_tiles;
+            #else
+            k_out_tensor_tile_id++;
+            #endif
+            v_out_tensor_tile_id += q_out_w_tiles;
         } else {
+            // If we finish one batch, always roll over to next tile in memory
+            // This is just the current_tile_id, except for K when we transpose heads
+            // In this case, decrement k_out_tensor_current_tile_id by the stride (q_out_h_tiles) and add 1 to roll over
             q_out_tensor_tile_id = q_out_tensor_current_tile_id;
+            #ifndef TRANSPOSE_K_HEADS
+            k_out_tensor_tile_id = k_out_tensor_current_tile_id;
+            #else
+            k_out_tensor_tile_id = ++k_out_tensor_current_tile_id - q_out_h_tiles; // inc by 1 and decrement by stride
+            #endif
+            v_out_tensor_tile_id = v_out_tensor_current_tile_id;
             q_out_h_dim = 0;
         }
-
-        kv_out_tensor_tile_id +=  kv_num_tiles;
-
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_out0, out_num_tiles_read);
     }
 
 }

--- a/tt_eager/tt_dnn/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_falcon7b.cpp
+++ b/tt_eager/tt_dnn/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_falcon7b.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <array>
+#include "dataflow_api.h"
+
+
+void kernel_main() {
+    // WRITER RUNTIME ARGS
+    uint32_t q_tensor_addr                       = get_arg_val<uint32_t>(0);
+    uint32_t k_tensor_addr                       = get_arg_val<uint32_t>(1);
+    uint32_t v_tensor_addr                       = get_arg_val<uint32_t>(2);
+    uint32_t num_blocks                          = get_arg_val<uint32_t>(3);
+    uint32_t q_out_h_dim                         = get_arg_val<uint32_t>(4);
+    uint32_t q_out_tensor_tile_id                = get_arg_val<uint32_t>(5);
+    uint32_t kv_out_tensor_tile_id               = get_arg_val<uint32_t>(6);
+
+    // COMPILE TIME ARGS
+    // interleaved accessor args
+    constexpr uint32_t out_is_dram               = get_compile_time_arg_val(0);
+    constexpr uint32_t q_num_tiles               = get_compile_time_arg_val(1);
+    constexpr uint32_t kv_num_tiles              = get_compile_time_arg_val(2);
+    constexpr uint32_t q_out_h_tiles             = get_compile_time_arg_val(3);
+    constexpr uint32_t q_out_w_tiles             = get_compile_time_arg_val(4);
+    constexpr uint32_t q_out_c                   = get_compile_time_arg_val(5);
+    constexpr uint32_t q_out_HtWt                = get_compile_time_arg_val(6);
+
+
+    constexpr uint32_t cb_id_out0 = 0; // same as cb_id_in0
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_id_out0);
+    const DataFormat data_format = get_dataformat(cb_id_out0);
+
+    constexpr bool out_is_dram_bool = out_is_dram == 1;
+    const InterleavedAddrGenFast<out_is_dram_bool> sq = {
+        .bank_base_address = q_tensor_addr,
+        .page_size = single_tile_size_bytes,
+        .data_format = data_format
+    };
+    const InterleavedAddrGenFast<out_is_dram_bool> sk = {
+        .bank_base_address = k_tensor_addr,
+        .page_size = single_tile_size_bytes,
+        .data_format = data_format
+    };
+    const InterleavedAddrGenFast<out_is_dram_bool> sv = {
+        .bank_base_address = v_tensor_addr,
+        .page_size = single_tile_size_bytes,
+        .data_format = data_format
+    };
+
+    constexpr uint32_t block_size = 1; // micro-block size for read/write; nothing to do with num_blocks
+    uint32_t l1_read_addr;
+    uint32_t out_num_tiles_read;
+    uint32_t q_out_tensor_current_tile_id; // need this to update q_out_tensor_tile_id
+    uint32_t out_tensor_current_tile_id;
+    uint32_t out_tensor_current_tile_id_along_c;
+
+    for (uint32_t block = 0; block < num_blocks; block++) {
+        l1_read_addr = get_read_ptr(cb_id_out0);
+        out_num_tiles_read = 0;
+
+        // q + create q head --> outputs: [B, num_heads, S, head_dim]
+        out_tensor_current_tile_id_along_c = q_out_tensor_tile_id;
+        for (uint32_t c_dim = 0; c_dim < q_out_c; c_dim++) {
+            q_out_tensor_current_tile_id = out_tensor_current_tile_id_along_c;
+            for (uint32_t w_dim = 0; w_dim < q_out_w_tiles; w_dim++) {
+                out_num_tiles_read += block_size;
+                cb_wait_front(cb_id_out0, out_num_tiles_read);
+
+                noc_async_write_tile(q_out_tensor_current_tile_id, sq, l1_read_addr);
+                l1_read_addr += single_tile_size_bytes;
+                q_out_tensor_current_tile_id++;
+            }
+            out_tensor_current_tile_id_along_c += q_out_HtWt;
+        }
+
+        // k
+        out_tensor_current_tile_id = kv_out_tensor_tile_id;
+        for (uint32_t i = 0; i < kv_num_tiles; i++) {
+            out_num_tiles_read += block_size;
+            cb_wait_front(cb_id_out0, out_num_tiles_read);
+
+            noc_async_write_tile(out_tensor_current_tile_id, sk, l1_read_addr);
+            l1_read_addr += single_tile_size_bytes;
+            out_tensor_current_tile_id++;
+        }
+
+        // v
+        out_tensor_current_tile_id = kv_out_tensor_tile_id;
+        for (uint32_t i = 0; i < kv_num_tiles; i++) {
+            out_num_tiles_read += block_size;
+            cb_wait_front(cb_id_out0, out_num_tiles_read);
+
+            noc_async_write_tile(out_tensor_current_tile_id, sv, l1_read_addr);
+            l1_read_addr += single_tile_size_bytes;
+            out_tensor_current_tile_id++;
+        }
+
+        // Update out_tensor_tile_id for next h_dim or batch if we finish one CHtWt
+        q_out_h_dim++;
+        if (q_out_h_dim < q_out_h_tiles) {
+            q_out_tensor_tile_id += q_out_w_tiles;
+        } else {
+            q_out_tensor_tile_id = q_out_tensor_current_tile_id;
+            q_out_h_dim = 0;
+        }
+
+        kv_out_tensor_tile_id +=  kv_num_tiles;
+
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out0, out_num_tiles_read);
+    }
+
+}

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -114,6 +114,7 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/concat/single_core/concat_op_single_core.cpp \
 	tt_eager/tt_dnn/op_library/concat/concat_op.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp \
+	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_falcon7b.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads.cpp \
 	tt_eager/tt_dnn/op_library/rotate_half/single_core/rotate_half_op_single_core.cpp \

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp
@@ -15,39 +15,56 @@ namespace tt {
 
 namespace tt_metal {
 
-operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &a, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &input_tensor, std::optional<const Tensor> input_tensor_kv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
 
-    const auto& ashape = a.shape();
+    const auto& input_shape = input_tensor.shape();
 
-    tt_metal::Device *device = a.device();
+    tt_metal::Device *device = input_tensor.device();
 
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+
+    const bool read_from_input_tensor_kv = input_tensor_kv.has_value();
 
     uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
-    tt_metal::Buffer *in0_buffer = a.buffer();
+    tt_metal::Buffer *in0_buffer = input_tensor.buffer();
     TT_ASSERT(in0_buffer->size() % single_tile_size == 0);
+
+    tt_metal::Buffer *in1_buffer;
+    uint32_t in1_buffer_addr = 0;
+    tt_metal::BufferType in1_buffer_type = tt_metal::BufferType::DRAM;
+    if (read_from_input_tensor_kv) {
+        in1_buffer = input_tensor_kv.value().buffer();
+        TT_ASSERT(in1_buffer->size() % single_tile_size == 0);
+        in1_buffer_addr = in1_buffer->address();
+        in1_buffer_type = in1_buffer->buffer_type();
+    }
 
 
     ////////////////////////////////////////////////////////////////////////////
     //                      TM Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    uint32_t per_tensor_tiles = ashape[3] / TILE_WIDTH; // 146
-    uint32_t q_num_tiles_per_tensor = 142;
-    uint32_t kv_num_tiles_per_tensor = 2;
+    uint32_t in0_w_tiles = input_shape[3] / TILE_WIDTH;
+    uint32_t in1_w_tiles = 0;
+    if (read_from_input_tensor_kv) {
+        in1_w_tiles = input_tensor_kv.value().shape()[3] / TILE_WIDTH;
+    }
 
     // Per output tensor args
-    // Output shape for Q is: [B, 71, s, 64] # Needs shuffling from [B, 1, s, 4544]
-    // Output shape for K/V is: [B, 1, s, 64] # Just split, no shuffling after
-    uint32_t q_out_h_tiles = ashape[2] / TILE_HEIGHT;
-    uint32_t q_out_w_tiles = 2; // head_dim
-    uint32_t q_out_c = q_num_tiles_per_tensor / q_out_w_tiles; // num_heads
+    // Output shape for Q is: [B, num_q_heads, s, head_dim], shuffled from [B, 1, s, num_q_heads * head_dim]
+    // Output shape for K/V is: [B, num_kv_heads, s, head_dim], shuffled from [B, 1, s, num_kv_heads * head_dim]
+    // NOTE: Output h and w dims are identical for Q, K, V, so any arg that is related to these dims for q_* can be shared for K, V
+    uint32_t q_out_h_tiles = input_shape[2] / TILE_HEIGHT;
+    uint32_t q_out_w_tiles = head_dim / TILE_WIDTH; // tiles along head_dim
     uint32_t q_out_HtWt = q_out_h_tiles * q_out_w_tiles;
-    uint32_t q_out_CHtWt = q_out_c * q_out_HtWt;
+    uint32_t q_out_CHtWt = num_q_heads * q_out_HtWt;
+    uint32_t kv_out_CHtWt = num_kv_heads * q_out_HtWt;
+    uint32_t q_num_tiles = num_q_heads * q_out_w_tiles;
+    uint32_t kv_num_tiles = num_kv_heads * q_out_w_tiles;
 
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    // Block is a unit of work; ie. num of per_tensor_tiles per core
-    uint32_t num_blocks = ashape[0] * ashape[1] * ashape[2] / TILE_HEIGHT;
+    // Block is a unit of work; ie. num of in0_w_tiles per core
+    uint32_t num_blocks = input_shape[0] * input_shape[1] * input_shape[2] / TILE_HEIGHT;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_blocks);
 
 
@@ -72,42 +89,101 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &a,
     ////////////////////////////////////////////////////////////////////////////
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    bool tile_dtype_is_bfloat16 = a.dtype() == tt::tt_metal::DataType::BFLOAT16;
+    bool tile_dtype_is_bfloat16 = input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16;
     bool in0_is_dram = in0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    bool in1_is_dram = false;
+    if (read_from_input_tensor_kv) {
+        in1_is_dram = in1_buffer_type == tt_metal::BufferType::DRAM ? 1 : 0;
+    }
+
+    // TODO: Q, K, V doesn't necessarily need to be the same output mem config
     bool out_is_dram = q_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> reader_compile_time_args = {
             // interleaved accessor args
             (std::uint32_t) in0_is_dram,
+            (std::uint32_t) in1_is_dram,
+            (std::uint32_t) q_num_tiles,
+            (std::uint32_t) kv_num_tiles,
     };
     std::vector<uint32_t> writer_compile_time_args = {
             // interleaved accessor args
             (std::uint32_t) out_is_dram,
-            (std::uint32_t) q_num_tiles_per_tensor,
-            (std::uint32_t) kv_num_tiles_per_tensor,
             (std::uint32_t) q_out_h_tiles,
             (std::uint32_t) q_out_w_tiles,
-            (std::uint32_t) q_out_c,
             (std::uint32_t) q_out_HtWt,
+            (std::uint32_t) num_q_heads, // q_out_c
+            (std::uint32_t) num_kv_heads, // kv_out_c
     };
+
+    std::map<string, string> reader_defines;
+    std::map<string, string> writer_defines;
+    if (transpose_k_heads) {
+        std::vector<uint32_t> compute_args_core_group_1 = {num_blocks_per_core_group_1 * kv_num_tiles};
+        auto compute_kernel_id_group_1 = tt_metal::CreateKernel(
+            program,
+            "tt_eager/tt_dnn/kernels/compute/transpose_wh.cpp",
+            core_group_1,
+            tt_metal::ComputeConfig{.compile_args = compute_args_core_group_1}
+        );
+
+        if (core_group_2.num_cores() > 0) {
+            std::vector<uint32_t> compute_args_core_group_2 = {num_blocks_per_core_group_2 * kv_num_tiles};
+            auto compute_kernel_id_group_2 = tt_metal::CreateKernel(
+                program,
+                "tt_eager/tt_dnn/kernels/compute/transpose_wh.cpp",
+                core_group_2,
+                tt_metal::ComputeConfig{.compile_args = compute_args_core_group_2}
+            );
+        }
+
+        reader_defines["TRANSPOSE_K_HEADS"] = "1";
+        writer_defines["TRANSPOSE_K_HEADS"] = "1";
+    }
+    if (read_from_input_tensor_kv) {
+        reader_defines["READ_FROM_INPUT_TENSOR_KV"] = "1";
+    }
 
     auto reader_kernel_id = tt_metal::CreateKernel(
         program,
-        "tt_eager/tt_dnn/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
+        "tt_eager/tt_dnn/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp",
         all_cores,
-        tt_metal::ReaderDataMovementConfig{.compile_args = reader_compile_time_args});
+        tt_metal::ReaderDataMovementConfig{.compile_args = reader_compile_time_args, .defines = reader_defines});
     auto writer_kernel_id = tt_metal::CreateKernel(
         program,
         "tt_eager/tt_dnn/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads.cpp",
         all_cores,
-        tt_metal::WriterDataMovementConfig{.compile_args = writer_compile_time_args});
+        tt_metal::WriterDataMovementConfig{.compile_args = writer_compile_time_args, .defines = writer_defines});
 
 
     // Create circular buffers
-    uint32_t src0_cb_index = 0;
-    uint32_t cb0_num_tiles = per_tensor_tiles * 2; // double buffer
-    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(cb0_num_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-		.set_page_size(src0_cb_index, single_tile_size);
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    uint32_t micro_block_size = 1; // Num tiles to read/wait for in reader and writer
+    uint32_t cb_num_tiles = micro_block_size * 4; // Quadruple buffer everything
+
+    // TODO: Investigate perf allocating full in0_w_tiles with double buffer
+    // uint32_t cb1_num_tiles = in0_w_tiles * 2; // double buffer; this runs out of space for generic shapes
+    uint32_t src1_cb_index = 1; // cb0 is needed for compute if we want to use generic transpose_wh compute kernel
+    uint32_t cb1_num_tiles = cb_num_tiles;
+    tt_metal::CircularBufferConfig cb_src1_config = tt_metal::CircularBufferConfig(cb1_num_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
+		.set_page_size(src1_cb_index, single_tile_size);
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+
+    // If we transpose_k_heads:
+    // - reader will write to cb0, instead of cb1
+    // - compute will wait on cb0 and write to cb16
+    // - writer will wait on cb 16, instead of cb1
+    if (transpose_k_heads) {
+        uint32_t src0_cb_index = 0;
+        uint32_t cb0_num_tiles = cb_num_tiles;
+        tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(cb0_num_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+		    .set_page_size(src0_cb_index, single_tile_size);
+        auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+        uint32_t out_cb_index = 16;
+        uint32_t out_cb_num_tiles = cb_num_tiles;
+        tt_metal::CircularBufferConfig cb_out_config = tt_metal::CircularBufferConfig(out_cb_num_tiles * single_tile_size, {{out_cb_index, cb_data_format}})
+		    .set_page_size(out_cb_index, single_tile_size);
+        auto cb_out = tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+    }
 
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++){
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -122,12 +198,16 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &a,
 
         std::vector<uint32_t> reader_runtime_args = {
             (std::uint32_t) in0_buffer->address(),
-            num_blocks_per_core * per_tensor_tiles,
-            num_blocks_written * per_tensor_tiles,
+            (std::uint32_t) in1_buffer_addr,
+            num_blocks_per_core,
+            num_blocks_written * in0_w_tiles,
+            num_blocks_written * in1_w_tiles,
         };
 
         uint32_t q_out_h_dim = num_blocks_written % q_out_h_tiles;
         uint32_t q_out_tensor_tile_id = num_blocks_written / q_out_h_tiles * q_out_CHtWt + q_out_h_dim * q_out_w_tiles;
+        uint32_t v_out_tensor_tile_id = num_blocks_written / q_out_h_tiles * kv_out_CHtWt + q_out_h_dim * q_out_w_tiles;
+        uint32_t k_out_tensor_tile_id = transpose_k_heads ? num_blocks_written / q_out_h_tiles * kv_out_CHtWt + q_out_h_dim : v_out_tensor_tile_id;
 
         std::vector<uint32_t> writer_runtime_args = {
             (std::uint32_t) q_buffer->address(), // q_tensor_addr
@@ -136,7 +216,8 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &a,
             num_blocks_per_core, // num_blocks
             q_out_h_dim, // q_out_h_dim
             q_out_tensor_tile_id, // q_out_tensor_tile_id
-            num_blocks_written * kv_num_tiles_per_tensor, // kv_out_tensor_tile_id
+            k_out_tensor_tile_id, // k_out_tensor_tile_id
+            v_out_tensor_tile_id, // v_out_tensor_tile_id
         };
 
         tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
@@ -144,42 +225,54 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &a,
         num_blocks_written += num_blocks_per_core;
     }
 
-    auto override_runtime_args_callback = [
+    auto override_runtime_arguments_callback = [
             reader_kernel_id,
             writer_kernel_id,
             num_cores,
-            num_cores_y
+            num_cores_y,
+            read_from_input_tensor_kv=read_from_input_tensor_kv
         ]
     (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
+        const void* operation,
+        Program &program,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        const std::vector<Tensor>& output_tensors
     ) {
 
-        auto src_dram_buffer = input_buffers.at(0);
+        auto src_buffer = input_tensors.at(0).buffer();
 
-        auto dst_dram_buffer_query = output_buffers.at(0);
-        auto dst_dram_buffer_key = output_buffers.at(1);
-        auto dst_dram_buffer_value = output_buffers.at(2);
+        uint32_t src_kv_buffer_addr = 0;
+        if (read_from_input_tensor_kv) {
+            src_kv_buffer_addr = optional_input_tensors.at(0).value().buffer()->address();
+        }
+
+        auto dst_buffer_query = output_tensors.at(0).buffer();
+        auto dst_buffer_key = output_tensors.at(1).buffer();
+        auto dst_buffer_value = output_tensors.at(2).buffer();
 
         for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++){
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
             {
                 auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_dram_buffer->address();
+                runtime_args[0] = src_buffer->address();
+
+                if (read_from_input_tensor_kv) {
+                    runtime_args[1] = src_kv_buffer_addr;
+                }
             }
 
             {
                 auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_dram_buffer_query->address();
-                runtime_args[1] = dst_dram_buffer_key->address();
-                runtime_args[2] = dst_dram_buffer_value->address();
+                runtime_args[0] = dst_buffer_query->address();
+                runtime_args[1] = dst_buffer_key->address();
+                runtime_args[2] = dst_buffer_value->address();
             }
         }
     };
 
-    return {std::move(program), override_runtime_args_callback};
+    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
 }
 
 } // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_falcon7b.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_falcon7b.cpp
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/nlp_tms/nlp_tms.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+
+using namespace tt::constants;
+using namespace tt;
+
+namespace tt {
+
+namespace tt_metal {
+
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_falcon7b(const Tensor &a, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
+
+    const auto& ashape = a.shape();
+
+    tt_metal::Device *device = a.device();
+
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+
+    uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
+    tt_metal::Buffer *in0_buffer = a.buffer();
+    TT_ASSERT(in0_buffer->size() % single_tile_size == 0);
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      TM Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t per_tensor_tiles = ashape[3] / TILE_WIDTH; // 146
+    uint32_t q_num_tiles_per_tensor = 142;
+    uint32_t kv_num_tiles_per_tensor = 2;
+
+    // Per output tensor args
+    // Output shape for Q is: [B, 71, s, 64] # Needs shuffling from [B, 1, s, 4544]
+    // Output shape for K/V is: [B, 1, s, 64] # Just split, no shuffling after
+    uint32_t q_out_h_tiles = ashape[2] / TILE_HEIGHT;
+    uint32_t q_out_w_tiles = 2; // head_dim
+    uint32_t q_out_c = q_num_tiles_per_tensor / q_out_w_tiles; // num_heads
+    uint32_t q_out_HtWt = q_out_h_tiles * q_out_w_tiles;
+    uint32_t q_out_CHtWt = q_out_c * q_out_HtWt;
+
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    // Block is a unit of work; ie. num of per_tensor_tiles per core
+    uint32_t num_blocks = ashape[0] * ashape[1] * ashape[2] / TILE_HEIGHT;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Grayskull Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    TT_ASSERT((output.size() == 3), "Output vector must be size 3 for split fused qkv!");
+    tt_metal::Tensor& q = output[0];
+    tt_metal::Tensor& k = output[1];
+    tt_metal::Tensor& v = output[2];
+
+    tt_metal::Buffer *q_buffer = q.buffer();
+    TT_ASSERT(q_buffer != nullptr, "Output q buffer should be allocated on device!");
+    tt_metal::Buffer *k_buffer = k.buffer();
+    TT_ASSERT(k_buffer != nullptr, "Output k buffer should be allocated on device!");
+    tt_metal::Buffer *v_buffer = v.buffer();
+    TT_ASSERT(v_buffer != nullptr, "Output v buffer should be allocated on device!");
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    bool tile_dtype_is_bfloat16 = a.dtype() == tt::tt_metal::DataType::BFLOAT16;
+    bool in0_is_dram = in0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    bool out_is_dram = q_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_compile_time_args = {
+            // interleaved accessor args
+            (std::uint32_t) in0_is_dram,
+    };
+    std::vector<uint32_t> writer_compile_time_args = {
+            // interleaved accessor args
+            (std::uint32_t) out_is_dram,
+            (std::uint32_t) q_num_tiles_per_tensor,
+            (std::uint32_t) kv_num_tiles_per_tensor,
+            (std::uint32_t) q_out_h_tiles,
+            (std::uint32_t) q_out_w_tiles,
+            (std::uint32_t) q_out_c,
+            (std::uint32_t) q_out_HtWt,
+    };
+
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig{.compile_args = reader_compile_time_args});
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/kernels/dataflow/writer_tm_tile_layout_nlp_create_qkv_heads_falcon7b.cpp",
+        all_cores,
+        tt_metal::WriterDataMovementConfig{.compile_args = writer_compile_time_args});
+
+
+    // Create circular buffers
+    uint32_t src0_cb_index = 0;
+    uint32_t cb0_num_tiles = per_tensor_tiles * 2; // double buffer
+    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(cb0_num_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+		.set_page_size(src0_cb_index, single_tile_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++){
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_blocks_per_core = 0;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_2;
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges");
+        }
+
+        std::vector<uint32_t> reader_runtime_args = {
+            (std::uint32_t) in0_buffer->address(),
+            num_blocks_per_core * per_tensor_tiles,
+            num_blocks_written * per_tensor_tiles,
+        };
+
+        uint32_t q_out_h_dim = num_blocks_written % q_out_h_tiles;
+        uint32_t q_out_tensor_tile_id = num_blocks_written / q_out_h_tiles * q_out_CHtWt + q_out_h_dim * q_out_w_tiles;
+
+        std::vector<uint32_t> writer_runtime_args = {
+            (std::uint32_t) q_buffer->address(), // q_tensor_addr
+            (std::uint32_t) k_buffer->address(), // k_tensor_addr
+            (std::uint32_t) v_buffer->address(), // v_tensor_addr
+            num_blocks_per_core, // num_blocks
+            q_out_h_dim, // q_out_h_dim
+            q_out_tensor_tile_id, // q_out_tensor_tile_id
+            num_blocks_written * kv_num_tiles_per_tensor, // kv_out_tensor_tile_id
+        };
+
+        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        num_blocks_written += num_blocks_per_core;
+    }
+
+    auto override_runtime_args_callback = [
+            reader_kernel_id,
+            writer_kernel_id,
+            num_cores,
+            num_cores_y
+        ]
+    (
+        const Program &program,
+        const std::vector<Buffer*>& input_buffers,
+        const std::vector<Buffer*>& output_buffers
+    ) {
+
+        auto src_dram_buffer = input_buffers.at(0);
+
+        auto dst_dram_buffer_query = output_buffers.at(0);
+        auto dst_dram_buffer_key = output_buffers.at(1);
+        auto dst_dram_buffer_value = output_buffers.at(2);
+
+        for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++){
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = src_dram_buffer->address();
+            }
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = dst_dram_buffer_query->address();
+                runtime_args[1] = dst_dram_buffer_key->address();
+                runtime_args[2] = dst_dram_buffer_value->address();
+            }
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+} // namespace tt_metal
+
+} // namespace tt

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -13,7 +13,8 @@ namespace tt {
 
 namespace tt_metal {
 
-void NlpTM::validate(const std::vector<Tensor>& input_tensors) const {
+// Hard-coded for Falcon7B
+void NlpCreateHeadsFalcon7B::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     const auto input_shape = input_tensor.shape();
 
@@ -22,84 +23,171 @@ void NlpTM::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
     TT_FATAL(input_tensor.layout() == Layout::TILE);
 
-    switch (this->nlp_tm_op_type) {
-        case NlpTMOpType::CREATE_QKV_HEADS:
-            TT_FATAL(input_shape[2] % TILE_HEIGHT == 0);
-            TT_FATAL((input_shape == Shape({input_shape[0], 1, input_shape[2], 4672})), "Unsupported input shape");
-            TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
-            break;
-        case NlpTMOpType::CONCAT_HEADS:
-            if (input_tensor.is_sharded()) {
-                TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
-                auto shard_spec = input_tensor.shard_spec().value();
-                TT_FATAL(shard_spec.shard_shape[1] == input_tensor.shape()[-1]);
-                TT_FATAL(shard_spec.shard_shape[0] % input_tensor.shape()[-2] == 0);
-                TT_FATAL(input_tensor.shape()[1] % (shard_spec.shard_shape[0] / input_tensor.shape()[-2]) == 0);
-                TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
-            } else {
-                TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
-            }
-            break;
-        default:
-            TT_FATAL(false, "Unknown nlp tm op in validate!");
-    }
+    TT_FATAL(input_shape[2] % TILE_HEIGHT == 0);
+    TT_FATAL((input_shape == Shape({input_shape[0], 1, input_shape[2], 4672})), "Unsupported input shape");
+    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
 }
 
-std::vector<Shape> NlpTM::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+std::vector<Shape> NlpCreateHeadsFalcon7B::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
     std::vector<Shape> output_shape_vec;
     const auto& input_tensor = input_tensors.at(0);
     const auto input_shape = input_tensor.shape();
-    switch (this->nlp_tm_op_type) {
-        case NlpTMOpType::CREATE_QKV_HEADS:
-            output_shape_vec = {(Shape) {input_shape[0], 71, input_shape[2], 64}, (Shape) {input_shape[0], 1, input_shape[2], 64}, (Shape) {input_shape[0], 1, input_shape[2], 64}};
-            break;
-        case NlpTMOpType::CONCAT_HEADS:
-            output_shape_vec = {(Shape) {input_shape[0], 1, input_shape[2], input_shape[1] * input_shape[3]}};
-            break;
-        default:
-            TT_ASSERT(false, "Unknown nlp tm op in compute_output_shapes!");
-    }
+    output_shape_vec = {(Shape) {input_shape[0], 71, input_shape[2], 64}, (Shape) {input_shape[0], 1, input_shape[2], 64}, (Shape) {input_shape[0], 1, input_shape[2], 64}};
     return output_shape_vec;
 }
 
-std::vector<Tensor> NlpTM::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+std::vector<Tensor> NlpCreateHeadsFalcon7B::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     if (this->output_mem_config.is_sharded()) {
-        if (this->nlp_tm_op_type == NlpTMOpType::CONCAT_HEADS) {
-            ShardSpec shard_spec = input_tensor.shard_spec().value();
-            uint32_t num_cores = shard_spec.num_cores();
-            uint32_t heads_per_shard = shard_spec.shard_shape[0] / input_tensor.shape()[-2];
-            shard_spec.shard_shape = {shard_spec.shard_shape[0] / heads_per_shard, shard_spec.shard_shape[1] * heads_per_shard};
-            return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), input_tensor.dtype(), Layout::TILE, input_tensor.device(), this->output_mem_config, shard_spec)};
-        } else {
-            TT_ASSERT(false);
-            return {};
-        }
+        TT_ASSERT(false);
+        return {};
     } else {
         return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.dtype(), Layout::TILE, this->output_mem_config);
     }
 }
 
-operation::ProgramWithCallbacks NlpTM::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
+operation::ProgramWithCallbacks NlpCreateHeadsFalcon7B::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
 
     CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
 
-    switch (this->nlp_tm_op_type) {
-        case NlpTMOpType::CREATE_QKV_HEADS:
-            return  multi_core_nlp_create_qkv_heads(input_tensor, output_tensors, compute_with_storage_grid_size);
-        case NlpTMOpType::CONCAT_HEADS:
-            return  multi_core_nlp_concat_heads(input_tensor, output_tensor, compute_with_storage_grid_size);
-        default:
-            TT_ASSERT(false, "Unknown nlp tm op in create_program!");
-    }
-    return {};
+    return  multi_core_nlp_create_qkv_heads_falcon7b(input_tensor, output_tensors, compute_with_storage_grid_size);
 }
 
-tt::stl::reflection::Attributes NlpTM::attributes() const {
+tt::stl::reflection::Attributes NlpCreateHeadsFalcon7B::attributes() const {
     return {
-        {"nlp_tm_op_type", this->nlp_tm_op_type},
+        {"output_mem_config", this->output_mem_config},
+    };
+}
+
+
+// Generic NLP CreateHeads op
+void NlpCreateHeads::validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto input_shape = input_tensor.shape();
+
+    // NOTE: Checks for head_dim and shape[3] is done in nlp_create_qkv_heads because it's needed to infer head_dim
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
+    TT_FATAL(input_tensor.layout() == Layout::TILE);
+
+    TT_FATAL(input_shape[2] % TILE_HEIGHT == 0, "Unsupported input shape");
+    TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
+    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+
+    if (optional_input_tensors.at(0).has_value()) {
+        const auto& input_tensor_kv = optional_input_tensors.at(0).value();
+        const auto input_shape_kv = input_tensor_kv.shape();
+
+        TT_FATAL(input_tensor_kv.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
+        TT_FATAL(input_tensor_kv.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
+        TT_FATAL(input_tensor_kv.dtype() == input_tensor.dtype(), "KV tensor dtype must be same as Q tensor dtype!");
+        TT_FATAL(input_tensor_kv.layout() == Layout::TILE);
+
+        TT_FATAL(input_shape_kv[0] == input_shape[0], "KV tensor batch dim must be same as Q tensor batch!");
+        TT_FATAL(input_shape_kv[1] == 1, "Unsupported input shape");
+        TT_FATAL(input_shape_kv[2] == input_shape[2], "KV tensor seq_len dim must be same as Q tensor seq_len!");
+    }
+}
+
+std::vector<Shape> NlpCreateHeads::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    std::vector<Shape> output_shape_vec;
+    const auto& input_tensor = input_tensors.at(0);
+    const auto input_shape = input_tensor.shape();
+    const Shape q_output_shape = {input_shape[0], this->num_q_heads, input_shape[2], this->head_dim};
+    const Shape v_output_shape = {input_shape[0], this->num_kv_heads, input_shape[2], this->head_dim};
+    const Shape k_output_shape = this->transpose_k_heads ? (Shape) {input_shape[0], this->num_kv_heads, this->head_dim, input_shape[2]} : v_output_shape;
+    output_shape_vec = {q_output_shape, k_output_shape, v_output_shape};
+
+    return output_shape_vec;
+}
+
+std::vector<Tensor> NlpCreateHeads::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    if (this->output_mem_config.is_sharded()) {
+        TT_FATAL(false, "Sharding is not supported for NlpCreateHeads yet.");
+    } else {
+        return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.dtype(), Layout::TILE, this->output_mem_config);
+    }
+}
+
+operation::ProgramWithCallbacks NlpCreateHeads::create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto& input_tensor_kv = optional_input_tensors.at(0);
+    auto& output_tensor = output_tensors.at(0);
+
+    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+
+    return  multi_core_nlp_create_qkv_heads(input_tensor, input_tensor_kv, this->num_q_heads, this->num_kv_heads, this->head_dim, this->transpose_k_heads, output_tensors, compute_with_storage_grid_size);
+}
+
+tt::stl::reflection::Attributes NlpCreateHeads::attributes() const {
+    return {
+        {"num_q_heads", this->num_q_heads},
+        {"num_kv_heads", this->num_kv_heads},
+        {"transpose_k_heads", this->transpose_k_heads},
+        {"output_mem_config", this->output_mem_config},
+    };
+}
+
+
+// Generic NLP ConcatHeads op
+void NlpConcatHeads::validate(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto input_shape = input_tensor.shape();
+
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
+    TT_FATAL(input_tensor.layout() == Layout::TILE);
+
+    if (input_tensor.is_sharded()) {
+        TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+        auto shard_spec = input_tensor.shard_spec().value();
+        TT_FATAL(shard_spec.shard_shape[1] == input_tensor.shape()[-1]);
+        TT_FATAL(shard_spec.shard_shape[0] % input_tensor.shape()[-2] == 0);
+        TT_FATAL(input_tensor.shape()[1] % (shard_spec.shard_shape[0] / input_tensor.shape()[-2]) == 0);
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
+    } else {
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+    }
+}
+
+std::vector<Shape> NlpConcatHeads::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    std::vector<Shape> output_shape_vec;
+    const auto& input_tensor = input_tensors.at(0);
+    const auto input_shape = input_tensor.shape();
+    output_shape_vec = {(Shape) {input_shape[0], 1, input_shape[2], input_shape[1] * input_shape[3]}};
+
+    return output_shape_vec;
+}
+
+std::vector<Tensor> NlpConcatHeads::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    if (this->output_mem_config.is_sharded()) {
+        ShardSpec shard_spec = input_tensor.shard_spec().value();
+        uint32_t num_cores = shard_spec.num_cores();
+        uint32_t heads_per_shard = shard_spec.shard_shape[0] / input_tensor.shape()[-2];
+        shard_spec.shard_shape = {shard_spec.shard_shape[0] / heads_per_shard, shard_spec.shard_shape[1] * heads_per_shard};
+        return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), input_tensor.dtype(), Layout::TILE, input_tensor.device(), this->output_mem_config, shard_spec)};
+    } else {
+        return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.dtype(), Layout::TILE, this->output_mem_config);
+    }
+}
+
+operation::ProgramWithCallbacks NlpConcatHeads::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    auto& output_tensor = output_tensors.at(0);
+
+    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+
+    return  multi_core_nlp_concat_heads(input_tensor, output_tensor, compute_with_storage_grid_size);
+}
+
+tt::stl::reflection::Attributes NlpConcatHeads::attributes() const {
+    return {
         {"output_mem_config", this->output_mem_config},
     };
 }

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.hpp
@@ -12,16 +12,11 @@ namespace tt {
 
 namespace tt_metal {
 
-enum class NlpTMOpType {
-    CREATE_QKV_HEADS = 0,
-    CONCAT_HEADS = 1,
-};
-
-operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &input_tensor_a, std::vector<Tensor> &output, CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_falcon7b(const Tensor &input_tensor_a, std::vector<Tensor> &output, CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &input_tensor, std::optional<const Tensor> input_tensor_kv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor> &output, CoreCoord compute_with_storage_grid_size);
 operation::ProgramWithCallbacks multi_core_nlp_concat_heads(const Tensor &input_tensor_a, Tensor &output, CoreCoord compute_with_storage_grid_size);
 
-struct NlpTM {
-    NlpTMOpType nlp_tm_op_type;
+struct NlpCreateHeadsFalcon7B {
     MemoryConfig output_mem_config;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
@@ -31,13 +26,59 @@ struct NlpTM {
     tt::stl::reflection::Attributes attributes() const;
 };
 
-inline std::vector<Tensor> nlp_create_qkv_heads(const Tensor &input_tensor_a, const MemoryConfig& mem_config) {
-    // TODO: Uplift to support generic qkv num_heads and head_dim; currently, hard-coded for falcon-7b
-    return operation::run(NlpTM{NlpTMOpType::CREATE_QKV_HEADS, mem_config}, {input_tensor_a});
+struct NlpCreateHeads {
+    const uint32_t num_q_heads;
+    const uint32_t num_kv_heads;
+    const uint32_t head_dim;
+    const bool transpose_k_heads;
+    MemoryConfig output_mem_config;
+
+    void validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const;
+    tt::stl::reflection::Attributes attributes() const;
+};
+
+struct NlpConcatHeads {
+    MemoryConfig output_mem_config;
+
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
+    tt::stl::reflection::Attributes attributes() const;
+};
+
+inline std::vector<Tensor> nlp_create_qkv_heads_falcon7b(const Tensor &input_tensor_a, const MemoryConfig& mem_config) {
+  // TODO: hard-coded for falcon-7b; can delete if we switch to the more generic one (but perf may be worse)
+  return operation::run(NlpCreateHeadsFalcon7B{mem_config}, {input_tensor_a});
+}
+inline std::vector<Tensor> nlp_create_qkv_heads(
+    const Tensor &input_tensor, std::optional<const Tensor> input_tensor_kv,
+    const uint32_t num_heads, std::optional<const uint32_t> num_kv_heads,
+    const bool transpose_k_heads,
+    const MemoryConfig& mem_config
+) {
+    const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_heads);
+
+    // Infer head_dim
+    uint32_t head_dim;
+    if (input_tensor_kv.has_value()) {
+        TT_FATAL(input_tensor.shape()[3] % num_heads == 0, "Unsupported input shape");
+        TT_FATAL(input_tensor_kv.value().shape()[3] % (2 * num_kv_heads_val) == 0, "Unsupported input shape");
+        head_dim = input_tensor.shape()[3] / num_heads;
+        TT_FATAL(input_tensor_kv.value().shape()[3] / (2 * num_kv_heads_val) == head_dim, "Head dims must be the same for Q and K, V");
+    } else {
+        TT_FATAL(input_tensor.shape()[3] % (num_heads + 2 * num_kv_heads_val) == 0, "Unsupported input shape");
+        head_dim = input_tensor.shape()[3] / (num_heads + 2 * num_kv_heads_val);
+    }
+
+    return operation::run(NlpCreateHeads{num_heads, num_kv_heads_val, head_dim, transpose_k_heads, mem_config}, {input_tensor}, {input_tensor_kv});
 }
 inline Tensor nlp_concat_heads(const Tensor &input_tensor_a, const MemoryConfig& mem_config) {
     // TODO: Uplift to support generic num_heads and head_dim; currently, hard-coded for falcon-7b
-    return operation::run(NlpTM{NlpTMOpType::CONCAT_HEADS, mem_config}, {input_tensor_a}).at(0);
+    return operation::run(NlpConcatHeads{mem_config}, {input_tensor_a}).at(0);
 }
 
 }  // namespace tt_metal

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -121,11 +121,15 @@ namespace tt::tt_metal::detail
         )doc");
 
         // Custom Generic NLP TMs
-        // TODO: Uplift nlp_create_qkv_heads to support generic qkv num_heads and head_dim
         // This op should support arbitrary B and S divisible by 32 on DRAM; on L1, might error out due to space
-        m_tensor.def("nlp_create_qkv_heads", &nlp_create_qkv_heads,
+        m_tensor.def("nlp_create_qkv_heads_falcon7b", &nlp_create_qkv_heads_falcon7b,
             py::arg().noconvert(), py::arg("output_mem_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Shuffles [B, 1, S, 4672] fused qkv matrix into 3 heads with shapes [B, 71, S, 64], [B, 1, S, 64], and [B, 1, S, 64].
+        )doc");
+        // More general implementation, but perf might be worse since the cbs are very small and writer calls noc_async_write_barrier() a lot
+        m_tensor.def("nlp_create_qkv_heads", &nlp_create_qkv_heads,
+            py::arg("input").noconvert(), py::arg("input_kv").noconvert() = std::nullopt, py::arg("num_heads").noconvert(), py::arg("num_kv_heads").noconvert() = std::nullopt, py::arg("transpose_k_heads").noconvert() = true, py::arg("output_mem_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Shuffles [B, 1, S, 3 * head_dim * num_heads] fused qkv matrix into 3 Q, K, and V heads with shapes [B, num_heads, S, head_dim], [B, num_kv_heads, head_dim, S], and [B, num_kv_heads, S, head_dim]. If optional ``input_kv`` tensor is provided, K and V will be created from ``input_kv`` and ``input`` should have shape [B, 1, S, head_dim * num_heads] instead. ``num_kv_heads`` defaults to ``num_heads`` if not provided. An additional transpose along the last two dims is performed by default for K heads, but this can be skipped with ``transpose_k_heads=false``.
         )doc");
         m_tensor.def("nlp_concat_heads", &nlp_concat_heads,
             py::arg().noconvert(), py::arg("output_mem_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(


### PR DESCRIPTION
- Add unit test (harness) for generic NlpCreateHeads
- Split NlpTM into NlpCreateHeads and NlpConcatHeads

TODOs:
- [x] Add second optional input for kv heads
- [x] Clean up and add more unit tests
- [x] Fix broken falcon tests that use `nlp_create_qkv_heads` and make sure no perf regression
- [x] Update docs

Also addressing this issue: https://github.com/tenstorrent-metal/tt-metal/issues/4603