### PR TITLE
#4614: gitmodules: Use https URLs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,20 +1,18 @@
 [submodule "src/ckernels/sfpi"]
 	path = tt_metal/third_party/sfpi
-	url = git@github.com:tenstorrent-metal/sfpi-rel.git
-
+	url = https://github.com/tenstorrent-metal/sfpi-rel.git
 [submodule "third_party/pybind11"]
 	path = tt_metal/third_party/pybind11
 	url = https://github.com/pybind/pybind11.git
-
 [submodule "third_party/lfs"]
 	path = tt_metal/third_party/lfs
-	url = git@github.com:tenstorrent-metal/lfs.git
+	url = https://github.com/tenstorrent-metal/lfs.git
 [submodule "tt_metal/third_party/taskflow"]
 	path = tt_metal/third_party/taskflow
 	url = https://github.com/taskflow/taskflow
 [submodule "tt_metal/third_party/tracy"]
 	path = tt_metal/third_party/tracy
-	url = git@github.com:tenstorrent-metal/tracy.git
+	url = https://github.com/tenstorrent-metal/tracy.git
 [submodule "tt_metal/third_party/umd"]
 	path = tt_metal/third_party/umd
-	url = git@github.com:tenstorrent-metal/umd.git
+	url = https://github.com/tenstorrent-metal/umd.git

--- a/README.md
+++ b/README.md
@@ -196,14 +196,14 @@ developer dependencies if you are a developer.
 ``<VERSION_NUMBER>`` is the release version you will be using. Otherwise, you can use ``main`` to get the latest development source.
 
 ```
-git clone git@github.com:tenstorrent-metal/tt-metal.git --recurse-submodules --branch <VERSION_NUMBER>
+git clone https://github.com/tenstorrent-metal/tt-metal.git --recurse-submodules --branch <VERSION_NUMBER>
 cd tt-metal
 ```
 
 For example, if you are trying to use version `v0.35.0`, you can execute:
 
 ```
-git clone git@github.com:tenstorrent-metal/tt-metal.git --recurse-submodules --branch v0.35.0
+git clone https://github.com/tenstorrent-metal/tt-metal.git --recurse-submodules --branch v0.35.0
 cd tt-metal
 ```
 


### PR DESCRIPTION
This means that if you clone with https://github.com/tenstorrent-metal/tt-metal, the submodules will also use https. Slight removal of friction for those not using SSH for github (cloning).

The alternative would be to use relative submodule paths, but that means that anyone forking the tt-metal repo also needs to fork the submodules for them to be possible to clone, which is awkward.