### PR TITLE
#0: dont import fallback_ops by default

### DIFF
--- a/tt_eager/tt_lib/__init__.py
+++ b/tt_eager/tt_lib/__init__.py
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ._C import tensor, device, dtx, profiler, program_cache, operations, ttnn
-from . import fallback_ops


### PR DESCRIPTION
#0: dont import fallback_ops by default
this improves the 'import tt_lib' time from approx 1s -> 0.03s.

CI Runs: https://github.com/tenstorrent-metal/tt-metal/actions/runs/7494509153