### PR TITLE
#5165: Add hyperbolic ops to ttnn

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 470
+personal_ws-1.1 en 474 
 ABI
 ADDI
 API
@@ -161,6 +161,7 @@ ZoneScoped
 abovementioned
 acc
 acos
+acosh
 addexp
 addr
 agrebenisan
@@ -169,9 +170,11 @@ apis
 arg
 args
 asin
+asinh
 asm
 async
 atan
+atanh
 autoclass
 autofunction
 backend
@@ -397,6 +400,7 @@ shft
 sigmoid
 signbit
 silu
+sinh
 sizeof
 skillset
 smi

--- a/docs/source/ttnn/api.rst
+++ b/docs/source/ttnn/api.rst
@@ -60,6 +60,11 @@ Pointwise Unary
    ttnn/asin
    ttnn/acos
    ttnn/atan
+   ttnn/sinh
+   ttnn/cosh
+   ttnn/asinh
+   ttnn/acosh
+   ttnn/atanh
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/acosh.rst
+++ b/docs/source/ttnn/ttnn/acosh.rst
@@ -1,0 +1,6 @@
+.. _ttnn.acosh:
+
+ttnn.acosh
+###############
+
+.. autofunction:: ttnn.acosh

--- a/docs/source/ttnn/ttnn/asinh.rst
+++ b/docs/source/ttnn/ttnn/asinh.rst
@@ -1,0 +1,6 @@
+.. _ttnn.asinh:
+
+ttnn.asinh
+###############
+
+.. autofunction:: ttnn.asinh

--- a/docs/source/ttnn/ttnn/atanh.rst
+++ b/docs/source/ttnn/ttnn/atanh.rst
@@ -1,0 +1,6 @@
+.. _ttnn.atanh:
+
+ttnn.atanh
+###############
+
+.. autofunction:: ttnn.atanh

--- a/docs/source/ttnn/ttnn/cosh.rst
+++ b/docs/source/ttnn/ttnn/cosh.rst
@@ -1,0 +1,6 @@
+.. _ttnn.cosh:
+
+ttnn.cosh
+###############
+
+.. autofunction:: ttnn.cosh

--- a/docs/source/ttnn/ttnn/sinh.rst
+++ b/docs/source/ttnn/ttnn/sinh.rst
@@ -1,0 +1,6 @@
+.. _ttnn.sinh:
+
+ttnn.sinh
+###############
+
+.. autofunction:: ttnn.sinh

--- a/tests/ttnn/sweep_tests/sweeps/acosh.py
+++ b/tests/ttnn/sweep_tests/sweeps/acosh.py
@@ -44,17 +44,17 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -1
-    high = 1
+    low = -1e-6
+    high = 1e6
 
     torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.acos(torch_input_tensor)
+    torch_output_tensor = torch.acosh(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.acos(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.acosh(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)

--- a/tests/ttnn/sweep_tests/sweeps/asin.py
+++ b/tests/ttnn/sweep_tests/sweeps/asin.py
@@ -19,6 +19,7 @@ parameters = {
     "input_dtype": [ttnn.bfloat16],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
 }
 
 
@@ -37,19 +38,20 @@ def run(
     input_dtype,
     input_memory_config,
     output_memory_config,
+    layout,
     *,
     device,
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
+    low = -1
+    high = 1
 
     torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
     torch_output_tensor = torch.asin(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
-        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
     output_tensor = ttnn.asin(input_tensor, memory_config=output_memory_config)

--- a/tests/ttnn/sweep_tests/sweeps/asinh.py
+++ b/tests/ttnn/sweep_tests/sweeps/asinh.py
@@ -44,17 +44,17 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -1
-    high = 1
+    low = -1e-6
+    high = 1e6
 
     torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.acos(torch_input_tensor)
+    torch_output_tensor = torch.asinh(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.acos(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.asinh(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)

--- a/tests/ttnn/sweep_tests/sweeps/atan.py
+++ b/tests/ttnn/sweep_tests/sweeps/atan.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from math import pi
 from typing import Optional, Tuple
 
 import torch
@@ -19,6 +20,7 @@ parameters = {
     "input_dtype": [ttnn.bfloat16],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
 }
 
 
@@ -37,19 +39,20 @@ def run(
     input_dtype,
     input_memory_config,
     output_memory_config,
+    layout,
     *,
     device,
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
+    low = -pi / 2
+    high = pi / 2
 
     torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
     torch_output_tensor = torch.atan(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
-        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
     output_tensor = ttnn.atan(input_tensor, memory_config=output_memory_config)

--- a/tests/ttnn/sweep_tests/sweeps/atanh.py
+++ b/tests/ttnn/sweep_tests/sweeps/atanh.py
@@ -44,17 +44,17 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -1
-    high = 1
+    low = -0.9
+    high = 0.9
 
     torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.acos(torch_input_tensor)
+    torch_output_tensor = torch.atanh(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.acos(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.atanh(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/cosh.py
+++ b/tests/ttnn/sweep_tests/sweeps/cosh.py
@@ -44,17 +44,17 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -1
-    high = 1
+    low = -9
+    high = 9
 
     torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.acos(torch_input_tensor)
+    torch_output_tensor = torch.cosh(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.acos(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.cosh(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)

--- a/tests/ttnn/sweep_tests/sweeps/sinh.py
+++ b/tests/ttnn/sweep_tests/sweeps/sinh.py
@@ -44,17 +44,17 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -1
-    high = 1
+    low = -9
+    high = 9
 
     torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.acos(torch_input_tensor)
+    torch_output_tensor = torch.sinh(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.acos(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.sinh(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)

--- a/tests/ttnn/sweep_tests/sweeps/tanh.py
+++ b/tests/ttnn/sweep_tests/sweeps/tanh.py
@@ -19,6 +19,7 @@ parameters = {
     "input_dtype": [ttnn.bfloat16],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
 }
 
 
@@ -37,19 +38,20 @@ def run(
     input_dtype,
     input_memory_config,
     output_memory_config,
+    layout,
     *,
     device,
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
+    low = -9
+    high = 9
 
     torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
     torch_output_tensor = torch.tanh(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
-        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
     output_tensor = ttnn.tanh(input_tensor, memory_config=output_memory_config)

--- a/tests/ttnn/unit_tests/operations/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/test_unary.py
@@ -102,3 +102,33 @@ def test_tan(device, h, w):
 @pytest.mark.parametrize("w", [128])
 def test_atan(device, h, w):
     run_unary_test(device, h, w, ttnn.atan, torch.atan)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_sinh(device, h, w):
+    run_unary_test(device, h, w, ttnn.sinh, torch.sinh)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_asinh(device, h, w):
+    run_unary_test(device, h, w, ttnn.asinh, torch.asinh)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_cosh(device, h, w):
+    run_unary_test(device, h, w, ttnn.cosh, torch.cosh, pcc=0.999)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_acosh(device, h, w):
+    run_unary_test(device, h, w, ttnn.acosh, torch.acosh)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_atanh(device, h, w):
+    run_unary_test(device, h, w, ttnn.atanh, torch.atanh)

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -105,6 +105,11 @@ from ttnn.operations.unary import (
     asin,
     acos,
     atan,
+    sinh,
+    cosh,
+    asinh,
+    acosh,
+    atanh,
 )
 
 from ttnn.operations.binary import (

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -32,6 +32,11 @@ def register_ttl_unary_function(name, ttl_unary_function):
             "asin": torch.asin,
             "acos": torch.acos,
             "atan": torch.atan,
+            "sinh": torch.sinh,
+            "cosh": torch.cosh,
+            "asinh": torch.asinh,
+            "acosh": torch.acosh,
+            "atanh": torch.atanh,
         }
         torch_function = name_to_torch_function[name]
         input_tensor = ttnn.to_torch(input_tensor)
@@ -109,6 +114,11 @@ TTL_UNARY_FUNCTIONS = [
     ("asin", ttl.tensor.asin),
     ("acos", ttl.tensor.acos),
     ("atan", ttl.tensor.atan),
+    ("sinh", ttl.tensor.sinh),
+    ("cosh", ttl.tensor.cosh),
+    ("asinh", ttl.tensor.asinh),
+    ("acosh", ttl.tensor.acosh),
+    ("atanh", ttl.tensor.atanh),
 ]
 
 


### PR DESCRIPTION
Add support to hyperbolic ops to ttnn
CI Test [Link](https://github.com/tenstorrent-metal/tt-metal/actions/runs/7812779740)
Sweep Test Results:
[acosh.csv](https://github.com/tenstorrent-metal/tt-metal/files/14191744/acosh.csv)
[asinh.csv](https://github.com/tenstorrent-metal/tt-metal/files/14191745/asinh.csv)
[atanh.csv](https://github.com/tenstorrent-metal/tt-metal/files/14191746/atanh.csv)
[cosh.csv](https://github.com/tenstorrent-metal/tt-metal/files/14191747/cosh.csv)
[sinh.csv](https://github.com/tenstorrent-metal/tt-metal/files/14191748/sinh.csv)
[tanh.csv](https://github.com/tenstorrent-metal/tt-metal/files/14191750/tanh.csv)
