### PR TITLE
#4490: Fix DPRINT hanging test to not check physical core coords

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/test_utils.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/test_utils.hpp
@@ -62,6 +62,19 @@ inline bool FileContainsAllStrings(string file_name, vector<string> &must_contai
     return false;
 }
 
+// Compare two strings with a (single-character) wildcard
+inline bool StringCompareWithWildcard(string& s1, string& s2, char wildcard) {
+    if (s1.size() != s2.size())
+        return false;
+
+    for (int idx = 0; idx < s1.size(); idx++) {
+        if (s1[idx] != s2[idx] && s1[idx] != wildcard && s2[idx] != wildcard)
+            return false;
+    }
+
+    return true;
+}
+
 // Checkes whether a given file matches a golden string.
 inline bool FilesMatchesString(string file_name, const string& expected) {
     // Open the input file.
@@ -83,7 +96,7 @@ inline bool FilesMatchesString(string file_name, const string& expected) {
     int line_num = 0;
     while (getline(file, line_a) && getline(expect_stream, line_b)) {
         line_num++;
-        if (line_a != line_b) {
+        if (!StringCompareWithWildcard(line_a, line_b, '*')) {
             tt::log_info(
                 tt::LogTest,
                 "Test Error: Line {} of {} did not match expected:\n\t{}\n\t{}",

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_hanging.cpp
@@ -15,8 +15,9 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
+// Some machines will run this test on different physical cores, so wildcard the exact coordinates.
 const std::string golden_output =
-R"(DPRINT server timed out on core (1,1) riscv 4, waiting on a RAISE signal: 1
+R"(DPRINT server timed out on core (*,*) riscv 4, waiting on a RAISE signal: 1
 )";
 
 static void RunTest(DPrintFixture* fixture, Device* device) {
@@ -43,15 +44,12 @@ try {
 }
 
     // Check the print log against golden output.
-    // TODO: dma look into CI error here, comment out this check for now. See #4490.
-    /*
     EXPECT_TRUE(
         FilesMatchesString(
             DPrintFixture::dprint_file_name,
             golden_output
         )
     );
-    */
 }
 
 TEST_F(DPrintFixture, TestPrintHanging) {


### PR DESCRIPTION
Issue here was that the test assumed that the hang would come from core (1,1). On just one of the CI machines row 1 is dead, and so the hang was coming from a different core. Just change the test to wildcard the core coords since it only runs on one core anyways.