### PR TITLE
#0: Fix an intermittent launch message transfer error

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/test_utils.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/test_utils.hpp
@@ -72,7 +72,7 @@ inline bool FileContainsAllStrings(string file_name, const vector<string> &must_
         return false;
 
     // Construct a set of required strings, we'll remove each one when it's found.
-    set<string> must_contain_set(must_contain.begin(), must_contain.end());
+    std::set<string> must_contain_set(must_contain.begin(), must_contain.end());
 
     if (log_file.is_open()) {
         string line;

--- a/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
@@ -70,6 +70,7 @@ void RunTest(Device *device) {
 
     auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
     log_info(LogTest, "Running program...");
+    try {
     if (slow_dispatch) {
         // Slow dispatch uses LaunchProgram
         tt::tt_metal::detail::LaunchProgram(device, program);
@@ -78,6 +79,12 @@ void RunTest(Device *device) {
         CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
         EnqueueProgram(cq, program, false);
         Finish(cq);
+    }
+    } catch (std::runtime_error& e) {
+        const string error = string(e.what());
+        log_info(tt::LogTest, "Caught exception: {}", error);
+        EXPECT_TRUE(false);
+        return;
     }
 
     // Check results

--- a/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
@@ -73,6 +73,7 @@ void RunTest(Device *device) {
     try {
     if (slow_dispatch) {
         // Slow dispatch uses LaunchProgram
+        log_info(LogTest, "Slow dispatch...");
         tt::tt_metal::detail::LaunchProgram(device, program);
     } else {
         // Fast Dispatch uses the command queue

--- a/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
@@ -84,6 +84,7 @@ void RunTest(Device *device) {
     } catch (std::out_of_range& e) {
         const string error = string(e.what());
         log_info(tt::LogTest, "Caught exception: {}", error);
+        throw e;
         EXPECT_TRUE(false);
         return;
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "test_utils.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+void RunTest(Device *device) {
+    // Set up program
+    Program program = Program();
+
+    std::set<CoreRange> core_ranges;
+    //CoreCoord grid_size = device->logical_grid_size();
+    CoreCoord grid_size = {5, 5};
+    for (uint32_t y = 0; y < grid_size.y; y++) {
+        for (uint32_t x = 0; x < grid_size.x; x++) {
+            CoreCoord core(x, y);
+            core_ranges.insert(CoreRange{.start=core, .end=core});
+        }
+    }
+
+    // Kernels on brisc + ncrisc that just add two numbers
+    KernelHandle brisc_kid = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
+        CoreRangeSet(core_ranges),
+        tt_metal::DataMovementConfig {
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default
+        }
+    );
+    KernelHandle ncrisc_kid = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
+        CoreRangeSet(core_ranges),
+        tt_metal::DataMovementConfig {
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default
+        }
+    );
+
+    // Write runtime args
+    auto get_first_arg = [](Device *device, CoreCoord &core, uint32_t multiplier) {
+        return (uint32_t) device->id() + (uint32_t) core.x * 10 * multiplier;
+    };
+    auto get_second_arg = [](Device *device, CoreCoord &core, uint32_t multiplier) {
+        return (uint32_t) core.y * 100 * multiplier;
+    };
+    for (auto &core_range : core_ranges) {
+        CoreCoord core = core_range.start;
+        std::vector<uint32_t> brisc_rt_args = {
+            get_first_arg(device, core, 1),
+            get_second_arg(device, core, 1)
+        };
+        std::vector<uint32_t> ncrisc_rt_args = {
+            get_first_arg(device, core, 2),
+            get_second_arg(device, core, 2)
+        };
+        SetRuntimeArgs(program, brisc_kid, core, brisc_rt_args);
+        SetRuntimeArgs(program, ncrisc_kid, core, ncrisc_rt_args);
+    }
+
+    auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    if (slow_dispatch) {
+        // Slow dispatch uses LaunchProgram
+        tt::tt_metal::detail::LaunchProgram(device, program);
+    } else {
+        // Fast Dispatch uses the command queue
+        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        EnqueueProgram(cq, program, false);
+        Finish(cq);
+    }
+
+    // Check results
+    for (auto &core_range : core_ranges) {
+        CoreCoord core = core_range.start;
+        std::vector<uint32_t> brisc_result;
+        tt_metal::detail::ReadFromDeviceL1(
+            device, core, BRISC_L1_RESULT_BASE, sizeof(uint32_t), brisc_result
+        );
+        std::vector<uint32_t> ncrisc_result;
+        tt_metal::detail::ReadFromDeviceL1(
+            device, core, NCRISC_L1_RESULT_BASE, sizeof(uint32_t), ncrisc_result
+        );
+        uint32_t expected_result = get_first_arg(device, core, 1) + get_second_arg(device, core, 1);
+        if (expected_result != brisc_result[0])
+            log_warning(
+                LogTest,
+                "Device {}, Core {}, BRISC result was incorrect. Expected {} but got {}",
+                device->id(),
+                core.str(),
+                expected_result,
+                brisc_result[0]
+            );
+        EXPECT_TRUE(expected_result == brisc_result[0]);
+        expected_result = get_first_arg(device, core, 2) + get_second_arg(device, core, 2);
+        if (expected_result != ncrisc_result[0])
+            log_warning(
+                LogTest,
+                "Device {}, Core {}, NCRISC result was incorrect. Expected {} but got {}",
+                device->id(),
+                core.str(),
+                expected_result,
+                ncrisc_result[0]
+            );
+        EXPECT_TRUE(expected_result == ncrisc_result[0]);
+    }
+}
+
+TEST(CommonMiscTests, AllCoresStressTest) {
+    auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    // Skip fast dispatch until it's supported for remote device.
+    if (!slow_dispatch)
+        GTEST_SKIP();
+    // Run 500 times to make sure that things work
+    for (int idx = 0; idx < 500; idx++) {
+        log_info(LogTest, "Running iteration #{}", idx);
+        // Need to open/close the device each time in order to reproduce original issue.
+        auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+        vector<Device*> devices_;
+        for (unsigned int id = 0; id < num_devices; id++) {
+            auto* device = tt::tt_metal::CreateDevice(id);
+            devices_.push_back(device);
+        }
+
+        // Run the test on each device
+        for (Device *device : devices_) {
+            RunTest(device);
+        }
+
+        // Close all devices
+        for (unsigned int id = 0; id < devices_.size(); id++) {
+            tt::tt_metal::CloseDevice(devices_.at(id));
+        }
+    }
+
+}

--- a/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
@@ -17,6 +17,7 @@ void RunTest(Device *device) {
     std::set<CoreRange> core_ranges;
     //CoreCoord grid_size = device->logical_grid_size();
     CoreCoord grid_size = {1, 1};
+    log_info(LogTest, "Creating core range...");
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord core(x, y);
@@ -25,6 +26,7 @@ void RunTest(Device *device) {
     }
 
     // Kernels on brisc + ncrisc that just add two numbers
+    log_info(LogTest, "Creating kernels...");
     KernelHandle brisc_kid = tt_metal::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
@@ -45,6 +47,7 @@ void RunTest(Device *device) {
     );
 
     // Write runtime args
+    log_info(LogTest, "Writing args...");
     auto get_first_arg = [](Device *device, CoreCoord &core, uint32_t multiplier) {
         return (uint32_t) device->id() + (uint32_t) core.x * 10 * multiplier;
     };
@@ -66,6 +69,7 @@ void RunTest(Device *device) {
     }
 
     auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    log_info(LogTest, "Running program...");
     if (slow_dispatch) {
         // Slow dispatch uses LaunchProgram
         tt::tt_metal::detail::LaunchProgram(device, program);
@@ -77,6 +81,7 @@ void RunTest(Device *device) {
     }
 
     // Check results
+    log_info(LogTest, "Checking results...");
     for (auto &core_range : core_ranges) {
         CoreCoord core = core_range.start;
         std::vector<uint32_t> brisc_result;
@@ -134,9 +139,11 @@ TEST(CommonMiscTests, AllCoresStressTest) {
         }
 
         // Close all devices
+        log_info(LogTest, "Closing devices...");
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }
+        log_info(LogTest, "Running iteration #{}", idx);
     }
 
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
@@ -80,7 +80,7 @@ void RunTest(Device *device) {
         EnqueueProgram(cq, program, false);
         Finish(cq);
     }
-    } catch (std::runtime_error& e) {
+    } catch (std::out_of_range& e) {
         const string error = string(e.what());
         log_info(tt::LogTest, "Caught exception: {}", error);
         EXPECT_TRUE(false);

--- a/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
@@ -36,6 +36,7 @@ void RunTest(Device *device) {
             .noc = NOC::RISCV_0_default
         }
     );
+    /*
     KernelHandle ncrisc_kid = tt_metal::CreateKernel(
         program,
         "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
@@ -45,6 +46,7 @@ void RunTest(Device *device) {
             .noc = NOC::RISCV_1_default
         }
     );
+    */
 
     // Write runtime args
     log_info(LogTest, "Writing args...");
@@ -65,7 +67,7 @@ void RunTest(Device *device) {
             get_second_arg(device, core, 2)
         };
         SetRuntimeArgs(program, brisc_kid, core, brisc_rt_args);
-        SetRuntimeArgs(program, ncrisc_kid, core, ncrisc_rt_args);
+        //SetRuntimeArgs(program, ncrisc_kid, core, ncrisc_rt_args);
     }
 
     auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
@@ -97,10 +99,12 @@ void RunTest(Device *device) {
         tt_metal::detail::ReadFromDeviceL1(
             device, core, BRISC_L1_RESULT_BASE, sizeof(uint32_t), brisc_result
         );
+        /*
         std::vector<uint32_t> ncrisc_result;
         tt_metal::detail::ReadFromDeviceL1(
             device, core, NCRISC_L1_RESULT_BASE, sizeof(uint32_t), ncrisc_result
         );
+        */
         uint32_t expected_result = get_first_arg(device, core, 1) + get_second_arg(device, core, 1);
         if (expected_result != brisc_result[0])
             log_warning(
@@ -112,6 +116,7 @@ void RunTest(Device *device) {
                 brisc_result[0]
             );
         EXPECT_TRUE(expected_result == brisc_result[0]);
+        /*
         expected_result = get_first_arg(device, core, 2) + get_second_arg(device, core, 2);
         if (expected_result != ncrisc_result[0])
             log_warning(
@@ -123,6 +128,7 @@ void RunTest(Device *device) {
                 ncrisc_result[0]
             );
         EXPECT_TRUE(expected_result == ncrisc_result[0]);
+        */
     }
 }
 
@@ -132,7 +138,7 @@ TEST(CommonMiscTests, AllCoresStressTest) {
     if (!slow_dispatch)
         GTEST_SKIP();
     // Run 500 times to make sure that things work
-    for (int idx = 0; idx < 500; idx++) {
+    for (int idx = 0; idx < 1; idx++) {
         log_info(LogTest, "Running iteration #{}", idx);
         // Need to open/close the device each time in order to reproduce original issue.
         auto num_devices = tt::tt_metal::GetNumAvailableDevices();

--- a/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
@@ -16,7 +16,7 @@ void RunTest(Device *device) {
 
     std::set<CoreRange> core_ranges;
     //CoreCoord grid_size = device->logical_grid_size();
-    CoreCoord grid_size = {5, 5};
+    CoreCoord grid_size = {1, 1};
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord core(x, y);

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -109,7 +109,7 @@ struct mailboxes_t {
 
 #ifndef TENSIX_FIRMWARE
 // Validate assumptions on mailbox layout on host compile
-static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, launch)) % 16 == 0);
+static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, launch)) % 32 == 0);
 static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, slave_sync.ncrisc) == MEM_SLAVE_RUN_MAILBOX_ADDRESS);
 static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, ncrisc_halt.stack_save) == MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS);
 static_assert(MEM_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_MAILBOX_END);

--- a/tt_metal/hw/inc/grayskull/dev_mem_map.h
+++ b/tt_metal/hw/inc/grayskull/dev_mem_map.h
@@ -50,7 +50,7 @@
 #define MEM_ZEROS_SIZE                 512
 
 #define MEM_BOOT_CODE_BASE             0
-#define MEM_MAILBOX_BASE               4
+#define MEM_MAILBOX_BASE               20
 #define MEM_MAILBOX_END                (MEM_MAILBOX_BASE + 128)
 #define MEM_ZEROS_BASE                 2048
 #define MEM_BRISC_FIRMWARE_BASE        (MEM_ZEROS_BASE + MEM_ZEROS_SIZE)
@@ -61,8 +61,8 @@
 
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 // Better way to do this would be to generate a file w/ these addresses
-#define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS    8
-#define MEM_SLAVE_RUN_MAILBOX_ADDRESS            32
+#define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS    MEM_MAILBOX_BASE + 4
+#define MEM_SLAVE_RUN_MAILBOX_ADDRESS            MEM_MAILBOX_BASE + 28
 
 /////////////
 // Initialization relocation L1 memory

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -50,7 +50,7 @@
 #define MEM_ZEROS_SIZE                 512
 
 #define MEM_BOOT_CODE_BASE             0
-#define MEM_MAILBOX_BASE               4
+#define MEM_MAILBOX_BASE               20
 #define MEM_MAILBOX_END                (MEM_MAILBOX_BASE + 128)
 #define MEM_ZEROS_BASE                 2048
 #define MEM_BRISC_FIRMWARE_BASE        (MEM_ZEROS_BASE + MEM_ZEROS_SIZE)
@@ -61,8 +61,8 @@
 
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 // Better way to do this would be to generate a file w/ these addresses
-#define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS    8
-#define MEM_SLAVE_RUN_MAILBOX_ADDRESS            32
+#define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS    MEM_MAILBOX_BASE + 4
+#define MEM_SLAVE_RUN_MAILBOX_ADDRESS            MEM_MAILBOX_BASE + 28
 
 /////////////
 // Initialization relocation L1 memory

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -272,18 +272,26 @@ void Kernel::set_binaries(chip_id_t device_id, std::vector<ll_api::memory> &&bin
 void DataMovementKernel::read_binaries(Device *device) {
     log_info(LogTest, "Called DMK::read_binaries on kernel {}...", this->name());
     TT_ASSERT ( !binary_path_.empty(), "Path to Kernel binaries not set!" );
+    log_info(LogTest, "    1");
     std::vector<ll_api::memory> binaries;
+    log_info(LogTest, "    2");
 
     // TODO(pgk): move the procssor types into the build system.  or just use integer indicies
     // TODO(pgk): consolidate read_binaries where possible
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
+    log_info(LogTest, "    3");
     const JitBuildState& build_state = device->build_kernel_state(JitBuildProcessorType::DATA_MOVEMENT, riscv_id);
+    log_info(LogTest, "    4");
     ll_api::memory binary_mem = llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_));
+    log_info(LogTest, "    5");
     this->binary_size16_ = llrt::get_binary_code_size16(binary_mem, riscv_id);
-    log_info(LogLoader, "RISC {} kernel binary size: {} in bytes", riscv_id, this->binary_size16_ * 16);
+    log_info(LogTest, "    6");
+    log_info(LogTest, "RISC {} kernel binary size: {} in bytes", riscv_id, this->binary_size16_ * 16);
 
     binaries.push_back(binary_mem);
+    log_info(LogTest, "    7");
     this->set_binaries(device->id(), std::move(binaries));
+    log_info(LogTest, "    8");
 }
 
 void EthernetKernel::read_binaries(Device *device) {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -270,6 +270,7 @@ void Kernel::set_binaries(chip_id_t device_id, std::vector<ll_api::memory> &&bin
 }
 
 void DataMovementKernel::read_binaries(Device *device) {
+    log_info(LogTest, "Called DMK::read_binaries on kernel {}...", this->name());
     TT_ASSERT ( !binary_path_.empty(), "Path to Kernel binaries not set!" );
     std::vector<ll_api::memory> binaries;
 
@@ -286,6 +287,7 @@ void DataMovementKernel::read_binaries(Device *device) {
 }
 
 void EthernetKernel::read_binaries(Device *device) {
+    log_info(LogTest, "Called EK::read_binaries on kernel {}...", this->name());
    // untested
     TT_ASSERT ( !binary_path_.empty(), "Path to Kernel binaries not set!" );
     std::vector<ll_api::memory> binaries;
@@ -297,6 +299,7 @@ void EthernetKernel::read_binaries(Device *device) {
 }
 
 void ComputeKernel::read_binaries(Device *device) {
+    log_info(LogTest, "Called CK::read_binaries on kernel {}...", this->name());
     TT_ASSERT ( !binary_path_.empty(), "Path to Kernel binaries not set!" );
     std::vector<ll_api::memory> binaries;
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -260,11 +260,13 @@ void ComputeKernel::generate_binaries(Device *device, JitBuildOptions& build_opt
 }
 
 void Kernel::set_binaries(chip_id_t device_id, std::vector<ll_api::memory> &&binaries) {
+    log_info(LogTest, "Adding binary with {} mems to device id {}", binaries.size(), device_id);
     if (this->binaries_.find(device_id) != this->binaries_.end()) {
         TT_ASSERT(this->binaries_.at(device_id) == binaries);
     } else {
         this->binaries_[device_id] = std::move(binaries);
     }
+    log_info(LogTest, "this->binaries_ now has {} elements", this->binaries_.size());
 }
 
 void DataMovementKernel::read_binaries(Device *device) {
@@ -277,7 +279,7 @@ void DataMovementKernel::read_binaries(Device *device) {
     const JitBuildState& build_state = device->build_kernel_state(JitBuildProcessorType::DATA_MOVEMENT, riscv_id);
     ll_api::memory binary_mem = llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_));
     this->binary_size16_ = llrt::get_binary_code_size16(binary_mem, riscv_id);
-    log_debug(LogLoader, "RISC {} kernel binary size: {} in bytes", riscv_id, this->binary_size16_ * 16);
+    log_info(LogLoader, "RISC {} kernel binary size: {} in bytes", riscv_id, this->binary_size16_ * 16);
 
     binaries.push_back(binary_mem);
     this->set_binaries(device->id(), std::move(binaries));

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -320,8 +320,10 @@ bool DataMovementKernel::configure(Device *device, const CoreCoord &logical_core
     if (not is_on_logical_core(logical_core)) {
         TT_THROW("Cannot configure kernel because it is not on core " + logical_core.str());
     }
+    log_info(LogTest, "Getting vals...:");
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
+    log_info(LogTest, "Getting binary...");
     ll_api::memory binary_mem = this->binaries(device_id).at(0);
 
     int riscv_id;
@@ -337,6 +339,7 @@ bool DataMovementKernel::configure(Device *device, const CoreCoord &logical_core
         default:
             TT_THROW("Unsupported data movement processor!");
     }
+    log_info(LogTest, "riscv id is {}, testing binary...", riscv_id);
 
     pass &= tt::llrt::test_load_write_read_risc_binary(binary_mem, device_id, worker_core, riscv_id);
     return pass;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -324,7 +324,10 @@ bool DataMovementKernel::configure(Device *device, const CoreCoord &logical_core
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
     log_info(LogTest, "Getting binary...");
-    ll_api::memory binary_mem = this->binaries(device_id).at(0);
+    auto bins = this->binaries(device_id);
+    log_info(LogTest, "Binary has {} mems...", bins.size());
+    ll_api::memory binary_mem = bins.at(0);
+    log_info(LogTest, "Got a binary mem...");
 
     int riscv_id;
     switch (this->config_.processor) {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -324,6 +324,9 @@ bool DataMovementKernel::configure(Device *device, const CoreCoord &logical_core
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
     log_info(LogTest, "Getting binary...");
+    log_info(LogTest, "Binaries are as follows:");
+    for (auto &id_and_mems : this->binaries_)
+        log_info(LogTest, "    Device id {} has {} mems...", id_and_mems.first, id_and_mems.second.size());
     auto bins = this->binaries(device_id);
     log_info(LogTest, "Binary has {} mems...", bins.size());
     ll_api::memory binary_mem = bins.at(0);

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -113,6 +113,12 @@ uint8_t ComputeKernel::expected_num_binaries() const {
 
 std::vector<ll_api::memory> const &Kernel::binaries(chip_id_t device_id) const {
     int expected_num_binaries = this->expected_num_binaries();
+    log_info(LogTest, "Searching binaries_ for device id: {}", device_id);
+    if (this->binaries_.find(device_id) != this->binaries_.end())
+        log_info(LogTest, "Found!");
+    else
+        log_info(LogTest, "Not Found!");
+    log_info(LogTest, "expected_num_binaries={}", expected_num_binaries);
     if (this->binaries_.find(device_id) != this->binaries_.end() and this->binaries_.at(device_id).size() != expected_num_binaries) {
         TT_THROW("Expected " + std::to_string(expected_num_binaries) + " binaries but have "
                     + std::to_string(this->binaries_.at(device_id).size()) + " for kernel " + this->name());
@@ -327,6 +333,7 @@ bool DataMovementKernel::configure(Device *device, const CoreCoord &logical_core
     log_info(LogTest, "Binaries are as follows:");
     for (auto &id_and_mems : this->binaries_)
         log_info(LogTest, "    Device id {} has {} mems...", id_and_mems.first, id_and_mems.second.size());
+    log_info(LogTest, "Binaries end");
     auto bins = this->binaries(device_id);
     log_info(LogTest, "Binary has {} mems...", bins.size());
     ll_api::memory binary_mem = bins.at(0);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -581,6 +581,7 @@ void Program::compile( Device * device )
 
     // compile all kernels in parallel
     for (Kernel * kernel : kernels_) {
+        log_info(LogTest, "compile kernel {}...", kernel->name());
         events.emplace_back ( detail::async ( [kernel, device, this] {
             ZoneScoped;
 
@@ -606,6 +607,7 @@ void Program::compile( Device * device )
             }
 
             kernel->set_binary_path(build_options.path);
+                    log_info(LogTest, "compile finished for kernel {}...", kernel->name());
         } ) );
     }
 
@@ -614,7 +616,8 @@ void Program::compile( Device * device )
 
     for (Kernel * kernel : kernels_) {
         log_info(LogTest, "read_binaries for kernel {}...", kernel->name());
-        events.emplace_back ( detail::async ( [kernel, device] { kernel->read_binaries(device); }));
+        events.emplace_back ( detail::async ( [kernel, device] { kernel->read_binaries(device);
+                    log_info(LogTest, "read_binaries finished for kernel {}...", kernel->name());}));
     }
 
     for (auto & f : events)

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -613,11 +613,13 @@ void Program::compile( Device * device )
         f.wait();
 
     for (Kernel * kernel : kernels_) {
+        log_info(LogTest, "read_binaries for kernel {}...", kernel->name());
         events.emplace_back ( detail::async ( [kernel, device] { kernel->read_binaries(device); }));
     }
 
     for (auto & f : events)
         f.wait();
+    log_info(LogTest, "All kernels binaries read");
 
     this->construct_core_range_set_for_worker_cores();
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -39,7 +39,11 @@ void ConfigureKernelGroup(const Program &program, const KernelGroup *kernel_grou
     log_info(LogTest, "3");
     if (kernel_group->riscv0_id.has_value()) {
         log_info(LogTest, "c");
-        detail::GetKernel(program, kernel_group->riscv0_id.value())->configure(device, logical_core);
+        log_info(LogTest, "Getting kernel...");
+        auto k = detail::GetKernel(program, kernel_group->riscv0_id.value());
+        log_info(LogTest, "Configuring...");
+        k->configure(device, logical_core);
+        log_info(LogTest, "Done...");
     }
     log_info(LogTest, "4");
     if (kernel_group->erisc_id.has_value()) {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -410,6 +410,7 @@ namespace detail {
         detail::WriteRuntimeArgsToDevice(device, program);
         log_info(LogTest, "Configuring...");
         detail::ConfigureDeviceWithProgram(device, program);
+        log_info(LogTest, "Barriers...");
         auto device_id = device->id();
 
         tt::Cluster::instance().dram_barrier(device_id);
@@ -447,12 +448,14 @@ namespace detail {
 
         auto device_id = device->id();
 
+        log_info(LogTest, "Validate cbs...");
         program.allocate_circular_buffers();
         detail::ValidateCircularBufferRegion(program, device);
 
         std::unordered_map<CoreType, std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
         for (const auto &[core_type, logical_cores] : logical_cores_used_in_program) {
             for (const auto &logical_core : logical_cores) {
+                log_info(LogTest, "Configuring core {}...", logical_core.str());
                 KernelGroup *kernel_group = program.kernels_on_core(logical_core);
                 CoreCoord physical_core = device->physical_core_from_logical_core(logical_core, core_type);
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -26,18 +26,27 @@ namespace tt_metal {
 namespace {
 
 void ConfigureKernelGroup(const Program &program, const KernelGroup *kernel_group, Device *device, const CoreCoord &logical_core) {
+    log_info(LogTest, "1");
     if (kernel_group->compute_id.has_value()) {
+        log_info(LogTest, "a");
         detail::GetKernel(program, kernel_group->compute_id.value())->configure(device, logical_core);
     }
+    log_info(LogTest, "2");
     if (kernel_group->riscv1_id.has_value()) {
+        log_info(LogTest, "b");
         detail::GetKernel(program, kernel_group->riscv1_id.value())->configure(device, logical_core);
     }
+    log_info(LogTest, "3");
     if (kernel_group->riscv0_id.has_value()) {
+        log_info(LogTest, "c");
         detail::GetKernel(program, kernel_group->riscv0_id.value())->configure(device, logical_core);
     }
+    log_info(LogTest, "4");
     if (kernel_group->erisc_id.has_value()) {
+        log_info(LogTest, "d");
         detail::GetKernel(program, kernel_group->erisc_id.value())->configure(device, logical_core);
     }
+    log_info(LogTest, "5");
 }
 
 std::optional<uint32_t> get_semaphore_address(const Program &program, const CoreRange &core_range) {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -458,11 +458,14 @@ namespace detail {
                 log_info(LogTest, "Configuring core {}...", logical_core.str());
                 KernelGroup *kernel_group = program.kernels_on_core(logical_core);
                 CoreCoord physical_core = device->physical_core_from_logical_core(logical_core, core_type);
+                log_info(LogTest, "Physical core is {}, configuring kernel group...", physical_core.str());
 
                 ConfigureKernelGroup(
                     program, kernel_group, device, logical_core);  // PROF_BEGIN("CONF_KERN") PROF_END("CONF_KERN")
+                log_info(LogTest, "Done configuring kernel group, configuring CBs...");
                 // TODO: add support for CB for ethernet cores
                 if (core_type == CoreType::WORKER) {
+                    log_info(LogTest, "Worker core...");
                     // CircularBufferConfigVec -- common across all kernels, so written once to the core
                     llrt::CircularBufferConfigVec circular_buffer_config_vec =
                         llrt::create_circular_buffer_config_vector();
@@ -487,6 +490,7 @@ namespace detail {
                     }
 
                     program.init_semaphores(*device, logical_core);
+                    log_info(LogTest, "Done configuring CBs...");
                 }
             }
         }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -417,6 +417,7 @@ namespace detail {
 
         std::unordered_map<CoreType, std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
         std::unordered_set<CoreCoord> not_done_cores;
+        log_info(LogTest, "Starting cores...");
         for (const auto &[core_type, logical_cores] : logical_cores_used_in_program) {
             for (const auto &logical_core : logical_cores) {
                 launch_msg_t *msg = &program.kernels_on_core(logical_core)->launch_msg;
@@ -426,9 +427,11 @@ namespace detail {
             }
         }
         // Wait for all cores to be done
+        log_info(LogTest, "Waiting for cores finish...");
         llrt::internal_::wait_until_cores_done(device_id, RUN_MSG_GO, not_done_cores);
 
         }//Profiler scope end
+        log_info(LogTest, "Program finished");
         DumpDeviceProfileResults(device, program);
     }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -404,8 +404,11 @@ namespace detail {
         detail::DispatchStateCheck( false );
         detail::ProfileTTMetalScope profile_this =
             detail::ProfileTTMetalScope(std::string("LaunchProgram ") + std::to_string(device->id()));
+        log_info(LogTest, "Compiling...");
         detail::CompileProgram(device, program);
+        log_info(LogTest, "Writing runtime args...");
         detail::WriteRuntimeArgsToDevice(device, program);
+        log_info(LogTest, "Configuring...");
         detail::ConfigureDeviceWithProgram(device, program);
         auto device_id = device->id();
 


### PR DESCRIPTION
Issue here is that the launch.run field could be read as true before the launch.enable_brisc and launch.enable_ncrisc fields.

This fixes the intermittent issues with the DPrint RaiseWait test (passes 500 consecutive iterations, previously would fail within 100)