### PR TITLE
#5082: power gradient is erroneous when exponent is in range (0-1)

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
@@ -61,17 +61,20 @@ def test_fw_exponent(input_shapes, exponent, device):
     ),
 )
 @pytest.mark.parametrize(
-    "exponent",
+    "exponent_and_pcc",
     [
-        0.0,
-        1.0,
-        2.0,
-        5.0,
+        (0.0, 0.99),
+        (1.0, 0.99),
+        (2.0, 0.99),
+        (5.0, 0.99),
+        (2.5, 0.60),
+        (0.5, 0.89),
     ],
 )
-def test_bw_unary_pow(input_shapes, exponent, device):
+def test_bw_unary_pow(input_shapes, exponent_and_pcc, device):
+    exponent, pcc = exponent_and_pcc
     in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device, True)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_pow_bw(grad_tensor, input_tensor, exponent=exponent)
 
@@ -83,5 +86,5 @@ def test_bw_unary_pow(input_shapes, exponent, device):
 
     golden_tensor = [in_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_results(tt_output_tensor_on_device, golden_tensor, pcc=pcc)
     assert status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -52,7 +52,10 @@ std::vector<Tensor> _unary_pow_bw(const Tensor& grad, const Tensor& input, float
         return grad_tensor;
     }
 
-    Tensor power_input = power(input, exponent - 1, output_mem_config);
+    Tensor power_input = power(input, fabs(exponent - 1.0f), output_mem_config);
+    if ( exponent < 1.0f ) {
+        power_input = recip(power_input,output_mem_config);
+    }
 
     Tensor result = mul_unary(power_input, exponent, output_mem_config);
     Tensor final_result = mul(result, grad, std::nullopt, output_mem_config);


### PR DESCRIPTION
- solution added but still low PCC
- we resolve the problem but the issue of low PCC is present for gradients of pow(x, exponent ) where exponent in $` \mathrm{range}[0,\infty]`$
