### PR TITLE
#5027: Optimize group attn matmul for Falcon40B decode

### DIFF
--- a/models/demos/falcon7b/tt/falcon_attention.py
+++ b/models/demos/falcon7b/tt/falcon_attention.py
@@ -290,7 +290,7 @@ class TtFalconAttention(nn.Module):
             )
 
         elif llm_mode == "decode":
-            attn_weights = tt_lib.operations.primary.transformers.attn_matmul(
+            attn_weights = tt_lib.operations.primary.transformers.group_attn_matmul(
                 query_layer,
                 key_layer_transposed,
                 compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
@@ -353,7 +353,7 @@ class TtFalconAttention(nn.Module):
             )
 
         elif llm_mode == "decode":
-            attn_output = tt_lib.operations.primary.transformers.attn_matmul(
+            attn_output = tt_lib.operations.primary.transformers.group_attn_matmul(
                 attn_weights,
                 value_layer,
                 compute_with_storage_grid_size=device.compute_with_storage_grid_size(),

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
@@ -13,20 +13,29 @@ void kernel_main() {
     uint32_t has_work_for_q_heads = get_arg_val<uint32_t>(i++);
     const bool has_work_for_q_heads_bool = has_work_for_q_heads == 1;
 
-    uint32_t src0_addr            = get_arg_val<uint32_t>(i++);
-    uint32_t src1_addr            = get_arg_val<uint32_t>(i++);
-    uint32_t Mt                   = get_arg_val<uint32_t>(i++);
-    uint32_t Kt                   = get_arg_val<uint32_t>(i++);
-    uint32_t Nt                   = get_arg_val<uint32_t>(i++);
-    uint32_t MtKt                 = get_arg_val<uint32_t>(i++);
-    uint32_t num_kv_heads         = get_arg_val<uint32_t>(i++); // in1[1] (ie. in1 C)
-    uint32_t in1_KtNt             = get_arg_val<uint32_t>(i++);
-    uint32_t in1_CKtNt_skip       = get_arg_val<uint32_t>(i++); // 0 if in0 and in1 Kt are the same
-    uint32_t in1_CKtNt_mul_32     = get_arg_val<uint32_t>(i++);
-    uint32_t blocks               = get_arg_val<uint32_t>(i++);
-    uint32_t in0_start_id         = get_arg_val<uint32_t>(i++);
-    uint32_t in1_start_id         = get_arg_val<uint32_t>(i++);
-    uint32_t kv_heads_addr_offset = get_arg_val<uint32_t>(i++);
+    uint32_t src1_addr                        = get_arg_val<uint32_t>(i++);
+    uint32_t Mt                               = get_arg_val<uint32_t>(i++);
+    uint32_t Nt                               = get_arg_val<uint32_t>(i++);
+    uint32_t num_kv_heads                     = get_arg_val<uint32_t>(i++); // in1[1] (ie. in1 C)
+    uint32_t in1_CKtNt                        = get_arg_val<uint32_t>(i++);
+    uint32_t in1_CKtNt_mul_32                 = get_arg_val<uint32_t>(i++);
+    uint32_t blocks                           = get_arg_val<uint32_t>(i++);
+    uint32_t in1_start_id                     = get_arg_val<uint32_t>(i++);
+
+    // matmul params
+    uint32_t in0_block_w                      = get_arg_val<uint32_t>(i++);
+    uint32_t out_subblock_w                   = get_arg_val<uint32_t>(i++);
+    uint32_t out_block_w                      = get_arg_val<uint32_t>(i++);
+    uint32_t in1_num_subblocks                = get_arg_val<uint32_t>(i++);
+    uint32_t in1_num_blocks                   = get_arg_val<uint32_t>(i++);
+    uint32_t in1_block_num_tiles              = get_arg_val<uint32_t>(i++);
+
+    // constants
+    uint32_t Nt_bytes                         = get_arg_val<uint32_t>(i++);
+    uint32_t in1_block_w_tile_bytes           = get_arg_val<uint32_t>(i++);
+    uint32_t out_last_subblock_w              = get_arg_val<uint32_t>(i++);
+    uint32_t in1_last_block_w_tile_read_bytes = get_arg_val<uint32_t>(i++);
+    uint32_t in1_last_block_addr_skip         = get_arg_val<uint32_t>(i++);
 
     uint32_t in1_mcast_dest_noc_start_x                  = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_dest_noc_start_y                  = get_arg_val<uint32_t>(i++);
@@ -46,22 +55,17 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t *in1_mcast_sender_noc_y  = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(i)); i+=in1_mcast_sender_num_y;
 
 
-    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
     #define transpose_hw_bool get_compile_time_arg_val(2) == 1
     constexpr bool row_major = (bool) get_compile_time_arg_val(3);
 
 
-    constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1; // mcast receive all kv_heads; compute chooses which kv_heads to use for matmul
     constexpr uint32_t cb_id_in2 = 2; // all interleaved or sharded KV heads for one user batch
-    constexpr uint32_t cb_id_intermed0 = 24;
-    constexpr uint32_t cb_id_intermed1 = 25;
-    constexpr uint32_t cb_id_intermed2 = 26;
 
-    constexpr uint32_t onetile = 1;
     constexpr uint32_t num_rows_in_one_tile = 32;
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
+    constexpr uint32_t in0_num_blocks_w = 1; // TODO: Must be 1; generalize to support inner dim blocking
 
     #ifndef IN1_SHARDED
     const DataFormat in1_data_format = get_dataformat(cb_id_in1);
@@ -114,122 +118,147 @@ void kernel_main() {
     uint64_t in1_mcast_receiver_semaphore_noc_addr = in1_multicast_noc_addr | in1_mcast_receiver_semaphore_addr;
 
 
-    // Only used for interleaved
-    uint32_t in1_batch;
-    uint32_t in1_Nt;
-    uint32_t in1_tensor_id;
-
+    #ifdef IN1_SHARDED
     // Only used for sharded
     // Don't need to track batch because user batch must be 32 (ie. Mt must be 1)
     uint64_t in1_sharded_cb_noc_addr_Nt = get_noc_addr(get_read_ptr(cb_id_in2));
     uint64_t in1_sharded_cb_noc_addr;
-    uint32_t Nt_bytes = Nt * in1_tile_bytes;
-    uint32_t in1_KtNt_bytes = in1_KtNt * in1_tile_bytes;
-    uint32_t in1_CKtNt_skip_bytes = in1_CKtNt_skip * in1_tile_bytes;
-    for (uint32_t b = 0; b < blocks; b++) {
+    uint32_t in1_block_w_tile_read_bytes = in1_block_w_tile_bytes;
+    #else
+    // Only used for interleaved
+    uint32_t in1_batch;
+    uint32_t in1_tensor_id_along_Nt;
+    uint32_t in1_tensor_id;
+    uint32_t in1_block_addr_skip = 0; // Skip padded subblocks to prevent reading from undefined memory
+    uint32_t out_subblock_w_ = out_subblock_w;
+    #endif
+
+    for (uint32_t b = 0; b < blocks; b++) { // TODO: Must be 1
+        #ifndef IN1_SHARDED
         in1_batch = in1_start_id;
+        #endif
 
-        for (uint32_t m = 0; m < Mt; m++) {
-            in1_Nt = in1_batch;
+        for (uint32_t m = 0; m < Mt; m++) { // TODO: Must be 1; generalize to support batch > 32 (ie. Mt > 1)
+            #ifndef IN1_SHARDED
+            in1_tensor_id_along_Nt = in1_batch;
+            #endif
+            for (uint32_t in1_block = 0; in1_block < in1_num_blocks; in1_block++) {
+                const bool last_out = in1_block == in1_num_blocks - 1;
+                if (last_out) {
+                    #ifdef IN1_SHARDED
+                    in1_block_w_tile_read_bytes = in1_last_block_w_tile_read_bytes;
+                    #else
+                    out_subblock_w_ = out_last_subblock_w;
+                    in1_block_addr_skip = in1_last_block_addr_skip;
+                    #endif
+                }
 
-            for (uint32_t n = 0; n < Nt; n++) {
-                in1_tensor_id = in1_Nt;
-                in1_sharded_cb_noc_addr = in1_sharded_cb_noc_addr_Nt;
-
+                #ifndef IN1_SHARDED
+                uint32_t in1_tensor_id = in1_tensor_id_along_Nt; // Tracks id along Kt, kv_heads, and batch
+                #endif
                 for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
-                    for (uint32_t kt = 0; kt < Kt; kt++) {
-                        cb_reserve_back(cb_id_in1, num_kv_heads);
-                        uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in1);
+                    for (uint32_t in0_block = 0; in0_block < in0_num_blocks_w; in0_block++) { // TODO: Must be 1; generalize to support inner dim blocking
+                        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+                        uint32_t l1_write_addr_in1 = get_write_ptr(cb_id_in1);
 
-                        // Read in1 tile at (kt, nt)
-                        if (tile_row_id == in1_mcast_sender_id) {
-                            // MCAST SENDER: send all kv_heads in one user batch
-                            #ifdef IN1_SHARDED
-                            // Copy to cb_id_in1 to mcast
-                            uint64_t in1_sharded_cb_current_noc_addr = in1_sharded_cb_noc_addr;
-                            uint32_t in2_current_l1_write_addr = l1_write_addr_in2;
-                            for (uint32_t kv_heads_id = 0; kv_heads_id < num_kv_heads; kv_heads_id++) {
-                                noc_async_read(in1_sharded_cb_current_noc_addr, in2_current_l1_write_addr, in1_tile_bytes);
-                                in1_sharded_cb_current_noc_addr += in1_KtNt_bytes; // Increment by Nt to get to next kv_heads
-                                in2_current_l1_write_addr += in1_tile_bytes;
-                            }
-                            // These indices are local to each core, so don't modify when looping num_rows_in_one_tile
-                            in1_sharded_cb_noc_addr += Nt_bytes; // Kt is in in1[2], so stride is Nt
-                            noc_async_read_barrier();
-                            #else
-                            uint32_t in1_tensor_current_id = in1_tensor_id;
-                            uint32_t in2_current_l1_write_addr = l1_write_addr_in2;
-                            for (uint32_t kv_heads_id = 0; kv_heads_id < num_kv_heads; kv_heads_id++) {
-                                noc_async_read_tile(in1_tensor_current_id, s1, in2_current_l1_write_addr);
+                        for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) { // TODO: Must be 1; for generic padding, need full + partial subblocks
+                            // Read in1 block
+                            if (tile_row_id == in1_mcast_sender_id) {
+                                // MCAST SENDER: send all kv_heads in one user batch
+                                #ifdef IN1_SHARDED
+                                // TODO: Try to optimize away the local copy and self-mcast instead for sharded; some things to try:
+                                // - block sharding so each core gets correct block along out width
+                                // - for post-attn, Nt is head_dim (eg. 2 tiles), so we can always just fully self-mcast
+                                // - overlap copy with mcasting to hide away the local copy time (maybe offload some work to writer)
 
-                                in1_tensor_current_id += in1_KtNt; // Increment by KtNt to get to next kv_heads
-                                in2_current_l1_write_addr += in1_tile_bytes;
+                                // Copy to cb_id_in1 to mcast
+                                uint64_t in1_sharded_cb_noc_addr = in1_sharded_cb_noc_addr_Nt;
+                                uint32_t in1_current_l1_write_addr = l1_write_addr_in1;
+                                for (uint32_t kv_heads_id = 0; kv_heads_id < num_kv_heads; kv_heads_id++) {
+                                    for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
+                                        noc_async_read(in1_sharded_cb_noc_addr, in1_current_l1_write_addr, in1_block_w_tile_read_bytes);
+                                        in1_sharded_cb_noc_addr += Nt_bytes; // Increment by Nt to get to next kt
+                                        in1_current_l1_write_addr += in1_block_w_tile_bytes;
+                                    }
+                                    // Next head follows after finishing KtNt, so no need to increment in1_current_l1_write_addr
+                                }
+                                // These indices are local to each core, so don't modify when looping num_rows_in_one_tile
+                                #else
+                                uint32_t in1_tensor_id_along_Kt = in1_tensor_id;
+                                uint32_t in1_current_l1_write_addr = l1_write_addr_in1;
+                                for (uint32_t kv_heads_id = 0; kv_heads_id < num_kv_heads; kv_heads_id++) {
+                                    for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
+                                        uint32_t in1_tensor_current_id = in1_tensor_id_along_Kt;
+                                        for (uint32_t w = 0; w < out_subblock_w_; w++) {
+                                            noc_async_read_tile(in1_tensor_current_id, s1, in1_current_l1_write_addr);
+                                            in1_tensor_current_id++; // Increment to get next Nt
+                                            in1_current_l1_write_addr += in1_tile_bytes;
+                                        }
+                                        in1_current_l1_write_addr += in1_block_addr_skip;
+                                        in1_tensor_id_along_Kt += Nt; // Increment by Nt to get next Kt
+                                    }
+                                    // Next head follows after finishing KtNt, so no need to increment
+                                }
+                                #endif
+                                noc_async_read_barrier();
+
+                                // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr (i.e. its value should be in1_mcast_num_dests), then reset
+                                // the semaphore_addr value back to zero for the next block
+                                noc_semaphore_wait(in1_mcast_sender_semaphore_addr_ptr, in1_mcast_num_dests);
+                                noc_semaphore_set(in1_mcast_sender_semaphore_addr_ptr, 0);
+
+                                // Now we have the block in the CB address, we can mcast to dests!
+                                // num_dests will source, since we are copying to a different local CB as well
+                                uint64_t in1_multicast_data_addr = in1_multicast_noc_addr | l1_write_addr_in1;
+                                noc_async_write_multicast(l1_write_addr_in1, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores);
+
+                                // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
+                                // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
+
+                                // We should also multicast VALID flag to destinations for receiver semaphore
+                                noc_semaphore_set_multicast(in1_mcast_receiver_semaphore_addr, in1_mcast_receiver_semaphore_noc_addr, in1_mcast_num_cores);
+
+                                // Write barrier needed to make sure we finish sending mcast flag before we modify locally
+                                noc_async_write_barrier();
+                            } else if (in1_mcast_sender_id < in1_mcast_grid_size) {
+                                // MCAST RECEIVER: receive all kv_heads in one user batch
+                                // All cores in mcast grid needs to participate in receiving otherwise data corruption since we mcast from and to the same CB
+
+                                // Set in1 semaphore value to INVALID
+                                noc_semaphore_set(in1_mcast_receiver_semaphore_addr_ptr, INVALID);
+
+                                // Atomic increment source core counter
+                                uint64_t in1_mcast_sender_semaphore_noc_addr = in1_mcast_sender_semaphore_noc_addr_vec[tile_row_id];
+                                noc_semaphore_inc(in1_mcast_sender_semaphore_noc_addr, 1);
+
+                                // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
+                                noc_semaphore_wait(in1_mcast_receiver_semaphore_addr_ptr, VALID);
                             }
-                            noc_async_read_barrier();
+                            if (has_work_for_q_heads_bool) {
+                                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                            } else {
+                                // Mcast is in lockstep; this makes write ptr addresses are synced properly for cores that only send and have no compute / writer active
+                                cb_push_back(cb_id_in1, in1_block_num_tiles);
+                                cb_pop_front(cb_id_in1, in1_block_num_tiles);
+                            }
+
+                            #ifndef IN1_SHARDED
+                            in1_tensor_id += in1_CKtNt;
                             #endif
-
-                            // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr (i.e. its value should be in1_mcast_num_dests), then reset
-                            // the semaphore_addr value back to zero for the next block
-                            noc_semaphore_wait(in1_mcast_sender_semaphore_addr_ptr, in1_mcast_num_dests);
-                            noc_semaphore_set(in1_mcast_sender_semaphore_addr_ptr, 0);
-
-                            // Now we have the block in the CB address, we can mcast to dests!
-                            // num_dests will source, since we are copying to a different local CB as well
-                            uint64_t in1_multicast_data_addr = in1_multicast_noc_addr | l1_write_addr_in2;
-                            noc_async_write_multicast(l1_write_addr_in2, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores);
-
-                            // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
-                            // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
-
-                            // We should also multicast VALID flag to destinations for receiver semaphore
-                            noc_semaphore_set_multicast(in1_mcast_receiver_semaphore_addr, in1_mcast_receiver_semaphore_noc_addr, in1_mcast_num_cores);
-
-                            // Write barrier needed to make sure we finish sending mcast flag before we modify locally
-                            noc_async_write_barrier();
-                        } else if (in1_mcast_sender_id < in1_mcast_grid_size) {
-                            // MCAST RECEIVER: receive all kv_heads in one user batch
-                            // All cores in mcast grid needs to participate in receiving otherwise data corruption since we mcast from and to the same CB
-
-                            // Set in1 semaphore value to INVALID
-                            noc_semaphore_set(in1_mcast_receiver_semaphore_addr_ptr, INVALID);
-
-                            // Atomic increment source core counter
-                            uint64_t in1_mcast_sender_semaphore_noc_addr = in1_mcast_sender_semaphore_noc_addr_vec[tile_row_id];
-                            noc_semaphore_inc(in1_mcast_sender_semaphore_noc_addr, 1);
-
-                            // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
-                            noc_semaphore_wait(in1_mcast_receiver_semaphore_addr_ptr, VALID);
-                        }
-                        if (has_work_for_q_heads_bool) {
-                            cb_push_back(cb_id_in1, num_kv_heads);
-                        } else {
-                            // Mcast is in lockstep; this makes write ptr addresses are synced properly for cores that only send and have no compute / writer active
-                            cb_push_back(cb_id_in1, num_kv_heads);
-                            cb_pop_front(cb_id_in1, num_kv_heads);
-                        }
-
-                        #if (transpose_hw_bool)
-                        in1_tensor_id++; // Kt is in in1[3], so it is contiguous in memory
-                        #else
-                        in1_tensor_id += Nt; // Kt is in in1[2], so stride is Nt
-                        #endif
-                    } // Kt loop
-
-                    in1_tensor_id += in1_CKtNt_skip; // different depending on transpose_hw
+                        } // in1_num_subblocks loop
+                    } // in0_num_blocks_w loop
                 } // 32 tiles loop
 
-                // Next tile in Nt
-                #if (transpose_hw_bool)
-                in1_Nt += Kt; // next tile in Nt is in in1[2], so stride is Kt
+                #ifdef IN1_SHARDED
+                in1_sharded_cb_noc_addr_Nt += in1_block_w_tile_bytes;
                 #else
-                in1_Nt++;
+                in1_tensor_id_along_Nt += out_block_w;
                 #endif
-
-                in1_sharded_cb_noc_addr_Nt += in1_tile_bytes;
-            } // Nt loop
-
-            // here, KtNt is the stride of the full in1 tensor (ie. max cache length is incorporated in one of Kt or Nt depending on transpose_hw)
-            in1_batch += in1_CKtNt_mul_32; // different depending on transpose_hw
+            } // in1_num_blocks loop
         } // Mt loop
+
+        #ifndef IN1_SHARDED
+        in1_batch += in1_CKtNt_mul_32; // different depending on transpose_hw
+        #endif
     } // B loop
 }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
@@ -8,8 +8,10 @@
 void kernel_main() {
     uint32_t i = 0;
 
-    uint32_t has_work = get_arg_val<uint32_t>(i++);
-    const bool has_work_bool = has_work == 1;
+    uint32_t has_work_for_mcast_kv_heads = get_arg_val<uint32_t>(i++);
+    if (has_work_for_mcast_kv_heads == 0) return;
+    uint32_t has_work_for_q_heads = get_arg_val<uint32_t>(i++);
+    const bool has_work_for_q_heads_bool = has_work_for_q_heads == 1;
 
     uint32_t src0_addr            = get_arg_val<uint32_t>(i++);
     uint32_t src1_addr            = get_arg_val<uint32_t>(i++);
@@ -32,6 +34,7 @@ void kernel_main() {
     uint32_t in1_mcast_dest_noc_end_y                    = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_num_dests                         = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_num_cores                         = get_arg_val<uint32_t>(i++);
+    uint32_t in1_mcast_grid_size                         = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_sender_semaphore_addr             = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_receiver_semaphore_addr           = get_arg_val<uint32_t>(i++);
 
@@ -48,10 +51,10 @@ void kernel_main() {
     #define transpose_hw_bool get_compile_time_arg_val(2) == 1
     constexpr bool row_major = (bool) get_compile_time_arg_val(3);
 
+
     constexpr uint32_t cb_id_in0 = 0;
-    constexpr uint32_t cb_id_in1 = 1; // copy single KV heads for Q heads
-    constexpr uint32_t cb_id_in2 = 2; // mcast receiver
-    constexpr uint32_t cb_id_in3 = 3; // all interleaved or sharded KV heads for one user batch
+    constexpr uint32_t cb_id_in1 = 1; // mcast receive all kv_heads; compute chooses which kv_heads to use for matmul
+    constexpr uint32_t cb_id_in2 = 2; // all interleaved or sharded KV heads for one user batch
     constexpr uint32_t cb_id_intermed0 = 24;
     constexpr uint32_t cb_id_intermed1 = 25;
     constexpr uint32_t cb_id_intermed2 = 26;
@@ -59,21 +62,6 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t num_rows_in_one_tile = 32;
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
-
-    #ifdef IN0_SHARDED
-    if (has_work_bool) {
-        cb_reserve_back(cb_id_in0, blocks * MtKt);
-        cb_push_back(cb_id_in0, blocks * MtKt);
-    }
-    #else
-    const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat in0_data_format = get_dataformat(cb_id_in0);
-    const InterleavedAddrGenFast<src0_is_dram> s0 = {
-        .bank_base_address = src0_addr,
-        .page_size = in0_tile_bytes,
-        .data_format = in0_data_format
-    };
-    #endif
 
     #ifndef IN1_SHARDED
     const DataFormat in1_data_format = get_dataformat(cb_id_in1);
@@ -126,73 +114,38 @@ void kernel_main() {
     uint64_t in1_mcast_receiver_semaphore_noc_addr = in1_multicast_noc_addr | in1_mcast_receiver_semaphore_addr;
 
 
-    // CB write ptr; no pop/push for cb 2 and 3 so write/read ptr's never change
-    uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in2);
-    uint32_t l1_write_addr_in3 = get_write_ptr(cb_id_in3);
-    uint64_t in1_multicast_data_addr = in1_multicast_noc_addr | l1_write_addr_in2;
-    uint64_t noc_l1_read_addr_for_kv_heads = get_noc_addr(l1_write_addr_in2 + kv_heads_addr_offset);
-
-    // TODO: Clean this up; don't think this will work if we double buffer intermed 1/2
-    uint32_t cb_intermed1_addr_initial = get_read_ptr(cb_id_intermed1);
-    uint32_t cb_intermed2_addr_initial = get_write_ptr(cb_id_intermed2);
-    uint32_t cb_intermed1_addr;
-    uint32_t cb_intermed2_addr;
-    constexpr uint32_t bfloat16_row_bytes = 64;
-
     // Only used for interleaved
-    uint32_t in0_batch = in0_start_id;
     uint32_t in1_batch;
-    uint32_t in0_Mt;
     uint32_t in1_Nt;
-    uint32_t in0_tensor_id;
     uint32_t in1_tensor_id;
 
     // Only used for sharded
     // Don't need to track batch because user batch must be 32 (ie. Mt must be 1)
-    uint64_t in1_sharded_cb_noc_addr_Nt = get_noc_addr(l1_write_addr_in3);  // Read/write ptr should be the same
+    uint64_t in1_sharded_cb_noc_addr_Nt = get_noc_addr(get_read_ptr(cb_id_in2));
     uint64_t in1_sharded_cb_noc_addr;
     uint32_t Nt_bytes = Nt * in1_tile_bytes;
     uint32_t in1_KtNt_bytes = in1_KtNt * in1_tile_bytes;
     uint32_t in1_CKtNt_skip_bytes = in1_CKtNt_skip * in1_tile_bytes;
     for (uint32_t b = 0; b < blocks; b++) {
-        in0_Mt = in0_batch;
         in1_batch = in1_start_id;
 
         for (uint32_t m = 0; m < Mt; m++) {
             in1_Nt = in1_batch;
 
-            #ifndef IN0_SHARDED
-            if (has_work_bool) {
-                in0_tensor_id = in0_Mt;
-                cb_reserve_back(cb_id_in0, Kt);
-                for (uint32_t kt = 0; kt < Kt; kt++) {
-                    // Read in0 tile at (mt, kt)
-                    uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                    noc_async_read_tile(in0_tensor_id, s0, l1_write_addr_in0);
-                    noc_async_read_barrier();
-                    cb_push_back(cb_id_in0, onetile);
-
-                    in0_tensor_id++; // in0 is MK
-                }
-            }
-            #endif
-
             for (uint32_t n = 0; n < Nt; n++) {
-                cb_intermed1_addr = cb_intermed1_addr_initial;
-                cb_intermed2_addr = cb_intermed2_addr_initial;
                 in1_tensor_id = in1_Nt;
                 in1_sharded_cb_noc_addr = in1_sharded_cb_noc_addr_Nt;
 
-                if (has_work_bool) {
-                    cb_reserve_back(cb_id_intermed2, 1);
-                }
                 for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
                     for (uint32_t kt = 0; kt < Kt; kt++) {
+                        cb_reserve_back(cb_id_in1, num_kv_heads);
+                        uint32_t l1_write_addr_in2 = get_write_ptr(cb_id_in1);
+
                         // Read in1 tile at (kt, nt)
                         if (tile_row_id == in1_mcast_sender_id) {
                             // MCAST SENDER: send all kv_heads in one user batch
                             #ifdef IN1_SHARDED
-                            // Copy to cb_id_in2 to mcast
+                            // Copy to cb_id_in1 to mcast
                             uint64_t in1_sharded_cb_current_noc_addr = in1_sharded_cb_noc_addr;
                             uint32_t in2_current_l1_write_addr = l1_write_addr_in2;
                             for (uint32_t kv_heads_id = 0; kv_heads_id < num_kv_heads; kv_heads_id++) {
@@ -222,7 +175,8 @@ void kernel_main() {
 
                             // Now we have the block in the CB address, we can mcast to dests!
                             // num_dests will source, since we are copying to a different local CB as well
-                            noc_async_write_multicast_loopback_src(l1_write_addr_in2, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores + 1);
+                            uint64_t in1_multicast_data_addr = in1_multicast_noc_addr | l1_write_addr_in2;
+                            noc_async_write_multicast(l1_write_addr_in2, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores);
 
                             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                             // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
@@ -230,10 +184,12 @@ void kernel_main() {
                             // We should also multicast VALID flag to destinations for receiver semaphore
                             noc_semaphore_set_multicast(in1_mcast_receiver_semaphore_addr, in1_mcast_receiver_semaphore_noc_addr, in1_mcast_num_cores);
 
-                            // Write barrier needed since we mcast to self, and also needed to finish sending mcast flag before we modify locally
+                            // Write barrier needed to make sure we finish sending mcast flag before we modify locally
                             noc_async_write_barrier();
-                        } else {
+                        } else if (in1_mcast_sender_id < in1_mcast_grid_size) {
                             // MCAST RECEIVER: receive all kv_heads in one user batch
+                            // All cores in mcast grid needs to participate in receiving otherwise data corruption since we mcast from and to the same CB
+
                             // Set in1 semaphore value to INVALID
                             noc_semaphore_set(in1_mcast_receiver_semaphore_addr_ptr, INVALID);
 
@@ -244,12 +200,12 @@ void kernel_main() {
                             // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
                             noc_semaphore_wait(in1_mcast_receiver_semaphore_addr_ptr, VALID);
                         }
-                        if (has_work_bool) {
-                            // Choose matching kv_heads for q_heads
-                            cb_reserve_back(cb_id_in1, onetile);
-                            noc_async_read(noc_l1_read_addr_for_kv_heads, get_write_ptr(cb_id_in1), in1_tile_bytes);
-                            noc_async_read_barrier();
-                            cb_push_back(cb_id_in1, onetile);
+                        if (has_work_for_q_heads_bool) {
+                            cb_push_back(cb_id_in1, num_kv_heads);
+                        } else {
+                            // Mcast is in lockstep; this makes write ptr addresses are synced properly for cores that only send and have no compute / writer active
+                            cb_push_back(cb_id_in1, num_kv_heads);
+                            cb_pop_front(cb_id_in1, num_kv_heads);
                         }
 
                         #if (transpose_hw_bool)
@@ -259,22 +215,8 @@ void kernel_main() {
                         #endif
                     } // Kt loop
 
-                    if (has_work_bool) {
-                        // Read 32 untilized tiles and select correct rows to reconstruct single correct tile
-                        cb_wait_front(cb_id_intermed1, 1);
-                        noc_async_read(get_noc_addr(cb_intermed1_addr), cb_intermed2_addr, bfloat16_row_bytes);
-                        noc_async_read_barrier();
-                        cb_pop_front(cb_id_intermed1, 1);
-                        cb_intermed1_addr += bfloat16_row_bytes;
-                        cb_intermed2_addr += bfloat16_row_bytes;
-                    }
-
                     in1_tensor_id += in1_CKtNt_skip; // different depending on transpose_hw
                 } // 32 tiles loop
-
-                if (has_work_bool) {
-                    cb_push_back(cb_id_intermed2, 1);
-                }
 
                 // Next tile in Nt
                 #if (transpose_hw_bool)
@@ -286,10 +228,8 @@ void kernel_main() {
                 in1_sharded_cb_noc_addr_Nt += in1_tile_bytes;
             } // Nt loop
 
-            in0_Mt += Kt;
             // here, KtNt is the stride of the full in1 tensor (ie. max cache length is incorporated in one of Kt or Nt depending on transpose_hw)
             in1_batch += in1_CKtNt_mul_32; // different depending on transpose_hw
         } // Mt loop
-        in0_batch += MtKt;
     } // B loop
 }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_transformer_group_attn_matmul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_transformer_group_attn_matmul.cpp
@@ -15,14 +15,27 @@ void kernel_main() {
     uint32_t Mt                   = get_arg_val<uint32_t>(i++);
     uint32_t Kt                   = get_arg_val<uint32_t>(i++);
     uint32_t Nt                   = get_arg_val<uint32_t>(i++);
-    uint32_t MtKt                 = get_arg_val<uint32_t>(i++);
     uint32_t num_kv_heads         = get_arg_val<uint32_t>(i++); // in1[1] (ie. in1 C)
-
+    uint32_t MtKt                 = get_arg_val<uint32_t>(i++);
     uint32_t blocks               = get_arg_val<uint32_t>(i++);
-    uint32_t out_num_tiles        = get_arg_val<uint32_t>(i++);
     uint32_t in0_start_id         = get_arg_val<uint32_t>(i++);
     uint32_t out_start_id         = get_arg_val<uint32_t>(i++);
-    uint32_t kv_heads_addr_offset = get_arg_val<uint32_t>(i++);
+
+    // matmul params
+    uint32_t in0_block_w                  = get_arg_val<uint32_t>(i++);
+    uint32_t out_subblock_w               = get_arg_val<uint32_t>(i++);
+    uint32_t out_block_w                  = get_arg_val<uint32_t>(i++);
+    uint32_t in1_num_subblocks            = get_arg_val<uint32_t>(i++);
+    uint32_t in1_num_blocks               = get_arg_val<uint32_t>(i++);
+    uint32_t in0_block_num_tiles          = get_arg_val<uint32_t>(i++);
+    uint32_t intermediate_num_tiles       = get_arg_val<uint32_t>(i++);
+    uint32_t out_num_tiles                = get_arg_val<uint32_t>(i++);
+
+    // constants
+    uint32_t bfloat16_row_bytes           = get_arg_val<uint32_t>(i++);
+    uint32_t bfloat16_Nt_bytes            = get_arg_val<uint32_t>(i++);
+    uint32_t out_last_subblock_w          = get_arg_val<uint32_t>(i++);
+    uint32_t bfloat16_last_row_bytes_read = get_arg_val<uint32_t>(i++);
 
 
     constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
@@ -37,13 +50,9 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t num_rows_in_one_tile = 32;
-    constexpr uint32_t bfloat16_row_bytes = 64;
     const uint32_t in1_tile_bytes = get_tile_size(cb_id_in1);
 
-    #ifdef IN0_SHARDED
-    cb_reserve_back(cb_id_in0, blocks * MtKt);
-    cb_push_back(cb_id_in0, blocks * MtKt);
-    #else
+    #ifndef IN0_SHARDED
     const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat in0_data_format = get_dataformat(cb_id_in0);
     const InterleavedAddrGenFast<src0_is_dram> s0 = {
@@ -63,59 +72,88 @@ void kernel_main() {
     };
     #endif
 
+
+    #ifndef IN0_SHARDED
     // Only used for interleaved
     uint32_t in0_batch = in0_start_id;
     uint32_t in0_Mt;
     uint32_t in0_tensor_id;
+    #endif
+
+    #ifndef OUT_SHARDED
     uint32_t out_tensor_id = out_start_id;
+    #endif
 
-    for (uint32_t b = 0; b < blocks; b++) {
+    uint32_t bfloat16_row_bytes_read = bfloat16_row_bytes;
+
+    for (uint32_t b = 0; b < blocks; b++) { // TODO: Must be 1
+        #ifndef IN0_SHARDED
         in0_Mt = in0_batch;
+        #endif
 
-        for (uint32_t m = 0; m < Mt; m++) {
+        for (uint32_t m = 0; m < Mt; m++) { // TODO: Must be 1; generalize to support batch > 32 (ie. Mt > 1)
+            // TODO: Generalize to support inner dim blocking; in0 reads has to moved within num_rows_in_one_tile loop
+            cb_reserve_back(cb_id_in0, in0_block_w);
             #ifndef IN0_SHARDED
             in0_tensor_id = in0_Mt;
-            cb_reserve_back(cb_id_in0, Kt);
-            for (uint32_t kt = 0; kt < Kt; kt++) {
-                // Read in0 tile at (mt, kt)
-                uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            for (uint32_t inner_dim = 0; inner_dim < in0_block_w; inner_dim++) {
+                // Read in0 block
                 noc_async_read_tile(in0_tensor_id, s0, l1_write_addr_in0);
-                noc_async_read_barrier();
-                cb_push_back(cb_id_in0, onetile);
 
-                in0_tensor_id++; // in0 is MK
+                l1_write_addr_in0 += in0_tile_bytes;
+                in0_tensor_id++;
             }
+            noc_async_read_barrier();
             #endif
+            cb_push_back(cb_id_in0, in0_block_w);
 
-            for (uint32_t n = 0; n < Nt; n++) {
-                cb_reserve_back(cb_id_intermed2, 1);
-                uint32_t cb_intermed2_addr = get_write_ptr(cb_id_intermed2);
+            cb_reserve_back(cb_id_intermed2, out_num_tiles);
+            uint32_t cb_intermed2_addr = get_write_ptr(cb_id_intermed2);
+            for (uint32_t in1_block = 0; in1_block < in1_num_blocks; in1_block++) {
+                const bool last_out = in1_block == in1_num_blocks - 1;
+                if (last_out) {
+                    bfloat16_row_bytes_read = bfloat16_last_row_bytes_read; // For padded subblocks, read partial untilized subblocks
+                }
 
                 uint32_t row_offset_bytes = 0;
+                uint32_t cb_intermed2_addr_curr_block = cb_intermed2_addr;
                 for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
-                    // Read 32 untilized tiles and select correct rows to reconstruct single correct tile
-                    cb_wait_front(cb_id_intermed1, 1);
-                    noc_async_read(get_noc_addr(get_read_ptr(cb_id_intermed1)) + row_offset_bytes, cb_intermed2_addr + row_offset_bytes, bfloat16_row_bytes);
-                    noc_async_read_barrier();
-                    cb_pop_front(cb_id_intermed1, 1);
-                    row_offset_bytes += bfloat16_row_bytes;
+                    for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) { // TODO: Must be 1; to generalize, need to handle untilizing + reading for subblocks
+                        // Read 32 untilized tiles and select correct rows to reconstruct single correct tile
+                        cb_wait_front(cb_id_intermed1, intermediate_num_tiles);
+                        noc_async_read(get_noc_addr(get_read_ptr(cb_id_intermed1)) + row_offset_bytes, cb_intermed2_addr_curr_block, bfloat16_row_bytes_read);
+                        noc_async_read_barrier();
+                        cb_pop_front(cb_id_intermed1, intermediate_num_tiles);
+                        row_offset_bytes += bfloat16_row_bytes;
+                        cb_intermed2_addr_curr_block += bfloat16_Nt_bytes;
+                    } // in1_num_subblocks loop
+
+                    #ifndef IN0_SHARDED
+                    in0_Mt += Kt;
+                    #endif
                 } // 32 tiles loop
+                cb_intermed2_addr += bfloat16_row_bytes;
 
-                cb_push_back(cb_id_intermed2, 1);
+            } // in1_num_blocks loop
+            cb_push_back(cb_id_intermed2, out_num_tiles);
 
-                #ifndef OUT_SHARDED
-                cb_wait_front(cb_id_out, onetile);
-                uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-                noc_async_write_tile(out_tensor_id, s, l1_read_addr);
-                noc_async_write_barrier();
-                cb_pop_front(cb_id_out, onetile);
+            #ifndef OUT_SHARDED
+            cb_wait_front(cb_id_out, out_num_tiles);
+            uint32_t l1_read_addr_out = get_read_ptr(cb_id_out);
+            for (uint32_t nt = 0; nt < Nt; nt++) { // TODO: Must be full MtNt; generalize to support Mt > 1 or blocks > 1
+                noc_async_write_tile(out_tensor_id, s, l1_read_addr_out);
+                l1_read_addr_out += out_tile_bytes;
                 out_tensor_id++;
-                #endif
-            } // Nt loop
-
-            in0_Mt += Kt;
+            }
+            noc_async_write_barrier();
+            cb_pop_front(cb_id_out, out_num_tiles);
+            #endif
         } // Mt loop
+
+        #ifndef IN0_SHARDED
         in0_batch += MtKt;
+        #endif
     } // B loop
 
     #ifdef OUT_SHARDED

--- a/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
@@ -86,43 +86,38 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         cb_src0 = tt_metal::CreateCircularBuffer(program, all_device_cores, src0_cb_config);
     }
 
-    // CB for in1 (ie. one kv_heads matching q_heads); for MQA, can probably optimize away unnecessary copies from cb2 to cb1
+    // CB for interleaved/sharded KV heads for mcasting; mcasts to same CB
+    // Then, push all KV_HEADS to compute and compute chooses which head to use for matmul
     uint32_t src1_cb_index = CB::c_in1;
-    uint32_t cb1_num_input_tiles = 2;
+    uint32_t cb1_num_input_tiles = 2 * KV_HEADS;
     tt_metal::CircularBufferConfig cb_src1_config = tt_metal::CircularBufferConfig(cb1_num_input_tiles * in1_single_tile_size, {{src1_cb_index, in1_data_format}})
 		.set_page_size(src1_cb_index, in1_single_tile_size);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_src1_config);
 
-    // CB for interleaved/sharded KV heads for mcasting; mcasts to same CB
-    uint32_t src2_cb_index = CB::c_in2;
-    uint32_t cb2_num_input_tiles = KV_HEADS;
-    tt_metal::CircularBufferConfig cb_src2_config = tt_metal::CircularBufferConfig(cb2_num_input_tiles * in1_single_tile_size, {{src2_cb_index, in1_data_format}})
-		.set_page_size(src2_cb_index, in1_single_tile_size);
-    auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_src2_config);
-
     // CB for sharded KV heads
-    CBHandle cb_src3 = 0;  // unused if KV heads is interleaved
+    CBHandle cb_src2 = 0;  // unused if KV heads is interleaved
     if (in1_is_sharded) {
-        uint32_t src3_cb_index = CB::c_in3;
-        uint32_t cb3_num_input_tiles = b.shard_spec().value().numel() / TILE_HW; // Should be full CKtNt and batch must be 32
-        tt_metal::CircularBufferConfig cb_src3_config = tt_metal::CircularBufferConfig(cb3_num_input_tiles * in1_single_tile_size, {{src3_cb_index, in1_data_format}})
-		    .set_page_size(src3_cb_index, in1_single_tile_size).set_globally_allocated_address(*src1_buffer);
-        cb_src3 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_src3_config);
+        uint32_t src2_cb_index = CB::c_in2;
+        uint32_t cb2_num_input_tiles = b.shard_spec().value().numel() / TILE_HW; // Should be full CKtNt and batch must be 32
+        tt_metal::CircularBufferConfig cb_src2_config = tt_metal::CircularBufferConfig(cb2_num_input_tiles * in1_single_tile_size, {{src2_cb_index, in1_data_format}})
+		    .set_page_size(src2_cb_index, in1_single_tile_size).set_globally_allocated_address(*src1_buffer);
+        cb_src2 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_src2_config);
     }
 
     // Intermediate CBs for handling untilizing, copying rows, and tilizing to output CB
+    constexpr uint32_t interm_cb_num_tiles = 2;
     uint32_t cb_intermed0_index = CB::c_intermed0;
-    tt_metal::CircularBufferConfig cb_interm0_config = tt_metal::CircularBufferConfig(1 * interm_single_tile_size, {{cb_intermed0_index, interm_data_format}})
+    tt_metal::CircularBufferConfig cb_interm0_config = tt_metal::CircularBufferConfig(interm_cb_num_tiles * interm_single_tile_size, {{cb_intermed0_index, interm_data_format}})
 		.set_page_size(cb_intermed0_index, interm_single_tile_size);
     auto cb_interm0 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_interm0_config);
 
     uint32_t cb_intermed1_index = CB::c_intermed1;
-    tt_metal::CircularBufferConfig cb_interm1_config = tt_metal::CircularBufferConfig(1 * interm_single_tile_size, {{cb_intermed1_index, interm_data_format}})
+    tt_metal::CircularBufferConfig cb_interm1_config = tt_metal::CircularBufferConfig(interm_cb_num_tiles * interm_single_tile_size, {{cb_intermed1_index, interm_data_format}})
 		.set_page_size(cb_intermed1_index, interm_single_tile_size);
     auto cb_interm1 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_interm1_config);
 
     uint32_t cb_intermed2_index = CB::c_intermed2;
-    tt_metal::CircularBufferConfig cb_interm2_config = tt_metal::CircularBufferConfig(1 * interm_single_tile_size, {{cb_intermed2_index, interm_data_format}})
+    tt_metal::CircularBufferConfig cb_interm2_config = tt_metal::CircularBufferConfig(interm_cb_num_tiles * interm_single_tile_size, {{cb_intermed2_index, interm_data_format}})
 		.set_page_size(cb_intermed2_index, interm_single_tile_size);
     auto cb_interm2 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_interm2_config);
 
@@ -152,14 +147,15 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 
     const uint32_t dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t) output_cb_index,
-        (std::uint32_t) dst_is_dram
+        (uint32_t) src0_is_dram,
+        (uint32_t) dst_is_dram,
+        (uint32_t) output_cb_index,
     };
 
     std::map<string, string> reader_kernel_defines;
     std::map<string, string> writer_kernel_defines;
     if (in0_is_sharded) {
-        reader_kernel_defines["IN0_SHARDED"] = "1";
+        writer_kernel_defines["IN0_SHARDED"] = "1";
     }
     if (in1_is_sharded) {
         reader_kernel_defines["IN1_SHARDED"] = "1";
@@ -208,14 +204,15 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 
     // Reader runtime args that need updating for each core (after setting some defaults based on shape)
     constexpr uint32_t HAS_WORK_VECTOR_IDX = 0;
-    constexpr uint32_t BLOCKS_VECTOR_IDX = 11;
-    constexpr uint32_t IN0_START_ID_VECTOR_IDX = 12;
-    constexpr uint32_t KV_HEADS_ADDR_OFFSET_VECTOR_IDX = 14;
-    constexpr uint32_t MCAST_SENDER_ID_VECTOR_IDX = 24;
-    constexpr uint32_t writer_runtime_args_size = 4;
-    constexpr uint32_t compute_runtime_args_size = 5;
-    // reader runtime args have 27 fixed args + mcast_sender coords for x and y (TODO: number of sender cores are currently hard-coded to be 32)
-    const uint32_t reader_runtime_args_size = 27 + in1_mcast_sender_noc_x.size() + in1_mcast_sender_noc_y.size();
+    constexpr uint32_t HAS_WORK_FOR_Q_HEADS_VECTOR_IDX = 1;
+    constexpr uint32_t BLOCKS_VECTOR_IDX = 12;
+    constexpr uint32_t IN0_START_ID_VECTOR_IDX = 13;
+    constexpr uint32_t KV_HEADS_ADDR_OFFSET_VECTOR_IDX = 15;
+    constexpr uint32_t MCAST_NUM_DESTS_VECTOR_IDX = 20;
+    constexpr uint32_t MCAST_NUM_CORES_VECTOR_IDX = 21;
+    constexpr uint32_t MCAST_SENDER_ID_VECTOR_IDX = 26;
+    constexpr uint32_t writer_runtime_args_size = 13;
+    constexpr uint32_t compute_runtime_args_size = 7;
 
     auto set_runtime_args = [
             num_tokens,
@@ -227,8 +224,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             writer_id,
             compute_kernel_id,
             cb_src0,
+            cb_src1,
             cb_src2,
-            cb_src3,
             cb_output,
             in0_single_tile_size,
             in1_single_tile_size,
@@ -242,11 +239,13 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             in1_mcast_sender_noc_x,
             in1_mcast_sender_noc_y,
             HAS_WORK_VECTOR_IDX,
+            HAS_WORK_FOR_Q_HEADS_VECTOR_IDX,
             BLOCKS_VECTOR_IDX,
             IN0_START_ID_VECTOR_IDX,
             KV_HEADS_ADDR_OFFSET_VECTOR_IDX,
+            MCAST_NUM_DESTS_VECTOR_IDX,
+            MCAST_NUM_CORES_VECTOR_IDX,
             MCAST_SENDER_ID_VECTOR_IDX,
-            reader_runtime_args_size,
             writer_runtime_args_size,
             compute_runtime_args_size
         ]
@@ -272,7 +271,9 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         // TODO: For sharded KV_heads, user batch must be 32 due to how we shard
         // TODO: To generalize to allow parallelizing/sharding across generic batch for KV_heads, we need to track sender cores across batch-number of rows instead of 32
         // TODO: Only support one block of work (ie. 1 Q head per core) because each core assumes only one KV_heads to use
-        auto [num_cores, all_cores, core_group_1, core_group_2, num_output_blocks_per_core_group_1, num_output_blocks_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, std::max(Q_HEADS, TILE_HEIGHT), row_major);
+        uint32_t num_active_cores = std::max(Q_HEADS, TILE_HEIGHT);
+        auto [num_cores, all_cores, core_group_1, core_group_2, num_output_blocks_per_core_group_1, num_output_blocks_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_active_cores, row_major);
+        // num_cores should be same as num_active_cores
         TT_FATAL(num_output_blocks_per_core_group_1 == 1 and num_output_blocks_per_core_group_2 == 0, "Group attention matmul only supports one q_heads per core. Increase compute grid size to at least have as many cores as q_heads!");
 
         // C = torch.matmul(A.transpose(0, 2) * B).transpose(0, 2)
@@ -297,17 +298,21 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         uint32_t in1_CKtNt_skip = in1_CKtNt - (transpose_hw_bool ? in1_Kt : Kt * Nt); // Decrement by how much we increment while iterating through Kt
 
         // Mcast receiver args
-        CoreRange all_cores_bounding_box = all_cores.bounding_box();
-        uint32_t mcast_num_cores = all_cores_bounding_box.size();
-        CoreCoord mcast_receiver_grid = all_cores_bounding_box.grid_size();
-        CoreCoord top_left_core = all_cores_bounding_box.start;
-        CoreCoord bottom_right_core = all_cores_bounding_box.end;
+        // NOTE: If Q_HEADS < 32, have all cores in mcast grid participate in semaphore syncing because we mcast KV_HEADS from/to the same CB
+        // Otherwise, data corruption if sender is in mcast grid and it starts populating its mcast CB as other senders are sending
+        CoreRangeSet mcast_receiver_cores = num_cores_to_corerange_set(Q_HEADS, compute_with_storage_grid_size, row_major);
+        CoreRange mcast_receiver_cores_bounding_box = mcast_receiver_cores.bounding_box();
+        uint32_t mcast_num_dests = mcast_receiver_cores.num_cores(); // same as num_active_cores if Q_HEADS >= 32; also, always same as Q_HEADS
+        uint32_t mcast_num_cores = mcast_receiver_cores_bounding_box.size();
+        CoreCoord top_left_core = mcast_receiver_cores_bounding_box.start;
+        CoreCoord bottom_right_core = mcast_receiver_cores_bounding_box.end;
         CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
         CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
         // Default reader runtime args
         std::vector<uint32_t> reader_runtime_args = {
-            0, // has_work
+            0, // has_work_for_mcast_kv_heads
+            0, // has_work_for_q_heads
             src0_buffer->address(),
             src1_buffer->address(),
             Mt,
@@ -328,8 +333,9 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             (uint32_t) (reader_noc_is_NOC_0 ? top_left_core_physical.y : bottom_right_core_physical.y), // in1_mcast_dest_noc_start_y
             (uint32_t) (reader_noc_is_NOC_0 ? bottom_right_core_physical.x : top_left_core_physical.x), // in1_mcast_dest_noc_end_x
             (uint32_t) (reader_noc_is_NOC_0 ? bottom_right_core_physical.y : top_left_core_physical.y), // in1_mcast_dest_noc_end_y
-            num_cores - 1, // in1_mcast_num_dests
-            mcast_num_cores - 1, // in1_mcast_num_cores
+            0, // in1_mcast_num_dests
+            0, // in1_mcast_num_cores
+            mcast_num_cores, // mcast grid size; in1_mcast_num_cores may change depending on if sender is part of the receiver grid or not
             in1_mcast_sender_semaphore,
             in1_mcast_receiver_semaphore,
             KV_HEADS * in1_single_tile_size, // in1_mcast_sender_size_bytes
@@ -341,6 +347,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         reader_runtime_args.insert(reader_runtime_args.end(), in1_mcast_sender_noc_x.begin(), in1_mcast_sender_noc_x.end());
         reader_runtime_args.insert(reader_runtime_args.end(), in1_mcast_sender_noc_y.begin(), in1_mcast_sender_noc_y.end());
 
+        CoreRange all_cores_bounding_box = all_cores.bounding_box();
         std::vector<CoreCoord> cores = grid_to_cores_with_noop(
             all_cores_bounding_box.end.x,
             all_cores_bounding_box.end.y,
@@ -368,30 +375,49 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 
             uint32_t kv_heads_id = i / (Q_HEADS / KV_HEADS);
             // Runtime method of turning off kernels/code blocks
-            // Needed because some cores only have partial readers for reading kv_heads
-            uint32_t has_work = i < Q_HEADS;
+            // Needed because some cores only have partial readers for reading/mcasting kv_heads
+            uint32_t has_work_for_q_heads = i < Q_HEADS; // compute and writer only does work if this is true; reader will only receive kv_heads if this is true
+            uint32_t has_work_for_mcast_kv_heads = i < num_active_cores; // reader only does any work if this is true
+            uint32_t mcast_num_cores_for_core = mcast_num_cores - (uint32_t) (i < mcast_num_cores); // if sender is not part of mcast grid, send to full grid
 
             // Update core dependent runtime args
-            reader_runtime_args[HAS_WORK_VECTOR_IDX] = has_work;
+            reader_runtime_args[HAS_WORK_VECTOR_IDX] = has_work_for_mcast_kv_heads;
+            reader_runtime_args[HAS_WORK_FOR_Q_HEADS_VECTOR_IDX] = has_work_for_q_heads;
             reader_runtime_args[BLOCKS_VECTOR_IDX] = num_output_blocks_per_core;
             reader_runtime_args[IN0_START_ID_VECTOR_IDX] = num_blocks_written * MtKt;
             reader_runtime_args[KV_HEADS_ADDR_OFFSET_VECTOR_IDX] = kv_heads_id * in1_single_tile_size;
+            // If Q_HEADS < 32, have all cores participate in receiving; std::min is needed for cases where mcast grid is > num_active_cores and non-active cores are turned off and don't receive
+            reader_runtime_args[MCAST_NUM_DESTS_VECTOR_IDX] = Q_HEADS < TILE_HEIGHT ? std::min(mcast_num_cores_for_core, num_active_cores - 1) : mcast_num_dests - 1;
+            reader_runtime_args[MCAST_NUM_CORES_VECTOR_IDX] = mcast_num_cores_for_core;
             reader_runtime_args[MCAST_SENDER_ID_VECTOR_IDX] = i;
 
             // Update runtime_args vectors
             all_reader_runtime_args[i] = reader_runtime_args;
             all_writer_runtime_args[i] = {
-                has_work,
+                has_work_for_q_heads,
+                src0_buffer->address(),
                 dst_buffer->address(),
-                num_output_blocks_per_core * MtNt, // num_tiles
-                num_blocks_written * MtNt, // start_id
+                Mt,
+                Kt,
+                Nt,
+                MtKt,
+                KV_HEADS,
+
+                num_output_blocks_per_core, // blocks of work
+                num_output_blocks_per_core * MtNt, // out_num_tiles
+                num_blocks_written * MtKt, // in0_start_id
+                num_blocks_written * MtNt, // out_start_id
+                kv_heads_id * in1_single_tile_size,
             };
             all_compute_runtime_args[i] = {
-                has_work,
+                has_work_for_q_heads,
                 num_output_blocks_per_core, // B
                 Mt, // Mt
                 Kt, // Kt
                 Nt, // Nt
+                KV_HEADS,
+
+                kv_heads_id,
             };
 
             num_blocks_written += num_output_blocks_per_core;
@@ -402,8 +428,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         SetRuntimeArgs(program, compute_kernel_id, cores, all_compute_runtime_args);
 
         // Update dynamic CBs
-        uint32_t cb2_num_input_tiles = KV_HEADS;
-        UpdateCircularBufferTotalSize(program, cb_src2, cb2_num_input_tiles * in1_single_tile_size);
+        uint32_t cb1_num_input_tiles = 2 * KV_HEADS;
+        UpdateCircularBufferTotalSize(program, cb_src1, cb1_num_input_tiles * in1_single_tile_size);
 
         if (in0_is_sharded) {
             uint32_t cb0_num_input_tiles = a.shard_spec().value().numel() / TILE_HW; // Should be full MtKt and C should be 1
@@ -411,9 +437,9 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             UpdateCircularBufferTotalSize(program, cb_src0, cb0_num_input_tiles * in0_single_tile_size);
         }
         if (in1_is_sharded) {
-            uint32_t cb3_num_input_tiles = b.shard_spec().value().numel() / TILE_HW; // Should be full CKtNt and batch must be 32
-            UpdateDynamicCircularBufferAddress(program, cb_src3, *src1_buffer);
-            UpdateCircularBufferTotalSize(program, cb_src3, cb3_num_input_tiles * in1_single_tile_size);
+            uint32_t cb2_num_input_tiles = b.shard_spec().value().numel() / TILE_HW; // Should be full CKtNt and batch must be 32
+            UpdateDynamicCircularBufferAddress(program, cb_src2, *src1_buffer);
+            UpdateCircularBufferTotalSize(program, cb_src2, cb2_num_input_tiles * in1_single_tile_size);
         }
         if (output_is_sharded) {
             uint32_t num_output_tiles = output.shard_spec().value().numel() / TILE_HW; // Should be full MtNt and C should be 1

--- a/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
@@ -47,8 +47,19 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 
     // See set_runtime_args for how input shapes are used; these are the variables needed for setting up kernels and CBs
     const bool transpose_hw_bool = transpose_hw.value_or(false);
+    const uint32_t num_tokens_val = num_tokens.value_or(0); // should not be nullopt if transpose_hw=true
     uint32_t KV_HEADS = bshape[1]; // bshape[0] is user batch
+    uint32_t Mt = ashape[2]/TILE_HEIGHT;
     uint32_t Kt = ashape[3]/TILE_WIDTH;
+    uint32_t Nt = transpose_hw_bool ? num_tokens_val/TILE_HEIGHT : bshape[3]/TILE_WIDTH;
+    uint32_t MtNt = Mt * Nt;
+
+    // Matmul blocking parameters; these determine how large CBs are
+    constexpr uint32_t HALF_DST_MAX = 8;
+    uint32_t out_subblock_w = std::min(Nt, HALF_DST_MAX);
+    uint32_t out_block_w = out_subblock_w;
+    uint32_t in0_block_w = Kt;
+    uint32_t in1_block_num_tiles = KV_HEADS * in0_block_w * out_subblock_w;
 
     // Mcast args
     auto in1_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_device_cores, INVALID);
@@ -80,7 +91,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 		    .set_page_size(src0_cb_index, in0_single_tile_size).set_globally_allocated_address(*src0_buffer);
         cb_src0 = tt_metal::CreateCircularBuffer(program, all_device_cores, src0_cb_config);
     } else {
-        uint32_t cb0_num_input_tiles = Kt * 2;
+        uint32_t cb0_num_input_tiles = in0_block_w; // TODO: Generalize; double buffer and add blocking along inner dim if we have Mt > 1
         tt_metal::CircularBufferConfig src0_cb_config = tt_metal::CircularBufferConfig(cb0_num_input_tiles * in0_single_tile_size, {{src0_cb_index, in0_data_format}})
 		    .set_page_size(src0_cb_index, in0_single_tile_size);
         cb_src0 = tt_metal::CreateCircularBuffer(program, all_device_cores, src0_cb_config);
@@ -89,7 +100,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
     // CB for interleaved/sharded KV heads for mcasting; mcasts to same CB
     // Then, push all KV_HEADS to compute and compute chooses which head to use for matmul
     uint32_t src1_cb_index = CB::c_in1;
-    uint32_t cb1_num_input_tiles = 2 * KV_HEADS;
+    uint32_t cb1_num_input_tiles = 2 * in1_block_num_tiles;
     tt_metal::CircularBufferConfig cb_src1_config = tt_metal::CircularBufferConfig(cb1_num_input_tiles * in1_single_tile_size, {{src1_cb_index, in1_data_format}})
 		.set_page_size(src1_cb_index, in1_single_tile_size);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_src1_config);
@@ -105,7 +116,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
     }
 
     // Intermediate CBs for handling untilizing, copying rows, and tilizing to output CB
-    constexpr uint32_t interm_cb_num_tiles = 2;
+    uint32_t interm_cb_num_tiles = 1 * out_block_w; // TODO: Generalize; should it be double buffered?
     uint32_t cb_intermed0_index = CB::c_intermed0;
     tt_metal::CircularBufferConfig cb_interm0_config = tt_metal::CircularBufferConfig(interm_cb_num_tiles * interm_single_tile_size, {{cb_intermed0_index, interm_data_format}})
 		.set_page_size(cb_intermed0_index, interm_single_tile_size);
@@ -117,7 +128,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
     auto cb_interm1 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_interm1_config);
 
     uint32_t cb_intermed2_index = CB::c_intermed2;
-    tt_metal::CircularBufferConfig cb_interm2_config = tt_metal::CircularBufferConfig(interm_cb_num_tiles * interm_single_tile_size, {{cb_intermed2_index, interm_data_format}})
+    tt_metal::CircularBufferConfig cb_interm2_config = tt_metal::CircularBufferConfig(MtNt * interm_single_tile_size, {{cb_intermed2_index, interm_data_format}})
 		.set_page_size(cb_intermed2_index, interm_single_tile_size);
     auto cb_interm2 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_interm2_config);
 
@@ -130,7 +141,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 		    .set_page_size(output_cb_index, output_single_tile_size).set_globally_allocated_address(*dst_buffer);
         cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_output_config);
     } else {
-        uint32_t num_output_tiles = 2;
+        uint32_t num_output_tiles = MtNt; // TODO: Should be MtNt if Mt > 1? Or, produce one Nt at a time and double buffer?
         tt_metal::CircularBufferConfig cb_output_config = tt_metal::CircularBufferConfig(num_output_tiles * output_single_tile_size, {{output_cb_index, output_data_format}})
 		    .set_page_size(output_cb_index, output_single_tile_size);
         cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_output_config);
@@ -202,18 +213,6 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_args}
     );
 
-    // Reader runtime args that need updating for each core (after setting some defaults based on shape)
-    constexpr uint32_t HAS_WORK_VECTOR_IDX = 0;
-    constexpr uint32_t HAS_WORK_FOR_Q_HEADS_VECTOR_IDX = 1;
-    constexpr uint32_t BLOCKS_VECTOR_IDX = 12;
-    constexpr uint32_t IN0_START_ID_VECTOR_IDX = 13;
-    constexpr uint32_t KV_HEADS_ADDR_OFFSET_VECTOR_IDX = 15;
-    constexpr uint32_t MCAST_NUM_DESTS_VECTOR_IDX = 20;
-    constexpr uint32_t MCAST_NUM_CORES_VECTOR_IDX = 21;
-    constexpr uint32_t MCAST_SENDER_ID_VECTOR_IDX = 26;
-    constexpr uint32_t writer_runtime_args_size = 13;
-    constexpr uint32_t compute_runtime_args_size = 7;
-
     auto set_runtime_args = [
             num_tokens,
             transpose_hw,
@@ -226,9 +225,13 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             cb_src0,
             cb_src1,
             cb_src2,
+            cb_interm0,
+            cb_interm1,
+            cb_interm2,
             cb_output,
             in0_single_tile_size,
             in1_single_tile_size,
+            interm_single_tile_size,
             output_single_tile_size,
             in0_is_sharded,
             in1_is_sharded,
@@ -238,16 +241,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             in1_mcast_receiver_semaphore,
             in1_mcast_sender_noc_x,
             in1_mcast_sender_noc_y,
-            HAS_WORK_VECTOR_IDX,
-            HAS_WORK_FOR_Q_HEADS_VECTOR_IDX,
-            BLOCKS_VECTOR_IDX,
-            IN0_START_ID_VECTOR_IDX,
-            KV_HEADS_ADDR_OFFSET_VECTOR_IDX,
-            MCAST_NUM_DESTS_VECTOR_IDX,
-            MCAST_NUM_CORES_VECTOR_IDX,
-            MCAST_SENDER_ID_VECTOR_IDX,
-            writer_runtime_args_size,
-            compute_runtime_args_size
+            HALF_DST_MAX
         ]
     (
         Program& program,
@@ -295,7 +289,32 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         // For transpose_hw=false, bshape[2] is max cache length
         uint32_t in1_KtNt = transpose_hw_bool ? bshape[2]/TILE_HEIGHT * in1_Kt : in1_Kt * Nt;
         uint32_t in1_CKtNt = KV_HEADS * in1_KtNt;
-        uint32_t in1_CKtNt_skip = in1_CKtNt - (transpose_hw_bool ? in1_Kt : Kt * Nt); // Decrement by how much we increment while iterating through Kt
+
+        // Matmul params
+        constexpr uint32_t out_subblock_h = 1; // TODO: Only support per_core_Mt = 1 (mcasting assumes batch=32 for now anyways)
+        constexpr uint32_t in1_num_subblocks = 1; // out_block_w / out_subblock_w
+        uint32_t out_subblock_w = std::min(Nt, HALF_DST_MAX);
+        uint32_t out_block_w = out_subblock_w;
+        uint32_t in0_block_w = Kt;
+        uint32_t in0_subblock_num_tiles = in0_block_w * out_subblock_h;
+        uint32_t in0_block_num_tiles = in0_subblock_num_tiles;
+        uint32_t in1_block_num_tiles_per_kv_heads = in0_block_w * out_subblock_w;
+        uint32_t in1_block_num_tiles = KV_HEADS * in1_block_num_tiles_per_kv_heads;
+        uint32_t out_subblock_num_tiles = out_subblock_h * out_block_w;
+        uint32_t intermediate_num_tiles = out_subblock_num_tiles;
+        uint32_t in1_num_blocks = (Nt - 1) / out_block_w + 1; // Rounds up to include nearest out_block_w; "padding" is handled internally
+        uint32_t in1_per_core_w = in1_num_subblocks * out_block_w;
+
+        uint32_t Nt_bytes = Nt * in1_single_tile_size;
+        uint32_t in1_block_w_tile_bytes = out_subblock_w * in1_single_tile_size;
+        uint32_t out_last_subblock_w = Nt % out_block_w == 0 ? out_block_w : Nt % out_block_w;
+        uint32_t in1_last_block_w_tile_read_bytes = out_last_subblock_w * in1_single_tile_size;
+        uint32_t in1_last_block_addr_skip = (out_subblock_w - out_last_subblock_w) * in1_single_tile_size;
+
+        constexpr uint32_t ONE_ROW_BFLOAT16_BYTES = 64;
+        uint32_t bfloat16_Nt_bytes = ONE_ROW_BFLOAT16_BYTES * Nt;
+        uint32_t bfloat16_row_bytes = ONE_ROW_BFLOAT16_BYTES * out_block_w; // TODO: Generalize
+        uint32_t bfloat16_last_row_bytes_read = ONE_ROW_BFLOAT16_BYTES * out_last_subblock_w;
 
         // Mcast receiver args
         // NOTE: If Q_HEADS < 32, have all cores in mcast grid participate in semaphore syncing because we mcast KV_HEADS from/to the same CB
@@ -311,41 +330,101 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 
         // Default reader runtime args
         std::vector<uint32_t> reader_runtime_args = {
-            0, // has_work_for_mcast_kv_heads
-            0, // has_work_for_q_heads
-            src0_buffer->address(),
+            0, // 0: has_work_for_mcast_kv_heads
+            0, // 1: has_work_for_q_heads
             src1_buffer->address(),
             Mt,
-            Kt,
             Nt,
-            MtKt,
             KV_HEADS,
-            in1_KtNt,
-            in1_CKtNt_skip, // Skip to get next batch for in1 after reading in0 Kt
+            in1_CKtNt,
             in1_CKtNt * TILE_HEIGHT, // in1 stride; skips 32 * KtNt in bshape[0] for one block of MtNt
-            0, // blocks of work
-            0, // in0_start_id
+            0, // 8: blocks of work
             0, // in1_start_id; always start at 0 for each block of work and let kernels handle id tracking; for sharded, this isn't used
-            0, // kv_heads_addr_offset; l1 offset in bytes to identify which kv_heads each q_heads is mapped to
+
+            in0_block_w,
+            out_subblock_w,
+            out_block_w,
+            in1_num_subblocks,
+            in1_num_blocks,
+            in1_block_num_tiles,
+
+            Nt_bytes,
+            in1_block_w_tile_bytes,
+            out_last_subblock_w,
+            in1_last_block_w_tile_read_bytes,
+            in1_last_block_addr_skip,
 
             // mcast args
             (uint32_t) (reader_noc_is_NOC_0 ? top_left_core_physical.x : bottom_right_core_physical.x), // in1_mcast_dest_noc_start_x
             (uint32_t) (reader_noc_is_NOC_0 ? top_left_core_physical.y : bottom_right_core_physical.y), // in1_mcast_dest_noc_start_y
             (uint32_t) (reader_noc_is_NOC_0 ? bottom_right_core_physical.x : top_left_core_physical.x), // in1_mcast_dest_noc_end_x
             (uint32_t) (reader_noc_is_NOC_0 ? bottom_right_core_physical.y : top_left_core_physical.y), // in1_mcast_dest_noc_end_y
-            0, // in1_mcast_num_dests
-            0, // in1_mcast_num_cores
+            0, // 25: in1_mcast_num_dests
+            0, // 26: in1_mcast_num_cores
             mcast_num_cores, // mcast grid size; in1_mcast_num_cores may change depending on if sender is part of the receiver grid or not
             in1_mcast_sender_semaphore,
             in1_mcast_receiver_semaphore,
-            KV_HEADS * in1_single_tile_size, // in1_mcast_sender_size_bytes
-            0, // in1_mcast_sender_id
+            in1_block_num_tiles * in1_single_tile_size, // in1_mcast_sender_size_bytes
+            0, // 31: in1_mcast_sender_id
             (uint32_t) in1_mcast_sender_noc_x.size(), // in1_mcast_sender_num_x
             (uint32_t) in1_mcast_sender_noc_y.size(), // in1_mcast_sender_num_y
         };
         // TODO: Length of these variables should be static in length since we hard-code 32 mcast sender cores and cache on compute_with_storage_grid_size
         reader_runtime_args.insert(reader_runtime_args.end(), in1_mcast_sender_noc_x.begin(), in1_mcast_sender_noc_x.end());
         reader_runtime_args.insert(reader_runtime_args.end(), in1_mcast_sender_noc_y.begin(), in1_mcast_sender_noc_y.end());
+
+        // Default writer runtime args
+        std::vector<uint32_t> writer_runtime_args = {
+            0, // 0: has_work_for_q_heads
+            src0_buffer->address(),
+            dst_buffer->address(),
+            Mt,
+            Kt,
+            Nt,
+            KV_HEADS,
+            MtKt,
+            0, // 8: blocks of work
+            0, // 9: in0_start_id
+            0, // 10: out_start_id
+
+            in0_block_w,
+            out_subblock_w,
+            out_block_w,
+            in1_num_subblocks,
+            in1_num_blocks,
+            in0_block_num_tiles,
+            intermediate_num_tiles,
+            MtNt, // out_num_tiles
+
+            bfloat16_row_bytes,
+            bfloat16_Nt_bytes,
+            out_last_subblock_w,
+            bfloat16_last_row_bytes_read,
+        };
+
+        // Default compute runtime args
+        std::vector<uint32_t> compute_runtime_args = {
+            0, // 0: has_work_for_q_heads
+            0, // 1: batch,
+            Mt,
+            0, // 3: num_kv_heads_skip
+            0, // 4: num_kv_heads_remaining
+
+            in0_block_w,
+            out_subblock_h,
+            out_subblock_w,
+            out_block_w,
+            in1_num_subblocks,
+            in1_num_blocks,
+            in0_block_num_tiles,
+            in1_block_num_tiles,
+            out_subblock_num_tiles,
+            intermediate_num_tiles,
+            MtNt, // out_num_tiles
+
+            in0_subblock_num_tiles,
+            in1_per_core_w,
+        };
 
         CoreRange all_cores_bounding_box = all_cores.bounding_box();
         std::vector<CoreCoord> cores = grid_to_cores_with_noop(
@@ -359,8 +438,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         uint32_t g2_numcores = core_group_2.num_cores();
 
         std::vector<std::vector<uint32_t>> all_reader_runtime_args = { cores.size(), reader_runtime_args };
-        std::vector<std::vector<uint32_t>> all_writer_runtime_args = { cores.size(), std::vector<uint32_t>(writer_runtime_args_size) };
-        std::vector<std::vector<uint32_t>> all_compute_runtime_args = { cores.size(), std::vector<uint32_t>(compute_runtime_args_size) };
+        std::vector<std::vector<uint32_t>> all_writer_runtime_args = { cores.size(), writer_runtime_args };
+        std::vector<std::vector<uint32_t>> all_compute_runtime_args = { cores.size(), compute_runtime_args };
 
         // Set runtime args
         uint32_t num_output_blocks_per_core;
@@ -381,44 +460,23 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             uint32_t mcast_num_cores_for_core = mcast_num_cores - (uint32_t) (i < mcast_num_cores); // if sender is not part of mcast grid, send to full grid
 
             // Update core dependent runtime args
-            reader_runtime_args[HAS_WORK_VECTOR_IDX] = has_work_for_mcast_kv_heads;
-            reader_runtime_args[HAS_WORK_FOR_Q_HEADS_VECTOR_IDX] = has_work_for_q_heads;
-            reader_runtime_args[BLOCKS_VECTOR_IDX] = num_output_blocks_per_core;
-            reader_runtime_args[IN0_START_ID_VECTOR_IDX] = num_blocks_written * MtKt;
-            reader_runtime_args[KV_HEADS_ADDR_OFFSET_VECTOR_IDX] = kv_heads_id * in1_single_tile_size;
+            all_reader_runtime_args[i][0] = has_work_for_mcast_kv_heads;
+            all_reader_runtime_args[i][1] = has_work_for_q_heads;
+            all_reader_runtime_args[i][8] = num_output_blocks_per_core;
             // If Q_HEADS < 32, have all cores participate in receiving; std::min is needed for cases where mcast grid is > num_active_cores and non-active cores are turned off and don't receive
-            reader_runtime_args[MCAST_NUM_DESTS_VECTOR_IDX] = Q_HEADS < TILE_HEIGHT ? std::min(mcast_num_cores_for_core, num_active_cores - 1) : mcast_num_dests - 1;
-            reader_runtime_args[MCAST_NUM_CORES_VECTOR_IDX] = mcast_num_cores_for_core;
-            reader_runtime_args[MCAST_SENDER_ID_VECTOR_IDX] = i;
+            all_reader_runtime_args[i][25] = Q_HEADS < TILE_HEIGHT ? std::min(mcast_num_cores_for_core, num_active_cores - 1) : mcast_num_dests - 1;
+            all_reader_runtime_args[i][26] = mcast_num_cores_for_core;
+            all_reader_runtime_args[i][31] = i;
 
-            // Update runtime_args vectors
-            all_reader_runtime_args[i] = reader_runtime_args;
-            all_writer_runtime_args[i] = {
-                has_work_for_q_heads,
-                src0_buffer->address(),
-                dst_buffer->address(),
-                Mt,
-                Kt,
-                Nt,
-                MtKt,
-                KV_HEADS,
+            all_writer_runtime_args[i][0] = has_work_for_q_heads;
+            all_writer_runtime_args[i][8] = num_output_blocks_per_core;
+            all_writer_runtime_args[i][9] = num_blocks_written * MtKt;
+            all_writer_runtime_args[i][10] = num_blocks_written * MtNt;
 
-                num_output_blocks_per_core, // blocks of work
-                num_output_blocks_per_core * MtNt, // out_num_tiles
-                num_blocks_written * MtKt, // in0_start_id
-                num_blocks_written * MtNt, // out_start_id
-                kv_heads_id * in1_single_tile_size,
-            };
-            all_compute_runtime_args[i] = {
-                has_work_for_q_heads,
-                num_output_blocks_per_core, // B
-                Mt, // Mt
-                Kt, // Kt
-                Nt, // Nt
-                KV_HEADS,
-
-                kv_heads_id,
-            };
+            all_compute_runtime_args[i][0] = has_work_for_q_heads;
+            all_compute_runtime_args[i][1] = num_output_blocks_per_core;
+            all_compute_runtime_args[i][3] = kv_heads_id * in1_block_num_tiles_per_kv_heads;
+            all_compute_runtime_args[i][4] = (KV_HEADS - kv_heads_id) * in1_block_num_tiles_per_kv_heads;
 
             num_blocks_written += num_output_blocks_per_core;
         }
@@ -427,23 +485,36 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         SetRuntimeArgs(program, writer_id, cores, all_writer_runtime_args);
         SetRuntimeArgs(program, compute_kernel_id, cores, all_compute_runtime_args);
 
-        // Update dynamic CBs
-        uint32_t cb1_num_input_tiles = 2 * KV_HEADS;
-        UpdateCircularBufferTotalSize(program, cb_src1, cb1_num_input_tiles * in1_single_tile_size);
-
+        // Update dynamic CBs (which is most of them)
         if (in0_is_sharded) {
             uint32_t cb0_num_input_tiles = a.shard_spec().value().numel() / TILE_HW; // Should be full MtKt and C should be 1
             UpdateDynamicCircularBufferAddress(program, cb_src0, *src0_buffer);
             UpdateCircularBufferTotalSize(program, cb_src0, cb0_num_input_tiles * in0_single_tile_size);
+        } else {
+            uint32_t cb0_num_input_tiles = in0_block_w; // TODO: Generalize; double buffer and add blocking along ineer dim if we have Mt > 1
+            UpdateCircularBufferTotalSize(program, cb_src0, cb0_num_input_tiles * in0_single_tile_size);
         }
+
+        uint32_t cb1_num_input_tiles = 2 * in1_block_num_tiles;
+        UpdateCircularBufferTotalSize(program, cb_src1, cb1_num_input_tiles * in1_single_tile_size);
+
         if (in1_is_sharded) {
             uint32_t cb2_num_input_tiles = b.shard_spec().value().numel() / TILE_HW; // Should be full CKtNt and batch must be 32
             UpdateDynamicCircularBufferAddress(program, cb_src2, *src1_buffer);
             UpdateCircularBufferTotalSize(program, cb_src2, cb2_num_input_tiles * in1_single_tile_size);
         }
+
+        uint32_t interm_cb_num_tiles = 1 * out_block_w; // TODO: Generalize; should it be double buffered?
+        UpdateCircularBufferTotalSize(program, cb_interm0, interm_cb_num_tiles * interm_single_tile_size);
+        UpdateCircularBufferTotalSize(program, cb_interm1, interm_cb_num_tiles * interm_single_tile_size);
+        UpdateCircularBufferTotalSize(program, cb_interm2, MtNt * interm_single_tile_size);
+
         if (output_is_sharded) {
             uint32_t num_output_tiles = output.shard_spec().value().numel() / TILE_HW; // Should be full MtNt and C should be 1
             UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+            UpdateCircularBufferTotalSize(program, cb_output, num_output_tiles * output_single_tile_size);
+        } else {
+            uint32_t num_output_tiles = MtNt; // TODO: Should be MtNt if Mt > 1? Or, produce one Nt at a time and double buffer?
             UpdateCircularBufferTotalSize(program, cb_output, num_output_tiles * output_single_tile_size);
         }
     };


### PR DESCRIPTION
- Move writer kenerl to tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow
- Writer does in0 and shuffling for intermediates
- Reader should only handle mcasting kv_heads
- Remove extra copy of kv_heads and have compute choose right offset for matmul
- Double buffer kv_heads cb
- Double buffer interm CBs
- Properly mcast to only Q_HEADS grid instead of full 32 when Q_HEADS < 32
- Reorder loops so that loop across batch_kv and untilize of rows, etc... is outside of K and N. Basically, maximize as much transfer as we can for kv_heads as possible. Need to introduce subblocks, num_subblocks, in0_block_w, etc... from matmul. Untilize as much as possible then tilize at the end