### PR TITLE
#4311: Automate determining and scheduling RC generation

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -2,6 +2,10 @@ name: Package and release
 
 on:
   workflow_dispatch:
+  schedule:
+    # Create rc every day at EOD of PST Mon-Wed + night of Sunday to kick off
+    # releases for beginning of work week
+    - cron: "0 1 * * 1,2,3,4"
 
 permissions:
   contents: write

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -1,8 +1,6 @@
 name: Package and release
 
 on:
-  push:
-    branches: ["release"]
   workflow_dispatch:
 
 permissions:
@@ -14,14 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       is-release-candidate: ${{ steps.get-is-release-candidate.outputs.is-release-candidate }}
+      should-create-release: ${{ steps.get-should-create-release.outputs.should-create-release }}
     steps:
       - name: Get is-release-candidate
         id: get-is-release-candidate
         run: |
-          isReleaseCandidate=${{ github.ref_type == 'branch' && github.event_name == 'push' }}
+          # A workflow dispatch on a tag is considered a release run for us.
+          isReleaseCandidate=${{ !(github.ref_type == 'tag' && github.event_name == 'workflow_dispatch') }}
           echo "is-release-candidate=$isReleaseCandidate" >> "$GITHUB_OUTPUT"
+      - name: Get should-create-release
+        id: get-should-create-release
+        run: |
+          # Run once to check for errors
+          ./scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && "--release-candidate" }}
+          shouldCreateRelease=$(scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && "--release-candidate" }})
+          echo "should-create-release=$shouldCreateRelease" >> "$GITHUB_OUTPUT"
   create-tag:
-    needs: [get-params]
+    needs: get-params
+    if: ${{ fromJSON(needs.get-params.outputs.should-create-release) }}
     uses: tenstorrent-metal/metal-workflows/.github/workflows/release-verify-or-create-tag.yaml@main
     with:
       fetch_depth: 0
@@ -30,8 +38,8 @@ jobs:
     secrets:
       CHECKOUT_TOKEN: ${{ secrets.CHECKOUT_TOKEN }}
   create-changelog:
-    permissions: read-all
     needs: create-tag
+    permissions: read-all
     runs-on: ubuntu-latest
     steps:
       - name: Create changelog

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -18,6 +18,8 @@ jobs:
       is-release-candidate: ${{ steps.get-is-release-candidate.outputs.is-release-candidate }}
       should-create-release: ${{ steps.get-should-create-release.outputs.should-create-release }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Get is-release-candidate
         id: get-is-release-candidate
         run: |

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -28,8 +28,8 @@ jobs:
         id: get-should-create-release
         run: |
           # Run once to check for errors
-          ./scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && "--release-candidate" }}
-          shouldCreateRelease=$(scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && "--release-candidate" }})
+          ./scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && '--release-candidate' }}
+          shouldCreateRelease=$(scripts/build_scripts/get_should_create_release.sh ${{ fromJSON(steps.get-is-release-candidate.outputs.is-release-candidate) && '--release-candidate' }})
           echo "should-create-release=$shouldCreateRelease" >> "$GITHUB_OUTPUT"
   create-tag:
     needs: get-params

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-tags: true
       - name: Get is-release-candidate
         id: get-is-release-candidate
         run: |

--- a/scripts/build_scripts/get_should_create_release.sh
+++ b/scripts/build_scripts/get_should_create_release.sh
@@ -51,9 +51,9 @@ if [ -z "$tags_at_head" ]; then
   all_rc_tags=false
 fi
 
-# WAIT WE MUST CONSIDER REPLAY OF RELEASE PIPELINE, probably ok because we just
-# redo jobs that failed only per tag...
-#
+# We considered issues that could arise by replaying a release pipeline, but
+# probably ok because we just redo jobs that failed only per tag...
+
 # If there are any tags in release_candidate mode, then we should not generate
 # any candidates because there are no releases created based off it
 if $release_candidate; then

--- a/scripts/build_scripts/get_should_create_release.sh
+++ b/scripts/build_scripts/get_should_create_release.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -eo pipefail
+
+release_candidate=false
+
+# Parse command line arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --release-candidate)
+      release_candidate=true
+      ;;
+    *)
+      echo "Error: Unknown option: $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# Function to check if a tag has "-rc" in its name
+is_rc_tag() {
+  tag_name="$1"
+  if [[ "$tag_name" == *"-rc"* ]]; then
+    # "True" value in bash, because it's a return code thing
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Check if the script is invoked inside a git repository
+if [ ! -d .git ]; then
+  echo "Error: Not a git repository."
+  exit 1
+fi
+
+# Check if there are any tags at the HEAD of the current branch
+tags_at_head=$(git tag --points-at HEAD)
+
+# Determine if any tags at the HEAD of the current branch have "-rc" in the name
+all_rc_tags=true
+
+for tag in $tags_at_head; do
+  if ! is_rc_tag "$tag"; then
+    all_rc_tags=false
+  fi
+done
+
+if [ -z "$tags_at_head" ]; then
+  all_rc_tags=false
+fi
+
+# WAIT WE MUST CONSIDER REPLAY OF RELEASE PIPELINE, probably ok because we just
+# redo jobs that failed only per tag...
+#
+# If there are any tags in release_candidate mode, then we should not generate
+# any candidates because there are no releases created based off it
+if $release_candidate; then
+  if [ -z "$tags_at_head" ]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+else
+  if [ -z "$tags_at_head" ]; then
+    echo "Error: No tags at HEAD of repo"
+    exit 1
+  elif $all_rc_tags; then
+    echo "true"
+  elif ! $all_rc_tags; then
+    echo "false"
+  else
+    echo "Error: We should never be coming into this branch, but made it for pattern matching practices"
+    exit 1
+  fi
+fi
+


### PR DESCRIPTION
- Create new script to determine whether to create release, also using existence rc as an input
- Integrate script into CI
- Remove release branch trigger for package + release