### PR TITLE
#4548: Move dispatch message to host memory

### DIFF
--- a/models/demos/resnet/tests/test_perf_accuracy_resnet.py
+++ b/models/demos/resnet/tests/test_perf_accuracy_resnet.py
@@ -193,7 +193,7 @@ def test_perf_bare_metal(
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time, iterations",
-    ((16, 0.015, 36, 50), (20, 0.015, 36, 50)),
+    ((16, 0.015, 36, 50), (20, 0.016, 36, 50)),
 )
 def test_perf_virtual_machine(
     use_program_cache,

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -257,13 +257,13 @@ class EnqueueProgramCommand : public Command {
     Device* device;
     Buffer& buffer;
     ProgramMap& program_to_dev_map;
-    const Program& program;
+    Program& program;
     SystemMemoryManager& manager;
     bool stall;
     std::optional<std::reference_wrapper<Trace>> trace = {};
 
    public:
-    EnqueueProgramCommand(uint32_t command_queue_id, Device*, Buffer&, ProgramMap&, SystemMemoryManager&, const Program& program, bool stall, std::optional<std::reference_wrapper<Trace>> trace);
+    EnqueueProgramCommand(uint32_t command_queue_id, Device*, Buffer&, ProgramMap&, SystemMemoryManager&, Program& program, bool stall, std::optional<std::reference_wrapper<Trace>> trace);
 
     const DeviceCommand assemble_device_command(uint32_t src_address);
 

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -41,10 +41,10 @@ class DeviceCommand {
     DeviceCommand();
 
     enum class TransferType : uint8_t {
-        RUNTIME_ARGS,
-        CB_CONFIGS,
         PROGRAM_MULTICAST_PAGES,
         PROGRAM_UNICAST_PAGES,
+        RUNTIME_ARGS,
+        CB_CONFIGS,
         GO_SIGNALS_MULTICAST,
         GO_SIGNALS_UNICAST,
         NUM_TRANSFER_TYPES

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
@@ -280,19 +280,19 @@ void write_and_launch_program(
         bool multicast = true;
         switch (transfer_type_idx) {
             DeviceCommand::TransferType transfer_type;
-            case (uint32_t) DeviceCommand::TransferType::RUNTIME_ARGS:
-                multicast = false;
-                num_pages_in_transfer = header->num_runtime_arg_pages;
-                break;
-            case (uint32_t) DeviceCommand::TransferType::CB_CONFIGS:
-                num_pages_in_transfer = header->num_cb_config_pages;
-                break;
             case (uint32_t) DeviceCommand::TransferType::PROGRAM_MULTICAST_PAGES:
                 num_pages_in_transfer = header->num_program_multicast_pages;
                 break;
             case (uint32_t) DeviceCommand::TransferType::PROGRAM_UNICAST_PAGES:
                 multicast = false;
                 num_pages_in_transfer = header->num_program_unicast_pages;
+                break;
+            case (uint32_t) DeviceCommand::TransferType::RUNTIME_ARGS:
+                multicast = false;
+                num_pages_in_transfer = header->num_runtime_arg_pages;
+                break;
+            case (uint32_t) DeviceCommand::TransferType::CB_CONFIGS:
+                num_pages_in_transfer = header->num_cb_config_pages;
                 break;
             case (uint32_t) DeviceCommand::TransferType::GO_SIGNALS_MULTICAST:
                 num_pages_in_transfer = header->num_go_signal_multicast_pages;


### PR DESCRIPTION
And shuffle order of command queue: send pgm first, rt args, cbs, go last

This is a perf regression in dispatch.  Shuffling the order of the command queue mitigates the cost of moving the dispatch message to the host

Plan is to refactor to run faster in the (near?) future