### PR TITLE
#4788: Implement Downsample2D using ttnn for stable_diffusion model

### DIFF
--- a/models/experimental/functional_stable_diffusion/tt/ttnn_functional_downsample_2d.py
+++ b/models/experimental/functional_stable_diffusion/tt/ttnn_functional_downsample_2d.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import ttnn
+import torch
+import torch.nn as nn
+from tt_lib.fallback_ops import fallback_ops
+from models.utility_functions import torch_to_tt_tensor_rm, tt_to_torch_tensor
+
+
+def permute_conv_parameters(weight, bias):
+    weight = ttnn.to_layout(weight, layout=ttnn.ROW_MAJOR_LAYOUT)
+    weight = ttnn.to_torch(weight)
+    weight = torch.permute(weight, (2, 3, 0, 1))
+    bias = ttnn.to_layout(bias, layout=ttnn.ROW_MAJOR_LAYOUT)
+    bias = ttnn.to_torch(bias)
+    return weight, bias
+
+
+def downsample_2d(
+    in_channels,
+    hidden_states,
+    device,
+    parameters,
+    use_conv=False,
+    out_channels=None,
+    padding=1,
+):
+    stride = 2
+
+    parameters.conv.weight, parameters.conv.bias = permute_conv_parameters(parameters.conv.weight, parameters.conv.bias)
+    parameters.conv.weight = torch_to_tt_tensor_rm(parameters.conv.weight, device, put_on_device=False)
+    parameters.conv.bias = torch_to_tt_tensor_rm(parameters.conv.bias, device, put_on_device=False)
+
+    if use_conv:
+        conv = fallback_ops.Conv2d(
+            parameters.conv.weight,
+            parameters.conv.bias,
+            in_channels,
+            out_channels,
+            kernel_size=3,
+            stride=stride,
+            padding=padding,
+        )
+
+    else:
+        assert in_channels == out_channels
+        assert False, " we don't support AvgPool2d, and we should not need it either"
+        conv = nn.AvgPool2d(kernel_size=stride, stride=stride)
+
+    assert hidden_states.shape[1] == in_channels
+
+    if use_conv and padding == 0:
+        pad = (0, 1, 0, 1)
+        hidden_states = ttnn.pad(hidden_states, pad, value=0)
+
+    assert hidden_states.shape[1] == in_channels
+
+    hidden_states = ttnn.to_torch(ttnn.from_device(ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)))
+
+    hidden_states = torch_to_tt_tensor_rm(hidden_states, device)
+    hidden_states = conv(hidden_states)
+    hidden_states = tt_to_torch_tensor(hidden_states)
+
+    hidden_states = ttnn.to_device(
+        ttnn.to_layout(ttnn.from_torch(hidden_states, ttnn.bfloat16), ttnn.TILE_LAYOUT),
+        device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    return hidden_states

--- a/tests/ttnn/integration_tests/stable_diffusion/test_downsample_2d.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_downsample_2d.py
@@ -1,0 +1,107 @@
+# # SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# # SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import pytest
+from torch import nn
+from diffusers import StableDiffusionPipeline
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.experimental.functional_stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.experimental.functional_stable_diffusion.tt.ttnn_functional_downsample_2d import downsample_2d
+
+
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
+@pytest.mark.parametrize(
+    "batch_size, in_channels, input_height, input_width, index",
+    [
+        (2, 320, 32, 32, 0),
+        (2, 640, 16, 16, 1),
+        (2, 1280, 8, 8, 2),
+    ],
+)
+def test_downsample_2d_256x256(device, model_name, batch_size, in_channels, input_height, input_width, index):
+    input_shape = batch_size, in_channels, input_height, input_width
+    pipe = StableDiffusionPipeline.from_pretrained(model_name, torch_dtype=torch.float32)
+    unet = pipe.unet
+    unet.eval()
+    unet_downblock = pipe.unet.down_blocks[index]
+    ref_model = unet_downblock.downsamplers[0]
+
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: unet, custom_preprocessor=custom_preprocessor, device=device
+    )
+    parameters = parameters.down_blocks[index].downsamplers[0]
+
+    torch_hidden_states = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+
+    torch_output = ref_model(torch_hidden_states)
+
+    ttnn_hidden_state = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(torch_hidden_states, dtype=ttnn.bfloat16), device), layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+
+    ttnn_output = downsample_2d(
+        in_channels=in_channels,
+        hidden_states=ttnn_hidden_state,
+        device=device,
+        parameters=parameters,
+        use_conv=True,
+        out_channels=in_channels,
+        padding=1,
+    )
+
+    ttnn_output_torch = ttnn.to_torch(ttnn.from_device(ttnn.to_layout(ttnn_output, ttnn.ROW_MAJOR_LAYOUT)))
+
+    assert_with_pcc(torch_output, ttnn_output_torch, 0.99)
+
+
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
+@pytest.mark.parametrize(
+    "batch_size, in_channels, input_height, input_width, index",
+    [
+        (2, 320, 64, 64, 0),
+        (2, 640, 32, 32, 1),
+        (2, 1280, 16, 16, 2),
+    ],
+)
+def test_downsample_2d_512x512(device, model_name, batch_size, in_channels, input_height, input_width, index):
+    input_shape = batch_size, in_channels, input_height, input_width
+    pipe = StableDiffusionPipeline.from_pretrained(model_name, torch_dtype=torch.float32)
+    unet = pipe.unet
+    unet.eval()
+    unet_downblock = pipe.unet.down_blocks[index]
+    ref_model = unet_downblock.downsamplers[0]
+
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: unet, custom_preprocessor=custom_preprocessor, device=device
+    )
+    parameters = parameters.down_blocks[index].downsamplers[0]
+
+    torch_hidden_states = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+
+    torch_output = ref_model(torch_hidden_states)
+
+    ttnn_hidden_state = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(torch_hidden_states, dtype=ttnn.bfloat16), device), layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+
+    ttnn_output = downsample_2d(
+        in_channels=in_channels,
+        hidden_states=ttnn_hidden_state,
+        device=device,
+        parameters=parameters,
+        use_conv=True,
+        out_channels=in_channels,
+        padding=1,
+    )
+
+    ttnn_output_torch = ttnn.to_torch(ttnn.from_device(ttnn.to_layout(ttnn_output, ttnn.ROW_MAJOR_LAYOUT)))
+
+    assert_with_pcc(torch_output, ttnn_output_torch, 0.99)


### PR DESCRIPTION
This PR contains the Downsample2D sub-module implemented using ttnn for the Stable diffusion model with fallback ops for conv. 