### PR TITLE
#4821: Add cumsum op to tt_dnn

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_moreh_cumsum.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_moreh_cumsum.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import tt_lib as ttl
+from models.utility_functions import comp_allclose_and_pcc
+
+TILE_HEIGHT = 32
+TILE_WIDTH = 32
+
+
+def get_tensors(input_shape, output_shape, device):
+    torch.manual_seed(2023)
+    npu_dtype = ttl.tensor.DataType.BFLOAT16
+    cpu_dtype = torch.bfloat16
+    npu_layout = ttl.tensor.Layout.TILE
+
+    torch_input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype, requires_grad=True)
+    torch_output = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
+
+    tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+
+    return tt_input, tt_output, torch_input
+
+
+def get_backward_tensors(output_grad_shape, input_grad_shape, device):
+    torch.manual_seed(2023)
+    npu_dtype = ttl.tensor.DataType.BFLOAT16
+    cpu_dtype = torch.bfloat16
+    npu_layout = ttl.tensor.Layout.TILE
+
+    torch_output_grad = torch.randint(-2, 3, output_grad_shape, dtype=cpu_dtype, requires_grad=True)
+    torch_input_grad = torch.randint(-2, 3, input_grad_shape, dtype=cpu_dtype)
+
+    tt_output_grad = ttl.tensor.Tensor(torch_output_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    tt_input_grad = ttl.tensor.Tensor(torch_input_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+
+    return tt_output_grad, tt_input_grad, torch_output_grad
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        ([1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1]),
+        ([4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1]),
+        ([4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1]),
+        ([8, 8, TILE_HEIGHT * 4 - 1, TILE_WIDTH * 4 - 1]),
+    ),
+    ids=[
+        "1, 1, TILE_HEIGHT-1,TILE_WIDTH - 1",
+        "4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1",
+        "4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1",
+        "8, 8, TILE_HEIGHT * 4 - 1, TILE_WIDTH * 4 - 1",
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    (
+        0,
+        1,
+    ),
+    ids=["0", "1"],
+)
+def test_moreh_cumsum_dim(input_shape, dim, device):
+    output_shape = input_shape.copy()
+
+    (tt_input, tt_output, torch_input) = get_tensors(input_shape, output_shape, device)
+
+    torch_output = torch.cumsum(torch_input, dim)
+
+    cpu_layout = ttl.tensor.Layout.ROW_MAJOR
+    tt_output_cpu = (
+        ttl.operations.primary.moreh_cumsum(tt_input, tt_output, dim=dim)
+        .cpu()
+        .to(cpu_layout)
+        .unpad_from_tile(output_shape)
+        .to_torch()
+    )
+
+    # test for equivalance
+    rtol = atol = 0.1
+    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+
+    logger.info(f"Out passing={passing}")
+    logger.info(f"Output pcc={output_pcc}")
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        ([1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1]),
+        ([4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1]),
+        ([4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1]),
+        ([8, 8, TILE_HEIGHT * 20 - 1, TILE_WIDTH * 20 - 1]),
+    ),
+    ids=[
+        "1, 1, TILE_HEIGHT-1,TILE_WIDTH - 1",
+        "4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1",
+        "4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1",
+        "8, 8, TILE_HEIGHT * 20 - 1, TILE_WIDTH * 20 - 1",
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    (
+        0,
+        1,
+    ),
+    ids=["0", "1"],
+)
+def test_moreh_cumsumsum_backward(input_shape, dim, device):
+    output_shape = input_shape.copy()
+
+    (_, _, torch_input) = get_tensors(input_shape, output_shape, device)
+    (tt_output_grad, tt_input_grad, torch_output_grad) = get_backward_tensors(output_shape, input_shape, device)
+
+    torch_output = torch.cumsum(torch_input, dim)
+    torch_output.backward(torch_output_grad)
+
+    cpu_layout = ttl.tensor.Layout.ROW_MAJOR
+    tt_input_grad_cpu = (
+        ttl.operations.primary.moreh_cumsum_backward(tt_output_grad, tt_input_grad, dim=dim)
+        .cpu()
+        .to(cpu_layout)
+        .unpad_from_tile(input_shape)
+        .to_torch()
+    )
+
+    # test for equivalance
+    rtol = atol = 0.1
+    passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_cpu, pcc=0.999, rtol=rtol, atol=atol)
+
+    logger.info(f"Out passing={passing}")
+    logger.info(f"Output pcc={output_pcc}")
+
+    assert passing

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -102,6 +102,8 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/moreh_layernorm_backward/moreh_layernorm_backward_op.cpp \
 	tt_eager/tt_dnn/op_library/moreh_layernorm_backward/input_grad/moreh_layernorm_backward_input_grad.cpp \
 	tt_eager/tt_dnn/op_library/moreh_layernorm_backward/gamma_beta_grad/moreh_layernorm_backward_gamma_beta_grad.cpp \
+	tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_nc/moreh_cumsum_nc.cpp \
+	tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.cpp \
 	tt_eager/tt_dnn/op_library/groupnorm/groupnorm_op.cpp \
 	tt_eager/tt_dnn/op_library/reshape/reshape_op.cpp \
 	tt_eager/tt_dnn/op_library/permute/permute_op.cpp \

--- a/tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/moreh_cumsum_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/moreh_cumsum_nc.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
+ALWI void REL() { release_dst(tt::DstMode::Half); }
+
+namespace NAMESPACE {
+void MAIN {
+    const auto num_tiles_to_cumsum = get_arg_val<uint32_t>(0);
+    const auto num_output_tiles_per_core = get_arg_val<uint32_t>(1);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t first_tile = 0;
+
+    binary_op_init_common(cb_in0, cb_in1);
+    cb_wait_front(cb_in1, onetile);
+
+    for (uint32_t i = 0; i < num_output_tiles_per_core; i++) {
+        bool enable_reload = false;
+        for (uint32_t j = 0; j < num_tiles_to_cumsum; ++j) {
+            ACQ();
+            uint32_t cb_add  = (enable_reload) ? (cb_intermed0) : (cb_in1);
+            cb_wait_front(cb_in0, onetile);
+
+            add_tiles_init();
+            add_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
+
+            cb_pop_front(cb_in0, onetile);
+            if (enable_reload) {
+                cb_pop_front(cb_intermed0, onetile);
+            }
+
+            // pack to intermed0
+            cb_reserve_back(cb_intermed0, onetile);
+            pack_tile(dst0, cb_intermed0);
+            cb_push_back(cb_intermed0, onetile);
+            REL();
+
+            // copy tile from intermed0 to out0
+            ACQ();
+            cb_wait_front(cb_intermed0, onetile);
+            copy_tile_to_dst_init_short();
+            copy_tile(tt::CB::c_intermed0, first_tile, dst0);
+            cb_reserve_back(cb_out0, onetile);
+            pack_tile(dst0, cb_out0);
+            cb_push_back(cb_out0, onetile);
+            REL();
+            enable_reload = true;
+        }
+        cb_pop_front(cb_intermed0, onetile);
+    }
+    cb_pop_front(cb_in1, onetile);
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/reader_moreh_cumsum_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/reader_moreh_cumsum_nc.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/utils.hpp"
+
+inline uint32_t get_read_tile_id(uint32_t tile_id, uint32_t dim, uint32_t CHtWt, uint32_t HtWt) {
+    return (dim == 0 ) ? (tile_id) : (tile_id / HtWt * CHtWt) + (tile_id % HtWt);
+}
+
+void kernel_main() {
+    const auto input_addr = get_arg_val<uint32_t>(0);
+    const auto num_tiles_to_cumsum = get_arg_val<uint32_t>(1);
+    const auto num_output_tiles_per_core = get_arg_val<uint32_t>(2);
+    const auto input_tile_offset = get_arg_val<uint32_t>(3);
+    const auto start_id = get_arg_val<uint32_t>(4);
+    const auto input_is_dram = (get_arg_val<uint32_t>(5) == 1);
+    const auto HtWt = get_arg_val<uint32_t>(6);
+    const auto CHtWt = get_arg_val<uint32_t>(7);
+    const auto dim = get_arg_val<uint32_t>(8);
+    const auto flip = (get_arg_val<uint32_t>(9) == 1);
+
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in1 = 1;
+
+    union {
+        float f;
+        uint32_t u;
+    } scaler;
+    scaler.f = 0.0f;
+    fill_cb_with_value(cb_id_in1, scaler.u);
+
+    uint32_t l1_write_addr_in0;
+    uint32_t input_tile_bytes = get_tile_size(cb_id_in0);
+    const auto input_data_format = get_dataformat(cb_id_in0);
+    const InterleavedAddrGenFast<true> dram_input_addrg = {
+        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    const InterleavedAddrGenFast<false> l1_input_addrg = {
+        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+
+    for (uint32_t i = start_id; i < start_id + num_output_tiles_per_core; i++) {
+        auto offset = input_tile_offset;
+        auto read_tile_id = get_read_tile_id(i, dim, CHtWt, HtWt);
+        if (flip) {
+            read_tile_id += (num_tiles_to_cumsum - 1) * offset;
+            offset *= -1;
+        }
+
+        for (uint32_t j = 0; j < num_tiles_to_cumsum; ++j) {
+            cb_reserve_back(cb_id_in0, onetile);
+            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            if (input_is_dram) {
+                noc_async_read_tile(read_tile_id, dram_input_addrg, l1_write_addr_in0);
+            } else {
+                noc_async_read_tile(read_tile_id, l1_input_addrg, l1_write_addr_in0);
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            read_tile_id += offset;
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/utils.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/utils.hpp
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void fill_cb_with_value(uint32_t cb_id, uint32_t value, int32_t num_of_elems = 1024) {
+    cb_reserve_back(cb_id, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_id));
+    for (int j = 0; j < num_of_elems; j++) {
+        ptr[j] = uint16_t(value >> 16);
+    }
+    cb_push_back(cb_id, 1);
+}
+
+void generate_mask_h_w(uint32_t cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
+    union {
+        float f;
+        uint32_t u;
+    } one;
+    one.f = 1.0f;
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+
+    const auto u16_one = uint16_t(one.u >> 16);
+    const auto u16_zero = uint16_t(zero.u >> 16);
+
+    cb_reserve_back(cb_mask_h_w, 2);
+
+    // mask_h
+    // first tile ptr
+    auto mask_h_ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask_h_w));
+    for (uint32_t w = 0; w < 16; w++) {
+        // sub tile 0
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16) {
+                mask_h_0 = 16;
+            }
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                mask_h_ptr[h * 16 + w] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w] = u16_zero;
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16) {
+                mask_h_0 = 16;
+            }
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                mask_h_ptr[h * 16 + w + 256] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w + 256] = u16_zero;
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                mask_h_ptr[h * 16 + w + 512] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w + 512] = u16_zero;
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                mask_h_ptr[h * 16 + w + 768] = u16_one;
+            }
+            for (; h < 16; h++) {
+                mask_h_ptr[h * 16 + w + 768] = u16_zero;
+            }
+        }
+    }
+
+    // mask_w
+    // second tile ptr
+    auto mask_w_ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask_h_w) + single_tile_size);
+    for (uint32_t h = 0; h < 16; h++) {
+        // sub tile 0
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16) {
+                mask_w_0 = 16;
+            }
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                mask_w_ptr[h * 16 + w] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w] = u16_zero;
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                mask_w_ptr[h * 16 + w + 256] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w + 256] = u16_zero;
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16) {
+                mask_w_0 = 16;
+            }
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                mask_w_ptr[h * 16 + w + 512] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w + 512] = u16_zero;
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                mask_w_ptr[h * 16 + w + 768] = u16_one;
+            }
+            for (; w < 16; w++) {
+                mask_w_ptr[h * 16 + w + 768] = u16_zero;
+            }
+        }
+    }
+
+    cb_push_back(cb_mask_h_w, 2);
+}
+
+void generate_mask_w(uint32_t cb_mask, uint32_t mask_w) {
+    union {
+        float f;
+        uint32_t u;
+    } one;
+    one.f = 1.0f;
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask));
+
+    for (uint32_t h = 0; h < 16; h++) {
+        // sub tile 0
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16)
+                mask_w_0 = 16;
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                ptr[h * 16 + w] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                ptr[h * 16 + w + 256] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 256] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16)
+                mask_w_0 = 16;
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                ptr[h * 16 + w + 512] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 512] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                ptr[h * 16 + w + 768] = uint16_t(one.u >> 16);
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 768] = uint16_t(zero.u >> 16);
+            }
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}
+
+void generate_mask_h(uint32_t cb_mask, uint32_t mask_h) {
+    union {
+        float f;
+        uint32_t u;
+    } one;
+    one.f = 1.0f;
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_mask));
+
+    for (uint32_t w = 0; w < 16; w++) {
+        // sub tile 0
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16)
+                mask_h_0 = 16;
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                ptr[h * 16 + w] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16)
+                mask_h_0 = 16;
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                ptr[h * 16 + w + 256] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 256] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                ptr[h * 16 + w + 512] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 512] = uint16_t(zero.u >> 16);
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                ptr[h * 16 + w + 768] = uint16_t(one.u >> 16);
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 768] = uint16_t(zero.u >> 16);
+            }
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}

--- a/tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/writer_moreh_cumsum_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/writer_moreh_cumsum_nc.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+
+inline uint32_t get_write_tile_id(uint32_t tile_id, uint32_t dim, uint32_t CHtWt, uint32_t HtWt) {
+    return (dim == 0 ) ? (tile_id) : (tile_id / HtWt * CHtWt) + (tile_id % HtWt);
+}
+
+void kernel_main() {
+    const auto output_addr = get_arg_val<uint32_t>(0);
+    const auto num_tiles_to_cumsum = get_arg_val<uint32_t>(1);
+    const auto num_output_tiles_per_core = get_arg_val<uint32_t>(2);
+    const auto input_tile_offset = get_arg_val<uint32_t>(3);
+    const auto start_id = get_arg_val<uint32_t>(4);
+    const auto output_is_dram = (get_arg_val<uint32_t>(5) == 1);
+    const auto HtWt = get_arg_val<uint32_t>(6);
+    const auto CHtWt = get_arg_val<uint32_t>(7);
+    const auto dim = get_arg_val<uint32_t>(8);
+    const auto flip = (get_arg_val<uint32_t>(9) == 1);
+
+    constexpr uint32_t cb_id_out = 16;
+    constexpr uint32_t onetile = 1;
+
+    uint32_t output_tile_bytes = get_tile_size(cb_id_out);
+    const auto output_data_format = get_dataformat(cb_id_out);
+    const InterleavedAddrGenFast<true> dram_output_addrg = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    const InterleavedAddrGenFast<false> l1_output_addrg = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+
+    for (uint32_t i = start_id; i < start_id + num_output_tiles_per_core; i++) {
+        auto write_tile_id = get_write_tile_id(i, dim, CHtWt, HtWt);
+        auto offset = input_tile_offset;
+        if (flip) {
+            write_tile_id += (num_tiles_to_cumsum - 1) * input_tile_offset;
+            offset *= -1;
+        }
+
+        for (uint32_t j = 0; j < num_tiles_to_cumsum; ++j) {
+            cb_wait_front(cb_id_out, onetile);
+            uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+            if (output_is_dram) {
+                noc_async_write_tile(write_tile_id, dram_output_addrg, l1_read_addr);
+            } else {
+                noc_async_write_tile(write_tile_id, l1_output_addrg, l1_read_addr);
+            }
+            noc_async_write_barrier();
+            cb_pop_front(cb_id_out, onetile);
+            write_tile_id += offset;
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_nc/moreh_cumsum_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_nc/moreh_cumsum_nc.cpp
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_eager/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace operations {
+
+namespace primary {
+
+operation::ProgramWithCallbacks moreh_cumsum_nc(
+    const Tensor &input, const Tensor &output, const int64_t &dim, const bool &flip) {
+    TT_ASSERT(dim == 0 || dim == 1);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto *device = input.device();
+    auto program = Program();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const auto cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const auto single_tile_size = detail::TileSize(cb_data_format);
+
+    const auto &input_shape = input.shape();
+    const auto &input_shape_without_padding = input_shape.without_padding();
+
+    const auto N = input_shape[0];
+    const auto C = input_shape[1];
+    const auto Ht = input_shape[2] / TILE_HEIGHT;
+    const auto Wt = input_shape[3] / TILE_WIDTH;
+    const auto HtWt = Ht * Wt;
+    const auto CHtWt = C * HtWt;
+    const auto NHtWt = N * HtWt;
+    const auto num_cumsum_tiles = input_shape[dim];
+    const auto input_tile_offset = (dim == 0) ? (CHtWt) : (HtWt);
+    const auto num_tiles_per_chip = (dim == 0) ? (CHtWt) : (NHtWt);
+
+    log_debug(LogOp, "N {} C {} Ht {} Wt {}", N, C, Ht, Wt);
+    log_debug(
+        LogOp,
+        "dim {} num_cumsum_tiles {} input_tile_offset {} num_tiles_per_chip {}",
+        dim,
+        num_cumsum_tiles,
+        input_tile_offset,
+        num_tiles_per_chip);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    CoreGridDesc core_grid(device);
+    const auto num_cores_y = core_grid.y_;
+    CoreCoord core_grid_coord = {.x = core_grid.x_, .y = num_cores_y};
+
+    const uint32_t in0_t = 2;        // input
+    const uint32_t in1_t = 1;        // zero
+    const uint32_t intermed0_t = 1;  // accumulated sum
+    const uint32_t out0_t = 2;       // output
+    const auto
+        [num_cores_to_be_used,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_cols_per_core_group_1,
+         num_cols_per_core_group_2] = tt_metal::split_work_to_cores(core_grid_coord, num_tiles_per_chip);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    CreateCircularBuffer(
+        program,
+        all_cores,
+        cb_data_format,
+        {
+            {CB::c_in0, in0_t},              // input
+            {CB::c_in1, in1_t},              // zero
+            {CB::c_intermed0, intermed0_t},  // accumulated sum
+            {CB::c_out0, out0_t},            // output
+        });
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> reader_compile_time_args;
+    std::vector<uint32_t> writer_compile_time_args;
+    const auto reader_kernel_file = "tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/reader_moreh_cumsum_nc.cpp";
+    const auto writer_kernel_file = "tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/writer_moreh_cumsum_nc.cpp";
+    const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
+    const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1};
+    std::map<string, string> compute_defines;
+    const auto compute_kernel_file = "tt_eager/tt_dnn/op_library/moreh_cumsum/kernels/moreh_cumsum_nc.cpp";
+    const auto compute_kernel_1_id = CreateComputeKernel(
+        program, compute_kernel_file, {core_group_1, num_cols_per_core_group_1, compute_args_group_1}, compute_defines);
+
+    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2};
+        compute_kernel_2_id = CreateComputeKernel(
+            program,
+            compute_kernel_file,
+            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
+            compute_defines);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_tiles_per_core;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_cumsum_tiles,
+             num_tiles_per_core,
+             input_tile_offset,
+             tile_offset,
+             static_cast<uint32_t>(is_dram(input)),
+             HtWt,
+             CHtWt,
+             static_cast<uint32_t>(dim),
+             flip});
+
+        SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {output.buffer()->address(),
+             num_cumsum_tiles,
+             num_tiles_per_core,
+             input_tile_offset,
+             tile_offset,
+             static_cast<uint32_t>(is_dram(output)),
+             HtWt,
+             CHtWt,
+             static_cast<uint32_t>(dim),
+             flip});
+
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            SetRuntimeArgs(program, compute_kernel_1_id, core, {num_cumsum_tiles, num_tiles_per_core});
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            TT_ASSERT(compute_kernel_2_id.has_value());
+            SetRuntimeArgs(program, compute_kernel_2_id.value(), core, {num_cumsum_tiles, num_tiles_per_core});
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges.");
+        }
+        tile_offset += num_tiles_per_core;
+    }
+
+    auto override_runtime_arguments_callback = [reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y](
+                                                   const void *operation,
+                                                   const Program &program,
+                                                   const std::vector<Tensor> &input_tensors,
+                                                   const std::vector<std::optional<const Tensor>> &,
+                                                   const std::vector<Tensor> &output_tensors) {
+        const auto *input_buffer = input_tensors.at(0).buffer();
+        const auto *output_buffer = input_tensors.at(1).buffer();
+        for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+            {
+                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = input_buffer->address();
+                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
+            }
+
+            {
+                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = output_buffer->address();
+                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
+            }
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.hpp"
+
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace operations {
+namespace primary {
+
+////////////////////////////////////////////////////////////////////////////
+//                         MorehCumSum
+////////////////////////////////////////////////////////////////////////////
+void MorehCumSum::validate(const std::vector<Tensor>& inputs) const {
+    TT_ASSERT((dim >= 0 && dim <= 3), "dim should be 0 - 3");
+    const auto& input = inputs.at(0);
+    const auto& output = inputs.at(1);
+
+    auto input_shape = input.shape();
+    const auto& output_shape = output.shape();
+    auto input_shape_wo_padding = input.shape().without_padding();
+    const auto& output_shape_wo_padding = output.shape().without_padding();
+
+    for (int i = 0; i < input_shape.rank(); ++i) {
+        TT_ASSERT(input_shape[i] == output_shape[i]);
+        TT_ASSERT(input_shape_wo_padding[i] == output_shape_wo_padding[i]);
+    }
+}
+
+std::vector<Tensor> MorehCumSum::create_output_tensors(const std::vector<Tensor>& inputs) const {
+    // Inplace
+    return {};
+}
+
+std::vector<Shape> MorehCumSum::compute_output_shapes(const std::vector<Tensor>& inputs) const {
+    // Inplace
+    return {};
+}
+
+operation::ProgramWithCallbacks MorehCumSum::create_program(
+    const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) const {
+    TT_ASSERT((dim >= 0 && dim <= 3), "dim should be 0 - 3");
+    auto& input = inputs.at(0);
+    auto& output = inputs.at(1);
+
+    if (dim == 2 || dim == 3) {
+        TT_ASSERT(false, "currenty only support moreh_cumsum op for dim 0, 1");
+    }
+
+    return moreh_cumsum_nc(input, output, dim, flip);
+}
+
+Tensor moreh_cumsum_(const Tensor& input, const Tensor& output, const int64_t& dim, const bool flip = false) {
+    operation::run(MorehCumSum{.dim = dim, .flip = flip}, {input, output});
+    return output;
+}
+
+Tensor moreh_cumsum_backward(const Tensor& output_grad, const Tensor& input_grad, const int64_t& dim) {
+    return moreh_cumsum_(output_grad, input_grad, dim, true);
+}
+
+Tensor moreh_cumsum(const Tensor& input, const Tensor& output, const int64_t& dim) {
+    return moreh_cumsum_(input, output, dim);
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.hpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_eager/tensor/tensor.hpp"
+
+namespace tt {
+
+namespace operations {
+
+namespace primary {
+
+using namespace tt_metal;
+
+struct MorehCumSum {
+    int64_t dim;
+    bool flip;
+    void validate(const std::vector<Tensor> &inputs) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &inputs) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
+    stl::reflection::Attributes attributes() const;
+    static constexpr auto attribute_names = std::make_tuple("dim", "flip");
+    const auto attribute_values() const { return std::make_tuple(std::cref(this->dim), std::cref(this->flip)); }
+};
+
+operation::ProgramWithCallbacks moreh_cumsum_nc(const Tensor &input, const Tensor &output, const int64_t &dim, const bool &flip);
+
+Tensor moreh_cumsum_backward(const Tensor &output_grad, const Tensor &input_grad, const int64_t &dim);
+
+Tensor moreh_cumsum(const Tensor &input, const Tensor &output, const int64_t &dim);
+
+}  // namespace primary
+
+}  // namespace operations
+
+}  // namespace tt

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -20,6 +20,7 @@
 #include "tt_dnn/op_library/softmax/softmax_op.hpp"
 #include "tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp"
 #include "tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_op.hpp"
+#include "tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.hpp"
 
 namespace py = pybind11;
 
@@ -529,6 +530,22 @@ void py_module(py::module& m_primary) {
         py::arg("output_grad").noconvert(),
         py::arg("input_grad").noconvert(),
         "Performs sum backward operation. Returns an input_grad tensor.");
+    m_primary.def(
+        "moreh_cumsum",
+        &moreh_cumsum,
+        py::arg("input").noconvert(),
+        py::arg("output").noconvert(),
+        py::kw_only(),
+        py::arg("dim").noconvert(),
+        "Performs cumsum operation. Returns an output tensor.");
+    m_primary.def(
+        "moreh_cumsum_backward",
+        &moreh_cumsum_backward,
+        py::arg("output_grad").noconvert(),
+        py::arg("input_grad").noconvert(),
+        py::kw_only(),
+        py::arg("dim").noconvert(),
+        "Performs cumsum backward operation. Returns an input_grad tensor.");
 }
 
 }  // namespace


### PR DESCRIPTION
This PR implements cumsum operation to tt_dnn library. (Related issue : #4821)
- cumsum op support for dim 0 and dim 1. (cumsum op for dim 2 and dim 3 are not implemented yet because there is no way to use SFPU and FPU.)