### PR TITLE
#5172: Use prefix argument of preprocess_model_parameters as is, without adding an extra dot

### DIFF
--- a/tests/ttnn/integration_tests/t5/test_ttnn_optimized_functional_t5.py
+++ b/tests/ttnn/integration_tests/t5/test_ttnn_optimized_functional_t5.py
@@ -182,7 +182,7 @@ def test_t5_layer_cross_attention(device, model_name, batch_size, sequence_size)
         initialize_model=lambda: model,
         custom_preprocessor=functional_t5.custom_preprocessor,
         device=device,
-        prefix="EncDecAttention",
+        prefix="EncDecAttention.",
     )
 
     hidden_states = ttnn.from_torch(torch_hidden_states, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/integration_tests/whisper/test_torch_functional_whisper.py
+++ b/tests/ttnn/integration_tests/whisper/test_torch_functional_whisper.py
@@ -37,7 +37,7 @@ def test_whisper_attention(model_name, batch_size, sequence_size, use_key_value_
         initialize_model=lambda: model,
         convert_to_ttnn=lambda *_: False,
         custom_preprocessor=torch_functional_whisper.custom_preprocessor,
-        prefix="encoder_attn" if use_key_value_states else "",
+        prefix="encoder_attn." if use_key_value_states else "",
     )
 
     attention_mask = None

--- a/tests/ttnn/integration_tests/whisper/test_ttnn_functional_whisper.py
+++ b/tests/ttnn/integration_tests/whisper/test_ttnn_functional_whisper.py
@@ -50,7 +50,7 @@ def test_whisper_attention(device, ttnn_model, model_name, batch_size, sequence_
         initialize_model=lambda: model,
         convert_to_ttnn=lambda *_: False,
         custom_preprocessor=torch_functional_whisper.custom_preprocessor,
-        prefix="encoder_attn" if use_key_value_states else "",
+        prefix="encoder_attn." if use_key_value_states else "",
     )
 
     torch_attention_mask = None
@@ -68,7 +68,7 @@ def test_whisper_attention(device, ttnn_model, model_name, batch_size, sequence_
         convert_to_ttnn=lambda *_: True,
         custom_preprocessor=ttnn_model.custom_preprocessor,
         device=device,
-        prefix="encoder_attn" if use_key_value_states else "",
+        prefix="encoder_attn." if use_key_value_states else "",
     )
     attention_mask = None
     output = ttnn_model.whisper_attention(
@@ -158,7 +158,7 @@ def test_encoder(device, ttnn_model, model_name, batch_size, feature_size, seque
         convert_to_ttnn=ttnn_model.convert_to_ttnn,
         custom_preprocessor=ttnn_model.custom_preprocessor,
         device=device,
-        prefix="encoder",
+        prefix="encoder.",
     )
 
     ttnn_inputs_embeds = ttnn_model.preprocess_encoder_inputs(
@@ -280,7 +280,7 @@ def test_decoder(device, ttnn_model, model_name, batch_size, sequence_size):
         convert_to_ttnn=ttnn_model.convert_to_ttnn,
         custom_preprocessor=ttnn_model.custom_preprocessor,
         device=device,
-        prefix="decoder",
+        prefix="decoder.",
     )
     ttnn_decoder_input_ids = ttnn.from_torch(decoder_input_ids, dtype=ttnn.bfloat16)
     ttnn_decoder_input_ids = ttnn.to_device(ttnn_decoder_input_ids, device)

--- a/tests/ttnn/integration_tests/whisper/test_ttnn_optimized_functional_whisper.py
+++ b/tests/ttnn/integration_tests/whisper/test_ttnn_optimized_functional_whisper.py
@@ -49,7 +49,7 @@ def test_whisper_attention(device, ttnn_model, model_name, batch_size, sequence_
         initialize_model=lambda: model,
         convert_to_ttnn=lambda *_: False,
         custom_preprocessor=torch_functional_whisper.custom_preprocessor,
-        prefix="encoder_attn" if use_key_value_states else "",
+        prefix="encoder_attn." if use_key_value_states else "",
     )
 
     torch_attention_mask = None
@@ -67,7 +67,7 @@ def test_whisper_attention(device, ttnn_model, model_name, batch_size, sequence_
         convert_to_ttnn=lambda *_: True,
         custom_preprocessor=ttnn_model.custom_preprocessor,
         device=device,
-        prefix="encoder_attn" if use_key_value_states else "",
+        prefix="encoder_attn." if use_key_value_states else "",
     )
     attention_mask = None
     output = ttnn_model.whisper_attention(
@@ -154,7 +154,7 @@ def test_encoder(device, ttnn_model, model_name, batch_size, feature_size, seque
         initialize_model=lambda: model,
         convert_to_ttnn=ttnn_model.convert_to_ttnn,
         custom_preprocessor=ttnn_model.custom_preprocessor,
-        prefix="encoder",
+        prefix="encoder.",
         device=device,
     )
 
@@ -276,7 +276,7 @@ def test_decoder(device, ttnn_model, model_name, batch_size, sequence_size):
         convert_to_ttnn=ttnn_model.convert_to_ttnn,
         custom_preprocessor=ttnn_model.custom_preprocessor,
         device=device,
-        prefix="decoder",
+        prefix="decoder.",
     )
     ttnn_decoder_input_ids = ttnn.from_torch(decoder_input_ids, dtype=ttnn.bfloat16)
     ttnn_decoder_input_ids = ttnn.to_device(ttnn_decoder_input_ids, device)

--- a/tests/ttnn/unit_tests/test_preprocess_model_parameters.py
+++ b/tests/ttnn/unit_tests/test_preprocess_model_parameters.py
@@ -97,7 +97,7 @@ def test_conv(
         model_name="conv",  # Name to use for the cache
         initialize_model=lambda: torch_conv,
         custom_preprocessor=custom_preprocessor,
-        prefix="conv",  # prefix is not needed if you have an actual CNN model. Just use the names of the torch.nn.Conv2d variables
+        prefix="conv.",  # prefix is not needed if you have an actual CNN model. Just use the names of the torch.nn.Conv2d variables
     )
     assert len(parameters) == 2
 

--- a/ttnn/ttnn/model_preprocessing.py
+++ b/ttnn/ttnn/model_preprocessing.py
@@ -125,7 +125,7 @@ def _preprocess_model_parameters(
                     child,
                     convert_to_ttnn=convert_to_ttnn,
                     custom_preprocessor=custom_preprocessor,
-                    name=f"{name}.{index}" if name else f"{index}",
+                    name=f"{name}{index}" if name else f"{index}",
                 )
                 for index, child in enumerate(model.children())
             ]
@@ -162,7 +162,7 @@ def _preprocess_model_parameters(
             child,
             convert_to_ttnn=convert_to_ttnn,
             custom_preprocessor=custom_preprocessor,
-            name=f"{name}.{child_name}" if name else child_name,
+            name=f"{name}{child_name}" if name else child_name,
         )
 
     for parameter_name, parameter in named_parameters:


### PR DESCRIPTION
#5172