### PR TITLE
#4854: Implement mistral transformer using ttnn

### DIFF
--- a/models/experimental/functional_mistral/tt/mistral_helper_funcs.py
+++ b/models/experimental/functional_mistral/tt/mistral_helper_funcs.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import tt_lib
+import torch
+from models.utility_functions import tt_to_torch_tensor, torch_to_tt_tensor_rm
+
+
+def _reshape_for_broadcast(freqs_cis, x_shape, x_dim):
+    ndim = x_dim
+    assert 1 < ndim
+    assert freqs_cis.shape == (x_shape[1], x_shape[-1]), (
+        freqs_cis.shape,
+        (x_shape[1], x_shape[-1]),
+    )
+    shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x_shape)]
+    return freqs_cis.view(*shape)
+
+
+def get_freqs_cis(freqs_cis, query_shape, key_shape, device, mem_config):
+    freqs_cis = _reshape_for_broadcast(freqs_cis, query_shape, 4)
+
+    freq_real = torch_to_tt_tensor_rm(freqs_cis.real, device)
+    freq_img = torch_to_tt_tensor_rm(freqs_cis.imag, device)
+    freqs_cis = tt_lib.tensor.complex_tensor(freq_real, freq_img)
+
+    freq_real.deallocate()
+    freq_img.deallocate()
+
+    t_one_xq = torch.ones(query_shape)
+    t_one_xq = ttnn.from_torch(t_one_xq, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    freqs_real = ttnn.to_layout(ttnn.Tensor(freqs_cis.real), layout=ttnn.TILE_LAYOUT)
+
+    freqs_imag = ttnn.to_layout(ttnn.Tensor(freqs_cis.imag), layout=ttnn.TILE_LAYOUT)
+
+    freqs_real = ttnn.pad(
+        freqs_real, padding=((0, t_one_xq.shape[-0] - freqs_real.shape[0]), (0, 0), (0, 0), (0, 0)), value=1
+    )
+    bcast_freq_re_xq = t_one_xq * freqs_real
+    freqs_imag = ttnn.pad(
+        freqs_imag, padding=((0, t_one_xq.shape[-0] - freqs_imag.shape[0]), (0, 0), (0, 0), (0, 0)), value=1
+    )
+
+    bcast_freq_im_xq = t_one_xq * freqs_imag
+    bcast_freq_xq = tt_lib.tensor.complex_tensor(bcast_freq_re_xq.value, bcast_freq_im_xq.value)
+
+    t_one_xk = torch.ones(key_shape)
+    t_one_xk = ttnn.from_torch(t_one_xk, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    bcast_freq_re_xk = ttnn.to_layout(t_one_xk * freqs_real, layout=ttnn.ROW_MAJOR_LAYOUT)
+    bcast_freq_im_xk = ttnn.to_layout(t_one_xk * freqs_imag, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    bcast_freq_xk = tt_lib.tensor.complex_tensor(bcast_freq_re_xk.value, bcast_freq_im_xk.value)
+
+    freqs_cis.deallocate()
+
+    return bcast_freq_xq, bcast_freq_xk

--- a/models/experimental/functional_mistral/tt/ttnn_functional_transformer.py
+++ b/models/experimental/functional_mistral/tt/ttnn_functional_transformer.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import tt_lib
+from models.experimental.functional_mistral.tt.mistral_helper_funcs import get_freqs_cis
+from models.experimental.functional_mistral.tt.ttnn_functional_rms_norm import rms_norm
+from models.experimental.functional_mistral.tt.ttnn_functional_transformer_block import transformer_block
+from models.utility_functions import tt_to_torch_tensor
+from typing import Optional
+
+
+def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> torch.Tensor:
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)  # type: ignore
+    freqs = torch.outer(t, freqs).float()  # type: ignore
+    return torch.polar(torch.ones_like(freqs), freqs)  # complex64
+
+
+def mistral_transformer(config, input_ids, positions, parameters, device, mem_config):
+    seqlen = input_ids.shape[-1]
+    bsz = input_ids.shape[0]
+    input_ids = ttnn.to_device(input_ids, device)
+    h = ttnn.embedding(input_ids, parameters.tok_embeddings.weight)
+    h = ttnn.to_layout(h, layout=ttnn.TILE_LAYOUT)
+    freq_cis = precompute_freqs_cis(config.head_dim, 128_000)
+    freqs_cis = freq_cis[positions]
+    query_shape = [bsz, seqlen, config.n_heads, config.head_dim // 2]
+    key_shape = [bsz, seqlen, config.n_kv_heads, config.head_dim // 2]
+    print("Query key shape :", query_shape, " ", key_shape)
+    bcast_freq_xq, bcast_freq_xk = get_freqs_cis(freqs_cis, query_shape, key_shape, device, mem_config)
+
+    mask: Optional[torch.Tensor] = None
+    if input_ids.shape[-1] > 1:
+        seqlen = input_ids.shape[-1]
+        tensor = tt_lib.tensor.full((1, 1, seqlen, seqlen), fill_value=1.0)
+        diagonal = 0
+
+        mask = tt_lib.tensor.tril(tensor, diagonal)
+        tensor.deallocate()
+
+        diagonal = -config.sliding_window
+        mask = tt_lib.tensor.triu(mask, diagonal)
+        mask = tt_to_torch_tensor(mask).squeeze(0).squeeze(0)
+        mask = ttnn.from_torch(mask, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT)
+        mask = ttnn.log(mask)
+        mask = ttnn.to_layout(
+            ttnn.pad(mask, ((0, 32 - mask.shape[-2] % 32), (0, 32 - mask.shape[-1] % 32)), value=-10000),
+            layout=ttnn.TILE_LAYOUT,
+        )
+
+    positions = ttnn.from_torch(positions, dtype=ttnn.bfloat16)
+
+    for params in parameters.layers:
+        h = transformer_block(
+            config, h, bcast_freq_xq, bcast_freq_xk, positions, mask, seqlen, params, device, mem_config
+        )
+
+    bcast_freq_xq.deallocate()
+    bcast_freq_xk.deallocate()
+
+    output_norm = rms_norm(config, input=h, parameters=parameters.norm.weight)
+    output = output_norm @ parameters.output.weight
+    return output

--- a/tests/ttnn/integration_tests/mistral/test_mistral_transformer.py
+++ b/tests/ttnn/integration_tests/mistral/test_mistral_transformer.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import tt_lib
+import pytest
+import json
+from pathlib import Path
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.experimental.mistral.tt.mistral_configuration import TtModelArgs
+from models.experimental.mistral.reference.model import Transformer
+from models.experimental.mistral.reference.tokenizer import Tokenizer
+from models.experimental.functional_mistral.tt.ttnn_functional_transformer import mistral_transformer
+from models.experimental.functional_mistral.tt.mistral_utility import custom_preprocessor
+from models.utility_functions import skip_for_wormhole_b0
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "batch_size",
+    (
+        (1),
+        (8),
+    ),
+)
+def test_mistral_transformer_inference(batch_size, model_location_generator, device, reset_seeds):
+    prompts = [
+        "'A man is sitting on a roof ",
+    ] * batch_size
+    model_path = model_location_generator("mistral-7B-v0.1", model_subdir="Mistral")
+    tokenizer = Tokenizer(str(Path(model_path) / "tokenizer.model"))
+    transformer = Transformer.from_folder(Path(model_path), n_layers=1, max_batch_size=batch_size, is_whole_model=False)
+    with open(model_path / "params.json", "r") as f:
+        model_args = TtModelArgs(**json.loads(f.read()))
+
+    model_args.max_batch_size = batch_size
+    model_args.n_layers = 1
+
+    reference_model = Transformer(args=model_args)
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: reference_model,
+        device=device,
+        custom_preprocessor=custom_preprocessor,
+    )
+    output_mem_config = tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    )
+    encoded_prompts = [tokenizer.encode(prompt) for prompt in prompts]
+    prompt_lens = [len(x) for x in encoded_prompts]
+    min_prompt_len = min(prompt_lens)
+    max_prompt_len = max(prompt_lens)
+    input_tokens = torch.full((len(prompts), max_prompt_len), tokenizer.pad_id, dtype=torch.long, device="cpu")
+    for i, encoded in enumerate(encoded_prompts):
+        input_tokens[i, : len(encoded)] = torch.tensor(encoded, dtype=torch.long)
+    positions = torch.arange(0, min_prompt_len)
+
+    reference_ouput = reference_model(input_tokens[:, :min_prompt_len], positions)
+    del reference_model
+    ttnn_input = ttnn.from_torch(input_tokens, dtype=ttnn.uint32, device=device)
+
+    output = mistral_transformer(
+        model_args,
+        ttnn_input,
+        positions,
+        parameters=parameters,
+        device=device,
+        mem_config=output_mem_config,
+    )
+    output = ttnn.to_layout(output, ttnn.ROW_MAJOR_LAYOUT)
+    output = ttnn.to_torch(ttnn.from_device(output))
+
+    assert_with_pcc(reference_ouput, output.to(reference_ouput.dtype), 0.98)


### PR DESCRIPTION
This PR has the mistral transformer implemented using ttnn ops(Unable to load the complete model, hence the test is enabled to use only a single layer)