### PR TITLE
Binary op Support in TTNN

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -400,6 +400,7 @@ smsg
 softmax
 sqrt
 square
+squared_difference
 sr
 src
 srca

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -295,6 +295,7 @@ iw
 iy
 jupyter
 ld
+ldexp
 leaky
 lez
 lgamma
@@ -304,6 +305,8 @@ llrt
 loadi
 loadis
 log
+logaddexp
+logaddexp2
 logical_and
 logical_andi
 logical_noti

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -370,6 +370,7 @@ rad
 randint
 randn
 rb
+rdiv
 recip
 reconfig
 regs
@@ -379,6 +380,7 @@ repo
 resnet
 riscv
 rmsg
+rpow
 rsqrt
 rst
 rsub

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -304,9 +304,13 @@ llrt
 loadi
 loadis
 log
+logical_and
 logical_andi
 logical_noti
+logical_not_unary
+logical_or
 logical_ori
+logical_xor
 logical_xori
 logit
 loopback

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -304,6 +304,10 @@ llrt
 loadi
 loadis
 log
+logical_andi
+logical_noti
+logical_ori
+logical_xori
 logit
 loopback
 ltz

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -271,6 +271,7 @@ hpp
 hs
 html
 hw
+hypot
 icb
 idst
 ie

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -170,6 +170,7 @@ asm
 async
 atan
 atanh
+atan2
 autoclass
 autofunction
 backend

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -334,6 +334,7 @@ nans
 ncrisc
 nd
 neg
+nextafter
 nez
 noc
 nodebias
@@ -347,6 +348,7 @@ numpy
 ocb
 oct
 onboarding
+outer
 parallelization
 parallelizes
 param

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -157,6 +157,7 @@ abs
 acc
 acos
 acosh
+addalpha
 addexp
 addr
 agrebenisan

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -408,6 +408,7 @@ srcb
 stderr
 storages
 struct
+subalpha
 submodule
 subvec
 sudo

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -483,4 +483,5 @@ wh
 ws
 xAA
 xFF
+xlogy
 xyz

--- a/docs/source/ttnn/operations.rst
+++ b/docs/source/ttnn/operations.rst
@@ -20,3 +20,4 @@ Operations
    operations/to_layout
    operations/to_torch
    operations/unary
+   operations/binary

--- a/docs/source/ttnn/operations/binary.rst
+++ b/docs/source/ttnn/operations/binary.rst
@@ -7,6 +7,12 @@ Binary Operations
 
 .. autofunction:: ttnn.hypot
 
+.. autofunction:: ttnn.ldexp
+
+.. autofunction:: ttnn.logaddexp
+
+.. autofunction:: ttnn.logaddexp2
+
 .. autofunction:: ttnn.logical_and
 
 .. autofunction:: ttnn.logical_or

--- a/docs/source/ttnn/operations/binary.rst
+++ b/docs/source/ttnn/operations/binary.rst
@@ -1,0 +1,4 @@
+Binary Operations
+=================
+
+.. autofunction:: ttnn.squared_difference

--- a/docs/source/ttnn/operations/binary.rst
+++ b/docs/source/ttnn/operations/binary.rst
@@ -7,4 +7,6 @@ Binary Operations
 
 .. autofunction:: ttnn.hypot
 
-.. autofunction:: ttnn.atna2
+.. autofunction:: ttnn.atan2
+
+.. autofunction:: ttnn.addalpha

--- a/docs/source/ttnn/operations/binary.rst
+++ b/docs/source/ttnn/operations/binary.rst
@@ -6,3 +6,5 @@ Binary Operations
 .. autofunction:: ttnn.subalpha
 
 .. autofunction:: ttnn.hypot
+
+.. autofunction:: ttnn.atna2

--- a/docs/source/ttnn/operations/binary.rst
+++ b/docs/source/ttnn/operations/binary.rst
@@ -2,3 +2,5 @@ Binary Operations
 =================
 
 .. autofunction:: ttnn.squared_difference
+
+.. autofunction:: ttnn.subalpha

--- a/docs/source/ttnn/operations/binary.rst
+++ b/docs/source/ttnn/operations/binary.rst
@@ -19,6 +19,10 @@ Binary Operations
 
 .. autofunction:: ttnn.logical_xor
 
+.. autofunction:: ttnn.nextafter
+
+.. autofunction:: ttnn.outer
+
 .. autofunction:: ttnn.squared_difference
 
 .. autofunction:: ttnn.subalpha

--- a/docs/source/ttnn/operations/binary.rst
+++ b/docs/source/ttnn/operations/binary.rst
@@ -1,12 +1,18 @@
 Binary Operations
 =================
 
-.. autofunction:: ttnn.squared_difference
-
-.. autofunction:: ttnn.subalpha
-
-.. autofunction:: ttnn.hypot
+.. autofunction:: ttnn.addalpha
 
 .. autofunction:: ttnn.atan2
 
-.. autofunction:: ttnn.addalpha
+.. autofunction:: ttnn.hypot
+
+.. autofunction:: ttnn.logical_and
+
+.. autofunction:: ttnn.logical_or
+
+.. autofunction:: ttnn.logical_xor
+
+.. autofunction:: ttnn.squared_difference
+
+.. autofunction:: ttnn.subalpha

--- a/docs/source/ttnn/operations/binary.rst
+++ b/docs/source/ttnn/operations/binary.rst
@@ -4,3 +4,5 @@ Binary Operations
 .. autofunction:: ttnn.squared_difference
 
 .. autofunction:: ttnn.subalpha
+
+.. autofunction:: ttnn.hypot

--- a/docs/source/ttnn/operations/binary.rst
+++ b/docs/source/ttnn/operations/binary.rst
@@ -26,3 +26,5 @@ Binary Operations
 .. autofunction:: ttnn.squared_difference
 
 .. autofunction:: ttnn.subalpha
+
+.. autofunction:: ttnn.xlogy

--- a/docs/source/ttnn/operations/unary.rst
+++ b/docs/source/ttnn/operations/unary.rst
@@ -81,6 +81,8 @@ Unary Operations
 
 .. autofunction:: ttnn.logical_noti
 
+.. autofunction:: ttnn.logical_not_unary
+
 .. autofunction:: ttnn.logical_ori
 
 .. autofunction:: ttnn.logical_xori

--- a/docs/source/ttnn/operations/unary.rst
+++ b/docs/source/ttnn/operations/unary.rst
@@ -77,6 +77,14 @@ Unary Operations
 
 .. autofunction:: ttnn.logit
 
+.. autofunction:: ttnn.logical_andi
+
+.. autofunction:: ttnn.logical_noti
+
+.. autofunction:: ttnn.logical_ori
+
+.. autofunction:: ttnn.logical_xori
+
 .. autofunction:: ttnn.mish
 
 .. autofunction:: ttnn.neg

--- a/docs/source/ttnn/operations/unary.rst
+++ b/docs/source/ttnn/operations/unary.rst
@@ -99,13 +99,19 @@ Unary Operations
 
 .. autofunction:: ttnn.rad2deg
 
+.. autofunction:: ttnn.rdiv
+
 .. autofunction:: ttnn.recip
 
 .. autofunction:: ttnn.relu
 
 .. autofunction:: ttnn.relu6
 
+.. autofunction:: ttnn.rpow
+
 .. autofunction:: ttnn.rsqrt
+
+.. autofunction:: ttnn.rsub
 
 .. autofunction:: ttnn.sigmoid
 

--- a/ttnn/__init__.py
+++ b/ttnn/__init__.py
@@ -59,6 +59,7 @@ from ttnn.core import (
 )
 
 from ttnn.unary import *
+from ttnn.binary import *
 
 import ttnn.decorators
 import ttnn.transformer

--- a/ttnn/binary.py
+++ b/ttnn/binary.py
@@ -47,7 +47,8 @@ def register_ttl_binary_function(name, ttl_binary_function, torch_function):
         Applies {name} to :attr:`input_tensor_a` and  :attr:`input_tensor_b` element-wise.
 
         .. math::
-            {name}(\\mathrm{{input\\_tensor}}_i)
+            {name}(\\mathrm{{input\\_tensor_a}}_i)
+            {name}(\\mathrm{{input\\_tensor_b}}_i)
 
         Args:
             * :attr:`input_tensor_a`
@@ -62,6 +63,8 @@ def register_ttl_binary_function(name, ttl_binary_function, torch_function):
             Tensor([ 1, 0], dtype=bfloat16 )
 
         """
+        if not (input_tensor_a.shape == input_tensor_b.shape):
+            raise RuntimeError("input_tensors must be of same size!")
 
         original_shape = input_tensor_a.shape
         input_tensor_a = _reshape_to_4D(input_tensor_a)
@@ -76,9 +79,85 @@ def register_ttl_binary_function(name, ttl_binary_function, torch_function):
             raise RuntimeError("input_tensors must be on device!")
 
         ttl_input_tensor_a = input_tensor_a.value
-        ttl_input_tensor_a = input_tensor_b.value
+        ttl_input_tensor_b = input_tensor_b.value
 
-        ttl_output_tensor = ttl_binary_function(ttl_input_tensor_a, ttl_input_tensor_a, output_mem_config=memory_config)
+        ttl_output_tensor = ttl_binary_function(ttl_input_tensor_a, ttl_input_tensor_b, output_mem_config=memory_config)
+
+        output_tensor = Tensor(ttl_output_tensor)
+        output_tensor = reshape(output_tensor, original_shape)
+        return output_tensor
+
+    setattr(THIS_MODULE, name, binary_function)
+    __all__.append(name)
+    return binary_function
+
+
+def register_ttl_binary_function_with_float_parameter(name, ttl_binary_function, torch_function):
+    def _torch_binary(input_tensor_a: Tensor, input_tensor_b: Tensor, parameter, **_):
+        import torch
+        import ttnn
+
+        input_tensor_a = ttnn.from_device(input_tensor_a)
+        input_tensor_a = ttnn.to_layout(input_tensor_a, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+        input_tensor_b = ttnn.from_device(input_tensor_b)
+        input_tensor_b = ttnn.to_layout(input_tensor_b, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_b = ttnn.to_torch(input_tensor_b)
+        assert torch_function, f"Torch function not implemented for {str(ttl_binary_function)}"
+        return torch_function(input_tensor_a, input_tensor_b, parameter)
+
+    @decorate_operation(torch_function=_torch_binary, name=name)
+    def binary_function(
+        input_tensor_a: Tensor,
+        input_tensor_b: Tensor,
+        parameter: float,
+        *,
+        memory_config: MemoryConfig = DRAM_MEMORY_CONFIG,
+    ) -> Tensor:
+        f"""{name}(input_tensor_a: Tensor, input_tensor_b: Tensor) -> Tensor
+
+        Applies {name} to :attr:`input_tensor_a`  and  :attr:`input_tensor_b` element-wise.
+
+        .. math::
+            {name}(\\mathrm{{input\\_tensor_a}}_i)
+            {name}(\\mathrm{{input\\_tensor_b}}_i)
+
+        Args:
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+
+        Example::
+
+            >>> tensor_a = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor_b = ttnn.to_device(ttnn.from_torch(torch.tensor((2, 2), dtype=torch.bfloat16)), device)
+            >>> output = ttnn.{name}(tensor_a, tensor_b, 2.0)
+            >>> print(output)
+            Tensor([ -3, -2], dtype=bfloat16 )
+
+        """
+
+        if not (input_tensor_a.shape == input_tensor_b.shape):
+            raise RuntimeError("input_tensors must be of same size!")
+
+        original_shape = input_tensor_a.shape
+        input_tensor_a = _reshape_to_4D(input_tensor_a)
+        input_tensor_b = _reshape_to_4D(input_tensor_b)
+
+        if not isinstance(input_tensor_a, Tensor) or not isinstance(input_tensor_b, Tensor):
+            raise TypeError("Expected both arguments to be a ttnn.Tensor")
+
+        if not has_storage_type_of(input_tensor_a, DEVICE_STORAGE_TYPE) or not has_storage_type_of(
+            input_tensor_b, DEVICE_STORAGE_TYPE
+        ):
+            raise RuntimeError("input_tensors must be on device!")
+
+        ttl_input_tensor_a = input_tensor_a.value
+        ttl_input_tensor_b = input_tensor_b.value
+
+        ttl_output_tensor = ttl_binary_function(
+            ttl_input_tensor_a, ttl_input_tensor_b, parameter, output_mem_config=memory_config
+        )
 
         output_tensor = Tensor(ttl_output_tensor)
         output_tensor = reshape(output_tensor, original_shape)
@@ -104,3 +183,11 @@ TTL_BINARY_FUNCTIONS = [
 
 for binary_function_name, ttl_binary_function, torch_function in TTL_BINARY_FUNCTIONS:
     register_ttl_binary_function(binary_function_name, ttl_binary_function, torch_function)
+
+
+TTL_BINARY_FUNCTIONS_WITH_FLOAT_PARAMETER = [
+    ("subalpha", ttl.tensor.subalpha, torch.sub),
+]
+
+for binary_function_name, ttl_binary_function, torch_function in TTL_BINARY_FUNCTIONS_WITH_FLOAT_PARAMETER:
+    register_ttl_binary_function_with_float_parameter(binary_function_name, ttl_binary_function, torch_function)

--- a/ttnn/binary.py
+++ b/ttnn/binary.py
@@ -179,6 +179,9 @@ def torch_squared_difference(x, y, *args, **kwargs):
 TTL_BINARY_FUNCTIONS = [
     ("atan2", ttl.tensor.atan2, torch.atan2),
     ("hypot", ttl.tensor.hypot, torch.hypot),
+    ("ldexp", ttl.tensor.ldexp, torch.ldexp),
+    ("logaddexp", ttl.tensor.logaddexp, torch.logaddexp),
+    ("logaddexp2", ttl.tensor.logaddexp2, torch.logaddexp2),
     ("logical_and", ttl.tensor.logical_and, torch.logical_and),
     ("logical_or", ttl.tensor.logical_or, torch.logical_or),
     ("logical_xor", ttl.tensor.logical_xor, torch.logical_xor),

--- a/ttnn/binary.py
+++ b/ttnn/binary.py
@@ -189,6 +189,7 @@ for binary_function_name, ttl_binary_function, torch_function in TTL_BINARY_FUNC
 
 TTL_BINARY_FUNCTIONS_WITH_FLOAT_PARAMETER = [
     ("subalpha", ttl.tensor.subalpha, torch.sub),
+    ("addalpha", ttl.tensor.addalpha, torch.add),
 ]
 
 for binary_function_name, ttl_binary_function, torch_function in TTL_BINARY_FUNCTIONS_WITH_FLOAT_PARAMETER:

--- a/ttnn/binary.py
+++ b/ttnn/binary.py
@@ -179,6 +179,7 @@ def torch_squared_difference(x, y, *args, **kwargs):
 TTL_BINARY_FUNCTIONS = [
     ("squared_difference", ttl.tensor.squared_difference, torch_squared_difference),
     ("hypot", ttl.tensor.hypot, torch.hypot),
+    ("atan2", ttl.tensor.atan2, torch.atan2),
 ]
 
 

--- a/ttnn/binary.py
+++ b/ttnn/binary.py
@@ -185,6 +185,8 @@ TTL_BINARY_FUNCTIONS = [
     ("logical_and", ttl.tensor.logical_and, torch.logical_and),
     ("logical_or", ttl.tensor.logical_or, torch.logical_or),
     ("logical_xor", ttl.tensor.logical_xor, torch.logical_xor),
+    ("nextafter", ttl.tensor.nextafter, torch.nextafter),
+    ("outer", ttl.tensor.outer, torch.outer),
     ("squared_difference", ttl.tensor.squared_difference, torch_squared_difference),
 ]
 

--- a/ttnn/binary.py
+++ b/ttnn/binary.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import sys
+import tt_lib as ttl
+from ttnn.core import reshape, _reshape_to_4D
+from ttnn.decorators import decorate_operation
+from typing import Union
+from ttnn.tensor import (
+    Tensor,
+    has_storage_type_of,
+    MemoryConfig,
+    DRAM_MEMORY_CONFIG,
+    DEVICE_STORAGE_TYPE,
+)
+from ttnn.core import reshape, _reshape_to_4D
+from ttnn.decorators import decorate_operation
+import torch
+import torch.nn.functional as F
+
+THIS_MODULE = sys.modules[__name__]
+
+__all__ = []
+
+
+def register_ttl_binary_function(name, ttl_binary_function, torch_function):
+    def _torch_binary(input_tensor_a: Tensor, input_tensor_b: Tensor, **_):
+        import torch
+        import ttnn
+
+        input_tensor_a = ttnn.from_device(input_tensor_a)
+        input_tensor_a = ttnn.to_layout(input_tensor_a, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+        input_tensor_b = ttnn.from_device(input_tensor_b)
+        input_tensor_b = ttnn.to_layout(input_tensor_b, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_b = ttnn.to_torch(input_tensor_b)
+        assert torch_function, f"Torch function not implemented for {str(ttl_binary_function)}"
+        return torch_function(input_tensor_a, input_tensor_b)
+
+    @decorate_operation(torch_function=_torch_binary, name=name)
+    def binary_function(
+        input_tensor_a: Tensor, input_tensor_b: Tensor, *, memory_config: MemoryConfig = DRAM_MEMORY_CONFIG
+    ) -> Tensor:
+        f"""{name}(input_tensor_a: Tensor, input_tensor_b: Tensor) -> Tensor
+
+        Applies {name} to :attr:`input_tensor_a` and  :attr:`input_tensor_b` element-wise.
+
+        .. math::
+            {name}(\\mathrm{{input\\_tensor}}_i)
+
+        Args:
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+
+        Example::
+
+            >>> tensor_a = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor_b = ttnn.to_device(ttnn.from_torch(torch.tensor((2, 2), dtype=torch.bfloat16)), device)
+            >>> output = ttnn.{name}(tensor_a, tensor_b)
+            >>> print(output)
+            Tensor([ 1, 0], dtype=bfloat16 )
+
+        """
+
+        original_shape = input_tensor_a.shape
+        input_tensor_a = _reshape_to_4D(input_tensor_a)
+        input_tensor_b = _reshape_to_4D(input_tensor_b)
+
+        if not isinstance(input_tensor_a, Tensor) or not isinstance(input_tensor_b, Tensor):
+            raise TypeError("Expected both arguments to be a ttnn.Tensor")
+
+        if not has_storage_type_of(input_tensor_a, DEVICE_STORAGE_TYPE) or not has_storage_type_of(
+            input_tensor_b, DEVICE_STORAGE_TYPE
+        ):
+            raise RuntimeError("input_tensors must be on device!")
+
+        ttl_input_tensor_a = input_tensor_a.value
+        ttl_input_tensor_a = input_tensor_b.value
+
+        ttl_output_tensor = ttl_binary_function(ttl_input_tensor_a, ttl_input_tensor_a, output_mem_config=memory_config)
+
+        output_tensor = Tensor(ttl_output_tensor)
+        output_tensor = reshape(output_tensor, original_shape)
+        return output_tensor
+
+    setattr(THIS_MODULE, name, binary_function)
+    __all__.append(name)
+    return binary_function
+
+
+# register functions
+
+
+def torch_squared_difference(x, y, *args, **kwargs):
+    t_diff = torch.sub(x, y)
+    return torch.square(t_diff)
+
+
+TTL_BINARY_FUNCTIONS = [
+    ("squared_difference", ttl.tensor.squared_difference, torch_squared_difference),
+]
+
+
+for binary_function_name, ttl_binary_function, torch_function in TTL_BINARY_FUNCTIONS:
+    register_ttl_binary_function(binary_function_name, ttl_binary_function, torch_function)

--- a/ttnn/binary.py
+++ b/ttnn/binary.py
@@ -178,6 +178,7 @@ def torch_squared_difference(x, y, *args, **kwargs):
 
 TTL_BINARY_FUNCTIONS = [
     ("squared_difference", ttl.tensor.squared_difference, torch_squared_difference),
+    ("hypot", ttl.tensor.hypot, torch.hypot),
 ]
 
 

--- a/ttnn/binary.py
+++ b/ttnn/binary.py
@@ -177,9 +177,12 @@ def torch_squared_difference(x, y, *args, **kwargs):
 
 
 TTL_BINARY_FUNCTIONS = [
-    ("squared_difference", ttl.tensor.squared_difference, torch_squared_difference),
-    ("hypot", ttl.tensor.hypot, torch.hypot),
     ("atan2", ttl.tensor.atan2, torch.atan2),
+    ("hypot", ttl.tensor.hypot, torch.hypot),
+    ("logical_and", ttl.tensor.logical_and, torch.logical_and),
+    ("logical_or", ttl.tensor.logical_or, torch.logical_or),
+    ("logical_xor", ttl.tensor.logical_xor, torch.logical_xor),
+    ("squared_difference", ttl.tensor.squared_difference, torch_squared_difference),
 ]
 
 
@@ -188,8 +191,8 @@ for binary_function_name, ttl_binary_function, torch_function in TTL_BINARY_FUNC
 
 
 TTL_BINARY_FUNCTIONS_WITH_FLOAT_PARAMETER = [
-    ("subalpha", ttl.tensor.subalpha, torch.sub),
     ("addalpha", ttl.tensor.addalpha, torch.add),
+    ("subalpha", ttl.tensor.subalpha, torch.sub),
 ]
 
 for binary_function_name, ttl_binary_function, torch_function in TTL_BINARY_FUNCTIONS_WITH_FLOAT_PARAMETER:

--- a/ttnn/binary.py
+++ b/ttnn/binary.py
@@ -188,6 +188,7 @@ TTL_BINARY_FUNCTIONS = [
     ("nextafter", ttl.tensor.nextafter, torch.nextafter),
     ("outer", ttl.tensor.outer, torch.outer),
     ("squared_difference", ttl.tensor.squared_difference, torch_squared_difference),
+    ("xlogy", ttl.tensor.xlogy, torch.xlogy),
 ]
 
 

--- a/ttnn/test/test_binary_tnn.py
+++ b/ttnn/test/test_binary_tnn.py
@@ -8,22 +8,22 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "input_shapes",
+    "input_shape_a, input_shape_b",
     (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 32, 32]), torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384]), torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384]), torch.Size([1, 3, 320, 384])),
     ),
 )
 class TestEltwiseBinary:
-    def test_ttnn_squared_difference(self, input_shapes):
+    def test_ttnn_squared_difference(self, input_shape_a, input_shape_b):
         device_id = 0
         device = ttnn.open(device_id)
 
         torch.manual_seed(0)
 
-        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
-        torch_b = torch.rand(input_shapes, dtype=torch.bfloat16)
+        torch_a = torch.rand(input_shape_a, dtype=torch.bfloat16)
+        torch_b = torch.rand(input_shape_b, dtype=torch.bfloat16)
 
         a = ttnn.from_torch(torch_a)
         b = ttnn.from_torch(torch_b)
@@ -37,6 +37,30 @@ class TestEltwiseBinary:
         print(f"shape: {output.shape}")
         print(f"dtype: {output.dtype}")
         print(f"layout: {output.layout}")
-        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    @pytest.mark.parametrize("alpha", [1.0, 2.5, -2.5])
+    def test_ttnn_subalpha(self, input_shape_a, input_shape_b, alpha):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shape_a, dtype=torch.bfloat16)
+        torch_b = torch.rand(input_shape_b, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+        b = ttnn.from_torch(torch_b)
+
+        a = ttnn.to_device(a, device)
+        b = ttnn.to_device(b, device)
+
+        output = ttnn.subalpha(a, b, alpha)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"shape: {output.shape}")
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
 
         ttnn.close(device)

--- a/ttnn/test/test_binary_tnn.py
+++ b/ttnn/test/test_binary_tnn.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+class TestEltwiseBinary:
+    def test_ttnn_squared_difference(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+        torch_b = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+        b = ttnn.from_torch(torch_b)
+
+        a = ttnn.to_device(a, device)
+        b = ttnn.to_device(b, device)
+
+        output = ttnn.squared_difference(a, b)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"shape: {output.shape}")
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)

--- a/ttnn/unary.py
+++ b/ttnn/unary.py
@@ -191,6 +191,7 @@ TTL_UNARY_FUNCTIONS = [
     ("lerp", ttl.tensor.lerp, torch.lerp),
     ("lgamma", ttl.tensor.lgamma, torch.lgamma),
     ("log", ttl.tensor.log, torch.log),
+    ("logical_not_unary", ttl.tensor.logical_not_unary, torch.logical_not),
     ("log10", ttl.tensor.log10, torch.log10),
     ("log1p", ttl.tensor.log1p, torch.log1p),
     ("log2", ttl.tensor.log2, torch.log2),

--- a/ttnn/unary.py
+++ b/ttnn/unary.py
@@ -231,6 +231,31 @@ TTL_UNARY_FUNCTIONS = [
 for unary_function_name, ttl_unary_function, torch_function in TTL_UNARY_FUNCTIONS:
     register_ttl_unary_function(unary_function_name, ttl_unary_function, torch_function)
 
+
+def torch_logical_andi(x, *args, **kwargs):
+    value = kwargs.pop("immediate")
+    result = torch.logical_and(x, torch.tensor(value, dtype=torch.int32))
+    return result
+
+
+def torch_logical_ori(x, *args, **kwargs):
+    value = kwargs.pop("immediate")
+    result = torch.logical_or(x, torch.tensor(value, dtype=torch.int32))
+    return result
+
+
+def torch_logical_xori(x, *args, **kwargs):
+    value = kwargs.pop("immediate")
+    result = torch.logical_xor(x, torch.tensor(value, dtype=torch.int32))
+    return result
+
+
+def torch_logical_noti(x, *args, **kwargs):
+    immediate = kwargs.pop("immediate")
+    result = torch.logical_not(torch.full_like(x, immediate)).to(torch.int32)
+    return result
+
+
 TTL_UNARY_FUNCTIONS_WITH_FLOAT_PARAMETER = [
     ("pow", ttl_pow, torch.pow),
     ("elu", ttl.tensor.elu, F.elu),
@@ -242,6 +267,10 @@ TTL_UNARY_FUNCTIONS_WITH_FLOAT_PARAMETER = [
     ("prelu", ttl.tensor.prelu, torch.prelu),
     ("polygamma", ttl.tensor.polygamma, torch.polygamma),
     ("logit", ttl.tensor.logit, torch.logit),
+    ("logical_ori", ttl.tensor.logical_ori, torch_logical_ori),
+    ("logical_andi", ttl.tensor.logical_andi, torch_logical_andi),
+    ("logical_xori", ttl.tensor.logical_xori, torch_logical_xori),
+    ("logical_noti", ttl.tensor.logical_noti, torch_logical_noti),
 ]
 
 for unary_function_name, ttl_unary_function, torch_function in TTL_UNARY_FUNCTIONS_WITH_FLOAT_PARAMETER:

--- a/ttnn/unary.py
+++ b/ttnn/unary.py
@@ -257,6 +257,21 @@ def torch_logical_noti(x, *args, **kwargs):
     return result
 
 
+def torch_rpow(x, *args, **kwargs):
+    dim = kwargs["factor"]
+    return torch.pow(dim, x)
+
+
+def torch_rsub(x, *args, **kwargs):
+    dim = kwargs["factor"]
+    return torch.sub(dim, x)
+
+
+def torch_rdiv(x, *args, **kwargs):
+    dim = kwargs["factor"]
+    return dim / x
+
+
 TTL_UNARY_FUNCTIONS_WITH_FLOAT_PARAMETER = [
     ("pow", ttl_pow, torch.pow),
     ("elu", ttl.tensor.elu, F.elu),
@@ -272,6 +287,9 @@ TTL_UNARY_FUNCTIONS_WITH_FLOAT_PARAMETER = [
     ("logical_andi", ttl.tensor.logical_andi, torch_logical_andi),
     ("logical_xori", ttl.tensor.logical_xori, torch_logical_xori),
     ("logical_noti", ttl.tensor.logical_noti, torch_logical_noti),
+    ("rdiv", ttl.tensor.rdiv, torch_rdiv),
+    ("rsub", ttl.tensor.rsub, torch_rsub),
+    ("rpow", ttl.tensor.rpow, torch_rpow),
 ]
 
 for unary_function_name, ttl_unary_function, torch_function in TTL_UNARY_FUNCTIONS_WITH_FLOAT_PARAMETER:


### PR DESCRIPTION
Added TTNN support for following ops
- Squared difference
- Subalpha
- Addalpha
- Atan2
- Hypot
- logical or, ori
- logical not unary, noti
- logical and, andi
- logical xor, xori
- ldexp
- logaddexp, logaddexp2
- rdiv
- rpow
- rsub
- nextafter
- outer
- xlogy
