### PR TITLE
Uplift ttlib matmul/bmm to support sharded tensors

### DIFF
--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -29,104 +29,104 @@ class Tensor {
         // ======================================================================================
         //                                  Hi Level APIs
         // ======================================================================================
-     Tensor(const Storage &storage, const Shape &shape, DataType dtype, Layout layout);
+        Tensor(const Storage &storage, const Shape &shape, DataType dtype, Layout layout);
 
-     Tensor(const Tensor &other) = default;
-     Tensor &operator=(const Tensor &other) = default;
+        Tensor(const Tensor &other) = default;
+        Tensor &operator=(const Tensor &other) = default;
 
-     Tensor(Tensor &&other) = default;
-     Tensor &operator=(Tensor &&other) = default;
+        Tensor(Tensor &&other) = default;
+        Tensor &operator=(Tensor &&other) = default;
 
-     ~Tensor();
+        ~Tensor();
 
-     void deallocate(bool force = false);
+        void deallocate(bool force = false);
 
-     Tensor to(
-         Device *target_device,
-         const MemoryConfig &mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) const;
+        Tensor to(
+            Device *target_device,
+            const MemoryConfig &mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) const;
 
-     Tensor to(Layout target_layout) const;
+        Tensor to(Layout target_layout) const;
 
-     Tensor pad(const Shape &output_tensor_shape, const Shape &input_tensor_start, float pad_value) const;
+        Tensor pad(const Shape &output_tensor_shape, const Shape &input_tensor_start, float pad_value) const;
 
-     Tensor cpu(bool blocking = true) const;
+        Tensor cpu(bool blocking = true) const;
 
-     Tensor cpu_sharded() const;
+        Tensor cpu_sharded() const;
 
-     Tensor unpad(const Shape &output_tensor_start, const Shape &output_tensor_end) const;
+        Tensor unpad(const Shape &output_tensor_start, const Shape &output_tensor_end) const;
 
-     Tensor pad_to_tile(float pad_value) const;
+        Tensor pad_to_tile(float pad_value) const;
 
-     Tensor unpad_from_tile(const Shape &output_tensor_shape) const;
+        Tensor unpad_from_tile(const Shape &output_tensor_shape) const;
 
-     const std::string write_to_string(Layout print_layout = Layout::ROW_MAJOR, bool pretty_print = false) const;
-     void print(Layout print_layout = Layout::ROW_MAJOR, bool pretty_print = false) const;
+        const std::string write_to_string(Layout print_layout = Layout::ROW_MAJOR, bool pretty_print = false) const;
+        void print(Layout print_layout = Layout::ROW_MAJOR, bool pretty_print = false) const;
 
-     Tensor extract_shard(const CoreCoord &core) const;
-     Tensor extract_shard(const uint32_t &core_id) const;
+        Tensor extract_shard(const CoreCoord &core) const;
+        Tensor extract_shard(const uint32_t &core_id) const;
 
-     // ======================================================================================
-     //                                  Low Level APIs
-     // ======================================================================================
-     Tensor reshape(int N, int C, int H, int W) const;
-     Tensor reshape(const Shape &new_shape) const;
+        // ======================================================================================
+        //                                  Low Level APIs
+        // ======================================================================================
+        Tensor reshape(int N, int C, int H, int W) const;
+        Tensor reshape(const Shape &new_shape) const;
 
-     // ======================================================================================
-     //                                      Getters
-     // ======================================================================================
-     const Storage &storage() const;
-     const Shape &shape() const { return this->shape_; }
-     DataType dtype() const { return this->dtype_; }
-     Layout layout() const { return this->layout_; }
+        // ======================================================================================
+        //                                      Getters
+        // ======================================================================================
+        const Storage &storage() const;
+        const Shape &shape() const { return this->shape_; }
+        DataType dtype() const { return this->dtype_; }
+        Layout layout() const { return this->layout_; }
 
-     // ======================================================================================
-     //                                      Extra Helper Functions
-     // ======================================================================================
+        // ======================================================================================
+        //                                      Extra Helper Functions
+        // ======================================================================================
 
-     StorageType storage_type() const;
-     const Shape strides() const;
-     uint32_t volume() const;
+        StorageType storage_type() const;
+        const Shape strides() const;
+        uint32_t volume() const;
 
-     bool is_allocated() const;
+        bool is_allocated() const;
 
-     // TODO(arakhmati): clean up the methods below
-     Buffer *buffer() const { return std::get<DeviceStorage>(this->storage_).buffer.get(); }
-     DeviceBuffer device_buffer() const { return std::get<DeviceStorage>(this->storage_).buffer; }
+        // TODO(arakhmati): clean up the methods below
+        Buffer *buffer() const { return std::get<DeviceStorage>(this->storage_).buffer.get(); }
+        DeviceBuffer device_buffer() const { return std::get<DeviceStorage>(this->storage_).buffer; }
 
-     Device *device() const {
-         auto buffer = this->buffer();
-         if (buffer == nullptr)
-             TT_THROW("Cannot get the device from a tensor without an allocated buffer");
-         return buffer->device();
-     }
-     const MemoryConfig memory_config() const {
-         return std::visit(
-             [](const auto &storage) -> MemoryConfig {
-                 using T = std::decay_t<decltype(storage)>;
-                 if constexpr (std::is_same_v<T, DeviceStorage>) {
-                     return storage.memory_config();
-                 } else {
-                     TT_THROW("MemoryConfig can only be obtained for a tensor with DeviceStorage");
-                 }
-             },
-             this->storage_);
-     }
-     const std::optional<ShardSpec> shard_spec() const { return this->memory_config().shard_spec; }
+        Device *device() const {
+            auto buffer = this->buffer();
+            if (buffer == nullptr)
+                TT_THROW("Cannot get the device from a tensor without an allocated buffer");
+            return buffer->device();
+        }
+        const MemoryConfig memory_config() const {
+            return std::visit(
+                [](const auto &storage) -> MemoryConfig {
+                    using T = std::decay_t<decltype(storage)>;
+                    if constexpr (std::is_same_v<T, DeviceStorage>) {
+                        return storage.memory_config();
+                    } else {
+                        TT_THROW("MemoryConfig can only be obtained for a tensor with DeviceStorage");
+                    }
+                },
+                this->storage_);
+        }
+        const std::optional<ShardSpec> shard_spec() const { return this->memory_config().shard_spec; }
 
-     const bool is_sharded() const { return this->memory_config().is_sharded(); }
+        const bool is_sharded() const { return this->storage_type() == StorageType::DEVICE ? this->memory_config().is_sharded() : false; }
 
-     // Size in bytes of a single element held in tensor
-     uint32_t element_size() const;
+        // Size in bytes of a single element held in tensor
+        uint32_t element_size() const;
 
-     static constexpr auto attribute_names = std::make_tuple("storage", "shape", "dtype", "layout");
-     const auto attribute_values() const {
-         return std::make_tuple(
-             std::cref(this->storage_), std::cref(this->shape_), std::cref(this->dtype_), std::cref(this->layout_));
-     }
+        static constexpr auto attribute_names = std::make_tuple("storage", "shape", "dtype", "layout");
+        const auto attribute_values() const {
+            return std::make_tuple(
+                std::cref(this->storage_), std::cref(this->shape_), std::cref(this->dtype_), std::cref(this->layout_));
+        }
 
-     std::vector<uint32_t> host_page_ordering();
+        std::vector<uint32_t> host_page_ordering();
 
-     const ttnn::Shape ttnn_shape() const { return ttnn::Shape(this->shape_); }
+        const ttnn::Shape ttnn_shape() const { return ttnn::Shape(this->shape_); }
 
     private:
      Storage storage_;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -943,7 +943,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
 
-    if (core_range.x > 1 && core_range.y > 1) {
+    if (core_range.x > 1 and core_range.y > 1) {
         return reuse_mcast_optimized_helpers::create_program_mcast_in0_in1(
             device,
             math_fidelity, fp32_dest_acc_en, math_approx_mode, packer_l1_acc,
@@ -959,12 +959,11 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
             in0_data_format, in1_data_format, bias_data_format, output_data_format,
             a.memory_config().is_sharded(), output.memory_config().is_sharded()
         );
-    } else if (core_range.x > 1) {
+    } else if (core_range.x > 1 or core_range.y > 1) {
         // Refer to bmm_op_multi_core_reuse_mcast_padding_generalized.cpp
-        TT_ASSERT(false, "mcast_in0 is not implemented yet.");
+        TT_ASSERT(false, "1D mcast for in0 or in1 is not implemented yet.");
     } else {
-        // Refer to bmm_op_multi_core_reuse_mcast_padding_generalized.cpp
-        TT_ASSERT(false, "mcast_in1 is not implemented yet.");
+        TT_ASSERT(false, "Grid is invalid for mcast matmul!");
     }
 
     return {};


### PR DESCRIPTION
On ttnn side, should be no change. We might want to assert that no grid is passed in, since we directly use grid from sharded tensors in ttlib `matmul` and `bmm`.