### PR TITLE
#4825: Fix embedding operation test sweeps

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/common.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/common.py
@@ -354,7 +354,7 @@ def shapes_and_datagen(shape_dict, datagen_dict, test_args_gen, test_tt_dtypes, 
                 num_embeddings = shape[2]
                 embedding_dim = shape[3]
 
-                input_rows_shape = [batch_size, 1, num_rows, 1]
+                input_rows_shape = [batch_size, 1, 1, num_rows]
                 weights_shape = [1, 1, num_embeddings, embedding_dim]
 
                 return [input_rows_shape, weights_shape]

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1080,7 +1080,7 @@ def embeddings(x, y, *args, **kwargs):
     x_ref = torch.clamp(x_ref, min=0, max=y.shape[-2] - 1)
 
     batch_size = x_shape[0]
-    num_rows = x_shape[2]
+    num_rows = x_shape[3]
     num_embeddings = y_shape[2]
     embedding_dim = y_shape[3]
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2207,7 +2207,7 @@ def embeddings(x, y, *args, device, dtype, layout, input_mem_config, output_mem_
     y_shape = y.shape
 
     batch_size = x_shape[0]
-    num_rows = x_shape[2]
+    num_rows = x_shape[3]
     embedding_dim = y_shape[3]
 
     x_ref = x.detach().clone()
@@ -2217,7 +2217,7 @@ def embeddings(x, y, *args, device, dtype, layout, input_mem_config, output_mem_
 
     t1 = ttl.tensor.Tensor(y, dtype[1]).to(device, input_mem_config[1])
 
-    t2 = ttl.tensor.embeddings(t0, t1, False, False, output_mem_config=output_mem_config)
+    t2 = ttl.tensor.embeddings(t0, t1, False, output_mem_config=output_mem_config)
 
     tt_data = t2.cpu().to_torch()
 


### PR DESCRIPTION
Fix ttlib call for the **embedding** operation, because the error message:

embeddings(): incompatible function arguments. The following argument types are supported: 1. (input: tt::tt_metal::Tensor, weights: tt::tt_metal::Tensor, tilized: bool = False, embeddings_type: tt_lib.tensor.EmbeddingsType = <EmbeddingsType.GENERIC: 0>, pad_token: Optional[int] = None, output_mem_config: tt_lib.tensor.MemoryConfig = tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM), output_dtype: Optional[tt_lib.tensor.DataType] = None) -> tt::tt_metal::Tensor Invoked with: <tt_lib.tensor.Tensor object at 0x7f6061300030>, <tt_lib.tensor.Tensor object at 0x7f6061300a70>, False, False; kwargs: output_mem_config=tt::tt_metal::MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM).

The call should be `t2 = ttl.tensor.embeddings(t0, t1, False, output_mem_config=output_mem_config)` instead of `t2 = ttl.tensor.embeddings(t0, t1, False, False, output_mem_config=output_mem_config)`.

After this, I also got the following error message:

`RuntimeError: TT_FATAL @ tt_eager/tt_dnn/op_library/embeddings/embeddings_op.cpp:510: a.shape()[1] == 1 && a.shape()[2] == 1`

Fix for this case is that the input tensor should have the shape (batch_size, 1, 1, num_rows) and the line `num_rows = x_shape[2]` should be changed to `num_rows = x_shape[3]` (files _tt_lib_ops.py_ and _pytorch_ops.py_).