### PR TITLE
FD tunnel to remote command processor

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
@@ -33,6 +33,7 @@ class DeviceFixture : public ::testing::Test {
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
+        tt::Cluster::instance().launch_internal_routing_for_ethernet_cores();
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
@@ -33,10 +33,11 @@ class DeviceFixture : public ::testing::Test {
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
-        tt::Cluster::instance().launch_internal_routing_for_ethernet_cores();
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     }
 
     void TearDown() override {
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }

--- a/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
@@ -27,6 +27,7 @@ class N300DeviceFixture : public ::testing::Test {
                 auto* device = tt::tt_metal::CreateDevice(id);
                 devices_.push_back(device);
             }
+            tt::Cluster::instance().launch_internal_routing_for_ethernet_cores();
 
         } else {
             GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
@@ -27,7 +27,7 @@ class N300DeviceFixture : public ::testing::Test {
                 auto* device = tt::tt_metal::CreateDevice(id);
                 devices_.push_back(device);
             }
-            tt::Cluster::instance().launch_internal_routing_for_ethernet_cores();
+            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
 
         } else {
             GTEST_SKIP();
@@ -35,6 +35,7 @@ class N300DeviceFixture : public ::testing::Test {
     }
 
     void TearDown() override {
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }

--- a/tests/tt_metal/tt_metal/unit_tests/multichip/device_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/multichip/device_cluster_api.cpp
@@ -37,8 +37,8 @@ TEST_F(N300DeviceFixture, ValidateEthernetConnectivity) {
     ASSERT_TRUE(device_1->get_inactive_ethernet_cores().size() == 14);
 
     // Check connectivity between chips
-    ASSERT_TRUE(device_0->get_ethernet_connected_chip_ids() == std::unordered_set({1}));
-    ASSERT_TRUE(device_1->get_ethernet_connected_chip_ids() == std::unordered_set({0}));
+    ASSERT_TRUE((device_0->get_ethernet_cores_grouped_by_connected_chips() == std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>>({{1, {{0, 8}, {0,9}}}})));
+    ASSERT_TRUE((device_1->get_ethernet_cores_grouped_by_connected_chips() == std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>>({{0, {{0, 0}, {0,1}}}})));
 
     for (const auto& core : device_0_active_eth_cores) {
         std::tuple<chip_id_t, CoreCoord> core_on_chip_1 = device_0->get_connected_ethernet_core(core);

--- a/tests/tt_metal/tt_metal/unit_tests/multichip/ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/multichip/ring_gather_kernels.cpp
@@ -80,7 +80,7 @@ std::vector<Device*> get_device_ring(std::vector<tt::tt_metal::Device*> devices)
     std::vector<std::vector<int>> adj(devices.size(), std::vector<int>(devices.size(), 0));
     for (uint32_t i = 0; i < devices.size(); ++i) {
         const auto& device = devices[i];
-        for (const auto& connected_device_id : device->get_ethernet_connected_chip_ids()) {
+        for (const auto& [connected_device_id, cores] : device->get_ethernet_cores_grouped_by_connected_chips()) {
             for (uint32_t j = 0; j < devices.size(); ++j) {
                 if (devices[j]->id() == connected_device_id) {
                     adj[i][j] = 1;

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -67,9 +67,11 @@ protected:
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     }
 
     void TearDown() override {
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
         // Close all opened devices
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_remote_dispatch_tunneling.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_remote_dispatch_tunneling.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+
+#include "command_queue_fixture.hpp"
+#include "command_queue_test_utils.hpp"
+#include "gtest/gtest.h"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "tt_metal/common/core_descriptor.hpp"
+
+using namespace tt::tt_metal;
+
+namespace remote_tests {
+
+TEST_F(CommandQueueMultiDeviceFixture, TestCommandReachesRemoteDevice) {
+    for (unsigned int id = 0; id < devices_.size(); id++) {
+        auto device = devices_.at(id);
+        if (device->is_mmio_capable()) {
+            continue;
+        }
+
+        CommandQueue &remote_cq = detail::GetCommandQueue(device);
+
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
+        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+        uint8_t num_hw_cqs = device->num_hw_cqs();
+        ASSERT_EQ(num_hw_cqs, 1) << "Expected this test to be run with single HW CQ test suite!";
+        uint8_t cq_id = 0;
+
+        uint32_t num_pages = 1;
+        uint32_t page_size = 2048;
+        uint32_t buff_size = num_pages * page_size;
+        Buffer bufa(device, buff_size, page_size, BufferType::DRAM);
+
+        std::vector<uint32_t> src(buff_size / sizeof(uint32_t), 0);
+        for (uint32_t i = 0; i < src.size(); i++) {
+            src.at(i) = i;
+        }
+
+        EnqueueWriteBuffer(remote_cq, bufa, src.data(), false);
+
+        uint32_t num_bytes_in_cmd_header = DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER * sizeof(uint32_t);
+
+        std::vector<uint32_t> cq_header(DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER);
+        tt::Cluster::instance().read_sysmem(cq_header.data(), num_bytes_in_cmd_header, CQ_START, mmio_device_id, channel);
+
+        tt_cxy_pair issue_q_reader_location = dispatch_core_manager::get(num_hw_cqs).issue_queue_reader_core(device->id(), channel, cq_id);
+        CoreCoord issue_q_physical_core = tt::get_physical_core_coordinate(issue_q_reader_location, CoreType::WORKER);
+        std::vector<uint32_t> issue_q_reader_header(DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER);
+        tt::Cluster::instance().read_core(issue_q_reader_header.data(), num_bytes_in_cmd_header, tt_cxy_pair(issue_q_reader_location.chip, issue_q_physical_core), L1_UNRESERVED_BASE);
+        EXPECT_EQ(cq_header, issue_q_reader_header) << "Remote issue queue reader did not read in expected command!";
+
+        tt_cxy_pair src_eth_router_location = tt::Cluster::instance().get_eth_core_for_dispatch_core(issue_q_reader_location, EthRouterMode::FD_SRC, device->id());
+        CoreCoord physical_src_eth_router = tt::get_physical_core_coordinate(src_eth_router_location, CoreType::ETH);
+        std::vector<uint32_t> source_router_header(DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER);
+        tt::Cluster::instance().read_core(source_router_header.data(), num_bytes_in_cmd_header, tt_cxy_pair(src_eth_router_location.chip, physical_src_eth_router), eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE);
+        EXPECT_EQ(cq_header, source_router_header) << "Ethernet router on local chip (src) did not receive expected command!";
+
+        // Need ethernet cores ot get out of FD mode to do host read backs from remote device
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+
+        tt_cxy_pair remote_processor_location = dispatch_core_manager::get(num_hw_cqs).remote_processor_core(device->id(), channel, cq_id);
+        CoreCoord remote_processor_physical_core = tt::get_physical_core_coordinate(remote_processor_location, CoreType::WORKER);
+
+        tt_cxy_pair dst_eth_router_location = tt::Cluster::instance().get_eth_core_for_dispatch_core(remote_processor_location, EthRouterMode::FD_DST, mmio_device_id);
+        CoreCoord physical_dst_eth_router = tt::get_physical_core_coordinate(dst_eth_router_location, CoreType::ETH);
+
+        std::vector<uint32_t> dst_router_header(DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER);
+        tt::Cluster::instance().read_core(dst_router_header.data(), num_bytes_in_cmd_header, tt_cxy_pair(dst_eth_router_location.chip, physical_dst_eth_router), eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE);
+        EXPECT_EQ(cq_header, dst_router_header) << "Ethernet router on remote chip (dst) did not receive expected command!";
+
+        std::vector<uint32_t> remote_cmd_processor_header(DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER);
+        tt::Cluster::instance().read_core(remote_cmd_processor_header.data(), num_bytes_in_cmd_header, tt_cxy_pair(remote_processor_location.chip, remote_processor_physical_core), L1_UNRESERVED_BASE);
+        EXPECT_EQ(cq_header, remote_cmd_processor_header) << "Remote command processor on remote chip did not receive expected command!";
+
+        std::vector<uint32_t> remote_cmd_processor_data(buff_size / sizeof(uint32_t));
+        tt::Cluster::instance().read_core(remote_cmd_processor_data.data(), buff_size, tt_cxy_pair(remote_processor_location.chip, remote_processor_physical_core), L1_UNRESERVED_BASE + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND);
+        EXPECT_EQ(src, remote_cmd_processor_data) << "Remote command processor on remote chip did not receive expected data!";
+    }
+}
+
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -51,6 +51,7 @@ class CommandQueueMultiDeviceFixture : public ::testing::Test {
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
+        tt::Cluster::instance().launch_internal_routing_for_ethernet_cores();
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -51,10 +51,11 @@ class CommandQueueMultiDeviceFixture : public ::testing::Test {
             auto* device = tt::tt_metal::CreateDevice(id);
             devices_.push_back(device);
         }
-        tt::Cluster::instance().launch_internal_routing_for_ethernet_cores();
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     }
 
     void TearDown() override {
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -553,14 +553,12 @@ namespace tt::tt_metal{
                         if (device_id != device->id()) {
                             // This means the issue queue and completion queue interfaces that service a remote device are being set up
                             // the issue queue interface needs to send fast dispatch packets to the "src" ethernet core
-                            CoreCoord logical_eth_router_src =
-                                tt::Cluster::instance().get_and_configure_corresponding_eth_core_for_device(
-                                    device->id(), issue_q_physical_core, EthRouterMode::FD_SRC, device_id);
+                            CoreCoord logical_eth_router_src = tt::Cluster::instance().get_eth_core_for_dispatch_core(
+                                issue_q_reader_location, EthRouterMode::FD_SRC, device_id);
                             consumer_physical_core = device->ethernet_core_from_logical_core(logical_eth_router_src);
-                            // TODO: remote processor core should use logical_eth_router_dst as producer
-                            CoreCoord logical_eth_router_dst =
-                                tt::Cluster::instance().get_and_configure_corresponding_eth_core_for_device(
-                                    device_id, issue_q_physical_core, EthRouterMode::FD_DST, device->id());
+
+                            tt::Cluster::instance().configure_eth_core_for_dispatch_core(
+                                issue_q_reader_location, EthRouterMode::FD_SRC, device_id);
                         }
 
                         std::map<string, string> producer_defines = {

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -553,7 +553,14 @@ namespace tt::tt_metal{
                         if (device_id != device->id()) {
                             // This means the issue queue and completion queue interfaces that service a remote device are being set up
                             // the issue queue interface needs to send fast dispatch packets to the "src" ethernet core
-                            consumer_physical_core = device->ethernet_core_from_logical_core(*device->get_active_ethernet_cores().begin());
+                            CoreCoord logical_eth_router_src =
+                                tt::Cluster::instance().get_and_configure_corresponding_eth_core_for_device(
+                                    device->id(), issue_q_physical_core, EthRouterMode::FD_SRC, device_id);
+                            consumer_physical_core = device->ethernet_core_from_logical_core(logical_eth_router_src);
+                            // TODO: remote processor core should use logical_eth_router_dst as producer
+                            CoreCoord logical_eth_router_dst =
+                                tt::Cluster::instance().get_and_configure_corresponding_eth_core_for_device(
+                                    device_id, issue_q_physical_core, EthRouterMode::FD_DST, device->id());
                         }
 
                         std::map<string, string> producer_defines = {

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -54,10 +54,9 @@ void __attribute__((section("erisc_l1_code"))) ApplicationHandler(void) {
         noc_local_state_init(n);
     }
     ncrisc_noc_full_sync();
-    while (1) {
-        if (erisc_info->num_bytes == 123) {
+    while (erisc_info->routing_enabled) {
+        if (erisc_info->launch_sd_kernel == 1) {
             kernel_init();
-            break;
         } else {
             risc_context_switch();
         }

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -6,11 +6,11 @@
 #include "ethernet/dataflow_api.h"
 #include "firmware_common.h"
 #include "generated_bank_to_noc_coord_mapping.h"
-#include "noc_nonblocking_api.h"
 #include "noc_parameters.h"
 #include "risc_attribs.h"
 #include "tools/profiler/kernel_profiler.hpp"
-#include "tt_eth_api.h"
+#include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/dispatch/kernels/command_queue_common.hpp"
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,12 +28,49 @@ uint32_t wIndex __attribute__((used));
 
 tt_l1_ptr mailboxes_t * const mailboxes = (tt_l1_ptr mailboxes_t *)(eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE);
 
+uint8_t noc_index = 0;  // TODO: remove hardcoding
 uint8_t my_x[NUM_NOCS] __attribute__((used));
 uint8_t my_y[NUM_NOCS] __attribute__((used));
 
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
+
+FORCE_INLINE
+void multicore_eth_cb_wait_front(db_cb_config_t *eth_db_cb_config, int32_t num_pages) {
+    DEBUG_STATUS('C', 'R', 'B', 'W');
+
+    uint16_t pages_received;
+    do {
+        pages_received = uint16_t(eth_db_cb_config->recv - eth_db_cb_config->ack);
+    } while (pages_received < num_pages);
+    DEBUG_STATUS('C', 'R', 'B', 'D');
+}
+
+FORCE_INLINE
+void multicore_eth_cb_pop_front(
+    db_cb_config_t *eth_db_cb_config,
+    const db_cb_config_t *remote_db_cb_config,
+    uint64_t producer_noc_encoding,
+    uint32_t num_pages) {
+    eth_db_cb_config->ack += num_pages;
+
+    uint32_t pages_ack_addr = (uint32_t)(&(remote_db_cb_config->ack));
+    noc_semaphore_set_remote((uint32_t)(&(eth_db_cb_config->ack)), producer_noc_encoding | pages_ack_addr);
+}
+
+FORCE_INLINE
+uint64_t get_dispatch_core_noc_encoding() {
+    uint32_t dispatch_noc_x = (uint32_t)((routing_info->dispatch_core_xy >> 16) & 0xFFFF);
+    uint32_t dispatch_noc_y = (uint32_t)(routing_info->dispatch_core_xy & 0xFFFF);
+    return uint64_t(NOC_XY_ENCODING(dispatch_noc_x, dispatch_noc_y)) << 32;
+}
+
+FORCE_INLINE
+void eth_db_acquire(volatile uint32_t *semaphore, uint64_t noc_encoding) {
+    while (semaphore[0] == 0 and routing_info->routing_enabled) {
+    }
+}
 
 void __attribute__((section("code_l1"))) risc_init() {
     for (uint32_t n = 0; n < NUM_NOCS; n++) {
@@ -54,13 +91,65 @@ void __attribute__((section("erisc_l1_code"))) ApplicationHandler(void) {
         noc_local_state_init(n);
     }
     ncrisc_noc_full_sync();
-    while (erisc_info->routing_enabled) {
-        if (erisc_info->launch_sd_kernel == 1) {
+    while (routing_info->routing_enabled != 1) {
+        internal_::risc_context_switch();
+    }
+    uint64_t dispatch_core_noc_encoding = get_dispatch_core_noc_encoding();
+    uint64_t eth_router_noc_encoding = uint64_t(NOC_XY_ENCODING(my_x[0], my_y[0])) << 32;
+
+    volatile tt_l1_ptr uint32_t *eth_db_semaphore_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t *>(eth_get_semaphore(0));
+
+    static constexpr uint32_t command_start_addr = eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE;
+
+    bool db_buf_switch = false;
+    while (routing_info->routing_enabled) {
+        // FD: assume that no more host -> remote writes are pending
+        if (erisc_info->launch_user_kernel == 1) {
             kernel_init();
+        } else if (routing_info->routing_mode == EthRouterMode::FD_SRC) {
+            eth_db_acquire(eth_db_semaphore_addr, eth_router_noc_encoding);
+            if (!routing_info->routing_enabled) {
+                break;
+            }
+            noc_semaphore_inc(
+                eth_router_noc_encoding | uint32_t(eth_db_semaphore_addr), -1);  // Two's complement addition
+            noc_async_write_barrier();
+
+            db_cb_config_t *eth_db_cb_config =
+                (db_cb_config_t
+                     *)(eth_l1_mem::address_map::CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
+            const db_cb_config_t *remote_db_cb_config =
+                (db_cb_config_t *)(CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
+            volatile tt_l1_ptr uint32_t *command_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t *>(command_start_addr);
+            uint32_t num_buffer_transfers = command_ptr[DeviceCommand::num_buffer_transfers_idx];
+            uint32_t producer_consumer_transfer_num_pages =
+                command_ptr[DeviceCommand::producer_consumer_transfer_num_pages_idx];
+            command_ptr += DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER;
+
+            for (uint32_t i = 0; i < num_buffer_transfers; i++) {
+                const uint32_t num_pages = command_ptr[2];
+                uint32_t num_writes_completed = 0;
+                while (num_writes_completed != num_pages) {
+                    uint32_t num_to_write = min(num_pages, producer_consumer_transfer_num_pages);
+                    multicore_eth_cb_wait_front(eth_db_cb_config, num_to_write);
+                    // contains device command, maybe just send pages, and send cmd once at the start
+                    internal_::send_fd_packets();
+                    multicore_eth_cb_pop_front(
+                        eth_db_cb_config, remote_db_cb_config, dispatch_core_noc_encoding, num_to_write);
+                    num_writes_completed += num_to_write;
+                }
+            }
+            noc_semaphore_inc(dispatch_core_noc_encoding | get_semaphore(0), 1);
+            noc_async_write_barrier();  // Barrier for now
+        } else if (routing_info->routing_mode == EthRouterMode::FD_DST) {
+            internal_::receive_fd_packets();
+            // TODO: add sync with remote processor
         } else {
-            risc_context_switch();
+            internal_::risc_context_switch();
         }
     }
-    disable_erisc_app();
+    internal_::disable_erisc_app();
     kernel_profiler::mark_time(CC_MAIN_END);
 }

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -200,7 +200,8 @@ void __attribute__((section("erisc_l1_code"))) ApplicationHandler(void) {
 
                 command_ptr += DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER; // jump to buffer transfer region
                 const uint32_t num_pages = command_ptr[2];
-                num_pages_to_tx = min(num_pages, producer_consumer_transfer_num_pages); // get num pages
+                // producer_consumer_transfer_num_pages is the total num of data pages that could fit in a FD packet
+                num_pages_to_tx = min(num_pages, producer_consumer_transfer_num_pages);
 
                 noc_async_write(src_addr, dst_noc_addr, page_size * num_pages_to_tx);
                 uint32_t l1_consumer_fifo_limit_16B =

--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -36,5 +36,5 @@ void __attribute__((section("erisc_l1_code"))) kernel_launch() {
     kernel_profiler::mark_time(CC_KERNEL_MAIN_START);
     kernel_main();
     kernel_profiler::mark_time(CC_KERNEL_MAIN_END);
-    erisc_info->num_bytes = 0;
+    erisc_info->launch_sd_kernel = 0;
 }

--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -36,5 +36,5 @@ void __attribute__((section("erisc_l1_code"))) kernel_launch() {
     kernel_profiler::mark_time(CC_KERNEL_MAIN_START);
     kernel_main();
     kernel_profiler::mark_time(CC_KERNEL_MAIN_END);
-    erisc_info->launch_sd_kernel = 0;
+    erisc_info->launch_user_kernel = 0;
 }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -16,13 +16,13 @@
 #include <stdint.h>
 
 #include "circular_buffer.h"
+#include "debug/sanitize_noc.h"
+#include "debug/status.h"
+#include "eth_l1_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "hostdevcommon/common_values.hpp"
 #include "risc_attribs.h"
 #include "third_party/umd/device/tt_silicon_driver_common.hpp"
-
-#include "debug/status.h"
-#include "debug/sanitize_noc.h"
 
 extern uint8_t noc_index;
 
@@ -1149,6 +1149,11 @@ FORCE_INLINE void noc_async_write_tile(
 FORCE_INLINE
 uint32_t get_semaphore(uint32_t semaphore_id) {
     return SEMAPHORE_BASE + semaphore_id * L1_ALIGNMENT;
+}
+
+FORCE_INLINE
+uint32_t eth_get_semaphore(uint32_t semaphore_id) {
+    return eth_l1_mem::address_map::SEMAPHORE_BASE + semaphore_id * sizeof(uint32_t);
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1153,7 +1153,7 @@ uint32_t get_semaphore(uint32_t semaphore_id) {
 
 FORCE_INLINE
 uint32_t eth_get_semaphore(uint32_t semaphore_id) {
-    return eth_l1_mem::address_map::SEMAPHORE_BASE + semaphore_id * sizeof(uint32_t);
+    return eth_l1_mem::address_map::SEMAPHORE_BASE + semaphore_id * L1_ALIGNMENT;
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -182,7 +182,7 @@ DebugPrinter operator <<(DebugPrinter dp, T val) {
         // buffer is full - wait for the host reader to flush+update rpos
         while (*dp.rpos() < *dp.wpos()) {
 #if defined(COMPILE_FOR_ERISC)
-            risc_context_switch();
+            internal_::risc_context_switch();
 #endif
             ; // wait for host to catch up to wpos with it's rpos
         }

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -112,9 +112,19 @@ static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, ncrisc_halt.stack_save) =
 static_assert(MEM_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_MAILBOX_END);
 #endif
 
+enum EthRouterMode : uint32_t {
+    FD_SRC = 0,
+    FD_DST = 1,
+    SD = 2,
+};
+
 struct routing_info_t {
     volatile uint32_t routing_enabled;
     volatile uint32_t routing_mode;
-    volatile uint32_t unused_arg0;
-    volatile uint32_t unused_arg1;
+    volatile uint32_t connected_chip_id;
+    volatile uint32_t dispatch_core_xy;
+    volatile uint32_t fd_buffer_msgs_sent;
+    uint32_t reserved_0_;
+    uint32_t reserved_1_;
+    uint32_t reserved_2_;
 };

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -111,3 +111,10 @@ static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, slave_sync.ncrisc) == MEM
 static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, ncrisc_halt.stack_save) == MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS);
 static_assert(MEM_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_MAILBOX_END);
 #endif
+
+struct routing_info_t {
+    volatile uint32_t routing_enabled;
+    volatile uint32_t routing_mode;
+    volatile uint32_t unused_arg0;
+    volatile uint32_t unused_arg1;
+};

--- a/tt_metal/hw/inc/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/ethernet/dataflow_api.h
@@ -85,13 +85,17 @@ void send_fd_packets() {
 }
 
 FORCE_INLINE
-void receive_fd_packets() {
+void wait_for_fd_packet() {
     // There may not be a valid cmd here, since DST router is always polling
     // This should only happen on cluster close
-    while (routing_info->fd_buffer_msgs_sent != 1 && routing_info->routing_enabled) {
+    while (routing_info->fd_buffer_msgs_sent != 1) {
         // TODO: add timer to restrict this
         risc_context_switch();
     }
+}
+
+FORCE_INLINE
+void ack_fd_packet() {
     routing_info->fd_buffer_msgs_sent = 0;
     eth_send_packet(
         0,

--- a/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
@@ -16,7 +16,9 @@ struct address_map {
   static constexpr std::int32_t FIRMWARE_BASE = 0;
   static constexpr std::int32_t ERISC_MEM_MAILBOX_BASE = 0;
 
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 0;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 0;
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = 0;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = 0;
   static constexpr std::int32_t ERISC_L1_ARG_BASE = 0;
 

--- a/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
@@ -26,6 +26,8 @@ struct address_map {
   static constexpr std::int32_t ERISC_APP_RESERVED_BASE = 0;
   static constexpr std::int32_t ERISC_APP_RESERVED_SIZE = 16;
   static constexpr std::int32_t ERISC_L1_UNRESERVED_BASE = 0;
+  static constexpr std::uint32_t SEMAPHORE_BASE = 0;
+  static constexpr std::uint32_t CQ_CONSUMER_CB_BASE = 0;
   static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = 0;
   static constexpr std::uint32_t FW_VERSION_ADDR = 0;
   static constexpr std::int32_t PRINT_BUFFER_ER = 0;

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -6,6 +6,8 @@
 
 #include <cstdint>
 
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
+
 namespace eth_l1_mem {
 
 
@@ -34,13 +36,17 @@ struct address_map {
   //    -  53 * 1024 eth app reserved buffer space
   //    - 106 * 1024 L1 unreserved buffer space
   static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
-  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 16;
-  static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 48;
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 32;
+  static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 32;
 
   static constexpr std::int32_t ERISC_BARRIER_BASE = TILE_HEADER_BUFFER_BASE;
   static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = ERISC_BARRIER_BASE + ERISC_BARRIER_SIZE;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = ERISC_APP_ROUTING_INFO_BASE + ERISC_APP_ROUTING_INFO_SIZE;
-  static constexpr std::int32_t ERISC_L1_ARG_BASE = ERISC_APP_SYNC_INFO_BASE + ERISC_APP_SYNC_INFO_SIZE;
+  static constexpr std::uint32_t SEMAPHORE_BASE = ERISC_APP_SYNC_INFO_BASE + ERISC_APP_SYNC_INFO_SIZE;
+
+  static constexpr uint32_t CQ_CONSUMER_CB_BASE = SEMAPHORE_BASE + SEMAPHORE_SIZE;  // SIZE from shared common addr
+
+  static constexpr std::int32_t ERISC_L1_ARG_BASE = CQ_CONSUMER_CB_BASE + 7 * L1_ALIGNMENT;
 
   static constexpr std::int32_t ERISC_APP_RESERVED_BASE = TILE_HEADER_BUFFER_BASE + 1024;
   static constexpr std::int32_t ERISC_APP_RESERVED_SIZE = 53 * 1024;

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -34,10 +34,12 @@ struct address_map {
   //    -  53 * 1024 eth app reserved buffer space
   //    - 106 * 1024 L1 unreserved buffer space
   static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
-  static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 64;
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 16;
+  static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 48;
 
   static constexpr std::int32_t ERISC_BARRIER_BASE = TILE_HEADER_BUFFER_BASE;
-  static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = ERISC_BARRIER_BASE + ERISC_BARRIER_SIZE;
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = ERISC_BARRIER_BASE + ERISC_BARRIER_SIZE;
+  static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = ERISC_APP_ROUTING_INFO_BASE + ERISC_APP_ROUTING_INFO_SIZE;
   static constexpr std::int32_t ERISC_L1_ARG_BASE = ERISC_APP_SYNC_INFO_BASE + ERISC_APP_SYNC_INFO_SIZE;
 
   static constexpr std::int32_t ERISC_APP_RESERVED_BASE = TILE_HEADER_BUFFER_BASE + 1024;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -257,7 +257,8 @@ void Device::clear_l1_state() {
     for (const auto &eth_core : this->get_active_ethernet_cores()) {
         CoreCoord physical_core = this->ethernet_core_from_logical_core(eth_core);
         std::vector<uint32_t> init_erisc_info_vec(
-            eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_SIZE / sizeof(uint32_t), 0);
+            (eth_l1_mem::address_map::MAX_L1_LOADING_SIZE - eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE) / sizeof(uint32_t),
+            0);
 
         llrt::write_hex_vec_to_core(
             this->id(), physical_core, init_erisc_info_vec, eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -169,7 +169,6 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
         int eriscv_id = build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 0;
         ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""));
         uint32_t kernel_size16 = llrt::get_binary_code_size16(binary_mem, eriscv_id);
-        llrt::write_hex_vec_to_core(this->id(), phys_core, {1}, eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE + 8);
         log_debug(LogDevice, "ERISC fw binary size: {} in bytes", kernel_size16 * 16);
         llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
         llrt::launch_erisc_app_fw_on_core(this->id(), phys_core);
@@ -223,7 +222,6 @@ void Device::initialize_and_launch_firmware() {
     }
 
     // Load erisc app base FW to eth cores
-    // TODO: we can optimize and split send/receive FD modes to two FWs
     for (const auto &eth_core : this->get_active_ethernet_cores()) {
         CoreCoord phys_eth_core = this->ethernet_core_from_logical_core(eth_core);
         this->initialize_firmware(phys_eth_core, &launch_msg);
@@ -407,8 +405,7 @@ std::vector<CoreCoord> Device::worker_cores_from_logical_cores(const std::vector
 }
 
 CoreCoord Device::ethernet_core_from_logical_core(const CoreCoord &logical_core) const {
-    const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
-    return soc_desc.get_physical_ethernet_core_from_logical(logical_core);
+    return tt::Cluster::instance().ethernet_core_from_logical_core(id_, logical_core);
 }
 
 std::vector<CoreCoord> Device::ethernet_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -169,8 +169,10 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
         int eriscv_id = build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 0;
         ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""));
         uint32_t kernel_size16 = llrt::get_binary_code_size16(binary_mem, eriscv_id);
+        llrt::write_hex_vec_to_core(this->id(), phys_core, {1}, eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE + 8);
         log_debug(LogDevice, "ERISC fw binary size: {} in bytes", kernel_size16 * 16);
         llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
+        llrt::launch_erisc_app_fw_on_core(this->id(), phys_core);
     } else {
         llrt::program_brisc_startup_addr(this->id(), phys_core);
         for (int riscv_id = 0; riscv_id < 5; riscv_id++) {

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -117,12 +117,6 @@ class Device {
         return tt::Cluster::instance().get_connected_ethernet_core(std::make_tuple(this->id_, eth_core));
     }
 
-    CoreCoord get_and_configure_corresponding_eth_core(
-        CoreCoord physical_dispatch_core, EthRouterMode mode, chip_id_t connected_chip_id) const {
-        return tt::Cluster::instance().get_and_configure_corresponding_eth_core_for_device(
-            this->id_, physical_dispatch_core, mode, connected_chip_id);
-    };
-
     bool is_mmio_capable() const {
         return tt::Cluster::instance().get_associated_mmio_device(this->id_) == this->id_;
     }

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -117,6 +117,12 @@ class Device {
         return tt::Cluster::instance().get_connected_ethernet_core(std::make_tuple(this->id_, eth_core));
     }
 
+    CoreCoord get_and_configure_corresponding_eth_core(
+        CoreCoord physical_dispatch_core, EthRouterMode mode, chip_id_t connected_chip_id) const {
+        return tt::Cluster::instance().get_and_configure_corresponding_eth_core_for_device(
+            this->id_, physical_dispatch_core, mode, connected_chip_id);
+    };
+
     bool is_mmio_capable() const {
         return tt::Cluster::instance().get_associated_mmio_device(this->id_) == this->id_;
     }

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -101,8 +101,8 @@ class Device {
 
     std::vector<CoreCoord> ethernet_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const;
 
-    std::unordered_set<chip_id_t> get_ethernet_connected_chip_ids() const {
-        return tt::Cluster::instance().get_ethernet_connected_chip_ids(this->id_);
+    std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> get_ethernet_cores_grouped_by_connected_chips() const {
+        return tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(this->id_);
     }
 
     std::unordered_set<CoreCoord> get_active_ethernet_cores() const {

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -388,7 +388,8 @@ const DeviceCommand EnqueueReadBufferCommand::assemble_device_command(uint32_t d
     DeviceCommand command = this->create_buffer_transfer_instruction(dst_address, padded_page_size, num_pages);
 
     // Targeting fast dispatch on remote device means commands have to be tunneled through ethernet
-    bool cmd_consumer_on_ethernet = not device->is_mmio_capable();
+    // Even when targeting fast dispatch on remote device, commands are tunneled through ethernet to consumer tensix cores
+    constexpr bool cmd_consumer_on_ethernet = false;
     uint32_t consumer_cb_num_pages = (get_consumer_data_buffer_size(cmd_consumer_on_ethernet) / padded_page_size);
 
     if (consumer_cb_num_pages >= 4) {
@@ -411,6 +412,27 @@ const DeviceCommand EnqueueReadBufferCommand::assemble_device_command(uint32_t d
     command.set_producer_cb_num_pages(producer_cb_num_pages);
     command.set_consumer_cb_num_pages(consumer_cb_num_pages);
     command.set_num_pages(num_pages);
+
+    // Targeting fast dispatch on remote device means commands have to be tunneled through ethernet
+    bool route_through_ethernet = not device->is_mmio_capable();
+    if (route_through_ethernet) {
+        uint32_t router_cb_num_pages = get_consumer_data_buffer_size(true) / padded_page_size;
+        // TODO: UPDATE THIS BY MEASURING PERF OF DIFFERENT VALUES
+        if (router_cb_num_pages >= 4) {
+            router_cb_num_pages = (router_cb_num_pages / 4) * 4;
+            command.set_producer_router_transfer_num_pages(router_cb_num_pages / 4);
+            command.set_consumer_router_transfer_num_pages(router_cb_num_pages / 4);
+        } else {
+            command.set_producer_router_transfer_num_pages(1);
+            command.set_consumer_router_transfer_num_pages(1);
+        }
+
+        uint32_t router_cb_size = router_cb_num_pages * padded_page_size;
+        TT_ASSERT(padded_page_size <= router_cb_size, "Page is too large to fit in router buffer");
+
+        command.set_router_cb_size(router_cb_size);
+        command.set_router_cb_num_pages(router_cb_num_pages);
+    }
 
     return command;
 }
@@ -515,10 +537,12 @@ const DeviceCommand EnqueueWriteBufferCommand::assemble_device_command(uint32_t 
         padded_page_size = align(this->buffer.page_size(), 32);
     }
 
-    // Targeting fast dispatch on remote device means commands have to be tunneled through ethernet
-    bool cmd_consumer_on_ethernet = not device->is_mmio_capable();
-    uint32_t consumer_cb_num_pages = (get_consumer_data_buffer_size(cmd_consumer_on_ethernet) / padded_page_size);
     DeviceCommand command = this->create_buffer_transfer_instruction(src_address, padded_page_size, num_pages);
+
+    // Targeting fast dispatch on remote device means commands have to be tunneled through ethernet
+    // Even when targeting fast dispatch on remote device, commands are tunneled through ethernet to consumer tensix cores
+    constexpr bool cmd_consumer_on_ethernet = false;
+    uint32_t consumer_cb_num_pages = (get_consumer_data_buffer_size(cmd_consumer_on_ethernet) / padded_page_size);
 
     if (consumer_cb_num_pages >= 4) {
         consumer_cb_num_pages = (consumer_cb_num_pages / 4) * 4;
@@ -539,6 +563,26 @@ const DeviceCommand EnqueueWriteBufferCommand::assemble_device_command(uint32_t 
     command.set_consumer_cb_num_pages(consumer_cb_num_pages);
     command.set_num_pages(num_pages);
 
+    // Targeting fast dispatch on remote device means commands have to be tunneled through ethernet
+    bool route_through_ethernet = not device->is_mmio_capable();
+    if (route_through_ethernet) {
+        uint32_t router_cb_num_pages = get_consumer_data_buffer_size(true) / padded_page_size;
+        // TODO: UPDATE THIS BY MEASURING PERF OF DIFFERENT VALUES
+        if (router_cb_num_pages >= 4) {
+            router_cb_num_pages = (router_cb_num_pages / 4) * 4;
+            command.set_producer_router_transfer_num_pages(router_cb_num_pages / 4);
+            command.set_consumer_router_transfer_num_pages(router_cb_num_pages / 4);
+        } else {
+            command.set_producer_router_transfer_num_pages(1);
+            command.set_consumer_router_transfer_num_pages(1);
+        }
+
+        uint32_t router_cb_size = router_cb_num_pages * padded_page_size;
+        TT_ASSERT(padded_page_size <= router_cb_size, "Page is too large to fit in router buffer");
+
+        command.set_router_cb_size(router_cb_size);
+        command.set_router_cb_num_pages(router_cb_num_pages);
+    }
 
     command.set_data_size(padded_page_size * num_pages);
     return command;
@@ -570,8 +614,6 @@ void EnqueueWriteBufferCommand::process() {
     }
 
     this->manager.issue_queue_push_back(cmd_size, LAZY_COMMAND_QUEUE_MODE, this->command_queue_id);
-
-    auto cmd_desc = cmd.get_desc();
 }
 
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -392,9 +392,9 @@ const DeviceCommand EnqueueReadBufferCommand::assemble_device_command(uint32_t d
     constexpr bool cmd_consumer_on_ethernet = false;
     uint32_t consumer_cb_num_pages = (get_consumer_data_buffer_size(cmd_consumer_on_ethernet) / padded_page_size);
 
-    if (consumer_cb_num_pages >= 4) {
-        consumer_cb_num_pages = (consumer_cb_num_pages / 4) * 4;
-        command.set_producer_consumer_transfer_num_pages(consumer_cb_num_pages / 4);
+    if (consumer_cb_num_pages >= DeviceCommand::SYNC_NUM_PAGES) {
+        consumer_cb_num_pages = (consumer_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES) * DeviceCommand::SYNC_NUM_PAGES;
+        command.set_producer_consumer_transfer_num_pages(consumer_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES);
     } else {
         command.set_producer_consumer_transfer_num_pages(1);
     }
@@ -417,11 +417,10 @@ const DeviceCommand EnqueueReadBufferCommand::assemble_device_command(uint32_t d
     bool route_through_ethernet = not device->is_mmio_capable();
     if (route_through_ethernet) {
         uint32_t router_cb_num_pages = get_consumer_data_buffer_size(true) / padded_page_size;
-        // TODO: UPDATE THIS BY MEASURING PERF OF DIFFERENT VALUES
-        if (router_cb_num_pages >= 4) {
-            router_cb_num_pages = (router_cb_num_pages / 4) * 4;
-            command.set_producer_router_transfer_num_pages(router_cb_num_pages / 4);
-            command.set_consumer_router_transfer_num_pages(router_cb_num_pages / 4);
+        if (router_cb_num_pages >= DeviceCommand::SYNC_NUM_PAGES) {
+            router_cb_num_pages = (router_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES) * DeviceCommand::SYNC_NUM_PAGES;
+            command.set_producer_router_transfer_num_pages(router_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES);
+            command.set_consumer_router_transfer_num_pages(router_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES);
         } else {
             command.set_producer_router_transfer_num_pages(1);
             command.set_consumer_router_transfer_num_pages(1);
@@ -544,9 +543,9 @@ const DeviceCommand EnqueueWriteBufferCommand::assemble_device_command(uint32_t 
     constexpr bool cmd_consumer_on_ethernet = false;
     uint32_t consumer_cb_num_pages = (get_consumer_data_buffer_size(cmd_consumer_on_ethernet) / padded_page_size);
 
-    if (consumer_cb_num_pages >= 4) {
-        consumer_cb_num_pages = (consumer_cb_num_pages / 4) * 4;
-        command.set_producer_consumer_transfer_num_pages(consumer_cb_num_pages / 4);
+    if (consumer_cb_num_pages >= DeviceCommand::SYNC_NUM_PAGES) {
+        consumer_cb_num_pages = (consumer_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES) * DeviceCommand::SYNC_NUM_PAGES;
+        command.set_producer_consumer_transfer_num_pages(consumer_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES);
     } else {
         command.set_producer_consumer_transfer_num_pages(1);
     }
@@ -567,11 +566,10 @@ const DeviceCommand EnqueueWriteBufferCommand::assemble_device_command(uint32_t 
     bool route_through_ethernet = not device->is_mmio_capable();
     if (route_through_ethernet) {
         uint32_t router_cb_num_pages = get_consumer_data_buffer_size(true) / padded_page_size;
-        // TODO: UPDATE THIS BY MEASURING PERF OF DIFFERENT VALUES
-        if (router_cb_num_pages >= 4) {
-            router_cb_num_pages = (router_cb_num_pages / 4) * 4;
-            command.set_producer_router_transfer_num_pages(router_cb_num_pages / 4);
-            command.set_consumer_router_transfer_num_pages(router_cb_num_pages / 4);
+        if (router_cb_num_pages >= DeviceCommand::SYNC_NUM_PAGES) {
+            router_cb_num_pages = (router_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES) * DeviceCommand::SYNC_NUM_PAGES;
+            command.set_producer_router_transfer_num_pages(router_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES);
+            command.set_consumer_router_transfer_num_pages(router_cb_num_pages / DeviceCommand::SYNC_NUM_PAGES);
         } else {
             command.set_producer_router_transfer_num_pages(1);
             command.set_consumer_router_transfer_num_pages(1);
@@ -740,7 +738,7 @@ const DeviceCommand EnqueueProgramCommand::assemble_device_command(uint32_t host
     }
 
     // This needs to be quite small, since programs are small
-    command.set_producer_consumer_transfer_num_pages(4);
+    command.set_producer_consumer_transfer_num_pages(DeviceCommand::SYNC_NUM_PAGES);
 
     return command;
 }

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -12,19 +12,19 @@ using namespace tt::tt_metal;
 
 // Starting L1 address of commands
 inline uint32_t get_command_start_l1_address(bool use_eth_l1) {
-    return (use_eth_l1 ? eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE : L1_UNRESERVED_BASE);
+    return (use_eth_l1 ? eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE : L1_UNRESERVED_BASE);
 }
 
 // Where issue queue interface core pulls in data (follows command)
 inline uint32_t get_data_section_l1_address(bool use_eth_l1) {
-    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE : L1_UNRESERVED_BASE;
+    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE : L1_UNRESERVED_BASE;
     return l1_base + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
 }
 
 // Space available in issue queue interface core pushing command data to consumer to dispatch or relay forward
 inline uint32_t get_producer_data_buffer_size(bool use_eth_l1) {
     uint32_t l1_size = use_eth_l1 ? MEM_ETH_SIZE : MEM_L1_SIZE;
-    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE : L1_UNRESERVED_BASE;
+    uint32_t l1_base = use_eth_l1 ? eth_l1_mem::address_map::ERISC_APP_RESERVED_BASE : L1_UNRESERVED_BASE;
     return (l1_size - (DeviceCommand::NUM_ENTRIES_IN_DEVICE_COMMAND * sizeof(uint32_t)) - l1_base);
 }
 

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -34,9 +34,13 @@ void DeviceCommand::set_producer_cb_size(const uint32_t cb_size) { this->desc[th
 
 void DeviceCommand::set_consumer_cb_size(const uint32_t cb_size) { this->desc[this->consumer_cb_size_idx] = cb_size; }
 
+void DeviceCommand::set_router_cb_size(const uint32_t cb_size) { this->desc[this->router_cb_size_idx] = cb_size; }
+
 void DeviceCommand::set_producer_cb_num_pages(const uint32_t cb_num_pages) { this->desc[this->producer_cb_num_pages_idx] = cb_num_pages; }
 
 void DeviceCommand::set_consumer_cb_num_pages(const uint32_t cb_num_pages) { this->desc[this->consumer_cb_num_pages_idx] = cb_num_pages; }
+
+void DeviceCommand::set_router_cb_num_pages(const uint32_t cb_num_pages) { this->desc[this->router_cb_num_pages_idx] = cb_num_pages; }
 
 void DeviceCommand::set_num_pages(uint32_t num_pages) { this->desc[this->num_pages_idx] = num_pages; }
 
@@ -67,6 +71,14 @@ uint32_t DeviceCommand::get_data_size() const { return this->desc[this->data_siz
 
 void DeviceCommand::set_producer_consumer_transfer_num_pages(const uint32_t producer_consumer_transfer_num_pages) {
     this->desc[this->producer_consumer_transfer_num_pages_idx] = producer_consumer_transfer_num_pages;
+}
+
+void DeviceCommand::set_producer_router_transfer_num_pages(const uint32_t producer_router_transfer_num_pages) {
+    this->desc[this->producer_router_transfer_num_pages_idx] = producer_router_transfer_num_pages;
+}
+
+void DeviceCommand::set_consumer_router_transfer_num_pages(const uint32_t consumer_router_transfer_num_pages) {
+    this->desc[this->consumer_router_transfer_num_pages_idx] = consumer_router_transfer_num_pages;
 }
 
 void DeviceCommand::update_buffer_transfer_src(const uint8_t buffer_transfer_idx, const uint32_t new_src) {

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <array>
 #include <vector>
 

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -26,6 +26,9 @@ class DeviceCommand {
     static constexpr uint32_t PROGRAM_PAGE_SIZE = 2048;
     static constexpr uint32_t NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION = COMMAND_PTR_SHARD_IDX + NUM_MAX_CORES*NUM_ENTRIES_PER_SHARD;
     static constexpr uint32_t NUM_POSSIBLE_BUFFER_TRANSFERS = 2;
+    // Perf measurements showed best results with divisions of 4 pages being transferred from producer -> consumer
+    // TODO (abhullar): Sync with agrebenisan to replicate measurments for producer -> router -> consumer path
+    static constexpr uint32_t SYNC_NUM_PAGES = 4;
 
     // Ensure any changes to this device command have asserts modified/extended
     static_assert(NUM_ENTRIES_IN_COMMAND_HEADER == 23);

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -20,7 +20,7 @@ class DeviceCommand {
     //TODO: investigate other num_cores
     static constexpr uint32_t MAX_HUGEPAGE_SIZE = 1 << 30; // 1GB;
     static constexpr uint32_t NUM_MAX_CORES = 108; //12 x 9
-    static constexpr uint32_t NUM_ENTRIES_IN_COMMAND_HEADER = 20;
+    static constexpr uint32_t NUM_ENTRIES_IN_COMMAND_HEADER = 23;
     static constexpr uint32_t NUM_ENTRIES_IN_DEVICE_COMMAND = 5632;
     static constexpr uint32_t NUM_BYTES_IN_DEVICE_COMMAND = NUM_ENTRIES_IN_DEVICE_COMMAND * sizeof(uint32_t);
     static constexpr uint32_t PROGRAM_PAGE_SIZE = 2048;
@@ -28,7 +28,7 @@ class DeviceCommand {
     static constexpr uint32_t NUM_POSSIBLE_BUFFER_TRANSFERS = 2;
 
     // Ensure any changes to this device command have asserts modified/extended
-    static_assert(NUM_ENTRIES_IN_COMMAND_HEADER == 20);
+    static_assert(NUM_ENTRIES_IN_COMMAND_HEADER == 23);
     static_assert((NUM_BYTES_IN_DEVICE_COMMAND % 32) == 0);
 
     // Command header
@@ -51,6 +51,10 @@ class DeviceCommand {
     static constexpr uint32_t data_size_idx = 16;
     static constexpr uint32_t producer_consumer_transfer_num_pages_idx = 17;
     static constexpr uint32_t sharded_buffer_num_cores_idx = 18;
+    static constexpr uint32_t router_cb_size_idx = 19;
+    static constexpr uint32_t router_cb_num_pages_idx = 20;
+    static constexpr uint32_t producer_router_transfer_num_pages_idx = 21;
+    static constexpr uint32_t consumer_router_transfer_num_pages_idx = 22;
 
     // Denotes which portion of the command queue needs to be wrapped
     enum class WrapRegion : uint8_t {
@@ -75,9 +79,13 @@ class DeviceCommand {
 
     void set_consumer_cb_size(const uint32_t cb_size);
 
+    void set_router_cb_size(const uint32_t cb_size);
+
     void set_producer_cb_num_pages(const uint32_t cb_num_pages);
 
     void set_consumer_cb_num_pages(const uint32_t cb_num_pages);
+
+    void set_router_cb_num_pages(const uint32_t cb_num_pages);
 
     void set_num_pages(const uint32_t num_pages);
 
@@ -89,10 +97,14 @@ class DeviceCommand {
 
     void set_producer_consumer_transfer_num_pages(const uint32_t producer_consumer_transfer_num_pages);
 
+    void set_producer_router_transfer_num_pages(const uint32_t producer_router_transfer_num_pages);
+
+    void set_consumer_router_transfer_num_pages(const uint32_t consumer_router_transfer_num_pages);
+
     uint32_t get_data_size() const;
 
     void update_buffer_transfer_src(const uint8_t buffer_transfer_idx, const uint32_t new_src);
-    
+
     void add_buffer_transfer_interleaved_instruction(
         const uint32_t src,
         const uint32_t dst,

--- a/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
@@ -17,49 +17,6 @@ struct db_cb_config_t {
 };
 static constexpr uint32_t l1_db_cb_addr_offset = sizeof(db_cb_config_t);
 
-// TODO: refactor consumer kernels and remove the following functions
-FORCE_INLINE
-uint32_t get_db_cb_l1_base(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_ack_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_recv_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 16);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_num_pages_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 32);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_page_size_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 48);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_total_size_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 64);
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_rd_ptr_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + 80);
-
-}
-
-FORCE_INLINE
-uint32_t get_db_cb_wr_ptr_addr(bool db_buf_switch) {
-    return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset + CQ_START);
-}
-
-
 template <uint32_t cmd_base_address, uint32_t consumer_data_buffer_size>
 FORCE_INLINE uint32_t get_command_slot_addr(bool db_buf_switch) {
     static constexpr uint32_t command0_start = cmd_base_address;

--- a/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
@@ -5,8 +5,19 @@
 #include "dataflow_api.h"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 
-static constexpr uint32_t l1_db_cb_addr_offset = 7 * 16;
+#define ATTR_ALIGNL1 __attribute__((aligned(L1_ALIGNMENT)))
+struct db_cb_config_t {
+    volatile uint32_t ack ATTR_ALIGNL1;
+    volatile uint32_t recv ATTR_ALIGNL1;
+    volatile uint32_t num_pages ATTR_ALIGNL1;
+    volatile uint32_t page_size ATTR_ALIGNL1;   // 16B
+    volatile uint32_t total_size ATTR_ALIGNL1;  // 16B
+    volatile uint32_t rd_ptr ATTR_ALIGNL1;      // 16B
+    volatile uint32_t wr_ptr ATTR_ALIGNL1;      // 16B
+};
+static constexpr uint32_t l1_db_cb_addr_offset = sizeof(db_cb_config_t);
 
+// TODO: refactor consumer kernels and remove the following functions
 FORCE_INLINE
 uint32_t get_db_cb_l1_base(bool db_buf_switch) {
     return CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset);
@@ -53,7 +64,7 @@ template <uint32_t cmd_base_address, uint32_t consumer_data_buffer_size>
 FORCE_INLINE uint32_t get_command_slot_addr(bool db_buf_switch) {
     static constexpr uint32_t command0_start = cmd_base_address;
     static constexpr uint32_t command1_start = command0_start + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + consumer_data_buffer_size;
-    return (db_buf_switch) ? command0_start : command1_start;
+    return (not db_buf_switch) ? command0_start : command1_start;
 }
 
 template <uint32_t cmd_base_address, uint32_t consumer_data_buffer_size>

--- a/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "dataflow_api.h"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 
@@ -17,24 +19,70 @@ struct db_cb_config_t {
 };
 static constexpr uint32_t l1_db_cb_addr_offset = sizeof(db_cb_config_t);
 
-template <uint32_t cmd_base_address, uint32_t consumer_data_buffer_size>
+template <uint32_t cmd_base_address, uint32_t data_buffer_size>
 FORCE_INLINE uint32_t get_command_slot_addr(bool db_buf_switch) {
     static constexpr uint32_t command0_start = cmd_base_address;
-    static constexpr uint32_t command1_start = command0_start + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + consumer_data_buffer_size;
+    static constexpr uint32_t command1_start = command0_start + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + data_buffer_size;
     return (not db_buf_switch) ? command0_start : command1_start;
 }
 
-template <uint32_t cmd_base_address, uint32_t consumer_data_buffer_size>
+template <uint32_t cmd_base_address, uint32_t data_buffer_size>
 FORCE_INLINE uint32_t get_db_buf_addr(bool db_buf_switch) {
     static constexpr uint32_t buf0_start = cmd_base_address + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
-    static constexpr uint32_t buf1_start = buf0_start + consumer_data_buffer_size + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
+    static constexpr uint32_t buf1_start = buf0_start + data_buffer_size + DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
     return (not db_buf_switch) ? buf0_start : buf1_start;
 }
-
 
 FORCE_INLINE
 void db_acquire(volatile uint32_t* semaphore, uint64_t noc_encoding) {
     while (semaphore[0] == 0);
     noc_semaphore_inc(noc_encoding | uint32_t(semaphore), -1); // Two's complement addition
     noc_async_write_barrier();
+}
+
+FORCE_INLINE
+void multicore_cb_push_back(
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_db_cb_config,
+    uint64_t consumer_noc_encoding,
+    uint32_t consumer_fifo_16b_limit,
+    uint32_t num_to_write) {
+    db_cb_config->recv += num_to_write;
+    db_cb_config->wr_ptr += db_cb_config->page_size * num_to_write;
+
+    if (db_cb_config->wr_ptr >= consumer_fifo_16b_limit) {
+        db_cb_config->wr_ptr -= db_cb_config->total_size;
+    }
+
+    uint32_t remote_pages_recv_addr = (uint32_t)(&(remote_db_cb_config->recv));
+    noc_semaphore_set_remote((uint32_t)(&(db_cb_config->recv)), consumer_noc_encoding | remote_pages_recv_addr);
+}
+
+FORCE_INLINE
+void multicore_cb_wait_front(db_cb_config_t* db_cb_config, int32_t num_pages) {
+    DEBUG_STATUS('C', 'R', 'B', 'W');
+
+    uint16_t pages_received;
+    do {
+        pages_received = uint16_t(db_cb_config->recv - db_cb_config->ack);
+    } while (pages_received < num_pages);
+    DEBUG_STATUS('C', 'R', 'B', 'D');
+}
+
+void multicore_cb_pop_front(
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_db_cb_config,
+    uint64_t producer_noc_encoding,
+    uint32_t consumer_fifo_limit,
+    uint32_t num_to_write,
+    uint32_t page_size) {
+    db_cb_config->ack += num_to_write;
+    db_cb_config->rd_ptr += page_size * num_to_write;
+
+    if ((db_cb_config->rd_ptr << 4) > consumer_fifo_limit) {
+        db_cb_config->rd_ptr -= db_cb_config->total_size;
+    }
+
+    uint32_t pages_ack_addr = (uint32_t)(&(remote_db_cb_config->ack));
+    noc_semaphore_set_remote((uint32_t)(&(db_cb_config->ack)), producer_noc_encoding | pages_ack_addr);
 }

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
@@ -52,16 +52,34 @@ void kernel_main() {
         uint32_t sharded_buffer_num_cores = command_ptr[DeviceCommand::sharded_buffer_num_cores_idx];
         uint32_t wrap = command_ptr[DeviceCommand::wrap_idx];
 
+        db_cb_config_t *db_cb_config = (db_cb_config_t *)(CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
+        const db_cb_config_t *remote_db_cb_config =
+            (db_cb_config_t *)(CQ_CONSUMER_CB_BASE + (db_buf_switch * l1_db_cb_addr_offset));
         if ((DeviceCommand::WrapRegion)wrap == DeviceCommand::WrapRegion::COMPLETION) {
             cq_write_interface.completion_fifo_wr_ptr = completion_queue_start_addr >> 4;     // Head to the beginning of the completion region
             cq_write_interface.completion_fifo_wr_toggle = not cq_write_interface.completion_fifo_wr_toggle;
             notify_host_of_completion_queue_write_pointer<host_completion_queue_write_ptr_addr>();
         } else if (is_program) {
-            write_and_launch_program(program_transfer_start_addr, num_pages, command_ptr, producer_noc_encoding, consumer_cb_size, consumer_cb_num_pages, producer_consumer_transfer_num_pages, db_buf_switch);
+            write_and_launch_program(
+                db_cb_config,
+                remote_db_cb_config,
+                program_transfer_start_addr,
+                num_pages,
+                command_ptr,
+                producer_noc_encoding,
+                producer_consumer_transfer_num_pages);
             wait_for_program_completion(num_workers);
         } else {
             command_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(buffer_transfer_start_addr);
-            write_buffers<host_completion_queue_write_ptr_addr>(command_ptr, completion_queue_start_addr, num_buffer_transfers,  sharded_buffer_num_cores, consumer_cb_size, consumer_cb_num_pages, producer_noc_encoding, producer_consumer_transfer_num_pages, db_buf_switch);
+            write_buffers<host_completion_queue_write_ptr_addr>(
+                db_cb_config,
+                remote_db_cb_config,
+                command_ptr,
+                completion_queue_start_addr,
+                num_buffer_transfers,
+                sharded_buffer_num_cores,
+                producer_noc_encoding,
+                producer_consumer_transfer_num_pages);
         }
 
         if (finish) {

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
@@ -35,35 +35,6 @@ void noc_async_write_multicast_one_packet_no_path_reserve(
 }
 
 FORCE_INLINE
-void multicore_cb_wait_front(db_cb_config_t* db_cb_config, int32_t num_pages) {
-    DEBUG_STATUS('C', 'R', 'B', 'W');
-
-    uint16_t pages_received;
-    do {
-        pages_received = uint16_t(db_cb_config->recv - db_cb_config->ack);
-    } while (pages_received < num_pages);
-    DEBUG_STATUS('C', 'R', 'B', 'D');
-}
-
-void multicore_cb_pop_front(
-    db_cb_config_t* db_cb_config,
-    const db_cb_config_t* remote_db_cb_config,
-    uint64_t producer_noc_encoding,
-    uint32_t consumer_fifo_limit,
-    uint32_t num_to_write,
-    uint32_t page_size) {
-    db_cb_config->ack += num_to_write;
-    db_cb_config->rd_ptr += page_size * num_to_write;
-
-    if ((db_cb_config->rd_ptr << 4) > consumer_fifo_limit) {
-        db_cb_config->rd_ptr -= db_cb_config->total_size;
-    }
-
-    uint32_t pages_ack_addr = (uint32_t)(&(remote_db_cb_config->ack));
-    noc_semaphore_set_remote((uint32_t)(&(db_cb_config->ack)), producer_noc_encoding | pages_ack_addr);
-}
-
-FORCE_INLINE
 uint32_t get_read_ptr(db_cb_config_t* db_cb_config) { return (db_cb_config->rd_ptr) << 4; }
 
 inline __attribute__((always_inline)) volatile uint32_t* get_cq_completion_write_ptr() {

--- a/tt_metal/impl/dispatch/kernels/command_queue_producer.cpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_producer.cpp
@@ -9,8 +9,9 @@ void kernel_main() {
     constexpr uint32_t issue_queue_start_addr = get_compile_time_arg_val(1);
     constexpr uint32_t command_start_addr = get_compile_time_arg_val(2);
     constexpr uint32_t data_section_addr = get_compile_time_arg_val(3);
-    constexpr uint32_t consumer_cmd_base_addr = get_compile_time_arg_val(4);
-    constexpr uint32_t consumer_data_buffer_size = get_compile_time_arg_val(5);
+    constexpr uint32_t data_buffer_size = get_compile_time_arg_val(4);
+    constexpr uint32_t consumer_cmd_base_addr = get_compile_time_arg_val(5);
+    constexpr uint32_t consumer_data_buffer_size = get_compile_time_arg_val(6);
 
     // Only the issue queue size is a runtime argument
     uint32_t issue_queue_size = get_arg_val<uint32_t>(0);
@@ -68,7 +69,7 @@ void kernel_main() {
         program_local_cb(data_section_addr, producer_cb_num_pages, page_size, producer_cb_size);
         while (db_semaphore_addr[0] == 0)
             ;  // Check that there is space in the consumer
-        program_consumer_cb<consumer_cmd_base_addr, consumer_data_buffer_size>(
+        program_consumer_cb<command_start_addr, data_buffer_size, consumer_cmd_base_addr, consumer_data_buffer_size>(
             db_cb_config,
             remote_db_cb_config,
             db_buf_switch,
@@ -76,7 +77,7 @@ void kernel_main() {
             consumer_cb_num_pages,
             page_size,
             consumer_cb_size);
-        relay_command<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, consumer_noc_encoding);
+        relay_command<command_start_addr, consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch, consumer_noc_encoding);
         if (stall) {
             while (*db_semaphore_addr != 2)
                 ;

--- a/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_producer.hpp
@@ -84,7 +84,7 @@ void program_local_cb(uint32_t data_section_addr, uint32_t num_pages, uint32_t p
     cb_interface[cb_id].fifo_page_size = page_size >> 4;
 }
 
-template <uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
+template <uint32_t producer_cmd_base_addr, uint32_t producer_data_buffer_size, uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
 FORCE_INLINE
 void program_consumer_cb(
     db_cb_config_t* db_cb_config,
@@ -98,15 +98,16 @@ void program_consumer_cb(
         This API programs the double-buffered CB space of the consumer. This API should be called
         before notifying the consumer that data is available.
     */
-    uint32_t cb_start_addr = get_db_buf_addr<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch);
+    uint32_t cb_start_rd_addr = get_db_buf_addr<producer_cmd_base_addr, producer_data_buffer_size>(db_buf_switch);
+    uint32_t cb_start_wr_addr = get_db_buf_addr<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch);
 
     db_cb_config->ack = 0;
     db_cb_config->recv = 0;
     db_cb_config->num_pages = num_pages;
     db_cb_config->page_size = page_size >> 4;
     db_cb_config->total_size = cb_size >> 4;
-    db_cb_config->rd_ptr = cb_start_addr >> 4;
-    db_cb_config->wr_ptr = cb_start_addr >> 4;
+    db_cb_config->rd_ptr = cb_start_rd_addr >> 4;
+    db_cb_config->wr_ptr = cb_start_wr_addr >> 4;
 
     noc_async_write(
         (uint32_t)(db_cb_config), consumer_noc_encoding | (uint32_t)(remote_db_cb_config), sizeof(db_cb_config_t));
@@ -150,33 +151,14 @@ bool cb_consumer_space_available(db_cb_config_t* db_cb_config, int32_t num_pages
     return free_space_pages >= num_pages;
 }
 
-
-FORCE_INLINE
-void multicore_cb_push_back(
-    db_cb_config_t* db_cb_config,
-    const db_cb_config_t* remote_db_cb_config,
-    uint64_t consumer_noc_encoding,
-    uint32_t consumer_fifo_16b_limit,
-    uint32_t num_to_write) {
-    db_cb_config->recv += num_to_write;
-    db_cb_config->wr_ptr += db_cb_config->page_size * num_to_write;
-
-    if (db_cb_config->wr_ptr >= consumer_fifo_16b_limit) {
-        db_cb_config->wr_ptr -= db_cb_config->total_size;
-    }
-
-    uint32_t remote_pages_recv_addr = (uint32_t)(&(remote_db_cb_config->recv));
-    noc_semaphore_set_remote((uint32_t)(&(db_cb_config->recv)), consumer_noc_encoding | remote_pages_recv_addr);
-}
-
-template <uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
+template <uint32_t cmd_base_addr, uint32_t consumer_cmd_base_addr, uint32_t consumer_data_buffer_size>
 FORCE_INLINE void relay_command(bool db_buf_switch, uint64_t consumer_noc_encoding) {
     /*
         Relays the current command to the consumer.
     */
 
     uint64_t consumer_command_slot_addr = consumer_noc_encoding | get_command_slot_addr<consumer_cmd_base_addr, consumer_data_buffer_size>(db_buf_switch);
-    noc_async_write(L1_UNRESERVED_BASE, consumer_command_slot_addr, DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND);
+    noc_async_write(cmd_base_addr, consumer_command_slot_addr, DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND);
     noc_async_write_barrier();
 }
 
@@ -355,6 +337,73 @@ void produce_for_eth_src_router(
                 num_writes_completed += num_to_write;
                 num_to_write = min(num_pages - num_writes_completed, producer_consumer_transfer_num_pages);
             }
+        }
+        command_ptr += DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION;
+    }
+}
+
+void transfer(
+    db_cb_config_t* db_cb_config,
+    const db_cb_config_t* remote_producer_db_cb_config,
+    const db_cb_config_t* remote_consumer_db_cb_config,
+    volatile tt_l1_ptr uint32_t* command_ptr,
+    uint32_t num_srcs,
+    uint32_t page_size,
+    uint32_t producer_cb_size,
+    uint32_t l1_producer_fifo_limit,
+    uint64_t producer_noc_encoding,
+    uint32_t consumer_cb_size,
+    uint32_t l1_consumer_fifo_limit,
+    uint64_t consumer_noc_encoding,
+    uint32_t producer_consumer_transfer_num_pages) {
+    /*
+        This API sends data from circular buffer in its L1 and writes data to the consumer core. On the consumer,
+        we partition the data space into 2 via double-buffering. There are two command slots, and two
+        data slots. Callees to transfer receive data into their local buffer and then check whether they can write to
+        the consumer. It continues like this in a loop, context switching between waiting to receive data and
+        writing to the consumer.
+    */
+
+    command_ptr += DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER;
+
+    for (uint32_t i = 0; i < num_srcs; i++) {
+        const uint32_t num_pages = command_ptr[2];
+        const uint32_t page_size = command_ptr[3];
+
+        uint32_t num_to_transfer = min(num_pages, producer_consumer_transfer_num_pages); // This must be a bigger number for perf.
+        uint32_t num_transfers_completed = 0;
+
+        // DPRINT << "TX: num pages: " << num_pages
+        //        << " page size: " << page_size
+        //        << " num to tx: " << num_to_transfer << ENDL();
+
+        while (num_transfers_completed != num_pages) {
+            // Wait for data to be received in local CB
+            multicore_cb_wait_front(db_cb_config, num_to_transfer);
+            uint32_t src_addr = (db_cb_config->rd_ptr) << 4;
+            // Transfer data to consumer CB
+            uint32_t dst_addr = (db_cb_config->wr_ptr << 4);
+            uint64_t dst_noc_addr = consumer_noc_encoding | dst_addr;
+            noc_async_write(src_addr, dst_noc_addr, page_size * num_to_transfer);
+            multicore_cb_push_back(
+                db_cb_config,
+                remote_consumer_db_cb_config,
+                consumer_noc_encoding,
+                l1_consumer_fifo_limit,
+                num_to_transfer);
+            noc_async_write_barrier();
+            // DPRINT << "TX: got the data and pushed to dispatcher" << ENDL();
+            // Signal to core that transferred the data to local CB that it can send next chunk
+            multicore_cb_pop_front(
+                db_cb_config,
+                remote_producer_db_cb_config,
+                producer_noc_encoding,
+                l1_producer_fifo_limit,
+                num_to_transfer,
+                db_cb_config->page_size);
+            // DPRINT << "TX: signal to debug that it tx data to dispatcher" << ENDL();
+            num_transfers_completed += num_to_transfer;
+            num_to_transfer = min(num_pages - num_transfers_completed, producer_consumer_transfer_num_pages);
         }
         command_ptr += DeviceCommand::NUM_ENTRIES_PER_BUFFER_TRANSFER_INSTRUCTION;
     }

--- a/tt_metal/impl/dispatch/kernels/remote_command_processor.cpp
+++ b/tt_metal/impl/dispatch/kernels/remote_command_processor.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/dispatch/kernels/command_queue_producer.hpp"
+
+// Receives fast dispatch packets from ethernet router and forwards them to dispatcher kernel
+void kernel_main() {
+    constexpr uint32_t cmd_base_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t data_section_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t data_buffer_size = get_compile_time_arg_val(2);
+    constexpr uint32_t producer_cmd_base_addr = get_compile_time_arg_val(3);
+    constexpr uint32_t producer_data_buffer_size = get_compile_time_arg_val(4);
+    constexpr uint32_t dispatcher_cmd_base_addr = get_compile_time_arg_val(5);
+    constexpr uint32_t dispatcher_data_buffer_size = get_compile_time_arg_val(6);
+
+    // Initialize the producer/consumer DB semaphore
+    // This represents how many buffers the producer can write to.
+    uint64_t producer_noc_encoding = uint64_t(NOC_XY_ENCODING(PRODUCER_NOC_X, PRODUCER_NOC_Y)) << 32;
+    uint64_t processor_noc_encoding = uint64_t(NOC_XY_ENCODING(my_x[0], my_y[0])) << 32;
+    uint64_t dispatcher_noc_encoding = uint64_t(NOC_XY_ENCODING(DISPATCHER_NOC_X, DISPATCHER_NOC_Y)) << 32;
+
+    volatile tt_l1_ptr uint32_t* rx_semaphore_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(0));  // Should be initialized to 1 by host
+    volatile tt_l1_ptr uint32_t* db_tx_semaphore_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(1));  // Should be num command slots by in the dispatcher
+
+    constexpr bool rx_buf_switch = false;   // atm only one slot to receive commands from ethernet
+    bool db_tx_buf_switch = false;
+    while (true) {
+        // Wait for ethernet router to supply a command
+        db_acquire(rx_semaphore_addr, processor_noc_encoding);
+
+        // For each instruction, we need to jump to the relevant part of the device command
+        uint32_t command_start_addr = get_command_slot_addr<cmd_base_addr, data_buffer_size>(rx_buf_switch);
+        volatile tt_l1_ptr uint32_t* command_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(command_start_addr);
+
+        uint32_t num_buffer_transfers = command_ptr[DeviceCommand::num_buffer_transfers_idx];
+        uint32_t stall = command_ptr[DeviceCommand::stall_idx];
+        uint32_t page_size = command_ptr[DeviceCommand::page_size_idx];
+        uint32_t producer_cb_size = command_ptr[DeviceCommand::producer_cb_size_idx];
+        uint32_t consumer_cb_size = command_ptr[DeviceCommand::consumer_cb_size_idx];
+        uint32_t producer_cb_num_pages = command_ptr[DeviceCommand::producer_cb_num_pages_idx];
+        uint32_t consumer_cb_num_pages = command_ptr[DeviceCommand::consumer_cb_num_pages_idx];
+        uint32_t num_pages = command_ptr[DeviceCommand::num_pages_idx];
+        uint32_t producer_consumer_transfer_num_pages = command_ptr[DeviceCommand::producer_consumer_transfer_num_pages_idx];
+
+        while (db_tx_semaphore_addr[0] == 0)
+            ;  // Check that there is space in the dispatcher
+
+        db_cb_config_t *db_cb_config = (db_cb_config_t *)(CQ_CONSUMER_CB_BASE + (rx_buf_switch * l1_db_cb_addr_offset));
+        db_cb_config_t *eth_db_cb_config =
+            (db_cb_config_t *)(eth_l1_mem::address_map::CQ_CONSUMER_CB_BASE + (rx_buf_switch * l1_db_cb_addr_offset));
+        db_cb_config_t *dispatcher_db_cb_config = (db_cb_config_t *)(CQ_CONSUMER_CB_BASE + (db_tx_buf_switch * l1_db_cb_addr_offset));
+
+        uint32_t consumer_cb_num_pages = command_ptr[DeviceCommand::consumer_cb_num_pages_idx];
+        uint32_t page_size = command_ptr[DeviceCommand::page_size_idx];
+        uint32_t consumer_cb_size = command_ptr[DeviceCommand::consumer_cb_size_idx];
+        program_consumer_cb<cmd_base_addr, data_buffer_size, dispatcher_cmd_base_addr, dispatcher_data_buffer_size>(
+            db_cb_config,
+            dispatcher_db_cb_config,
+            db_tx_buf_switch,
+            dispatcher_noc_encoding,
+            consumer_cb_num_pages,
+            page_size,
+            consumer_cb_size);
+
+        relay_command<cmd_base_addr, dispatcher_cmd_base_addr, dispatcher_data_buffer_size>(db_tx_buf_switch, dispatcher_noc_encoding);
+        if (stall) {
+            while (*db_tx_semaphore_addr != 2)
+                ;
+        }
+
+        // Decrement the semaphore value
+        noc_semaphore_inc(producer_noc_encoding | uint32_t(db_tx_semaphore_addr), -1);  // Two's complement addition
+        noc_async_write_barrier();
+
+        // Notify the consumer
+        noc_semaphore_inc(dispatcher_noc_encoding | get_semaphore(0), 1);
+        noc_async_write_barrier();  // Barrier for now
+
+        transfer(
+            db_cb_config,
+            eth_db_cb_config,
+            dispatcher_db_cb_config,
+            command_ptr,
+            num_buffer_transfers,
+            page_size,
+            producer_cb_size,
+            (get_db_buf_addr<producer_cmd_base_addr, producer_data_buffer_size>(rx_buf_switch) + producer_cb_size) >> 4,
+            producer_noc_encoding,
+            consumer_cb_size,
+            (get_db_buf_addr<dispatcher_cmd_base_addr, dispatcher_data_buffer_size>(db_tx_buf_switch) + consumer_cb_size) >> 4,
+            dispatcher_noc_encoding,
+            producer_consumer_transfer_num_pages);
+
+        // Notify producer ethernet router that it has completed transferring a command
+        noc_semaphore_inc(producer_noc_encoding | get_semaphore(0), 1);
+        noc_async_write_barrier(); // Barrier for now
+
+        db_tx_buf_switch = not db_tx_buf_switch;
+    }
+}

--- a/tt_metal/impl/dispatch/kernels/remote_issue_queue_reader.cpp
+++ b/tt_metal/impl/dispatch/kernels/remote_issue_queue_reader.cpp
@@ -71,7 +71,7 @@ void kernel_main() {
         program_local_cb(data_section_addr, producer_cb_num_pages, page_size, producer_cb_size);
         while (db_semaphore_addr[0] == 0)
             ;  // Check that there is space in the consumer
-        program_consumer_cb_2(
+        program_consumer_cb<consumer_cmd_base_addr, consumer_data_buffer_size>(
             db_cb_config,
             eth_db_cb_config,
             db_buf_switch,
@@ -79,7 +79,8 @@ void kernel_main() {
             consumer_cb_num_pages,
             page_size,
             consumer_cb_size);
-        relay_command(db_buf_switch, ((uint64_t)eth_consumer_noc_encoding << 32));
+        relay_command<consumer_cmd_base_addr, consumer_data_buffer_size>(
+            db_buf_switch, ((uint64_t)eth_consumer_noc_encoding << 32));
         // Decrement the semaphore value
         noc_semaphore_inc(((uint64_t)producer_noc_encoding << 32) | uint32_t(db_semaphore_addr), -1);  // Two's complement addition
         noc_async_write_barrier();
@@ -89,7 +90,7 @@ void kernel_main() {
         noc_async_write_barrier();  // Barrier for now
 
         // Fetch data and send to the consumer
-        produce_for_eth_src_router(
+        produce_for_eth_src_router<consumer_cmd_base_addr, consumer_data_buffer_size>(
             command_ptr,
             num_buffer_transfers,
             sharded_buffer_num_cores,

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -145,8 +145,7 @@ void write_launch_msg_to_core(chip_id_t chip, CoreCoord core, launch_msg_t *msg)
     msg->mode = DISPATCH_MODE_HOST;
     TT_ASSERT(sizeof(launch_msg_t) % sizeof(uint32_t) == 0);
     if (static_cast<bool>(msg->enable_erisc)) {
-        llrt::write_hex_vec_to_core(chip, core, {123}, eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE);
-        launch_erisc_app_fw_on_core(chip, core);
+        llrt::write_hex_vec_to_core(chip, core, {0x1}, eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE);
     } else {
         tt::Cluster::instance().write_core(
             (void *)msg, sizeof(launch_msg_t), tt_cxy_pair(chip, core), GET_MAILBOX_ADDRESS_HOST(launch));
@@ -287,7 +286,7 @@ namespace internal_ {
 static bool check_if_riscs_on_specified_core_done(chip_id_t chip_id, const CoreCoord &core, int run_state) {
     if (is_ethernet_core(core, chip_id)) {
         const auto &readback_vec =
-            read_hex_vec_from_core(chip_id, core, eth_l1_mem::address_map::LAUNCH_ERISC_APP_FLAG, sizeof(uint32_t));
+            read_hex_vec_from_core(chip_id, core, eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE, sizeof(uint32_t));
         return (readback_vec[0] == 0);
     } else {
         std::function<bool(uint64_t)> get_mailbox_is_done = [&](uint64_t run_mailbox_address) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -47,6 +47,8 @@ Cluster::Cluster() {
     this->initialize_device_drivers();
 
     this->assert_risc_reset();
+
+    this->set_routing_config_for_ethernet_cores();
 }
 
 void Cluster::detect_arch_and_target() {
@@ -316,6 +318,22 @@ void Cluster::start_driver(chip_id_t mmio_device_id, tt_device_params &device_pa
 
 Cluster::~Cluster() {
     log_info(tt::LogDevice, "Closing user mode device drivers");
+    // Disable internal ethernet routing
+    for (const auto &[assoc_mmio_device, devices] : this->devices_grouped_by_assoc_mmio_device_) {
+        const routing_info_t routing_info_disabled = {
+            .routing_enabled = 0, .routing_mode = 0, .fd_buffer_msgs_sent = 0};
+        for (const auto &chip_id : devices) {
+            for (const auto &eth_core : this->get_active_ethernet_cores(chip_id)) {
+                tt_cxy_pair this_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+                write_core(
+                    (void *)&routing_info_disabled,
+                    sizeof(routing_info_t),
+                    this_phys_core,
+                    eth_l1_mem::address_map::ERISC_APP_ROUTING_INFO_BASE,
+                    false);
+            }
+        }
+    }
 
     for (const auto &[mmio_device_id, device_driver] : this->mmio_device_id_to_driver_) {
         device_driver->close_device();
@@ -562,27 +580,36 @@ uint64_t Cluster::get_pcie_base_addr_from_device(chip_id_t chip_id) const {
 }
 
 // Ethernet cluster api
-std::unordered_set<chip_id_t> Cluster::get_ethernet_connected_chip_ids(chip_id_t chip_id) const {
-    std::unordered_set<chip_id_t> connected_chips;
+std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> Cluster::get_ethernet_cores_grouped_by_connected_chips(chip_id_t chip_id) const {
+    const auto &soc_desc = get_soc_desc(chip_id);
+    std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> connected_chips;
     const auto &all_eth_connections = this->cluster_desc_->get_ethernet_connections();
     if (all_eth_connections.find(chip_id) == all_eth_connections.end()) {
         return {};
     }
     for (const auto &[eth_chan, connected_chip_chan] : all_eth_connections.at(chip_id)) {
-        connected_chips.insert(std::get<0>(connected_chip_chan));
+        const auto &other_chip_id = std::get<0>(connected_chip_chan);
+        if (connected_chips.find(other_chip_id) == connected_chips.end()) {
+          std::unordered_set<CoreCoord> active_ethernet_cores;
+
+          for (const auto &channel_pair :
+               this->cluster_desc_->get_directly_connected_ethernet_channels_between_chips(chip_id, other_chip_id)) {
+              ethernet_channel_t local_chip_chan = std::get<0>(channel_pair);
+              active_ethernet_cores.insert(get_soc_desc(chip_id).chan_to_logical_eth_core_map.at(local_chip_chan));
+          }
+          connected_chips.insert({other_chip_id, active_ethernet_cores});
+        } else {
+            continue;
+        }
     }
     return connected_chips;
 }
 
 std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(chip_id_t chip_id) const {
     std::unordered_set<CoreCoord> active_ethernet_cores;
-    const auto &connected_chips = this->get_ethernet_connected_chip_ids(chip_id);
-    for (auto &other_chip_id : connected_chips) {
-        for (const auto &channel_pair :
-             this->cluster_desc_->get_directly_connected_ethernet_channels_between_chips(chip_id, other_chip_id)) {
-            ethernet_channel_t local_chip_chan = std::get<0>(channel_pair);
-            active_ethernet_cores.insert(get_soc_desc(chip_id).chan_to_logical_eth_core_map.at(local_chip_chan));
-        }
+    const auto &connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(chip_id);
+    for (const auto &[other_chip_id, eth_cores] : connected_chips) {
+            active_ethernet_cores.insert(eth_cores.begin(), eth_cores.end());
     }
     return active_ethernet_cores;
 }
@@ -610,6 +637,100 @@ std::tuple<chip_id_t, CoreCoord> Cluster::get_connected_ethernet_core(std::tuple
         this->cluster_desc_->get_chip_and_channel_of_remote_ethernet_core(std::get<0>(eth_core), eth_chan);
     return std::make_tuple(
         std::get<0>(connected_eth_core), soc_desc.chan_to_logical_eth_core_map.at(std::get<1>(connected_eth_core)));
+}
+
+CoreCoord Cluster::ethernet_core_from_logical_core(chip_id_t chip_id, const CoreCoord &logical_core) const {
+    const metal_SocDescriptor &soc_desc = get_soc_desc(chip_id);
+    return soc_desc.get_physical_ethernet_core_from_logical(logical_core);
+}
+
+void Cluster::set_routing_config_for_ethernet_cores() {
+    const char *TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    for (const auto &[assoc_mmio_device, devices] : this->devices_grouped_by_assoc_mmio_device_) {
+        for (const auto &chip_id : devices) {
+            if (this->device_eth_router_config_.find(chip_id) == this->device_eth_router_config_.end()) {
+                this->device_eth_router_config_.insert({chip_id, {}});
+            }
+        }
+        for (const auto &chip_id : devices) {
+            if (TT_METAL_SLOW_DISPATCH_MODE == nullptr) {
+                for (const auto &[connected_chip_id, active_eth_cores] :
+                     this->get_ethernet_cores_grouped_by_connected_chips(chip_id)) {
+                    TT_ASSERT(
+                        (active_eth_cores.size() % 2 == 0),
+                        "Must have even number of eth links between tow devices for fast dispatch routing.");
+                    bool set_src = true;
+                    for (const auto &eth_core : active_eth_cores) {
+                        const auto connected_eth_core =
+                            std::get<1>(this->get_connected_ethernet_core(std::make_tuple(chip_id, eth_core)));
+                        if (this->device_eth_router_config_.at(chip_id).find(eth_core) ==
+                            this->device_eth_router_config_.at(chip_id).end()) {
+                            tt_cxy_pair this_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+                            tt_cxy_pair connected_phys_core(
+                                connected_chip_id,
+                                ethernet_core_from_logical_core(connected_chip_id, connected_eth_core));
+                            if (devices.find(connected_chip_id) != devices.end()) {
+                                // only setup fd tunneling for devices grouped with same mmio device
+                                if (set_src) {
+                                    this->device_eth_router_config_.at(chip_id).insert(
+                                        {eth_core, tt::EthRouterMode::FD_SRC});
+                                    this->device_eth_router_config_.at(connected_chip_id)
+                                        .insert({connected_eth_core, tt::EthRouterMode::FD_DST});
+                                } else {
+                                    this->device_eth_router_config_.at(chip_id).insert(
+                                        {eth_core, tt::EthRouterMode::FD_DST});
+                                    this->device_eth_router_config_.at(connected_chip_id)
+                                        .insert({connected_eth_core, tt::EthRouterMode::FD_SRC});
+                                }
+                                set_src = !set_src;
+                            } else {
+                                this->device_eth_router_config_.at(chip_id).insert({eth_core, tt::EthRouterMode::SD});
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Slow dispatch mode
+                for (const auto &eth_core : this->get_active_ethernet_cores(chip_id)) {
+                    this->device_eth_router_config_.at(chip_id).insert({eth_core, tt::EthRouterMode::SD});
+                }
+            }
+        }
+    }
+}
+
+void Cluster::launch_internal_routing_for_ethernet_cores() const {
+    const uint32_t routing_info_addr = eth_l1_mem::address_map::ERISC_APP_ROUTING_INFO_BASE;
+    // TODO: initialize devices if user does not
+    // Must initialize remote chips first, then mmio chips since once mmio chips are doing fd routing
+    // we do not always context switch to base FW
+    std::cout << " launching interal routing " << std::endl;
+    for (const auto &[assoc_mmio_device, devices] : this->devices_grouped_by_assoc_mmio_device_) {
+        for (const auto &chip_id : devices) {
+            if (chip_id == assoc_mmio_device) {
+                continue;
+            } else {
+                for (const auto &[eth_core, mode] : this->device_eth_router_config_.at(chip_id)) {
+                    const routing_info_t routing_info = {
+                        .routing_enabled = 1, .routing_mode = (uint32_t)mode, .fd_buffer_msgs_sent = 0};
+                    tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+                    write_core((void *)&routing_info, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
+                }
+            }
+        }
+        for (const auto &chip_id : devices) {
+            if (chip_id == assoc_mmio_device) {
+                for (const auto &[eth_core, mode] : this->device_eth_router_config_.at(chip_id)) {
+                    const routing_info_t routing_info = {
+                        .routing_enabled = 1, .routing_mode = (uint32_t)mode, .fd_buffer_msgs_sent = 0};
+                    tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+                    write_core((void *)&routing_info, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
+                }
+            } else {
+                continue;
+            }
+        }
+    }
 }
 
 uint32_t Cluster::get_tensix_soft_reset_addr() const {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -48,7 +48,7 @@ Cluster::Cluster() {
 
     this->assert_risc_reset();
 
-    this->set_routing_config_for_ethernet_cores();
+    this->initialize_routing_info_for_ethernet_cores();
 }
 
 void Cluster::detect_arch_and_target() {
@@ -318,22 +318,6 @@ void Cluster::start_driver(chip_id_t mmio_device_id, tt_device_params &device_pa
 
 Cluster::~Cluster() {
     log_info(tt::LogDevice, "Closing user mode device drivers");
-    // Disable internal ethernet routing
-    for (const auto &[assoc_mmio_device, devices] : this->devices_grouped_by_assoc_mmio_device_) {
-        const routing_info_t routing_info_disabled = {
-            .routing_enabled = 0, .routing_mode = 0, .fd_buffer_msgs_sent = 0};
-        for (const auto &chip_id : devices) {
-            for (const auto &eth_core : this->get_active_ethernet_cores(chip_id)) {
-                tt_cxy_pair this_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
-                write_core(
-                    (void *)&routing_info_disabled,
-                    sizeof(routing_info_t),
-                    this_phys_core,
-                    eth_l1_mem::address_map::ERISC_APP_ROUTING_INFO_BASE,
-                    false);
-            }
-        }
-    }
 
     for (const auto &[mmio_device_id, device_driver] : this->mmio_device_id_to_driver_) {
         device_driver->close_device();
@@ -644,12 +628,12 @@ CoreCoord Cluster::ethernet_core_from_logical_core(chip_id_t chip_id, const Core
     return soc_desc.get_physical_ethernet_core_from_logical(logical_core);
 }
 
-void Cluster::set_routing_config_for_ethernet_cores() {
+void Cluster::initialize_routing_info_for_ethernet_cores() {
     const char *TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
     for (const auto &[assoc_mmio_device, devices] : this->devices_grouped_by_assoc_mmio_device_) {
         for (const auto &chip_id : devices) {
-            if (this->device_eth_router_config_.find(chip_id) == this->device_eth_router_config_.end()) {
-                this->device_eth_router_config_.insert({chip_id, {}});
+            if (this->device_eth_routing_info_.find(chip_id) == this->device_eth_routing_info_.end()) {
+                this->device_eth_routing_info_.insert({chip_id, {}});
             }
         }
         for (const auto &chip_id : devices) {
@@ -663,71 +647,162 @@ void Cluster::set_routing_config_for_ethernet_cores() {
                     for (const auto &eth_core : active_eth_cores) {
                         const auto connected_eth_core =
                             std::get<1>(this->get_connected_ethernet_core(std::make_tuple(chip_id, eth_core)));
-                        if (this->device_eth_router_config_.at(chip_id).find(eth_core) ==
-                            this->device_eth_router_config_.at(chip_id).end()) {
+                        if (this->device_eth_routing_info_.at(chip_id).find(eth_core) ==
+                            this->device_eth_routing_info_.at(chip_id).end()) {
                             tt_cxy_pair this_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
                             tt_cxy_pair connected_phys_core(
                                 connected_chip_id,
                                 ethernet_core_from_logical_core(connected_chip_id, connected_eth_core));
+                            routing_info_t routing_config_local = {
+                                .routing_enabled = 0,
+                                .routing_mode = EthRouterMode::SD,
+                                .connected_chip_id = (uint32_t)connected_chip_id,
+                                .dispatch_core_xy = 0xffffffff,
+                                .fd_buffer_msgs_sent = 0};
+                            routing_info_t routing_config_remote = {
+                                .routing_enabled = 0,
+                                .routing_mode = EthRouterMode::SD,
+                                .connected_chip_id = (uint32_t)chip_id,
+                                .dispatch_core_xy = 0xffffffff,
+                                .fd_buffer_msgs_sent = 0};
                             if (devices.find(connected_chip_id) != devices.end()) {
                                 // only setup fd tunneling for devices grouped with same mmio device
                                 if (set_src) {
-                                    this->device_eth_router_config_.at(chip_id).insert(
-                                        {eth_core, tt::EthRouterMode::FD_SRC});
-                                    this->device_eth_router_config_.at(connected_chip_id)
-                                        .insert({connected_eth_core, tt::EthRouterMode::FD_DST});
+                                    routing_config_local.routing_mode = EthRouterMode::FD_SRC;
+                                    this->device_eth_routing_info_.at(chip_id).insert({eth_core, routing_config_local});
+                                    routing_config_remote.routing_mode = EthRouterMode::FD_DST;
+                                    this->device_eth_routing_info_.at(connected_chip_id)
+                                        .insert({connected_eth_core, routing_config_remote});
                                 } else {
-                                    this->device_eth_router_config_.at(chip_id).insert(
-                                        {eth_core, tt::EthRouterMode::FD_DST});
-                                    this->device_eth_router_config_.at(connected_chip_id)
-                                        .insert({connected_eth_core, tt::EthRouterMode::FD_SRC});
+                                    routing_config_local.routing_mode = EthRouterMode::FD_DST;
+                                    this->device_eth_routing_info_.at(chip_id).insert({eth_core, routing_config_local});
+                                    routing_config_remote.routing_mode = EthRouterMode::FD_SRC;
+                                    this->device_eth_routing_info_.at(connected_chip_id)
+                                        .insert({connected_eth_core, routing_config_remote});
                                 }
                                 set_src = !set_src;
                             } else {
-                                this->device_eth_router_config_.at(chip_id).insert({eth_core, tt::EthRouterMode::SD});
+                                routing_config_local.routing_mode = EthRouterMode::SD;
+                                this->device_eth_routing_info_.at(chip_id).insert({eth_core, routing_config_local});
                             }
                         }
                     }
                 }
             } else {
                 // Slow dispatch mode
-                for (const auto &eth_core : this->get_active_ethernet_cores(chip_id)) {
-                    this->device_eth_router_config_.at(chip_id).insert({eth_core, tt::EthRouterMode::SD});
+                const uint32_t routing_info_addr = eth_l1_mem::address_map::ERISC_APP_ROUTING_INFO_BASE;
+                for (const auto &[connected_chip_id, active_eth_cores] :
+                     this->get_ethernet_cores_grouped_by_connected_chips(chip_id)) {
+                    for (const auto &eth_core : active_eth_cores) {
+                        routing_info_t routing_config_sd = {
+                            .routing_enabled = 0,
+                            .routing_mode = EthRouterMode::SD,
+                            .connected_chip_id = (uint32_t)connected_chip_id,
+                            .dispatch_core_xy = 0xffffffff,
+                            .fd_buffer_msgs_sent = 0};
+                        this->device_eth_routing_info_.at(chip_id).insert({eth_core, routing_config_sd});
+                        // For slow dispatch, write routing info to device here. For fast dispatch, device calls
+                        // initialize command queue which writes routing info to device
+                        tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+                        write_core(
+                            (void *)&routing_config_sd,
+                            sizeof(routing_info_t),
+                            eth_phys_core,
+                            routing_info_addr,
+                            false);
+                    }
                 }
             }
         }
     }
 }
 
-void Cluster::launch_internal_routing_for_ethernet_cores() const {
+CoreCoord Cluster::get_and_configure_corresponding_eth_core_for_device(
+    chip_id_t chip_id, CoreCoord physical_dispatch_core, EthRouterMode mode, chip_id_t connected_chip_id) const {
+    const uint32_t routing_info_addr = eth_l1_mem::address_map::ERISC_APP_ROUTING_INFO_BASE;
+    for (auto [eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
+        // copy of values, original cluster routing info is not updated
+        if ((routing_info.routing_mode == (uint32_t)mode) and
+            (routing_info.connected_chip_id == (uint32_t)connected_chip_id)) {
+            routing_info.dispatch_core_xy =
+                ((physical_dispatch_core.x & 0xFFFF) << 16 | (physical_dispatch_core.y & 0xFFFF));
+            tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+
+            log_debug(
+                tt::LogDevice,
+                "Configuring internal routing mode {}: dispatch core {} <---> eth core {} ",
+                mode,
+                physical_dispatch_core.str(),
+                eth_phys_core.str());
+            write_core((void *)&routing_info, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
+            return eth_core;
+        }
+    }
+    TT_ASSERT(false, "Cluster does not contain requested eth routing core");
+    return {};
+}
+
+void Cluster::set_internal_routing_info_for_ethernet_cores(bool enable_internal_routing) const {
     const uint32_t routing_info_addr = eth_l1_mem::address_map::ERISC_APP_ROUTING_INFO_BASE;
     // TODO: initialize devices if user does not
     // Must initialize remote chips first, then mmio chips since once mmio chips are doing fd routing
     // we do not always context switch to base FW
-    std::cout << " launching interal routing " << std::endl;
+    const routing_info_t routing_info_disabled = {
+        .routing_enabled = 0,
+        .routing_mode = EthRouterMode::SD,
+        .connected_chip_id = 0,
+        .dispatch_core_xy = 0xffffffff,
+        .fd_buffer_msgs_sent = 0};
     for (const auto &[assoc_mmio_device, devices] : this->devices_grouped_by_assoc_mmio_device_) {
         for (const auto &chip_id : devices) {
-            if (chip_id == assoc_mmio_device) {
-                continue;
-            } else {
-                for (const auto &[eth_core, mode] : this->device_eth_router_config_.at(chip_id)) {
-                    const routing_info_t routing_info = {
-                        .routing_enabled = 1, .routing_mode = (uint32_t)mode, .fd_buffer_msgs_sent = 0};
-                    tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
-                    write_core((void *)&routing_info, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
+            for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
+                tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+                if (chip_id == assoc_mmio_device and not enable_internal_routing) {
+                    // Disable internal ethernet routing for mmio devices
+                    write_core(
+                        (void *)&routing_info_disabled,
+                        sizeof(routing_info_t),
+                        eth_phys_core,
+                        routing_info_addr,
+                        false);
+                } else if (chip_id != assoc_mmio_device and enable_internal_routing) {
+                    // Enable internal ethernet routing for non-mmio devices
+                    std::vector<uint32_t> enable_vec = {1};
+                    write_core(
+                        enable_vec.data(),
+                        enable_vec.size() * sizeof(uint32_t),
+                        eth_phys_core,
+                        routing_info_addr,
+                        false);
+
+                } else {
+                    continue;
                 }
             }
         }
         for (const auto &chip_id : devices) {
-            if (chip_id == assoc_mmio_device) {
-                for (const auto &[eth_core, mode] : this->device_eth_router_config_.at(chip_id)) {
-                    const routing_info_t routing_info = {
-                        .routing_enabled = 1, .routing_mode = (uint32_t)mode, .fd_buffer_msgs_sent = 0};
-                    tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
-                    write_core((void *)&routing_info, sizeof(routing_info_t), eth_phys_core, routing_info_addr, false);
+            for (const auto &[eth_core, routing_info] : this->device_eth_routing_info_.at(chip_id)) {
+                tt_cxy_pair eth_phys_core(chip_id, ethernet_core_from_logical_core(chip_id, eth_core));
+                if (chip_id != assoc_mmio_device and not enable_internal_routing) {
+                    // Disable internal ethernet routing for non-mmio devices
+                    write_core(
+                        (void *)&routing_info_disabled,
+                        sizeof(routing_info_t),
+                        eth_phys_core,
+                        routing_info_addr,
+                        false);
+                } else if (chip_id == assoc_mmio_device and enable_internal_routing) {
+                    // Enable internal ethernet routing for mmio devices
+                    std::vector<uint32_t> enable_vec = {1};
+                    write_core(
+                        enable_vec.data(),
+                        enable_vec.size() * sizeof(uint32_t),
+                        eth_phys_core,
+                        routing_info_addr,
+                        false);
+                } else {
+                    continue;
                 }
-            } else {
-                continue;
             }
         }
     }

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -125,12 +125,23 @@ class Cluster {
     // Configures routing mapping of ethernet cores
     void initialize_routing_info_for_ethernet_cores();
 
-    // Dispatch core is managed by device, so this is an api for device to write the routing info to each eth core used
-    // in FD tunneling Returns logical eth core that communicates with specified dispatch core
-    CoreCoord get_and_configure_corresponding_eth_core_for_device(
-        chip_id_t chip_id, CoreCoord physical_dispatch_core, EthRouterMode mode, chip_id_t connected_chip_id) const;
+    // Dispatch core is managed by device, so this is an api for device to get the each eth core used in FD tunneling.
+    // Returns logical eth core that communicates with specified dispatch core
+    tt_cxy_pair get_eth_core_for_dispatch_core(
+        tt_cxy_pair logical_dispatch_core, EthRouterMode mode, chip_id_t connected_chip_id) const;
 
-    // Writes eth routing config to device, assumes that device is initialized
+    // Writes router config to corresponding eth core
+    void configure_eth_core_for_dispatch_core(
+        tt_cxy_pair logical_dispatch_core, EthRouterMode mode, chip_id_t connected_chip_id) const;
+
+    // Internal routing for SD and FD enables launching user ethernet kernels and FD tunneling for all devices in the
+    // cluster. When using multiple devices in a cluster, this should be the flow:
+    //       CreateDevice(0)
+    //       CreateDevice(1)
+    //       set_internal_routing_info_for_ethernet_cores(true);
+    //       set_internal_routing_info_for_ethernet_cores(false);
+    //       CloseDevice(0)
+    //       CloseDevice(1)
     void set_internal_routing_info_for_ethernet_cores(bool enable_internal_routing) const;
 
     // Returns MMIO device ID (logical) that controls given `device_id`. If `device_id` is MMIO device it is returned.


### PR DESCRIPTION
PR to program FD_DST ethernet router and connect this to remote command processor on the remote chip

Unit test added to enqueue a single command and read it back from L1 through each core in the data path.

Additional tests targeting remote FD will be added in future PRs that bring up remaining FD kernels. 