### PR TITLE
Aliu/fd tunneling pr

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
@@ -33,9 +33,11 @@ class DeviceFixture : public ::testing::Test {
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     }
 
     void TearDown() override {
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }

--- a/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
@@ -27,6 +27,7 @@ class N300DeviceFixture : public ::testing::Test {
                 auto* device = tt::tt_metal::CreateDevice(id);
                 devices_.push_back(device);
             }
+            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
 
         } else {
             GTEST_SKIP();
@@ -34,6 +35,7 @@ class N300DeviceFixture : public ::testing::Test {
     }
 
     void TearDown() override {
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -53,9 +53,11 @@ protected:
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     }
 
     void TearDown() override {
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
         // Close all opened devices
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -51,9 +51,11 @@ class CommandQueueMultiDeviceFixture : public ::testing::Test {
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     }
 
     void TearDown() override {
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }
@@ -83,9 +85,11 @@ class CommandQueuePCIDevicesFixture : public ::testing::Test {
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     }
 
     void TearDown() override {
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -533,7 +533,12 @@ namespace tt::tt_metal{
                     if (device_id != device->id()) {
                         // This means the issue queue and completion queue interfaces that service a remote device are being set up
                         // the issue queue interface needs to send fast dispatch packets to the "src" ethernet core
-                        consumer_physical_core = device->ethernet_core_from_logical_core(*device->get_active_ethernet_cores().begin());
+                        CoreCoord logical_eth_router_src = tt::Cluster::instance().get_eth_core_for_dispatch_core(
+                            issue_q_reader_location, EthRouterMode::FD_SRC, device_id);
+                        consumer_physical_core = device->ethernet_core_from_logical_core(logical_eth_router_src);
+
+                        tt::Cluster::instance().configure_eth_core_for_dispatch_core(
+                            issue_q_reader_location, EthRouterMode::FD_SRC, device_id);
                     }
 
                     std::map<string, string> producer_defines = {

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -123,10 +123,8 @@ void __attribute__((section("erisc_l1_code"))) ApplicationHandler(void) {
             noc_async_write_barrier();
 
             db_cb_config_t *eth_db_cb_config =
-                (db_cb_config_t
-                     *)(eth_l1_mem::address_map::CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
-            const db_cb_config_t *remote_db_cb_config =
-                (db_cb_config_t *)(CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
+                get_local_db_cb_config(eth_l1_mem::address_map::CQ_CONSUMER_CB_BASE, db_buf_switch);
+            const db_cb_config_t *remote_db_cb_config = get_remote_db_cb_config(CQ_CONSUMER_CB_BASE, db_buf_switch);
             volatile tt_l1_ptr uint32_t *command_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t *>(command_start_addr);
             volatile tt_l1_ptr CommandHeader *header = (CommandHeader *)command_ptr;

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -6,11 +6,11 @@
 #include "ethernet/dataflow_api.h"
 #include "firmware_common.h"
 #include "generated_bank_to_noc_coord_mapping.h"
-#include "noc_nonblocking_api.h"
 #include "noc_parameters.h"
 #include "risc_attribs.h"
 #include "tools/profiler/kernel_profiler.hpp"
-#include "tt_eth_api.h"
+#include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/dispatch/kernels/command_queue_common.hpp"
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,12 +26,42 @@ namespace kernel_profiler {
 uint32_t wIndex __attribute__((used));
 }
 
+uint8_t noc_index = 0;  // TODO: remove hardcoding
 uint8_t my_x[NUM_NOCS] __attribute__((used));
 uint8_t my_y[NUM_NOCS] __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
+
+FORCE_INLINE
+void multicore_eth_cb_wait_front(db_cb_config_t *eth_db_cb_config, int32_t num_pages) {
+    DEBUG_STATUS('C', 'R', 'B', 'W');
+
+    uint16_t pages_received;
+    do {
+        pages_received = uint16_t(eth_db_cb_config->recv - eth_db_cb_config->ack);
+    } while (pages_received < num_pages);
+    DEBUG_STATUS('C', 'R', 'B', 'D');
+}
+
+FORCE_INLINE
+void multicore_eth_cb_pop_front(
+    db_cb_config_t *eth_db_cb_config,
+    const db_cb_config_t *remote_db_cb_config,
+    uint64_t producer_noc_encoding,
+    uint32_t num_pages) {
+    eth_db_cb_config->ack += num_pages;
+
+    uint32_t pages_ack_addr = (uint32_t)(&(remote_db_cb_config->ack));
+    noc_semaphore_set_remote((uint32_t)(&(eth_db_cb_config->ack)), producer_noc_encoding | pages_ack_addr);
+}
+
+FORCE_INLINE
+void eth_db_acquire(volatile uint32_t *semaphore, uint64_t noc_encoding) {
+    while (semaphore[0] == 0 and routing_info->routing_enabled and erisc_info->launch_user_kernel == 0) {
+    }
+}
 
 void __attribute__((section("code_l1"))) risc_init() {
     for (uint32_t n = 0; n < NUM_NOCS; n++) {
@@ -40,6 +70,15 @@ void __attribute__((section("code_l1"))) risc_init() {
         my_y[n] = (noc_id_reg >> NOC_ADDR_NODE_ID_BITS) & NOC_NODE_ID_MASK;
     }
 }
+
+void __attribute__((section("code_l1"))) router_init() {
+    relay_src_noc_encoding = uint32_t(NOC_XY_ENCODING(routing_info->relay_src_x, routing_info->relay_src_y));
+    relay_dst_noc_encoding = uint32_t(NOC_XY_ENCODING(routing_info->relay_dst_x, routing_info->relay_dst_y));
+
+    eth_router_noc_encoding = uint32_t(NOC_XY_ENCODING(my_x[0], my_y[0]));
+    my_routing_mode = (EthRouterMode)routing_info->routing_mode;
+}
+
 void __attribute__((section("erisc_l1_code"))) ApplicationHandler(void) {
     kernel_profiler::init_profiler();
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
@@ -51,14 +90,72 @@ void __attribute__((section("erisc_l1_code"))) ApplicationHandler(void) {
         noc_local_state_init(n);
     }
     ncrisc_noc_full_sync();
-    while (erisc_info->routing_enabled) {
+    while (routing_info->routing_enabled != 1) {
+        internal_::risc_context_switch();
+    }
+
+    router_init();
+
+    volatile tt_l1_ptr uint32_t *eth_db_semaphore_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t *>(eth_get_semaphore(0));
+
+    static constexpr uint32_t command_start_addr = eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE;
+
+    bool db_buf_switch = false;
+    while (routing_info->routing_enabled) {
+        // FD: assume that no more host -> remote writes are pending
         if (erisc_info->launch_user_kernel == 1) {
             kernel_profiler::mark_time(CC_MAIN_START);
             kernel_init();
             kernel_profiler::mark_time(CC_MAIN_END);
+        }
+        if (my_routing_mode == EthRouterMode::FD_SRC) {
+            eth_db_acquire(eth_db_semaphore_addr, ((uint64_t)eth_router_noc_encoding << 32));
+            if (erisc_info->launch_user_kernel == 1) {
+                continue;
+            }
+            if (routing_info->routing_enabled == 0) {
+                break;
+            }
+            noc_semaphore_inc(
+                ((uint64_t)eth_router_noc_encoding << 32) | uint32_t(eth_db_semaphore_addr),
+                -1);  // Two's complement addition
+            noc_async_write_barrier();
+
+            db_cb_config_t *eth_db_cb_config =
+                (db_cb_config_t
+                     *)(eth_l1_mem::address_map::CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
+            const db_cb_config_t *remote_db_cb_config =
+                (db_cb_config_t *)(CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
+            volatile tt_l1_ptr uint32_t *command_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t *>(command_start_addr);
+            volatile tt_l1_ptr CommandHeader *header = (CommandHeader *)command_ptr;
+            uint32_t num_buffer_transfers = header->num_buffer_transfers;
+            uint32_t producer_consumer_transfer_num_pages = header->producer_consumer_transfer_num_pages;
+            command_ptr += DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER;
+
+            for (uint32_t i = 0; i < num_buffer_transfers; i++) {
+                const uint32_t num_pages = command_ptr[2];
+                uint32_t num_writes_completed = 0;
+                while (num_writes_completed != num_pages) {
+                    uint32_t num_to_write = min(num_pages, producer_consumer_transfer_num_pages);
+                    multicore_eth_cb_wait_front(eth_db_cb_config, num_to_write);
+                    // contains device command, maybe just send pages, and send cmd once at the start
+                    internal_::send_fd_packets();
+                    multicore_eth_cb_pop_front(
+                        eth_db_cb_config, remote_db_cb_config, ((uint64_t)relay_src_noc_encoding << 32), num_to_write);
+                    num_writes_completed += num_to_write;
+                }
+            }
+            noc_semaphore_inc(((uint64_t)relay_src_noc_encoding << 32) | get_semaphore(0), 1);
+            noc_async_write_barrier();  // Barrier for now
+        } else if (my_routing_mode == EthRouterMode::FD_DST) {
+            internal_::receive_fd_packets();
+            // TODO: add sync with remote processor
         } else {
             internal_::risc_context_switch();
         }
     }
-    disable_erisc_app();
+    internal_::disable_erisc_app();
+    kernel_profiler::mark_time(CC_MAIN_END);
 }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -16,13 +16,13 @@
 #include <stdint.h>
 
 #include "circular_buffer.h"
+#include "debug/sanitize_noc.h"
+#include "debug/status.h"
+#include "eth_l1_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "hostdevcommon/common_values.hpp"
 #include "risc_attribs.h"
 #include "third_party/umd/device/tt_silicon_driver_common.hpp"
-
-#include "debug/status.h"
-#include "debug/sanitize_noc.h"
 
 extern uint8_t noc_index;
 
@@ -1149,6 +1149,11 @@ FORCE_INLINE void noc_async_write_tile(
 FORCE_INLINE
 uint32_t get_semaphore(uint32_t semaphore_id) {
     return SEMAPHORE_BASE + semaphore_id * L1_ALIGNMENT;
+}
+
+FORCE_INLINE
+uint32_t eth_get_semaphore(uint32_t semaphore_id) {
+    return eth_l1_mem::address_map::SEMAPHORE_BASE + semaphore_id * L1_ALIGNMENT;
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -114,3 +114,24 @@ static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, slave_sync.ncrisc) == MEM
 static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, ncrisc_halt.stack_save) == MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS);
 static_assert(MEM_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_MAILBOX_END);
 #endif
+
+enum EthRouterMode : uint32_t {
+    FD_SRC = 0,
+    FD_DST = 1,
+    SD = 2,
+};
+
+struct routing_info_t {
+    volatile uint32_t routing_enabled;
+    volatile uint32_t routing_mode;
+    volatile uint32_t connected_chip_id;
+    volatile uint32_t unused_arg0;
+    volatile uint32_t relay_src_x;
+    volatile uint32_t relay_src_y;
+    volatile uint32_t relay_dst_x;
+    volatile uint32_t relay_dst_y;
+    volatile uint32_t fd_buffer_msgs_sent;
+    uint32_t reserved_0_;
+    uint32_t reserved_1_;
+    uint32_t reserved_2_;
+};

--- a/tt_metal/hw/inc/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/ethernet/dataflow_api.h
@@ -4,21 +4,26 @@
 
 #pragma once
 
+#include "dev_msgs.h"
 #include "eth_l1_address_map.h"
+#include "noc_nonblocking_api.h"
 #include "risc_common.h"
 #include "tt_eth_api.h"
-#include "noc_nonblocking_api.h"
+
 #include "../dataflow_api.h"
+
+#define FORCE_INLINE inline __attribute__((always_inline))
 
 inline void RISC_POST_STATUS(uint32_t status) {
     volatile uint32_t *ptr = (volatile uint32_t *)(NOC_CFG(ROUTER_CFG_2));
     ptr[0] = status;
 }
+
 struct erisc_info_t {
     volatile uint32_t launch_user_kernel;
-    volatile uint32_t routing_mode;
-    volatile uint32_t routing_enabled;
     volatile uint32_t unused_arg0;
+    volatile uint32_t unused_arg1;
+    volatile uint32_t unused_arg2;
     volatile uint32_t user_buffer_bytes_sent;
     uint32_t reserved_0_;
     uint32_t reserved_1_;
@@ -29,9 +34,16 @@ struct erisc_info_t {
     uint32_t reserved_5_;
 };
 
+// Routing info
+uint32_t relay_src_noc_encoding;
+uint32_t relay_dst_noc_encoding;
+uint32_t eth_router_noc_encoding;
+EthRouterMode my_routing_mode;
+
 tt_l1_ptr mailboxes_t *const mailboxes = (tt_l1_ptr mailboxes_t *)(eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE);
 
 erisc_info_t *erisc_info = (erisc_info_t *)(eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE);
+routing_info_t *routing_info = (routing_info_t *)(eth_l1_mem::address_map::ERISC_APP_ROUTING_INFO_BASE);
 volatile uint32_t *flag_disable = (uint32_t *)(eth_l1_mem::address_map::LAUNCH_ERISC_APP_FLAG);
 
 extern uint32_t __erisc_jump_table;
@@ -43,17 +55,14 @@ void (*rtos_context_switch_ptr)();
 FORCE_INLINE
 void reset_erisc_info() { erisc_info->user_buffer_bytes_sent = 0; }
 
-FORCE_INLINE
-void disable_erisc_app() { flag_disable[0] = 0; }
-
 namespace internal_ {
+FORCE_INLINE
 void __attribute__((section("code_l1"))) risc_context_switch() {
     ncrisc_noc_full_sync();
     rtos_context_switch_ptr();
     ncrisc_noc_counters_init();
 }
 
-FORCE_INLINE
 void check_and_context_switch() {
     uint32_t start_time = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
     uint32_t end_time = start_time;
@@ -75,9 +84,65 @@ void notify_dispatch_core_done(uint64_t dispatch_addr) {
     }
     noc_fast_atomic_increment_l1(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, 1, 31 /*wrap*/, false /*linked*/);
 }
+
+
+FORCE_INLINE
+void disable_erisc_app() { flag_disable[0] = 0; }
+
+FORCE_INLINE
+void send_fd_packets() {
+    eth_send_packet(
+        0,
+        (eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE) >> 4,
+        ((eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE)) >> 4,
+        (eth_l1_mem::address_map::ERISC_APP_RESERVED_SIZE) >> 4);
+    routing_info->fd_buffer_msgs_sent = 1;
+    eth_send_packet(
+        0,
+        ((uint32_t)(&(routing_info->fd_buffer_msgs_sent))) >> 4,
+        ((uint32_t)(&(routing_info->fd_buffer_msgs_sent))) >> 4,
+        1);
+    // There should always be a valid cmd here, since eth_db_acquire completed
+    while (routing_info->fd_buffer_msgs_sent != 0) {
+        // TODO: add timer to restrict this
+        risc_context_switch();
+    }
+}
+
+FORCE_INLINE
+void receive_fd_packets() {
+    // There may not be a valid cmd here, since DST router is always polling
+    // This should only happen on cluster close
+    while (routing_info->fd_buffer_msgs_sent != 1 && routing_info->routing_enabled) {
+        // TODO: add timer to restrict this
+        risc_context_switch();
+    }
+    routing_info->fd_buffer_msgs_sent = 0;
+    eth_send_packet(
+        0,
+        ((uint32_t)(&(routing_info->fd_buffer_msgs_sent))) >> 4,
+        ((uint32_t)(&(routing_info->fd_buffer_msgs_sent))) >> 4,
+        1);
+}
+
 }  // namespace internal_
 
-
+void run_routing() {
+    // TODO: maybe split into two FWs? or this may be better to sometimes allow each eth core to do both send and
+    // receive of fd packets
+    if (my_routing_mode == EthRouterMode::FD_SRC) {
+        // TODO: port changes from erisc to here
+        internal_::risc_context_switch();
+    } else if (my_routing_mode == EthRouterMode::FD_DST) {
+        // TODO: port changes from erisc to here
+        internal_::risc_context_switch();
+    } else if (my_routing_mode == EthRouterMode::SD) {
+        // slow dispatch mode
+        internal_::risc_context_switch();
+    } else {
+        internal_::risc_context_switch();
+    }
+}
 /**
  * A blocking call that waits until the value of a local L1 memory address on
  * the Tensix core executing this function becomes equal to a target value.
@@ -94,7 +159,7 @@ void notify_dispatch_core_done(uint64_t dispatch_addr) {
 FORCE_INLINE
 void eth_noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
     while ((*sem_addr) != val) {
-        internal_::risc_context_switch();
+        run_routing();
     }
 }
 
@@ -109,7 +174,7 @@ void eth_noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val)
 FORCE_INLINE
 void eth_noc_async_read_barrier() {
     while (!ncrisc_noc_reads_flushed(noc_index)) {
-        internal_::risc_context_switch();
+        run_routing();
     }
 }
 
@@ -124,7 +189,7 @@ void eth_noc_async_read_barrier() {
 FORCE_INLINE
 void eth_noc_async_write_barrier() {
     while (!ncrisc_noc_nonposted_writes_flushed(noc_index)) {
-        internal_::risc_context_switch();
+        run_routing();
     }
 }
 
@@ -173,7 +238,7 @@ void eth_wait_for_receiver_done() {
         ((uint32_t)(&(erisc_info->user_buffer_bytes_sent))) >> 4,
         1);
     while (erisc_info->user_buffer_bytes_sent != 0) {
-        internal_::risc_context_switch();
+        run_routing();
     }
 }
 
@@ -225,7 +290,7 @@ void eth_wait_for_remote_receiver_done_and_get_local_receiver_data(
 FORCE_INLINE
 void eth_wait_for_bytes(uint32_t num_bytes) {
     while (erisc_info->user_buffer_bytes_sent != num_bytes) {
-        internal_::risc_context_switch();
+        run_routing();
     }
 }
 

--- a/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
@@ -16,7 +16,9 @@ struct address_map {
   static constexpr std::int32_t FIRMWARE_BASE = 0;
   static constexpr std::int32_t ERISC_MEM_MAILBOX_BASE = 0;
 
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 0;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 0;
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = 0;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = 0;
   static constexpr std::int32_t ERISC_L1_ARG_BASE = 0;
 
@@ -24,6 +26,8 @@ struct address_map {
   static constexpr std::int32_t ERISC_APP_RESERVED_BASE = 0;
   static constexpr std::int32_t ERISC_APP_RESERVED_SIZE = 16;
   static constexpr std::int32_t ERISC_L1_UNRESERVED_BASE = 0;
+  static constexpr std::uint32_t SEMAPHORE_BASE = 0;
+  static constexpr std::uint32_t CQ_CONSUMER_CB_BASE = 0;
   static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = 0;
   static constexpr std::uint32_t FW_VERSION_ADDR = 0;
   static constexpr std::int32_t PRINT_BUFFER_ER = 0;

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -6,6 +6,8 @@
 
 #include <cstdint>
 
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
+
 namespace eth_l1_mem {
 
 
@@ -34,11 +36,17 @@ struct address_map {
   //    -  53 * 1024 eth app reserved buffer space
   //    - 106 * 1024 L1 unreserved buffer space
   static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
-  static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 64;
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 48;
+  static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 32;
 
   static constexpr std::int32_t ERISC_BARRIER_BASE = TILE_HEADER_BUFFER_BASE;
-  static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = ERISC_BARRIER_BASE + ERISC_BARRIER_SIZE;
-  static constexpr std::int32_t ERISC_L1_ARG_BASE = ERISC_APP_SYNC_INFO_BASE + ERISC_APP_SYNC_INFO_SIZE;
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = ERISC_BARRIER_BASE + ERISC_BARRIER_SIZE;
+  static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = ERISC_APP_ROUTING_INFO_BASE + ERISC_APP_ROUTING_INFO_SIZE;
+  static constexpr std::uint32_t SEMAPHORE_BASE = ERISC_APP_SYNC_INFO_BASE + ERISC_APP_SYNC_INFO_SIZE;
+
+  static constexpr uint32_t CQ_CONSUMER_CB_BASE = SEMAPHORE_BASE + SEMAPHORE_SIZE;  // SIZE from shared common addr
+
+  static constexpr std::int32_t ERISC_L1_ARG_BASE = CQ_CONSUMER_CB_BASE + 7 * L1_ALIGNMENT;
 
   static constexpr std::int32_t ERISC_APP_RESERVED_BASE = TILE_HEADER_BUFFER_BASE + 1024;
   static constexpr std::int32_t ERISC_APP_RESERVED_SIZE = 53 * 1024;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -169,7 +169,6 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
         int eriscv_id = build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 0;
         ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""));
         uint32_t kernel_size16 = llrt::get_binary_code_size16(binary_mem, eriscv_id);
-        llrt::write_hex_vec_to_core(this->id(), phys_core, {1}, eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE + 8);
         log_debug(LogDevice, "ERISC fw binary size: {} in bytes", kernel_size16 * 16);
         llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
         llrt::launch_erisc_app_fw_on_core(this->id(), phys_core);
@@ -223,7 +222,6 @@ void Device::initialize_and_launch_firmware() {
     }
 
     // Load erisc app base FW to eth cores
-    // TODO: we can optimize and split send/receive FD modes to two FWs
     for (const auto &eth_core : this->get_active_ethernet_cores()) {
         CoreCoord phys_eth_core = this->ethernet_core_from_logical_core(eth_core);
         this->initialize_firmware(phys_eth_core, &launch_msg);
@@ -408,8 +406,7 @@ std::vector<CoreCoord> Device::worker_cores_from_logical_cores(const std::vector
 }
 
 CoreCoord Device::ethernet_core_from_logical_core(const CoreCoord &logical_core) const {
-    const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
-    return soc_desc.get_physical_ethernet_core_from_logical(logical_core);
+    return tt::Cluster::instance().ethernet_core_from_logical_core(id_, logical_core);
 }
 
 std::vector<CoreCoord> Device::ethernet_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const {

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -12,19 +12,19 @@ using namespace tt::tt_metal;
 
 // Starting L1 address of commands
 inline uint32_t get_command_start_l1_address(bool use_eth_l1) {
-    return (use_eth_l1 ? eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE : L1_UNRESERVED_BASE);
+    return (use_eth_l1 ? eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE : L1_UNRESERVED_BASE);
 }
 
 // Where issue queue interface core pulls in data (follows command)
 inline uint32_t get_data_section_l1_address(bool use_eth_l1) {
-    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE : L1_UNRESERVED_BASE;
+    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE : L1_UNRESERVED_BASE;
     return l1_base + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
 }
 
 // Space available in issue queue interface core pushing command data to consumer to dispatch or relay forward
 inline uint32_t get_producer_data_buffer_size(bool use_eth_l1) {
     uint32_t l1_size = use_eth_l1 ? MEM_ETH_SIZE : MEM_L1_SIZE;
-    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE : L1_UNRESERVED_BASE;
+    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE : L1_UNRESERVED_BASE;
     return (l1_size - (DeviceCommand::NUM_ENTRIES_IN_DEVICE_COMMAND * sizeof(uint32_t)) - l1_base);
 }
 

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <array>
 #include <vector>
 

--- a/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
@@ -5,7 +5,6 @@
 #include "dataflow_api.h"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 
-static constexpr uint32_t l1_db_cb_addr_offset = 7 * 16;
 static constexpr uint32_t NUM_COMMAND_SLOTS = 2;
 
 #define ATTR_ALIGNL1 __attribute__((aligned(L1_ALIGNMENT)))
@@ -19,49 +18,6 @@ struct db_cb_config_t {
     volatile uint32_t wr_ptr ATTR_ALIGNL1;      // 16B
 };
 static constexpr uint32_t l1_db_cb_addr_offset = sizeof(db_cb_config_t);
-
-// TODO: refactor consumer kernels and remove the following functions
-FORCE_INLINE
-uint32_t get_db_cb_l1_base(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_ack_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_recv_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 16);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_num_pages_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 32);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_page_size_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 48);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_total_size_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 64);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_rd_ptr_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 80);
-
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_wr_ptr_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + CQ_START);
-}
-
 
 template <uint32_t cmd_base_address, uint32_t consumer_data_buffer_size>
 FORCE_INLINE uint32_t get_command_slot_addr(bool db_buf_switch) {
@@ -85,13 +41,15 @@ void db_acquire(volatile uint32_t* semaphore, uint64_t noc_encoding) {
 }
 
 // Local refers to the core that is calling this function
-db_cb_config_t* get_local_db_cb_config(uint32_t base_addr, bool db_buf_switch) {
+tt_l1_ptr db_cb_config_t* get_local_db_cb_config(uint32_t base_addr, bool db_buf_switch) {
+    // TODO: remove multiply here
     db_cb_config_t* db_cb_config = (db_cb_config_t*)(base_addr + (db_buf_switch * l1_db_cb_addr_offset));
     return db_cb_config;
 }
 
 // Remote refers to any other core on the same chip
-const db_cb_config_t* get_remote_db_cb_config(uint32_t base_addr, bool db_buf_switch) {
+tt_l1_ptr const db_cb_config_t* get_remote_db_cb_config(uint32_t base_addr, bool db_buf_switch) {
+    // TODO: remove multiply here
     const db_cb_config_t* db_cb_config = (db_cb_config_t*)(base_addr + (db_buf_switch * l1_db_cb_addr_offset));
     return db_cb_config;
 }

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
@@ -35,45 +35,36 @@ void noc_async_write_multicast_one_packet_no_path_reserve(
 }
 
 FORCE_INLINE
-void multicore_cb_wait_front(bool db_buf_switch, int32_t num_pages) {
+void multicore_cb_wait_front(db_cb_config_t* db_cb_config, int32_t num_pages) {
     DEBUG_STATUS('C', 'R', 'B', 'W');
-
-    uint32_t pages_acked = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_ack_addr(db_buf_switch));
-    volatile tt_l1_ptr uint32_t* pages_received_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_recv_addr(db_buf_switch));
 
     uint16_t pages_received;
     do {
-        pages_received = uint16_t(*pages_received_ptr) - pages_acked;
+        pages_received = uint16_t(db_cb_config->recv - db_cb_config->ack);
     } while (pages_received < num_pages);
     DEBUG_STATUS('C', 'R', 'B', 'D');
 }
 
 void multicore_cb_pop_front(
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_db_cb_config,
     uint64_t producer_noc_encoding,
-    bool db_buf_switch,
-    uint32_t fifo_limit,
-    uint32_t fifo_size,
-    uint32_t num_pages,
-    uint32_t page_size) {
-    volatile tt_l1_ptr uint32_t* CQ_CONSUMER_CB_ACK_PTR = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_ack_addr(db_buf_switch));
-    volatile tt_l1_ptr uint32_t* CQ_CONSUMER_CB_READ_PTR =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_rd_ptr_addr(db_buf_switch));
+    uint32_t consumer_fifo_limit_16B,
+    uint32_t num_to_write,
+    uint32_t page_size_16B) {
+    db_cb_config->ack += num_to_write;
+    db_cb_config->rd_ptr += page_size_16B * num_to_write;
 
-    *CQ_CONSUMER_CB_ACK_PTR += num_pages;
-    *CQ_CONSUMER_CB_READ_PTR += (page_size * num_pages) >> 4;
-
-    if ((*CQ_CONSUMER_CB_READ_PTR << 4) > fifo_limit) {
-        *CQ_CONSUMER_CB_READ_PTR -= fifo_size >> 4;
+    if (db_cb_config->rd_ptr >= consumer_fifo_limit_16B) {
+        db_cb_config->rd_ptr -= db_cb_config->total_size;
     }
 
-    uint32_t pages_ack_addr = get_db_cb_ack_addr(db_buf_switch);
-    noc_semaphore_set_remote(uint32_t(CQ_CONSUMER_CB_ACK_PTR), producer_noc_encoding | pages_ack_addr);
+    uint32_t pages_ack_addr = (uint32_t)(&(remote_db_cb_config->ack));
+    noc_semaphore_set_remote((uint32_t)(&(db_cb_config->ack)), producer_noc_encoding | pages_ack_addr);
 }
 
 FORCE_INLINE
-uint32_t get_read_ptr(bool db_buf_switch) {
-    return *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_rd_ptr_addr(db_buf_switch)) << 4;
-}
+uint32_t get_read_ptr(db_cb_config_t* db_cb_config) { return (db_cb_config->rd_ptr) << 4; }
 
 inline __attribute__((always_inline)) volatile uint32_t* get_cq_completion_write_ptr() {
     return reinterpret_cast<volatile uint32_t*>(CQ_COMPLETION_WRITE_PTR);
@@ -132,17 +123,15 @@ void completion_queue_push_back(const uint32_t completion_queue_start_addr, uint
 
 template <uint32_t host_completion_queue_write_ptr_addr>
 FORCE_INLINE void write_buffers(
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_db_cb_config,
     volatile tt_l1_ptr uint32_t* command_ptr,
     const uint32_t completion_queue_start_addr,
     uint32_t num_destinations,
     bool sharded,
     uint32_t sharded_buffer_num_cores,
-    uint32_t consumer_cb_size,
-    uint32_t consumer_cb_num_pages,
     uint64_t producer_noc_encoding,
-    uint32_t producer_consumer_transfer_num_pages,
-    bool db_buf_switch) {
-
+    uint32_t producer_consumer_transfer_num_pages) {
 
     for (uint32_t i = 0; i < num_destinations; i++) {
         const uint32_t bank_base_address = command_ptr[1];
@@ -152,8 +141,8 @@ FORCE_INLINE void write_buffers(
         const uint32_t dst_page_index = command_ptr[7];
 
         uint32_t num_to_write;
-        uint32_t src_addr = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_rd_ptr_addr(db_buf_switch)) << 4;
-        uint32_t l1_consumer_fifo_limit = src_addr + consumer_cb_size - 1;
+        uint32_t src_addr = get_read_ptr(db_cb_config);
+        uint32_t l1_consumer_fifo_limit = src_addr + (db_cb_config->total_size << 4);
 
         BufferType buffer_type = (BufferType)dst_buf_type;
         Buffer buffer;
@@ -172,17 +161,17 @@ FORCE_INLINE void write_buffers(
         uint32_t end_page_id = page_id + num_pages;
         while (page_id < end_page_id) {
             num_to_write = min(end_page_id - page_id, producer_consumer_transfer_num_pages);
-            multicore_cb_wait_front(db_buf_switch, num_to_write);
-            uint32_t src_addr = get_read_ptr(db_buf_switch);
+            multicore_cb_wait_front(db_cb_config, num_to_write);
+            uint32_t src_addr = get_read_ptr(db_cb_config);
             buffer.noc_async_write_buffer(src_addr, page_id, num_to_write);
             noc_async_writes_flushed();
             multicore_cb_pop_front(
+                db_cb_config,
+                remote_db_cb_config,
                 producer_noc_encoding,
-                db_buf_switch,
-                l1_consumer_fifo_limit,
-                consumer_cb_size,
+                (l1_consumer_fifo_limit >> 4),
                 num_to_write,
-                page_size);
+                db_cb_config->page_size);
             page_id += num_to_write;
         }
         if (buffer_type == BufferType::SYSTEM_MEMORY) {
@@ -222,19 +211,17 @@ FORCE_INLINE void write_program_page(uint32_t page_addr, volatile tt_l1_ptr uint
 
 template <bool multicast>
 FORCE_INLINE void program_page_transfer(
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_db_cb_config,
     volatile tt_l1_ptr uint32_t*& command_ptr,
     uint64_t producer_noc_encoding,
-    uint32_t consumer_cb_size,
-    uint32_t consumer_cb_num_pages,
     uint32_t producer_consumer_transfer_num_pages,
-    bool db_buf_switch,
     uint32_t num_pages_in_transfer) {
-
-    uint32_t l1_consumer_fifo_limit = get_read_ptr(db_buf_switch) + consumer_cb_size - 1;
+    uint32_t l1_consumer_fifo_limit = get_read_ptr(db_cb_config) + (db_cb_config->total_size << 4);
     for (uint32_t page_idx = 0; page_idx < num_pages_in_transfer;) {
         uint32_t num_to_write = min(num_pages_in_transfer - page_idx, producer_consumer_transfer_num_pages);
-        multicore_cb_wait_front(db_buf_switch, num_to_write);
-        uint32_t src_addr = get_read_ptr(db_buf_switch);
+        multicore_cb_wait_front(db_cb_config, num_to_write);
+        uint32_t src_addr = get_read_ptr(db_cb_config);
         for (uint32_t i = 0; i < num_to_write; i++) {
             write_program_page<multicast>(src_addr, command_ptr, i == num_to_write - 1);
             src_addr += DeviceCommand::PROGRAM_PAGE_SIZE;
@@ -242,26 +229,24 @@ FORCE_INLINE void program_page_transfer(
         page_idx += num_to_write;
         noc_async_writes_flushed();
         multicore_cb_pop_front(
+            db_cb_config,
+            remote_db_cb_config,
             producer_noc_encoding,
-            db_buf_switch,
-            l1_consumer_fifo_limit,
-            consumer_cb_size,
+            (l1_consumer_fifo_limit >> 4),
             num_to_write,
-            DeviceCommand::PROGRAM_PAGE_SIZE);
+            (DeviceCommand::PROGRAM_PAGE_SIZE >> 4));
     }
 }
 
 FORCE_INLINE
 void write_and_launch_program(
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_db_cb_config,
     uint32_t program_transfer_start_addr,
     uint32_t num_pages,
     volatile tt_l1_ptr uint32_t*& command_ptr,
     uint64_t producer_noc_encoding,
-    uint32_t consumer_cb_size,
-    uint32_t consumer_cb_num_pages,
-    uint32_t producer_consumer_transfer_num_pages,
-    bool db_buf_switch) {
-
+    uint32_t producer_consumer_transfer_num_pages) {
     if (not num_pages) {
         return;
     }
@@ -304,9 +289,21 @@ void write_and_launch_program(
         }
 
         if (multicast) {
-            program_page_transfer<true>(command_ptr, producer_noc_encoding, consumer_cb_size, consumer_cb_num_pages, producer_consumer_transfer_num_pages, db_buf_switch, num_pages_in_transfer);
+            program_page_transfer<true>(
+                db_cb_config,
+                remote_db_cb_config,
+                command_ptr,
+                producer_noc_encoding,
+                producer_consumer_transfer_num_pages,
+                num_pages_in_transfer);
         } else {
-            program_page_transfer<false>(command_ptr, producer_noc_encoding, consumer_cb_size, consumer_cb_num_pages, producer_consumer_transfer_num_pages, db_buf_switch, num_pages_in_transfer);
+            program_page_transfer<false>(
+                db_cb_config,
+                remote_db_cb_config,
+                command_ptr,
+                producer_noc_encoding,
+                producer_consumer_transfer_num_pages,
+                num_pages_in_transfer);
         }
     }
 }

--- a/tt_metal/impl/dispatch/kernels/command_queue_producer.cpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_producer.cpp
@@ -53,6 +53,8 @@ void kernel_main() {
         uint32_t sharded_buffer_num_cores = header->sharded_buffer_num_cores;
         uint32_t restart = header->restart;
 
+        db_cb_config_t* db_cb_config = get_local_db_cb_config(CQ_CONSUMER_CB_BASE, db_buf_switch);
+        const db_cb_config_t* remote_db_cb_config = get_remote_db_cb_config(CQ_CONSUMER_CB_BASE, db_buf_switch);
         if ((DeviceCommand::WrapRegion)wrap == DeviceCommand::WrapRegion::ISSUE) {
             // Basically popfront without the extra conditional
             cq_read_interface.issue_fifo_rd_ptr = cq_read_interface.issue_fifo_limit - cq_read_interface.issue_fifo_size;  // Head to beginning of command queue
@@ -73,7 +75,14 @@ void kernel_main() {
         }
         program_local_cb(data_section_addr, producer_cb_num_pages, page_size, producer_cb_size);
         wait_consumer_space_available(db_semaphore_addr);
-        program_consumer_cb<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, consumer_noc_encoding, consumer_cb_num_pages, page_size, consumer_cb_size);
+        program_consumer_cb<consumer_cmd_base_addr, consumer_data_buffer_size>(
+            db_cb_config,
+            remote_db_cb_config,
+            db_buf_switch,
+            consumer_noc_encoding,
+            consumer_cb_num_pages,
+            page_size,
+            consumer_cb_size);
         relay_command<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, consumer_noc_encoding);
         if (stall) {
             wait_consumer_idle(db_semaphore_addr);
@@ -87,14 +96,13 @@ void kernel_main() {
             num_buffer_transfers,
             is_sharded,
             sharded_buffer_num_cores,
-            page_size,
             producer_cb_size,
             producer_cb_num_pages,
-            consumer_cb_size,
-            consumer_cb_num_pages,
             consumer_noc_encoding,
             producer_consumer_transfer_num_pages,
-            db_buf_switch);
+            db_buf_switch,
+            db_cb_config,
+            remote_db_cb_config);
 
         issue_queue_pop_front<host_issue_queue_read_ptr_addr>(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + data_size);
 

--- a/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_metal/impl/dispatch/kernels/command_queue_common.hpp"
-#include "tt_metal/hostdevcommon/common_values.hpp"
 #include "risc_attribs.h"
+#include "tt_metal/hostdevcommon/common_values.hpp"
+#include "tt_metal/impl/dispatch/kernels/command_queue_common.hpp"
 
 CQReadInterface cq_read_interface;
 
@@ -134,6 +134,36 @@ void program_consumer_cb(bool db_buf_switch, uint64_t consumer_noc_encoding, uin
     noc_async_write_barrier();  // barrier for now
 }
 
+void program_consumer_cb_2(
+    // TODO: delete program_consumer_cb and use this one
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_db_cb_config,
+    bool db_buf_switch,
+    uint64_t consumer_noc_encoding,
+    uint32_t num_pages,
+    uint32_t page_size,
+    uint32_t cb_size) {
+    /*
+        This API programs the double-buffered CB space of the consumer. This API should be called
+        before notifying the consumer that data is available.
+    */
+    constexpr uint32_t consumer_cmd_base_addr = get_compile_time_arg_val(5);
+    constexpr uint32_t consumer_data_buffer_size = get_compile_time_arg_val(6);
+    uint32_t cb_start_addr = get_db_buf_addr<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch);
+
+    db_cb_config->ack = 0;
+    db_cb_config->recv = 0;
+    db_cb_config->num_pages = num_pages;
+    db_cb_config->page_size = page_size >> 4;
+    db_cb_config->total_size = cb_size >> 4;
+    db_cb_config->rd_ptr = cb_start_addr >> 4;
+    db_cb_config->wr_ptr = cb_start_addr >> 4;
+
+    noc_async_write(
+        (uint32_t)(db_cb_config), consumer_noc_encoding | (uint32_t)(remote_db_cb_config), sizeof(db_cb_config_t));
+    noc_async_write_barrier();  // barrier for now
+}
+
 FORCE_INLINE
 bool cb_producer_space_available(int32_t num_pages) {
     uint32_t operand = 0;
@@ -172,7 +202,21 @@ bool cb_consumer_space_available(bool db_buf_switch, int32_t num_pages) {
 }
 
 FORCE_INLINE
-void multicore_cb_push_back(uint64_t consumer_noc_encoding, uint32_t consumer_fifo_limit, uint32_t consumer_fifo_size, bool db_buf_switch, uint32_t page_size, uint32_t num_to_write) {
+bool cb_consumer_space_available_2(db_cb_config_t* db_cb_config, int32_t num_pages) {
+    // TODO: delete cb_consumer_space_available and use this one
+
+    DEBUG_STATUS('C', 'R', 'B', 'W');
+
+    uint16_t free_space_pages_wrap = db_cb_config->num_pages - (db_cb_config->recv - db_cb_config->ack);
+    int32_t free_space_pages = (int32_t)free_space_pages_wrap;
+    DEBUG_STATUS('C', 'R', 'B', 'D');
+
+    return free_space_pages >= num_pages;
+}
+
+FORCE_INLINE
+void multicore_cb_push_back(uint64_t consumer_noc_encoding, uint32_t consumer_fifo_limit, uint32_t consumer_fifo_size,
+bool db_buf_switch, uint32_t page_size, uint32_t num_to_write) {
     // TODO(agrebenisan): Should create a multi-core CB interface... struct in L1
     volatile tt_l1_ptr uint32_t* CQ_CONSUMER_CB_RECV_PTR = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_recv_addr(db_buf_switch));
     volatile tt_l1_ptr uint32_t* CQ_CONSUMER_CB_WRITE_PTR = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_wr_ptr_addr(db_buf_switch));
@@ -189,6 +233,24 @@ void multicore_cb_push_back(uint64_t consumer_noc_encoding, uint32_t consumer_fi
 }
 
 template <uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
+FORCE_INLINE
+void multicore_cb_push_back_2(
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_db_cb_config,
+    uint64_t consumer_noc_encoding,
+    uint32_t consumer_fifo_16b_limit,
+    uint32_t num_to_write) {
+    db_cb_config->recv += num_to_write;
+    db_cb_config->wr_ptr += db_cb_config->page_size * num_to_write;
+
+    if (db_cb_config->wr_ptr >= consumer_fifo_16b_limit) {
+        db_cb_config->wr_ptr -= db_cb_config->total_size;
+    }
+
+    uint32_t remote_pages_recv_addr = (uint32_t)(&(remote_db_cb_config->recv));
+    noc_semaphore_set_remote((uint32_t)(&(db_cb_config->recv)), consumer_noc_encoding | remote_pages_recv_addr);
+}
+
 FORCE_INLINE
 void relay_command(bool db_buf_switch, uint64_t consumer_noc_encoding) {
     /*
@@ -267,6 +329,97 @@ void produce(
                 uint32_t l1_read_ptr = get_read_ptr(0);
                 noc_async_write(l1_read_ptr, dst_noc_addr, page_size * num_to_write);
                 multicore_cb_push_back(consumer_noc_encoding, l1_consumer_fifo_limit, consumer_cb_size, db_buf_switch, page_size, num_to_write);
+                noc_async_write_barrier();
+                cb_pop_front(0, num_to_write);
+                num_writes_completed += num_to_write;
+                num_to_write = min(num_pages - num_writes_completed, producer_consumer_transfer_num_pages);
+            }
+        }
+        command_ptr += DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION;
+    }
+}
+
+void produce_for_eth_src_router(
+    volatile tt_l1_ptr uint32_t* command_ptr,
+    uint32_t num_srcs,
+    uint32_t sharded_buffer_num_cores,
+    uint32_t producer_cb_size,
+    uint32_t producer_cb_num_pages,
+    uint64_t eth_consumer_noc_encoding,
+    uint32_t producer_consumer_transfer_num_pages,
+    bool db_buf_switch,
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* eth_db_cb_config) {
+    /*
+        This API prefetches data from host memory and writes data to the an ethernet core that relays the command
+        to a remote chip, which will have a corresponding remote processor to consume the command.
+    */
+    constexpr uint32_t consumer_cmd_base_addr = get_compile_time_arg_val(5);
+    constexpr uint32_t consumer_data_buffer_size = get_compile_time_arg_val(6);
+    uint32_t consumer_cb_size = (db_cb_config->total_size << 4);
+    uint32_t consumer_cb_num_pages = db_cb_config->num_pages;
+
+    command_ptr += DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER;
+    uint32_t l1_consumer_fifo_limit_16B =
+        (get_db_buf_addr<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch) + consumer_cb_size) >> 4;
+
+    bool sharded = sharded_buffer_num_cores > 1;
+
+    for (uint32_t i = 0; i < num_srcs; i++) {
+        const uint32_t bank_base_address = command_ptr[0];
+        const uint32_t num_pages = command_ptr[2];
+        const uint32_t page_size = command_ptr[3];
+        const uint32_t src_buf_type = command_ptr[4];
+        const uint32_t src_page_index = command_ptr[6];
+
+        uint32_t fraction_of_producer_cb_num_pages = consumer_cb_num_pages / 2;
+
+        uint32_t num_to_read = min(num_pages, fraction_of_producer_cb_num_pages);
+        uint32_t num_to_write =
+            min(num_pages, producer_consumer_transfer_num_pages);  // This must be a bigger number for perf.
+        uint32_t num_reads_issued = 0;
+        uint32_t num_reads_completed = 0;
+        uint32_t num_writes_completed = 0;
+        uint32_t src_page_id = src_page_index;
+
+        Buffer buffer;
+        if ((BufferType)src_buf_type == BufferType::SYSTEM_MEMORY or not(sharded)) {
+            buffer.init((BufferType)src_buf_type, bank_base_address, page_size);
+        } else {
+            buffer.init_sharded(
+                page_size, sharded_buffer_num_cores, bank_base_address, command_ptr + COMMAND_PTR_SHARD_IDX);
+        }
+
+        while (num_writes_completed != num_pages) {
+            // Context switch between reading in pages and sending them to the consumer.
+            // These APIs are non-blocking to allow for context switching.
+            if (cb_producer_space_available(num_to_read) and num_reads_issued < num_pages) {
+                uint32_t l1_write_ptr = get_write_ptr(0);
+                buffer.noc_async_read_buffer(l1_write_ptr, src_page_id, num_to_read);
+                cb_push_back(0, num_to_read);
+                num_reads_issued += num_to_read;
+                src_page_id += num_to_read;
+
+                uint32_t num_pages_left = num_pages - num_reads_issued;
+                num_to_read = min(num_pages_left, fraction_of_producer_cb_num_pages);
+            }
+
+            if (num_reads_issued > num_writes_completed and cb_consumer_space_available_2(db_cb_config, num_to_write)) {
+                if (num_writes_completed == num_reads_completed) {
+                    noc_async_read_barrier();
+                    num_reads_completed = num_reads_issued;
+                }
+
+                uint32_t dst_addr = (db_cb_config->wr_ptr << 4);
+                uint64_t dst_noc_addr = eth_consumer_noc_encoding | dst_addr;
+                uint32_t l1_read_ptr = get_read_ptr(0);
+                noc_async_write(l1_read_ptr, dst_noc_addr, page_size * num_to_write);
+                multicore_cb_push_back_2(
+                    db_cb_config,
+                    eth_db_cb_config,
+                    eth_consumer_noc_encoding,
+                    l1_consumer_fifo_limit_16B,
+                    num_to_write);
                 noc_async_write_barrier();
                 cb_pop_front(0, num_to_write);
                 num_writes_completed += num_to_write;

--- a/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
@@ -106,36 +106,7 @@ void program_local_cb(uint32_t data_section_addr, uint32_t num_pages, uint32_t p
 
 template <uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
 FORCE_INLINE
-void program_consumer_cb(bool db_buf_switch, uint64_t consumer_noc_encoding, uint32_t num_pages, uint32_t page_size, uint32_t cb_size) {
-    /*
-        This API programs the double-buffered CB space of the consumer. This API should be called
-        before notifying the consumer that data is available.
-    */
-
-    uint32_t acked_addr = get_db_cb_ack_addr(db_buf_switch);
-    uint32_t recv_addr = get_db_cb_recv_addr(db_buf_switch);
-    uint32_t num_pages_addr = get_db_cb_num_pages_addr(db_buf_switch);
-    uint32_t page_size_addr = get_db_cb_page_size_addr(db_buf_switch);
-    uint32_t total_size_addr = get_db_cb_total_size_addr(db_buf_switch);
-    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(acked_addr)[0] = 0;
-    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(recv_addr)[0] = 0;
-    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(num_pages_addr)[0] = num_pages;
-    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_size_addr)[0] = page_size >> 4;
-    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(total_size_addr)[0] = cb_size >> 4;
-
-    uint32_t rd_ptr_addr = get_db_cb_rd_ptr_addr(db_buf_switch);
-    uint32_t wr_ptr_addr = get_db_cb_wr_ptr_addr(db_buf_switch);
-    uint32_t cb_start_addr = get_db_buf_addr<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch);
-    reinterpret_cast<volatile uint32_t*>(rd_ptr_addr)[0] = cb_start_addr >> 4;
-    reinterpret_cast<volatile uint32_t*>(wr_ptr_addr)[0] = cb_start_addr >> 4;
-
-    uint32_t cb_base = get_db_cb_l1_base(db_buf_switch);
-    noc_async_write(cb_base, consumer_noc_encoding | cb_base, 7 * 16);
-    noc_async_write_barrier();  // barrier for now
-}
-
-void program_consumer_cb_2(
-    // TODO: delete program_consumer_cb and use this one
+void program_consumer_cb(
     db_cb_config_t* db_cb_config,
     const db_cb_config_t* remote_db_cb_config,
     bool db_buf_switch,
@@ -147,8 +118,6 @@ void program_consumer_cb_2(
         This API programs the double-buffered CB space of the consumer. This API should be called
         before notifying the consumer that data is available.
     */
-    constexpr uint32_t consumer_cmd_base_addr = get_compile_time_arg_val(5);
-    constexpr uint32_t consumer_data_buffer_size = get_compile_time_arg_val(6);
     uint32_t cb_start_addr = get_db_buf_addr<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch);
 
     db_cb_config->ack = 0;
@@ -186,23 +155,7 @@ bool cb_producer_space_available(int32_t num_pages) {
 }
 
 FORCE_INLINE
-bool cb_consumer_space_available(bool db_buf_switch, int32_t num_pages) {
-
-    DEBUG_STATUS('C', 'R', 'B', 'W');
-
-    uint16_t pages_acked = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_ack_addr(db_buf_switch));
-    uint16_t pages_recv = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_recv_addr(db_buf_switch));
-    uint32_t num_pages_consumer = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_num_pages_addr(db_buf_switch));
-
-    uint16_t free_space_pages_wrap = num_pages_consumer - (pages_recv - pages_acked);
-    int32_t free_space_pages = (int32_t)free_space_pages_wrap;
-    DEBUG_STATUS('C', 'R', 'B', 'D');
-
-    return free_space_pages >= num_pages;
-}
-
-FORCE_INLINE
-bool cb_consumer_space_available_2(db_cb_config_t* db_cb_config, int32_t num_pages) {
+bool cb_consumer_space_available(db_cb_config_t* db_cb_config, int32_t num_pages) {
     // TODO: delete cb_consumer_space_available and use this one
 
     DEBUG_STATUS('C', 'R', 'B', 'W');
@@ -214,27 +167,9 @@ bool cb_consumer_space_available_2(db_cb_config_t* db_cb_config, int32_t num_pag
     return free_space_pages >= num_pages;
 }
 
+
 FORCE_INLINE
-void multicore_cb_push_back(uint64_t consumer_noc_encoding, uint32_t consumer_fifo_limit, uint32_t consumer_fifo_size,
-bool db_buf_switch, uint32_t page_size, uint32_t num_to_write) {
-    // TODO(agrebenisan): Should create a multi-core CB interface... struct in L1
-    volatile tt_l1_ptr uint32_t* CQ_CONSUMER_CB_RECV_PTR = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_recv_addr(db_buf_switch));
-    volatile tt_l1_ptr uint32_t* CQ_CONSUMER_CB_WRITE_PTR = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_wr_ptr_addr(db_buf_switch));
-
-    *CQ_CONSUMER_CB_RECV_PTR += num_to_write;
-    *CQ_CONSUMER_CB_WRITE_PTR += (page_size * num_to_write) >> 4;
-
-    if ((*CQ_CONSUMER_CB_WRITE_PTR << 4) >= consumer_fifo_limit) {
-        *CQ_CONSUMER_CB_WRITE_PTR -= consumer_fifo_size >> 4;
-    }
-
-    uint32_t pages_recv_addr = get_db_cb_recv_addr(db_buf_switch);
-    noc_semaphore_set_remote(uint32_t(CQ_CONSUMER_CB_RECV_PTR), consumer_noc_encoding | pages_recv_addr);
-}
-
-template <uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
-FORCE_INLINE
-void multicore_cb_push_back_2(
+void multicore_cb_push_back(
     db_cb_config_t* db_cb_config,
     const db_cb_config_t* remote_db_cb_config,
     uint64_t consumer_noc_encoding,
@@ -251,8 +186,8 @@ void multicore_cb_push_back_2(
     noc_semaphore_set_remote((uint32_t)(&(db_cb_config->recv)), consumer_noc_encoding | remote_pages_recv_addr);
 }
 
-FORCE_INLINE
-void relay_command(bool db_buf_switch, uint64_t consumer_noc_encoding) {
+template <uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
+FORCE_INLINE void relay_command(bool db_buf_switch, uint64_t consumer_noc_encoding) {
     /*
         Relays the current command to the consumer.
     */
@@ -264,8 +199,17 @@ void relay_command(bool db_buf_switch, uint64_t consumer_noc_encoding) {
 
 template <uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
 void produce(
-    volatile tt_l1_ptr uint32_t* command_ptr, uint32_t num_srcs, bool sharded, uint32_t sharded_buffer_num_cores, uint32_t page_size, uint32_t producer_cb_size, uint32_t producer_cb_num_pages,
-    uint32_t consumer_cb_size, uint32_t consumer_cb_num_pages, uint64_t consumer_noc_encoding, uint32_t producer_consumer_transfer_num_pages, bool db_buf_switch) {
+    volatile tt_l1_ptr uint32_t* command_ptr,
+    uint32_t num_srcs,
+    bool sharded,
+    uint32_t sharded_buffer_num_cores,
+    uint32_t producer_cb_size,
+    uint32_t producer_cb_num_pages,
+    uint64_t consumer_noc_encoding,
+    uint32_t producer_consumer_transfer_num_pages,
+    bool db_buf_switch,
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_db_cb_config) {
     /*
         This API prefetches data from host memory and writes data to the consumer core. On the consumer,
         we partition the data space into 2 via double-buffering. There are two command slots, and two
@@ -273,9 +217,12 @@ void produce(
         the consumer. It continues like this in a loop, context switching between pulling in data and
         writing to the consumer.
     */
+    uint32_t consumer_cb_size = (db_cb_config->total_size << 4);
+    uint32_t consumer_cb_num_pages = db_cb_config->num_pages;
 
     command_ptr += DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER;
-    uint32_t l1_consumer_fifo_limit = get_db_buf_addr<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch) + consumer_cb_size;
+    uint32_t l1_consumer_fifo_limit_16B =
+        (get_db_buf_addr<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch) + consumer_cb_size) >> 4;
 
 
     for (uint32_t i = 0; i < num_srcs; i++) {
@@ -318,17 +265,18 @@ void produce(
                 num_to_read = min(num_pages_left, fraction_of_producer_cb_num_pages);
             }
 
-            if (num_reads_issued > num_writes_completed and cb_consumer_space_available(db_buf_switch, num_to_write)) {
+            if (num_reads_issued > num_writes_completed and cb_consumer_space_available(db_cb_config, num_to_write)) {
                 if (num_writes_completed == num_reads_completed) {
                     noc_async_read_barrier();
                     num_reads_completed = num_reads_issued;
                 }
 
-                uint32_t dst_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_db_cb_wr_ptr_addr(db_buf_switch))[0] << 4;
+                uint32_t dst_addr = (db_cb_config->wr_ptr << 4);
                 uint64_t dst_noc_addr = consumer_noc_encoding | dst_addr;
                 uint32_t l1_read_ptr = get_read_ptr(0);
                 noc_async_write(l1_read_ptr, dst_noc_addr, page_size * num_to_write);
-                multicore_cb_push_back(consumer_noc_encoding, l1_consumer_fifo_limit, consumer_cb_size, db_buf_switch, page_size, num_to_write);
+                multicore_cb_push_back(
+                    db_cb_config, remote_db_cb_config, consumer_noc_encoding, l1_consumer_fifo_limit_16B, num_to_write);
                 noc_async_write_barrier();
                 cb_pop_front(0, num_to_write);
                 num_writes_completed += num_to_write;
@@ -339,6 +287,7 @@ void produce(
     }
 }
 
+template <uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
 void produce_for_eth_src_router(
     volatile tt_l1_ptr uint32_t* command_ptr,
     uint32_t num_srcs,
@@ -354,8 +303,6 @@ void produce_for_eth_src_router(
         This API prefetches data from host memory and writes data to the an ethernet core that relays the command
         to a remote chip, which will have a corresponding remote processor to consume the command.
     */
-    constexpr uint32_t consumer_cmd_base_addr = get_compile_time_arg_val(5);
-    constexpr uint32_t consumer_data_buffer_size = get_compile_time_arg_val(6);
     uint32_t consumer_cb_size = (db_cb_config->total_size << 4);
     uint32_t consumer_cb_num_pages = db_cb_config->num_pages;
 
@@ -404,7 +351,7 @@ void produce_for_eth_src_router(
                 num_to_read = min(num_pages_left, fraction_of_producer_cb_num_pages);
             }
 
-            if (num_reads_issued > num_writes_completed and cb_consumer_space_available_2(db_cb_config, num_to_write)) {
+            if (num_reads_issued > num_writes_completed and cb_consumer_space_available(db_cb_config, num_to_write)) {
                 if (num_writes_completed == num_reads_completed) {
                     noc_async_read_barrier();
                     num_reads_completed = num_reads_issued;
@@ -414,7 +361,7 @@ void produce_for_eth_src_router(
                 uint64_t dst_noc_addr = eth_consumer_noc_encoding | dst_addr;
                 uint32_t l1_read_ptr = get_read_ptr(0);
                 noc_async_write(l1_read_ptr, dst_noc_addr, page_size * num_to_write);
-                multicore_cb_push_back_2(
+                multicore_cb_push_back(
                     db_cb_config,
                     eth_db_cb_config,
                     eth_consumer_noc_encoding,

--- a/tt_metal/impl/dispatch/kernels/remote_issue_queue_reader.cpp
+++ b/tt_metal/impl/dispatch/kernels/remote_issue_queue_reader.cpp
@@ -3,19 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/impl/dispatch/kernels/command_queue_producer.hpp"
-// #include "debug/dprint.h"
 
 // TODO: commonize pieces with command_queue_producer
 void kernel_main() {
     constexpr uint32_t host_issue_queue_read_ptr_addr = get_compile_time_arg_val(0);
     constexpr uint32_t issue_queue_start_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t command_start_addr = get_compile_time_arg_val(2);
-    constexpr uint32_t data_section_addr = get_compile_time_arg_val(3);
-    constexpr uint32_t consumer_cmd_base_addr = get_compile_time_arg_val(4);
-    constexpr uint32_t consumer_data_buffer_size = get_compile_time_arg_val(5);
-
-    // Only the issue queue size is a runtime argument
-    uint32_t issue_queue_size = get_arg_val<uint32_t>(0);
+    uint32_t issue_queue_size = get_compile_time_arg_val(2);  // not constexpr since can change
+    constexpr uint32_t command_start_addr = get_compile_time_arg_val(3);
+    constexpr uint32_t data_section_addr = get_compile_time_arg_val(4);
+    constexpr uint32_t consumer_cmd_base_addr = get_compile_time_arg_val(5);
+    constexpr uint32_t consumer_data_buffer_size = get_compile_time_arg_val(6);
 
     setup_issue_queue_read_interface(issue_queue_start_addr, issue_queue_size);
 
@@ -23,13 +20,13 @@ void kernel_main() {
     // This represents how many buffers the producer can write to.
     // At the beginning, it can write to two different buffers.
     uint32_t producer_noc_encoding = uint32_t(NOC_XY_ENCODING(my_x[0], my_y[0]));
-    uint32_t consumer_noc_encoding = uint32_t(NOC_XY_ENCODING(CONSUMER_NOC_X, CONSUMER_NOC_Y));
+    uint32_t eth_consumer_noc_encoding = uint32_t(NOC_XY_ENCODING(CONSUMER_NOC_X, CONSUMER_NOC_Y));
     uint32_t pcie_core_noc_encoding = uint32_t(NOC_XY_ENCODING(PCIE_NOC_X, PCIE_NOC_Y));
 
     volatile tt_l1_ptr uint32_t* db_semaphore_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(0));  // Should be initialized to num command slots by host (1 for remote cq)
 
-    bool db_buf_switch = false;
+    bool db_buf_switch = false; //TODO: toggle db buf switch when adding double buffering on eth core
     while (true) {
 
         issue_queue_wait_front();
@@ -55,7 +52,13 @@ void kernel_main() {
         uint32_t sharded_buffer_num_cores = header->sharded_buffer_num_cores;
         uint32_t wrap = header->wrap;
 
+        db_cb_config_t *db_cb_config = (db_cb_config_t *)(CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
+        // const because we only use this to get noc dst addr
+        const db_cb_config_t *eth_db_cb_config =
+            (db_cb_config_t *)(eth_l1_mem::address_map::CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
+
         if ((DeviceCommand::WrapRegion)wrap == DeviceCommand::WrapRegion::ISSUE) {
+            // TODO: do we need this?
             // Basically popfront without the extra conditional
             cq_read_interface.issue_fifo_rd_ptr = cq_read_interface.issue_fifo_limit - cq_read_interface.issue_fifo_size;  // Head to beginning of command queue
             cq_read_interface.issue_fifo_rd_toggle = not cq_read_interface.issue_fifo_rd_toggle;
@@ -64,35 +67,38 @@ void kernel_main() {
         }
 
         program_local_cb(data_section_addr, producer_cb_num_pages, page_size, producer_cb_size);
-        while (db_semaphore_addr[0] == 0)
-            ;  // Check that there is space in the consumer
-        // program_consumer_cb<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, ((uint64_t)consumer_noc_encoding << 32), consumer_cb_num_pages, page_size, consumer_cb_size);
-        // relay_command<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, ((uint64_t)consumer_noc_encoding << 32));
-
+        wait_consumer_space_available(db_semaphore_addr);
+        program_consumer_cb_2(
+            db_cb_config,
+            eth_db_cb_config,
+            db_buf_switch,
+            ((uint64_t)eth_consumer_noc_encoding << 32),
+            consumer_cb_num_pages,
+            page_size,
+            consumer_cb_size);
+        relay_command(db_buf_switch, ((uint64_t)eth_consumer_noc_encoding << 32));
         // Decrement the semaphore value
         noc_semaphore_inc(((uint64_t)producer_noc_encoding << 32) | uint32_t(db_semaphore_addr), -1);  // Two's complement addition
         noc_async_write_barrier();
 
-        // Notify the consumer
-        // noc_semaphore_inc( ((uint64_t)consumer_noc_encoding << 32) | get_semaphore(0), 1);
-        // noc_async_write_barrier();  // Barrier for now
+        // Notify the eth SRC router
+        noc_semaphore_inc(((uint64_t)eth_consumer_noc_encoding << 32) | uint32_t(eth_get_semaphore(0)), 1);
+        noc_async_write_barrier();  // Barrier for now
 
         // Fetch data and send to the consumer
-        // produce<consumer_cmd_base_addr, consumer_data_buffer_size>(
-        //     command_ptr,
-        //     num_buffer_transfers,
-        //     sharded_buffer_num_cores,
-        //     page_size,
-        //     producer_cb_size,
-        //     producer_cb_num_pages,
-        //     consumer_cb_size,
-        //     consumer_cb_num_pages,
-        //     ((uint64_t)consumer_noc_encoding << 32),
-        //     producer_consumer_transfer_num_pages,
-        //     db_buf_switch);
+        produce_for_eth_src_router(
+            command_ptr,
+            num_buffer_transfers,
+            sharded_buffer_num_cores,
+            producer_cb_size,
+            producer_cb_num_pages,
+            ((uint64_t)eth_consumer_noc_encoding << 32),
+            producer_consumer_transfer_num_pages,
+            db_buf_switch,
+            db_cb_config,
+            eth_db_cb_config);
 
         issue_queue_pop_front<host_issue_queue_read_ptr_addr>(DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + data_size);
 
-        // db_buf_switch = not db_buf_switch; // only 1 command slot on consumer side
     }
 }


### PR DESCRIPTION
This is working: host sending FD cmds/data --> remote issue core --> eth SRC router --> eth DST router. 

### Features overview:
- Added some cluster apis to enable and disable internal routing (slow and fast dispatch depending on env). Enable should be called after all devices are initialized, disable should be called right before all devices are closed. We should make this into some user facing cluster handle.
- Eth kernels, integrated with Almeet's remote issue queue changes. Split ethernet dataflow apis into user facing and `internal_` namespaced apis.
- Refactored dispatch kernels to use an L1 struct for db cb configs.