### PR TITLE
#4794: Implement DownBlock2D using ttnn for stable_diffusion model

### DIFF
--- a/models/experimental/functional_stable_diffusion/tt/ttnn_functional_downblock_2d.py
+++ b/models/experimental/functional_stable_diffusion/tt/ttnn_functional_downblock_2d.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from models.experimental.functional_stable_diffusion.tt.ttnn_functional_resnetblock2d import resnetBlock2D
+from models.experimental.functional_stable_diffusion.tt.ttnn_functional_downsample_2d import downsample_2d
+
+
+def downblock2d(
+    temb,
+    hidden_states,
+    device,
+    in_channels,
+    out_channels,
+    temb_channels,
+    dropout=0.0,
+    num_layers=1,
+    resnet_eps=1e-6,
+    resnet_time_scale_shift="default",
+    resnet_act_fn="swish",
+    resnet_groups=32,
+    resnet_pre_norm=True,
+    output_scale_factor=1.0,
+    add_downsample=False,
+    downsample_padding=1,
+    parameters=None,
+):
+    output_states = ()
+    for i in range(num_layers):
+        in_channels = in_channels if i == 0 else out_channels
+        resnet = resnetBlock2D(
+            device=device,
+            input_tensor=hidden_states,
+            temb=temb,
+            in_channels=in_channels,
+            parameters=parameters.resnets[i],
+            temb_channels=temb_channels,
+            groups=resnet_groups,
+            time_embedding_norm=resnet_time_scale_shift,
+            non_linearity=resnet_act_fn,
+            output_scale_factor=output_scale_factor,
+            out_channels=out_channels,
+            pre_norm=resnet_pre_norm,
+            eps=resnet_eps,
+            up=False,
+            down=False,
+        )
+
+        hidden_states = resnet
+        output_states += (hidden_states,)
+
+    if add_downsample:
+        downsamplers = [
+            downsample_2d(
+                in_channels=in_channels,
+                hidden_states=hidden_states,
+                use_conv=True,
+                out_channels=out_channels,
+                padding=downsample_padding,
+                name="op",
+                parameters=parameters.downsamplers[0],
+                device=device,
+            )
+        ]
+
+        for downsampler in downsamplers:
+            hidden_states = downsampler
+            output_states += (hidden_states,)
+
+    return hidden_states, output_states

--- a/tests/ttnn/integration_tests/stable_diffusion/test_down_block_2d.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_down_block_2d.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import pytest
+from diffusers import StableDiffusionPipeline
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import skip_for_wormhole_b0
+from ttnn.model_preprocessing import preprocess_model_parameters
+
+from models.experimental.functional_stable_diffusion.custom_preprocessing import custom_preprocessor
+from models.experimental.functional_stable_diffusion.tt.ttnn_functional_downblock_2d import downblock2d
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (2, 1280, 4, 4),
+    ],
+)
+@pytest.mark.parametrize(
+    "temb_shape",
+    [
+        (1, 1, 2, 1280),
+    ],
+)
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
+def test_down_block_2d_256x256_ttnn(input_shape, temb_shape, device, model_name, reset_seeds):
+    pipe = StableDiffusionPipeline.from_pretrained(model_name, torch_dtype=torch.float32)
+    unet = pipe.unet
+    unet.eval()
+    unet_downblock = pipe.unet.down_blocks[3]
+    unet_resnet_downblock_module_list = unet_downblock.resnets
+
+    _, in_channels, _, _ = input_shape
+    _, _, _, temb_channels = temb_shape
+
+    torch_hidden_states = torch.randn(input_shape, dtype=torch.float32)
+    temb = torch.randn(temb_shape, dtype=torch.float32)
+
+    torch_output, torch_output_states = unet_downblock(torch_hidden_states, temb.squeeze(0).squeeze(0))
+
+    ttnn_hidden_states = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(torch_hidden_states, dtype=ttnn.bfloat16), device),
+        layout=ttnn.TILE_LAYOUT,
+    )
+    ttnn_temb = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(temb, dtype=ttnn.bfloat16), device),
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: unet,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    parameters = parameters.down_blocks[3]
+
+    ttnn_down_block = downblock2d(
+        temb=ttnn_temb,
+        hidden_states=ttnn_hidden_states,
+        device=device,
+        in_channels=in_channels,
+        out_channels=in_channels,
+        temb_channels=temb_channels,
+        dropout=0.0,
+        num_layers=2,
+        resnet_eps=1e-05,
+        resnet_time_scale_shift="default",
+        resnet_act_fn="silu",
+        resnet_groups=32,
+        resnet_pre_norm=True,
+        output_scale_factor=1.0,
+        add_downsample=False,
+        downsample_padding=1,
+        parameters=parameters,
+    )
+
+    ttnn_out, ttnn_output_states = ttnn_down_block
+    ttnn_output = ttnn.to_layout(ttnn_out, ttnn.ROW_MAJOR_LAYOUT)
+    ttnn_output = ttnn.from_device(ttnn_output)
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output_torch, 0.99)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (2, 1280, 8, 8),
+    ],
+)
+@pytest.mark.parametrize(
+    "temb_shape",
+    [
+        (1, 1, 2, 1280),
+    ],
+)
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize("model_name", ["CompVis/stable-diffusion-v1-4"])
+def test_down_block_2d_512x512(input_shape, temb_shape, device, model_name, reset_seeds):
+    pipe = StableDiffusionPipeline.from_pretrained(model_name, torch_dtype=torch.float32)
+    unet = pipe.unet
+    unet.eval()
+    unet_downblock = pipe.unet.down_blocks[3]
+    unet_resnet_downblock_module_list = unet_downblock.resnets
+
+    _, in_channels, _, _ = input_shape
+    _, _, _, temb_channels = temb_shape
+
+    torch_hidden_states = torch.randn(input_shape, dtype=torch.float32)
+    temb = torch.randn(temb_shape, dtype=torch.float32)
+
+    torch_output, torch_output_states = unet_downblock(torch_hidden_states, temb.squeeze(0).squeeze(0))
+
+    ttnn_hidden_states = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(torch_hidden_states, dtype=ttnn.bfloat16), device),
+        layout=ttnn.TILE_LAYOUT,
+    )
+    ttnn_temb = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(temb, dtype=ttnn.bfloat16), device),
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: unet,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    parameters = parameters.down_blocks[3]
+
+    ttnn_down_block = downblock2d(
+        temb=ttnn_temb,
+        hidden_states=ttnn_hidden_states,
+        device=device,
+        in_channels=in_channels,
+        out_channels=in_channels,
+        temb_channels=temb_channels,
+        dropout=0.0,
+        num_layers=2,
+        resnet_eps=1e-05,
+        resnet_time_scale_shift="default",
+        resnet_act_fn="silu",
+        resnet_groups=32,
+        resnet_pre_norm=True,
+        output_scale_factor=1.0,
+        add_downsample=False,
+        downsample_padding=1,
+        parameters=parameters,
+    )
+
+    ttnn_out, ttnn_output_states = ttnn_down_block
+    ttnn_output = ttnn.to_layout(ttnn_out, ttnn.ROW_MAJOR_LAYOUT)
+    ttnn_output = ttnn.from_device(ttnn_output)
+    ttnn_output_torch = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output_torch, 0.99)


### PR DESCRIPTION
This PR contains the DownBlock2D sub-module implemented using ttnn for the Stable diffusion model with fallback ops for conv.