### PR TITLE
#4506: SSD gs demo benchmarking

### DIFF
--- a/models/experimental/ssd/reference/utils/metrics.py
+++ b/models/experimental/ssd/reference/utils/metrics.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+
+def load_ground_truth_labels(label_file):
+    with open(label_file, "r") as file:
+        lines = file.readlines()
+    labels = []
+    for line in lines:
+        line = line.strip().split()
+        labels.append({"class": int(line[0]), "bbox": [float(coord) for coord in line[1:]]})
+    return labels
+
+
+# Function to compute IoU (Intersection over Union) between two bounding boxes
+def calculate_iou(box1, box2):
+    # Extract coordinates of bounding boxes
+    b1_x, b1_y, b1_w, b1_h = box1
+    b2_x, b2_y, b2_w, b2_h = box2
+
+    # Calculate coordinates of intersection area
+    x1 = max(b1_x - b1_w / 2, b2_x - b2_w / 2)
+    y1 = max(b1_y - b1_h / 2, b2_y - b2_h / 2)
+    x2 = min(b1_x + b1_w / 2, b2_x + b2_w / 2)
+    y2 = min(b1_y + b1_h / 2, b2_y + b2_h / 2)
+
+    # Calculate area of intersection
+    intersection = max(0, x2 - x1) * max(0, y2 - y1)
+
+    # Calculate area of union
+    union = b1_w * b1_h + b2_w * b2_h - intersection
+
+    # Calculate IoU
+    iou = intersection / (union + 1e-16)
+    return iou
+
+
+# Compute Average Precision (AP) for a single class
+def calculate_ap(predictions, ground_truth, iou_threshold=0.5):
+    # Sort predictions by confidence score in descending order
+    predictions = sorted(predictions, key=lambda x: x["confidence"], reverse=True)
+
+    true_positives = np.zeros(len(predictions))
+    false_positives = np.zeros(len(predictions))
+    num_ground_truth = len(ground_truth)
+
+    for i, prediction in enumerate(predictions):
+        iou_max = 0
+        gt_match = -1
+
+        # Match prediction with ground truth with highest IoU
+        for j, gt_list in enumerate(ground_truth):
+            for gt in gt_list:
+                iou = calculate_iou(prediction["bbox"], gt["bbox"])
+                if iou > iou_max:
+                    iou_max = iou
+                    gt_match = j
+
+        # If IoU exceeds threshold and class matches, it's a true positive
+        if iou_max >= iou_threshold and prediction["class"] == ground_truth[gt_match]["class"]:
+            true_positives[i] = 1
+        else:
+            false_positives[i] = 1
+
+    # Compute precision and recall
+    cumulative_tp = np.cumsum(true_positives)
+    cumulative_fp = np.cumsum(false_positives)
+    recall = cumulative_tp / num_ground_truth
+    precision = cumulative_tp / (cumulative_tp + cumulative_fp + 1e-16)
+
+    # Compute Average Precision (AP) using precision-recall curve
+    ap = 0
+    for t in np.arange(0, 1.1, 0.1):
+        if np.sum(recall >= t) == 0:
+            p = 0
+        else:
+            p = np.max(precision[recall >= t])
+        ap = ap + p / 11
+
+    return ap

--- a/models/experimental/ssd/tests/test_perf_accuracy_ssd.py
+++ b/models/experimental/ssd/tests/test_perf_accuracy_ssd.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import torch
+import pytest
+
+from PIL import Image
+from loguru import logger
+from collections import defaultdict
+
+from models.utility_functions import (
+    torch_to_tt_tensor_rm,
+    disable_persistent_kernel_cache,
+    enable_persistent_kernel_cache,
+)
+from models.utility_functions import Profiler
+from models.perf.perf_utils import prep_perf_report
+from models.experimental.ssd.tt.ssd_lite import ssd_for_object_detection
+from models.experimental.ssd.reference.utils.metrics import load_ground_truth_labels, calculate_ap
+
+import torchvision.transforms as transforms
+from torchvision.models.detection import (
+    SSDLite320_MobileNet_V3_Large_Weights,
+    ssdlite320_mobilenet_v3_large as pretrained,
+)
+
+
+BATCH_SIZE = 1
+
+
+def run_perf_ssd(
+    device,
+    expected_inference_time,
+    expected_compile_time,
+    imagenet_sample_input,
+    model_location_generator,
+    iterations,
+):
+    profiler = Profiler()
+    disable_persistent_kernel_cache()
+    first_key = "first_iter"
+    second_key = "second_iter"
+    third_key = "third_key"
+    cpu_key = "ref_key"
+    comments = "SSD_lite"
+
+    torch_model = pretrained(weights=SSDLite320_MobileNet_V3_Large_Weights.DEFAULT)
+    torch_model.eval()
+
+    tt_input = torch_to_tt_tensor_rm(imagenet_sample_input, device, put_on_device=True)
+
+    tt_model = ssd_for_object_detection(device)
+    tt_model.eval()
+
+    data_path = model_location_generator("coco128", model_subdir="ssd")
+    image_files = os.listdir(data_path / "images/train2017")
+    label_files = os.listdir(data_path / "labels/train2017")
+
+    with torch.no_grad():
+        profiler.start(cpu_key)
+        torch_output = torch_model(imagenet_sample_input)
+        profiler.end(cpu_key)
+
+        profiler.start(first_key)
+        tt_output = tt_model(tt_input)
+        profiler.end(first_key)
+
+        enable_persistent_kernel_cache()
+
+        profiler.start(second_key)
+        tt_output = tt_model(tt_input)
+        profiler.end(second_key)
+
+        all_predictions = []
+        all_ground_truths = []
+        iteration = 0
+
+        profiler.start(third_key)
+        while iteration < iterations:
+            image_file = image_files[iteration]
+            image = os.path.join(data_path / "images/train2017", image_file)
+
+            label_file = image_file.split(".")[0] + ".txt"
+            label = os.path.join(data_path / "labels/train2017", label_file)
+
+            if os.path.exists(label):
+                reference_labels = load_ground_truth_labels(label)
+                all_ground_truths.append(reference_labels)
+
+                image = Image.open(image)
+                image = image.resize((224, 224))
+                image = transforms.ToTensor()(image).unsqueeze(0)
+
+                tt_model = ssd_for_object_detection(device)
+                tt_model.eval()
+                tt_input = torch_to_tt_tensor_rm(image, device)
+                tt_output = tt_model(tt_input)
+
+                class_confidence = defaultdict(float)
+                class_bbox = {}
+
+                for i in range(len(tt_output[0]["scores"])):
+                    label = int(tt_output[0]["labels"][i])
+                    confidence = float(tt_output[0]["scores"][i])
+                    bbox = [float(coord) for coord in tt_output[0]["boxes"][i]]
+
+                    if confidence > class_confidence[label]:
+                        class_confidence[label] = confidence
+                        class_bbox[label] = bbox
+
+                for label, confidence in class_confidence.items():
+                    prediction = {"class": label, "confidence": confidence, "bbox": class_bbox[label]}
+                    all_predictions.append(prediction)
+
+            iteration += 1
+
+        ap = calculate_ap(all_predictions, all_ground_truths)
+        logger.info(f"Mean Average Precision (mAP): {ap}")
+
+        profiler.end(third_key)
+
+    first_iter_time = profiler.get(first_key)
+    second_iter_time = profiler.get(second_key)
+    third_iter_time = profiler.get(third_key)
+    cpu_time = profiler.get(cpu_key)
+
+    prep_perf_report(
+        model_name="SSD",
+        batch_size=BATCH_SIZE,
+        inference_and_compile_time=first_iter_time,
+        inference_time=second_iter_time,
+        expected_compile_time=expected_inference_time,
+        expected_inference_time=expected_compile_time,
+        comments=comments,
+        inference_time_cpu=cpu_time,
+    )
+
+    compile_time = first_iter_time - second_iter_time
+
+    logger.info(f"SSD inference time: {second_iter_time}")
+    logger.info(f"SSD compile time: {compile_time}")
+    logger.info(f"ssd inference for {iterations} samples: {third_iter_time}")
+
+
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "expected_inference_time, expected_compile_time, iterations",
+    (
+        (
+            13.48890358,
+            0.5188875198,
+            50,
+        ),
+    ),
+)
+def test_perf_bare_metal(
+    use_program_cache,
+    device,
+    expected_inference_time,
+    expected_compile_time,
+    imagenet_sample_input,
+    model_location_generator,
+    iterations,
+):
+    run_perf_ssd(
+        device,
+        expected_inference_time,
+        expected_compile_time,
+        imagenet_sample_input,
+        model_location_generator,
+        iterations,
+    )
+
+
+@pytest.mark.models_performance_virtual_machine
+@pytest.mark.parametrize(
+    "expected_inference_time, expected_compile_time, iterations,",
+    (
+        (
+            13.48890358,
+            0.5188875198,
+            50,
+        ),
+    ),
+)
+def test_perf_virtual_machine(
+    use_program_cache,
+    device,
+    expected_inference_time,
+    expected_compile_time,
+    imagenet_sample_input,
+    model_location_generator,
+    iterations,
+):
+    run_perf_ssd(
+        device,
+        expected_inference_time,
+        expected_compile_time,
+        imagenet_sample_input,
+        model_location_generator,
+        iterations,
+    )

--- a/models/experimental/ssd/tt/ssd_classification_head.py
+++ b/models/experimental/ssd/tt/ssd_classification_head.py
@@ -46,9 +46,7 @@ class TtSSDclassificationhead(nn.Module):
                 device=device,
             )
             self.classification_head.append(self.conv)
-            weight = torch_to_tt_tensor_rm(
-                state_dict[f"{base_address}.{i}.1.weight"], device, put_on_device=False
-            )
+            weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}.{i}.1.weight"], device, put_on_device=False)
 
             self.convolution = fallback_ops.Conv2d(
                 weights=weight,
@@ -80,9 +78,7 @@ class TtSSDclassificationhead(nn.Module):
             result = result.permute(0, 3, 4, 1, 2)
             result = result.reshape(N, -1, self.num_classes)
 
-            result = torch_to_tt_tensor_rm(
-                result, device=self.device, put_on_device=False
-            )
+            result = torch_to_tt_tensor_rm(result, device=self.device, put_on_device=False)
             all_results.append(result)
 
-        return tt_lib.tensor.concat(all_results, 2)
+        return fallback_ops.concat(all_results, 2)

--- a/models/experimental/ssd/tt/ssd_regression_head.py
+++ b/models/experimental/ssd/tt/ssd_regression_head.py
@@ -48,9 +48,7 @@ class TtSSDregressionhead(nn.Module):
                 device=device,
             )
             self.regression_head.append(self.conv)
-            weight = torch_to_tt_tensor_rm(
-                state_dict[f"{base_address}.{i}.1.weight"], device, put_on_device=False
-            )
+            weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}.{i}.1.weight"], device, put_on_device=False)
 
             self.convolution = fallback_ops.Conv2d(
                 weights=weight,
@@ -85,4 +83,4 @@ class TtSSDregressionhead(nn.Module):
             result = torch_to_tt_tensor_rm(result, self.device)
             all_results.append(result)
 
-        return tt_lib.tensor.concat(all_results, 2)
+        return fallback_ops.concat(all_results, 2)


### PR DESCRIPTION
This PR contains benchmarking of SSD using 50 samples of coco128 dataset

The performance metrics are:
- average precision: 0.0

Note: The model's low PCC is affecting the average precision during benchmarking.
- PCC for Scores: 0.4450223310843609
- PCC for Labels: -0.29295572559612937
- PCC for Boxes: 0.16220816595909118
