### PR TITLE
#0: add reviewers to frequently touched ops docs file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -111,6 +111,7 @@ models/metal_BERT_large_11 @tt-aho @TT-BrianLiu
 functional_*/ @eyonland @arakhmati
 
 # docs
+docs/source/ttnn/dependencies/tt_lib.rst @eyonland @arakhmati @muthutt
 # docs/source/apis/host_apis/ @abhullar-tt @TT-billteng @davorchap @tt-rkim
 # docs/source/apis/host_apis2.rst @abhullar-tt @TT-billteng @davorchap @tt-rkim
 # docs/source/apis/kernel_apis/ @davorchap @DrJessop @pgkeller @tt-rkim


### PR DESCRIPTION
#0: add reviewers to frequently touched ops docs file
This helps to,
- Increase ops team development cycles
- Reduce noise to other developers
