### PR TITLE
#0: Fix dprint server lock not being released before throw

### DIFF
--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -430,6 +430,7 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
                     to_string(wait_signal) + "\n";
                 stream << error_str << flush;
                 log_warning(tt::LogMetal, "Debug Print Server encountered an error: {}", error_str);
+                raise_wait_lock_.unlock();
                 TT_THROW(error_str);
                 server_killed_due_to_hang_ = true;
             }


### PR DESCRIPTION
Manually verified that the test fails on my BM before this fix, and that is passes after this fix