### PR TITLE
Adding interface to assign dispatch kernels to dispatch functionality and adding kernel to service remote command queue

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -16,8 +16,10 @@ void measure_latency(string kernel_name) {
     const int device_id = 0;
     tt_metal::Device *device = tt_metal::CreateDevice(device_id);
 
-    CoreCoord producer_logical_core = *device->producer_cores().begin();
-    CoreCoord consumer_logical_core = *device->consumer_cores().begin();
+    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+    uint8_t num_hw_cqs = device->num_hw_cqs();
+    CoreCoord producer_logical_core = tt_metal::dispatch_core_manager::get(num_hw_cqs).issue_queue_reader_core(device->id(), channel, 0);
+    CoreCoord consumer_logical_core = tt_metal::dispatch_core_manager::get(num_hw_cqs).completion_queue_writer_core(device->id(), channel, 0);
 
     auto first_worker_physical_core = device->worker_core_from_logical_core({0, 0});
 

--- a/tt_metal/common/metal_soc_descriptor.h
+++ b/tt_metal/common/metal_soc_descriptor.h
@@ -50,6 +50,10 @@ struct metal_SocDescriptor : public tt_SocDescriptor {
     const std::vector<CoreCoord>& get_logical_ethernet_cores() const;
     const std::vector<CoreCoord>& get_physical_ethernet_cores() const;
 
+    CoreCoord get_physical_ethernet_core_from_logical(const CoreCoord &logical_coord) const;
+    CoreCoord get_physical_tensix_core_from_logical(const CoreCoord &logical_coord) const;
+    CoreCoord get_physical_core_from_logical_core(const CoreCoord &logical_coord, const CoreType &core_type) const;
+
     tt_cxy_pair convert_to_umd_coordinates(const tt_cxy_pair& physical_cxy) const;
 
    private:

--- a/tt_metal/core_descriptors/grayskull_120_arch.yaml
+++ b/tt_metal/core_descriptors/grayskull_120_arch.yaml
@@ -17,11 +17,8 @@ E150:
     storage_cores: # Relative to grid of tensix cores
       [[1, -1],[2, -1],[3, -1],[4, -1],[5, -1],[7, -1],[8, -1],[9, -1],[10, -1],[11, -1]]
 
-    producer_cores:
-      [[0, -1]]
-
-    consumer_cores:
-      [[6, -1]]
+    dispatch_cores:
+      [[0, -1], [6, -1]]
   2:
     l1_bank_size:
       524288
@@ -33,11 +30,8 @@ E150:
     storage_cores: # Relative to grid of tensix cores
       [[2, -1],[3, -1],[4, -1],[5, -1],[8, -1],[9, -1],[10, -1],[11, -1]]
 
-    producer_cores:
-      [[0, -1], [1, -1]]
-
-    consumer_cores:
-      [[6, -1], [7, -1]]
+    dispatch_cores:
+      [[0, -1], [1, -1], [6, -1], [7, -1]]
 
 E75:
   1:
@@ -51,11 +45,8 @@ E75:
     storage_cores: # Relative to grid of tensix cores
       [[11, 1], [11, 2], [11, 3], [11, 5], [11, 6], [11, 7]]
 
-    producer_cores:
-      [[11, 0]]
-
-    consumer_cores:
-      [[11, 4]]
+    dispatch_cores:
+      [[11, 0], [11, 4]]
   2:
     l1_bank_size:
       1048576
@@ -67,8 +58,5 @@ E75:
     storage_cores: # Relative to grid of tensix cores
       [[11, 2], [11, 3], [11, 6], [11, 7]]
 
-    producer_cores:
-      [[11, 0], [11, 1]]
-
-    consumer_cores:
-      [[11, 4], [11, 5]]
+    dispatch_cores:
+      [[11, 0], [11, 1], [11, 4], [11, 5]]

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
@@ -17,11 +17,8 @@ galaxy:
     storage_cores:
       []
 
-    producer_cores:
-      [[0, -1]]
-
-    consumer_cores:
-      [[1, -1]]
+    dispatch_cores:
+      [[0, -1], [1, -1]]
 
 nebula_x1:
   1:
@@ -35,11 +32,8 @@ nebula_x1:
     storage_cores:
       []
 
-    producer_cores:
-      [[0, -1]]
-
-    consumer_cores:
-      [[4, -1]]
+    dispatch_cores:
+      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
   2:
     l1_bank_size:
@@ -52,11 +46,8 @@ nebula_x1:
     storage_cores:
       []
 
-    producer_cores:
-      [[0, -1], [1, -1]]
-
-    consumer_cores:
-      [[4, -1], [5, -1]]
+    dispatch_cores:
+      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
 
 nebula_x2:
   1:
@@ -70,11 +61,9 @@ nebula_x2:
     storage_cores: # Relative to grid of tensix cores
       [[2, -1], [3, -1], [6, -1], [7, -1]]
 
-    producer_cores:
-      [[0, -1]]
+    dispatch_cores:
+      [[0, -1], [1, -1], [4, -1], [5, -1]]
 
-    consumer_cores:
-      [[1, -1]]
   2:
     l1_bank_size:
       749568
@@ -86,8 +75,5 @@ nebula_x2:
     storage_cores: # Relative to grid of tensix cores
       [[2, -1], [3, -1], [6, -1], [7, -1]]
 
-    producer_cores:
-      [[0, -1], [1, -1]]
-
-    consumer_cores:
-      [[4, -1], [5, -1]]
+    dispatch_cores:
+      [[0, -1], [1, -1], [4, -1], [5, -1]]

--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -25,8 +25,6 @@
 uint8_t noc_index = NOC_INDEX;
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
-CQReadInterface cq_read_interface;
-CQWriteInterface cq_write_interface;
 
 void __attribute__((section("erisc_l1_code"))) kernel_launch() {
     rtos_context_switch_ptr = (void (*)())RtosTable[0];

--- a/tt_metal/hw/inc/circular_buffer.h
+++ b/tt_metal/hw/inc/circular_buffer.h
@@ -25,9 +25,6 @@ struct CQWriteInterface {
     uint32_t completion_fifo_wr_toggle;
 };
 
-extern CQReadInterface cq_read_interface;   // set up in command_queue_producer
-extern CQWriteInterface cq_write_interface; // set up in command_queue_consumer
-
 struct CBInterface {
     uint32_t fifo_size;
     uint32_t fifo_limit; // range is inclusive of the limit

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -145,9 +145,6 @@ class Device {
     // Set of logical storage only core coordinates
     const std::set<CoreCoord> &storage_only_cores() const { return this->storage_only_cores_; }
 
-    const std::set<CoreCoord> &producer_cores() const { return this->producer_cores_; }
-    const std::set<CoreCoord> &consumer_cores() const { return this->consumer_cores_; }
-
     std::unique_ptr<SystemMemoryManager> manager;
     vector<std::unique_ptr<Program, tt::tt_metal::detail::ProgramDeleter>> command_queue_programs;
 
@@ -182,6 +179,7 @@ class Device {
     void build_firmware();
     void initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg);
     void initialize_and_launch_firmware();
+    void initialize_command_queue();
     void clear_l1_state();
 
     std::pair<int, int> build_processor_type_to_index(JitBuildProcessorType t) const;
@@ -205,13 +203,8 @@ class Device {
     JitBuildStateSet firmware_build_states_;
     JitBuildStateSet kernel_build_states_;
 
-    // Allows access to sysmem_writer
-    friend class CommandQueue;
-
     std::set<CoreCoord> compute_cores_;
     std::set<CoreCoord> storage_only_cores_;
-    std::set<CoreCoord> producer_cores_;
-    std::set<CoreCoord> consumer_cores_;
     std::set<CoreCoord> ethernet_cores_;
 
     const uint8_t num_hw_cqs_;

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -4,16 +4,60 @@
 
 #pragma once
 #include "tt_metal/common/base.hpp"
+#include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 #include "tt_metal/llrt/llrt.hpp"
 #include "tt_metal/common/math.hpp"
 using namespace tt::tt_metal;
 
+// Starting L1 address of commands
+inline uint32_t get_command_start_l1_address(bool use_eth_l1) {
+    return (use_eth_l1 ? eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE : L1_UNRESERVED_BASE);
+}
+
+// Where issue queue interface core pulls in data (follows command)
+inline uint32_t get_data_section_l1_address(bool use_eth_l1) {
+    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE : L1_UNRESERVED_BASE;
+    return l1_base + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
+}
+
+// Space available in issue queue interface core pushing command data to consumer to dispatch or relay forward
+inline uint32_t get_producer_data_buffer_size(bool use_eth_l1) {
+    uint32_t l1_size = use_eth_l1 ? MEM_ETH_SIZE : MEM_L1_SIZE;
+    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE : L1_UNRESERVED_BASE;
+    return (l1_size - (DeviceCommand::NUM_ENTRIES_IN_DEVICE_COMMAND * sizeof(uint32_t)) - l1_base);
+}
+
+// Space available in core receiving command data to dispatch or relay forward
+inline uint32_t get_consumer_data_buffer_size(bool use_eth_l1) {
+    uint32_t num_consumer_cmd_slots = use_eth_l1 ? 1 : 2;
+    uint32_t producer_data_buffer_size = get_producer_data_buffer_size(use_eth_l1);
+    return (producer_data_buffer_size - ((num_consumer_cmd_slots - 1) * DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND)) / num_consumer_cmd_slots;
+}
+
+/// @brief Get offset of the command queue relative to its channel
+/// @param cq_id uint8_t ID the command queue
+/// @param cq_size uint32_t size of the command queue
+/// @return uint32_t relative offset
+inline uint32_t get_relative_cq_offset(uint8_t cq_id, uint32_t cq_size) {
+    return cq_id * cq_size;
+}
+
+/// @brief Get absolute offset of the command queue
+/// @param channel uint16_t channel ID (hugepage)
+/// @param cq_id uint8_t ID the command queue
+/// @param cq_size uint32_t size of the command queue
+/// @return uint32_t absolute offset
+inline uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_size) {
+    return (DeviceCommand::MAX_HUGEPAGE_SIZE * channel) + get_relative_cq_offset(cq_id, cq_size);
+}
+
 template <bool addr_16B>
-inline uint32_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint32_t cq_channel, uint32_t cq_channel_size) {
+inline uint32_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t recv;
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
-    tt::Cluster::instance().read_sysmem(&recv, sizeof(uint32_t), HOST_CQ_ISSUE_READ_PTR + cq_channel * cq_channel_size, mmio_device_id, channel);
+    tt::Cluster::instance().read_sysmem(&recv, sizeof(uint32_t), HOST_CQ_ISSUE_READ_PTR + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
     if (not addr_16B) {
         return recv << 4;
     }
@@ -21,11 +65,11 @@ inline uint32_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint32_t cq_channel, uint
 }
 
 template <bool addr_16B>
-inline uint32_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint32_t cq_channel, uint32_t cq_channel_size) {
+inline uint32_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t recv;
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
-    tt::Cluster::instance().read_sysmem(&recv, sizeof(uint32_t), HOST_CQ_COMPLETION_WRITE_PTR + cq_channel * cq_channel_size, mmio_device_id, channel);
+    tt::Cluster::instance().read_sysmem(&recv, sizeof(uint32_t), HOST_CQ_COMPLETION_WRITE_PTR + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
     if (not addr_16B) {
         return recv << 4;
     }
@@ -39,14 +83,14 @@ struct SystemMemoryCQInterface {
     // Equation for issue fifo size is
     // | issue_fifo_wr_ptr + command size B - issue_fifo_rd_ptr |
     // Space available would just be issue_fifo_limit - issue_fifo_size
-    SystemMemoryCQInterface(uint8_t channel, uint32_t channel_size):
-      command_issue_region_size(tt::round_up((channel_size - CQ_START) * this->default_issue_queue_split, 32)),
-      command_completion_region_size((channel_size - CQ_START) - this->command_issue_region_size),
+    SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id, uint32_t cq_size):
+      command_issue_region_size(tt::round_up((cq_size - CQ_START) * this->default_issue_queue_split, 32)),
+      command_completion_region_size((cq_size - CQ_START) - this->command_issue_region_size),
       issue_fifo_size(command_issue_region_size >> 4),
-      issue_fifo_limit(((CQ_START + this->command_issue_region_size) + channel * channel_size) >> 4),
+      issue_fifo_limit(((CQ_START + this->command_issue_region_size) + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4),
       completion_fifo_size(command_completion_region_size >> 4),
       completion_fifo_limit(issue_fifo_limit + completion_fifo_size),
-      offset(channel * channel_size)
+      offset(get_absolute_cq_offset(channel, cq_id, cq_size))
      {
         TT_ASSERT(this->issue_fifo_limit != 0, "Cannot have a 0 fifo limit");
         this->issue_fifo_wr_ptr = (CQ_START + this->offset) >> 4;  // In 16B words
@@ -73,102 +117,99 @@ struct SystemMemoryCQInterface {
     uint32_t completion_fifo_rd_ptr;
     bool completion_fifo_rd_toggle;
 };
+
 class SystemMemoryManager {
    private:
     chip_id_t device_id;
     const uint32_t m_dma_buf_size;
     const std::function<void(uint32_t, uint32_t, const uint8_t*, uint32_t)> fast_write_callable;
-    const std::function<CoreCoord (CoreCoord)>worker_from_logical_callable;
     vector<uint32_t> issue_byte_addrs;
     vector<uint32_t> completion_byte_addrs;
     char* cq_sysmem_start;
     vector<SystemMemoryCQInterface> cq_interfaces;
-    uint32_t cq_channel_size;
+    uint32_t cq_size;
+    uint32_t channel_offset;
 
    public:
-    SystemMemoryManager(chip_id_t device_id, const std::vector<pair<CoreCoord, CoreCoord>> &cq_cores, const std::function<CoreCoord (CoreCoord)> &worker_from_logical) :
+    SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs) :
         device_id(device_id),
         m_dma_buf_size(tt::Cluster::instance().get_m_dma_buf_size(device_id)),
         fast_write_callable(
-            tt::Cluster::instance().get_fast_pcie_static_tlb_write_callable(device_id)),
-        worker_from_logical_callable(worker_from_logical) {
+            tt::Cluster::instance().get_fast_pcie_static_tlb_write_callable(device_id)) {
 
-        TT_ASSERT(cq_cores.size(), "cq_cores size must be positive");
-
-        uint8_t num_hw_cqs = cq_cores.size();
         this->issue_byte_addrs.resize(num_hw_cqs);
         this->completion_byte_addrs.resize(num_hw_cqs);
 
-        uint32_t idx = 0;
-        for (const auto& [producer_core, consumer_core]: cq_cores) {
-            const std::tuple<uint32_t, uint32_t> producer_tlb_data = tt::Cluster::instance().get_tlb_data(tt_cxy_pair(device_id, this->worker_from_logical_callable(producer_core))).value();
-            auto [producer_tlb_offset, producer_tlb_size] = producer_tlb_data;
-            this->issue_byte_addrs[idx] = producer_tlb_offset + CQ_ISSUE_WRITE_PTR % producer_tlb_size;
-            const std::tuple<uint32_t, uint32_t> consumer_tlb_data = tt::Cluster::instance().get_tlb_data(tt_cxy_pair(device_id, this->worker_from_logical_callable(consumer_core))).value();
-            auto [consumer_tlb_offset, consumer_tlb_size] = consumer_tlb_data;
-            this->completion_byte_addrs[idx] = consumer_tlb_offset + CQ_COMPLETION_READ_PTR % consumer_tlb_size;
-            idx++;
-        }
-
         // Split hugepage into however many pieces as there are CQs
-        uint32_t channel_size = tt::Cluster::instance().get_host_channel_size(device_id, tt::Cluster::instance().get_assigned_channel_for_device(device_id)) / num_hw_cqs;
-        char* hugepage_start = (char*) tt::Cluster::instance().host_dma_address(0, tt::Cluster::instance().get_associated_mmio_device(device_id), tt::Cluster::instance().get_assigned_channel_for_device(device_id));
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
+        char* hugepage_start = (char*) tt::Cluster::instance().host_dma_address(0, mmio_device_id, channel);
         this->cq_sysmem_start = hugepage_start;
+        this->cq_size = tt::Cluster::instance().get_host_channel_size(mmio_device_id, channel) / num_hw_cqs;
+        this->channel_offset = DeviceCommand::MAX_HUGEPAGE_SIZE * channel;
 
-        for (uint8_t channel = 0; channel < num_hw_cqs; channel++) {
-            this->cq_interfaces.push_back(SystemMemoryCQInterface(channel, channel_size));
+        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+            tt_cxy_pair issue_queue_reader_core = dispatch_core_manager::get(num_hw_cqs).issue_queue_reader_core(device_id, channel, cq_id);
+            const std::tuple<uint32_t, uint32_t> issue_interface_tlb_data = tt::Cluster::instance().get_tlb_data(tt_cxy_pair(issue_queue_reader_core.chip, tt::get_physical_core_coordinate(issue_queue_reader_core, CoreType::WORKER))).value();
+            auto [issue_tlb_offset, issue_tlb_size] = issue_interface_tlb_data;
+            this->issue_byte_addrs[cq_id] = issue_tlb_offset + CQ_ISSUE_WRITE_PTR % issue_tlb_size;
+
+            tt_cxy_pair completion_queue_writer_core = dispatch_core_manager::get(num_hw_cqs).completion_queue_writer_core(device_id, channel, cq_id);
+            const std::tuple<uint32_t, uint32_t> completion_interface_tlb_data = tt::Cluster::instance().get_tlb_data(tt_cxy_pair(completion_queue_writer_core.chip, tt::get_physical_core_coordinate(completion_queue_writer_core, CoreType::WORKER))).value();
+            auto [completion_tlb_offset, completion_tlb_size] = completion_interface_tlb_data;
+            this->completion_byte_addrs[cq_id] = completion_tlb_offset + CQ_COMPLETION_READ_PTR % completion_tlb_size;
+
+            this->cq_interfaces.push_back(SystemMemoryCQInterface(channel, cq_id, this->cq_size));
         }
-        this->cq_channel_size = channel_size;
     }
 
-
-    void reset(const uint8_t channel) {
-        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
+    void reset(const uint8_t cq_id) {
+        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
         cq_interface.issue_fifo_wr_ptr = (CQ_START + cq_interface.offset) >> 4;  // In 16B words
         cq_interface.issue_fifo_wr_toggle = 0;
         cq_interface.completion_fifo_rd_ptr = cq_interface.issue_fifo_limit;
         cq_interface.completion_fifo_rd_toggle = 0;
     }
 
-    void set_custom_issue_limit_for_trace(const uint8_t channel, const uint32_t new_limit) {
-        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
+    void set_custom_issue_limit_for_trace(const uint8_t cq_id, const uint32_t new_limit) {
+        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
         cq_interface.issue_fifo_limit = (new_limit >> 4);
     }
 
-    uint32_t get_issue_queue_size(const uint8_t channel) const {
-        return this->cq_interfaces[channel].issue_fifo_size << 4;
+    uint32_t get_issue_queue_size(const uint8_t cq_id) const {
+        return this->cq_interfaces[cq_id].issue_fifo_size << 4;
     }
 
-    uint32_t get_issue_queue_limit(const uint8_t channel) const {
-        return this->cq_interfaces[channel].issue_fifo_limit << 4;
+    uint32_t get_issue_queue_limit(const uint8_t cq_id) const {
+        return this->cq_interfaces[cq_id].issue_fifo_limit << 4;
     }
 
-    uint32_t get_completion_queue_size(const uint8_t channel) const {
-        return this->cq_interfaces[channel].completion_fifo_size << 4;
+    uint32_t get_completion_queue_size(const uint8_t cq_id) const {
+        return this->cq_interfaces[cq_id].completion_fifo_size << 4;
     }
 
-    uint32_t get_completion_queue_limit(const uint8_t channel) const {
-        return this->cq_interfaces[channel].completion_fifo_limit << 4;
+    uint32_t get_completion_queue_limit(const uint8_t cq_id) const {
+        return this->cq_interfaces[cq_id].completion_fifo_limit << 4;
     }
 
-    uint32_t get_issue_queue_write_ptr(const uint8_t channel) const {
-        return this->cq_interfaces[channel].issue_fifo_wr_ptr << 4;
+    uint32_t get_issue_queue_write_ptr(const uint8_t cq_id) const {
+        return this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4;
     }
 
-    uint32_t get_completion_queue_read_ptr(const uint8_t channel) const {
-        return this->cq_interfaces[channel].completion_fifo_rd_ptr << 4;
+    uint32_t get_completion_queue_read_ptr(const uint8_t cq_id) const {
+        return this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4;
     }
 
-    void issue_queue_reserve_back(uint32_t cmd_size_B, const uint8_t channel) const {
+    void issue_queue_reserve_back(uint32_t cmd_size_B, const uint8_t cq_id) const {
         uint32_t cmd_size_16B = align(cmd_size_B, 32) >> 4;
 
         uint32_t rd_ptr_and_toggle;
         uint32_t rd_ptr;
         uint32_t rd_toggle;
-        const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
 
+        const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
         do {
-            rd_ptr_and_toggle = get_cq_issue_rd_ptr<true>(this->device_id, channel, this->cq_channel_size);
+            rd_ptr_and_toggle = get_cq_issue_rd_ptr<true>(this->device_id, cq_id, this->cq_size);
             rd_ptr = rd_ptr_and_toggle & 0x7fffffff;
             rd_toggle = rd_ptr_and_toggle >> 31;
         } while (
@@ -181,25 +222,28 @@ class SystemMemoryManager {
     }
 
     void cq_write(const void* data, uint32_t size_in_bytes, uint32_t write_ptr) const {
-        void* user_scratchspace = this->cq_sysmem_start + write_ptr;
+        // this->cq_sysmem_start gives start of hugepage for a given channel from perspective of host
+        //  but all rd/wr pointers include channel offset from address 0 to match device side pointers
+        //  so channel offset needs to be subtracted to get address relative to channel
+        void* user_scratchspace = this->cq_sysmem_start + (write_ptr - this->channel_offset);
 
         memcpy(user_scratchspace, data, size_in_bytes);
     }
 
-    void send_issue_queue_write_ptr(const uint8_t channel) const {
-        const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
+    void send_issue_queue_write_ptr(const uint8_t cq_id) const {
+        const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
         uint32_t write_ptr_and_toggle =
             cq_interface.issue_fifo_wr_ptr | (cq_interface.issue_fifo_wr_toggle << 31);
-        this->fast_write_callable(this->issue_byte_addrs[channel], 4, (uint8_t*)&write_ptr_and_toggle, this->m_dma_buf_size);
+        this->fast_write_callable(this->issue_byte_addrs[cq_id], 4, (uint8_t*)&write_ptr_and_toggle, this->m_dma_buf_size);
         tt_driver_atomics::sfence();
     }
 
-    void issue_queue_push_back(uint32_t push_size_B, bool lazy, const uint8_t channel) {
+    void issue_queue_push_back(uint32_t push_size_B, bool lazy, const uint8_t cq_id) {
         // All data needs to be 32B aligned
 
         uint32_t push_size_16B = align(push_size_B, 32) >> 4;
 
-        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
+        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
 
         cq_interface.issue_fifo_wr_ptr += push_size_16B;
 
@@ -212,48 +256,48 @@ class SystemMemoryManager {
 
         // Notify dispatch core
         if (not lazy) {
-            this->send_issue_queue_write_ptr(channel);
+            this->send_issue_queue_write_ptr(cq_id);
         }
     }
 
-    void completion_queue_wait_front(const uint8_t channel) {
+    void completion_queue_wait_front(const uint8_t cq_id) {
         uint32_t write_ptr_and_toggle;
         uint32_t write_ptr;
         uint32_t write_toggle;
-        const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
+        const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
         do {
-            write_ptr_and_toggle = get_cq_completion_wr_ptr<true>(this->device_id, channel, this->cq_channel_size);
+            write_ptr_and_toggle = get_cq_completion_wr_ptr<true>(this->device_id, cq_id, this->cq_size);
             write_ptr = write_ptr_and_toggle & 0x7fffffff;
             write_toggle = write_ptr_and_toggle >> 31;
         } while (cq_interface.completion_fifo_rd_ptr == write_ptr and cq_interface.completion_fifo_rd_toggle == write_toggle);
     }
 
-    void send_completion_queue_read_ptr(const uint8_t channel) const {
-        const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
+    void send_completion_queue_read_ptr(const uint8_t cq_id) const {
+        const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
 
         uint32_t read_ptr_and_toggle =
             cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
-        this->fast_write_callable(this->completion_byte_addrs[channel], 4, (uint8_t*)&read_ptr_and_toggle, this->m_dma_buf_size);
+        this->fast_write_callable(this->completion_byte_addrs[cq_id], 4, (uint8_t*)&read_ptr_and_toggle, this->m_dma_buf_size);
         tt_driver_atomics::sfence();
     }
 
-    void wrap_issue_queue_wr_ptr(const uint8_t channel) {
-        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
+    void wrap_issue_queue_wr_ptr(const uint8_t cq_id) {
+        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
         cq_interface.issue_fifo_wr_ptr = (CQ_START + cq_interface.offset) >> 4;
         cq_interface.issue_fifo_wr_toggle = not cq_interface.issue_fifo_wr_toggle;
-        this->send_issue_queue_write_ptr(channel);
+        this->send_issue_queue_write_ptr(cq_id);
     }
 
-    void wrap_completion_queue_rd_ptr(const uint8_t channel) {
-        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
+    void wrap_completion_queue_rd_ptr(const uint8_t cq_id) {
+        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
         cq_interface.completion_fifo_rd_ptr = cq_interface.issue_fifo_limit;
         cq_interface.completion_fifo_rd_toggle = not cq_interface.completion_fifo_rd_toggle;
     }
 
-    void completion_queue_pop_front(uint32_t data_read_B, const uint8_t channel) {
+    void completion_queue_pop_front(uint32_t data_read_B, const uint8_t cq_id) {
         uint32_t data_read_16B = align(data_read_B, 32) >> 4;
 
-        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[channel];
+        SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
         cq_interface.completion_fifo_rd_ptr += data_read_16B;
         if (cq_interface.completion_fifo_rd_ptr >= cq_interface.completion_fifo_limit) {
             cq_interface.completion_fifo_rd_ptr = cq_interface.command_issue_region_size >> 4;
@@ -261,7 +305,7 @@ class SystemMemoryManager {
         }
 
         // Notify dispatch core
-        this->send_completion_queue_read_ptr(channel);
+        this->send_completion_queue_read_ptr(cq_id);
     }
 
 };

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -16,16 +16,12 @@ class DeviceCommand {
 
     // Constants
     //TODO: investigate other num_cores
+    static constexpr uint32_t MAX_HUGEPAGE_SIZE = 1 << 30; // 1GB;
     static constexpr uint32_t NUM_MAX_CORES = 108; //12 x 9
     static constexpr uint32_t NUM_ENTRIES_IN_COMMAND_HEADER = 20;
     static constexpr uint32_t NUM_ENTRIES_IN_DEVICE_COMMAND = 5632;
     static constexpr uint32_t NUM_BYTES_IN_DEVICE_COMMAND = NUM_ENTRIES_IN_DEVICE_COMMAND * sizeof(uint32_t);
-    static constexpr uint32_t DATA_SECTION_ADDRESS = L1_UNRESERVED_BASE + NUM_BYTES_IN_DEVICE_COMMAND;
     static constexpr uint32_t PROGRAM_PAGE_SIZE = 2048;
-    static constexpr uint32_t PRODUCER_DATA_BUFFER_SIZE =
-        (MEM_L1_SIZE - (NUM_ENTRIES_IN_DEVICE_COMMAND * sizeof(uint32_t)) - L1_UNRESERVED_BASE);
-    static constexpr uint32_t CONSUMER_DATA_BUFFER_SIZE = (PRODUCER_DATA_BUFFER_SIZE - NUM_BYTES_IN_DEVICE_COMMAND) / 2;
-    static constexpr uint32_t DEVICE_COMMAND_DATA_ADDR = L1_UNRESERVED_BASE + NUM_BYTES_IN_DEVICE_COMMAND;
     static constexpr uint32_t NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION = COMMAND_PTR_SHARD_IDX + NUM_MAX_CORES*NUM_ENTRIES_PER_SHARD;
     static constexpr uint32_t NUM_POSSIBLE_BUFFER_TRANSFERS = 2;
 

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "common/core_descriptor.hpp"
+
+namespace tt::tt_metal {
+
+// Dispatch core manager APIs track which cores are assigned to which dispatch functionality
+
+// A command queue is split into an issue queue and completion queue
+//  Host enqueues commands and data to be sent to device into the issue queue, and device reads from the issue queue.
+//  command_queue_producer and remote_issue_queue_reader kernels read commands targetting the MMIO or remote device respectively from the issue queue
+//  Device writes data into the completion queue for host to read back
+//  command_queue_consumer and remote_completion_queue_writer (to be added) kernels write into the completion queue for MMIO or remote device respectively
+//  Currently two cores are used to interface with each command queue region, marked as `issue_queue_reader` and `completion_queue_writer` below
+// One core dispatches commands to worker cores on the device `command_dispatcher`
+// The `remote_x` cores are used for remote fast dispatch and receive / transmit fast dispatch packets from ethernet cores
+
+// std::optional is used to determine whether core has been assigned
+// tt_cxy_pair is used over CoreCoord to denote location because remote device command queue interface cores are on the associated MMIO device
+struct dispatch_core_types_t {
+    std::optional<tt_cxy_pair> issue_queue_reader = std::nullopt;  // Pulls commands from the issue queue for a given command queue on a device
+    std::optional<tt_cxy_pair> completion_queue_writer = std::nullopt; // Pushes to completion queue for a given command queue on a device
+    std::optional<tt_cxy_pair> command_dispatcher = std::nullopt; // Relays work to worker cores on device that command is targeting. Currently for MMIO devices, command_dispatcher == completion_queue_writer
+    // TODO (abhullar): consider renaming these when supporting GH #3953 and #3954
+    std::optional<tt_cxy_pair> remote_processor = std::nullopt;    // Receives fast dispatch commands from ethernet router and relays to command_dispatcher
+    std::optional<tt_cxy_pair> remote_signaller = std::nullopt;    // Transmits data from command_dispatcher to ethernet router to send fast dispatch results off chip
+};
+
+class dispatch_core_manager {
+   public:
+    dispatch_core_manager &operator=(const dispatch_core_manager &) = delete;
+    dispatch_core_manager &operator=(dispatch_core_manager &&other) noexcept = delete;
+    dispatch_core_manager(const dispatch_core_manager &) = delete;
+    dispatch_core_manager(dispatch_core_manager &&other) noexcept = delete;
+
+    // Ugly to accept num HW CQs here but it is needed to pull the correct number of initially available dispatch cores for assignment
+    static dispatch_core_manager &get(uint8_t num_hw_cqs) {
+        static dispatch_core_manager inst = dispatch_core_manager(num_hw_cqs);
+        return inst;
+    }
+
+    /// @brief Gets the location of the kernel desginated to read from the issue queue region from a particular command queue
+    ///         Each command queue has an issue queue where host enqueues commands. This core relays to the dispatcher core to interpret and launch
+    ///         For remote devices, this core is located on the associated MMIO device since it can access sysmem (location of command queue)
+    /// @param device_id ID of the device that a fast dispatch command targets
+    /// @param channel assigned to the command queue where commands are enqueued
+    /// @param cq_id ID of the command queue within the channel
+    /// @return tt_cxy_pair logical location (chip + core coordinate) of the issue queue interface
+    const tt_cxy_pair &issue_queue_reader_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+        dispatch_core_types_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+        if (assignment.issue_queue_reader.has_value()) {
+            return assignment.issue_queue_reader.value();
+        }
+        // Issue queue interface is on the MMIO device
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+        CoreCoord issue_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
+        assignment.issue_queue_reader = tt_cxy_pair(mmio_device_id, issue_queue_coord.x, issue_queue_coord.y);
+        return assignment.issue_queue_reader.value();
+    }
+
+    /// @brief Gets the location of the kernel desginated to write to the completion queue region for a particular command queue
+    ///         Each command queue has one completion queue
+    ///         For MMIO devices this core is the same as the dispatcher core because one kernel is responisble for interpreting + relaying commands and writing to completion queue
+    ///         For remote devices, this core is located on the associated MMIO device since it can access sysmem (location of command queue)
+    /// @param device_id ID of the device that a fast dispatch command targets
+    /// @param channel assigned to the command queue
+    /// @param cq_id ID of the command queue within the channel
+    /// @return tt_cxy_pair logical location (chip + core coordinate) of the completion queue interface
+    const tt_cxy_pair &completion_queue_writer_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+        dispatch_core_types_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+        if (assignment.completion_queue_writer.has_value()) {
+            return assignment.completion_queue_writer.value();
+        }
+        // Completion queue interface is on the MMIO device
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+        CoreCoord completion_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
+        assignment.completion_queue_writer = tt_cxy_pair(mmio_device_id, completion_queue_coord.x, completion_queue_coord.y);
+        if (mmio_device_id == device_id) {
+            // For MMIO devices completion queue core is same as command dispatcher core
+            TT_ASSERT(not assignment.command_dispatcher.has_value(), "Command dispatcher core {} must match completion queue interface core for MMIO device {}", assignment.command_dispatcher.value().str(), device_id);
+            assignment.command_dispatcher = assignment.completion_queue_writer;
+        }
+        return assignment.completion_queue_writer.value();
+    }
+
+    /// @brief Gets the location of the kernel designated to relay fast dispatch commands to worker cores from a particular command queue
+    /// @param device_id ID of the device that should be running the command
+    /// @param channel assigned to the command queue where commands are enqueued
+    /// @param cq_id ID of the command queue within the channel
+    /// @return tt_cxy_pair logical location (chip + core coordinate) of the dispatcher core
+    const tt_cxy_pair &command_dispatcher_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+        dispatch_core_types_t &assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
+        if (assignment.command_dispatcher.has_value()) {
+            return assignment.command_dispatcher.value();
+        }
+        CoreCoord command_dispatcher_coord = this->get_next_available_dispatch_core(device_id);
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+        assignment.command_dispatcher = tt_cxy_pair(device_id, command_dispatcher_coord.x, command_dispatcher_coord.y);
+        if (mmio_device_id == device_id) {
+            // For MMIO devices completion queue core is same as command dispatcher core
+            TT_ASSERT(not assignment.completion_queue_writer.has_value(), "Command dispatcher core must match completion queue interface core for MMIO device {}", device_id);
+            assignment.completion_queue_writer = assignment.command_dispatcher;
+        }
+        return assignment.command_dispatcher.value();
+    }
+
+    const std::optional<tt_cxy_pair> &remote_processor_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+        TT_THROW("Do not currently support programming remote processor dispatch core. See https://github.com/tenstorrent-metal/tt-metal/issues/3953");
+        return this->dispatch_core_assignments[device_id][channel][cq_id].remote_processor;
+    }
+
+    const std::optional<tt_cxy_pair> &remote_signaller_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
+        TT_THROW("Do not currently support programming remote signaller dispatch core. See https://github.com/tenstorrent-metal/tt-metal/issues/3954");
+        return this->dispatch_core_assignments[device_id][channel][cq_id].remote_signaller;
+    }
+
+   private:
+    /// @brief dispatch_core_manager constructor initializes a list of cores per device that are designated for any dispatch functionality
+    ///         This list contains dispatch cores that have not been assigned to a particular dispatch function
+    /// @param num_hw_cqs is used to get the correct collection of dispatch cores for a particular device
+    dispatch_core_manager(uint8_t num_hw_cqs) {
+        for (chip_id_t device_id = 0; device_id < tt::Cluster::instance().number_of_devices(); device_id++) {
+            std::list<CoreCoord> &logical_dispatch_cores = this->available_dispatch_cores_by_device[device_id];
+            for (const CoreCoord &logical_dispatch_core : tt::get_logical_dispatch_cores(device_id, num_hw_cqs)) {
+                logical_dispatch_cores.push_back(logical_dispatch_core);
+            }
+        }
+    }
+
+    /// @brief getting any
+    /// @param device_id
+    /// @return
+    CoreCoord get_next_available_dispatch_core(chip_id_t device_id) {
+        if (this->available_dispatch_cores_by_device.find(device_id) == this->available_dispatch_cores_by_device.end()) {
+            TT_THROW("Invalid device ID to assign dispatch cores {}", device_id);
+        }
+        if (this->available_dispatch_cores_by_device.at(device_id).empty()) {
+            TT_THROW("No more available dispatch cores on device {} to assign. Expand dispatch cores specified in core descriptor YAML", device_id);
+        }
+        CoreCoord avail_dispatch_core = this->available_dispatch_cores_by_device.at(device_id).front();
+        this->available_dispatch_cores_by_device.at(device_id).pop_front();
+        return avail_dispatch_core;
+    }
+
+    // {device ID : {channel (hugepage) : {cq_id : dispatch assignment}}}
+    // Each device has an assigned hugepage at a specific channel that holds (up to 2) hardware command queues (represented by cq_id)
+    std::unordered_map<chip_id_t, std::unordered_map<uint16_t, std::unordered_map<uint8_t, dispatch_core_types_t>>> dispatch_core_assignments;
+    std::unordered_map<chip_id_t, std::list<CoreCoord>> available_dispatch_cores_by_device;
+};
+
+
+}   // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
@@ -8,12 +8,6 @@
 static constexpr uint32_t l1_db_cb_addr_offset = 7 * 16;
 
 FORCE_INLINE
-uint32_t get_db_cb_command_slot_addr(bool db_buf_switch) {
-    constexpr static uint32_t second_buffer_offset = (MEM_L1_SIZE - L1_UNRESERVED_BASE) / 2;
-    return L1_UNRESERVED_BASE + (db_buf_switch * second_buffer_offset);
-}
-
-FORCE_INLINE
 uint32_t get_db_cb_l1_base(bool db_buf_switch) {
     return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset);
 }
@@ -55,17 +49,17 @@ uint32_t get_db_cb_wr_ptr_addr(bool db_buf_switch) {
 }
 
 
-FORCE_INLINE
-uint32_t get_command_slot_addr(bool db_buf_switch) {
-    static constexpr uint32_t command0_start = L1_UNRESERVED_BASE;
-    static constexpr uint32_t command1_start = command0_start + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + DeviceCommand::CONSUMER_DATA_BUFFER_SIZE;
+template <uint32_t cmd_base_address, uint32_t consumer_data_buffer_size>
+FORCE_INLINE uint32_t get_command_slot_addr(bool db_buf_switch) {
+    static constexpr uint32_t command0_start = cmd_base_address;
+    static constexpr uint32_t command1_start = command0_start + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + consumer_data_buffer_size;
     return (db_buf_switch) ? command0_start : command1_start;
 }
 
-FORCE_INLINE
-uint32_t get_db_buf_addr(bool db_buf_switch) {
-    static constexpr uint32_t buf0_start = L1_UNRESERVED_BASE + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
-    static constexpr uint32_t buf1_start = buf0_start + DeviceCommand::CONSUMER_DATA_BUFFER_SIZE + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
+template <uint32_t cmd_base_address, uint32_t consumer_data_buffer_size>
+FORCE_INLINE uint32_t get_db_buf_addr(bool db_buf_switch) {
+    static constexpr uint32_t buf0_start = cmd_base_address + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
+    static constexpr uint32_t buf1_start = buf0_start + consumer_data_buffer_size + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
     return (not db_buf_switch) ? buf0_start : buf1_start;
 }
 

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
@@ -20,10 +20,10 @@ void kernel_main() {
     constexpr uint32_t completion_queue_start_addr = get_compile_time_arg_val(1);
     constexpr uint32_t completion_queue_size = get_compile_time_arg_val(2);
     constexpr uint32_t host_finish_addr = get_compile_time_arg_val(3);
+    constexpr uint32_t cmd_base_address = get_compile_time_arg_val(4);
+    constexpr uint32_t consumer_data_buffer_size = get_compile_time_arg_val(5);
 
     volatile uint32_t* db_semaphore_addr = reinterpret_cast<volatile uint32_t*>(SEMAPHORE_BASE);
-
-    static constexpr uint32_t command_start_addr = L1_UNRESERVED_BASE; // Space between L1_UNRESERVED_BASE -> data_start is for commands
 
     uint64_t producer_noc_encoding = uint64_t(NOC_XY_ENCODING(PRODUCER_NOC_X, PRODUCER_NOC_Y)) << 32;
     uint64_t consumer_noc_encoding = uint64_t(NOC_XY_ENCODING(my_x[0], my_y[0])) << 32;
@@ -35,7 +35,7 @@ void kernel_main() {
         db_acquire(db_semaphore_addr, consumer_noc_encoding);
 
         // For each instruction, we need to jump to the relevant part of the device command
-        uint32_t command_start_addr = get_command_slot_addr(db_buf_switch);
+        uint32_t command_start_addr = get_command_slot_addr<cmd_base_address, consumer_data_buffer_size>(db_buf_switch);
         uint32_t buffer_transfer_start_addr = command_start_addr + (DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER * sizeof(uint32_t));
         uint32_t program_transfer_start_addr = buffer_transfer_start_addr + ((DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION * DeviceCommand::NUM_POSSIBLE_BUFFER_TRANSFERS) * sizeof(uint32_t));
 

--- a/tt_metal/impl/dispatch/kernels/remote_issue_queue_reader.cpp
+++ b/tt_metal/impl/dispatch/kernels/remote_issue_queue_reader.cpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/impl/dispatch/kernels/command_queue_producer.hpp"
+// #include "debug/dprint.h"
 
+// TODO: commonize pieces with command_queue_producer
 void kernel_main() {
     constexpr uint32_t host_issue_queue_read_ptr_addr = get_compile_time_arg_val(0);
     constexpr uint32_t issue_queue_start_addr = get_compile_time_arg_val(1);
@@ -20,12 +22,12 @@ void kernel_main() {
     // Initialize the producer/consumer DB semaphore
     // This represents how many buffers the producer can write to.
     // At the beginning, it can write to two different buffers.
-    uint64_t producer_noc_encoding = uint64_t(NOC_XY_ENCODING(my_x[0], my_y[0])) << 32;
-    uint64_t consumer_noc_encoding = uint64_t(NOC_XY_ENCODING(CONSUMER_NOC_X, CONSUMER_NOC_Y)) << 32;
-    uint64_t pcie_core_noc_encoding = uint64_t(NOC_XY_ENCODING(PCIE_NOC_X, PCIE_NOC_Y)) << 32;
+    uint32_t producer_noc_encoding = uint32_t(NOC_XY_ENCODING(my_x[0], my_y[0]));
+    uint32_t consumer_noc_encoding = uint32_t(NOC_XY_ENCODING(CONSUMER_NOC_X, CONSUMER_NOC_Y));
+    uint32_t pcie_core_noc_encoding = uint32_t(NOC_XY_ENCODING(PCIE_NOC_X, PCIE_NOC_Y));
 
     volatile tt_l1_ptr uint32_t* db_semaphore_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(0));  // Should be initialized to 2 by host
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(0));  // Should be initialized to num command slots by host (1 for remote cq)
 
     bool db_buf_switch = false;
     while (true) {
@@ -34,7 +36,7 @@ void kernel_main() {
 
         // Read in command
         uint32_t rd_ptr = (cq_read_interface.issue_fifo_rd_ptr << 4);
-        uint64_t src_noc_addr = pcie_core_noc_encoding | rd_ptr;
+        uint64_t src_noc_addr = ((uint64_t)pcie_core_noc_encoding << 32) | rd_ptr;
         noc_async_read(src_noc_addr, command_start_addr, min(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, issue_queue_size - rd_ptr));
         noc_async_read_barrier();
 
@@ -42,17 +44,15 @@ void kernel_main() {
         volatile tt_l1_ptr uint32_t* command_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(command_start_addr);
         uint32_t data_size = command_ptr[DeviceCommand::data_size_idx];
         uint32_t num_buffer_transfers = command_ptr[DeviceCommand::num_buffer_transfers_idx];
-        uint32_t stall = command_ptr[DeviceCommand::stall_idx];
         uint32_t page_size = command_ptr[DeviceCommand::page_size_idx];
         uint32_t producer_cb_size = command_ptr[DeviceCommand::producer_cb_size_idx];
         uint32_t consumer_cb_size = command_ptr[DeviceCommand::consumer_cb_size_idx];
         uint32_t producer_cb_num_pages = command_ptr[DeviceCommand::producer_cb_num_pages_idx];
         uint32_t consumer_cb_num_pages = command_ptr[DeviceCommand::consumer_cb_num_pages_idx];
         uint32_t num_pages = command_ptr[DeviceCommand::num_pages_idx];
-        uint32_t wrap = command_ptr[DeviceCommand::wrap_idx];
         uint32_t producer_consumer_transfer_num_pages = command_ptr[DeviceCommand::producer_consumer_transfer_num_pages_idx];
         uint32_t sharded_buffer_num_cores = command_ptr[DeviceCommand::sharded_buffer_num_cores_idx];
-        uint32_t finish = command_ptr[DeviceCommand::finish_idx];
+        uint32_t wrap = command_ptr[DeviceCommand::wrap_idx];
 
         if ((DeviceCommand::WrapRegion)wrap == DeviceCommand::WrapRegion::ISSUE) {
             // Basically popfront without the extra conditional
@@ -65,36 +65,33 @@ void kernel_main() {
         program_local_cb(data_section_addr, producer_cb_num_pages, page_size, producer_cb_size);
         while (db_semaphore_addr[0] == 0)
             ;  // Check that there is space in the consumer
-        program_consumer_cb<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, consumer_noc_encoding, consumer_cb_num_pages, page_size, consumer_cb_size);
-        relay_command<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, consumer_noc_encoding);
-        if (stall) {
-            while (*db_semaphore_addr != 2)
-                ;
-        }
+        // program_consumer_cb<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, ((uint64_t)consumer_noc_encoding << 32), consumer_cb_num_pages, page_size, consumer_cb_size);
+        // relay_command<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, ((uint64_t)consumer_noc_encoding << 32));
+
         // Decrement the semaphore value
-        noc_semaphore_inc(producer_noc_encoding | uint32_t(db_semaphore_addr), -1);  // Two's complement addition
+        noc_semaphore_inc(((uint64_t)producer_noc_encoding << 32) | uint32_t(db_semaphore_addr), -1);  // Two's complement addition
         noc_async_write_barrier();
 
         // Notify the consumer
-        noc_semaphore_inc(consumer_noc_encoding | get_semaphore(0), 1);
-        noc_async_write_barrier();  // Barrier for now
+        // noc_semaphore_inc( ((uint64_t)consumer_noc_encoding << 32) | get_semaphore(0), 1);
+        // noc_async_write_barrier();  // Barrier for now
 
         // Fetch data and send to the consumer
-        produce<consumer_cmd_base_addr, consumer_data_buffer_size>(
-            command_ptr,
-            num_buffer_transfers,
-            sharded_buffer_num_cores,
-            page_size,
-            producer_cb_size,
-            producer_cb_num_pages,
-            consumer_cb_size,
-            consumer_cb_num_pages,
-            consumer_noc_encoding,
-            producer_consumer_transfer_num_pages,
-            db_buf_switch);
+        // produce<consumer_cmd_base_addr, consumer_data_buffer_size>(
+        //     command_ptr,
+        //     num_buffer_transfers,
+        //     sharded_buffer_num_cores,
+        //     page_size,
+        //     producer_cb_size,
+        //     producer_cb_num_pages,
+        //     consumer_cb_size,
+        //     consumer_cb_num_pages,
+        //     ((uint64_t)consumer_noc_encoding << 32),
+        //     producer_consumer_transfer_num_pages,
+        //     db_buf_switch);
 
         issue_queue_pop_front<host_issue_queue_read_ptr_addr>(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + data_size);
 
-        db_buf_switch = not db_buf_switch;
+        // db_buf_switch = not db_buf_switch; // only 1 command slot on consumer side
     }
 }

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -130,6 +130,12 @@ class Cluster {
 
     uint32_t get_tensix_soft_reset_addr() const;
 
+    // Returns collection of devices that are controlled by the specified MMIO device inclusive of the MMIO device
+    const std::set<chip_id_t> &get_devices_controlled_by_mmio_device(chip_id_t mmio_device_id) const {
+        TT_ASSERT(this->devices_grouped_by_assoc_mmio_device_.count(mmio_device_id), "Expected device {} to be an MMIO device!", mmio_device_id);
+        return this->devices_grouped_by_assoc_mmio_device_.at(mmio_device_id);
+    }
+
    private:
     Cluster();
     ~Cluster();


### PR DESCRIPTION

Host changes
- create dispatch core assigner interface to track which dispatch cores are assigned to which dispatch functionalities because with multi-chip fast dispatch we have more dispatch functionality than just cq producer and cq consumer (defined in dispatch_core_manager.hpp)
- update SendDispatchKernelsToDevice to program remote cq interface cores as well as mmio dispatch cores when initializing mmio device
- update CQ interface apis to account for hugepage channel offsets (each device has a hugepage in different channel)

Device changes
- added remote_issue_queue_interface kernel to pull commands from remote command queue. In this PR that kernel doesn't do anything but @aliuTT is working on integrating it to the ethernet core