### PR TITLE
#0: enable whb0  arch sweep tests

### DIFF
--- a/tests/ttnn/sweep_tests/test_add.py
+++ b/tests/ttnn/sweep_tests/test_add.py
@@ -8,10 +8,9 @@ import ttnn
 
 from tests.ttnn.sweep_tests.sweep import sweep_or_reproduce
 from tests.ttnn.utils_for_testing import check_with_pcc
-from models.utility_functions import skip_for_wormhole_b0, torch_random
+from models.utility_functions import torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_sizes": [(1,)],

--- a/tests/ttnn/sweep_tests/test_layer_norm.py
+++ b/tests/ttnn/sweep_tests/test_layer_norm.py
@@ -8,10 +8,9 @@ import ttnn
 
 from tests.ttnn.sweep_tests.sweep import sweep_or_reproduce
 from tests.ttnn.utils_for_testing import check_with_pcc
-from models.utility_functions import skip_for_wormhole_b0, torch_random
+from models.utility_functions import torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_sizes": [(1,)],

--- a/tests/ttnn/sweep_tests/test_linear.py
+++ b/tests/ttnn/sweep_tests/test_linear.py
@@ -8,10 +8,9 @@ import ttnn
 
 from tests.ttnn.sweep_tests.sweep import sweep_or_reproduce
 from tests.ttnn.utils_for_testing import check_with_pcc
-from models.utility_functions import skip_for_wormhole_b0, torch_random
+from models.utility_functions import torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_sizes": [(1,)],

--- a/tests/ttnn/sweep_tests/test_matmul.py
+++ b/tests/ttnn/sweep_tests/test_matmul.py
@@ -11,7 +11,6 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_sizes": [(1,)],

--- a/tests/ttnn/sweep_tests/test_mul.py
+++ b/tests/ttnn/sweep_tests/test_mul.py
@@ -11,7 +11,6 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_sizes": [(1,)],

--- a/tests/ttnn/sweep_tests/test_softmax.py
+++ b/tests/ttnn/sweep_tests/test_softmax.py
@@ -11,7 +11,6 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_sizes": [(1,)],

--- a/tests/ttnn/sweep_tests/test_sub.py
+++ b/tests/ttnn/sweep_tests/test_sub.py
@@ -11,7 +11,6 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_sizes": [(1,)],

--- a/tests/ttnn/sweep_tests/test_transformer_attention_softmax.py
+++ b/tests/ttnn/sweep_tests/test_transformer_attention_softmax.py
@@ -11,7 +11,6 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_size": [1],

--- a/tests/ttnn/sweep_tests/test_transformer_concatenate_heads.py
+++ b/tests/ttnn/sweep_tests/test_transformer_concatenate_heads.py
@@ -11,7 +11,6 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_size": [1],

--- a/tests/ttnn/sweep_tests/test_transformer_split_heads.py
+++ b/tests/ttnn/sweep_tests/test_transformer_split_heads.py
@@ -11,7 +11,6 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_size": [1],

--- a/tests/ttnn/sweep_tests/test_transformer_split_key_value_and_split_heads.py
+++ b/tests/ttnn/sweep_tests/test_transformer_split_key_value_and_split_heads.py
@@ -11,7 +11,6 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_size": [1],

--- a/tests/ttnn/sweep_tests/test_transformer_split_query_key_value_and_split_heads.py
+++ b/tests/ttnn/sweep_tests/test_transformer_split_query_key_value_and_split_heads.py
@@ -11,7 +11,6 @@ from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0, torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "batch_size": [1],

--- a/tests/ttnn/sweep_tests/test_unary.py
+++ b/tests/ttnn/sweep_tests/test_unary.py
@@ -8,10 +8,9 @@ import ttnn
 
 from tests.ttnn.sweep_tests.sweep import sweep_or_reproduce
 from tests.ttnn.utils_for_testing import check_with_pcc
-from models.utility_functions import skip_for_wormhole_b0, torch_random
+from models.utility_functions import torch_random
 
 
-@skip_for_wormhole_b0()
 def test_sweep(device, sweep_index):
     parameters = {
         "ttnn_function,torch_function": [


### PR DESCRIPTION
#0: enable whb0  arch sweep tests verified to be passing


Operator | WHB0 Sweep
-- | --
unary | OK
add | OK
sub | OK
mul | OK
matmul | OK
linear | OK
layer norm | OK
tx attn softmax | OK
tx concat heads | OK
tx split heads | OK
tx split kv split heads | OK
tx split query kv split heads | OK
softmax | OK

</google-sheets-html-origin>