### PR TITLE
#4775: Add lt,gt,ne,sqrt,relu,clamp,log,abs, le backward op sweeps

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/pytorch_backward_clamp.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/pytorch_backward_clamp.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - clamp-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - clamp-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/pytorch_backward_clamp_max.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/pytorch_backward_clamp_max.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - clamp-max-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_max_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - clamp-max-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_max_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/pytorch_backward_clamp_min.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/pytorch_backward_clamp_min.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - clamp-min-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_min_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - clamp-min-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_min_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/pytorch_backward_sqrt.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/pytorch_backward_sqrt.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - sqrt-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_sqrt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - sqrt-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_sqrt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_binary_le.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_binary_le.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - binary-le-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_binary_le_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - binary-le-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_binary_le_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_gt.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_gt.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - gt-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_gt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - gt-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_gt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_log.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_log.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - log-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_log_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - log-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_log_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_lt.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_lt.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - lt-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_lt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - lt-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_lt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_ne.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_ne.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - ne-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_ne_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - ne-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_ne_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_neg.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_neg.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - neg-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_neg_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - neg-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_neg_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_relu.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_relu.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - relu-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_relu_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - relu-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_relu_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_rsub.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_backward_rsub.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - rsub-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_rsub_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - rsub-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_rsub_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_abs.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_abs.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - abs-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_abs_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - bs-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_abs_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_binary_le.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_binary_le.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - binary-le-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_binary_le_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - binary-le-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_binary_le_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_clamp.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_clamp.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - clamp-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - clamp-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_clamp_max.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_clamp_max.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - clamp-max-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_max_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - clamp-max-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_max_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_clamp_min.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_clamp_min.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - clamp-min-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_min_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - clamp-min-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_clamp_min_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_gt.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_gt.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - gt-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_gt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - gt-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_gt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_log.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_log.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - log-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_log_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - log-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_log_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_lt.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_lt.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - lt-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_lt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - lt-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_lt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_ne.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_ne.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - ne-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_ne_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - ne-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [12, 24, 512, 512]
+        interval: [1, 1, 1, 2]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_ne_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_neg.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_neg.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - neg-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_neg_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - neg-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_neg_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_relu.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_relu.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - relu-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_relu_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - relu-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_relu_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_rsub.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_rsub.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - rsub-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_rsub_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - rsub-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM"]
+      output-file: backward_rsub_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_sqrt.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_backward_sqrt.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - sqrt-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_sqrt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - sqrt-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_sqrt_sweep.csv
+      env:
+        TT_METAL_SLOW_DISPATCH_MODE: [""]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2297,3 +2297,268 @@ def complex_imag(x, *args, device, dtype, layout, input_mem_config, output_mem_c
     tt_result = tt2torch_tensor(tt_result)
 
     return tt_result
+
+
+@setup_host_and_device
+def abs_bw(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttl.tensor.abs_bw(t0, t1, output_mem_config)[0]
+
+    return tt2torch_tensor(t2)
+
+
+@setup_host_and_device
+def sqrt_bw(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttl.tensor.sqrt_bw(t0, t1, output_mem_config)[0]
+
+    return tt2torch_tensor(t2)
+
+
+@setup_host_and_device
+def relu_bw(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttl.tensor.relu_bw(t0, t1, output_mem_config)[0]
+
+    return tt2torch_tensor(t2)
+
+
+@setup_host_and_device
+def neg_bw(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttl.tensor.neg_bw(t0, t1, output_mem_config)[0]
+
+    return tt2torch_tensor(t2)
+
+
+@setup_host_and_device
+def log_bw(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttl.tensor.log_bw(t0, t1, output_mem_config)[0]
+
+    return tt2torch_tensor(t2)
+
+
+@setup_host_and_device
+def gt_bw(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+
+    t1 = ttl.tensor.gt_bw(t0, output_mem_config)[0]
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
+def lt_bw(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+
+    t1 = ttl.tensor.lt_bw(t0, output_mem_config)[0]
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
+def ne_bw(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+
+    t1 = ttl.tensor.ne_bw(t0, output_mem_config)[0]
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
+def rsub_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    z,  # other_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+
+    t3 = ttl.tensor.rsub_bw(t0, t1, t2, output_mem_config)[0]
+
+    return tt2torch_tensor(t3)
+
+
+@setup_host_and_device
+def binary_le_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t3 = ttl.tensor.binary_le_bw(t0, t1, output_mem_config)[0]
+
+    return tt2torch_tensor(t3)
+
+
+@setup_host_and_device
+def clamp_min_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    scalar,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t3 = ttl.tensor.clamp_min_bw(t0, t1, scalar, output_mem_config)[0]
+
+    return tt2torch_tensor(t3)
+
+
+@setup_host_and_device
+def clamp_max_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    scalar,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t3 = ttl.tensor.clamp_max_bw(t0, t1, scalar, output_mem_config)[0]
+
+    return tt2torch_tensor(t3)
+
+
+@setup_host_and_device
+def clamp_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    scalar,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    if scalar >= 0:
+        max = scalar
+        min = -scalar
+    else:
+        max = -scalar
+        min = scalar
+
+    t3 = ttl.tensor.clamp_bw(t0, t1, min, max, output_mem_config)[0]
+
+    return tt2torch_tensor(t3)


### PR DESCRIPTION
Added backward operation sweeps:

- log_bw
- rsub_bw
- abs_bw
- sqrt_bw
- neg_bw
- lt_bw
- gt_bw
- relu_bw
- ne_bw
- clamp_bw
- clamp_min_bw
- clamp_max_bw
- binary_le_bw

and unit tests for the ones which are failing on GS (clamp, clamp min, clamp max, sqrt)