### PR TITLE
#4605: Export relational operator to ttnn

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -243,6 +243,7 @@ enqueue
 enqueued
 enum
 env
+eq
 eqz
 erf
 erfc
@@ -263,6 +264,8 @@ genindex
 gez
 grayskull
 grey
+gt
+gte
 gtz
 hardshrink
 hardsigmoid
@@ -317,6 +320,8 @@ logical_xor
 logical_xori
 logit
 loopback
+lt
+lte
 ltz
 lut
 lv
@@ -333,6 +338,7 @@ namespace
 nans
 ncrisc
 nd
+ne
 neg
 nextafter
 nez

--- a/docs/source/ttnn/operations.rst
+++ b/docs/source/ttnn/operations.rst
@@ -21,3 +21,4 @@ Operations
    operations/to_torch
    operations/unary
    operations/binary
+   operations/relational

--- a/docs/source/ttnn/operations/relational.rst
+++ b/docs/source/ttnn/operations/relational.rst
@@ -1,0 +1,24 @@
+Relational Operations
+=====================
+
+.. autofunction:: ttnn.gez
+
+.. autofunction:: ttnn.gtz
+
+.. autofunction:: ttnn.eqz
+
+.. autofunction:: ttnn.ltz
+
+.. autofunction:: ttnn.nez
+
+.. autofunction:: ttnn.gt
+
+.. autofunction:: ttnn.gte
+
+.. autofunction:: ttnn.eq
+
+.. autofunction:: ttnn.lt
+
+.. autofunction:: ttnn.lte
+
+.. autofunction:: ttnn.ne

--- a/tests/ttnn/test/test_relational_tnn.py
+++ b/tests/ttnn/test/test_relational_tnn.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+class TestEltwiseRelational:
+    def test_ttnn_gt(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+        torch_b = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+        b = ttnn.from_torch(torch_b)
+
+        a = ttnn.to_device(a, device)
+        b = ttnn.to_device(b, device)
+
+        output = ttnn.gt(a, b)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_gte(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+        torch_b = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+        b = ttnn.from_torch(torch_b)
+
+        a = ttnn.to_device(a, device)
+        b = ttnn.to_device(b, device)
+
+        output = ttnn.gte(a, b)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_eq(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+        torch_b = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+        b = ttnn.from_torch(torch_b)
+
+        a = ttnn.to_device(a, device)
+        b = ttnn.to_device(b, device)
+
+        output = ttnn.eq(a, b)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_lt(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+        torch_b = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+        b = ttnn.from_torch(torch_b)
+
+        a = ttnn.to_device(a, device)
+        b = ttnn.to_device(b, device)
+
+        output = ttnn.lt(a, b)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_lte(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+        torch_b = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+        b = ttnn.from_torch(torch_b)
+
+        a = ttnn.to_device(a, device)
+        b = ttnn.to_device(b, device)
+
+        output = ttnn.lte(a, b)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_ne(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+        torch_b = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+        b = ttnn.from_torch(torch_b)
+
+        a = ttnn.to_device(a, device)
+        b = ttnn.to_device(b, device)
+
+        output = ttnn.ne(a, b)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_gtz(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+
+        a = ttnn.to_device(a, device)
+
+        output = ttnn.gtz(a)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_gez(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+
+        a = ttnn.to_device(a, device)
+
+        output = ttnn.gez(a)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_eqz(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+
+        a = ttnn.to_device(a, device)
+
+        output = ttnn.eqz(a)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_ltz(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+
+        a = ttnn.to_device(a, device)
+
+        output = ttnn.ltz(a)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)
+
+    def test_ttnn_nez(self, input_shapes):
+        device_id = 0
+        device = ttnn.open(device_id)
+
+        torch.manual_seed(0)
+
+        torch_a = torch.rand(input_shapes, dtype=torch.bfloat16)
+
+        a = ttnn.from_torch(torch_a)
+
+        a = ttnn.to_device(a, device)
+
+        output = ttnn.nez(a)
+        output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+
+        print(f"dtype: {output.dtype}")
+        print(f"layout: {output.layout}")
+        # print(f"first row: {output[:1]}")
+
+        ttnn.close(device)

--- a/ttnn/__init__.py
+++ b/ttnn/__init__.py
@@ -60,6 +60,7 @@ from ttnn.core import (
 
 from ttnn.unary import *
 from ttnn.binary import *
+from ttnn.relational import *
 
 import ttnn.decorators
 import ttnn.transformer

--- a/ttnn/relational.py
+++ b/ttnn/relational.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import sys
+import tt_lib as ttl
+from ttnn.core import reshape, _reshape_to_4D
+from ttnn.decorators import decorate_operation
+from typing import Union
+from ttnn.tensor import (
+    Tensor,
+    has_storage_type_of,
+    MemoryConfig,
+    DRAM_MEMORY_CONFIG,
+    DEVICE_STORAGE_TYPE,
+)
+from ttnn.core import reshape, _reshape_to_4D
+from ttnn.decorators import decorate_operation
+import torch
+import torch.nn.functional as F
+
+THIS_MODULE = sys.modules[__name__]
+
+__all__ = []
+
+
+def register_ttl_relational_function(name, ttl_relational_function, torch_function):
+    def _torch_relational(input_tensor_a: Tensor, input_tensor_b: Tensor, **_):
+        import torch
+        import ttnn
+
+        input_tensor_a = ttnn.from_device(input_tensor_a)
+        input_tensor_a = ttnn.to_layout(input_tensor_a, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+        input_tensor_b = ttnn.from_device(input_tensor_b)
+        input_tensor_b = ttnn.to_layout(input_tensor_b, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_b = ttnn.to_torch(input_tensor_b)
+        assert torch_function, f"Torch function not implemented for {str(ttl_relational_function)}"
+        return torch_function(input_tensor_a, input_tensor_b)
+
+    @decorate_operation(torch_function=_torch_relational, name=name)
+    def relational_function(
+        input_tensor_a: Tensor, input_tensor_b: Tensor, *, memory_config: MemoryConfig = DRAM_MEMORY_CONFIG
+    ) -> Tensor:
+        f"""{name}(input_tensor_a: Tensor, input_tensor_b: Tensor) -> Tensor
+
+        Applies {name} to :attr:`input_tensor_a` and  :attr:`input_tensor_b` element-wise.
+
+        .. math::
+            {name}(\\mathrm{{input\\_tensor}}_i)
+
+        Args:
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+
+        Example::
+
+            >>> tensor_a = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor_b = ttnn.to_device(ttnn.from_torch(torch.tensor((2, 2), dtype=torch.bfloat16)), device)
+            >>> output = ttnn.{name}(tensor_a, tensor_b)
+            >>> print(output)
+            Tensor([ 1, 0], dtype=bfloat16 )
+
+        """
+
+        original_shape = input_tensor_a.shape
+        input_tensor_a = _reshape_to_4D(input_tensor_a)
+        input_tensor_b = _reshape_to_4D(input_tensor_b)
+
+        if not isinstance(input_tensor_a, Tensor) or not isinstance(input_tensor_b, Tensor):
+            raise TypeError("Expected both arguments to be a ttnn.Tensor")
+
+        if not has_storage_type_of(input_tensor_a, DEVICE_STORAGE_TYPE) or not has_storage_type_of(
+            input_tensor_b, DEVICE_STORAGE_TYPE
+        ):
+            raise RuntimeError("input_tensors must be on device!")
+
+        ttl_input_tensor_a = input_tensor_a.value
+        ttl_input_tensor_b = input_tensor_b.value
+
+        ttl_output_tensor = ttl_relational_function(
+            ttl_input_tensor_a, ttl_input_tensor_b, output_mem_config=memory_config
+        )
+
+        output_tensor = Tensor(ttl_output_tensor)
+        output_tensor = reshape(output_tensor, original_shape)
+        return output_tensor
+
+    setattr(THIS_MODULE, name, relational_function)
+    __all__.append(name)
+    return relational_function
+
+
+# register functions
+def torch_gte(x, y, *args, **kwargs):
+    return x >= y
+
+
+def torch_lte(x, y, *args, **kwargs):
+    return x <= y
+
+
+TTL_RELATIONAL_FUNCTIONS = [
+    ("gt", ttl.tensor.gt, torch.gt),
+    ("gte", ttl.tensor.gte, torch_gte),
+    ("eq", ttl.tensor.eq, torch.eq),
+    ("lt", ttl.tensor.lt, torch.lt),
+    ("lte", ttl.tensor.lte, torch_lte),
+    ("ne", ttl.tensor.ne, torch.ne),
+]
+
+
+for relational_function_name, ttl_relational_function, torch_function in TTL_RELATIONAL_FUNCTIONS:
+    register_ttl_relational_function(relational_function_name, ttl_relational_function, torch_function)
+
+
+def register_ttl_relational_function_with_zero(name, ttl_relational_function, torch_function):
+    def _torch_relational(input_tensor_a: Tensor, **_):
+        import torch
+        import ttnn
+
+        input_tensor_a = ttnn.from_device(input_tensor_a)
+        input_tensor_a = ttnn.to_layout(input_tensor_a, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_a = ttnn.to_torch(input_tensor_a)
+
+        assert torch_function, f"Torch function not implemented for {str(ttl_relational_function)}"
+        return torch_function(input_tensor_a)
+
+    @decorate_operation(torch_function=_torch_relational, name=name)
+    def relational_function(input_tensor_a: Tensor, *, memory_config: MemoryConfig = DRAM_MEMORY_CONFIG) -> Tensor:
+        f"""{name}(input_tensor_a: Tensor) -> Tensor
+
+        Applies {name} to :attr:`input_tensor_a`  element-wise.
+
+        .. math::
+            {name}(\\mathrm{{input\\_tensor}}_i)
+
+        Args:
+            * :attr:`input_tensor_a`
+
+        Example::
+
+            >>> tensor_a = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> output = ttnn.{name}(tensor_a, tensor_b)
+            >>> print(output)
+            Tensor([ 1, 0], dtype=bfloat16 )
+
+        """
+
+        original_shape = input_tensor_a.shape
+        input_tensor_a = _reshape_to_4D(input_tensor_a)
+
+        if not isinstance(input_tensor_a, Tensor):
+            raise TypeError("Expected both arguments to be a ttnn.Tensor")
+
+        if not has_storage_type_of(input_tensor_a, DEVICE_STORAGE_TYPE):
+            raise RuntimeError("input_tensors must be on device!")
+
+        ttl_input_tensor_a = input_tensor_a.value
+
+        ttl_output_tensor = ttl_relational_function(ttl_input_tensor_a, output_mem_config=memory_config)
+
+        output_tensor = Tensor(ttl_output_tensor)
+        output_tensor = reshape(output_tensor, original_shape)
+        return output_tensor
+
+    setattr(THIS_MODULE, name, relational_function)
+    __all__.append(name)
+    return relational_function
+
+
+# register functions
+def torch_gtz(x, *args, **kwargs):
+    return (x > 0.0).to(x.dtype)
+
+
+def torch_gez(x, *args, **kwargs):
+    return (x >= 0.0).to(x.dtype)
+
+
+def torch_eqz(x, *args, **kwargs):
+    return (x == 0.0).to(x.dtype)
+
+
+def torch_ltz(x, *args, **kwargs):
+    return (x < 0.0).to(x.dtype)
+
+
+def torch_nez(x, *args, **kwargs):
+    return (x != 0.0).to(x.dtype)
+
+
+TTL_RELATIONAL_FUNCTIONS_WITH_ZERO = [
+    ("gtz", ttl.tensor.gtz, torch_gtz),
+    ("gez", ttl.tensor.gez, torch_gez),
+    ("eqz", ttl.tensor.eqz, torch_eqz),
+    ("ltz", ttl.tensor.ltz, torch_ltz),
+    ("nez", ttl.tensor.nez, torch_nez),
+]
+
+
+for relational_function_name, ttl_relational_function, torch_function in TTL_RELATIONAL_FUNCTIONS_WITH_ZERO:
+    register_ttl_relational_function_with_zero(relational_function_name, ttl_relational_function, torch_function)


### PR DESCRIPTION
Added TTNN support for following ops

- Gez
- Gtz
- Eqz
- Ltz
- Nez
- Gt
- Gte
- Eq
- Lt
- Lte
- Ne