### PR TITLE
#4683: Support tracing

### DIFF
--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueProgram.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueProgram.rst
@@ -1,4 +1,4 @@
 EnqueueProgram
 ==============
 
-.. doxygenfunction:: EnqueueProgram(CommandQueue& cq, Program& program, bool blocking)
+void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking, optional<stdreference_wrapper<Trace>> trace = {});

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueReadBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueReadBuffer
 ==================
 
-.. doxygenfunction:: EnqueueReadBuffer(CommandQueue &cq, Buffer &buffer, std::vector<uint32_t> &dst, bool blocking)
+.. doxygenfunction:: EnqueueReadBuffer(CommandQueue &cq, Buffer &buffer, vector<uint32_t> &dst, bool blocking)
 .. doxygenfunction:: EnqueueReadBuffer(CommandQueue &cq, Buffer &buffer, void* dst, bool blocking)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueWriteBuffer.rst
@@ -1,5 +1,5 @@
 EnqueueWriteBuffer
 ==================
 
-.. doxygenfunction:: EnqueueWriteBuffer(CommandQueue &cq, Buffer &buffer, std::vector<uint32_t> &src, bool blocking)
+.. doxygenfunction:: EnqueueWriteBuffer(CommandQueue &cq, Buffer &buffer, vector<uint32_t> &src, bool blocking)
 .. doxygenfunction:: EnqueueWriteBuffer(CommandQueue &cq, Buffer &buffer, const void* src, bool blocking)

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueTrace.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+
+#include "command_queue_fixture.hpp"
+#include "gtest/gtest.h"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+
+using namespace tt::tt_metal;
+
+struct TestBufferConfig {
+    uint32_t num_pages;
+    uint32_t page_size;
+    BufferType buftype;
+};
+
+Program create_simple_unary_program(const Buffer& input, const Buffer& output) {
+    Program program = CreateProgram();
+
+    CoreCoord worker = {0, 0};
+    auto reader_kernel = CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/reader_unary.cpp",
+        worker,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    auto writer_kernel = CreateKernel(
+        program,
+        "tt_metal/kernels/dataflow/writer_unary.cpp",
+        worker,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    auto sfpu_kernel = CreateKernel(
+        program,
+        "tt_metal/kernels/compute/eltwise_sfpu.cpp",
+        worker,
+        ComputeConfig{
+            .math_approx_mode = true,
+            .compile_args = {1, 1},
+            .defines = {{"SFPU_OP_EXP_INCLUDE", "1"}, {"SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);"}}});
+
+    CircularBufferConfig input_cb_config = CircularBufferConfig(2048, {{0, tt::DataFormat::Float16_b}})
+            .set_page_size(0, 2048);
+
+    CoreRange core_range({0, 0});
+    CreateCircularBuffer(program, core_range, input_cb_config);
+    vector<uint32_t> writer_rt_args = {
+        output.address(),
+        (uint32_t)output.noc_coordinates().x,
+        (uint32_t)output.noc_coordinates().y,
+        output.num_pages()
+    };
+    SetRuntimeArgs(program, writer_kernel, worker, writer_rt_args);
+
+    CircularBufferConfig output_cb_config = CircularBufferConfig(2048, {{16, tt::DataFormat::Float16_b}})
+            .set_page_size(16, 2048);
+
+    CreateCircularBuffer(program, core_range, output_cb_config);
+    vector<uint32_t> reader_rt_args = {
+        input.address(),
+        (uint32_t)input.noc_coordinates().x,
+        (uint32_t)input.noc_coordinates().y,
+        input.num_pages()
+    };
+    SetRuntimeArgs(program, reader_kernel, worker, reader_rt_args);
+
+    return program;
+}
+
+// All basic trace tests just assert that the replayed result exactly matches
+// the eager mode results
+namespace basic_tests {
+
+TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTrace) {
+
+    Buffer input(this->device_, 2048, 2048, BufferType::DRAM);
+    Buffer output(this->device_, 2048, 2048, BufferType::DRAM);
+
+    CommandQueue trace_queue(this->device_, 0);
+    CommandQueue data_movement_queue(this->device_, 1);
+
+    Program simple_program = create_simple_unary_program(input, output);
+    vector<uint32_t> input_data(input.size() / sizeof(uint32_t), 0);
+    for (uint32_t i = 0; i < input_data.size(); i++) {
+        input_data[i] = i;
+    }
+    // EnqueueWriteBuffer(data_movement_queue, input, input_data.data(), true);
+    Trace trace = BeginTrace(trace_queue);
+    EnqueueProgram(trace_queue, simple_program, false, trace);
+    Finish(trace_queue);
+    EndTrace(trace);
+    vector<uint32_t> eager_output_data;
+    eager_output_data.resize(input_data.size());
+    EnqueueReadBuffer(data_movement_queue, output, eager_output_data.data(), true);
+
+    vector<uint32_t> trace_output_data;
+    trace_output_data.resize(input_data.size());
+    EnqueueTrace(trace, true);
+    EnqueueReadBuffer(data_movement_queue, output, trace_output_data.data(), true);
+
+    EXPECT_TRUE(eager_output_data == trace_output_data);
+}
+} // end namespace basic_tests

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -442,10 +442,51 @@ namespace tt::tt_metal{
             );
         }
 
-        inline void SendDispatchKernelsToDevice(Device *device, const SystemMemoryManager& manager, const uint32_t hugepage_channel) {
-            ZoneScoped;
+        inline void CommandQueueInit(Device* device, const CoreCoord& producer_core, const CoreCoord& consumer_core, SystemMemoryManager& manager, const uint8_t command_queue_channel) {
+            // // Place the cores into reset since need to update a lot of core info
+            // tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(device->id(), device->worker_core_from_logical_core(producer_core)));
+            // tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(device->id(), device->worker_core_from_logical_core(consumer_core)));
+            // tt::Cluster::instance().l1_barrier(device->id());
 
-            Program dispatch_program = CreateProgram();
+            // Reset the host manager's pointer for this command queue
+            manager.reset(command_queue_channel);
+
+            // Re-start the pointers
+            vector<uint32_t> issue_queue_read_ptr = {manager.get_issue_queue_write_ptr(command_queue_channel) >> 4};
+            vector<uint32_t> completion_queue_wr_ptr = {manager.get_completion_queue_read_ptr(command_queue_channel) >> 4};
+            detail::WriteToDeviceL1(device, producer_core, CQ_ISSUE_READ_PTR, issue_queue_read_ptr);
+            detail::WriteToDeviceL1(device, producer_core, CQ_ISSUE_WRITE_PTR, issue_queue_read_ptr);
+            detail::WriteToDeviceL1(device, consumer_core, CQ_COMPLETION_READ_PTR, completion_queue_wr_ptr);
+            detail::WriteToDeviceL1(device, consumer_core, CQ_COMPLETION_WRITE_PTR, completion_queue_wr_ptr);
+
+            // Need to update the issue queue limit to be exactly equal to the command data in the queue
+            Program& command_queue_program = *device->command_queue_programs[command_queue_channel];
+            KernelHandle producer_kernel_handle = command_queue_program.kernels_on_core(producer_core)->riscv0_id.value();
+            uint32_t issue_queue_size = manager.get_issue_queue_size(command_queue_channel);
+            vector<uint32_t> producer_runtime_args = {issue_queue_size};
+            SetRuntimeArgs(
+                command_queue_program,
+                producer_kernel_handle,
+                producer_core,
+                producer_runtime_args);
+
+            detail::WriteRuntimeArgsToDevice(device, command_queue_program);
+            detail::ConfigureDeviceWithProgram(device, command_queue_program);
+            tt::Cluster::instance().dram_barrier(device->id());
+            tt::Cluster::instance().l1_barrier(device->id());
+
+            std::vector<uint32_t> pointers(CQ_START / sizeof(uint32_t), 0);
+            tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+            uint16_t huge_page_channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+            const uint32_t hugepage_size = tt::Cluster::instance().get_host_channel_size(device->id(), huge_page_channel);
+            const uint32_t cq_channel_size = hugepage_size / device->num_hw_cqs();
+            pointers[HOST_CQ_ISSUE_READ_PTR / sizeof(uint32_t)] = (CQ_START + command_queue_channel * cq_channel_size) >> 4;
+            pointers[HOST_CQ_COMPLETION_WRITE_PTR / sizeof(uint32_t)] = (CQ_START + manager.get_issue_queue_size(command_queue_channel) + command_queue_channel * cq_channel_size) >> 4;
+            tt::Cluster::instance().write_sysmem(pointers.data(), pointers.size() * sizeof(uint32_t), command_queue_channel * cq_channel_size, device->id(), huge_page_channel);
+        }
+
+        inline void CompileCommandQueuePrograms(Device *device, const SystemMemoryManager& manager, const uint32_t hugepage_channel, vector<unique_ptr<Program, ProgramDeleter>>& command_queue_programs) {
+            ZoneScoped;
 
             const uint32_t cq_size = tt::Cluster::instance().get_host_channel_size(device->id(), hugepage_channel) / device->producer_cores().size();
             TT_ASSERT(device->producer_cores().size() == device->consumer_cores().size(), "There must be the same number of producers as there are consumers");
@@ -453,12 +494,12 @@ namespace tt::tt_metal{
             TT_ASSERT(device->producer_cores().size() < 3, "There can be at most 2 hardware command queues on a given device");
 
             uint8_t cq_channel = 0;
-            vector<int> dummy;
             std::transform(
                 device->producer_cores().begin(), device->producer_cores().end(),
-                device->consumer_cores().begin(), std::back_inserter(dummy),
-                [&device, &dispatch_program, &cq_channel, &cq_size, &manager](const CoreCoord& producer_logical_core, const CoreCoord& consumer_logical_core) {
+                device->consumer_cores().begin(), std::back_inserter(command_queue_programs),
+                [&device, &cq_channel, &cq_size, &manager](const CoreCoord& producer_logical_core, const CoreCoord& consumer_logical_core) {
 
+                    unique_ptr<Program, ProgramDeleter> command_queue_program_ptr(new Program);
                     CoreCoord producer_physical_core = device->worker_core_from_logical_core(producer_logical_core);
                     CoreCoord consumer_physical_core = device->worker_core_from_logical_core(consumer_logical_core);
 
@@ -477,7 +518,7 @@ namespace tt::tt_metal{
                     uint32_t host_issue_queue_read_ptr_addr = HOST_CQ_ISSUE_READ_PTR + cq_channel * cq_size;
                     uint32_t issue_queue_start_addr = CQ_START + cq_channel * cq_size;
                     uint32_t issue_queue_size = manager.get_issue_queue_size(cq_channel);
-                    vector<uint32_t> producer_compile_args = {host_issue_queue_read_ptr_addr, issue_queue_start_addr, issue_queue_size};
+                    vector<uint32_t> producer_compile_args = {host_issue_queue_read_ptr_addr, issue_queue_start_addr};
 
                     uint32_t host_completion_queue_write_ptr_addr = HOST_CQ_COMPLETION_WRITE_PTR + cq_channel * cq_size;
                     uint32_t completion_queue_start_addr = CQ_START + issue_queue_size + cq_channel * cq_size;
@@ -486,7 +527,7 @@ namespace tt::tt_metal{
                     vector<uint32_t> consumer_compile_args = {host_completion_queue_write_ptr_addr, completion_queue_start_addr, completion_queue_size, host_finish_addr};
 
                     tt::tt_metal::CreateKernel(
-                        dispatch_program,
+                        *command_queue_program_ptr,
                         "tt_metal/impl/dispatch/kernels/command_queue_producer.cpp",
                         producer_logical_core,
                         tt::tt_metal::DataMovementConfig {
@@ -496,7 +537,7 @@ namespace tt::tt_metal{
                             .defines = producer_defines});
 
                     tt::tt_metal::CreateKernel(
-                        dispatch_program,
+                        *command_queue_program_ptr,
                         "tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp",
                         consumer_logical_core,
                         tt::tt_metal::DataMovementConfig {
@@ -505,32 +546,13 @@ namespace tt::tt_metal{
                             .compile_args = consumer_compile_args,
                             .defines = consumer_defines});
 
-                    tt::tt_metal::CreateSemaphore(dispatch_program, producer_logical_core, 2);
-                    tt::tt_metal::CreateSemaphore(dispatch_program, consumer_logical_core, 0);
+                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, producer_logical_core, 2);
+                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, consumer_logical_core, 0);
 
-                    CompileProgram(device, dispatch_program);
-
-                    ConfigureDeviceWithProgram(device, dispatch_program);
-
-                    // The read and write pointers are equal by this point, but the logic may look a bit
-                    // awkward
-                    vector<uint32_t> issue_queue_read_ptr = {manager.get_issue_queue_write_ptr(cq_channel) >> 4};
-                    vector<uint32_t> completion_queue_wr_ptr = {manager.get_completion_queue_read_ptr(cq_channel) >> 4};
-
-                    WriteToDeviceL1(device, producer_logical_core, CQ_ISSUE_READ_PTR, issue_queue_read_ptr);
-                    WriteToDeviceL1(device, producer_logical_core, CQ_ISSUE_WRITE_PTR, issue_queue_read_ptr);
-                    WriteToDeviceL1(device, consumer_logical_core, CQ_COMPLETION_READ_PTR, completion_queue_wr_ptr);
-                    WriteToDeviceL1(device, consumer_logical_core, CQ_COMPLETION_WRITE_PTR, completion_queue_wr_ptr);
-                    tt::Cluster::instance().l1_barrier(device->id());
-
-                    launch_msg_t msg = dispatch_program.kernels_on_core(producer_logical_core)->launch_msg;
-                    tt::llrt::write_launch_msg_to_core(device->id(), producer_physical_core, &msg);
-                    tt::llrt::write_launch_msg_to_core(device->id(), consumer_physical_core, &msg);
-
+                    CompileProgram(device, *command_queue_program_ptr);
                     cq_channel++;
-                    return 0;
+                    return command_queue_program_ptr;
                 });
         }
-
     }
 }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -26,11 +26,10 @@ uint32_t get_noc_multicast_encoding(const CoreCoord& top_left, const CoreCoord& 
 
 uint32_t get_noc_unicast_encoding(CoreCoord coord) { return NOC_XY_ENCODING(NOC_X(coord.x), NOC_Y(coord.y)); }
 
-ProgramMap ConstructProgramMap(const Device* device, Program& program, const CoreCoord& dispatch_logical_core) {
+ProgramMap ConstructProgramMap(const Device* device, Program& program) {
     /*
         TODO(agrebenisan): Move this logic to compile program
     */
-    CoreCoord dispatch_core = device->worker_core_from_logical_core(dispatch_logical_core);
     vector<transfer_info> runtime_arg_page_transfers;
     vector<transfer_info> cb_config_page_transfers;
     vector<transfer_info> program_page_transfers;
@@ -406,7 +405,7 @@ void EnqueueReadBufferCommand::process() {
     uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_channel);
     this->read_buffer_addr = this->manager.get_completion_queue_read_ptr(this->command_queue_channel);
 
-    const auto cmd = this->assemble_device_command(this->read_buffer_addr);
+    const DeviceCommand cmd = this->assemble_device_command(this->read_buffer_addr);
 
     this->manager.issue_queue_reserve_back(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, this->command_queue_channel);
     this->manager.cq_write(cmd.get_desc().data(), DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, write_ptr);
@@ -509,7 +508,6 @@ const DeviceCommand EnqueueWriteBufferCommand::assemble_device_command(uint32_t 
     command.set_data_size(padded_page_size * num_pages);
 
     TT_ASSERT(padded_page_size <= consumer_cb_size, "Page is too large to fit in consumer buffer");
-
     return command;
 }
 
@@ -517,7 +515,7 @@ void EnqueueWriteBufferCommand::process() {
     uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_channel);
     uint32_t system_memory_temporary_storage_address = write_ptr + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
 
-    const auto cmd = this->assemble_device_command(system_memory_temporary_storage_address);
+    const DeviceCommand cmd = this->assemble_device_command(system_memory_temporary_storage_address);
     uint32_t data_size_in_bytes = cmd.get_data_size();
 
     uint32_t cmd_size = DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + data_size_in_bytes;
@@ -550,10 +548,12 @@ EnqueueProgramCommand::EnqueueProgramCommand(
     ProgramMap& program_to_dev_map,
     SystemMemoryManager& manager,
     const Program& program,
-    bool stall
+    bool stall,
+    std::optional<std::reference_wrapper<Trace>> trace
     ) :
     command_queue_channel(command_queue_channel), buffer(buffer), program_to_dev_map(program_to_dev_map), manager(manager), program(program), stall(stall) {
     this->device = device;
+    this->trace = trace;
 }
 
 const DeviceCommand EnqueueProgramCommand::assemble_device_command(uint32_t host_data_src) {
@@ -675,6 +675,8 @@ void EnqueueProgramCommand::process() {
     this->manager.issue_queue_reserve_back(cmd_size, this->command_queue_channel);
     this->manager.cq_write(cmd.get_desc().data(), DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, write_ptr);
 
+    bool tracing = this->trace.has_value();
+    vector<uint32_t> trace_host_data;
     uint32_t start_addr = system_memory_temporary_storage_address;
     constexpr static uint32_t padding_alignment = 16;
     for (size_t kernel_id = 0; kernel_id < this->program.num_kernels(); kernel_id++) {
@@ -683,6 +685,11 @@ void EnqueueProgramCommand::process() {
             const auto & core_runtime_args = kernel->runtime_args(c);
             this->manager.cq_write(core_runtime_args.data(), core_runtime_args.size() * sizeof(uint32_t), system_memory_temporary_storage_address);
             system_memory_temporary_storage_address = align(system_memory_temporary_storage_address + core_runtime_args.size() * sizeof(uint32_t), padding_alignment);
+
+            if (tracing) {
+                trace_host_data.insert(trace_host_data.end(), core_runtime_args.begin(), core_runtime_args.end());
+                trace_host_data.resize(align(trace_host_data.size(), padding_alignment / sizeof(uint32_t)));
+            }
         }
     }
 
@@ -694,10 +701,20 @@ void EnqueueProgramCommand::process() {
             cb_data = {cb->address() >> 4, cb->size() >> 4, cb->num_pages(buffer_index), cb->size() / cb->num_pages(buffer_index) >> 4};
             this->manager.cq_write(cb_data.data(), padding_alignment, system_memory_temporary_storage_address);
             system_memory_temporary_storage_address += padding_alignment;
+            if (tracing) {
+                // No need to resize since cb_data size is guaranteed to be 16 bytes
+                trace_host_data.insert(trace_host_data.end(), cb_data.begin(), cb_data.end());
+            }
         }
     }
 
     this->manager.issue_queue_push_back(cmd_size, LAZY_COMMAND_QUEUE_MODE, this->command_queue_channel);
+    if (tracing) {
+        uint32_t trace_node_num_bytes = DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + sizeof(uint32_t) * trace_host_data.size();
+        Trace::TraceNode trace_node = {.command = cmd, .data = trace_host_data, .command_type = this->type(), .num_bytes = trace_node_num_bytes};
+        Trace& trace_ = trace.value();
+        trace_.record(trace_node);
+    }
 }
 
 EnqueueCommandType EnqueueProgramCommand::type() { return this->type_; }
@@ -712,7 +729,7 @@ const DeviceCommand FinishCommand::assemble_device_command(uint32_t) {
 
 void FinishCommand::process() {
     uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_channel);
-    const auto cmd = this->assemble_device_command(0);
+    const DeviceCommand cmd = this->assemble_device_command(0);
     uint32_t cmd_size = DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
     this->manager.issue_queue_reserve_back(cmd_size, this->command_queue_channel);
     this->manager.cq_write(cmd.get_desc().data(), DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, write_ptr);
@@ -728,6 +745,7 @@ EnqueueWrapCommand::EnqueueWrapCommand(uint32_t command_queue_channel, Device* d
 
 const DeviceCommand EnqueueWrapCommand::assemble_device_command(uint32_t) {
     DeviceCommand command;
+    command.wrap(this->wrap_region);
     return command;
 }
 
@@ -739,13 +757,9 @@ void EnqueueWrapCommand::process() {
     // To ensure that the issue queue write pointer does wrap, we need the wrap packet to be the full size of the issue queue
     uint32_t wrap_packet_size_bytes = std::min(space_left_in_bytes, DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND);
 
-    // Since all of the values will be 0, this will be equivalent to
-    // a bunch of NOPs
-    vector<uint32_t> command_vector(wrap_packet_size_bytes / sizeof(uint32_t), 0);
-    command_vector[DeviceCommand::wrap_idx] = (uint32_t)this->wrap_region;
-
+    const DeviceCommand cmd = this->assemble_device_command(0);
     this->manager.issue_queue_reserve_back(wrap_packet_size_bytes, this->command_queue_channel);
-    this->manager.cq_write(command_vector.data(), command_vector.size() * sizeof(uint32_t), write_ptr);
+    this->manager.cq_write(cmd.get_desc().data(), wrap_packet_size_bytes, write_ptr);
     if (this->wrap_region == DeviceCommand::WrapRegion::COMPLETION) {
         // Wrap the read pointers for completion queue because device will start writing data at head of completion queue and there are no more reads to be done at current completion queue write pointer
         // If we don't wrap the read then the subsequent read buffer command may attempt to read past the total command queue size
@@ -760,24 +774,28 @@ void EnqueueWrapCommand::process() {
 EnqueueCommandType EnqueueWrapCommand::type() { return this->type_; }
 
 // CommandQueue section
-CommandQueue::CommandQueue(Device* device, uint32_t command_queue_channel): manager(*device->sysmem_manager) {
+CommandQueue::CommandQueue(Device* device, uint32_t command_queue_channel): manager(*device->manager) {
     this->device = device;
     this->command_queue_channel = command_queue_channel;
 
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
     this->command_queue_channel_size = tt::Cluster::instance().get_host_channel_size(mmio_device_id, tt::Cluster::instance().get_assigned_channel_for_device(mmio_device_id)) / device->producer_cores().size();
 
-    uint32_t channel_idx = 0;
-    const auto& dispatch_cores = device->consumer_cores();
-    if (auto it = std::find_if(dispatch_cores.begin(), dispatch_cores.end(),
-        [&channel_idx, &command_queue_channel](const CoreCoord& coord) {
-            return (channel_idx++ == command_queue_channel);
+    const auto get_used_core = [this, &command_queue_channel](const set<CoreCoord>& cores, CoreCoord& target) {
+        uint32_t channel_idx = 0;
+        if (auto it = std::find_if(cores.begin(), cores.end(),
+            [&channel_idx, &command_queue_channel](const CoreCoord& coord) {
+                return (channel_idx++ == command_queue_channel);
+            }
+        ); it != cores.end()) {
+            target = *it;
+        } else {
+            TT_THROW("Could not find a dispatch core for the provided channel");
         }
-    ); it != dispatch_cores.end()) {
-        this->dispatch_core = *it;
-    } else {
-        TT_THROW("Could not find a dispatch core for the provided channel");
-    }
+    };
+
+    get_used_core(device->producer_cores(), this->producer_core);
+    get_used_core(device->consumer_cores(), this->consumer_core);
 }
 
 CommandQueue::~CommandQueue() {}
@@ -843,7 +861,7 @@ void CommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking)
     uint32_t src_page_index = 0;
     while (total_pages_to_read > 0) {
         if ((this->manager.get_issue_queue_write_ptr(this->command_queue_channel)) + read_buffer_command_size >= this->manager.get_issue_queue_limit(this->command_queue_channel)) {
-            this->wrap();
+            this->wrap(DeviceCommand::WrapRegion::ISSUE, blocking);
         }
 
         const uint32_t command_completion_limit = this->manager.get_completion_queue_limit(this->command_queue_channel);
@@ -890,9 +908,7 @@ void CommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking)
 }
 
 void CommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking) {
-
     ZoneScopedN("CommandQueue_write_buffer");
-    TT_FATAL(not blocking, "EnqueueWriteBuffer only has support for non-blocking mode currently");
 
     // TODO(agrebenisan): Fix these asserts after implementing multi-core CQ
     TT_ASSERT(
@@ -918,7 +934,7 @@ void CommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool bl
         uint32_t pages_to_write = std::min(total_pages_to_write, (uint32_t)num_pages_available);
         if (pages_to_write == 0) {
             // No space for command and data
-            this->wrap();
+            this->wrap(DeviceCommand::WrapRegion::ISSUE, blocking);
             num_pages_available = (int32_t(command_issue_limit - this->manager.get_issue_queue_write_ptr(this->command_queue_channel)) - int32_t(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND)) / int32_t(padded_page_size);
             pages_to_write = std::min(total_pages_to_write, (uint32_t)num_pages_available);
         }
@@ -932,7 +948,7 @@ void CommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool bl
     }
 }
 
-void CommandQueue::enqueue_program(Program& program, bool blocking) {
+void CommandQueue::enqueue_program(Program& program, std::optional<std::reference_wrapper<Trace>> trace, bool blocking) {
     ZoneScopedN("CommandQueue_enqueue_program");
     TT_FATAL(not blocking, "EnqueueProgram only has support for non-blocking mode currently");
 
@@ -948,7 +964,7 @@ void CommandQueue::enqueue_program(Program& program, bool blocking) {
     map<uint64_t, unique_ptr<Buffer>>& program_to_buffer = this->program_to_buffer(this->device->id());
     if (not program_to_buffer.count(program_id)) {
         stall = true;
-        ProgramMap program_to_device_map = ConstructProgramMap(this->device, program, this->dispatch_core);
+        ProgramMap program_to_device_map = ConstructProgramMap(this->device, program);
 
         vector<uint32_t>& program_pages = program_to_device_map.program_pages;
         uint32_t program_data_size_in_bytes = program_pages.size() * sizeof(uint32_t);
@@ -964,16 +980,6 @@ void CommandQueue::enqueue_program(Program& program, bool blocking) {
 
         map<uint64_t, ProgramMap>& program_to_dev_map = this->program_to_dev_map(device->id());
         program_to_dev_map.emplace(program_id, std::move(program_to_device_map));
-
-        const char *READ_BACK_PROGRAMS = std::getenv("TT_METAL_READ_BACK_PROGRAMS");
-        if (READ_BACK_PROGRAMS != nullptr) {
-            tt::log_debug(tt::LogDispatch, "Reading back binary");
-            vector<uint32_t> read_back;
-            read_back.resize(program_to_dev_map[program_id].program_pages.size());
-            this->enqueue_read_buffer(*program_to_buffer.at(program_id), read_back.data(), true);
-            TT_ASSERT(read_back == program_to_dev_map[program_id].program_pages, "Binary sent to device differs from that read back");
-            tt::log_debug(tt::LogDispatch, "Binary matched");
-        }
     }
 
     tt::log_debug(tt::LogDispatch, "EnqueueProgram for channel {}", this->command_queue_channel);
@@ -985,9 +991,9 @@ void CommandQueue::enqueue_program(Program& program, bool blocking) {
 
     if ((this->manager.get_issue_queue_write_ptr(this->command_queue_channel)) + host_data_and_device_command_size >=
         this->manager.get_issue_queue_size(this->command_queue_channel)) {
-        TT_ASSERT(
+        TT_FATAL(
             host_data_and_device_command_size <= this->manager.get_issue_queue_size(this->command_queue_channel) - CQ_START, "EnqueueProgram command size too large");
-        this->wrap();
+        this->wrap(DeviceCommand::WrapRegion::ISSUE, blocking);
     }
 
     EnqueueProgramCommand command(
@@ -997,26 +1003,16 @@ void CommandQueue::enqueue_program(Program& program, bool blocking) {
         this->program_to_dev_map(this->device->id()).at(program_id),
         this->manager,
         program,
-        stall);
+        stall,
+        trace);
 
     this->enqueue_command(command, blocking);
 }
 
-void CommandQueue::finish() {
-    ZoneScopedN("CommandQueue_finish");
-    if ((this->manager.get_issue_queue_write_ptr(this->command_queue_channel)) + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND >=
-        this->manager.get_issue_queue_limit(this->command_queue_channel)) {
-        this->wrap();
-    }
-    tt::log_debug(tt::LogDispatch, "Finish for channel {}", this->command_queue_channel);
-
-    FinishCommand command(this->command_queue_channel, this->device, this->manager);
-    this->enqueue_command(command, false);
-
+void CommandQueue::wait_finish() {
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device->id());
 
-    // We then poll to check that we're done.
     uint32_t finish_addr_offset = this->command_queue_channel * this->command_queue_channel_size;
     uint32_t finish;
     do {
@@ -1033,6 +1029,19 @@ void CommandQueue::finish() {
     tt::Cluster::instance().write_sysmem(&finish, 4, HOST_CQ_FINISH_PTR + finish_addr_offset, mmio_device_id, channel);
 }
 
+void CommandQueue::finish() {
+    ZoneScopedN("CommandQueue_finish");
+    if ((this->manager.get_issue_queue_write_ptr(this->command_queue_channel)) + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND >=
+        this->manager.get_issue_queue_limit(this->command_queue_channel)) {
+        this->wrap(DeviceCommand::WrapRegion::ISSUE, false);
+    }
+    tt::log_debug(tt::LogDispatch, "Finish for channel {}", this->command_queue_channel);
+
+    FinishCommand command(this->command_queue_channel, this->device, this->manager);
+    this->enqueue_command(command, false);
+    this->wait_finish();
+}
+
 void CommandQueue::wrap(DeviceCommand::WrapRegion wrap_region, bool blocking) {
     ZoneScopedN("CommandQueue_wrap");
     tt::log_debug(tt::LogDispatch, "EnqueueWrap for channel {}", this->command_queue_channel);
@@ -1040,9 +1049,66 @@ void CommandQueue::wrap(DeviceCommand::WrapRegion wrap_region, bool blocking) {
     this->enqueue_command(command, blocking);
 }
 
+void CommandQueue::reset() {
+    // Place the cores into reset since need to update a lot of core info
+    tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->device->id(), this->device->worker_core_from_logical_core(this->producer_core)));
+    tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->device->id(), this->device->worker_core_from_logical_core(this->consumer_core)));
+    tt::Cluster::instance().l1_barrier(this->device->id());
+
+    detail::CommandQueueInit(this->device, this->producer_core, this->consumer_core, this->manager, this->command_queue_channel);
+}
+
+void CommandQueue::launch(launch_msg_t& msg) {
+    tt::Cluster::instance().deassert_risc_reset_at_core(tt_cxy_pair(this->device->id(), this->device->worker_core_from_logical_core(this->producer_core)));
+    tt::Cluster::instance().deassert_risc_reset_at_core(tt_cxy_pair(this->device->id(), this->device->worker_core_from_logical_core(this->consumer_core)));
+
+    std::unordered_set<CoreCoord> not_done_cores = {
+        this->device->worker_core_from_logical_core(this->producer_core),
+        this->device->worker_core_from_logical_core(this->consumer_core)};
+
+    llrt::internal_::wait_until_cores_done(this->device->id(), RUN_MSG_INIT, not_done_cores);
+
+    tt::llrt::write_launch_msg_to_core(this->device->id(), this->device->worker_core_from_logical_core(this->producer_core), &msg);
+    tt::llrt::write_launch_msg_to_core(this->device->id(), this->device->worker_core_from_logical_core(this->consumer_core), &msg);
+    llrt::internal_::wait_until_cores_done(this->device->id(), RUN_MSG_GO, not_done_cores);
+}
+
+Trace::Trace(CommandQueue& command_queue): command_queue(command_queue) {
+    this->trace_complete = false;
+    this->num_bytes = 0;
+}
+
+void Trace::record(const TraceNode& trace_node) {
+    TT_ASSERT(not this->trace_complete, "Cannot record any more for a completed trace");
+    this->num_bytes += trace_node.num_bytes;
+    this->history.push_back(trace_node);
+}
+
+void Trace::create_replay() {
+    this->command_queue.reset();
+
+    // Reconstruct the hugepage from the command cache
+    SystemMemoryManager& manager = this->command_queue.manager;
+    const uint32_t command_queue_channel = this->command_queue.command_queue_channel;
+    const bool lazy_push = true;
+    for (auto& [device_command, data, command_type, num_bytes]: this->history) {
+        uint32_t issue_write_ptr = manager.get_issue_queue_write_ptr(command_queue_channel);
+        device_command.update_buffer_transfer_src(0, issue_write_ptr + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND);
+        manager.cq_write(device_command.get_desc().data(), DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, issue_write_ptr);
+        manager.issue_queue_push_back(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, lazy_push, command_queue_channel);
+
+        uint32_t host_data_size = align(data.size() * sizeof(uint32_t), 16);
+        manager.cq_write(data.data(), host_data_size, manager.get_issue_queue_write_ptr(command_queue_channel));
+        vector<uint32_t> read_back(host_data_size / sizeof(uint32_t), 0);
+        tt::Cluster::instance().read_sysmem(read_back.data(), host_data_size, issue_write_ptr + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, 0, 0);
+        manager.issue_queue_push_back(host_data_size, lazy_push, command_queue_channel);
+    }
+}
+
 void EnqueueReadBuffer(CommandQueue& cq, Buffer& buffer, vector<uint32_t>& dst, bool blocking) {
     // TODO(agrebenisan): Move to deprecated
-    detail::DispatchStateCheck(true);
+    ZoneScoped;
+    tt_metal::detail::DispatchStateCheck(true);
     TT_FATAL(blocking, "Non-blocking EnqueueReadBuffer not yet supported");
 
     // Only resizing here to keep with the original implementation. Notice how in the void*
@@ -1053,35 +1119,39 @@ void EnqueueReadBuffer(CommandQueue& cq, Buffer& buffer, vector<uint32_t>& dst, 
 
 void EnqueueWriteBuffer(CommandQueue& cq, Buffer& buffer, vector<uint32_t>& src, bool blocking) {
     // TODO(agrebenisan): Move to deprecated
-    detail::DispatchStateCheck(true);
+    ZoneScoped;
+    tt_metal::detail::DispatchStateCheck(true);
     cq.enqueue_write_buffer(buffer, src.data(), blocking);
 }
 
 void EnqueueReadBuffer(CommandQueue& cq, Buffer& buffer, void* dst, bool blocking) {
-    detail::DispatchStateCheck(true);
+    ZoneScoped;
+    tt_metal::detail::DispatchStateCheck(true);
     cq.enqueue_read_buffer(buffer, dst, blocking);
 }
 
 void EnqueueWriteBuffer(CommandQueue& cq, Buffer& buffer, const void* src, bool blocking) {
-    detail::DispatchStateCheck(true);
+    ZoneScoped;
+    tt_metal::detail::DispatchStateCheck(true);
     cq.enqueue_write_buffer(buffer, src, blocking);
 }
 
-void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking) {
+void EnqueueProgram(CommandQueue& cq, Program& program, bool blocking, std::optional<std::reference_wrapper<Trace>> trace) {
     ZoneScoped;
     TT_ASSERT(cq.command_queue_channel == 0, "EnqueueProgram only supported on first command queue on device for time being.");
-    detail::DispatchStateCheck(true);
+    tt_metal::detail::DispatchStateCheck(true);
 
     detail::CompileProgram(cq.device, program);
 
     program.allocate_circular_buffers();
     detail::ValidateCircularBufferRegion(program, cq.device);
 
-    cq.enqueue_program(program, blocking);
+    cq.enqueue_program(program, trace, blocking);
 }
 
 void Finish(CommandQueue& cq) {
-    detail::DispatchStateCheck(true);
+    ZoneScoped;
+    tt_metal::detail::DispatchStateCheck(true);
     cq.finish();
 }
 
@@ -1089,6 +1159,45 @@ void ClearProgramCache(CommandQueue& cq) {
     detail::DispatchStateCheck(true);
     cq.program_to_buffer(cq.device->id()).clear();
     cq.program_to_dev_map(cq.device->id()).clear();
+}
+
+Trace BeginTrace(CommandQueue& command_queue) {
+    Finish(command_queue); // Ensures that nothing being executed in command queue prior to beginning our trace
+    // Resets the command queue state
+    command_queue.reset();
+    Program& command_queue_program = *command_queue.device->command_queue_programs[command_queue.command_queue_channel];
+    launch_msg_t msg = command_queue_program.kernels_on_core(command_queue.producer_core)->launch_msg;
+    command_queue.launch(msg);
+
+    return Trace(command_queue);
+}
+
+void EndTrace(Trace& trace) {
+    TT_ASSERT(not trace.trace_complete, "Already completed this trace");
+    Finish(trace.command_queue);
+    SystemMemoryManager& manager = trace.command_queue.manager;
+    const uint32_t command_queue_channel = trace.command_queue.command_queue_channel;
+    TT_FATAL(trace.num_bytes <= manager.get_issue_queue_limit(command_queue_channel), "Trace does not fit in system memory");
+    trace.trace_complete = true;
+    trace.create_replay();
+
+    // Resend dispatch kernels to device with updated limits
+    manager.set_custom_issue_limit_for_trace(command_queue_channel, trace.num_bytes);
+    trace.command_queue.reset();
+    CommandQueue& command_queue = trace.command_queue;
+    Program& command_queue_program = *command_queue.device->command_queue_programs[command_queue_channel];
+    launch_msg_t msg = command_queue_program.kernels_on_core(command_queue.producer_core)->launch_msg;
+    command_queue.launch(msg);
+}
+
+void EnqueueTrace(Trace& trace, bool blocking) {
+    // Run the trace
+    trace.command_queue.manager.issue_queue_push_back(trace.num_bytes, false, trace.command_queue.command_queue_channel);
+
+    // This will block because the wr toggles will be different between the host and the device
+    if (blocking) {
+        trace.command_queue.manager.issue_queue_reserve_back(0, trace.command_queue.command_queue_channel);
+    }
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -69,6 +69,11 @@ void DeviceCommand::set_producer_consumer_transfer_num_pages(const uint32_t prod
     this->desc[this->producer_consumer_transfer_num_pages_idx] = producer_consumer_transfer_num_pages;
 }
 
+void DeviceCommand::update_buffer_transfer_src(const uint8_t buffer_transfer_idx, const uint32_t new_src) {
+    this->desc[DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER + buffer_transfer_idx * DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION] = new_src;
+}
+
+
 void DeviceCommand::add_buffer_transfer_instruction(
     const uint32_t src,
     const uint32_t dst,
@@ -141,7 +146,6 @@ void DeviceCommand::add_buffer_transfer_instruction_sharded(
 void DeviceCommand::write_program_entry(const uint32_t value) {
     this->desc.at(this->program_transfer_idx) = value;
     this->program_transfer_idx++;
-
 }
 
 void DeviceCommand::add_write_page_partial_instruction(

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -104,6 +104,8 @@ class DeviceCommand {
         const uint32_t dst_page_index
     );
 
+    void update_buffer_transfer_src(const uint8_t buffer_transfer_idx, const uint32_t new_src);
+
     void add_buffer_transfer_instruction_sharded(
         const uint32_t src,
         const uint32_t dst,

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp"
-// #include "debug/dprint.h"
 
 // The read interface for the issue region is set up on the device, the write interface belongs to host
 // Opposite for completion region where device sets up the write interface and host owns read interface
@@ -56,13 +55,13 @@ void kernel_main() {
         if ((DeviceCommand::WrapRegion)wrap == DeviceCommand::WrapRegion::COMPLETION) {
             cq_write_interface.completion_fifo_wr_ptr = completion_queue_start_addr >> 4;     // Head to the beginning of the completion region
             cq_write_interface.completion_fifo_wr_toggle = not cq_write_interface.completion_fifo_wr_toggle;
-            notify_host_of_completion_queue_write_pointer();
+            notify_host_of_completion_queue_write_pointer<host_completion_queue_write_ptr_addr>();
         } else if (is_program) {
             write_and_launch_program(program_transfer_start_addr, num_pages, command_ptr, producer_noc_encoding, consumer_cb_size, consumer_cb_num_pages, producer_consumer_transfer_num_pages, db_buf_switch);
             wait_for_program_completion(num_workers);
         } else {
             command_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(buffer_transfer_start_addr);
-            write_buffers(command_ptr, completion_queue_start_addr, num_buffer_transfers,  sharded_buffer_num_cores, consumer_cb_size, consumer_cb_num_pages, producer_noc_encoding, producer_consumer_transfer_num_pages, db_buf_switch);
+            write_buffers<host_completion_queue_write_ptr_addr>(command_ptr, completion_queue_start_addr, num_buffer_transfers,  sharded_buffer_num_cores, consumer_cb_size, consumer_cb_num_pages, producer_noc_encoding, producer_consumer_transfer_num_pages, db_buf_switch);
         }
 
         if (finish) {

--- a/tt_metal/impl/dispatch/kernels/command_queue_producer.cpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_producer.cpp
@@ -62,7 +62,9 @@ void setup_issue_queue_read_interface(const uint32_t issue_region_rd_ptr, const 
 void kernel_main() {
     constexpr uint32_t host_issue_queue_read_ptr_addr = get_compile_time_arg_val(0);
     constexpr uint32_t issue_queue_start_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t issue_queue_size = get_compile_time_arg_val(2);
+
+    // Only the issue queue size is a runtime argument
+    uint32_t issue_queue_size = get_arg_val<uint32_t>(0);
 
     setup_issue_queue_read_interface(issue_queue_start_addr, issue_queue_size);
 
@@ -107,7 +109,7 @@ void kernel_main() {
             // Basically popfront without the extra conditional
             cq_read_interface.issue_fifo_rd_ptr = cq_read_interface.issue_fifo_limit - cq_read_interface.issue_fifo_size;  // Head to beginning of command queue
             cq_read_interface.issue_fifo_rd_toggle = not cq_read_interface.issue_fifo_rd_toggle;
-            notify_host_of_issue_queue_read_pointer();
+            notify_host_of_issue_queue_read_pointer<host_issue_queue_read_ptr_addr>();
             continue;
         }
 
@@ -142,7 +144,7 @@ void kernel_main() {
             producer_consumer_transfer_num_pages,
             db_buf_switch);
 
-        issue_queue_pop_front(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + data_size);
+        issue_queue_pop_front<host_issue_queue_read_ptr_addr>(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + data_size);
 
         db_buf_switch = not db_buf_switch;
     }


### PR DESCRIPTION
In this PR, we support the ability to make a trace (capturing a sequence of programs and replaying them).

We only support adding EnqueueProgram to the trace. Once you create a trace, it is undefined behaviour to continue using the EnqueueProgram APIs. You must call EnqueueTrace to get predictable behaviour.

If you would like to EnqueuePrograms and WriteBuffers, for now, you must use two command queues. One command queue to run the programs, and another to store and load the buffer data.