### PR TITLE
#4620: Improve test_pgm_dispatch

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/pgm_dispatch_perf.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/pgm_dispatch_perf.cpp
@@ -2,77 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// NULL kernel is not 0 length so this is smaller than you might think
-#if KERNEL_BYTES >= 256
-uint64_t data1[30] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 512
-uint64_t data2[32] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 1024
-uint64_t data3[64] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 2 * 1024
-uint64_t data4[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 3 * 1024
-uint64_t data5[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 4 * 1024
-uint64_t data6[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 5 * 1024
-uint64_t data7[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 6 * 1024
-uint64_t data8[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 7 * 1024
-uint64_t data9[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 8 * 1024
-uint64_t data10[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 9 * 1024
-uint64_t data11[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 10 * 1024
-uint64_t data12[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 11 * 1024
-uint64_t data13[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 12 * 1024
-uint64_t data14[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 13 * 1024
-uint64_t data15[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 14 * 1024
-uint64_t data16[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 15 * 1024
-uint64_t data17[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
-#endif
-
-#if KERNEL_BYTES >= 16 * 1024
-uint64_t data18[128] __attribute__ ((section ("l1_data"))) __attribute__((used));
+// NULL kernel is not 0, subtract off overhead
+#if KERNEL_BYTES > 30
+uint8_t data1[KERNEL_BYTES-30] __attribute__ ((section ("l1_data"))) __attribute__((used));
 #endif
 
 #ifdef COMPILE_FOR_TRISC

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -26,7 +26,12 @@ uint8_t noc_index = NOC_INDEX;
 
 void kernel_launch() {
 
-#if !defined(DEBUG_NULL_KERNELS) || defined(DISPATCH_KERNEL)
+#if defined(DEBUG_NULL_KERNELS) && !defined(DISPATCH_KERNEL)
+#ifdef KERNEL_RUN_TIME
+    uint64_t end_time = c_tensix_core::read_wall_clock() + KERNEL_RUN_TIME;
+    while (c_tensix_core::read_wall_clock() < end_time);
+#endif
+#else
     firmware_kernel_common_init((void tt_l1_ptr *)MEM_BRISC_INIT_LOCAL_L1_BASE);
 
     noc_local_state_init(noc_index);

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "risc_common.h"
+#include "tensix.h"
+#include "tensix_types.h"
+#include "noc.h"
 #include "noc_overlay_parameters.h"
 #include "noc_nonblocking_api.h"
 #include "stream_io_map.h"
@@ -13,6 +16,7 @@
 #include "tools/profiler/kernel_profiler.hpp"
 #include "dataflow_api.h"
 #include "tensix_functions.h"
+#include "c_tensix_core.h"
 
 #include "kernel.cpp"
 
@@ -24,7 +28,12 @@ uint32_t noc_nonposted_writes_acked[NUM_NOCS];
 
 void kernel_launch() {
 
-#if !defined(DEBUG_NULL_KERNELS) || defined(DISPATCH_KERNEL)
+#if defined(DEBUG_NULL_KERNELS) && !defined(DISPATCH_KERNEL)
+#ifdef KERNEL_RUN_TIME
+    uint64_t end_time = c_tensix_core::read_wall_clock() + KERNEL_RUN_TIME;
+    while (c_tensix_core::read_wall_clock() < KERNEL_RUN_TIME);
+#endif
+#else
     firmware_kernel_common_init((void tt_l1_ptr *)MEM_NCRISC_INIT_LOCAL_L1_BASE);
 
     noc_local_state_init(noc_index);

--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -31,7 +31,11 @@ volatile tt_reg_ptr uint * pc_buf_base = reinterpret_cast<volatile uint *>(PC_BU
 
 void kernel_launch()
 {
-#if !defined(DEBUG_NULL_KERNELS) || defined(DISPATCH_KERNEL)
+#if defined(DEBUG_NULL_KERNELS) && !defined(DISPATCH_KERNEL)
+#ifdef KERNEL_RUN_TIME
+    ckernel::wait(KERNEL_RUN_TIME);
+#endif
+#else
     tt_l1_ptr uint *local_l1_start_addr = (tt_l1_ptr uint *)PREPROCESSOR_EXPAND(MEM_TRISC, COMPILE_FOR_TRISC, _INIT_LOCAL_L1_BASE);
     firmware_kernel_common_init(local_l1_start_addr);
 


### PR DESCRIPTION
Simplify sizing
Add -r for kernel run time in cycles
Add -z for lazy mode
Add -f to time just the finish call (w/ lazy mode)