### PR TITLE
#4799: Implement CrossAttnDownBlock2D sub-module using ttnn for stabl…

### DIFF
--- a/models/experimental/functional_stable_diffusion/tt/ttnn_functional_cross_attention_down_block_2d.py
+++ b/models/experimental/functional_stable_diffusion/tt/ttnn_functional_cross_attention_down_block_2d.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.functional_stable_diffusion.tt.ttnn_functional_resnetblock2d import resnetBlock2D
+from models.experimental.functional_stable_diffusion.tt.ttnn_functional_transformer_2d import transformer_2d_model
+from models.experimental.functional_stable_diffusion.tt.ttnn_functional_downsample_2d import downsample_2d
+
+
+def cross_attention_down_block_2d(
+    hidden_states,
+    encoder_hidden_states,
+    temb,
+    add_downsample=True,
+    attention_mask=None,
+    cross_attention_kwargs={},
+    config=None,
+    num_layers=2,
+    in_channels: int = None,
+    out_channels: int = None,
+    resnet_eps: float = 1e-6,
+    resnet_act_fn: str = "swish",
+    dual_cross_attention=False,
+    temb_channels=1280,
+    groups=32,
+    time_embedding_norm="default",
+    output_scale_factor=1.0,
+    use_in_shortcut=False,
+    resnet_groups: int = 32,
+    resnet_pre_norm: bool = True,
+    downsample_padding: int = 1,
+    cross_attention_dim: int = 768,
+    attn_num_head_channels: int = 8,
+    use_linear_projection=False,
+    only_cross_attention=False,
+    upcast_attention=False,
+    resnet_time_scale_shift: str = "default",
+    *,
+    parameters,
+    device,
+):
+    output_states = ()
+
+    for index, (resnet, attn) in enumerate(zip(parameters.resnets, parameters.attentions)):
+        in_channels = in_channels if index == 0 else out_channels
+        use_in_shortcut = True if "conv_shortcut" in resnet else False
+        hidden_states = resnetBlock2D(
+            hidden_states,
+            temb=temb,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            temb_channels=temb_channels,
+            parameters=resnet,
+            device=device,
+            use_in_shortcut=use_in_shortcut,
+            eps=resnet_eps,
+            groups=resnet_groups,
+            time_embedding_norm=resnet_time_scale_shift,
+            non_linearity=resnet_act_fn,
+            output_scale_factor=output_scale_factor,
+            pre_norm=resnet_pre_norm,
+        )
+        if not dual_cross_attention:
+            hidden_states = transformer_2d_model(
+                hidden_states,
+                attn,
+                config,
+                encoder_hidden_states,
+                attention_head_dim=out_channels // attn_num_head_channels,
+                in_channels=out_channels,
+                num_layers=1,
+                cross_attention_dim=cross_attention_dim,
+                norm_num_groups=resnet_groups,
+                use_linear_projection=use_linear_projection,
+                only_cross_attention=only_cross_attention,
+                upcast_attention=upcast_attention,
+                device=device,
+            )
+
+        output_states += (hidden_states,)
+
+    if add_downsample is not None:
+        hidden_states = downsample_2d(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            hidden_states=hidden_states,
+            padding=downsample_padding,
+            device=device,
+            parameters=parameters.downsamplers[0],
+            use_conv=True,
+        )
+        output_states += (hidden_states,)
+    return hidden_states, output_states

--- a/tests/ttnn/integration_tests/stable_diffusion/test_ttnn_cross_attention_down_block_2d.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_ttnn_cross_attention_down_block_2d.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from torch import nn
+from diffusers import StableDiffusionPipeline
+import ttnn
+
+from models.experimental.functional_stable_diffusion.tt.ttnn_functional_cross_attention_down_block_2d import (
+    cross_attention_down_block_2d,
+)
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.utility_functions import skip_for_wormhole_b0, tt_to_torch_tensor
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.experimental.functional_stable_diffusion.custom_preprocessing import custom_preprocessor
+
+
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
+@pytest.mark.parametrize(
+    "N, C, H, W, index, in_channels",
+    [
+        (
+            2,
+            320,
+            32,
+            32,
+            0,
+            320,
+        ),
+        (
+            2,
+            320,
+            16,
+            16,
+            0,
+            320,
+        ),
+        (
+            2,
+            640,
+            8,
+            8,
+            2,
+            1280,
+        ),
+    ],
+)
+def test_cross_attn_down_block_2d_256x256(device, model_name, N, C, H, W, index, in_channels):
+    torch.manual_seed(0)
+
+    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    down_block = pipe.unet.down_blocks[index]
+    down_block.eval()
+    state_dict = pipe.unet.state_dict()
+    config = pipe.unet.config
+
+    hidden_states_shape = torch.Size([N, C, H, W])
+    hidden_states = torch.randn(hidden_states_shape)
+
+    encoder_hidden_states_shape = torch.Size([1, 2, 77, 768])
+    encoder_hidden_states = torch.randn(encoder_hidden_states_shape)
+
+    temb_shape = torch.Size([1, 1, 2, 1280])
+    temb = torch.randn(temb_shape)
+
+    attention_mask = None
+    cross_attention_kwargs = None
+
+    torch_output, torch_list_out = down_block(
+        hidden_states,
+        temb.squeeze(0).squeeze(0),
+        encoder_hidden_states=encoder_hidden_states.squeeze(0),
+        attention_mask=attention_mask,
+        cross_attention_kwargs=cross_attention_kwargs,
+    )
+
+    hidden_states = ttnn.from_torch(hidden_states, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    hidden_states = ttnn.to_device(hidden_states, device)
+
+    encoder_hidden_states = ttnn.from_torch(encoder_hidden_states, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    encoder_hidden_states = ttnn.to_device(encoder_hidden_states, device)
+
+    temb = ttnn.from_torch(temb, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    temb = ttnn.to_device(temb, device)
+
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: down_block,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+
+    ttnn_output, _ = cross_attention_down_block_2d(
+        hidden_states,
+        encoder_hidden_states,
+        temb,
+        in_channels=in_channels,
+        out_channels=in_channels,
+        attention_mask=None,
+        add_downsample=True,
+        cross_attention_kwargs={},
+        config=config,
+        parameters=parameters,
+        device=device,
+    )
+
+    ttnn_output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_output, ttnn_output, 0.98)
+
+
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
+@pytest.mark.parametrize(
+    "N, C, H, W, index, in_channels",
+    [
+        (
+            2,
+            320,
+            64,
+            64,
+            0,
+            320,
+        ),
+        (
+            2,
+            320,
+            32,
+            32,
+            0,
+            320,
+        ),
+        (
+            2,
+            640,
+            16,
+            16,
+            2,
+            1280,
+        ),
+    ],
+)
+def test_cross_attn_down_block_2d_512x512(device, model_name, N, C, H, W, index, in_channels):
+    torch.manual_seed(0)
+
+    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)
+    down_block = pipe.unet.down_blocks[index]
+    down_block.eval()
+    state_dict = pipe.unet.state_dict()
+    config = pipe.unet.config
+
+    hidden_states_shape = torch.Size([N, C, H, W])
+    hidden_states = torch.randn(hidden_states_shape)
+    encoder_hidden_states_shape = torch.Size([1, 2, 77, 768])
+    encoder_hidden_states = torch.randn(encoder_hidden_states_shape)
+
+    temb_shape = torch.Size([1, 1, 2, 1280])
+    temb = torch.randn(temb_shape)
+
+    attention_mask = None
+    cross_attention_kwargs = None
+
+    torch_output, torch_list_out = down_block(
+        hidden_states,
+        temb.squeeze(0).squeeze(0),
+        encoder_hidden_states=encoder_hidden_states.squeeze(0),
+        attention_mask=attention_mask,
+        cross_attention_kwargs=cross_attention_kwargs,
+    )
+
+    hidden_states = ttnn.from_torch(hidden_states, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    hidden_states = ttnn.to_device(hidden_states, device)
+
+    encoder_hidden_states = ttnn.from_torch(encoder_hidden_states, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    encoder_hidden_states = ttnn.to_device(encoder_hidden_states, device)
+
+    temb = ttnn.from_torch(temb, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    temb = ttnn.to_device(temb, device)
+
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: down_block,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+
+    ttnn_output, _ = cross_attention_down_block_2d(
+        hidden_states,
+        encoder_hidden_states,
+        temb,
+        in_channels=in_channels,
+        out_channels=in_channels,
+        attention_mask=None,
+        add_downsample=True,
+        cross_attention_kwargs={},
+        config=config,
+        parameters=parameters,
+        device=device,
+    )
+    ttnn_output = ttnn.to_torch(ttnn_output)
+    assert_with_pcc(torch_output, ttnn_output, 0.98)


### PR DESCRIPTION
This PR contains the CrossAttnDownBlock2D sub-module implemented using ttnn for the stable diffusion model.

For the following cases we are getting a PCC < 0.16 and for other 4 test cases we are getting PCC =~ 0.8.

- Shape 1: 256x256

    hidden_states: case 3: [2, 640, 8, 8]
    PCC : 0.12622983116773254

- Shape 2: 512x512

    hidden_states case 3: [2, 640, 16, 16]
    PCC: 0.167559617771942
    