### PR TITLE
#0: Reduce timeout of multi queue single device FD post commit

### DIFF
--- a/.github/workflows/multi-queue-single-device-fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/multi-queue-single-device-fast-dispatch-build-and-unit-tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Build tt-metal CPP tests
         run: make tests
       - name: Run pre/post regression tests
-        timeout-minutes: 120
+        timeout-minutes: 5
         run: |
           source build/python_env/bin/activate
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type post_commit --dispatch-mode fast-multi-queue-single-device


### PR DESCRIPTION
 to 5 mins for run step as that's probably all we need