### PR TITLE
#4946: Add inv trig ops to ttnn

### DIFF
--- a/docs/source/ttnn/api.rst
+++ b/docs/source/ttnn/api.rst
@@ -57,6 +57,9 @@ Pointwise Unary
    ttnn/sin
    ttnn/cos
    ttnn/tan
+   ttnn/asin
+   ttnn/acos
+   ttnn/atan
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/acos.rst
+++ b/docs/source/ttnn/ttnn/acos.rst
@@ -1,0 +1,6 @@
+.. _ttnn.acos:
+
+ttnn.acos
+###############
+
+.. autofunction:: ttnn.acos

--- a/docs/source/ttnn/ttnn/asin.rst
+++ b/docs/source/ttnn/ttnn/asin.rst
@@ -1,0 +1,6 @@
+.. _ttnn.asin:
+
+ttnn.asin
+###############
+
+.. autofunction:: ttnn.asin

--- a/docs/source/ttnn/ttnn/atan.rst
+++ b/docs/source/ttnn/ttnn/atan.rst
@@ -1,0 +1,6 @@
+.. _ttnn.atan:
+
+ttnn.atan
+###############
+
+.. autofunction:: ttnn.atan

--- a/tests/ttnn/sweep_tests/sweeps/acos.py
+++ b/tests/ttnn/sweep_tests/sweeps/acos.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -0.1
+    high = 0.1
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
+    torch_output_tensor = torch.acos(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.acos(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/asin.py
+++ b/tests/ttnn/sweep_tests/sweeps/asin.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -0.1
+    high = 0.1
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
+    torch_output_tensor = torch.asin(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.asin(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/atan.py
+++ b/tests/ttnn/sweep_tests/sweeps/atan.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -0.1
+    high = 0.1
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
+    torch_output_tensor = torch.atan(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.atan(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/unit_tests/operations/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/test_unary.py
@@ -76,11 +76,29 @@ def test_sin(device, h, w):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
+def test_asin(device, h, w):
+    run_unary_test(device, h, w, ttnn.asin, torch.asin, pcc=0.999)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
 def test_cos(device, h, w):
     run_unary_test(device, h, w, ttnn.cos, torch.cos, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
+def test_acos(device, h, w):
+    run_unary_test(device, h, w, ttnn.acos, torch.acos, pcc=0.999)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
 def test_tan(device, h, w):
     run_unary_test(device, h, w, ttnn.tan, torch.tan)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_atan(device, h, w):
+    run_unary_test(device, h, w, ttnn.atan, torch.atan)

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -84,6 +84,9 @@ from ttnn.operations.unary import (
     sin,
     cos,
     tan,
+    asin,
+    acos,
+    atan,
 )
 
 from ttnn.operations.binary import (

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -29,6 +29,9 @@ def register_ttl_unary_function(name, ttl_unary_function):
             "sin": torch.sin,
             "cos": torch.cos,
             "tan": torch.tan,
+            "asin": torch.asin,
+            "acos": torch.acos,
+            "atan": torch.atan,
         }
         torch_function = name_to_torch_function[name]
         input_tensor = ttnn.to_torch(input_tensor)
@@ -101,6 +104,9 @@ TTL_UNARY_FUNCTIONS = [
     ("sin", ttl.tensor.sin),
     ("cos", ttl.tensor.cos),
     ("tan", ttl.tensor.tan),
+    ("asin", ttl.tensor.asin),
+    ("acos", ttl.tensor.acos),
+    ("atan", ttl.tensor.atan),
 ]
 
 


### PR DESCRIPTION
Add support for inverse trig ops to TTNN
CI Test [Link](https://github.com/tenstorrent-metal/tt-metal/actions/runs/7722287345)
Sweep Test Results:
[asin.csv](https://github.com/tenstorrent-metal/tt-metal/files/14108965/asin.csv)
[acos.csv](https://github.com/tenstorrent-metal/tt-metal/files/14108966/acos.csv)
[atan.csv](https://github.com/tenstorrent-metal/tt-metal/files/14108968/atan.csv)
