### PR TITLE
Add watcher-specific CI tests

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "ckernel.h"
+#include "debug/status.h"
+
+// Wait cycles to create a ~1sec delay
+#define WAIT_CYCLES 1200000000
+// Flag address for syncing between cores (BRISC controls this)
+#define SYNC_ADDR 409600
+
+// Helper function to sync execution by forcing other riscs to wait for brisc, which in turn waits
+// for a set number of cycles.
+void hacky_sync(uint32_t sync_num) {
+    volatile tt_l1_ptr uint32_t* sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(SYNC_ADDR);
+#if defined(COMPILE_FOR_BRISC)
+    ckernel::wait(WAIT_CYCLES);
+    *(sync_ptr) = sync_num;
+#else
+    while (*(sync_ptr) != sync_num) { ; }
+#endif
+}
+
+/*
+ * A test for the watcher waypointing feature.
+*/
+#if defined(COMPILE_FOR_BRISC) | defined(COMPILE_FOR_NCRISC)
+void kernel_main() {
+#else
+#include "compute_kernel_api/common.h"
+namespace NAMESPACE {
+void MAIN {
+#endif
+
+    // Post a new waypoint with a delay after (to let the watcher poll it)
+    hacky_sync(1);
+    DEBUG_STATUS('A', 'A', 'A', 'A');
+    hacky_sync(2);
+    DEBUG_STATUS('B', 'B', 'B', 'B');
+    hacky_sync(3);
+    DEBUG_STATUS('C', 'C', 'C', 'C');
+    hacky_sync(4);
+#if defined(COMPILE_FOR_BRISC) | defined(COMPILE_FOR_NCRISC)
+}
+#else
+}
+}
+#endif

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
@@ -6,17 +6,12 @@
 #include "ckernel.h"
 #include "debug/status.h"
 
-// Wait cycles to create a ~1sec delay
-#define WAIT_CYCLES 1200000000
-// Flag address for syncing between cores (BRISC controls this)
-#define SYNC_ADDR 409600
-
 // Helper function to sync execution by forcing other riscs to wait for brisc, which in turn waits
 // for a set number of cycles.
-void hacky_sync(uint32_t sync_num) {
-    volatile tt_l1_ptr uint32_t* sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(SYNC_ADDR);
+void hacky_sync(uint32_t sync_num, uint32_t wait_cycles, uint32_t sync_addr) {
+    volatile tt_l1_ptr uint32_t* sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sync_addr);
 #if defined(COMPILE_FOR_BRISC)
-    ckernel::wait(WAIT_CYCLES);
+    ckernel::wait(wait_cycles);
     *(sync_ptr) = sync_num;
 #else
     while (*(sync_ptr) != sync_num) { ; }
@@ -33,15 +28,17 @@ void kernel_main() {
 namespace NAMESPACE {
 void MAIN {
 #endif
+    uint32_t sync_wait_cycles = get_arg_val<uint32_t>(0);
+    uint32_t sync_address     = get_arg_val<uint32_t>(1);
 
     // Post a new waypoint with a delay after (to let the watcher poll it)
-    hacky_sync(1);
+    hacky_sync(1, sync_wait_cycles, sync_address);
     DEBUG_STATUS('A', 'A', 'A', 'A');
-    hacky_sync(2);
+    hacky_sync(2, sync_wait_cycles, sync_address);
     DEBUG_STATUS('B', 'B', 'B', 'B');
-    hacky_sync(3);
+    hacky_sync(3, sync_wait_cycles, sync_address);
     DEBUG_STATUS('C', 'C', 'C', 'C');
-    hacky_sync(4);
+    hacky_sync(4, sync_wait_cycles, sync_address);
 #if defined(COMPILE_FOR_BRISC) | defined(COMPILE_FOR_NCRISC)
 }
 #else

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/impl/dispatch/command_queue.hpp"
+
+// A dispatch-agnostic test fixture
+class CommonFixture: public ::testing::Test {
+public:
+    inline static const string dprint_file_name = "gtest_dprint_log.txt";
+
+    // A function to run a program, according to which dispatch mode is set.
+    void RunProgram(Device* device, Program& program) {
+        if (this->slow_dispatch_) {
+            // Slow dispatch uses LaunchProgram
+            tt::tt_metal::detail::LaunchProgram(device, program);
+        } else {
+            // Fast Dispatch uses the command queue
+            CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+            EnqueueProgram(cq, program, false);
+            Finish(cq);
+        }
+    }
+
+protected:
+    tt::ARCH arch_;
+    vector<Device*> devices_;
+    bool slow_dispatch_;
+    bool has_remote_devices_;
+
+    void SetUp() override {
+        // Skip for slow dispatch for now
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            tt::log_info(tt::LogTest, "Running test using Slow Dispatch");
+            slow_dispatch_ = true;
+        } else {
+            tt::log_info(tt::LogTest, "Running test using Fast Dispatch");
+            slow_dispatch_ = false;
+        }
+        // Set up all available devices
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+        auto num_pci_devices = tt::tt_metal::GetNumPCIeDevices();
+        // An extra flag for if we have remote devices, as some tests are disabled for fast
+        // dispatch + remote devices.
+        this->has_remote_devices_ = num_devices > num_pci_devices;
+        for (unsigned int id = 0; id < num_devices; id++) {
+            if (SkipTest(id))
+                continue;
+            auto* device = tt::tt_metal::CreateDevice(id);
+            devices_.push_back(device);
+        }
+    }
+
+    void TearDown() override {
+        // Close all opened devices
+        for (unsigned int id = 0; id < devices_.size(); id++) {
+            tt::tt_metal::CloseDevice(devices_.at(id));
+        }
+    }
+
+    bool SkipTest(unsigned int device_id) {
+        // Skip condition is fast dispatch for remote devices
+        if (this->has_remote_devices_ && !this->slow_dispatch_ && device_id != 0) {
+            log_info(
+                tt::LogTest,
+                "Skipping test on device {} due to fast dispatch unsupported on remote devices.",
+                device_id
+            );
+            return true;
+        }
+
+        // Also skip all devices after device 0 for grayskull. This to match all other tests
+        // targetting device 0 by default (and to not cause issues with BMs that have E300s).
+        // TODO: when we can detect only supported devices, this check can be removed.
+        if (this->arch_ == tt::ARCH::GRAYSKULL && device_id > 0) {
+            log_info(
+                tt::LogTest,
+                "Skipping test on device {} due to unsupported E300",
+                device_id
+            );
+            return true;
+        }
+
+        return false;
+    }
+
+    void RunTestOnDevice(
+        const std::function<void()>& run_function,
+        Device* device
+    ) {
+        if (SkipTest(device->id()))
+            return;
+        log_info(tt::LogTest, "Running test on device {}.", device->id());
+        run_function();
+        log_info(tt::LogTest, "Finished running test on device {}.", device->id());
+    }
+};

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -11,8 +11,6 @@
 // A dispatch-agnostic test fixture
 class CommonFixture: public ::testing::Test {
 public:
-    inline static const string dprint_file_name = "gtest_dprint_log.txt";
-
     // A function to run a program, according to which dispatch mode is set.
     void RunProgram(Device* device, Program& program) {
         if (this->slow_dispatch_) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -2,50 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "gtest/gtest.h"
-#include "tt_metal/detail/tt_metal.hpp"
-#include "tt_metal/host_api.hpp"
-#include "tt_metal/test_utils/env_vars.hpp"
-#include "tt_metal/impl/dispatch/command_queue.hpp"
-#include "tt_metal/llrt/rtoptions.hpp"
+#include "common_fixture.hpp"
 #include "impl/debug/dprint_server.hpp"
 
-// A version of CommandQueueFixture with DPrint enabled on the first core.
-class DPrintFixture: public ::testing::Test {
+// A version of CommonFixture with DPrint enabled on all cores.
+class DPrintFixture: public CommonFixture {
 public:
     inline static const string dprint_file_name = "gtest_dprint_log.txt";
 
     // A function to run a program, according to which dispatch mode is set.
     void RunProgram(Device* device, Program& program) {
-        if (this->slow_dispatch_) {
-            // Slow dispatch uses LaunchProgram
-            tt::tt_metal::detail::LaunchProgram(device, program);
-        } else {
-            // Fast Dispatch uses the command queue
-            CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
-            EnqueueProgram(cq, program, false);
-            Finish(cq);
-        }
-
-        // Wait for the print server to catch up if needed.
+        // Only difference is that we need to wait for the print server to catch
+        // up after running a test.
+        CommonFixture::RunProgram(device, program);
         tt::DprintServerAwait();
     }
-protected:
-    tt::ARCH arch_;
-    vector<Device*> devices_;
-    bool slow_dispatch_;
-    bool has_remote_devices_;
 
+protected:
     void SetUp() override {
-        // Skip for slow dispatch for now
-        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (slow_dispatch) {
-            tt::log_info(tt::LogTest, "Running test using Slow Dispatch");
-            slow_dispatch_ = true;
-        } else {
-            tt::log_info(tt::LogTest, "Running test using Fast Dispatch");
-            slow_dispatch_ = false;
-        }
         // The core range (physical) needs to be set >= the set of all cores
         // used by all tests using this fixture, so set dprint enabled for
         // all cores and all devices
@@ -54,26 +28,14 @@ protected:
         // Send output to a file so the test can check after program is run.
         tt::llrt::OptionsG.set_dprint_file_name(dprint_file_name);
 
-        // Set up all available devices
-        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
-        auto num_devices = tt::tt_metal::GetNumAvailableDevices();
-        auto num_pci_devices = tt::tt_metal::GetNumPCIeDevices();
-        // An extra flag for if we have remote devices, as some tests are disabled for fast
-        // dispatch + remote devices.
-        this->has_remote_devices_ = num_devices > num_pci_devices;
-        for (unsigned int id = 0; id < num_devices; id++) {
-            if (SkipTest(id))
-                continue;
-            auto* device = tt::tt_metal::CreateDevice(id);
-            devices_.push_back(device);
-        }
+        // Parent class initializes devices and any necessary flags
+        CommonFixture::SetUp();
     }
 
     void TearDown() override {
-        // Close all opened devices
-        for (unsigned int id = 0; id < devices_.size(); id++) {
-            tt::tt_metal::CloseDevice(devices_.at(id));
-        }
+        // Parent class tears down devices
+        CommonFixture::TearDown();
+
         // Remove the DPrint output file after the test is finished.
         std::remove(dprint_file_name.c_str());
 
@@ -83,41 +45,14 @@ protected:
         tt::llrt::OptionsG.set_dprint_file_name("");
     }
 
-    bool SkipTest(unsigned int device_id) {
-        // Skip condition is fast dispatch for remote devices
-        if (this->has_remote_devices_ && !this->slow_dispatch_ && device_id != 0) {
-            log_info(
-                tt::LogTest,
-                "Skipping test on device {} due to fast dispatch unsupported on remote devices.",
-                device_id
-            );
-            return true;
-        }
-
-        // Also skip all devices after device 0 for grayskull. This to match all other tests
-        // targetting device 0 by default (and to not cause issues with BMs that have E300s).
-        // TODO: when we can detect only supported devices, this check can be removed.
-        if (this->arch_ == tt::ARCH::GRAYSKULL && device_id > 0) {
-            log_info(
-                tt::LogTest,
-                "Skipping test on device {} due to unsupported E300",
-                device_id
-            );
-            return true;
-        }
-
-        return false;
-    }
-
     void RunTestOnDevice(
         const std::function<void(DPrintFixture*, Device*)>& run_function,
         Device* device
     ) {
-        if (SkipTest(device->id()))
-            return;
-        log_info(tt::LogTest, "Running test on device {}.", device->id());
-        run_function(this, device);
-        log_info(tt::LogTest, "Finished running test on device {}.", device->id());
+        auto run_function_no_args = [=]() {
+            run_function(this, device);
+        };
+        CommonFixture::RunTestOnDevice(run_function_no_args, device);
         tt::DPrintServerClearLogFile();
         tt::DPrintServerClearSignals();
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -27,6 +27,7 @@ protected:
         tt::llrt::OptionsG.set_dprint_all_chips(true);
         // Send output to a file so the test can check after program is run.
         tt::llrt::OptionsG.set_dprint_file_name(dprint_file_name);
+        tt::llrt::OptionsG.set_test_mode_enabled(true);
 
         // Parent class initializes devices and any necessary flags
         CommonFixture::SetUp();
@@ -43,6 +44,7 @@ protected:
         tt::llrt::OptionsG.set_dprint_cores({});
         tt::llrt::OptionsG.set_dprint_all_cores(false);
         tt::llrt::OptionsG.set_dprint_file_name("");
+        tt::llrt::OptionsG.set_test_mode_enabled(false);
     }
 
     void RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <thread>
+#include "common_fixture.hpp"
+#include "llrt/watcher.hpp"
+
+// A version of CommonFixture with watcher enabled
+class WatcherFixture: public CommonFixture {
+public:
+    inline static const string log_file_name = "built/watcher.log";
+    inline static const int interval_ms = 250;
+
+    // A function to run a program, according to which dispatch mode is set.
+    void RunProgram(Device* device, Program& program) {
+        // Only difference is that we need to wait for the print server to catch
+        // up after running a test.
+        CommonFixture::RunProgram(device, program);
+        // Wait for a watcher interval to make sure that we get a reading after program finish.
+        std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
+    }
+
+protected:
+    void SetUp() override {
+
+        // Enable watcher for this test
+        tt::llrt::OptionsG.set_watcher_enabled(true);
+        tt::llrt::OptionsG.set_watcher_interval(interval_ms);
+        tt::llrt::OptionsG.set_watcher_dump_all(false);
+        tt::llrt::OptionsG.set_watcher_append(false);
+
+        // Parent class initializes devices and any necessary flags
+        CommonFixture::SetUp();
+    }
+
+    void TearDown() override {
+        // Parent class tears down devices
+        CommonFixture::TearDown();
+
+        // Remove the watcher output file after the test is finished.
+        std::remove(log_file_name.c_str());
+
+        // Reset watcher settings
+        tt::llrt::OptionsG.set_watcher_enabled(false);
+        tt::llrt::OptionsG.set_watcher_interval(0);
+        tt::llrt::OptionsG.set_watcher_dump_all(false);
+        tt::llrt::OptionsG.set_watcher_append(false);
+    }
+
+    void RunTestOnDevice(
+        const std::function<void(WatcherFixture*, Device*)>& run_function,
+        Device* device
+    ) {
+        auto run_function_no_args = [=]() {
+            run_function(this, device);
+        };
+        CommonFixture::RunTestOnDevice(run_function_no_args, device);
+        // Wait for a final watcher poll and then clear the log.
+        std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
+        tt::llrt::watcher_clear_log();
+    }
+};

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
@@ -30,6 +30,7 @@ protected:
         tt::llrt::OptionsG.set_watcher_interval(interval_ms);
         tt::llrt::OptionsG.set_watcher_dump_all(false);
         tt::llrt::OptionsG.set_watcher_append(false);
+        tt::llrt::watcher_clear_log();
 
         // Parent class initializes devices and any necessary flags
         CommonFixture::SetUp();
@@ -47,6 +48,7 @@ protected:
         tt::llrt::OptionsG.set_watcher_interval(0);
         tt::llrt::OptionsG.set_watcher_dump_all(false);
         tt::llrt::OptionsG.set_watcher_append(false);
+        tt::llrt::watcher_server_clear_error_flag();
     }
 
     void RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
@@ -27,16 +27,19 @@ protected:
     int  watcher_previous_interval;
     bool watcher_previous_dump_all;
     bool watcher_previous_append;
+    bool test_mode_previous;
     void SetUp() override {
         // Enable watcher for this test, save the previous state so we can restore it later.
         watcher_previous_enabled = tt::llrt::OptionsG.get_watcher_enabled();
         watcher_previous_interval = tt::llrt::OptionsG.get_watcher_interval();
         watcher_previous_dump_all = tt::llrt::OptionsG.get_watcher_dump_all();
         watcher_previous_append = tt::llrt::OptionsG.get_watcher_append();
+        test_mode_previous = tt::llrt::OptionsG.get_test_mode_enabled();
         tt::llrt::OptionsG.set_watcher_enabled(true);
         tt::llrt::OptionsG.set_watcher_interval(interval_ms);
         tt::llrt::OptionsG.set_watcher_dump_all(false);
         tt::llrt::OptionsG.set_watcher_append(false);
+        tt::llrt::OptionsG.set_test_mode_enabled(true);
         tt::llrt::watcher_clear_log();
 
         // Parent class initializes devices and any necessary flags
@@ -55,6 +58,7 @@ protected:
         tt::llrt::OptionsG.set_watcher_interval(watcher_previous_interval);
         tt::llrt::OptionsG.set_watcher_dump_all(watcher_previous_dump_all);
         tt::llrt::OptionsG.set_watcher_append(watcher_previous_append);
+        tt::llrt::OptionsG.set_test_mode_enabled(test_mode_previous);
         tt::llrt::watcher_server_clear_error_flag();
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
@@ -23,9 +23,16 @@ public:
     }
 
 protected:
+    bool watcher_previous_enabled;
+    int  watcher_previous_interval;
+    bool watcher_previous_dump_all;
+    bool watcher_previous_append;
     void SetUp() override {
-
-        // Enable watcher for this test
+        // Enable watcher for this test, save the previous state so we can restore it later.
+        watcher_previous_enabled = tt::llrt::OptionsG.get_watcher_enabled();
+        watcher_previous_interval = tt::llrt::OptionsG.get_watcher_interval();
+        watcher_previous_dump_all = tt::llrt::OptionsG.get_watcher_dump_all();
+        watcher_previous_append = tt::llrt::OptionsG.get_watcher_append();
         tt::llrt::OptionsG.set_watcher_enabled(true);
         tt::llrt::OptionsG.set_watcher_interval(interval_ms);
         tt::llrt::OptionsG.set_watcher_dump_all(false);
@@ -43,11 +50,11 @@ protected:
         // Remove the watcher output file after the test is finished.
         std::remove(log_file_name.c_str());
 
-        // Reset watcher settings
-        tt::llrt::OptionsG.set_watcher_enabled(false);
-        tt::llrt::OptionsG.set_watcher_interval(0);
-        tt::llrt::OptionsG.set_watcher_dump_all(false);
-        tt::llrt::OptionsG.set_watcher_append(false);
+        // Reset watcher settings to their previous values
+        tt::llrt::OptionsG.set_watcher_enabled(watcher_previous_enabled);
+        tt::llrt::OptionsG.set_watcher_interval(watcher_previous_interval);
+        tt::llrt::OptionsG.set_watcher_dump_all(watcher_previous_dump_all);
+        tt::llrt::OptionsG.set_watcher_append(watcher_previous_append);
         tt::llrt::watcher_server_clear_error_flag();
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -1,0 +1,125 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "watcher_fixture.hpp"
+#include "test_utils.hpp"
+#include "llrt/llrt.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "common/bfloat16.hpp"
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// A test for checking watcher waypoints.
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+static void RunTest(WatcherFixture* fixture, Device* device) {
+    // Set up program
+    Program program = Program();
+
+    // Set up dram buffers
+    uint32_t single_tile_size = 2 * 1024;
+    uint32_t num_tiles = 50;
+    uint32_t dram_buffer_size = single_tile_size * num_tiles;
+    uint32_t l1_buffer_addr = 400 * 1024;
+
+
+    tt_metal::InterleavedBufferConfig dram_config{
+                            .device=device,
+                            .size = dram_buffer_size,
+                            .page_size = dram_buffer_size,
+                            .buffer_type = tt_metal::BufferType::DRAM
+                            };
+    auto input_dram_buffer = CreateBuffer(dram_config);
+    uint32_t input_dram_buffer_addr = input_dram_buffer.address();
+
+    auto output_dram_buffer = CreateBuffer(dram_config);
+    uint32_t output_dram_buffer_addr = output_dram_buffer.address();
+
+    auto input_dram_noc_xy = input_dram_buffer.noc_coordinates();
+    auto output_dram_noc_xy = output_dram_buffer.noc_coordinates();
+
+    // A DRAM copy kernel, we'll feed it incorrect inputs to test sanitization.
+    constexpr CoreCoord core = {0, 0}; // Run kernel on first core
+    auto dram_copy_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
+        core,
+        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+    // Write to the input DRAM buffer
+    std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
+        dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+    tt_metal::detail::WriteToBuffer(input_dram_buffer, input_vec);
+
+    // Write runtime args - update to a core that doesn't exist
+    output_dram_noc_xy.x = 16;
+    output_dram_noc_xy.y = 16;
+    tt_metal::SetRuntimeArgs(
+        program,
+        dram_copy_kernel,
+        core,
+        {l1_buffer_addr,
+        input_dram_buffer_addr,
+        (std::uint32_t)input_dram_noc_xy.x,
+        (std::uint32_t)input_dram_noc_xy.y,
+        output_dram_buffer_addr,
+        (std::uint32_t)output_dram_noc_xy.x,
+        (std::uint32_t)output_dram_noc_xy.y,
+        dram_buffer_size});
+
+    // Run the kernel, expect an exception here
+    try {
+        fixture->RunProgram(device, program);
+    } catch (std::runtime_error& e) {
+        const string expected = "Command Queue could not finish: device hang due to illegal NoC transaction. See build/watcher.log for details.";
+        const string error = string(e.what());
+        log_info(tt::LogTest, "Caught exception (one is expected in this test): {}", error);
+        EXPECT_TRUE(error.find(expected) != string::npos);
+    }
+
+    // We should be able to find the expected watcher error in the log as well.
+    CoreCoord phys_core = device->worker_core_from_logical_core(core);
+    string expected = "Device x, Core (x=x,y=x):    NAWW,*,*,*,*  brisc using noc0 tried to access core (16,16) L1[addr=0x00019020,len=102400]";
+    expected[7] = '0' + device->id();
+    expected[18] = '0' + phys_core.x;
+    expected[22] = '0' + phys_core.y;
+    EXPECT_TRUE(
+        FileContainsAllStrings(
+            fixture->log_file_name,
+            {expected}
+        )
+    );
+}
+
+// Run tests for host-side sanitization (uses functions that are from watcher.hpp).
+void CheckHostSanitization(Device *device) {
+    // Try reading from a core that doesn't exist
+    constexpr CoreCoord core = {16, 16};
+    uint64_t addr = 0;
+    uint32_t sz_bytes = 4;
+    try {
+        llrt::read_hex_vec_from_core(device->id(), core, addr, sz_bytes);
+    } catch (std::runtime_error& e) {
+        const string expected = "Host watcher: bad {} NOC coord {}\nread\n" + core.str();
+        const string error = string(e.what());
+        log_info(tt::LogTest, "Caught exception (one is expected in this test): {}", error);
+        EXPECT_TRUE(error.find(expected) != string::npos);
+    }
+}
+
+TEST_F(WatcherFixture, TestWatcherSanitize) {
+    // Skip this test for slow dipatch for now. Due to how llrt currently sits below device, it's
+    // tricky to check watcher server status from the finish loop for slow dispatch. Once issue #4363
+    // is resolved, we should add a check for print server handing in slow dispatch as well.
+    if (this->slow_dispatch_)
+        GTEST_SKIP();
+
+    CheckHostSanitization(this->devices_[0]);
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(RunTest, device);
+    }
+}

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "watcher_fixture.hpp"
+#include "test_utils.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// A test for checking watcher waypoints.
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+// Some machines will run this test on different physical cores, so wildcard the exact coordinates
+// and replace them at runtime.
+std::vector<string> ordered_waypoints = {
+    "Device *, Core (x=*,y=*):    AAAA,AAAA,AAAA,AAAA,AAAA",
+    "Device *, Core (x=*,y=*):    BBBB,BBBB,BBBB,BBBB,BBBB",
+    "Device *, Core (x=*,y=*):    CCCC,CCCC,CCCC,CCCC,CCCC"
+};
+
+static void RunTest(WatcherFixture* fixture, Device* device) {
+    // Set up program
+    Program program = Program();
+
+    // Test runs on a 5x5 grid
+    CoreCoord xy_start = {0, 0};
+    CoreCoord xy_end = {4, 4};
+
+    // Run a kernel that posts waypoints and waits on certain gating values to be written before
+    // posting the next waypoint.
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp",
+        CoreRange{
+            .start = xy_start,
+            .end = xy_end
+        },
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}
+    );
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp",
+        CoreRange{
+            .start = xy_start,
+            .end = xy_end
+        },
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}
+    );
+    CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp",
+        CoreRange{
+            .start = xy_start,
+            .end = xy_end
+        },
+        ComputeConfig{}
+    );
+
+    // Run the program in a new thread, we'll have to update gate values in this thread.
+    fixture->RunProgram(device, program);
+
+    // Check that the expected waypoints are in the watcher log, a set for each core.
+    for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
+        for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
+            CoreCoord core = {x, y};
+            CoreCoord phys_core = device->worker_core_from_logical_core(core);
+            // Need to update the expected strings based on each core.
+            for (int idx = 0; idx < ordered_waypoints.size(); idx++) {
+                ordered_waypoints[idx][7] = '0' + device->id();
+                ordered_waypoints[idx][18] = '0' + phys_core.x;
+                ordered_waypoints[idx][22] = '0' + phys_core.y;
+            }
+            EXPECT_TRUE(
+                FileContainsAllStringsInOrder(
+                    fixture->log_file_name,
+                    ordered_waypoints
+                )
+            );
+        }
+    }
+}
+
+TEST_F(WatcherFixture, TestWatcherWaypoints) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(RunTest, device);
+    }
+}

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -113,6 +113,7 @@ void JitBuildEnv::init(uint32_t device_id, tt::ARCH arch)
         "-I" + this->root_ + "tt_metal/hw/inc/" + this->aliased_arch_name_ + "/noc " +
         "-I" + this->root_ + "tt_metal/third_party/umd/device/" + this->arch_name_ + " " + // TODO(fixme)
         "-I" + this->root_ + "tt_metal/hw/ckernels/" + this->arch_name_ + "/common/inc " + // TODO(fixme) datamovement fw shouldn't read this
+        "-I" + this->root_ + "tt_metal/hw/ckernels/" + this->arch_name_ + "/llk_lib " +
         "-I" + this->root_ + "tt_metal/hw/ckernels/" + this->arch_name_ + "/metal/common " +
         "-I" + this->root_ + "tt_metal/hw/ckernels/" + this->arch_name_ + "/metal/llk_io ";
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -28,25 +28,7 @@ RunTimeOptions::RunTimeOptions() {
 
     build_map_enabled = (getenv("TT_METAL_KERNEL_MAP") != nullptr);
 
-    watcher_enabled = false;
-    watcher_interval_ms = 0;
-    const char *watcher_enable_str = getenv("TT_METAL_WATCHER");
-    if (watcher_enable_str != nullptr) {
-        int sleep_val = 0;
-        sscanf(watcher_enable_str, "%d", &sleep_val);
-        if (strstr(watcher_enable_str, "ms") == nullptr) {
-            sleep_val *= 1000;
-        }
-        watcher_enabled = true;
-        watcher_interval_ms = sleep_val;
-    }
-
-    watcher_dump_all = false;
-    const char *watcher_dump_all_str = getenv("TT_METAL_WATCHER_DUMP_ALL");
-    if (watcher_dump_all_str != nullptr) {
-        watcher_dump_all = true;
-    }
-
+    ParseWatcherEnv();
     ParseDPrintEnv();
 
     profiler_enabled = false;
@@ -67,6 +49,26 @@ const std::string& RunTimeOptions::get_root_dir() {
     }
 
     return root_dir;
+}
+
+void RunTimeOptions::ParseWatcherEnv() {
+    watcher_interval_ms = 0;
+    const char *watcher_enable_str = getenv("TT_METAL_WATCHER");
+    watcher_enabled = (watcher_enable_str != nullptr);
+    if (watcher_enabled) {
+        int sleep_val = 0;
+        sscanf(watcher_enable_str, "%d", &sleep_val);
+        if (strstr(watcher_enable_str, "ms") == nullptr) {
+            sleep_val *= 1000;
+        }
+        watcher_interval_ms = sleep_val;
+    }
+
+    const char *watcher_dump_all_str = getenv("TT_METAL_WATCHER_DUMP_ALL");
+    watcher_dump_all = (watcher_dump_all_str != nullptr);
+
+    const char *watcher_append_str = getenv("TT_METAL_WATCHER_APPEND");
+    watcher_append = (watcher_append_str != nullptr);
 }
 
 void RunTimeOptions::ParseDPrintEnv() {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -31,6 +31,9 @@ RunTimeOptions::RunTimeOptions() {
     ParseWatcherEnv();
     ParseDPrintEnv();
 
+    // Test mode has no env var, default is disabled
+    test_mode_enabled = false;
+
     profiler_enabled = false;
 #if defined(PROFILER)
     const char *profiler_enabled_str = std::getenv("TT_METAL_DEVICE_PROFILER");

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -26,6 +26,7 @@ class RunTimeOptions {
     bool watcher_enabled;
     int watcher_interval_ms;
     bool watcher_dump_all;
+    bool watcher_append;
 
     std::vector<CoreCoord> dprint_cores;
     bool dprint_all_cores;
@@ -45,9 +46,16 @@ public:
 
     inline bool get_build_map_enabled() { return build_map_enabled; }
 
-    inline bool get_watcher_enabled() { return watcher_enabled; }
-    inline int get_watcher_interval() { return watcher_interval_ms; }
-    inline int get_watcher_dump_all() { return watcher_dump_all; }
+    // Info from watcher environment variables, setters included so that user
+    // can override with a SW call.
+    inline bool get_watcher_enabled()                 { return watcher_enabled; }
+    inline void set_watcher_enabled(bool enabled)     { watcher_enabled = enabled; }
+    inline int get_watcher_interval()                 { return watcher_interval_ms; }
+    inline void set_watcher_interval(int interval_ms) { watcher_interval_ms = interval_ms; }
+    inline int get_watcher_dump_all()                 { return watcher_dump_all; }
+    inline void set_watcher_dump_all(bool dump_all)   { watcher_dump_all = dump_all; }
+    inline int get_watcher_append()                   { return watcher_append; }
+    inline void set_watcher_append(bool append)       { watcher_append = append; }
 
     // Info from DPrint environment variables, setters included so that user can
     // override with a SW call.
@@ -105,6 +113,9 @@ private:
     void ParseDPrintChipIds(const char* env_var);
     void ParseDPrintRiscvMask(const char* env_var);
     void ParseDPrintFileName(const char* env_var);
+
+    // Helper function to parse watcher-specific environment variables.
+    void ParseWatcherEnv();
 };
 
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -35,6 +35,8 @@ class RunTimeOptions {
     uint32_t dprint_riscv_mask;
     std::string dprint_file_name;
 
+    bool test_mode_enabled;
+
     bool profiler_enabled;
 
     bool null_kernels;
@@ -100,6 +102,14 @@ public:
     inline void set_dprint_file_name(std::string file_name) {
         dprint_file_name = file_name;
     }
+
+    // Used for both watcher and dprint servers, this dev option (no corresponding env var) sets
+    // whether to catch exceptions (test mode = true) coming from debug servers or to throw them
+    // (test mode = false). We need to catch for gtesting, since an unhandled exception will kill
+    // the gtest (and can't catch an exception from the server thread in main thread), but by
+    // default we should throw so that the user can see the exception as soon as it happens.
+    bool get_test_mode_enabled() { return test_mode_enabled; }
+    inline void set_test_mode_enabled(bool enable) { test_mode_enabled = enable; }
 
     inline bool get_profiler_enabled() { return profiler_enabled; }
 

--- a/tt_metal/llrt/watcher.cpp
+++ b/tt_metal/llrt/watcher.cpp
@@ -501,9 +501,14 @@ static void watcher_loop(int sleep_usecs) {
             try {
                 dump(logfile, false);
             } catch (std::runtime_error& e) {
-                watcher::watcher_killed_due_to_error = true;
-                watcher::enabled = false;
-                break;
+                // Depending on whether test mode is enabled, catch and stop server, or re-throw.
+                if (OptionsG.get_test_mode_enabled()) {
+                    watcher::watcher_killed_due_to_error = true;
+                    watcher::enabled = false;
+                    break;
+                } else {
+                    throw e;
+                }
             }
 
             fprintf(logfile, "\n");

--- a/tt_metal/llrt/watcher.cpp
+++ b/tt_metal/llrt/watcher.cpp
@@ -57,6 +57,7 @@ constexpr uint16_t DEBUG_SANITIZE_NOC_SENTINEL_OK_16 = 0xbada;
 static bool enabled = false;
 static std::mutex watch_mutex;
 static std::unordered_map<void *, std::shared_ptr<WatcherDevice>> devices;
+static string logfile_path = "";
 static FILE *logfile = nullptr;
 static std::chrono::time_point start_time = std::chrono::system_clock::now();
 static std::vector<string> kernel_names;
@@ -75,7 +76,7 @@ static FILE * create_file(const string& log_path) {
 
     FILE *f;
 
-    const char *fmode = getenv("TT_METAL_WATCHER_APPEND") ? "a" : "w";
+    const char *fmode = OptionsG.get_watcher_append()? "a" : "w";
     string fname = log_path + "watcher.log";
     if ((f = fopen(fname.c_str(), fmode)) == nullptr) {
         TT_THROW("Watcher failed to create log file\n");
@@ -412,6 +413,7 @@ static void validate_kernel_ids(FILE *f,
 static void dump_core(FILE *f, std::map<int, bool>& used_kernel_names, WatcherDevice *wdev, CoreCoord core, bool dump_all) {
 
     string pad(11 - core.str().length(), ' ');
+    fprintf(f, "Device %i, ", wdev->device_id_);
     fprintf(f, "Core %s:%s  ", core.str().c_str(), pad.c_str());
 
     std::vector<uint32_t> data;
@@ -610,6 +612,7 @@ void watcher_attach(void *dev,
 
     if (!watcher::enabled && OptionsG.get_watcher_enabled()) {
 
+        watcher::logfile_path = log_path;
         watcher::logfile = watcher::create_file(log_path);
 
         int sleep_usecs = OptionsG.get_watcher_interval() * 1000;
@@ -662,6 +665,10 @@ int watcher_register_kernel(const string& name) {
     watcher::kernel_names.push_back(name);
 
     return watcher::kernel_names.size() - 1;
+}
+
+void watcher_clear_log() {
+    watcher::logfile = watcher::create_file(watcher::logfile_path);
 }
 
 } // namespace llrt

--- a/tt_metal/llrt/watcher.hpp
+++ b/tt_metal/llrt/watcher.hpp
@@ -20,5 +20,8 @@ void watcher_sanitize_host_noc_write(const metal_SocDescriptor &soc_d, CoreCoord
 
 int watcher_register_kernel(const string& name);
 
+// Helper function to clear the watcher log file
+void watcher_clear_log();
+
 } // namespace llrt
 } // namespace tt

--- a/tt_metal/llrt/watcher.hpp
+++ b/tt_metal/llrt/watcher.hpp
@@ -20,6 +20,13 @@ void watcher_sanitize_host_noc_write(const metal_SocDescriptor &soc_d, CoreCoord
 
 int watcher_register_kernel(const string& name);
 
+// Check whether the watcher server has been killed due to an error detected.
+bool watcher_server_killed_due_to_error();
+// Function to clear this flag, so that non-watcher runs can continue as normal.
+// TODO(dma): this doesn't currently clear the actual error codes on the device. Once watcher is
+// moved out of llrt we can change this to watcher_clear_errors().
+void watcher_server_clear_error_flag();
+
 // Helper function to clear the watcher log file
 void watcher_clear_log();
 


### PR DESCRIPTION
- Refactor dispatch-agnostic test fixtures to have a common fixture, and dprint/watcher-specific fixtures
- Add tests for watcher waypointing and sanitization
- Some minor changes tot he watcher server to enable gtesting