### PR TITLE
#4231: Fine-tune the unary ops for add, sub, div, mul binops with one scalar constant arg

### DIFF
--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -67,6 +67,12 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string,std::string>
         case UnaryOpType::LEAKY_RELU:
             defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1";
             break;
+        case UnaryOpType::ADD_UNARY_SFPU:
+        case UnaryOpType::SUB_UNARY_SFPU:
+        case UnaryOpType::MUL_UNARY_SFPU:
+        case UnaryOpType::DIV_UNARY_SFPU:
+            defines["SFPU_OP_BINOP_WITH_SCALAR_INCLUDE"] = "1";
+            break;
         case UnaryOpType::IDENTITY:
             defines["SFPU_OP_IDENTITY_INCLUDE"] = "1";
             break;
@@ -119,6 +125,10 @@ std::pair<string, string> get_op_init_and_func_parameterized(UnaryOpType op_type
         case UnaryOpType::ERFC: op_init_and_name = {"erfc_tile_init({1});", fmt::format("erfc_tile({0}, {1}u);", idst, std::to_string((uint32_t)param0))}; break;
         case UnaryOpType::RDIV: op_init_and_name = {}; break;
         case UnaryOpType::RSUB: op_init_and_name = {"rsub_tile_init();", fmt::format("rsub_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
+        case UnaryOpType::SUB_UNARY_SFPU: op_init_and_name = {"binop_with_scalar_tile_init();", fmt::format("sub_unary_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
+        case UnaryOpType::ADD_UNARY_SFPU: op_init_and_name = {"binop_with_scalar_tile_init();", fmt::format("add_unary_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
+        case UnaryOpType::MUL_UNARY_SFPU: op_init_and_name = {"binop_with_scalar_tile_init();", fmt::format("mul_unary_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
+        case UnaryOpType::DIV_UNARY_SFPU: op_init_and_name = {"binop_with_scalar_tile_init();", fmt::format("div_unary_tile({}, {}u);", idst, Converter::to_hex(1.0f/param0))}; break;
         default:
         TT_ASSERT( false && "unexpected parameterized type");
     };

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <limits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_converter.h"
+#include "noc_nonblocking_api.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+enum { ADD = 0, SUB = 1, MUL = 2, DIV = 3, RSUB = 4 };
+
+template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
+void calculate_binop_with_scalar(uint32_t param) {
+    const vFloat parameter = Converter::to_float(param);
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat val = dst_reg[0];
+        vFloat result = 0.0f;
+
+        if constexpr (BINOP_MODE == ADD) {
+            result = val + parameter;
+        } else if constexpr (BINOP_MODE == SUB) {
+            result = val - parameter;
+        } else if constexpr (BINOP_MODE == MUL) {
+            result = val * parameter;
+        } else if constexpr (BINOP_MODE == DIV) {
+            // parameter is inverted from host side and passed down
+            result = val * parameter;
+        } else if constexpr (BINOP_MODE == RSUB) {
+            result = parameter - val;
+        }
+        dst_reg[0] = result;
+        dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_add(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_sub(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_mul(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_div(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+void calculate_rsub(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(param);
+    return;
+}
+
+template <bool APPROXIMATION_MODE>
+void calculate_binop_with_scalar_init() {}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_sfpu_binop_with_unary.h"
+#include "llk_math_eltwise_unary_sfpu_1_param.h"
+#include "llk_math_eltwise_unary_sfpu_common_includes.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE, int binop_mode, DstSync Dst = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(uint dst_index, uint32_t param1, int vector_mode = VectorMode::RC ) {
+    llk_math_eltwise_unary_sfpu_1_param<APPROXIMATE, Dst>(
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 4>,
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 4>,
+        dst_index,
+        vector_mode,
+        param1);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
+    llk_math_eltwise_unary_sfpu_init<APPROXIMATE>(sfpu::calculate_binop_with_scalar_init<APPROXIMATE>);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <limits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_converter.h"
+#include "noc_nonblocking_api.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+enum {
+    ADD = 0,
+    SUB = 1,
+    MUL = 2,
+    DIV = 3,
+    RSUB = 4,
+};  // BINOP_MODE
+
+template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
+void calculate_binop_with_scalar(uint32_t param) {
+    const vFloat parameter = Converter::to_float(param);
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat val = dst_reg[0];
+        vFloat result = 0.0f;
+
+        if constexpr (BINOP_MODE == ADD) {
+            result = val + parameter;
+        } else if constexpr (BINOP_MODE == SUB) {
+            result = val - parameter;
+        } else if constexpr (BINOP_MODE == MUL) {
+            result = val * parameter;
+        } else if constexpr (BINOP_MODE == DIV) {
+            // inversion is carried out on host side and passed down
+            result = val * parameter;
+        } else if constexpr (BINOP_MODE == RSUB) {
+            result = parameter - val;
+        }
+
+        dst_reg[0] = result;
+        dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_add(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_sub(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_mul(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_div(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(param);
+    return;
+}
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+void calculate_rsub(uint32_t param) {
+    calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(param);
+    return;
+}
+
+template <bool APPROXIMATION_MODE>
+void calculate_binop_with_scalar_init() {}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_binop_with_scalar.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_sfpu_binop_with_unary.h"
+#include "llk_math_eltwise_unary_sfpu_1_param.h"
+#include "llk_math_eltwise_unary_sfpu_common_includes.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE, int binop_mode, DstSync Dst = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar(uint dst_index, uint32_t param1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_1_param<APPROXIMATE, Dst>(
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>,
+        ckernel::sfpu::calculate_binop_with_scalar<APPROXIMATE, binop_mode, 8>,
+        dst_index,
+        vector_mode,
+        param1);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_binop_with_scalar_init() {
+    llk_math_eltwise_unary_sfpu_init<APPROXIMATE>(sfpu::calculate_binop_with_scalar_init<APPROXIMATE>);
+}
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/binop_with_scalar.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/binop_with_scalar.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_binop_with_scalar.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+/**
+ * Performs a simple elementwise binop with scalar operation on the input: y = binop(x,scalar)
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | tile_index     | The index of the tile in DST register buffer to perform requested operation| uint32_t | Must be less than the size of the DST register buffer | True     |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | mode           | 0, 1, 2, 3, and 4                                                          | uint32_t | 0, 1, 2, 3, 4 corresponding to add, mul, sub, div,    | True     |
+ * |                |                                                                            |          | and rsub                                              |          |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | param1         | fp32 value scalar encoded as uint32                                        | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ */
+enum { ADD_UNARY = 0, SUB_UNARY = 1, MUL_UNARY = 2, DIV_UNARY = 3, RSUB_UNARY = 4 };
+ALWI void add_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, ADD_UNARY, SyncHalf>(idst, param1)));
+}
+
+ALWI void sub_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, SUB_UNARY, SyncHalf>(idst, param1)));
+}
+
+ALWI void mul_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, MUL_UNARY, SyncHalf>(idst, param1)));
+}
+
+ALWI void div_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, DIV_UNARY, SyncHalf>(idst, param1)));
+}
+
+ALWI void rsub_unary_tile(uint32_t idst, uint32_t param1) {
+    MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar<APPROX, RSUB_UNARY, SyncHalf>(idst, param1)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void binop_with_scalar_tile_init() { MATH((llk_math_eltwise_unary_sfpu_binop_with_scalar_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -64,11 +64,14 @@
 #include "compute_kernel_api/eltwise_unary/identity.h"
 #endif
 
-#if SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
-#include "compute_kernel_api.h"
+#if SFPU_OP_BINOP_WITH_SCALAR_INCLUDE
+#include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
 #endif
 
 #if SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
 #include "compute_kernel_api.h"
 #endif
 
+#if SFPU_OP_COMPUTE_KERNEL_API_INCLUDE
+#include "compute_kernel_api.h"
+#endif


### PR DESCRIPTION
#4231: Fine-tune the unary ops to improve performance and cut down kernel launches
     : move add, sub, div, mul binops with scalar tied in as full featured
unary op on sfpu
#0: undo SFPU ADD SUB MUL DIV etc."
This reverts commit bc5ca143d2539a5c365893a62fe1831da68b017e. #0: update llk binary with scalar
