### PR TITLE
#4858: Add support for float to int typecast

### DIFF
--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -1552,7 +1552,30 @@ Tensor argmax(
     return operation::decorate_as_composite(__func__, _argmax)(input_a, dim, all, output_mem_config);
 }
 
+
+Tensor _typecast(const Tensor& input_a, const DataType& dtype, const MemoryConfig& output_mem_config) {
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(dtype);
+    if(cb_data_format == tt::DataFormat::UInt16)
+    {
+        return to_uint16(input_a,output_mem_config);
+    }
+    else if(cb_data_format == tt::DataFormat::UInt32)
+    {
+        return to_uint32(input_a,output_mem_config);
+    }
+    else{
+        return to_bfloat(input_a, dtype, output_mem_config);
+    }
+}
+
+Tensor typecast(const Tensor& input_tensors, const DataType& dtype, const MemoryConfig& output_mem_config ) {
+    return operation::decorate_as_composite(__func__, _typecast)(input_tensors, dtype, output_mem_config);
+}
+
+
 Tensor _argmin(const Tensor& input_a, int64_t _dim, bool all, const MemoryConfig& output_mem_config) {
+    auto& input_shape = input_a.shape();
+    TT_FATAL(input_shape.rank() == 4,"supported for rank-4 tensors at this time");
 
     Tensor neg_input =  neg(input_a, output_mem_config);
     return (argmax(neg_input, _dim, all, output_mem_config));

--- a/tt_eager/tt_dnn/op_library/copy/copy_op.cpp
+++ b/tt_eager/tt_dnn/op_library/copy/copy_op.cpp
@@ -87,8 +87,8 @@ Tensor clone(const Tensor& input, const MemoryConfig& output_mem_config, std::op
     return operation::run(Copy{output_mem_config, output_dtype.value_or(input.dtype())}, {input}).at(0);
 }
 
-Tensor typecast(const Tensor& input_tensor, const DataType& dtype, const MemoryConfig& output_mem_config ) {
-    return operation::run(Copy{output_mem_config, dtype}, {input_tensor}).at(0);
+Tensor to_bfloat(const Tensor& input_tensor, const DataType& dtype, const MemoryConfig& output_mem_config ) {
+        return operation::run(Copy{output_mem_config, dtype}, {input_tensor}).at(0);
 }
 
 //unary assign

--- a/tt_eager/tt_dnn/op_library/copy/copy_op.hpp
+++ b/tt_eager/tt_dnn/op_library/copy/copy_op.hpp
@@ -43,6 +43,7 @@ Tensor clone(const Tensor& input, const MemoryConfig& output_mem_config = operat
 
 Tensor typecast(const Tensor& input_tensor, const DataType& dtype, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+Tensor to_bfloat(const Tensor& input_tensor, const DataType& dtype, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 //unary assign
 Tensor assign(const Tensor& input, const MemoryConfig& output_mem_config, std::optional<const DataType> output_dtype = std::nullopt);
 

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -145,6 +145,8 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, stri
         case UnaryOpType::LOG: op_init_and_name = {"log_tile_init();", fmt::format("log_tile({});", idst)}; break;
         case UnaryOpType::TANH: op_init_and_name = {"tanh_tile_init();", fmt::format("tanh_tile({});", idst)}; break;
         case UnaryOpType::SIGNBIT: op_init_and_name = {"signbit_tile_init();", fmt::format("signbit_tile({});", idst)}; break;
+        case UnaryOpType::TO_UINT16: op_init_and_name = {"to_uint16_tile_init();", fmt::format("to_uint16_tile({});", idst)}; break;
+        case UnaryOpType::TO_UINT32: op_init_and_name = {"to_uint32_tile_init();", fmt::format("to_uint32_tile({});", idst)}; break;
         case UnaryOpType::SIN: op_init_and_name = {"sin_tile_init();", fmt::format("sin_tile({});", idst)}; break;
         case UnaryOpType::COS: op_init_and_name = {"cos_tile_init();", fmt::format("cos_tile({});", idst)}; break;
         case UnaryOpType::ISFINITE: op_init_and_name = {"isfinite_tile_init();", fmt::format("isfinite_tile({});", idst)}; break;

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -73,7 +73,9 @@ enum class UnaryOpType {
     ADD_UNARY_SFPU = 55,
     SUB_UNARY_SFPU = 56,
     MUL_UNARY_SFPU = 57,
-    DIV_UNARY_SFPU = 58
+    DIV_UNARY_SFPU = 58,
+    TO_UINT16 = 59,
+    TO_UINT32 = 60
 };
 
 template <typename T>
@@ -251,6 +253,8 @@ constexpr auto isneginf = make_eltwise_unary<UnaryOpType::ISNEGINF>{};
 constexpr auto isnan = make_eltwise_unary<UnaryOpType::ISNAN>{};
 constexpr auto sign = make_eltwise_unary<UnaryOpType::SIGN>{};
 constexpr auto signbit = make_eltwise_unary<UnaryOpType::SIGNBIT>{};
+constexpr auto to_uint16 = make_eltwise_unary<UnaryOpType::TO_UINT16>{};
+constexpr auto to_uint32 = make_eltwise_unary<UnaryOpType::TO_UINT32>{};
 constexpr auto square = make_eltwise_unary<UnaryOpType::SQUARE>{};
 constexpr auto atan = make_eltwise_unary<UnaryOpType::ATAN>{};
 constexpr auto eqz = make_eltwise_unary<UnaryOpType::EQZ>{};

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -82,6 +82,26 @@ inline void llk_math_eltwise_unary_sfpu_signbit_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::signbit, APPROXIMATE>();
 }
 
+template <bool APPROXIMATE, DstSync dst_sync = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_to_uint16(uint dst_index, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu<SfpuType::to_uint16, APPROXIMATE, dst_sync>(dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_to_uint16_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::to_uint16, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, DstSync dst_sync = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_to_uint32(uint dst_index, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu<SfpuType::to_uint32, APPROXIMATE, dst_sync>(dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_to_uint32_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::to_uint32, APPROXIMATE>();
+}
+
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tanh_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>();

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_common_includes.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_common_includes.h
@@ -101,7 +101,11 @@ inline void llk_math_calculate_sfpu(
         calculate_atan<APPROXIMATION_MODE, ITERATIONS>();
     } else if constexpr (operation == SfpuType::signbit) {
         calculate_signbit<APPROXIMATION_MODE, ITERATIONS>();
-    } else if constexpr (operation == SfpuType::silu) {
+    }else if constexpr (operation == SfpuType::to_uint16) {
+        calculate_to_uint16<APPROXIMATION_MODE, ITERATIONS>();
+    }else if constexpr (operation == SfpuType::to_uint32) {
+        calculate_to_uint32<APPROXIMATION_MODE, ITERATIONS>();
+    }else if constexpr (operation == SfpuType::silu) {
         calculate_silu<APPROXIMATION_MODE, ITERATIONS>();
     }
     //erf, erfc are dispatched directly.

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/metal_ckernel_sfpu.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/metal_ckernel_sfpu.h
@@ -236,6 +236,164 @@ inline void calculate_signbit()
 
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_to_uint16()
+{
+
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vFloat val = dst_reg[0];
+        vFloat result = 0;
+
+        for(int i=0; i<47 ; i++)
+        {
+            v_if( val >= 0.0f)
+            {
+                v_if ( val >= 10000.0f  ){
+                result += 10000;
+                val -= 10000.0f;
+                }
+                v_elseif ( val >= 1000.0f  ){
+                    result += 1000;
+                    val -= 1000.0f;
+                }
+                v_elseif ( val >= 100.0f  ){
+                    result += 100;
+                    val -= 100.0f;
+                }
+                v_elseif ( val >= 10.0f ){
+                    result += 10;
+                    val -= 10.0f;
+                }
+                v_elseif ( val >= 1.0f){
+                    result += 1;
+                    val -= 1.0f;
+                }
+                v_endif;
+            }
+            v_elseif(val <  0.0f)
+            {
+                v_if ( val <= 10000.0f  ){
+                result -= 10000;
+                val += 10000.0f;
+                }
+                v_elseif ( val <= 1000.0f  ){
+                    result -= 1000;
+                    val += 1000.0f;
+                }
+                v_elseif ( val <= 100.0f  ){
+                    result -= 100;
+                    val += 100.0f;
+                }
+                v_elseif ( val <= 10.0f ){
+                    result -= 10;
+                    val += 10.0f;
+                }
+                v_elseif ( val <= 1.0f){
+                    result -= 1;
+                    val += 1.0f;
+                }
+                v_endif;
+            }
+            v_endif;
+        }
+        dst_reg[0] = result;
+
+        dst_reg++;
+    }
+
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_to_uint32()
+{
+
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vFloat result = 0;
+        vFloat val = dst_reg[0];
+
+        for(int i = 0; i < 95; i++)
+        {
+            v_if(val >= 0.0f)
+            {
+                v_if ( val >= 100000000.0f){
+                    result += 100000000;
+                    val -= 100000000.0f;
+                } v_elseif ( val >= 10000000.0f){
+                    result += 10000000;
+                    val -= 10000000.0f;
+                } v_elseif ( val >= 10000000.0f){
+                    result += 10000000;
+                    val -= 10000000.0f;
+                } v_elseif ( val >= 1000000.0f){
+                    result += 1000000;
+                    val -= 1000000.0f;
+                } v_elseif ( val >= 100000.0f){
+                    result += 100000;
+                    val -= 100000.0f;
+                } v_elseif ( val >= 10000.0f){
+                    result += 10000;
+                    val -= 10000.0f;
+                }v_elseif ( val >= 1000.0f){
+                    result += 1000;
+                    val -= 1000.0f;
+                } v_elseif ( val >= 100.0f){
+                    result += 100;
+                    val -= 100.0f;
+                } v_elseif ( val >= 10.0f){
+                    result += 10;
+                    val -= 10.0f;
+                } v_elseif ( val >= 1.0f){
+                    result += 1;
+                    val -= 1.0f;
+                }
+                v_endif;
+            }
+            v_elseif(val < 0.0f)
+            {
+                v_if ( val <= 100000000.0f){
+                    result -= 100000000;
+                    val += 100000000.0f;
+                } v_elseif ( val <= 10000000.0f){
+                    result -= 10000000;
+                    val += 10000000.0f;
+                } v_elseif ( val <= 10000000.0f){
+                    result -= 10000000;
+                    val += 10000000.0f;
+                } v_elseif ( val <= 1000000.0f){
+                    result -= 1000000;
+                    val += 1000000.0f;
+                } v_elseif ( val <= 100000.0f){
+                    result -= 100000;
+                    val += 100000.0f;
+                } v_elseif ( val <= 10000.0f){
+                    result -= 10000;
+                    val += 10000.0f;
+                }v_elseif ( val <= 1000.0f){
+                    result -= 1000;
+                    val += 1000.0f;
+                } v_elseif ( val <= 100.0f){
+                    result -= 100;
+                    val += 100.0f;
+                } v_elseif ( val <= 10.0f){
+                    result -= 10;
+                    val += 10.0f;
+                } v_elseif ( val <= 1.0f){
+                    result -= 1;
+                    val += 1.0f;
+                }
+                v_endif;
+            }
+            v_endif;
+        }
+        dst_reg[0] = result;
+
+        dst_reg++;
+    }
+
+}
+
 template <bool APPROXIMATION_MODE,int ITERATIONS>
 inline void calculate_power_iterative(const uint exponent)
 {

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu_types.h
@@ -60,5 +60,7 @@ enum SfpuType {
   silu,
   mask,
   negative,
+  to_uint16,
+  to_uint32,
   unused,
 };

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -206,8 +206,21 @@ ALWI void signbit_tile(uint32_t idst) {
     MATH(( llk_math_eltwise_unary_sfpu_signbit<APPROX, SyncHalf>(idst) ));
 }
 
+ALWI void to_uint16_tile_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_to_uint16_init<APPROX>() ));
+}
 
+ALWI void to_uint16_tile(uint32_t idst) {
+    MATH(( llk_math_eltwise_unary_sfpu_to_uint16<APPROX, SyncHalf>(idst) ));
+}
 
+ALWI void to_uint32_tile_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_to_uint32_init<APPROX>() ));
+}
+
+ALWI void to_uint32_tile(uint32_t idst) {
+    MATH(( llk_math_eltwise_unary_sfpu_to_uint32<APPROX, SyncHalf>(idst) ));
+}
 /**
  * Performs element-wise computation of absolute value on each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in


### PR DESCRIPTION
- Add support for float to int using a numeric ladder; this is not optimal implementation but we shall proceed with this for now
- C-kernel is written to fill out the SFPU SIMD lanes 
   - Bharane, Uma have resolved issues in using while loop/For loop, break statement in ckernel.
