### PR TITLE
#4854: Implement attention and rms_norm sub-module using ttnn for mis…

### DIFF
--- a/models/experimental/functional_mistral/tt/ttnn_functional_attention.py
+++ b/models/experimental/functional_mistral/tt/ttnn_functional_attention.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import tt_lib
+import torch
+from models.utility_functions import torch_to_tt_tensor_rm, tt_to_torch_tensor
+
+
+def apply_rotary_emb(xq, xk, bcast_freq_xq, bcast_freq_xk, device, mem_config):
+    t_xq = ttnn.to_torch(ttnn.from_device(xq))
+    t_xk = ttnn.to_torch(ttnn.from_device(xk))
+
+    xq_real = torch_to_tt_tensor_rm(t_xq[..., :, :, ::2], device)
+    xq_img = torch_to_tt_tensor_rm(t_xq[..., :, :, 1::2], device)
+
+    xq = tt_lib.tensor.complex_tensor(xq_real, xq_img)
+
+    xq_real.deallocate()
+    xq_img.deallocate()
+
+    xk_real = torch_to_tt_tensor_rm(t_xk[..., :, :, ::2], device)
+    xk_img = torch_to_tt_tensor_rm(t_xk[..., :, :, 1::2], device)
+    xk = tt_lib.tensor.complex_tensor(xk_real, xk_img)
+
+    xk_real.deallocate()
+    xk_img.deallocate()
+
+    xq_out = tt_lib.tensor.complex_mul(xq, bcast_freq_xq, output_mem_config=mem_config)
+
+    xk_out = tt_lib.tensor.complex_mul(xk, bcast_freq_xk, output_mem_config=mem_config)
+
+    xq_out = tt_lib.tensor.concat([xq_out.real, xq_out.imag], -1, mem_config)
+    xk_out = tt_lib.tensor.concat([xk_out.real, xk_out.imag], -1, mem_config)
+    xq, xk = tt_to_torch_tensor(xq_out).to(torch.float32), tt_to_torch_tensor(xk_out).to(torch.float32)
+
+    xq_out.deallocate()
+    xk_out.deallocate()
+    # FIXME: move this operation to on-device - should be easy.
+
+    shapes = xq.shape
+    dindex = shapes[3] // 2
+    xq_out = torch.empty(xq.shape)
+    # for col in range(dindex):
+    #    xq_out[:,:,:,2*col] = xq[:,:,:,col]
+    #    xq_out[:,:,:,2*col+1] = xq[:,:,:,col+dindex]
+    xq_out[:, :, :, ::2] = xq[:, :, :, :dindex]
+    xq_out[:, :, :, 1::2] = xq[:, :, :, dindex:]
+
+    shapes = xk.shape
+    dindex = shapes[3] // 2
+    xk_out = torch.empty(xk.shape)
+    xk_out[:, :, :, ::2] = xk[:, :, :, :dindex]
+    xk_out[:, :, :, 1::2] = xk[:, :, :, dindex:]
+
+    return xq_out, xk_out
+
+
+def repeat_kv(key, values, repeats, device):
+    dim = 2
+    keys = ttnn.to_layout(ttnn.to_device(ttnn.from_torch(key, dtype=ttnn.bfloat16), device), layout=ttnn.TILE_LAYOUT)
+    values = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(values, dtype=ttnn.bfloat16), device), layout=ttnn.TILE_LAYOUT
+    )
+    keys = ttnn.repeat_interleave(keys, repeats, dim)
+    values = ttnn.repeat_interleave(values, repeats, dim)
+    return keys, values
+
+
+def attention(config, x, bcast_freq_xq, bcast_freq_xk, positions, mask, seqlen, parameters, device, mem_config):
+    bsz, _, _ = x.shape
+    xq = x @ parameters.wq.weight
+    xk = x @ parameters.wk.weight
+    xv = x @ parameters.wv.weight
+
+    xq = ttnn.to_layout(xq, ttnn.ROW_MAJOR_LAYOUT)
+    xk = ttnn.to_layout(xk, ttnn.ROW_MAJOR_LAYOUT)
+    xv = ttnn.to_layout(xv, ttnn.ROW_MAJOR_LAYOUT)
+
+    xq = xq[:, :seqlen, :]
+    xk = xk[:, :seqlen, :]
+    xv = xv[:, :seqlen, :]
+
+    xq = ttnn.reshape(xq, (bsz, seqlen, config.n_heads, config.head_dim))
+    xk = ttnn.reshape(xk, (bsz, seqlen, config.n_kv_heads, config.head_dim))
+    xv = ttnn.reshape(xv, (bsz, seqlen, config.n_kv_heads, config.head_dim))
+
+    xq, xk = apply_rotary_emb(xq, xk, bcast_freq_xq, bcast_freq_xk, device, mem_config)
+
+    positions = ttnn.to_torch(ttnn.from_device(positions)).squeeze(0).squeeze(0).squeeze(0)
+
+    scatter_pos = (positions[-config.sliding_window :] % config.sliding_window)[None, :, None, None]
+    scatter_pos = scatter_pos.to(torch.int64)
+    scatter_pos = scatter_pos.repeat(bsz, 1, config.n_kv_heads, config.head_dim)
+
+    cache_k = tt_lib.tensor.empty(
+        [config.max_batch_size, config.sliding_window, config.n_kv_heads, config.head_dim],
+        layout=tt_lib.tensor.Layout.ROW_MAJOR,
+        device=device,
+        output_mem_config=config.out_mem_config,
+    )
+    cache_k = tt_to_torch_tensor(cache_k).to(torch.float32)
+    cache_v = tt_lib.tensor.empty(
+        [config.max_batch_size, config.sliding_window, config.n_kv_heads, config.head_dim],
+        layout=tt_lib.tensor.Layout.ROW_MAJOR,
+        device=device,
+        output_mem_config=config.out_mem_config,
+    )
+    cache_v = tt_to_torch_tensor(cache_v).to(torch.float32)
+    cache_k[:bsz].scatter_(dim=1, index=scatter_pos, src=xk[:, -config.sliding_window :])
+    xv = ttnn.to_torch(xv).to(torch.float32)
+    cache_v[:bsz].scatter_(dim=1, index=scatter_pos, src=xv[:, -config.sliding_window :])
+
+    if positions.shape[0] > 1:
+        key, value = repeat_kv(xk, xv, config.n_heads // config.n_kv_heads, device)
+    else:
+        curr_pos = int(positions[-1].item() + 1)
+        key, value = repeat_kv(
+            cache_k[:bsz, :curr_pos, ...], cache_v[:bsz, :curr_pos, ...], config.n_heads // config.n_kv_heads, device
+        )
+
+    xq = ttnn.to_layout(ttnn.to_device(ttnn.from_torch(xq, dtype=ttnn.bfloat16), device), layout=ttnn.TILE_LAYOUT)
+    query = ttnn.permute(xq, (0, 2, 1, 3))
+
+    key = ttnn.permute(ttnn.to_device(key, device), (0, 2, 3, 1))
+
+    value = ttnn.permute(ttnn.to_device(value, device), (0, 2, 1, 3))
+
+    scores = query @ key
+    scores = scores * config.head_dim**-0.5
+    scores = ttnn.to_device(scores, device)
+
+    if mask is not None:
+        scores = ttnn.permute(scores, (2, 3, 0, 1))
+        mask = ttnn.to_torch(mask).unsqueeze(0).unsqueeze(0)
+        mask = ttnn.from_torch(mask, dtype=ttnn.bfloat16)
+        mask = ttnn.to_layout(mask, layout=ttnn.TILE_LAYOUT)
+        mask = ttnn.to_device(mask, device)
+        value1 = scores.shape[-1]
+        value2 = scores.shape[-2]
+        value3 = scores.shape[1]
+        value4 = scores.shape[0]
+
+        mask = ttnn.pad(
+            mask,
+            padding=(
+                (0, value4 - mask.shape[0]),
+                (0, value3 - mask.shape[1]),
+                (0, value2 - mask.shape[-2]),
+                (0, value1 - mask.shape[-1]),
+            ),
+            value=0,
+        )
+
+        scores = ttnn.add(scores, mask)
+        scores = ttnn.permute(scores, (2, 3, 0, 1))
+
+    scores = ttnn.softmax(scores, dim=-1)
+    output = scores @ value
+    output = ttnn.permute(output, (0, 2, 1, 3))
+    output = ttnn.to_torch(output)
+    output = torch_to_tt_tensor_rm(output, device, put_on_device=True)
+    output = tt_lib.tensor.reshape(output, 1, bsz, seqlen, -1)
+    output = tt_to_torch_tensor(output)
+    output = ttnn.to_device(
+        ttnn.to_layout(ttnn.from_torch(output, dtype=ttnn.bfloat16), layout=ttnn.TILE_LAYOUT), device
+    )
+    output = output @ parameters.wo.weight
+    return output

--- a/models/experimental/functional_mistral/tt/ttnn_functional_rms_norm.py
+++ b/models/experimental/functional_mistral/tt/ttnn_functional_rms_norm.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+def rms_norm(config, input: ttnn.Tensor, *, parameters):
+    return ttnn.rms_norm(input, parameters, epsilon=config.norm_eps)

--- a/tests/ttnn/integration_tests/mistral/test_mistral_attention.py
+++ b/tests/ttnn/integration_tests/mistral/test_mistral_attention.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import tt_lib
+from ttnn.model_preprocessing import preprocess_model_parameters
+
+import json
+from pathlib import Path
+from models.experimental.mistral.tt.mistral_configuration import TtModelArgs
+from models.experimental.mistral.reference.model import Transformer
+from models.experimental.mistral.reference.model import Attention
+from models.experimental.mistral.mistral_helper_funcs import get_freqs_cis
+from models.experimental.functional_mistral.tt.ttnn_functional_attention import attention
+from models.utility_functions import skip_for_wormhole_b0
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@skip_for_wormhole_b0()
+def test_mistral_attention_inference(model_location_generator, device, reset_seeds):
+    model_path = model_location_generator("mistral-7B-v0.1", model_subdir="Mistral")
+    transformer = Transformer.from_folder(Path(model_path), n_layers=1, max_batch_size=1, is_whole_model=False)
+    state_dict = torch.load(model_path / "consolidated.00.pth")
+    with open(model_path / "params.json", "r") as f:
+        model_args = TtModelArgs(**json.loads(f.read()))
+    state_dict = {k[19:]: v for k, v in state_dict.items() if (k.startswith("layers.0.attention."))}
+
+    ref_model = transformer.layers[0].attention
+    ref_model.eval()
+
+    model_args.max_batch_size = 1
+    model_args.n_layers = 32
+
+    model_args.max_batch_size = 1
+
+    reference_model = Attention(args=model_args)
+    reference_model.load_state_dict(state_dict)
+    output_mem_config = tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    )
+
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: ref_model,
+        device=device,
+    )
+
+    input = torch.rand(1, 11, 4096)
+    seqlen = input.shape[1]
+    empty_tensor = torch.zeros((11, 64))
+    freqs_cis = torch.complex(empty_tensor, empty_tensor)
+    query_shape = [1, 11, model_args.n_heads, model_args.head_dim // 2]
+    key_shape = [1, 11, model_args.n_kv_heads, model_args.head_dim // 2]
+    bcast_freq_xq, bcast_freq_xk = get_freqs_cis(freqs_cis, query_shape, key_shape, device, output_mem_config)
+    positions = torch.arange(0, 11)
+    mask = torch.randn(11, 11)
+    reference_ouput = reference_model(input, freqs_cis, positions, mask=mask)
+
+    ttnn_input = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(input, dtype=ttnn.bfloat16), device), layout=ttnn.TILE_LAYOUT
+    )
+    positions = ttnn.from_torch(positions, dtype=ttnn.bfloat16)
+    mask = ttnn.to_layout(ttnn.from_torch(mask, dtype=ttnn.bfloat16), layout=ttnn.TILE_LAYOUT)
+    output = attention(
+        model_args,
+        ttnn_input,
+        bcast_freq_xq,
+        bcast_freq_xk,
+        positions,
+        mask,
+        seqlen,
+        parameters=parameters,
+        device=device,
+        mem_config=output_mem_config,
+    )
+
+    output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+    output = ttnn.from_device(output)
+
+    output = ttnn.to_torch(output).squeeze(0)
+    assert_with_pcc(reference_ouput, output.to(reference_ouput.dtype), 0.98)

--- a/tests/ttnn/integration_tests/mistral/test_mistral_rms_norm.py
+++ b/tests/ttnn/integration_tests/mistral/test_mistral_rms_norm.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+import ttnn
+
+import json
+from pathlib import Path
+from models.experimental.mistral.tt.mistral_configuration import TtModelArgs
+from models.experimental.mistral.reference.model import Transformer
+from models.experimental.mistral.reference.model import RMSNorm
+from models.experimental.functional_mistral.tt.ttnn_functional_rms_norm import rms_norm
+from models.utility_functions import skip_for_wormhole_b0
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@skip_for_wormhole_b0()
+def test_mistral_rms_norm_inference(model_location_generator, device, reset_seeds):
+    model_path = model_location_generator("mistral-7B-v0.1", model_subdir="Mistral")
+    transformer = Transformer.from_folder(Path(model_path), n_layers=32, max_batch_size=1, is_whole_model=True)
+    state_dict = torch.load(model_path / "consolidated.00.pth")
+    state_dict = {k[24:]: v for k, v in state_dict.items() if (k.startswith("layers.0.attention_norm."))}
+    with open(model_path / "params.json", "r") as f:
+        model_args = TtModelArgs(**json.loads(f.read()))
+
+    model_args.max_batch_size = 1
+    model_args.n_layers = 32
+    dim = 4096
+
+    model_args.max_batch_size = 1
+
+    reference_model = RMSNorm(dim=dim)
+    reference_model.load_state_dict(state_dict)
+
+    input = torch.rand(1, 11, 4096)
+    reference_ouput = reference_model(input)
+
+    ttnn_input = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(input, dtype=ttnn.bfloat16), device), layout=ttnn.TILE_LAYOUT
+    )
+    parameters = ttnn.to_layout(
+        ttnn.to_device(ttnn.from_torch(transformer.layers[0].attention_norm.weight, dtype=ttnn.bfloat16), device),
+        layout=ttnn.TILE_LAYOUT,
+    )
+    output = rms_norm(model_args, ttnn_input, parameters=parameters)
+    output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+    output = ttnn.from_device(output)
+    output = ttnn.to_torch(output)
+
+    assert_with_pcc(reference_ouput, output.to(reference_ouput.dtype), 0.99)

--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -155,7 +155,7 @@ def permute(input_tensor: ttnn.Tensor, order: Tuple[int, ...]) -> ttnn.Tensor:
         def torch_permute(tensor, order):
             return tensor.permute(order).contiguous().clone()
 
-        tensor = ttnn.to_torch(tensor)
+        tensor = ttnn.to_torch(input_tensor)
         tensor = ttl.tensor.decorate_external_operation(torch_permute, function_name="torch.permute")(tensor, order)
         tensor = ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device)
         return tensor


### PR DESCRIPTION
This PR has the following.

- mistral rms_norm and mistral attention sub-modules implemented using ttnn ops.
- Fix for ttnn.permute op UnboundLocalError [#5150](https://github.com/tenstorrent-metal/tt-metal/issues/5150)
