### PR TITLE
#4742: Add mean op to tt_dnn

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -259,6 +259,10 @@ autofunction:: tt_lib.operations.primary.matmul
 
 .. autofunction:: tt_lib.operations.primary.transformers.scale_mask_softmax_in_place
 
+.. autofunction:: tt_lib.operations.primary.moreh_mean
+
+.. autofunction:: tt_lib.operations.primary.moreh_mean_backward
+
 
 Enums
 =====

--- a/tests/tt_eager/python_api_testing/unit_testing/test_moreh_mean.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_moreh_mean.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import tt_lib as ttl
+from models.utility_functions import comp_allclose_and_pcc, skip_for_wormhole_b0
+
+TILE_HEIGHT = 32
+TILE_WIDTH = 32
+
+
+def get_tensors(input_shape, output_shape, device):
+    npu_dtype = ttl.tensor.DataType.BFLOAT16
+    cpu_dtype = torch.bfloat16
+    npu_layout = ttl.tensor.Layout.TILE
+
+    # create tensors for forward
+    torch_input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype, requires_grad=True)
+    torch_output = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
+
+    tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+
+    return tt_input, tt_output, torch_input
+
+
+def get_backward_tensors(output_grad_shape, input_grad_shape, device):
+    npu_dtype = ttl.tensor.DataType.BFLOAT16
+    cpu_dtype = torch.bfloat16
+    npu_layout = ttl.tensor.Layout.TILE
+
+    torch_output_grad = torch.randint(-2, 3, output_grad_shape, dtype=cpu_dtype)
+    torch_input_grad = torch.randint(-2, 3, input_grad_shape, dtype=cpu_dtype)
+
+    tt_output_grad = ttl.tensor.Tensor(torch_output_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    tt_input_grad = ttl.tensor.Tensor(torch_input_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+
+    return tt_output_grad, tt_input_grad, torch_output_grad
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        ([1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1]),
+        ([4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1]),
+        ([4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1]),
+        ([8, 8, TILE_HEIGHT * 4 - 1, TILE_WIDTH * 4 - 1]),
+    ),
+    ids=[
+        "1, 1, TILE_HEIGHT-1,TILE_WIDTH - 1",
+        "4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1",
+        "4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1",
+        "8, 8, TILE_HEIGHT * 4 - 1, TILE_WIDTH * 4 - 1",
+    ],
+)
+@pytest.mark.parametrize(
+    "dims",
+    (
+        [0],
+        [0, 1],
+        [0, 1, 2],
+        [0, 1, 2, 3],
+        [0, 1, 3],
+        [0, 2, 3],
+        [1],
+        [1, 2],
+        [1, 2, 3],
+        [1, 3],
+        [2],
+        [2, 3],
+        [3],
+    ),
+    ids=["0", "0,1", "0,1,2", "0,1,2,3", "0,1,3", "0,2,3", "1", "1,2", "1,2,3", "1,3", "2", "2,3", "3"],
+)
+def test_moreh_mean_dims(input_shape, dims, device):
+    torch.manual_seed(2023)
+    output_shape = input_shape.copy()
+
+    for dim in dims:
+        output_shape[dim] = 1
+
+    (tt_input, tt_output, torch_input) = get_tensors(input_shape, output_shape, device)
+
+    torch_output = torch.mean(torch_input, dims, True)
+
+    cpu_layout = ttl.tensor.Layout.ROW_MAJOR
+    tt_output_cpu = (
+        ttl.operations.primary.moreh_mean(tt_input, tt_output, dims=dims)
+        .cpu()
+        .to(cpu_layout)
+        .unpad_from_tile(output_shape)
+        .to_torch()
+    )
+
+    # test for equivalance
+    rtol = atol = 0.1
+    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+
+    logger.info(f"Out passing={passing}")
+    logger.info(f"Output pcc={output_pcc}")
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        ([1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1]),
+        ([4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1]),
+        ([4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1]),
+        ([8, 8, TILE_HEIGHT * 20 - 1, TILE_WIDTH * 20 - 1]),
+    ),
+    ids=[
+        "1, 1, TILE_HEIGHT-1,TILE_WIDTH - 1",
+        "4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1",
+        "4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1",
+        "8, 8, TILE_HEIGHT * 20 - 1, TILE_WIDTH * 20 - 1",
+    ],
+)
+@pytest.mark.parametrize(
+    "dims",
+    (
+        [0],
+        [0, 1],
+        [0, 1, 2],
+        [0, 1, 2, 3],
+        [0, 1, 3],
+        [0, 2, 3],
+        [1],
+        [1, 2],
+        [1, 2, 3],
+        [1, 3],
+        [2],
+        [2, 3],
+        [3],
+    ),
+    ids=["0", "0,1", "0,1,2", "0,1,2,3", "0,1,3", "0,2,3", "1", "1,2", "1,2,3", "1,3", "2", "2,3", "3"],
+)
+def test_moreh_mean_backward(input_shape, dims, device):
+    torch.manual_seed(2023)
+    output_shape = input_shape.copy()
+
+    for dim in dims:
+        output_shape[dim] = 1
+
+    (_, _, torch_input) = get_tensors(input_shape, output_shape, device)
+    (tt_output_grad, tt_input_grad, torch_output_grad) = get_backward_tensors(output_shape, input_shape, device)
+
+    torch_output = torch.mean(torch_input, dims, True)
+    torch_output.backward(torch_output_grad)
+
+    cpu_layout = ttl.tensor.Layout.ROW_MAJOR
+    tt_input_grad_cpu = (
+        ttl.operations.primary.moreh_mean_backward(tt_output_grad, tt_input_grad)
+        .cpu()
+        .to(cpu_layout)
+        .unpad_from_tile(input_shape)
+        .to_torch()
+    )
+
+    # test for equivalance
+    rtol = atol = 0.1
+    passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_cpu, pcc=0.999, rtol=rtol, atol=atol)
+
+    logger.info(f"Out passing={passing}")
+    logger.info(f"Output pcc={output_pcc}")
+
+    assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/test_moreh_mean.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_moreh_mean.py
@@ -7,35 +7,45 @@ import torch
 from loguru import logger
 
 import tt_lib as ttl
-from models.utility_functions import comp_allclose_and_pcc, skip_for_wormhole_b0
+from models.utility_functions import comp_allclose_and_pcc, comp_pcc
 
 TILE_HEIGHT = 32
 TILE_WIDTH = 32
 
 
-def get_tensors(input_shape, output_shape, device):
+def get_tensors(input_shape, output_shape, use_randint, device):
     npu_dtype = ttl.tensor.DataType.BFLOAT16
-    cpu_dtype = torch.bfloat16
     npu_layout = ttl.tensor.Layout.TILE
+    cpu_dtype = torch.float
 
-    # create tensors for forward
-    torch_input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype, requires_grad=True)
-    torch_output = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
+    if use_randint:
+        torch_input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype)
+        torch_output = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
+    else:
+        torch_input = torch.rand(input_shape, dtype=cpu_dtype) * 200 - 100
+        torch_output = torch.rand(output_shape, dtype=cpu_dtype) * 200 - 100
 
+    torch_input = torch_input.bfloat16().requires_grad_()
+    torch_output = torch_output.bfloat16()
     tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
     tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-
     return tt_input, tt_output, torch_input
 
 
-def get_backward_tensors(output_grad_shape, input_grad_shape, device):
+def get_backward_tensors(output_grad_shape, input_grad_shape, use_randint, device):
     npu_dtype = ttl.tensor.DataType.BFLOAT16
-    cpu_dtype = torch.bfloat16
     npu_layout = ttl.tensor.Layout.TILE
+    cpu_dtype = torch.float
 
-    torch_output_grad = torch.randint(-2, 3, output_grad_shape, dtype=cpu_dtype)
-    torch_input_grad = torch.randint(-2, 3, input_grad_shape, dtype=cpu_dtype)
+    if use_randint:
+        torch_input_grad = torch.randint(-2, 3, input_grad_shape, dtype=cpu_dtype)
+        torch_output_grad = torch.randint(-2, 3, output_grad_shape, dtype=cpu_dtype)
+    else:
+        torch_input_grad = torch.rand(input_grad_shape, dtype=cpu_dtype) * 200 - 100
+        torch_output_grad = torch.rand(output_grad_shape, dtype=cpu_dtype) * 200 - 100
 
+    torch_input_grad = torch_input_grad.bfloat16()
+    torch_output_grad = torch_output_grad.bfloat16()
     tt_output_grad = ttl.tensor.Tensor(torch_output_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
     tt_input_grad = ttl.tensor.Tensor(torch_input_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
 
@@ -76,14 +86,19 @@ def get_backward_tensors(output_grad_shape, input_grad_shape, device):
     ),
     ids=["0", "0,1", "0,1,2", "0,1,2,3", "0,1,3", "0,2,3", "1", "1,2", "1,2,3", "1,3", "2", "2,3", "3"],
 )
-def test_moreh_mean_dims(input_shape, dims, device):
+@pytest.mark.parametrize(
+    "use_randint",
+    (True, False),
+    ids=["True", "False"],
+)
+def test_moreh_mean_dims(input_shape, dims, use_randint, device):
     torch.manual_seed(2023)
     output_shape = input_shape.copy()
 
     for dim in dims:
         output_shape[dim] = 1
 
-    (tt_input, tt_output, torch_input) = get_tensors(input_shape, output_shape, device)
+    (tt_input, tt_output, torch_input) = get_tensors(input_shape, output_shape, use_randint, device)
 
     torch_output = torch.mean(torch_input, dims, True)
 
@@ -98,7 +113,10 @@ def test_moreh_mean_dims(input_shape, dims, device):
 
     # test for equivalance
     rtol = atol = 0.1
-    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+    if use_randint:
+        passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+    else:
+        passing, output_pcc = comp_pcc(torch_output, tt_output_cpu, pcc=0.999)
 
     logger.info(f"Out passing={passing}")
     logger.info(f"Output pcc={output_pcc}")
@@ -140,15 +158,22 @@ def test_moreh_mean_dims(input_shape, dims, device):
     ),
     ids=["0", "0,1", "0,1,2", "0,1,2,3", "0,1,3", "0,2,3", "1", "1,2", "1,2,3", "1,3", "2", "2,3", "3"],
 )
-def test_moreh_mean_backward(input_shape, dims, device):
+@pytest.mark.parametrize(
+    "use_randint",
+    (True, False),
+    ids=["True", "False"],
+)
+def test_moreh_mean_backward(input_shape, dims, use_randint, device):
     torch.manual_seed(2023)
     output_shape = input_shape.copy()
 
     for dim in dims:
         output_shape[dim] = 1
 
-    (_, _, torch_input) = get_tensors(input_shape, output_shape, device)
-    (tt_output_grad, tt_input_grad, torch_output_grad) = get_backward_tensors(output_shape, input_shape, device)
+    (_, _, torch_input) = get_tensors(input_shape, output_shape, use_randint, device)
+    (tt_output_grad, tt_input_grad, torch_output_grad) = get_backward_tensors(
+        output_shape, input_shape, use_randint, device
+    )
 
     torch_output = torch.mean(torch_input, dims, True)
     torch_output.backward(torch_output_grad)
@@ -164,7 +189,12 @@ def test_moreh_mean_backward(input_shape, dims, device):
 
     # test for equivalance
     rtol = atol = 0.1
-    passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_cpu, pcc=0.999, rtol=rtol, atol=atol)
+    if use_randint:
+        passing, output_pcc = comp_allclose_and_pcc(
+            torch_input.grad, tt_input_grad_cpu, pcc=0.999, rtol=rtol, atol=atol
+        )
+    else:
+        passing, output_pcc = comp_pcc(torch_input.grad, tt_input_grad_cpu, pcc=0.999)
 
     logger.info(f"Out passing={passing}")
     logger.info(f"Output pcc={output_pcc}")

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -95,6 +95,12 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp \
 	tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward.cpp \
 	tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_op.cpp \
+	tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_h/moreh_mean_h.cpp \
+	tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_w/moreh_mean_w.cpp \
+	tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_nc/moreh_mean_nc.cpp \
+	tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_op.cpp \
+	tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward.cpp \
+	tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.cpp \
 	tt_eager/tt_dnn/op_library/layernorm/multi_core/layernorm_op_multi_core.cpp \
 	tt_eager/tt_dnn/op_library/layernorm/layernorm_op.cpp \
 	tt_eager/tt_dnn/op_library/moreh_bmm/moreh_bmm_op.cpp \

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_h.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/mask.h"
+#include "compute_kernel_api/reduce.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
+ALWI void REL() { release_dst(tt::DstMode::Half); }
+
+namespace NAMESPACE {
+void MAIN {
+
+    uint32_t Ht = get_compile_time_arg_val(0);
+    uint32_t Wt = get_compile_time_arg_val(1);
+    uint32_t NC = get_compile_time_arg_val(2);
+    constexpr uint32_t origin_H = get_compile_time_arg_val(3);
+
+    auto cb_input = tt::CB::c_in0;
+    constexpr auto cb_scaler = tt::CB::c_in2;
+    constexpr auto cb_mask_h = tt::CB::c_in3;
+    constexpr auto cb_accum_dst = tt::CB::c_intermed0;
+    constexpr auto cb_masked_input = tt::CB::c_intermed1;
+    constexpr auto cb_out = tt::CB::c_out0;
+    constexpr uint32_t TILE_H = 32;
+    constexpr bool do_mask_h = (origin_H % TILE_H) != 0;
+
+    binary_op_init_common(cb_input, cb_input);
+
+    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+
+    constexpr int onetile = 1;
+    int reduce_dst_idx = 0;
+    const uint32_t mask_dst_idx = reduce_dst_idx + 1;
+
+    if (do_mask_h) {
+        cb_wait_front(cb_mask_h, onetile);
+    }
+
+    uint32_t count = 0;
+    for (uint32_t nc = 0; nc < NC; nc++) {
+        for (uint32_t wt = 0; wt < Wt; ++wt) {
+            // tiles are expected to be coming in in NCWH order (H-contiguous)
+            // reducing in W means out[0][w] = sum(h=0..H-1, in[h][w])
+            // in this case we just sequentially add to accumulator all the H-tiles in a column
+            cb_input = tt::CB::c_in0;
+            bool is_h_single_tile = (Ht == 1);
+
+            if (!is_h_single_tile) {
+                ACQ();
+                for (uint32_t ht = 0; ht < Ht - 1; ++ht) {
+                    cb_wait_front(cb_input, onetile);
+
+                    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                    reduce_tile(REDUCE_OP, REDUCE_DIM, cb_input, cb_scaler, 0, 0, reduce_dst_idx);
+                    reduce_revert_delta();
+
+                    cb_pop_front(cb_input, onetile);
+                }
+                cb_reserve_back(cb_accum_dst, onetile);
+                pack_tile(reduce_dst_idx, cb_accum_dst);
+                cb_push_back(cb_accum_dst, onetile);
+                REL();
+            }
+
+            if (do_mask_h) {
+                ACQ();
+                cb_wait_front(cb_input, onetile);
+                copy_tile_init();
+                copy_tile(cb_input, 0, reduce_dst_idx);
+                copy_tile(cb_mask_h, 0, mask_dst_idx);
+                mask_tile_init();
+                mask_tile(reduce_dst_idx, mask_dst_idx);
+
+                cb_reserve_back(cb_masked_input, onetile);
+                pack_tile(reduce_dst_idx, cb_masked_input);
+                cb_push_back(cb_masked_input, onetile);
+
+                cb_pop_front(cb_input, onetile);
+                cb_input = cb_masked_input;
+                REL();
+            }
+
+            ACQ();
+            cb_wait_front(cb_input, onetile);
+            if (!is_h_single_tile) {
+                cb_wait_front(cb_accum_dst, onetile);
+                copy_tile_init();
+                copy_tile(cb_accum_dst, 0, reduce_dst_idx);
+            }
+
+            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_tile(REDUCE_OP, REDUCE_DIM, cb_input, cb_scaler, 0, 0, reduce_dst_idx);
+            reduce_revert_delta();
+
+            cb_reserve_back(cb_out, onetile);
+            pack_tile(reduce_dst_idx, cb_out);
+            cb_push_back(cb_out, onetile);
+
+            cb_pop_front(cb_input, onetile);
+            if (!is_h_single_tile) {
+                cb_pop_front(cb_accum_dst, onetile);
+            }
+            REL();
+        }
+    }
+
+    if (do_mask_h) {
+        cb_pop_front(cb_mask_h, onetile);
+    }
+    cb_pop_front(cb_scaler, onetile);
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_nc.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/bcast.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
+ALWI void REL() { release_dst(tt::DstMode::Half); }
+
+namespace NAMESPACE {
+void MAIN {
+    const auto num_input_tiles = get_arg_val<uint32_t>(0);
+    const auto num_output_tiles = get_arg_val<uint32_t>(1);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_scalar = tt::CB::c_in2;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t dst1 = 1;
+    constexpr uint32_t first_tile = 0;
+
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in1);
+
+    cb_wait_front(cb_in1, onetile);
+    cb_wait_front(cb_scalar, 1);  // scalar tile from the reader
+
+    for (uint32_t i = 0; i < num_output_tiles; i++) {
+        bool enable_reload = false;
+        for (uint32_t j = 0; j < num_input_tiles; ++j) {
+            bool last_out = (j == num_input_tiles - 1);
+
+            ACQ();
+            cb_wait_front(cb_in0, onetile);
+            if (enable_reload) {
+                cb_wait_front(cb_intermed0, onetile);
+            }
+
+            uint32_t cb_add  = (enable_reload) ? (cb_intermed0) : (cb_in1);
+            add_tiles_init();
+            add_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
+
+            cb_pop_front(cb_in0, onetile);
+            if (enable_reload) {
+                cb_pop_front(cb_intermed0, onetile);
+            }
+
+            cb_reserve_back(cb_intermed0, onetile);
+            pack_tile(dst0, cb_intermed0);
+            cb_push_back(cb_intermed0, onetile);
+            REL();
+
+            enable_reload = true;
+        }
+
+        // output * (1 / number_of_elements)
+        ACQ();
+        cb_wait_front(cb_intermed0, onetile);
+        mul_tiles_bcast_scalar_init_short();
+        mul_tiles_bcast<BroadcastType::SCALAR>(cb_intermed0, cb_scalar, 0, 0, 0);
+        cb_reserve_back(cb_out0, onetile);
+        pack_tile(dst0, cb_out0);
+        cb_push_back(cb_out0, onetile);
+        cb_pop_front(cb_intermed0, onetile);
+        REL();
+    }
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_w.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/mask.h"
+#include "compute_kernel_api/reduce.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
+ALWI void REL() { release_dst(tt::DstMode::Half); }
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t Ht = get_compile_time_arg_val(0);
+    uint32_t Wt = get_compile_time_arg_val(1);
+    uint32_t NC = get_compile_time_arg_val(2);
+    constexpr uint32_t origin_W = get_compile_time_arg_val(3);
+
+
+    auto cb_input = tt::CB::c_in0;
+    constexpr auto cb_scaler = tt::CB::c_in2;
+    constexpr auto cb_mask_w = tt::CB::c_in3;
+    constexpr auto cb_accum_dst = tt::CB::c_intermed0;
+    constexpr auto cb_masked_input = tt::CB::c_intermed1;
+    constexpr auto cb_out = tt::CB::c_out0;
+    constexpr uint32_t TILE_W = 32;
+    constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
+
+    binary_op_init_common(cb_input, cb_input);
+
+    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+
+    constexpr int onetile = 1;
+    int reduce_dst_idx = 0;
+    const uint32_t mask_dst_idx = reduce_dst_idx + 1;
+
+    if (do_mask_w) {
+        cb_wait_front(cb_mask_w, onetile);
+    }
+
+    for (uint32_t nc = 0; nc < NC; nc++) {
+        for (uint32_t ht = 0; ht < Ht; ++ht) {
+            // tiles are expected to be coming in in NCHW order (W-contiguous)
+            // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
+            // in this case we just sequentially add to accumulator all the W-tiles in a row
+            cb_input = tt::CB::c_in0;
+            bool is_w_single_tile = (Wt == 1);
+            if (!is_w_single_tile) {
+                ACQ();
+                for (uint32_t wt = 0; wt < Wt - 1; ++wt) {
+                    cb_wait_front(cb_input, onetile);
+
+                    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                    reduce_tile(REDUCE_OP, REDUCE_DIM, cb_input, cb_scaler, 0, 0, reduce_dst_idx);
+                    reduce_revert_delta();
+
+                    cb_pop_front(cb_input, onetile);
+                }
+                cb_reserve_back(cb_accum_dst, onetile);
+                pack_tile(reduce_dst_idx, cb_accum_dst);
+                cb_push_back(cb_accum_dst, onetile);
+                REL();
+            }
+
+            if (do_mask_w) {
+                ACQ();
+                cb_wait_front(cb_input, onetile);
+                copy_tile_init();
+                copy_tile(cb_input, 0, reduce_dst_idx);
+                copy_tile(cb_mask_w, 0, mask_dst_idx);
+                mask_tile_init();
+                mask_tile(reduce_dst_idx, mask_dst_idx);
+
+                cb_reserve_back(cb_masked_input, onetile);
+                pack_tile(reduce_dst_idx, cb_masked_input);
+                cb_push_back(cb_masked_input, onetile);
+
+                cb_pop_front(cb_input, onetile);
+                cb_input = cb_masked_input;
+                REL();
+            }
+
+            ACQ();
+            cb_wait_front(cb_input, onetile);
+            if (!is_w_single_tile) {
+                cb_wait_front(cb_accum_dst, onetile);
+                copy_tile_init();
+                copy_tile(cb_accum_dst, 0, reduce_dst_idx);
+            }
+
+            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_tile(REDUCE_OP, REDUCE_DIM, cb_input, cb_scaler, 0, 0, reduce_dst_idx);
+            reduce_revert_delta();
+
+            cb_reserve_back(cb_out, onetile);
+            pack_tile(reduce_dst_idx, cb_out);
+            cb_push_back(cb_out, onetile);
+
+            cb_pop_front(cb_input, onetile);
+            if (!is_w_single_tile) {
+                cb_pop_front(cb_accum_dst, onetile);
+            }
+            REL();
+        }
+    }
+
+    if (do_mask_w) {
+        cb_pop_front(cb_mask_w, onetile);
+    }
+    cb_pop_front(cb_scaler, onetile);
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_h.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/moreh_mean/kernels/utils.hpp"
+
+void kernel_main() {
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+    uint32_t col_start_tile_id = get_arg_val<uint32_t>(1); // Start id in column major order. This should be the start of a column
+    uint32_t curr_col_in_batch = get_arg_val<uint32_t>(2);
+    uint32_t num_cols = get_arg_val<uint32_t>(3); // number of cols to read
+    uint32_t mask_h = get_arg_val<uint32_t>(4);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t Ht  = get_compile_time_arg_val(1);
+    constexpr uint32_t Wt  = get_compile_time_arg_val(2);
+    constexpr uint32_t HtWt  = get_compile_time_arg_val(3);
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    #ifdef REDUCE_SCALER
+    constexpr uint32_t cb_id_in2 = 2;
+    constexpr uint32_t scaler = get_compile_time_arg_val(4);
+    cb_reserve_back(cb_id_in2, 1);
+    constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
+    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t write_addr = get_write_ptr(cb_id_in2);
+    // Fill tile with zeros
+    for (uint32_t i = 0; i < num_zeros_reads; ++i) {
+        noc_async_read(zeros_noc_addr, write_addr, MEM_ZEROS_SIZE);
+        write_addr += MEM_ZEROS_SIZE;
+    }
+    noc_async_read_barrier();
+    if constexpr (scaler != 0) {
+        volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id_in2));
+        uint32_t idx = 0;
+        for (uint32_t k = 0; k < 4; ++k) {
+            uint32_t curr_idx = idx;
+            for (uint32_t j = 0; j < 8; ++j) {
+                ptr[curr_idx] = scaler;
+                curr_idx++;
+            }
+            idx += 128;
+        }
+    }
+    cb_push_back(cb_id_in2, 1);
+    #endif
+
+    constexpr uint32_t cb_id_mask_h = 3;
+#ifdef DO_MASK_H
+    generate_mask_h(cb_id_mask_h, mask_h);
+#endif
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t w = curr_col_in_batch;
+
+    // this reader will read a NHW tensor in NWH order
+    for (uint32_t i = 0; i < num_cols; i++) {
+        uint32_t curr_id = col_start_tile_id;
+        for (uint32_t j = 0; j < Ht; j++) {
+            cb_reserve_back(cb_id_in0, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            noc_async_read_tile(curr_id, s, l1_write_addr);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            curr_id += Wt; // stride in H
+        }
+        w++;
+        if (w == Wt) {
+            col_start_tile_id = curr_id - Wt + 1;
+            w = 0;
+        } else {
+            col_start_tile_id++;
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_nc.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/moreh_mean/kernels/utils.hpp"
+#include "debug/dprint.h"
+
+inline uint32_t get_read_tile_id(uint32_t tile_id, uint32_t dim, uint32_t input_tile_offset, uint32_t HtWt) {
+    return (dim == 0 ) ? (tile_id) : (tile_id / HtWt * input_tile_offset) + (tile_id % HtWt);
+}
+
+void kernel_main() {
+    const auto input_addr = get_arg_val<uint32_t>(0);
+    const auto num_input_tiles = get_arg_val<uint32_t>(1);
+    const auto num_output_tiles = get_arg_val<uint32_t>(2);
+    const auto input_tile_offset = get_arg_val<uint32_t>(3);
+    const auto start_id = get_arg_val<uint32_t>(4);
+    const auto input_is_dram = (get_arg_val<uint32_t>(5) == 1);
+    const auto HtWt = get_arg_val<uint32_t>(6);
+    const auto CHtWt = get_arg_val<uint32_t>(7);
+    const auto dim = get_arg_val<uint32_t>(8);
+
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in1 = 1;
+    constexpr uint32_t cb_id_in2 = 2;
+
+    union {
+        float f;
+        uint32_t u;
+    } scaler;
+    scaler.f = 0.0f;
+    fill_cb_with_value(cb_id_in1, scaler.u);
+
+    scaler.f = 1.0f / num_input_tiles;
+    fill_cb_with_value(cb_id_in2, scaler.u, 1);
+
+    uint32_t l1_write_addr_in0;
+    uint32_t input_tile_bytes = get_tile_size(cb_id_in0);
+    const auto input_data_format = get_dataformat(cb_id_in0);
+    const InterleavedAddrGenFast<true> dram_input_addrg = {
+        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    const InterleavedAddrGenFast<false> l1_input_addrg = {
+        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+
+    for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
+        auto read_tile_id = get_read_tile_id(i, dim, CHtWt, HtWt);
+        for (uint32_t j = 0; j < num_input_tiles; ++j) {
+            cb_reserve_back(cb_id_in0, onetile);
+            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            if (input_is_dram) {
+                noc_async_read_tile(read_tile_id, dram_input_addrg, l1_write_addr_in0);
+            } else {
+                noc_async_read_tile(read_tile_id, l1_input_addrg, l1_write_addr_in0);
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            read_tile_id += input_tile_offset;
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_w.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/moreh_mean/kernels/utils.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t mask_w = get_arg_val<uint32_t>(3);
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t scaler = get_compile_time_arg_val(1);
+
+    constexpr uint32_t cb_id_in2 = 2;
+    cb_reserve_back(cb_id_in2, 1);
+    constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
+    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t write_addr = get_write_ptr(cb_id_in2);
+    // Fill tile with zeros
+    for (uint32_t i = 0; i < num_zeros_reads; ++i) {
+        noc_async_read(zeros_noc_addr, write_addr, MEM_ZEROS_SIZE);
+        write_addr += MEM_ZEROS_SIZE;
+    }
+    noc_async_read_barrier();
+    if constexpr (scaler != 0) {
+        volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id_in2));
+        uint32_t idx = 0;
+        for (uint32_t k = 0; k < 4; ++k) {
+            uint32_t curr_idx = idx;
+            for (uint32_t j = 0; j < 8; ++j) {
+                ptr[curr_idx] = scaler;
+                curr_idx++;
+            }
+            idx += 128;
+        }
+    }
+    cb_push_back(cb_id_in2, 1);
+
+    constexpr uint32_t cb_id_mask_w = 3;
+#ifdef DO_MASK_W
+    generate_mask_w(cb_id_mask_w, mask_w);
+#endif
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        cb_reserve_back(cb_id_in0, onetile);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/utils.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/utils.hpp
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void fill_cb_with_value(uint32_t cb_id, uint32_t value, int32_t num_of_elems = 1024) {
+    cb_reserve_back(cb_id, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_id));
+    for (int j = 0; j < num_of_elems; j++) {
+        ptr[j] = uint16_t(value >> 16);
+    }
+    cb_push_back(cb_id, 1);
+}
+
+void generate_mask_h_w(uint32_t cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
+    union {
+        float f;
+        uint32_t u;
+    } one;
+    one.f = 1.0f;
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+
+    const auto u16_one = uint16_t(one.u >> 16);
+    const auto u16_zero = uint16_t(zero.u >> 16);
+
+    cb_reserve_back(cb_mask_h_w, 2);
+
+    // mask_h
+    // first tile ptr
+    auto mask_h_ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask_h_w));
+    for (uint32_t w = 0; w < 16; w++) {
+        // sub tile 0
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16) {
+                mask_h_0 = 16;
+            }
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                mask_h_ptr[h * 16 + w] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w] = u16_zero;
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16) {
+                mask_h_0 = 16;
+            }
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                mask_h_ptr[h * 16 + w + 256] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w + 256] = u16_zero;
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                mask_h_ptr[h * 16 + w + 512] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w + 512] = u16_zero;
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                mask_h_ptr[h * 16 + w + 768] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w + 768] = u16_zero;
+            }
+        }
+    }
+
+    // mask_w
+    // second tile ptr
+    auto mask_w_ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask_h_w) + single_tile_size);
+    for (uint32_t h = 0; h < 16; h++) {
+        // sub tile 0
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16) {
+                mask_w_0 = 16;
+            }
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                mask_w_ptr[h * 16 + w] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w] = u16_zero;
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                mask_w_ptr[h * 16 + w + 256] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w + 256] = u16_zero;
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16) {
+                mask_w_0 = 16;
+            }
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                mask_w_ptr[h * 16 + w + 512] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w + 512] = u16_zero;
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                mask_w_ptr[h * 16 + w + 768] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w + 768] = u16_zero;
+            }
+        }
+    }
+
+    cb_push_back(cb_mask_h_w, 2);
+}
+
+void generate_mask_w(uint32_t cb_mask, uint32_t mask_w) {
+    union {
+        float f;
+        uint32_t u;
+    } one;
+    one.f = 1.0f;
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask));
+
+    for (uint32_t h = 0; h < 16; h++) {
+        // sub tile 0
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16)
+                mask_w_0 = 16;
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                ptr[h * 16 + w] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                ptr[h * 16 + w + 256] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 256] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16)
+                mask_w_0 = 16;
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                ptr[h * 16 + w + 512] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 512] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                ptr[h * 16 + w + 768] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 768] = uint16_t(zero.u >> 16);
+            }
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}
+
+void generate_mask_h(uint32_t cb_mask, uint32_t mask_h) {
+    union {
+        float f;
+        uint32_t u;
+    } one;
+    one.f = 1.0f;
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask));
+
+    for (uint32_t w = 0; w < 16; w++) {
+        // sub tile 0
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16)
+                mask_h_0 = 16;
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                ptr[h * 16 + w] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16)
+                mask_h_0 = 16;
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                ptr[h * 16 + w + 256] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 256] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                ptr[h * 16 + w + 512] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 512] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                ptr[h * 16 + w + 768] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 768] = uint16_t(zero.u >> 16);
+            }
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_nc.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    const auto output_addr = get_arg_val<uint32_t>(0);
+    const auto num_tiles = get_arg_val<uint32_t>(1);
+    const auto start_id = get_arg_val<uint32_t>(2);
+    const auto output_is_dram = (get_arg_val<uint32_t>(3) == 1);
+
+    constexpr uint32_t cb_id_out = 16;
+    constexpr uint32_t onetile = 1;
+
+    uint32_t output_tile_bytes = get_tile_size(cb_id_out);
+    const auto output_data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<true> dram_output_addrg = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    const InterleavedAddrGenFast<false> l1_output_addrg = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        uint32_t write_tile_id = i;
+        cb_wait_front(cb_id_out, onetile);
+
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        if (output_is_dram) {
+            noc_async_write_tile(write_tile_id, dram_output_addrg, l1_read_addr);
+        } else {
+            noc_async_write_tile(write_tile_id, l1_output_addrg, l1_read_addr);
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+        cb_wait_front(cb_id_out, onetile);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_h/moreh_mean_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_h/moreh_mean_h.cpp
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+
+#include "tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
+#include "tt_dnn/op_library/reduce/reduce_op.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace operations {
+
+namespace primary {
+
+// TODO: Consolidate into moreh_sum_h
+operation::ProgramWithCallbacks moreh_mean_h(const Tensor &a, const Tensor &output) {
+    tt_metal::ReduceOpMath reduce_op = tt_metal::ReduceOpMath::SUM;
+    tt_metal::ReduceOpDim reduce_dim = tt_metal::ReduceOpDim::H;
+
+    const auto shape = a.shape();
+    uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
+
+    uint32_t Wt = W / TILE_WIDTH;
+    uint32_t Ht = H / TILE_HEIGHT;
+    uint32_t HtWt = Ht * Wt;
+
+    // check mask for h-dim
+    const auto input_shape_without_padding = shape.without_padding();
+    const auto origin_H = input_shape_without_padding[2];
+    const bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
+    const auto mask_h = do_mask_h ? origin_H % TILE_HEIGHT : TILE_HEIGHT;
+
+    float scaler = 1.0f / origin_H;
+
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    uint32_t src0_single_tile_size = tt_metal::detail::TileSize(src0_cb_data_format);
+    tt::DataFormat scaler_cb_data_format = DataFormat::Float16_b;
+    uint32_t scaler_single_tile_size = tt_metal::detail::TileSize(src0_cb_data_format);
+    tt::DataFormat mask_h_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t mask_h_single_tile_size = tt_metal::detail::TileSize(mask_h_cb_data_format);
+    tt::DataFormat intermed_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t intermed_single_tile_size= tt_metal::detail::TileSize(intermed_cb_data_format);
+    tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
+
+    uint32_t num_tiles = a.volume() / TILE_HW;
+
+    tt_metal::Device *device = a.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto num_cols = NC * Wt;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_cols);
+
+    string compute_kernel_name = "tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_h.cpp";
+
+    uint32_t src0_cb_index = CB::c_in0;
+    CBHandle cb_src0;
+    uint32_t src1_cb_index = CB::c_in1;
+    CBHandle cb_src1 = 0;
+    uint32_t num_input_tiles = 2;
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
+            .set_page_size(src0_cb_index, src0_single_tile_size);
+    cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    uint32_t scaler_cb_index = CB::c_in2;
+    tt_metal::CircularBufferConfig cb_scaler_config =
+        tt_metal::CircularBufferConfig(1 * scaler_single_tile_size, {{scaler_cb_index, scaler_cb_data_format}})
+            .set_page_size(scaler_cb_index, scaler_single_tile_size);
+    auto cb_scaler = tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
+
+    tt_metal::CircularBufferConfig cb_mask_h_config =
+        tt_metal::CircularBufferConfig(mask_h_single_tile_size, {{CB::c_in3, mask_h_cb_data_format}})
+            .set_page_size(CB::c_in3, mask_h_single_tile_size);
+    auto cb_mask_h = tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_h_config);
+
+    tt_metal::CircularBufferConfig cb_intermed0_config =
+        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed0, intermed_cb_data_format}})
+            .set_page_size(CB::c_intermed0, intermed_single_tile_size);
+    auto cb_intermed0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
+
+    tt_metal::CircularBufferConfig cb_intermed1_config =
+        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed1, intermed_cb_data_format}})
+            .set_page_size(CB::c_intermed1, intermed_single_tile_size);
+    auto cb_intermed1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
+
+    uint32_t output_cb_index = CB::c_out0;  // output operands start at index 16
+    CBHandle cb_output;
+    uint32_t num_output_tiles = 2;
+    tt_metal::CircularBufferConfig cb_output_config =
+        tt_metal::CircularBufferConfig(num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
+            .set_page_size(output_cb_index, dst_single_tile_size);
+    cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    tt_metal::Buffer *src0_buffer = a.buffer();
+    tt_metal::KernelHandle reader_kernel_id;
+    bfloat16 bfloat_scaler_value = bfloat16(scaler);
+    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_is_dram, Ht, Wt, HtWt, packed_scaler_value};
+
+    std::map<string, string> reader_defines;
+    reader_defines["REDUCE_SCALER"] = "1";
+    if (do_mask_h) {
+        reader_defines["DO_MASK_H"] = "1";
+    }
+    reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_h.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig{.compile_args = reader_compile_time_args, .defines = reader_defines});
+
+    tt_metal::Buffer *dst_buffer = output.buffer();
+    tt_metal::KernelHandle writer_kernel_id;
+
+    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+
+    writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt_metal::WriterDataMovementConfig{.compile_args = writer_compile_time_args});
+    std::map<string, string> reduce_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    vector<uint32_t> compute_kernel_args_group_1 = {
+        Ht,                         // Ht
+        num_cols_per_core_group_1,  // Wt
+        1,                          // NC
+        origin_H
+    };
+
+    auto reduce_compute_kernel_group_1_id = tt_metal::CreateKernel(
+        program,
+        compute_kernel_name,
+        core_group_1,
+        tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_1, .defines = reduce_defines});
+
+    if (!core_group_2.ranges().empty()) {
+        vector<uint32_t> compute_kernel_args_group_2 = {
+            Ht,                         // Ht
+            num_cols_per_core_group_2,  // Wt
+            1,                          // NC
+            origin_H
+        };
+
+        auto reduce_compute_kernel_group_2_id = tt_metal::CreateKernel(
+            program,
+            compute_kernel_name,
+            core_group_2,
+            tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_2, .defines = reduce_defines});
+    }
+
+    for (uint32_t i = 0, num_cols_read = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_cols_per_core = 0;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_cols_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_cols_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges");
+        }
+        tt_metal::SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {a.buffer()->address(),
+             num_cols_read / Wt * HtWt + num_cols_read % Wt,
+             num_cols_read % Wt,
+             num_cols_per_core,
+             mask_h
+             });
+
+        tt_metal::SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {
+                output.buffer()->address(),
+                num_cols_per_core,  // number of tiles to write
+                num_cols_read       // output tile start index
+            });
+        num_cols_read += num_cols_per_core;
+    }
+
+    auto override_runtime_arguments_callback = [reader_kernel_id = reader_kernel_id,
+                                                writer_kernel_id = writer_kernel_id,
+                                                cb_src1 = cb_src1,
+                                                cb_output = cb_output,
+                                                num_cores = num_cores,
+                                                num_cores_y = num_cores_y](
+                                                   const void *operation,
+                                                   Program &program,
+                                                   const std::vector<Tensor> &input_tensors,
+                                                   const std::vector<std::optional<const Tensor>> &,
+                                                   const std::vector<Tensor> &output_tensors) {
+        auto src_buffer = input_tensors.at(0).buffer();
+        auto dst_buffer = output_tensors.at(0).buffer();
+
+        for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = src_buffer->address();
+            }
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = dst_buffer->address();
+            }
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_nc/moreh_mean_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_nc/moreh_mean_nc.cpp
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
+#include "tt_dnn/op_library/bcast/bcast_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_eager/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace operations {
+
+namespace primary {
+
+operation::ProgramWithCallbacks moreh_mean_nc(const Tensor &input, const Tensor &output, int64_t dim) {
+    TT_ASSERT(dim == 0 || dim == 1);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto *device = input.device();
+    auto program = Program();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const auto cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const auto single_tile_size = detail::TileSize(cb_data_format);
+
+    const auto &input_shape = input.shape();
+    const auto &input_shape_without_padding = input_shape.without_padding();
+
+    const auto N = input_shape[0];
+    const auto C = input_shape[1];
+    const auto Ht = input_shape[2] / TILE_HEIGHT;
+    const auto Wt = input_shape[3] / TILE_WIDTH;
+    const auto HtWt = Ht * Wt;
+    const auto CHtWt = C * Ht * Wt;
+    const auto num_reduce_input_tile = input_shape[dim];
+    const auto input_tile_offset = (dim == 0) ? (CHtWt) : (HtWt);
+    const auto num_output_tiles = output.volume() / TILE_HW;
+
+    log_debug(LogTest, "N {} C {} Ht {} Wt {}", N, C, Ht, Wt);
+    log_debug(
+        LogTest,
+        "dim {} num_reduce_input_tile {} input_tile_offset {}, num_output_tiles {}",
+        dim,
+        num_reduce_input_tile,
+        input_tile_offset,
+        num_output_tiles);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    CoreGridDesc core_grid(device);
+    const auto num_cores_y = core_grid.y_;
+    CoreCoord core_grid_coord = {.x = core_grid.x_, .y = num_cores_y};
+
+    const uint32_t in0_t = 2;        // input
+    const uint32_t in1_t = 1;        // zero
+    const uint32_t in2_t = 1;        // scalar
+    const uint32_t intermed0_t = 1;  // accumulated mean
+    const uint32_t out0_t = 2;       // output
+    const auto
+        [num_cores_to_be_used,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_cols_per_core_group_1,
+         num_cols_per_core_group_2] = tt_metal::split_work_to_cores(core_grid_coord, num_output_tiles);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    CreateCircularBuffer(
+        program,
+        all_cores,
+        cb_data_format,
+        {
+            {CB::c_in0, in0_t},              // input
+            {CB::c_in1, in1_t},              // zero
+            {CB::c_in2, in2_t},              // scalar
+            {CB::c_intermed0, intermed0_t},  // accumulated mean
+            {CB::c_out0, out0_t},            // output
+        });
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> reader_compile_time_args;
+    std::vector<uint32_t> writer_compile_time_args;
+    const auto reader_kernel_file = "tt_eager/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_nc.cpp";
+    const auto writer_kernel_file = "tt_eager/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_nc.cpp";
+    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
+    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1};
+    std::map<string, string> compute_defines;
+    const auto compute_kernel_file = "tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_nc.cpp";
+    const auto compute_kernel_1_id = CreateComputeKernel(
+        program, compute_kernel_file, {core_group_1, num_cols_per_core_group_1, compute_args_group_1}, compute_defines);
+
+    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2};
+        compute_kernel_2_id = CreateComputeKernel(
+            program,
+            compute_kernel_file,
+            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
+            compute_defines);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_tiles_per_core;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_reduce_input_tile,
+             num_tiles_per_core,
+             input_tile_offset,
+             tile_offset,
+             static_cast<uint32_t>(is_dram(input)),
+             HtWt,
+             CHtWt,
+             static_cast<uint32_t>(dim)
+             });
+
+        SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {output.buffer()->address(), num_tiles_per_core, tile_offset, static_cast<uint32_t>(is_dram(output))});
+
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            SetRuntimeArgs(program, compute_kernel_1_id, core, {num_reduce_input_tile, num_tiles_per_core});
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            TT_ASSERT(compute_kernel_2_id.has_value());
+            SetRuntimeArgs(program, compute_kernel_2_id.value(), core, {num_reduce_input_tile, num_tiles_per_core});
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges.");
+        }
+        tile_offset += num_tiles_per_core;
+    }
+
+    auto override_runtime_arguments_callback = [reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y](
+                                                   const void *operation,
+                                                   const Program &program,
+                                                   const std::vector<Tensor> &input_tensors,
+                                                   const std::vector<std::optional<const Tensor>> &,
+                                                   const std::vector<Tensor> &output_tensors) {
+        const auto *input_buffer = input_tensors.at(0).buffer();
+        const auto *output_buffer = input_tensors.at(1).buffer();
+        for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+            {
+                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = input_buffer->address();
+                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
+            }
+
+            {
+                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = output_buffer->address();
+                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
+            }
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_op.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
+
+#include "tt_dnn/op_library/reduce/reduce_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace operations {
+namespace primary {
+
+////////////////////////////////////////////////////////////////////////////
+//                         MorehMean
+////////////////////////////////////////////////////////////////////////////
+void MorehMean::validate(const std::vector<Tensor>& inputs) const {
+    TT_ASSERT((dim >= 0 && dim <= 3), "dim should be 0 - 3");
+    const auto& input = inputs.at(0);
+    const auto& output = inputs.at(1);
+
+    auto input_shape = input.shape();
+    const auto& output_shape = output.shape();
+    auto input_shape_wo_padding = input.shape().without_padding();
+    const auto& output_shape_wo_padding = output.shape().without_padding();
+
+    if (dim == 0 || dim == 1) {
+        input_shape[dim] = 1;
+        input_shape_wo_padding[dim] = 1;
+    } else {
+        input_shape[dim] = TILE_HEIGHT;
+        input_shape_wo_padding[dim] = 1;
+    }
+
+    for (int i = 0; i < input_shape.rank(); ++i) {
+        TT_ASSERT(input_shape[i] == output_shape[i]);
+        TT_ASSERT(input_shape_wo_padding[i] == output_shape_wo_padding[i]);
+    }
+}
+
+std::vector<Tensor> MorehMean::create_output_tensors(const std::vector<Tensor>& inputs) const {
+    // Inplace
+    return {};
+}
+
+std::vector<Shape> MorehMean::compute_output_shapes(const std::vector<Tensor>& inputs) const {
+    // Inplace
+    return {};
+}
+
+operation::ProgramWithCallbacks MorehMean::create_program(
+    const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) const {
+    TT_ASSERT((dim >= 0 && dim <= 3), "dim should be 0 - 3");
+    auto& input = inputs.at(0);
+    auto& output = inputs.at(1);
+
+    if (dim == 0 || dim == 1) {
+        return moreh_mean_nc(input, output, dim);
+    } else if (dim == 2) {
+        return moreh_mean_h(input, output);
+    } else {
+        return moreh_mean_w(input, output);
+    }
+}
+
+inline Shape compute_output_shape(const Shape& input_shape, const int64_t& dim) {
+    auto output_shape = input_shape;
+    auto padding = output_shape.padding();
+    switch (dim) {
+        case 0:
+        case 1: output_shape[dim] = 1; break;
+        case 2:
+            output_shape[dim] = TILE_HEIGHT;
+            padding[dim] = Padding::PadDimension{0, 31};
+            break;
+        case 3:
+            output_shape[dim] = TILE_WIDTH;
+            padding[dim] = Padding::PadDimension{0, 31};
+            break;
+    }
+
+    return {Shape(output_shape, padding)};
+}
+
+inline Tensor create_output_tensor(
+    const Tensor& input_tensor, const Shape& output_shape, const MemoryConfig& mem_config) {
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE);
+    return create_device_tensor(output_shape, input_tensor.dtype(), Layout::TILE, input_tensor.device(), mem_config);
+}
+
+// output as arg
+Tensor moreh_mean_(const Tensor& input, const Tensor& output, const int64_t& dim) {
+    operation::run(MorehMean{.dim = dim}, {input, output});
+    return output;
+}
+
+// output creation inside
+Tensor moreh_mean_(const Tensor& input, const int64_t& dim, const MemoryConfig& mem_config) {
+    const auto& input_shape = input.shape();
+    const auto& output_shape = compute_output_shape(input_shape, dim);
+    auto output = create_output_tensor(input, output_shape, mem_config);
+
+    const auto& output_shape_wo_padding = output.shape().without_padding();
+    operation::run(MorehMean{.dim = dim}, {input, output});
+    return output;
+}
+
+Tensor moreh_mean(
+    const Tensor& input,
+    const Tensor& output,
+    std::vector<int64_t>& dims,
+    const MemoryConfig& mem_config) {
+    // reduce for all dims
+    if (dims.empty()) {
+        dims = {0, 1, 2, 3};
+    }
+
+    std::vector<int64_t> sorted_dims = dims;
+    std::sort(sorted_dims.begin(), sorted_dims.end());
+
+    auto temp_input = input;
+    for (uint32_t i = dims.size() - 1; i > 0; i--) {
+        log_debug(LogTest, "{}:{} dim {}", __func__, __LINE__, sorted_dims[i]);
+        auto temp_output = moreh_mean_(temp_input, sorted_dims[i], mem_config);
+        temp_input = temp_output;
+    }
+    log_debug(LogTest, "{}:{} dim {}", __func__, __LINE__, sorted_dims.front());
+    moreh_mean_(temp_input, output, sorted_dims.front());
+    return output;
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_eager/tensor/tensor.hpp"
+
+namespace tt {
+
+namespace operations {
+
+namespace primary {
+
+using namespace tt_metal;
+
+struct MorehMean {
+    int64_t dim;
+    void validate(const std::vector<Tensor> &inputs) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &inputs) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
+    stl::reflection::Attributes attributes() const;
+    static constexpr auto attribute_names = std::make_tuple("dim");
+    const auto attribute_values() const { return std::make_tuple(std::cref(this->dim)); }
+};
+
+operation::ProgramWithCallbacks moreh_mean_nc(const Tensor &input, const Tensor &output, int64_t dim);
+// revised from reduce_op
+operation::ProgramWithCallbacks moreh_mean_w(const Tensor &a, const Tensor &output);
+operation::ProgramWithCallbacks moreh_mean_h(const Tensor &a, const Tensor &output);
+
+Tensor moreh_mean_(
+    const Tensor &input,
+    std::optional<std::reference_wrapper<const Tensor>> output,
+    const int64_t &dim,
+    const MemoryConfig &mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+Tensor moreh_mean(
+    const Tensor &input,
+    const Tensor &output,
+    std::vector<int64_t> &dims,
+    const MemoryConfig &mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+}  // namespace primary
+
+}  // namespace operations
+
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_w/moreh_mean_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_w/moreh_mean_w.cpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+// based on reduce_op_multi_core_w.cpp in reduce op
+
+#include <algorithm>
+
+#include "tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
+#include "tt_dnn/op_library/reduce/reduce_op.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace operations {
+
+namespace primary {
+
+// TODO: Consolidate into moreh_sum_w
+operation::ProgramWithCallbacks moreh_mean_w(const Tensor &a, const Tensor &output) {
+    tt_metal::ReduceOpMath reduce_op = tt_metal::ReduceOpMath::SUM;
+    tt_metal::ReduceOpDim reduce_dim = tt_metal::ReduceOpDim::W;
+
+    const auto shape = a.shape();
+    uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
+    uint32_t HW = H * W;
+
+    uint32_t Wt = W / TILE_WIDTH;
+    uint32_t Ht = H / TILE_HEIGHT;
+
+    // check mask for w-dim
+    const auto input_shape_without_padding = shape.without_padding();
+    const auto origin_W = input_shape_without_padding[3];
+    const bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
+    const auto mask_w = do_mask_w ? origin_W % TILE_WIDTH : TILE_WIDTH;
+
+    float scaler = 1.0f / origin_W;
+
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
+    uint32_t src0_single_tile_size = tt_metal::detail::TileSize(src0_cb_data_format);
+    // Scaler datatype is hardcoded bfloat16 due to tile creation in reader
+    tt::DataFormat scaler_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t scaler_single_tile_size = tt_metal::detail::TileSize(scaler_cb_data_format);
+    tt::DataFormat mask_w_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t mask_w_single_tile_size = tt_metal::detail::TileSize(mask_w_cb_data_format);
+    tt::DataFormat intermed_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t intermed_single_tile_size= tt_metal::detail::TileSize(intermed_cb_data_format);
+    tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());
+    uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
+
+    uint32_t num_tiles = a.volume() / TILE_HW;
+
+    tt_metal::Device *device = a.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto num_rows = NC * Ht;
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_rows);
+
+    string compute_kernel_name = "tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_w.cpp";
+
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
+            .set_page_size(src0_cb_index, src0_single_tile_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    tt_metal::CircularBufferConfig cb_scaler_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * scaler_single_tile_size, {{CB::c_in2, scaler_cb_data_format}})
+            .set_page_size(CB::c_in2, scaler_single_tile_size);
+    auto cb_scaler = tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
+
+    tt_metal::CircularBufferConfig cb_mask_w_config =
+        tt_metal::CircularBufferConfig(mask_w_single_tile_size, {{CB::c_in3, mask_w_cb_data_format}})
+            .set_page_size(CB::c_in3, mask_w_single_tile_size);
+    auto cb_mask_w = tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_w_config);
+
+    tt_metal::CircularBufferConfig cb_intermed0_config =
+        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed0, intermed_cb_data_format}})
+            .set_page_size(CB::c_intermed0, intermed_single_tile_size);
+    auto cb_intermed0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
+
+    tt_metal::CircularBufferConfig cb_intermed1_config =
+        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed1, intermed_cb_data_format}})
+            .set_page_size(CB::c_intermed1, intermed_single_tile_size);
+    auto cb_intermed1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
+
+    uint32_t output_cb_index = 16;  // output operands start at index 16
+    uint32_t num_output_tiles = 2;
+    tt_metal::CircularBufferConfig cb_output_config =
+        tt_metal::CircularBufferConfig(num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
+            .set_page_size(output_cb_index, dst_single_tile_size);
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    bfloat16 bfloat_scaler_value = bfloat16(scaler);
+    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    tt_metal::Buffer *src_buffer = a.buffer();
+    bool src_is_dram = src_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram, packed_scaler_value};
+    tt_metal::Buffer *dst_buffer = output.buffer();
+    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+
+
+    std::map<string, string> reader_defines{};
+    if (do_mask_w) {
+        reader_defines["DO_MASK_W"] = "1";
+    }
+    tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_w.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig{.compile_args = reader_compile_time_args, reader_defines});
+
+    tt_metal::KernelHandle writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt_metal::WriterDataMovementConfig{.compile_args = writer_compile_time_args});
+
+    std::map<string, string> reduce_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    vector<uint32_t> compute_kernel_args_group_1 = {
+        num_rows_per_core_group_1,  // Ht
+        Wt,                         // Wt
+        1,                          // NC
+        origin_W,
+    };
+
+    auto reduce_compute_kernel_group_1_id = tt_metal::CreateKernel(
+        program,
+        compute_kernel_name,
+        core_group_1,
+        tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_1, .defines = reduce_defines});
+
+    if (!core_group_2.ranges().empty()) {
+        vector<uint32_t> compute_kernel_args_group_2 = {
+            num_rows_per_core_group_2,  // Ht
+            Wt,                         // Wt
+            1,                          // NC
+            origin_W,
+        };
+
+        auto reduce_compute_kernel_group_2_id = tt_metal::CreateKernel(
+            program,
+            compute_kernel_name,
+            core_group_2,
+            tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_2, .defines = reduce_defines});
+    }
+
+    uint32_t out_dim_divider = Wt;
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_rows_per_core = 0;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_2;
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges");
+        }
+        uint32_t num_tensor_tiles_per_core = num_rows_per_core * Wt;
+        tt_metal::SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {
+                a.buffer()->address(),
+                num_tensor_tiles_per_core,
+                num_tiles_read,  // tile index of row to start reading from
+                mask_w
+            });
+
+        tt_metal::SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {
+                output.buffer()->address(),
+                num_tensor_tiles_per_core / out_dim_divider,  // number of tiles to write
+                num_tiles_read / out_dim_divider              // output tile start index
+            });
+        num_tiles_read += num_tensor_tiles_per_core;
+    }
+
+    auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, num_cores, num_cores_y](
+                                              const Program &program,
+                                              const std::vector<Buffer *> &input_buffers,
+                                              const std::vector<Buffer *> &output_buffers) {
+        auto src_dram_buffer = input_buffers.at(0);
+
+        auto dst_dram_buffer = output_buffers.at(0);
+
+        for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = src_dram_buffer->address();
+            }
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = dst_dram_buffer->address();
+            }
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/moreh_mean_backward.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/moreh_mean_backward.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/bcast.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
+ALWI void REL() { release_dst(tt::DstMode::Half); }
+
+namespace NAMESPACE {
+void MAIN {
+    const auto num_output_tiles = get_arg_val<uint32_t>(0);
+    const auto n_need_bcast = get_arg_val<uint32_t>(1);
+    const auto c_need_bcast = get_arg_val<uint32_t>(2);
+    const auto ht_need_bcast = get_arg_val<uint32_t>(3);
+    const auto wt_need_bcast = get_arg_val<uint32_t>(4);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;  // input
+    constexpr auto cb_in1 = tt::CB::c_in1;  // zero tile
+    constexpr auto cb_scalar = tt::CB::c_in2;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t dst0 = 0;
+
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in1);
+    cb_wait_front(cb_in1, onetile);
+    for (uint32_t i = 0; i < num_output_tiles; i++) {
+        ACQ();
+        cb_wait_front(cb_in0, onetile);
+        if (ht_need_bcast && wt_need_bcast) {
+            add_bcast_scalar_init_short();
+            add_tiles_bcast_scalar(cb_in1, cb_in0, 0, 0, dst0);
+        } else if (ht_need_bcast) {
+            add_bcast_rows_init_short();
+            add_tiles_bcast_rows(cb_in1, cb_in0, 0, 0, dst0);
+        } else if (wt_need_bcast) {
+            add_bcast_cols_init_short();
+            add_tiles_bcast_cols(cb_in1, cb_in0, 0, 0, dst0);
+        } else {
+            copy_tile_init();
+            copy_tile(cb_in0, 0, dst0);
+        }
+        cb_reserve_back(cb_intermed0, onetile);
+        pack_tile(dst0, cb_intermed0);
+        cb_push_back(cb_intermed0, onetile);
+        cb_pop_front(cb_in0, onetile);
+        REL();
+
+        // output * (1 / number_of_elements)
+        ACQ();
+        cb_wait_front(cb_intermed0, onetile);
+        mul_tiles_bcast_scalar_init_short();
+        mul_tiles_bcast<BroadcastType::SCALAR>(cb_intermed0, cb_scalar, 0, 0, 0);
+        cb_reserve_back(cb_out0, onetile);
+        pack_tile(dst0, cb_out0);
+        cb_push_back(cb_out0, onetile);
+        cb_pop_front(cb_intermed0, onetile);
+        REL();
+
+    }
+    cb_pop_front(cb_in1, onetile);
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/reader_moreh_mean_backward.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/reader_moreh_mean_backward.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tt_eager/tt_dnn/op_library/moreh_sum_backward/kernels/utils.hpp"
+
+template <typename T>
+inline T get_next_arg_val()
+{
+    static int arg_idx = 0;
+    return get_arg_val<T> (arg_idx++);
+}
+
+void kernel_main() {
+    const auto output_grad_addr = get_next_arg_val<uint32_t>();
+    const auto num_output_tiles = get_next_arg_val<uint32_t>();
+    const auto start_id = get_next_arg_val<uint32_t>();
+    const auto output_grad_is_dram = (get_next_arg_val<uint32_t>() == 1);
+
+    const auto output_grad_n = get_next_arg_val<uint32_t>();
+    const auto output_grad_c = get_next_arg_val<uint32_t>();
+    const auto output_grad_ht = get_next_arg_val<uint32_t>();
+    const auto output_grad_wt = get_next_arg_val<uint32_t>();
+
+    const auto input_grad_n = get_next_arg_val<uint32_t>();
+    const auto input_grad_c = get_next_arg_val<uint32_t>();
+    const auto input_grad_ht = get_next_arg_val<uint32_t>();
+    const auto input_grad_wt = get_next_arg_val<uint32_t>();
+
+    const auto n_need_bcast = get_next_arg_val<uint32_t>();
+    const auto c_need_bcast = get_next_arg_val<uint32_t>();
+    const auto ht_need_bcast = get_next_arg_val<uint32_t>();
+    const auto wt_need_bcast = get_next_arg_val<uint32_t>();
+    const auto num_dim = get_next_arg_val<uint32_t>();
+
+    const auto output_grad_HtWt = output_grad_ht * output_grad_wt;
+    const auto output_grad_CHtWt = output_grad_c * output_grad_HtWt;
+
+    const auto input_grad_HtWt = input_grad_ht * input_grad_wt;
+    const auto input_grad_CHtWt = input_grad_c * input_grad_HtWt;
+
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in1 = 1;
+    constexpr uint32_t cb_id_in2 = 2;
+
+    // zero tile
+    union {
+        float f;
+        uint32_t u;
+    } scaler;
+    scaler.f = 0.0f;
+    fill_cb_with_value(cb_id_in1, scaler.u);
+
+    scaler.f = 1.0f / num_dim;
+    fill_cb_with_value(cb_id_in2, scaler.u, 1);
+
+    uint32_t l1_write_addr_in0;
+    uint32_t output_grad_tile_bytes = get_tile_size(cb_id_in0);
+    const auto output_grad_data_format = get_dataformat(cb_id_in0);
+    const InterleavedAddrGenFast<true> dram_output_grad_addrg = {
+        .bank_base_address = output_grad_addr,
+        .page_size = output_grad_tile_bytes,
+        .data_format = output_grad_data_format};
+    const InterleavedAddrGenFast<false> l1_output_grad_addrg = {
+        .bank_base_address = output_grad_addr,
+        .page_size = output_grad_tile_bytes,
+        .data_format = output_grad_data_format};
+
+    for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
+        const auto cur_n = i / input_grad_CHtWt;
+        const auto cur_c = (i / input_grad_HtWt) % input_grad_c;
+        const auto cur_ht = (i / input_grad_wt) % input_grad_ht;
+        const auto cur_wt = i % input_grad_wt;
+
+        const auto target_n = (n_need_bcast) ? (0) : (cur_n);
+        const auto target_c = (c_need_bcast) ? (0) : (cur_c);
+        const auto target_ht = (ht_need_bcast) ? (0) : (cur_ht);
+        const auto target_wt = (wt_need_bcast) ? (0) : (cur_wt);
+
+        auto read_tile_id =
+            target_n * output_grad_CHtWt + target_c * output_grad_HtWt + target_ht * output_grad_wt + target_wt;
+
+        cb_reserve_back(cb_id_in0, onetile);
+        l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+        if (output_grad_is_dram) {
+            noc_async_read_tile(read_tile_id, dram_output_grad_addrg, l1_write_addr_in0);
+        } else {
+            noc_async_read_tile(read_tile_id, l1_output_grad_addrg, l1_write_addr_in0);
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/reader_moreh_mean_backward.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/reader_moreh_mean_backward.cpp
@@ -8,34 +8,39 @@
 #include "debug/dprint.h"
 #include "tt_eager/tt_dnn/op_library/moreh_sum_backward/kernels/utils.hpp"
 
-template <typename T>
-inline T get_next_arg_val()
-{
-    static int arg_idx = 0;
-    return get_arg_val<T> (arg_idx++);
-}
+class NextArg {
+   private:
+    int arg_idx = 0;
+
+   public:
+    template <typename T>
+    T get_next_arg_val() {
+        return get_arg_val<T>(arg_idx++);
+    }
+};
 
 void kernel_main() {
-    const auto output_grad_addr = get_next_arg_val<uint32_t>();
-    const auto num_output_tiles = get_next_arg_val<uint32_t>();
-    const auto start_id = get_next_arg_val<uint32_t>();
-    const auto output_grad_is_dram = (get_next_arg_val<uint32_t>() == 1);
+    NextArg arg_fetcher;
+    const auto output_grad_addr = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto num_output_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto output_grad_is_dram = (arg_fetcher.get_next_arg_val<uint32_t>() == 1);
 
-    const auto output_grad_n = get_next_arg_val<uint32_t>();
-    const auto output_grad_c = get_next_arg_val<uint32_t>();
-    const auto output_grad_ht = get_next_arg_val<uint32_t>();
-    const auto output_grad_wt = get_next_arg_val<uint32_t>();
+    const auto output_grad_n = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto output_grad_c = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto output_grad_ht = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto output_grad_wt = arg_fetcher.get_next_arg_val<uint32_t>();
 
-    const auto input_grad_n = get_next_arg_val<uint32_t>();
-    const auto input_grad_c = get_next_arg_val<uint32_t>();
-    const auto input_grad_ht = get_next_arg_val<uint32_t>();
-    const auto input_grad_wt = get_next_arg_val<uint32_t>();
+    const auto input_grad_n = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto input_grad_c = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto input_grad_ht = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto input_grad_wt = arg_fetcher.get_next_arg_val<uint32_t>();
 
-    const auto n_need_bcast = get_next_arg_val<uint32_t>();
-    const auto c_need_bcast = get_next_arg_val<uint32_t>();
-    const auto ht_need_bcast = get_next_arg_val<uint32_t>();
-    const auto wt_need_bcast = get_next_arg_val<uint32_t>();
-    const auto num_dim = get_next_arg_val<uint32_t>();
+    const auto n_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto c_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto ht_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto wt_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto num_dim = arg_fetcher.get_next_arg_val<uint32_t>();
 
     const auto output_grad_HtWt = output_grad_ht * output_grad_wt;
     const auto output_grad_CHtWt = output_grad_c * output_grad_HtWt;

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/utils.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/utils.hpp
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void fill_cb_with_value(uint32_t cb_id, uint32_t value, int32_t num_of_elems = 1024) {
+    cb_reserve_back(cb_id, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_id));
+    for (int j = 0; j < num_of_elems; j++) {
+        ptr[j] = uint16_t(value >> 16);
+    }
+    cb_push_back(cb_id, 1);
+}
+
+void generate_mask_h_w(uint32_t cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
+    union {
+        float f;
+        uint32_t u;
+    } one;
+    one.f = 1.0f;
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+
+    const auto u16_one = uint16_t(one.u >> 16);
+    const auto u16_zero = uint16_t(zero.u >> 16);
+
+    cb_reserve_back(cb_mask_h_w, 2);
+
+    // mask_h
+    // first tile ptr
+    auto mask_h_ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask_h_w));
+    for (uint32_t w = 0; w < 16; w++) {
+        // sub tile 0
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16) {
+                mask_h_0 = 16;
+            }
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                mask_h_ptr[h * 16 + w] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w] = u16_zero;
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16) {
+                mask_h_0 = 16;
+            }
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                mask_h_ptr[h * 16 + w + 256] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w + 256] = u16_zero;
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                mask_h_ptr[h * 16 + w + 512] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w + 512] = u16_zero;
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                mask_h_ptr[h * 16 + w + 768] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w + 768] = u16_zero;
+            }
+        }
+    }
+
+    // mask_w
+    // second tile ptr
+    auto mask_w_ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask_h_w) + single_tile_size);
+    for (uint32_t h = 0; h < 16; h++) {
+        // sub tile 0
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16) {
+                mask_w_0 = 16;
+            }
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                mask_w_ptr[h * 16 + w] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w] = u16_zero;
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                mask_w_ptr[h * 16 + w + 256] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w + 256] = u16_zero;
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16) {
+                mask_w_0 = 16;
+            }
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                mask_w_ptr[h * 16 + w + 512] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w + 512] = u16_zero;
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                mask_w_ptr[h * 16 + w + 768] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w + 768] = u16_zero;
+            }
+        }
+    }
+
+    cb_push_back(cb_mask_h_w, 2);
+}
+
+void generate_mask_w(uint32_t cb_mask, uint32_t mask_w) {
+    union {
+        float f;
+        uint32_t u;
+    } one;
+    one.f = 1.0f;
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask));
+
+    for (uint32_t h = 0; h < 16; h++) {
+        // sub tile 0
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16)
+                mask_w_0 = 16;
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                ptr[h * 16 + w] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                ptr[h * 16 + w + 256] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 256] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16)
+                mask_w_0 = 16;
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                ptr[h * 16 + w + 512] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 512] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                ptr[h * 16 + w + 768] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 768] = uint16_t(zero.u >> 16);
+            }
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}
+
+void generate_mask_h(uint32_t cb_mask, uint32_t mask_h) {
+    union {
+        float f;
+        uint32_t u;
+    } one;
+    one.f = 1.0f;
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask));
+
+    for (uint32_t w = 0; w < 16; w++) {
+        // sub tile 0
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16)
+                mask_h_0 = 16;
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                ptr[h * 16 + w] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16)
+                mask_h_0 = 16;
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                ptr[h * 16 + w + 256] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 256] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                ptr[h * 16 + w + 512] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 512] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                ptr[h * 16 + w + 768] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 768] = uint16_t(zero.u >> 16);
+            }
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/writer_moreh_mean_backward.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/writer_moreh_mean_backward.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    const auto output_addr = get_arg_val<uint32_t>(0);
+    const auto num_tiles = get_arg_val<uint32_t>(1);
+    const auto start_id = get_arg_val<uint32_t>(2);
+    const auto output_is_dram = (get_arg_val<uint32_t>(3) == 1);
+
+    constexpr uint32_t cb_id_out = 16;
+    constexpr uint32_t onetile = 1;
+
+    uint32_t output_tile_bytes = get_tile_size(cb_id_out);
+    const auto output_data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<true> dram_output_addrg = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    const InterleavedAddrGenFast<false> l1_output_addrg = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        uint32_t write_tile_id = i;
+        cb_wait_front(cb_id_out, onetile);
+
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        if (output_is_dram) {
+            noc_async_write_tile(write_tile_id, dram_output_addrg, l1_read_addr);
+        } else {
+            noc_async_write_tile(write_tile_id, l1_output_addrg, l1_read_addr);
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward.cpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_eager/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace operations {
+
+namespace primary {
+
+operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output_grad, const Tensor &input_grad) {
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto *device = output_grad.device();
+    auto program = Program();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const auto cb_data_format = datatype_to_dataformat_converter(output_grad.dtype());
+    const auto single_tile_size = detail::TileSize(cb_data_format);
+
+    const auto &output_grad_shape = output_grad.shape();
+    const auto &output_grad_shape_wo_padding = output_grad_shape.without_padding();
+    const auto output_grad_n = output_grad_shape[0];
+    const auto output_grad_c = output_grad_shape[1];
+    const auto output_grad_ht = output_grad_shape[2] / TILE_HEIGHT;
+    const auto output_grad_wt = output_grad_shape[3] / TILE_WIDTH;
+    const auto output_grad_origin_h = output_grad_shape_wo_padding[2];
+    const auto output_grad_origin_w = output_grad_shape_wo_padding[3];
+
+    const auto &input_grad_shape = input_grad.shape();
+    const auto &input_grad_shape_wo_padding = input_grad_shape.without_padding();
+    const auto input_grad_n = input_grad_shape[0];
+    const auto input_grad_c = input_grad_shape[1];
+    const auto input_grad_ht = input_grad_shape[2] / TILE_HEIGHT;
+    const auto input_grad_wt = input_grad_shape[3] / TILE_WIDTH;
+    const auto input_grad_origin_h = input_grad_shape_wo_padding[2];
+    const auto input_grad_origin_w = input_grad_shape_wo_padding[3];
+
+    const auto n_need_bcast = (output_grad_n != input_grad_n);
+    const auto c_need_bcast = (output_grad_c != input_grad_c);
+    const auto ht_need_bcast = (output_grad_origin_h != input_grad_origin_h);
+    const auto wt_need_bcast = (output_grad_origin_w != input_grad_origin_w);
+    const auto num_input_grad_tiles = input_grad.volume() / TILE_HW;
+
+    uint32_t num_dim = 1;
+    if (n_need_bcast) num_dim *= input_grad_n;
+    if (c_need_bcast) num_dim *= input_grad_c;
+    if (ht_need_bcast) num_dim *= input_grad_origin_h;
+    if (wt_need_bcast) num_dim *= input_grad_origin_w;
+
+    log_info(LogOp, "num_dim {}", num_dim);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    CoreGridDesc core_grid(device);
+    const auto num_cores_y = core_grid.y_;
+    CoreCoord core_grid_coord = {.x = core_grid.x_, .y = num_cores_y};
+
+    const uint32_t in0_t = 2;        // input
+    const uint32_t in1_t = 1;        // zero
+    const uint32_t in2_t = 1;        // scalar
+    const uint32_t intermed0_t = 1;  // accumulated mean
+    const uint32_t out0_t = 2;       // output
+    const auto
+        [num_cores_to_be_used,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_cols_per_core_group_1,
+         num_cols_per_core_group_2] = tt_metal::split_work_to_cores(core_grid_coord, num_input_grad_tiles);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    CreateCircularBuffer(
+        program,
+        all_cores,
+        cb_data_format,
+        {
+            {CB::c_in0, in0_t},              // input
+            {CB::c_in1, in1_t},              // zero
+            {CB::c_in2, in2_t},              // scalar
+            {CB::c_intermed0, intermed0_t},  // temp
+            {CB::c_out0, out0_t},            // output
+        });
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> reader_compile_time_args;
+    std::vector<uint32_t> writer_compile_time_args;
+    const auto reader_kernel_file = "tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/reader_moreh_mean_backward.cpp";
+    const auto writer_kernel_file = "tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/writer_moreh_mean_backward.cpp";
+    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
+    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1};
+    std::map<string, string> compute_defines;
+    const auto compute_kernel_file = "tt_eager/tt_dnn/op_library/moreh_mean_backward/kernels/moreh_mean_backward.cpp";
+    const auto compute_kernel_1_id = CreateComputeKernel(
+        program, compute_kernel_file, {core_group_1, num_cols_per_core_group_1, compute_args_group_1}, compute_defines);
+
+    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2};
+        compute_kernel_2_id = CreateComputeKernel(
+            program,
+            compute_kernel_file,
+            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
+            compute_defines);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_tiles_per_core;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {output_grad.buffer()->address(),
+             num_tiles_per_core,
+             tile_offset,
+             static_cast<uint32_t>(is_dram(output_grad)),
+             output_grad_n,
+             output_grad_c,
+             output_grad_ht,
+             output_grad_wt,
+             input_grad_n,
+             input_grad_c,
+             input_grad_ht,
+             input_grad_wt,
+             n_need_bcast,
+             c_need_bcast,
+             ht_need_bcast,
+             wt_need_bcast,
+             num_dim});
+
+        SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {input_grad.buffer()->address(),
+             num_tiles_per_core,
+             tile_offset,
+             static_cast<uint32_t>(is_dram(input_grad))});
+
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            SetRuntimeArgs(
+                program,
+                compute_kernel_1_id,
+                core,
+                {num_tiles_per_core, n_need_bcast, c_need_bcast, ht_need_bcast, wt_need_bcast});
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            TT_ASSERT(compute_kernel_2_id.has_value());
+            SetRuntimeArgs(
+                program,
+                compute_kernel_2_id.value(),
+                core,
+                {num_tiles_per_core, n_need_bcast, c_need_bcast, ht_need_bcast, wt_need_bcast});
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges.");
+        }
+        tile_offset += num_tiles_per_core;
+    }
+
+    auto override_runtime_arguments_callback = [reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y](
+                                                   const void *operation,
+                                                   const Program &program,
+                                                   const std::vector<Tensor> &input_tensors,
+                                                   const std::vector<std::optional<const Tensor>> &,
+                                                   const std::vector<Tensor> &output_tensors) {
+        const auto *output_grad_buffer = input_tensors.at(0).buffer();
+        const auto *input_grad_buffer = input_tensors.at(1).buffer();
+        for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+            {
+                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = output_grad_buffer->address();
+                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
+            }
+
+            {
+                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = input_grad_buffer->address();
+                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
+            }
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp"
+
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/tools/profiler/op_profiler.hpp"
+
+namespace tt {
+
+using namespace constants;
+
+namespace operations {
+namespace primary {
+
+////////////////////////////////////////////////////////////////////////////
+//                         MorehMeanBackward
+////////////////////////////////////////////////////////////////////////////
+void MorehMeanBackward::validate(const std::vector<Tensor>& inputs) const {
+    const auto& output_grad = inputs.at(0);
+    const auto& input_grad = inputs.at(1);
+
+    auto output_grad_shape = output_grad.shape();
+    const auto& input_grad_shape = input_grad.shape();
+    auto output_grad_shape_wo_padding = output_grad.shape().without_padding();
+    const auto& input_grad_shape_wo_padding = input_grad.shape().without_padding();
+}
+
+operation::ProgramWithCallbacks MorehMeanBackward::create_program(
+    const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) const {
+    auto& output_grad = inputs.at(0);
+    auto& input_grad = inputs.at(1);
+
+    return moreh_mean_backward_program(output_grad, input_grad);
+}
+
+std::vector<Tensor> MorehMeanBackward::create_output_tensors(const std::vector<Tensor>& inputs) const {
+    // Inplace
+    return {};
+}
+
+std::vector<Shape> MorehMeanBackward::compute_output_shapes(const std::vector<Tensor>& inputs) const {
+    // Inplace
+    return {};
+}
+
+tt::stl::reflection::Attributes MorehMeanBackward::attributes() const { return {}; }
+
+Tensor moreh_mean_backward_(const Tensor& output_grad, const Tensor& input_grad) {
+    operation::run(MorehMeanBackward{}, {output_grad, input_grad});
+    return input_grad;
+}
+
+Tensor moreh_mean_backward(const Tensor& output_grad, const Tensor& input_grad) {
+    return moreh_mean_backward_(output_grad, input_grad);
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+#include <vector>
+
+#include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/run_operation.hpp"
+
+namespace tt {
+
+namespace operations {
+
+namespace primary {
+
+using namespace tt_metal;
+
+struct MorehMeanBackward {
+    void validate(const std::vector<Tensor> &inputs) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &inputs) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
+    tt::stl::reflection::Attributes attributes() const;
+};
+
+operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output_grad, const Tensor &input_grad);
+
+Tensor moreh_mean_backward(const Tensor &output_grad, const Tensor &input_grad);
+
+}  // namespace primary
+
+}  // namespace operations
+
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ * SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -31,6 +31,8 @@
 #include "tt_dnn/op_library/groupnorm/groupnorm_op.hpp"
 #include "tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm_op.hpp"
 #include "tt_dnn/op_library/moreh_groupnorm_backward/moreh_groupnorm_backward_op.hpp"
+#include "tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
+#include "tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp"
 
 namespace py = pybind11;
 
@@ -846,6 +848,22 @@ void py_module(py::module& m_primary) {
         R"doc(
         "Performs a moreh_groupnorm_backward operation.
     )doc");
+
+    m_primary.def(
+        "moreh_mean",
+        &moreh_mean,
+        py::arg("input").noconvert(),
+        py::arg("output").noconvert(),
+        py::kw_only(),
+        py::arg("dims").noconvert() = std::vector<int64_t>(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        "Performs mean operation. Returns an output tensor.");
+    m_primary.def(
+        "moreh_mean_backward",
+        &moreh_mean_backward,
+        py::arg("output_grad").noconvert(),
+        py::arg("input_grad").noconvert(),
+        "Performs mean backward operation. Returns an input_grad tensor.");
 }
 
 }  // namespace


### PR DESCRIPTION
This PR implements mean operation to tt_dnn library. (Related issue : https://github.com/tenstorrent-metal/tt-metal/issues/4742 )
This PR includes PR #4744. It uses several features such as mask_tile API for WH_B0 and bcast APIs implemented in PR #4744.

- Add moreh_mean (forward) op
- Add moreh_mean_backward op
- Add pytest script for moreh_mean and moreh_mean_backward ops