### PR TITLE
#4632: Add dprint server support for eth cores

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/erisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/erisc_print.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint_test_common.h"
+
+/*
+ * Test printing from a kernel running on BRISC.
+*/
+
+void kernel_main() {
+    DPRINT << "Test Debug Print: ERISC" << ENDL();
+    print_test_data();
+}

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dprint_fixture.hpp"
+#include "gtest/gtest.h"
+#include "test_utils.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+
+////////////////////////////////////////////////////////////////////////////////
+// A test for printing from ethernet cores.
+////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+const std::string golden_output =
+R"(Test Debug Print: ERISC
+Basic Types:
+101-1.618@0.122559
+SETPRECISION/FIXED/DEFAULTFLOAT:
+3.1416
+3.14159012
+3.14159
+3.141590118
+SETW:
+    123456123456  ab
+HEX/OCT/DEC:
+1e240361100123456)";
+
+static void RunTest(DPrintFixture* fixture, Device* device) {
+    // Try printing on all ethernet cores on this device
+    int count = 0;
+    for (const auto& core : device->get_active_ethernet_cores()) {
+    // Set up program and command queue
+    Program program = Program();
+
+        // Create the kernel
+        KernelHandle erisc_kernel_id = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/erisc_print.cpp",
+            core,
+            tt_metal::experimental::EthernetConfig{
+                .eth_mode = tt_metal::Eth::RECEIVER,
+                .noc = tt_metal::NOC::NOC_0
+            }
+        );
+
+        // Run the program
+        log_info(
+            tt::LogTest,
+            "Running print test on eth core {}:({},{})",
+            device->id(),
+            core.x,
+            core.y
+        );
+        fixture->RunProgram(device, program);
+
+        // Check the print log against golden output.
+        EXPECT_TRUE(
+            FilesMatchesString(
+                DPrintFixture::dprint_file_name,
+                golden_output
+            )
+        );
+
+        // Clear the log file for the next core's test
+        tt::DPrintServerClearLogFile();
+    }
+}
+
+TEST_F(DPrintFixture, TestPrintEthCores) {
+    if (!this->slow_dispatch_) {
+        log_info(
+            tt::LogTest,
+            "Skipping test due to fast dispatch dprint unsupported on eth cores."
+        );
+        GTEST_SKIP();
+    }
+    for (Device* device : this->devices_) {
+        // Skip if no ethernet cores on this device
+        if (device->get_active_ethernet_cores().size() == 0) {
+            log_info(tt::LogTest, "Skipping device {} due to no ethernet cores...", device->id());
+            continue;
+        }
+        this->RunTestOnDevice(RunTest, device);
+    }
+}

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
@@ -32,8 +32,8 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
     // Try printing on all ethernet cores on this device
     int count = 0;
     for (const auto& core : device->get_active_ethernet_cores()) {
-    // Set up program and command queue
-    Program program = Program();
+        // Set up program and command queue
+        Program program = Program();
 
         // Create the kernel
         KernelHandle erisc_kernel_id = CreateKernel(

--- a/tt_metal/hw/inc/debug/dprint_test_common.h
+++ b/tt_metal/hw/inc/debug/dprint_test_common.h
@@ -18,8 +18,11 @@ inline void print_test_data() {
     DPRINT << DEFAULTFLOAT();
     DPRINT << "SETW:\n" << SETW(10) << my_int << my_int << SETW(4) << "ab" << ENDL();
     DPRINT << "HEX/OCT/DEC:\n" << HEX() << my_int << OCT() << my_int << DEC() << my_int << ENDL();
+#ifndef COMPILE_FOR_ERISC
+    // Eth cores don't have CBs, so don't try TSLICE printing.
     DPRINT << "SLICE:\n";
     cb_wait_front(tt::CB::c_in0, 1);
     DPRINT << TSLICE(tt::CB::c_in0, 0, SliceRange::hw0_32_8());
     DPRINT << TSLICE(tt::CB::c_in0, 0, SliceRange::hw0_32_4());
+#endif
 }

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -22,6 +22,7 @@ enum DebugPrintHartFlags : unsigned int {
 };
 
 constexpr int DPRINT_NRISCVS = 5;
+constexpr int DPRINT_NRISCVS_ETH = 1;
 
 /*
 @brief Attaches a device to be monitored by the print server. If no devices were present on the


### PR DESCRIPTION
Adding support for dprint from ethernet cores:
- Server-side changes to include reading from ethernet cores. Main difference here is that the ethernet cores only have 1 risc and the print buffer address is different.
- Small device-side fix to context switch while waiting for room in the print buffer (erisc only)
- Add a test that prints from all active ethernet cores

CI running: https://github.com/tenstorrent-metal/tt-metal/actions/runs/7506100051