### PR TITLE
Fix an intermittent launch message transfer error

### DIFF
--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -105,6 +105,7 @@ run_frequent_api_pipeline_tests() {
 
     # Please put model runs in here from now on - thank you
     if [[ $dispatch_mode == "slow" ]]; then
+        TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_frequent
         echo "Running Python API unit tests in SD for frequent..."
         ./tests/scripts/run_python_api_unit_tests.sh
     else

--- a/tests/tt_metal/tt_metal/module.mk
+++ b/tests/tt_metal/tt_metal/module.mk
@@ -2,6 +2,7 @@ include $(TT_METAL_HOME)/tests/tt_metal/tt_metal/unit_tests_common/module.mk
 include $(TT_METAL_HOME)/tests/tt_metal/tt_metal/unit_tests/module.mk
 include $(TT_METAL_HOME)/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/module.mk
 include $(TT_METAL_HOME)/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/module.mk
+include $(TT_METAL_HOME)/tests/tt_metal/tt_metal/unit_tests_frequent/module.mk
 # Programming examples for external users
 include $(TT_METAL_HOME)/tt_metal/programming_examples/module.mk
 
@@ -79,7 +80,7 @@ TT_METAL_TESTS_DEPS = $(addprefix $(OBJDIR)/, $(TT_METAL_TESTS_SRCS:.cpp=.d))
 -include $(TT_METAL_TESTS_DEPS)
 
 # Each module has a top level target as the entrypoint which must match the subdir name
-tests/tt_metal: $(TT_METAL_TESTS) programming_examples tests/tt_metal/unit_tests tests/tt_metal/unit_tests_fast_dispatch tests/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue
+tests/tt_metal: $(TT_METAL_TESTS) programming_examples tests/tt_metal/unit_tests tests/tt_metal/unit_tests_fast_dispatch tests/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue tests/tt_metal/unit_tests_frequent
 tests/tt_metal/all: $(TT_METAL_TESTS)
 tests/tt_metal/%: $(TESTDIR)/tt_metal/% ;
 

--- a/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
@@ -31,7 +31,7 @@ Program initialize_program_data_movement(Device *device, const CoreRangeSet &cor
 
     auto add_two_ints_kernel = tt_metal::CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/test_kernels/riscv_draft/add_two_ints.cpp",
+        "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
         core_range_set,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});

--- a/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/misc/run_many_times.cpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "test_utils.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+void RunTest(Device *device) {
+    // Set up program
+    Program program = Program();
+
+    std::set<CoreRange> core_ranges;
+    //CoreCoord grid_size = device->logical_grid_size();
+    CoreCoord grid_size = {5, 5};
+    for (uint32_t y = 0; y < grid_size.y; y++) {
+        for (uint32_t x = 0; x < grid_size.x; x++) {
+            CoreCoord core(x, y);
+            core_ranges.insert(CoreRange{.start=core, .end=core});
+        }
+    }
+
+    // Kernels on brisc + ncrisc that just add two numbers
+    KernelHandle brisc_kid = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
+        CoreRangeSet(core_ranges),
+        tt_metal::DataMovementConfig {
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default
+        }
+    );
+    KernelHandle ncrisc_kid = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/add_two_ints.cpp",
+        CoreRangeSet(core_ranges),
+        tt_metal::DataMovementConfig {
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default
+        }
+    );
+
+    // Write runtime args
+    auto get_first_arg = [](Device *device, CoreCoord &core, uint32_t multiplier) {
+        return (uint32_t) device->id() + (uint32_t) core.x * 10 * multiplier;
+    };
+    auto get_second_arg = [](Device *device, CoreCoord &core, uint32_t multiplier) {
+        return (uint32_t) core.y * 100 * multiplier;
+    };
+    for (auto &core_range : core_ranges) {
+        CoreCoord core = core_range.start;
+        std::vector<uint32_t> brisc_rt_args = {
+            get_first_arg(device, core, 1),
+            get_second_arg(device, core, 1)
+        };
+        std::vector<uint32_t> ncrisc_rt_args = {
+            get_first_arg(device, core, 2),
+            get_second_arg(device, core, 2)
+        };
+        SetRuntimeArgs(program, brisc_kid, core, brisc_rt_args);
+        SetRuntimeArgs(program, ncrisc_kid, core, ncrisc_rt_args);
+    }
+
+    auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    if (slow_dispatch) {
+        // Slow dispatch uses LaunchProgram
+        tt::tt_metal::detail::LaunchProgram(device, program);
+    } else {
+        // Fast Dispatch uses the command queue
+        CommandQueue& cq = tt::tt_metal::detail::GetCommandQueue(device);
+        EnqueueProgram(cq, program, false);
+        Finish(cq);
+    }
+
+    // Check results
+    for (auto &core_range : core_ranges) {
+        CoreCoord core = core_range.start;
+        std::vector<uint32_t> brisc_result;
+        tt_metal::detail::ReadFromDeviceL1(
+            device, core, BRISC_L1_RESULT_BASE, sizeof(uint32_t), brisc_result
+        );
+        std::vector<uint32_t> ncrisc_result;
+        tt_metal::detail::ReadFromDeviceL1(
+            device, core, NCRISC_L1_RESULT_BASE, sizeof(uint32_t), ncrisc_result
+        );
+        uint32_t expected_result = get_first_arg(device, core, 1) + get_second_arg(device, core, 1);
+        if (expected_result != brisc_result[0])
+            log_warning(
+                LogTest,
+                "Device {}, Core {}, BRISC result was incorrect. Expected {} but got {}",
+                device->id(),
+                core.str(),
+                expected_result,
+                brisc_result[0]
+            );
+        EXPECT_TRUE(expected_result == brisc_result[0]);
+        expected_result = get_first_arg(device, core, 2) + get_second_arg(device, core, 2);
+        if (expected_result != ncrisc_result[0])
+            log_warning(
+                LogTest,
+                "Device {}, Core {}, NCRISC result was incorrect. Expected {} but got {}",
+                device->id(),
+                core.str(),
+                expected_result,
+                ncrisc_result[0]
+            );
+        EXPECT_TRUE(expected_result == ncrisc_result[0]);
+    }
+}
+
+TEST(Common, AllCoresRunManyTimes) {
+    auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    // Skip fast dispatch until it's supported for remote device.
+    if (!slow_dispatch)
+        GTEST_SKIP();
+    // Run 500 times to make sure that things work
+    for (int idx = 0; idx < 500; idx++) {
+        log_info(LogTest, "Running iteration #{}", idx);
+        // Need to open/close the device each time in order to reproduce original issue.
+        auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+        vector<Device*> devices_;
+        for (unsigned int id = 0; id < num_devices; id++) {
+            auto* device = tt::tt_metal::CreateDevice(id);
+            devices_.push_back(device);
+        }
+
+        // Run the test on each device
+        for (Device *device : devices_) {
+            RunTest(device);
+        }
+
+        // Close all devices
+        for (unsigned int id = 0; id < devices_.size(); id++) {
+            tt::tt_metal::CloseDevice(devices_.at(id));
+        }
+    }
+
+}

--- a/tests/tt_metal/tt_metal/unit_tests_frequent/module.mk
+++ b/tests/tt_metal/tt_metal/unit_tests_frequent/module.mk
@@ -1,0 +1,29 @@
+# Every variable in subdir must be prefixed with subdir (emulating a namespace)
+
+TT_METAL_UNIT_TESTS_FREQUENT_SRCS_HOME = tests/tt_metal/tt_metal/unit_tests_frequent
+
+TT_METAL_UNIT_TESTS_FREQUENT = $(wildcard ${TT_METAL_UNIT_TESTS_FREQUENT_SRCS_HOME}/**/*.cpp)
+
+TT_METAL_UNIT_TESTS_FREQUENT_OBJ_HOME = tt_metal/tests/unit_tests_frequent/
+TT_METAL_UNIT_TESTS_FREQUENT_SRCS = $(patsubst $(TT_METAL_UNIT_TESTS_FREQUENT_SRCS_HOME)%, $(TT_METAL_UNIT_TESTS_FREQUENT_OBJ_HOME)%, $(TT_METAL_UNIT_TESTS_FREQUENT))
+
+TT_METAL_UNIT_TESTS_FREQUENT_INCLUDES = $(TEST_INCLUDES) $(TT_METAL_INCLUDES) -I$(TT_METAL_HOME)/$(TT_METAL_UNIT_TESTS_FREQUENT_SRCS_HOME)/common
+TT_METAL_UNIT_TESTS_FREQUENT_LDFLAGS = $(TT_METAL_UNIT_TESTS_LDFLAGS)
+
+TT_METAL_UNIT_TESTS_FREQUENT_OBJS = $(addprefix $(OBJDIR)/, $(TT_METAL_UNIT_TESTS_FREQUENT_SRCS:.cpp=.o))
+TT_METAL_UNIT_TESTS_FREQUENT_DEPS = $(addprefix $(OBJDIR)/, $(TT_METAL_UNIT_TESTS_FREQUENT_SRCS:.cpp=.d))
+
+-include $(TT_METAL_UNIT_TESTS_FREQUENT_DEPS)
+
+# Each module has a top level target as the entrypoint which must match the subdir name
+tests/tt_metal/unit_tests_frequent: $(TESTDIR)/tt_metal/unit_tests_frequent
+
+.PRECIOUS: $(TESTDIR)/tt_metal/unit_tests_frequent
+$(TESTDIR)/tt_metal/unit_tests_frequent: $(TT_METAL_UNIT_TESTS_FREQUENT_OBJS) $(TT_METAL_LIB)
+	@mkdir -p $(@D)
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(TT_METAL_UNIT_TESTS_FREQUENT_INCLUDES) -o $@ $^ $(LDFLAGS) $(TT_METAL_UNIT_TESTS_FREQUENT_LDFLAGS)
+
+.PRECIOUS: $(OBJDIR)/$(TT_METAL_UNIT_TESTS_FREQUENT_OBJ_HOME)/%.o
+$(OBJDIR)/$(TT_METAL_UNIT_TESTS_FREQUENT_OBJ_HOME)/%.o: $(TT_METAL_UNIT_TESTS_FREQUENT_SRCS_HOME)/%.cpp
+	@mkdir -p $(@D)
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(TT_METAL_UNIT_TESTS_FREQUENT_INCLUDES) -c -o $@ $<

--- a/tests/tt_metal/tt_metal/unit_tests_frequent/tests/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_frequent/tests/run_many_times.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "gtest/gtest.h"
-#include "test_utils.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/host_api.hpp"
 

--- a/tests/tt_metal/tt_metal/unit_tests_frequent/tests_main.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_frequent/tests_main.cpp
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -109,7 +109,7 @@ struct mailboxes_t {
 
 #ifndef TENSIX_FIRMWARE
 // Validate assumptions on mailbox layout on host compile
-static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, launch)) % 16 == 0);
+static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, launch)) % 32 == 0);
 static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, slave_sync.ncrisc) == MEM_SLAVE_RUN_MAILBOX_ADDRESS);
 static_assert(MEM_MAILBOX_BASE + offsetof(mailboxes_t, ncrisc_halt.stack_save) == MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS);
 static_assert(MEM_MAILBOX_BASE + sizeof(mailboxes_t) < MEM_MAILBOX_END);

--- a/tt_metal/hw/inc/grayskull/dev_mem_map.h
+++ b/tt_metal/hw/inc/grayskull/dev_mem_map.h
@@ -50,7 +50,7 @@
 #define MEM_ZEROS_SIZE                 512
 
 #define MEM_BOOT_CODE_BASE             0
-#define MEM_MAILBOX_BASE               4
+#define MEM_MAILBOX_BASE               20
 #define MEM_MAILBOX_END                (MEM_MAILBOX_BASE + 128)
 #define MEM_ZEROS_BASE                 2048
 #define MEM_BRISC_FIRMWARE_BASE        (MEM_ZEROS_BASE + MEM_ZEROS_SIZE)
@@ -61,8 +61,8 @@
 
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 // Better way to do this would be to generate a file w/ these addresses
-#define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS    8
-#define MEM_SLAVE_RUN_MAILBOX_ADDRESS            32
+#define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS    MEM_MAILBOX_BASE + 4
+#define MEM_SLAVE_RUN_MAILBOX_ADDRESS            MEM_MAILBOX_BASE + 28
 
 /////////////
 // Initialization relocation L1 memory

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -50,7 +50,7 @@
 #define MEM_ZEROS_SIZE                 512
 
 #define MEM_BOOT_CODE_BASE             0
-#define MEM_MAILBOX_BASE               4
+#define MEM_MAILBOX_BASE               20
 #define MEM_MAILBOX_END                (MEM_MAILBOX_BASE + 128)
 #define MEM_ZEROS_BASE                 2048
 #define MEM_BRISC_FIRMWARE_BASE        (MEM_ZEROS_BASE + MEM_ZEROS_SIZE)
@@ -61,8 +61,8 @@
 
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 // Better way to do this would be to generate a file w/ these addresses
-#define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS    8
-#define MEM_SLAVE_RUN_MAILBOX_ADDRESS            32
+#define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS    MEM_MAILBOX_BASE + 4
+#define MEM_SLAVE_RUN_MAILBOX_ADDRESS            MEM_MAILBOX_BASE + 28
 
 /////////////
 // Initialization relocation L1 memory

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1048,14 +1048,14 @@ void Program::compile( Device * device )
     }
 
     for (auto & f : events)
-        f.wait();
+        f.get();
 
     for (auto kernel : kernels_) {
         events.emplace_back ( detail::async ( [kernel, device] { kernel->read_binaries(device); }));
     }
 
     for (auto & f : events)
-        f.wait();
+        f.get();
 
     this->construct_core_range_set_for_worker_cores();
 


### PR DESCRIPTION
Issue here is that the launch.run field could be read as true before the launch.enable_brisc and launch.enable_ncrisc fields.
This fixes the intermittent issues with the DPrint RaiseWait test (passes 500 consecutive iterations, previously would fail within 100)

This PR also includes a couple of fixes I found when trying to get this new test to pass on CI.