### PR TITLE
#4885: Move program device map to program

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -258,7 +258,6 @@ def device(device_init_destroy):
 
     device = ttl.device.GetDefaultDevice()
     yield device
-    ttl.device.ClearCommandQueueProgramCache(device)
     ttl.device.DeallocateBuffers(device)
 
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -21,7 +21,6 @@ def setup_tt_tensor(x, device, layout, input_mem_config, dtype):
 def setup_host_and_device(func):
     def wrap(*args, device, **kwargs):
         output = func(*args, device=device, **kwargs)
-        ttl.device.ClearCommandQueueProgramCache(device)
         ttl.device.DeallocateBuffers(device)
         return output
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -83,10 +83,13 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
 
     // We should be able to find the expected watcher error in the log as well.
     CoreCoord phys_core = device->worker_core_from_logical_core(core);
-    string expected = "Device x, Core (x=x,y=x):    NAWW,*,*,*,*  brisc using noc0 tried to access core (16,16) L1[addr=0x00019020,len=102400]";
+    string expected = "Device x, Core (x=x,y=x):    NAWW,*,*,*,*  brisc using noc0 tried to access core (16,16) L1[addr=0x********,len=102400]";
     expected[7] = '0' + device->id();
     expected[18] = '0' + phys_core.x;
     expected[22] = '0' + phys_core.y;
+    string addr = fmt::format("{:08x}", output_dram_buffer_addr);
+    expected.replace(99, addr.length(), addr);
+
     EXPECT_TRUE(
         FileContainsAllStrings(
             fixture->log_file_name,

--- a/tests/ttnn/sweep_tests/sweep.py
+++ b/tests/ttnn/sweep_tests/sweep.py
@@ -86,7 +86,6 @@ def _run_single_test(run, skip, is_expected_to_fail, permutation, *, device):
     finally:
         import tt_lib as ttl
 
-        ttl.device.ClearCommandQueueProgramCache(device)
         ttl.device.DeallocateBuffers(device)
     return status, message
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -133,9 +133,6 @@ void DeviceModule(py::module &m_device) {
     m_device.def("DeallocateBuffers", &detail::DeallocateBuffers, R"doc(
         Deallocate all buffers associated with Device handle
     )doc");
-    m_device.def("ClearCommandQueueProgramCache", &detail::ClearCommandQueueProgramCache, R"doc(
-        Deallocate the program cache saved by the command queue
-    )doc");
 }
 
 void ProfilerModule(py::module &m_profiler) {

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -308,13 +308,6 @@ namespace tt::tt_metal{
             device->deallocate_buffers();
         }
 
-        inline void ClearCommandQueueProgramCache(Device *device)
-        {
-            if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
-                ClearProgramCache(device);
-            }
-        }
-
         inline void GenerateDeviceHeaders(Device *device,
                                           const std::string &path)
         {

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -22,478 +22,7 @@ namespace tt::tt_metal {
 
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 
-namespace {
-
-    map<uint64_t, unique_ptr<Buffer>>& program_to_buffer(const chip_id_t chip_id) {
-        static map<chip_id_t, map<uint64_t, unique_ptr<Buffer>>> chip_to_program_to_buffer;
-        if (chip_to_program_to_buffer.count(chip_id)) {
-            return chip_to_program_to_buffer[chip_id];
-        }
-        map<uint64_t, unique_ptr<Buffer>> dummy;
-        chip_to_program_to_buffer.emplace(chip_id, std::move(dummy));
-        return chip_to_program_to_buffer[chip_id];
-    }
-
-    map<uint64_t, ProgramMap>& program_to_dev_map(const chip_id_t chip_id) {
-        static map<chip_id_t, map<uint64_t, ProgramMap>> chip_to_program_to_dev_map;
-        if (chip_to_program_to_dev_map.count(chip_id)) {
-            return chip_to_program_to_dev_map[chip_id];
-        }
-        map<uint64_t, ProgramMap> dummy;
-        chip_to_program_to_dev_map.emplace(chip_id, std::move(dummy));
-        return chip_to_program_to_dev_map[chip_id];
-    };
-}
-
-namespace detail{
-    void ClearProgramCache(Device * device) {
-        detail::DispatchStateCheck(true);
-        program_to_buffer(device->id()).clear();
-        program_to_dev_map(device->id()).clear();
-    }
-}
-
-uint32_t get_noc_multicast_encoding(const CoreCoord& top_left, const CoreCoord& bottom_right) {
-    return NOC_MULTICAST_ENCODING(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
-}
-
 uint32_t get_noc_unicast_encoding(CoreCoord coord) { return NOC_XY_ENCODING(NOC_X(coord.x), NOC_Y(coord.y)); }
-
-ProgramMap ConstructProgramMap(const Device* device, Program& program) {
-    /*
-        TODO(agrebenisan): Move this logic to compile program
-    */
-    std::unordered_map<PageTransferType, vector<transfer_info>> program_page_transfers = {
-        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
-    std::unordered_map<PageTransferType, vector<transfer_info>> runtime_arg_page_transfers = {
-        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
-    std::unordered_map<PageTransferType, vector<transfer_info>> cb_config_page_transfers = {
-        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
-    std::unordered_map<PageTransferType, vector<transfer_info>> go_signal_page_transfers = {
-        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
-    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_program_pages = {
-        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
-    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_runtime_arg_pages = {
-        {PageTransferType::MULTICAST, {}},
-        {PageTransferType::UNICAST,
-         {}}};  // Corresponds to the number of transfers within host data pages across all host data pages
-    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_cb_config_pages = {
-        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
-    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_go_signal_pages = {
-        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
-
-    static const map<RISCV, uint32_t> processor_to_local_mem_addr = {
-        {RISCV::BRISC, MEM_BRISC_INIT_LOCAL_L1_BASE},
-        {RISCV::NCRISC, MEM_NCRISC_INIT_LOCAL_L1_BASE},
-        {RISCV::TRISC0, MEM_TRISC0_INIT_LOCAL_L1_BASE},
-        {RISCV::TRISC1, MEM_TRISC1_INIT_LOCAL_L1_BASE},
-        {RISCV::TRISC2, MEM_TRISC2_INIT_LOCAL_L1_BASE},
-        {RISCV::ERISC, eth_l1_mem::address_map::FIRMWARE_BASE}};
-
-    static const map<RISCV, uint32_t> processor_to_l1_arg_base_addr = {
-        {RISCV::BRISC, BRISC_L1_ARG_BASE},
-        {RISCV::NCRISC, NCRISC_L1_ARG_BASE},
-        {RISCV::COMPUTE, TRISC_L1_ARG_BASE},
-        {RISCV::ERISC, eth_l1_mem::address_map::ERISC_L1_ARG_BASE},
-    };
-
-    uint32_t num_transfers_within_page = 0;
-
-    uint32_t src = 0;
-    vector<uint32_t> program_pages;
-    uint32_t program_page_idx = 0;
-    uint32_t program_new_page_tracker = 0;
-    constexpr static uint32_t noc_transfer_alignment_in_bytes = 16;
-
-    auto update_program_page_transfers = [&num_transfers_within_page](
-                                             uint32_t src,
-                                             uint32_t num_bytes,
-                                             uint32_t dst,
-                                             vector<transfer_info>& transfers,
-                                             vector<uint32_t>& num_transfers_per_page,
-                                             const vector<pair<uint32_t, uint32_t>>& dst_noc_transfer_info,
-                                             bool linked = false) -> uint32_t {
-        while (num_bytes) {
-            uint32_t num_bytes_left_in_page = DeviceCommand::PROGRAM_PAGE_SIZE - (src % DeviceCommand::PROGRAM_PAGE_SIZE);
-            uint32_t num_bytes_in_transfer = std::min(num_bytes_left_in_page, num_bytes);
-            src = align(src + num_bytes_in_transfer, noc_transfer_alignment_in_bytes);
-
-            uint32_t transfer_instruction_idx = 1;
-            for (const auto& [dst_noc_encoding, num_receivers] : dst_noc_transfer_info) {
-                bool last = transfer_instruction_idx == dst_noc_transfer_info.size();
-                transfer_info transfer_instruction = {.size_in_bytes = num_bytes_in_transfer, .dst = dst, .dst_noc_encoding = dst_noc_encoding, .num_receivers = num_receivers, .last_transfer_in_group = last, .linked = linked};
-                transfers.push_back(transfer_instruction);
-                num_transfers_within_page++;
-                transfer_instruction_idx++;
-            }
-
-            dst += num_bytes_in_transfer;
-            num_bytes -= num_bytes_in_transfer;
-
-            if ((src % DeviceCommand::PROGRAM_PAGE_SIZE) == 0) {
-                num_transfers_per_page.push_back(num_transfers_within_page);
-                num_transfers_within_page = 0;
-            }
-        }
-
-        return src;
-    };
-
-    auto extract_dst_noc_multicast_info =
-        [&device](const set<CoreRange>& ranges, const CoreType core_type) -> vector<pair<uint32_t, uint32_t>> {
-        // This API extracts all the pairs of noc multicast encodings given a set of core ranges
-        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info;
-        for (const CoreRange& core_range : ranges) {
-            CoreCoord physical_start = device->physical_core_from_logical_core(core_range.start, core_type);
-            CoreCoord physical_end = device->physical_core_from_logical_core(core_range.end, core_type);
-
-            uint32_t dst_noc_multicast_encoding = get_noc_multicast_encoding(physical_start, physical_end);
-
-            uint32_t num_receivers = core_range.size();
-            dst_noc_multicast_info.push_back(std::make_pair(dst_noc_multicast_encoding, num_receivers));
-        }
-        return dst_noc_multicast_info;
-    };
-
-    auto update_program_pages_with_new_page = [&program_pages, &src, &program_new_page_tracker]() {
-        program_pages.resize(program_pages.size() + align(src, DeviceCommand::PROGRAM_PAGE_SIZE) / sizeof(uint32_t), 0);
-        src = 0;
-        program_new_page_tracker++;
-    };
-    auto align_program_page_idx_to_new_page = [&program_page_idx, &program_new_page_tracker]() {
-        program_page_idx = align(program_page_idx, DeviceCommand::PROGRAM_PAGE_SIZE / sizeof(uint32_t));
-        program_new_page_tracker--;
-    };
-
-    auto update_program_page_for_kernel_group =
-        [&program_page_transfers,
-         &num_transfers_in_program_pages,
-         &update_program_page_transfers,
-         &extract_dst_noc_multicast_info,
-         &device,
-         &program](uint32_t src, const KernelGroup& kernel_group, PageTransferType page_transfer_type) -> uint32_t {
-        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
-            extract_dst_noc_multicast_info(kernel_group.core_ranges.ranges(), kernel_group.get_core_type());
-
-        // So far, we don't support linking optimizations for kernel groups
-        // which use multiple core ranges
-        bool linked = dst_noc_multicast_info.size() == 1;
-
-        vector<KernelHandle> kernel_ids;
-        if (kernel_group.riscv0_id)
-            kernel_ids.push_back(kernel_group.riscv0_id.value());
-        if (kernel_group.riscv1_id)
-            kernel_ids.push_back(kernel_group.riscv1_id.value());
-        if (kernel_group.compute_id)
-            kernel_ids.push_back(kernel_group.compute_id.value());
-        if (kernel_group.erisc_id)
-            kernel_ids.push_back(kernel_group.erisc_id.value());
-
-        for (size_t i = 0; i < kernel_ids.size(); i++) {
-            KernelHandle kernel_id = kernel_ids[i];
-            vector<RISCV> sub_kernels;
-            const Kernel* kernel = detail::GetKernel(program, kernel_id);
-            if (kernel->processor() == RISCV::COMPUTE) {
-                sub_kernels = {RISCV::TRISC0, RISCV::TRISC1, RISCV::TRISC2};
-            } else {
-                sub_kernels = {kernel->processor()};
-            }
-
-            uint32_t sub_kernel_index = 0;
-            const auto& binaries = kernel->binaries(device->id());
-            for (size_t j = 0; j < binaries.size(); j++) {
-                const ll_api::memory& kernel_bin = binaries[j];
-
-                uint32_t k = 0;
-                uint32_t num_spans = kernel_bin.num_spans();
-                kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
-                    linked &= (i != kernel_ids.size() - 1) or (j != binaries.size() - 1) or (k != num_spans - 1);
-                    uint64_t relo_addr =
-                        tt::llrt::relocate_dev_addr(dst, processor_to_local_mem_addr.at(sub_kernels[sub_kernel_index]));
-
-                    uint32_t num_bytes = len * sizeof(uint32_t);
-
-                    if (page_transfer_type == PageTransferType::UNICAST) {
-                        for (const auto& logical_core : kernel->logical_cores()) {
-                            uint32_t dst_noc = get_noc_unicast_encoding(
-                                device->physical_core_from_logical_core(logical_core, kernel_group.get_core_type()));
-                            src = update_program_page_transfers(
-                                src,
-                                num_bytes,
-                                relo_addr,
-                                program_page_transfers.at(PageTransferType::UNICAST),
-                                num_transfers_in_program_pages.at(PageTransferType::UNICAST),
-                                {{dst_noc, 1}});
-                        }
-                    } else if (page_transfer_type == PageTransferType::MULTICAST) {
-                        src = update_program_page_transfers(
-                            src,
-                            num_bytes,
-                            relo_addr,
-                            program_page_transfers.at(PageTransferType::MULTICAST),
-                            num_transfers_in_program_pages.at(PageTransferType::MULTICAST),
-                            dst_noc_multicast_info,
-                            linked);
-                    }
-                    k++;
-                });
-                sub_kernel_index++;
-            }
-        }
-        return src;
-    };
-    auto populate_program_binaries_pages =
-        [&program_pages, &program_page_idx, &device, &program](const KernelGroup& kernel_group) {
-            vector<KernelHandle> kernel_ids;
-            if (kernel_group.riscv0_id)
-                kernel_ids.push_back(kernel_group.riscv0_id.value());
-            if (kernel_group.riscv1_id)
-                kernel_ids.push_back(kernel_group.riscv1_id.value());
-            if (kernel_group.compute_id)
-                kernel_ids.push_back(kernel_group.compute_id.value());
-            if (kernel_group.erisc_id)
-                kernel_ids.push_back(kernel_group.erisc_id.value());
-            for (KernelHandle kernel_id : kernel_ids) {
-                const Kernel* kernel = detail::GetKernel(program, kernel_id);
-
-                for (const ll_api::memory& kernel_bin : kernel->binaries(device->id())) {
-                    kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
-                        std::copy(mem_ptr, mem_ptr + len, program_pages.begin() + program_page_idx);
-
-                        program_page_idx =
-                            align(program_page_idx + len, noc_transfer_alignment_in_bytes / sizeof(uint32_t));
-                    });
-                }
-            }
-        };
-
-    // Step 1: Get transfer info for runtime args (soon to just be host data). We
-    // want to send host data first because of the higher latency to pull
-    // in host data.
-    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
-        Kernel* kernel = detail::GetKernel(program, kernel_id);
-        uint32_t dst = processor_to_l1_arg_base_addr.at(kernel->processor());
-        const auto& kernel_core_type = kernel->get_kernel_core_type();
-        for (const auto& core_coord : kernel->cores_with_runtime_args()) {
-            CoreCoord physical_core =
-                device->physical_core_from_logical_core(core_coord, kernel->get_kernel_core_type());
-            const auto& runtime_args = kernel->runtime_args(core_coord);
-            uint32_t num_bytes = runtime_args.size() * sizeof(uint32_t);
-            uint32_t dst_noc = get_noc_unicast_encoding(physical_core);
-
-            // Only one receiver per set of runtime arguments
-            src = update_program_page_transfers(
-                src,
-                num_bytes,
-                dst,
-                runtime_arg_page_transfers.at(PageTransferType::MULTICAST),
-                num_transfers_in_runtime_arg_pages.at(PageTransferType::MULTICAST),
-                {{dst_noc, 1}});
-        }
-    }
-
-    // Cleanup step of separating runtime arg pages from program pages
-    if (num_transfers_within_page) {
-        num_transfers_in_runtime_arg_pages.at(PageTransferType::MULTICAST).push_back(num_transfers_within_page);
-        num_transfers_within_page = 0;
-    }
-
-    src = 0;  // Resetting since in a new page
-    // Step 2: Continue constructing pages for circular buffer configs
-    for (const shared_ptr<CircularBuffer>& cb : program.circular_buffers()) {
-        // No CB support for ethernet cores
-        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
-            extract_dst_noc_multicast_info(cb->core_ranges().ranges(), CoreType::WORKER);
-        constexpr static uint32_t num_bytes = UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
-        for (const auto buffer_index : cb->buffer_indices()) {
-            src = update_program_page_transfers(
-                src,
-                num_bytes,
-                CIRCULAR_BUFFER_CONFIG_BASE + buffer_index * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t),
-                cb_config_page_transfers.at(PageTransferType::MULTICAST),
-                num_transfers_in_cb_config_pages.at(PageTransferType::MULTICAST),
-                dst_noc_multicast_info);
-        }
-    }
-
-    // Cleanup step of separating runtime arg pages from program pages
-    if (num_transfers_within_page) {
-        num_transfers_in_cb_config_pages.at(PageTransferType::MULTICAST).push_back(num_transfers_within_page);
-        num_transfers_within_page = 0;
-    }
-
-    // Split kernel groups by multicast/unicast, program multicast transfers first then unicast
-    std::vector<KernelGroup> kernel_group_multicast;
-    std::vector<KernelGroup> kernel_group_unicast;
-    for (const KernelGroup& kernel_group : program.get_kernel_groups()) {
-        if (kernel_group.get_core_type() == CoreType::WORKER) {
-            kernel_group_multicast.emplace_back(kernel_group);
-        } else if (kernel_group.get_core_type() == CoreType::ETH) {
-            kernel_group_unicast.emplace_back(kernel_group);
-        } else {
-            TT_ASSERT(false, "Constructing command for unsupported core type");
-        }
-    }
-    // Enqueue program binaries and go siggals in this order:
-    // - Multicast Program Binaries
-    // - Unicast Program Binaries
-    // - Multicast Go Signals
-    // - Unicast Go Signals
-    // This probably has better perf than sending binaries and go signals together:
-    // - Multicast Program Binaries
-    // - Multicast Go Signals
-    // - Unicast Program Binaries
-    // - Unicast Go Signals
-    // Step 3a (Multicast): Determine the transfer information for each program binary
-    src = 0;  // Restart src since multicast program binaries begins in a new page
-    for (const KernelGroup& kernel_group : kernel_group_multicast) {
-        src = update_program_page_for_kernel_group(src, kernel_group, PageTransferType::MULTICAST);
-    }
-    // Step 4 (Multicast): Continue constructing pages for semaphore configs, only multicast/worker cores supported
-    for (const Semaphore& semaphore : program.semaphores()) {
-        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
-            extract_dst_noc_multicast_info(semaphore.core_range_set().ranges(), CoreType::WORKER);
-
-        src = update_program_page_transfers(
-            src,
-            L1_ALIGNMENT,
-            semaphore.address(),
-            program_page_transfers.at(PageTransferType::MULTICAST),
-            num_transfers_in_program_pages.at(PageTransferType::MULTICAST),
-            dst_noc_multicast_info);
-    }
-
-    if (num_transfers_within_page) {
-        num_transfers_in_program_pages.at(PageTransferType::MULTICAST).push_back(num_transfers_within_page);
-        num_transfers_within_page = 0;
-    }
-
-    // Step 3b (Unicast)
-    // skipping step 4 since no semaphore support
-    update_program_pages_with_new_page();  // sets src to 0 since unicast program binaries begins in new page
-    for (const KernelGroup& kernel_group : kernel_group_unicast) {
-        src = update_program_page_for_kernel_group(src, kernel_group, PageTransferType::UNICAST);
-    }
-    if (num_transfers_within_page) {
-        num_transfers_in_program_pages.at(PageTransferType::UNICAST).push_back(num_transfers_within_page);
-        num_transfers_within_page = 0;
-    }
-
-    // Step 5a (Multicast): Continue constructing pages for GO signals, multicast first then unicast
-    update_program_pages_with_new_page();  // sets src to 0 since multicast signals begins in new page
-    for (KernelGroup& kernel_group : kernel_group_multicast) {
-        kernel_group.launch_msg.mode = DISPATCH_MODE_DEV;
-        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
-            extract_dst_noc_multicast_info(kernel_group.core_ranges.ranges(), kernel_group.get_core_type());
-        src = update_program_page_transfers(
-            src,
-            sizeof(launch_msg_t),
-            GET_MAILBOX_ADDRESS_HOST(launch),
-            go_signal_page_transfers.at(PageTransferType::MULTICAST),
-            num_transfers_in_go_signal_pages.at(PageTransferType::MULTICAST),
-            dst_noc_multicast_info);
-    }
-    if (num_transfers_within_page) {
-        num_transfers_in_go_signal_pages.at(PageTransferType::MULTICAST).push_back(num_transfers_within_page);
-        num_transfers_within_page = 0;
-    }
-
-    // Step 5b (Unicast)
-    update_program_pages_with_new_page();  // sets src to 0 since unicast signals begins in new page
-    for (const KernelGroup& kernel_group : kernel_group_unicast) {
-        if (kernel_group.get_core_type() == CoreType::ETH) {
-            const Kernel* kernel = detail::GetKernel(program, kernel_group.erisc_id.value());
-            for (const auto& logical_eth_core : kernel->logical_cores()) {
-                uint32_t dst_noc =
-                    get_noc_unicast_encoding(device->physical_core_from_logical_core(logical_eth_core, CoreType::ETH));
-                src = update_program_page_transfers(
-                    src,
-                    sizeof(uint32_t),
-                    eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE,
-                    go_signal_page_transfers.at(PageTransferType::UNICAST),
-                    num_transfers_in_go_signal_pages.at(PageTransferType::UNICAST),
-                    {{dst_noc, 1}});
-            }
-        } else {
-            TT_ASSERT(false, "All non-ethernet core go signals should be muticasted");
-        }
-    }
-    if (num_transfers_within_page) {
-        num_transfers_in_go_signal_pages.at(PageTransferType::UNICAST).push_back(num_transfers_within_page);
-        num_transfers_within_page = 0;
-    }
-
-    // Allocate some more space for GO signal
-    update_program_pages_with_new_page();  // sets src to 0, but not needed
-
-    // Create a vector of all program binaries/cbs/semaphores
-    align_program_page_idx_to_new_page();
-    for (const KernelGroup& kernel_group : kernel_group_multicast) {
-        populate_program_binaries_pages(kernel_group);
-    }
-
-    for (const Semaphore& semaphore : program.semaphores()) {
-        program_pages[program_page_idx] = semaphore.initial_value();
-        program_page_idx += 4;
-    }
-
-    align_program_page_idx_to_new_page();
-    for (const KernelGroup& kernel_group : kernel_group_unicast) {
-        populate_program_binaries_pages(kernel_group);
-    }
-
-    // Since GO signal begin in a new page, I need to advance my idx
-    align_program_page_idx_to_new_page();
-    // uint32_t dispatch_core_word = ((uint32_t)dispatch_core.y << 16) | dispatch_core.x;
-    for (KernelGroup& kernel_group : kernel_group_multicast) {
-        // TODO(agrebenisan): Hanging when we extend the launch msg. Needs to be investigated. For now,
-        // only supporting enqueue program for cq 0 on a device.
-        // kernel_group.launch_msg.dispatch_core_x = dispatch_core.x;
-        // kernel_group.launch_msg.dispatch_core_y = dispatch_core.y;
-        static_assert(sizeof(launch_msg_t) % sizeof(uint32_t) == 0);
-        uint32_t* launch_message_data = (uint32_t*)&kernel_group.launch_msg;
-        for (int i = 0; i < sizeof(launch_msg_t) / sizeof(uint32_t); i++) {
-            program_pages[program_page_idx + i] = launch_message_data[i];
-        }
-        program_page_idx += sizeof(launch_msg_t) / sizeof(uint32_t);
-    }
-
-    align_program_page_idx_to_new_page();
-    for (KernelGroup& kernel_group : kernel_group_unicast) {
-        if (kernel_group.get_core_type() == CoreType::ETH) {
-            const Kernel* kernel = detail::GetKernel(program, kernel_group.erisc_id.value());
-            for (const auto& logical_eth_core : kernel->logical_cores()) {
-                program_pages[program_page_idx] = 1;
-                program_page_idx += 4;  // 16 byte L1 alignment
-            }
-        } else {
-            TT_ASSERT(false, "All non-ethernet core go signals should be muticasted");
-        }
-    }
-
-    TT_ASSERT(
-        program_new_page_tracker == 0, "Number of new program pages not aligned between sizing and populating data.");
-
-    uint32_t num_workers = 0;
-    // Explicitly sum the worker and eth cores, since we don't have support for all core types
-    if (program.logical_cores().find(CoreType::WORKER) != program.logical_cores().end()) {
-        num_workers += program.logical_cores().at(CoreType::WORKER).size();
-    } else if (program.logical_cores().find(CoreType::ETH) != program.logical_cores().end()) {
-        num_workers += program.logical_cores().at(CoreType::ETH).size();
-    }
-    return {
-        .num_workers = num_workers,
-        .program_pages = std::move(program_pages),
-        .program_page_transfers = std::move(program_page_transfers),
-        .runtime_arg_page_transfers = std::move(runtime_arg_page_transfers),
-        .cb_config_page_transfers = std::move(cb_config_page_transfers),
-        .go_signal_page_transfers = std::move(go_signal_page_transfers),
-        .num_transfers_in_program_pages = std::move(num_transfers_in_program_pages),
-        .num_transfers_in_runtime_arg_pages = std::move(num_transfers_in_runtime_arg_pages),
-        .num_transfers_in_cb_config_pages = std::move(num_transfers_in_cb_config_pages),
-        .num_transfers_in_go_signal_pages = std::move(num_transfers_in_go_signal_pages),
-    };
-}
 
 EnqueueRestartCommand::EnqueueRestartCommand(
     uint32_t command_queue_channel,
@@ -789,21 +318,21 @@ void EnqueueWriteBufferCommand::process() {
 EnqueueProgramCommand::EnqueueProgramCommand(
     uint32_t command_queue_id,
     Device* device,
-    Buffer& buffer,
-    ProgramMap& program_to_dev_map,
-    SystemMemoryManager& manager,
     const Program& program,
+    SystemMemoryManager& manager,
     bool stall,
     std::optional<std::reference_wrapper<Trace>> trace
     ) :
-    command_queue_id(command_queue_id), buffer(buffer), program_to_dev_map(program_to_dev_map), manager(manager), program(program), stall(stall) {
+    command_queue_id(command_queue_id), manager(manager), program(program), stall(stall) {
     this->device = device;
     this->trace = trace;
 }
 
 const DeviceCommand EnqueueProgramCommand::assemble_device_command(uint32_t host_data_src) {
     DeviceCommand command;
-    command.set_num_workers(this->program_to_dev_map.num_workers);
+    command.set_num_workers(this->program.program_device_map.num_workers);
+
+    const Program& program = this->program;
 
     auto populate_program_data_transfer_instructions =
         [&command](const vector<uint32_t>& num_transfers_per_page, const vector<transfer_info>& transfers_in_pages) {
@@ -826,17 +355,17 @@ const DeviceCommand EnqueueProgramCommand::assemble_device_command(uint32_t host
     constexpr static uint32_t dummy_dst_addr = 0;
     constexpr static uint32_t dummy_buffer_type = 0;
     uint32_t num_runtime_arg_pages =
-        this->program_to_dev_map.num_transfers_in_runtime_arg_pages.at(PageTransferType::MULTICAST).size();
+        program.program_device_map.num_transfers_in_runtime_arg_pages.at(PageTransferType::MULTICAST).size();
     uint32_t num_cb_config_pages =
-        this->program_to_dev_map.num_transfers_in_cb_config_pages.at(PageTransferType::MULTICAST).size();
+        program.program_device_map.num_transfers_in_cb_config_pages.at(PageTransferType::MULTICAST).size();
     uint32_t num_program_multicast_binary_pages =
-        this->program_to_dev_map.num_transfers_in_program_pages.at(PageTransferType::MULTICAST).size();
+        program.program_device_map.num_transfers_in_program_pages.at(PageTransferType::MULTICAST).size();
     uint32_t num_program_unicast_binary_pages =
-        this->program_to_dev_map.num_transfers_in_program_pages.at(PageTransferType::UNICAST).size();
+        program.program_device_map.num_transfers_in_program_pages.at(PageTransferType::UNICAST).size();
     uint32_t num_go_signal_multicast_pages =
-        this->program_to_dev_map.num_transfers_in_go_signal_pages.at(PageTransferType::MULTICAST).size();
+        program.program_device_map.num_transfers_in_go_signal_pages.at(PageTransferType::MULTICAST).size();
     uint32_t num_go_signal_unicast_pages =
-        this->program_to_dev_map.num_transfers_in_go_signal_pages.at(PageTransferType::UNICAST).size();
+        program.program_device_map.num_transfers_in_go_signal_pages.at(PageTransferType::UNICAST).size();
     uint32_t num_host_data_pages = num_runtime_arg_pages + num_cb_config_pages;
     uint32_t num_cached_pages = num_program_multicast_binary_pages + num_go_signal_multicast_pages +
                                 num_program_unicast_binary_pages + num_go_signal_unicast_pages;
@@ -867,47 +396,47 @@ const DeviceCommand EnqueueProgramCommand::assemble_device_command(uint32_t host
 
         if (num_runtime_arg_pages) {
             populate_program_data_transfer_instructions(
-                this->program_to_dev_map.num_transfers_in_runtime_arg_pages.at(PageTransferType::MULTICAST),
-                this->program_to_dev_map.runtime_arg_page_transfers.at(PageTransferType::MULTICAST));
+                program.program_device_map.num_transfers_in_runtime_arg_pages.at(PageTransferType::MULTICAST),
+                program.program_device_map.runtime_arg_page_transfers.at(PageTransferType::MULTICAST));
         }
 
         if (num_cb_config_pages) {
             populate_program_data_transfer_instructions(
-                this->program_to_dev_map.num_transfers_in_cb_config_pages.at(PageTransferType::MULTICAST),
-                this->program_to_dev_map.cb_config_page_transfers.at(PageTransferType::MULTICAST));
+                program.program_device_map.num_transfers_in_cb_config_pages.at(PageTransferType::MULTICAST),
+                program.program_device_map.cb_config_page_transfers.at(PageTransferType::MULTICAST));
         }
     }
 
     if (num_cached_pages) {
         command.add_buffer_transfer_interleaved_instruction(
-            this->buffer.address(),
+            program.buffer->address(),
             dummy_dst_addr,
             num_cached_pages,
             DeviceCommand::PROGRAM_PAGE_SIZE,
-            uint32_t(this->buffer.buffer_type()),
+            uint32_t(program.buffer->buffer_type()),
             dummy_buffer_type, page_index_offset, page_index_offset);
 
         if (num_program_multicast_binary_pages) {
             populate_program_data_transfer_instructions(
-                this->program_to_dev_map.num_transfers_in_program_pages.at(PageTransferType::MULTICAST),
-                this->program_to_dev_map.program_page_transfers.at(PageTransferType::MULTICAST));
+                program.program_device_map.num_transfers_in_program_pages.at(PageTransferType::MULTICAST),
+                program.program_device_map.program_page_transfers.at(PageTransferType::MULTICAST));
         }
 
         if (num_program_unicast_binary_pages) {
             populate_program_data_transfer_instructions(
-                this->program_to_dev_map.num_transfers_in_program_pages.at(PageTransferType::UNICAST),
-                this->program_to_dev_map.program_page_transfers.at(PageTransferType::UNICAST));
+                program.program_device_map.num_transfers_in_program_pages.at(PageTransferType::UNICAST),
+                program.program_device_map.program_page_transfers.at(PageTransferType::UNICAST));
         }
 
         if (num_go_signal_multicast_pages) {
             populate_program_data_transfer_instructions(
-                this->program_to_dev_map.num_transfers_in_go_signal_pages.at(PageTransferType::MULTICAST),
-                this->program_to_dev_map.go_signal_page_transfers.at(PageTransferType::MULTICAST));
+                program.program_device_map.num_transfers_in_go_signal_pages.at(PageTransferType::MULTICAST),
+                program.program_device_map.go_signal_page_transfers.at(PageTransferType::MULTICAST));
         }
         if (num_go_signal_unicast_pages) {
             populate_program_data_transfer_instructions(
-                this->program_to_dev_map.num_transfers_in_go_signal_pages.at(PageTransferType::UNICAST),
-                this->program_to_dev_map.go_signal_page_transfers.at(PageTransferType::UNICAST));
+                program.program_device_map.num_transfers_in_go_signal_pages.at(PageTransferType::UNICAST),
+                program.program_device_map.go_signal_page_transfers.at(PageTransferType::UNICAST));
         }
     }
 
@@ -1226,40 +755,21 @@ void CommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool bl
 void CommandQueue::enqueue_program(Program& program, std::optional<std::reference_wrapper<Trace>> trace, bool blocking) {
     ZoneScopedN("CommandQueue_enqueue_program");
 
-    // Need to relay the program into DRAM if this is the first time
-    // we are seeing it
-    const uint64_t program_id = program.get_id();
-
     // Whether or not we should stall the producer from prefetching binary data. If the
     // data is cached, then we don't need to stall, otherwise we need to wait for the
     // data to land in DRAM first
-    bool stall = false;
-    // No shared cache so far, can come at a later time
-    map<uint64_t, unique_ptr<Buffer>>& program_to_buffer = ::program_to_buffer(this->device->id());
-    if (not program_to_buffer.count(program_id)) {
+    bool stall;
+    if (not program.loaded_onto_device) {
+        this->enqueue_write_buffer(*program.buffer, program.program_device_map.program_pages.data(), false);
         stall = true;
-        ProgramMap program_to_device_map = ConstructProgramMap(this->device, program);
-
-        vector<uint32_t>& program_pages = program_to_device_map.program_pages;
-        uint32_t program_data_size_in_bytes = program_pages.size() * sizeof(uint32_t);
-
-        uint32_t write_buffer_command_size = DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + program_data_size_in_bytes;
-
-        program_to_buffer.emplace(
-            program_id,
-            std::make_unique<Buffer>(
-                this->device, program_data_size_in_bytes, DeviceCommand::PROGRAM_PAGE_SIZE, BufferType::DRAM));
-
-        this->enqueue_write_buffer(*program_to_buffer.at(program_id), program_pages.data(), false);
-
-        map<uint64_t, ProgramMap>& program_to_dev_map = ::program_to_dev_map(device->id());
-        program_to_dev_map.emplace(program_id, std::move(program_to_device_map));
+        program.loaded_onto_device = true;
+    } else {
+        stall = false;
     }
 
     tt::log_debug(tt::LogDispatch, "EnqueueProgram for channel {}", this->id);
-
-    uint32_t host_data_num_pages = ::program_to_dev_map(this->device->id()).at(program_id).runtime_arg_page_transfers.size() + ::program_to_dev_map(this->device->id()).at(program_id).cb_config_page_transfers.size();
-
+    ProgramDeviceMap& program_device_map = program.program_device_map;
+    uint32_t host_data_num_pages = program_device_map.runtime_arg_page_transfers.size() + program_device_map.cb_config_page_transfers.size();
     uint32_t host_data_and_device_command_size =
         DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND + (host_data_num_pages * DeviceCommand::PROGRAM_PAGE_SIZE);
 
@@ -1273,10 +783,8 @@ void CommandQueue::enqueue_program(Program& program, std::optional<std::referenc
     EnqueueProgramCommand command(
         this->id,
         this->device,
-        *::program_to_buffer(this->device->id()).at(program_id),
-        ::program_to_dev_map(this->device->id()).at(program_id),
-        this->manager,
         program,
+        this->manager,
         stall,
         trace);
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -27,30 +27,6 @@ using std::weak_ptr;
 using std::tuple;
 using std::unique_ptr;
 
-struct transfer_info {
-    uint32_t size_in_bytes;
-    uint32_t dst;
-    uint32_t dst_noc_encoding;
-    uint32_t num_receivers;
-    bool last_transfer_in_group;
-    bool linked;
-};
-
-enum class PageTransferType { MULTICAST, UNICAST };
-
-struct ProgramMap {
-    uint32_t num_workers;
-    vector<uint32_t> program_pages;
-    std::unordered_map<PageTransferType, vector<transfer_info>> program_page_transfers;
-    std::unordered_map<PageTransferType, vector<transfer_info>> runtime_arg_page_transfers;
-    std::unordered_map<PageTransferType, vector<transfer_info>> cb_config_page_transfers;
-    std::unordered_map<PageTransferType, vector<transfer_info>> go_signal_page_transfers;
-    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_program_pages;
-    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_runtime_arg_pages;
-    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_cb_config_pages;
-    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_go_signal_pages;
-};
-
 // Only contains the types of commands which are enqueued onto the device
 enum class EnqueueCommandType { ENQUEUE_READ_BUFFER, ENQUEUE_WRITE_BUFFER, ENQUEUE_PROGRAM, FINISH, ENQUEUE_WRAP, ENQUEUE_RESTART, INVALID };
 
@@ -255,15 +231,13 @@ class EnqueueProgramCommand : public Command {
    private:
     uint32_t command_queue_id;
     Device* device;
-    Buffer& buffer;
-    ProgramMap& program_to_dev_map;
     const Program& program;
     SystemMemoryManager& manager;
     bool stall;
     std::optional<std::reference_wrapper<Trace>> trace = {};
 
    public:
-    EnqueueProgramCommand(uint32_t command_queue_id, Device*, Buffer&, ProgramMap&, SystemMemoryManager&, const Program& program, bool stall, std::optional<std::reference_wrapper<Trace>> trace);
+    EnqueueProgramCommand(uint32_t command_queue_id, Device* device, const Program& program, SystemMemoryManager& manager, bool stall, std::optional<std::reference_wrapper<Trace>> trace);
 
     const DeviceCommand assemble_device_command(uint32_t src_address);
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -95,7 +95,7 @@ auto Program::semaphores_on_core(const CoreCoord &core) const {
 
 std::atomic<uint64_t> Program::program_counter = 0;
 
-Program::Program(): id(program_counter++),worker_crs_({}), local_circular_buffer_allocation_needed_(false) {
+Program::Program(): id(program_counter++),worker_crs_({}), local_circular_buffer_allocation_needed_(false), loaded_onto_device(false) {
 }
 
 KernelHandle Program::add_kernel(std::shared_ptr<Kernel> kernel) {
@@ -560,6 +560,447 @@ void Program::invalidate_compile() {
     }
 }
 
+ProgramDeviceMap ConstructProgramDeviceMap(const Device* device, Program& program) {
+    /*
+        TODO(agrebenisan): Move this logic to compile program
+    */
+    std::unordered_map<PageTransferType, vector<transfer_info>> program_page_transfers = {
+        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
+    std::unordered_map<PageTransferType, vector<transfer_info>> runtime_arg_page_transfers = {
+        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
+    std::unordered_map<PageTransferType, vector<transfer_info>> cb_config_page_transfers = {
+        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
+    std::unordered_map<PageTransferType, vector<transfer_info>> go_signal_page_transfers = {
+        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
+    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_program_pages = {
+        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
+    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_runtime_arg_pages = {
+        {PageTransferType::MULTICAST, {}},
+        {PageTransferType::UNICAST,
+         {}}};  // Corresponds to the number of transfers within host data pages across all host data pages
+    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_cb_config_pages = {
+        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
+    std::unordered_map<PageTransferType, vector<uint32_t>> num_transfers_in_go_signal_pages = {
+        {PageTransferType::MULTICAST, {}}, {PageTransferType::UNICAST, {}}};
+
+    static const map<RISCV, uint32_t> processor_to_local_mem_addr = {
+        {RISCV::BRISC, MEM_BRISC_INIT_LOCAL_L1_BASE},
+        {RISCV::NCRISC, MEM_NCRISC_INIT_LOCAL_L1_BASE},
+        {RISCV::TRISC0, MEM_TRISC0_INIT_LOCAL_L1_BASE},
+        {RISCV::TRISC1, MEM_TRISC1_INIT_LOCAL_L1_BASE},
+        {RISCV::TRISC2, MEM_TRISC2_INIT_LOCAL_L1_BASE},
+        {RISCV::ERISC, eth_l1_mem::address_map::FIRMWARE_BASE}};
+
+    static const map<RISCV, uint32_t> processor_to_l1_arg_base_addr = {
+        {RISCV::BRISC, BRISC_L1_ARG_BASE},
+        {RISCV::NCRISC, NCRISC_L1_ARG_BASE},
+        {RISCV::COMPUTE, TRISC_L1_ARG_BASE},
+        {RISCV::ERISC, eth_l1_mem::address_map::ERISC_L1_ARG_BASE},
+    };
+
+    uint32_t num_transfers_within_page = 0;
+
+    uint32_t src = 0;
+    vector<uint32_t> program_pages;
+    uint32_t program_page_idx = 0;
+    uint32_t program_new_page_tracker = 0;
+    constexpr static uint32_t noc_transfer_alignment_in_bytes = 16;
+
+    auto update_program_page_transfers = [&num_transfers_within_page](
+                                             uint32_t src,
+                                             uint32_t num_bytes,
+                                             uint32_t dst,
+                                             vector<transfer_info>& transfers,
+                                             vector<uint32_t>& num_transfers_per_page,
+                                             const vector<pair<uint32_t, uint32_t>>& dst_noc_transfer_info,
+                                             bool linked = false) -> uint32_t {
+        while (num_bytes) {
+            uint32_t num_bytes_left_in_page = DeviceCommand::PROGRAM_PAGE_SIZE - (src % DeviceCommand::PROGRAM_PAGE_SIZE);
+            uint32_t num_bytes_in_transfer = std::min(num_bytes_left_in_page, num_bytes);
+            src = align(src + num_bytes_in_transfer, noc_transfer_alignment_in_bytes);
+
+            uint32_t transfer_instruction_idx = 1;
+            for (const auto& [dst_noc_encoding, num_receivers] : dst_noc_transfer_info) {
+                bool last = transfer_instruction_idx == dst_noc_transfer_info.size();
+                transfer_info transfer_instruction = {.size_in_bytes = num_bytes_in_transfer, .dst = dst, .dst_noc_encoding = dst_noc_encoding, .num_receivers = num_receivers, .last_transfer_in_group = last, .linked = linked};
+                transfers.push_back(transfer_instruction);
+                num_transfers_within_page++;
+                transfer_instruction_idx++;
+            }
+
+            dst += num_bytes_in_transfer;
+            num_bytes -= num_bytes_in_transfer;
+
+            if ((src % DeviceCommand::PROGRAM_PAGE_SIZE) == 0) {
+                num_transfers_per_page.push_back(num_transfers_within_page);
+                num_transfers_within_page = 0;
+            }
+        }
+
+        return src;
+    };
+
+    auto extract_dst_noc_multicast_info =
+        [&device](const set<CoreRange>& ranges, const CoreType core_type) -> vector<pair<uint32_t, uint32_t>> {
+        // This API extracts all the pairs of noc multicast encodings given a set of core ranges
+        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info;
+        for (const CoreRange& core_range : ranges) {
+            CoreCoord physical_start = device->physical_core_from_logical_core(core_range.start, core_type);
+            CoreCoord physical_end = device->physical_core_from_logical_core(core_range.end, core_type);
+
+            uint32_t dst_noc_multicast_encoding = NOC_MULTICAST_ENCODING(physical_start.x, physical_start.y, physical_end.x, physical_end.y);
+
+            uint32_t num_receivers = core_range.size();
+            dst_noc_multicast_info.push_back(std::make_pair(dst_noc_multicast_encoding, num_receivers));
+        }
+        return dst_noc_multicast_info;
+    };
+
+    auto update_program_pages_with_new_page = [&program_pages, &src, &program_new_page_tracker]() {
+        program_pages.resize(program_pages.size() + align(src, DeviceCommand::PROGRAM_PAGE_SIZE) / sizeof(uint32_t), 0);
+        src = 0;
+        program_new_page_tracker++;
+    };
+    auto align_program_page_idx_to_new_page = [&program_page_idx, &program_new_page_tracker]() {
+        program_page_idx = align(program_page_idx, DeviceCommand::PROGRAM_PAGE_SIZE / sizeof(uint32_t));
+        program_new_page_tracker--;
+    };
+
+    auto get_noc_unicast_encoding = [](const CoreCoord& coord) {
+        return NOC_XY_ENCODING(NOC_X(coord.x), NOC_Y(coord.y));
+    };
+
+    auto update_program_page_for_kernel_group =
+        [&program_page_transfers,
+         &num_transfers_in_program_pages,
+         &update_program_page_transfers,
+         &extract_dst_noc_multicast_info,
+         &device,
+         &program,
+         &get_noc_unicast_encoding](uint32_t src, const KernelGroup& kernel_group, PageTransferType page_transfer_type) -> uint32_t {
+        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
+            extract_dst_noc_multicast_info(kernel_group.core_ranges.ranges(), kernel_group.get_core_type());
+
+        // So far, we don't support linking optimizations for kernel groups
+        // which use multiple core ranges
+        bool linked = dst_noc_multicast_info.size() == 1;
+
+        vector<KernelHandle> kernel_ids;
+        if (kernel_group.riscv0_id)
+            kernel_ids.push_back(kernel_group.riscv0_id.value());
+        if (kernel_group.riscv1_id)
+            kernel_ids.push_back(kernel_group.riscv1_id.value());
+        if (kernel_group.compute_id)
+            kernel_ids.push_back(kernel_group.compute_id.value());
+        if (kernel_group.erisc_id)
+            kernel_ids.push_back(kernel_group.erisc_id.value());
+
+        for (size_t i = 0; i < kernel_ids.size(); i++) {
+            KernelHandle kernel_id = kernel_ids[i];
+            vector<RISCV> sub_kernels;
+            const Kernel* kernel = detail::GetKernel(program, kernel_id);
+            if (kernel->processor() == RISCV::COMPUTE) {
+                sub_kernels = {RISCV::TRISC0, RISCV::TRISC1, RISCV::TRISC2};
+            } else {
+                sub_kernels = {kernel->processor()};
+            }
+
+            uint32_t sub_kernel_index = 0;
+            const auto& binaries = kernel->binaries(device->id());
+            for (size_t j = 0; j < binaries.size(); j++) {
+                const ll_api::memory& kernel_bin = binaries[j];
+
+                uint32_t k = 0;
+                uint32_t num_spans = kernel_bin.num_spans();
+                kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
+                    linked &= (i != kernel_ids.size() - 1) or (j != binaries.size() - 1) or (k != num_spans - 1);
+                    uint64_t relo_addr =
+                        tt::llrt::relocate_dev_addr(dst, processor_to_local_mem_addr.at(sub_kernels[sub_kernel_index]));
+
+                    uint32_t num_bytes = len * sizeof(uint32_t);
+
+                    if (page_transfer_type == PageTransferType::UNICAST) {
+                        for (const auto& logical_core : kernel->logical_cores()) {
+                            uint32_t dst_noc = get_noc_unicast_encoding(
+                                device->physical_core_from_logical_core(logical_core, kernel_group.get_core_type()));
+                            src = update_program_page_transfers(
+                                src,
+                                num_bytes,
+                                relo_addr,
+                                program_page_transfers.at(PageTransferType::UNICAST),
+                                num_transfers_in_program_pages.at(PageTransferType::UNICAST),
+                                {{dst_noc, 1}});
+                        }
+                    } else if (page_transfer_type == PageTransferType::MULTICAST) {
+                        src = update_program_page_transfers(
+                            src,
+                            num_bytes,
+                            relo_addr,
+                            program_page_transfers.at(PageTransferType::MULTICAST),
+                            num_transfers_in_program_pages.at(PageTransferType::MULTICAST),
+                            dst_noc_multicast_info,
+                            linked);
+                    }
+                    k++;
+                });
+                sub_kernel_index++;
+            }
+        }
+        return src;
+    };
+    auto populate_program_binaries_pages =
+        [&program_pages, &program_page_idx, &device, &program](const KernelGroup& kernel_group) {
+            vector<KernelHandle> kernel_ids;
+            if (kernel_group.riscv0_id)
+                kernel_ids.push_back(kernel_group.riscv0_id.value());
+            if (kernel_group.riscv1_id)
+                kernel_ids.push_back(kernel_group.riscv1_id.value());
+            if (kernel_group.compute_id)
+                kernel_ids.push_back(kernel_group.compute_id.value());
+            if (kernel_group.erisc_id)
+                kernel_ids.push_back(kernel_group.erisc_id.value());
+            for (KernelHandle kernel_id : kernel_ids) {
+                const Kernel* kernel = detail::GetKernel(program, kernel_id);
+
+                for (const ll_api::memory& kernel_bin : kernel->binaries(device->id())) {
+                    kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
+                        std::copy(mem_ptr, mem_ptr + len, program_pages.begin() + program_page_idx);
+
+                        program_page_idx =
+                            align(program_page_idx + len, noc_transfer_alignment_in_bytes / sizeof(uint32_t));
+                    });
+                }
+            }
+        };
+
+    // Step 1: Get transfer info for runtime args (soon to just be host data). We
+    // want to send host data first because of the higher latency to pull
+    // in host data.
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
+        Kernel* kernel = detail::GetKernel(program, kernel_id);
+        uint32_t dst = processor_to_l1_arg_base_addr.at(kernel->processor());
+        const auto& kernel_core_type = kernel->get_kernel_core_type();
+        for (const auto& core_coord : kernel->cores_with_runtime_args()) {
+            CoreCoord physical_core =
+                device->physical_core_from_logical_core(core_coord, kernel->get_kernel_core_type());
+            const auto& runtime_args = kernel->runtime_args(core_coord);
+            uint32_t num_bytes = runtime_args.size() * sizeof(uint32_t);
+            uint32_t dst_noc = get_noc_unicast_encoding(physical_core);
+
+            // Only one receiver per set of runtime arguments
+            src = update_program_page_transfers(
+                src,
+                num_bytes,
+                dst,
+                runtime_arg_page_transfers.at(PageTransferType::MULTICAST),
+                num_transfers_in_runtime_arg_pages.at(PageTransferType::MULTICAST),
+                {{dst_noc, 1}});
+        }
+    }
+
+    // Cleanup step of separating runtime arg pages from program pages
+    if (num_transfers_within_page) {
+        num_transfers_in_runtime_arg_pages.at(PageTransferType::MULTICAST).push_back(num_transfers_within_page);
+        num_transfers_within_page = 0;
+    }
+
+    src = 0;  // Resetting since in a new page
+    // Step 2: Continue constructing pages for circular buffer configs
+    for (const shared_ptr<CircularBuffer>& cb : program.circular_buffers()) {
+        // No CB support for ethernet cores
+        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
+            extract_dst_noc_multicast_info(cb->core_ranges().ranges(), CoreType::WORKER);
+        constexpr static uint32_t num_bytes = UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+        for (const auto buffer_index : cb->buffer_indices()) {
+            src = update_program_page_transfers(
+                src,
+                num_bytes,
+                CIRCULAR_BUFFER_CONFIG_BASE + buffer_index * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t),
+                cb_config_page_transfers.at(PageTransferType::MULTICAST),
+                num_transfers_in_cb_config_pages.at(PageTransferType::MULTICAST),
+                dst_noc_multicast_info);
+        }
+    }
+
+    // Cleanup step of separating runtime arg pages from program pages
+    if (num_transfers_within_page) {
+        num_transfers_in_cb_config_pages.at(PageTransferType::MULTICAST).push_back(num_transfers_within_page);
+        num_transfers_within_page = 0;
+    }
+
+    // Split kernel groups by multicast/unicast, program multicast transfers first then unicast
+    std::vector<KernelGroup> kernel_group_multicast;
+    std::vector<KernelGroup> kernel_group_unicast;
+    for (const KernelGroup& kernel_group : program.get_kernel_groups()) {
+        if (kernel_group.get_core_type() == CoreType::WORKER) {
+            kernel_group_multicast.emplace_back(kernel_group);
+        } else if (kernel_group.get_core_type() == CoreType::ETH) {
+            kernel_group_unicast.emplace_back(kernel_group);
+        } else {
+            TT_ASSERT(false, "Constructing command for unsupported core type");
+        }
+    }
+    // Enqueue program binaries and go siggals in this order:
+    // - Multicast Program Binaries
+    // - Unicast Program Binaries
+    // - Multicast Go Signals
+    // - Unicast Go Signals
+    // This probably has better perf than sending binaries and go signals together:
+    // - Multicast Program Binaries
+    // - Multicast Go Signals
+    // - Unicast Program Binaries
+    // - Unicast Go Signals
+    // Step 3a (Multicast): Determine the transfer information for each program binary
+    src = 0;  // Restart src since multicast program binaries begins in a new page
+    for (const KernelGroup& kernel_group : kernel_group_multicast) {
+        src = update_program_page_for_kernel_group(src, kernel_group, PageTransferType::MULTICAST);
+    }
+    // Step 4 (Multicast): Continue constructing pages for semaphore configs, only multicast/worker cores supported
+    for (const Semaphore& semaphore : program.semaphores()) {
+        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
+            extract_dst_noc_multicast_info(semaphore.core_range_set().ranges(), CoreType::WORKER);
+
+        src = update_program_page_transfers(
+            src,
+            L1_ALIGNMENT,
+            semaphore.address(),
+            program_page_transfers.at(PageTransferType::MULTICAST),
+            num_transfers_in_program_pages.at(PageTransferType::MULTICAST),
+            dst_noc_multicast_info);
+    }
+
+    if (num_transfers_within_page) {
+        num_transfers_in_program_pages.at(PageTransferType::MULTICAST).push_back(num_transfers_within_page);
+        num_transfers_within_page = 0;
+    }
+
+    // Step 3b (Unicast)
+    // skipping step 4 since no semaphore support
+    update_program_pages_with_new_page();  // sets src to 0 since unicast program binaries begins in new page
+    for (const KernelGroup& kernel_group : kernel_group_unicast) {
+        src = update_program_page_for_kernel_group(src, kernel_group, PageTransferType::UNICAST);
+    }
+    if (num_transfers_within_page) {
+        num_transfers_in_program_pages.at(PageTransferType::UNICAST).push_back(num_transfers_within_page);
+        num_transfers_within_page = 0;
+    }
+
+    // Step 5a (Multicast): Continue constructing pages for GO signals, multicast first then unicast
+    update_program_pages_with_new_page();  // sets src to 0 since multicast signals begins in new page
+    for (KernelGroup& kernel_group : kernel_group_multicast) {
+        kernel_group.launch_msg.mode = DISPATCH_MODE_DEV;
+        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
+            extract_dst_noc_multicast_info(kernel_group.core_ranges.ranges(), kernel_group.get_core_type());
+        src = update_program_page_transfers(
+            src,
+            sizeof(launch_msg_t),
+            GET_MAILBOX_ADDRESS_HOST(launch),
+            go_signal_page_transfers.at(PageTransferType::MULTICAST),
+            num_transfers_in_go_signal_pages.at(PageTransferType::MULTICAST),
+            dst_noc_multicast_info);
+    }
+    if (num_transfers_within_page) {
+        num_transfers_in_go_signal_pages.at(PageTransferType::MULTICAST).push_back(num_transfers_within_page);
+        num_transfers_within_page = 0;
+    }
+
+    // Step 5b (Unicast)
+    update_program_pages_with_new_page();  // sets src to 0 since unicast signals begins in new page
+    for (const KernelGroup& kernel_group : kernel_group_unicast) {
+        if (kernel_group.get_core_type() == CoreType::ETH) {
+            const Kernel* kernel = detail::GetKernel(program, kernel_group.erisc_id.value());
+            for (const auto& logical_eth_core : kernel->logical_cores()) {
+                uint32_t dst_noc =
+                    get_noc_unicast_encoding(device->physical_core_from_logical_core(logical_eth_core, CoreType::ETH));
+                src = update_program_page_transfers(
+                    src,
+                    sizeof(uint32_t),
+                    eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE,
+                    go_signal_page_transfers.at(PageTransferType::UNICAST),
+                    num_transfers_in_go_signal_pages.at(PageTransferType::UNICAST),
+                    {{dst_noc, 1}});
+            }
+        } else {
+            TT_ASSERT(false, "All non-ethernet core go signals should be muticasted");
+        }
+    }
+    if (num_transfers_within_page) {
+        num_transfers_in_go_signal_pages.at(PageTransferType::UNICAST).push_back(num_transfers_within_page);
+        num_transfers_within_page = 0;
+    }
+
+    // Allocate some more space for GO signal
+    update_program_pages_with_new_page();  // sets src to 0, but not needed
+
+    // Create a vector of all program binaries/cbs/semaphores
+    align_program_page_idx_to_new_page();
+    for (const KernelGroup& kernel_group : kernel_group_multicast) {
+        populate_program_binaries_pages(kernel_group);
+    }
+
+    for (const Semaphore& semaphore : program.semaphores()) {
+        program_pages[program_page_idx] = semaphore.initial_value();
+        program_page_idx += 4;
+    }
+
+    align_program_page_idx_to_new_page();
+    for (const KernelGroup& kernel_group : kernel_group_unicast) {
+        populate_program_binaries_pages(kernel_group);
+    }
+
+    // Since GO signal begin in a new page, I need to advance my idx
+    align_program_page_idx_to_new_page();
+    // uint32_t dispatch_core_word = ((uint32_t)dispatch_core.y << 16) | dispatch_core.x;
+    for (KernelGroup& kernel_group : kernel_group_multicast) {
+        // TODO(agrebenisan): Hanging when we extend the launch msg. Needs to be investigated. For now,
+        // only supporting enqueue program for cq 0 on a device.
+        // kernel_group.launch_msg.dispatch_core_x = dispatch_core.x;
+        // kernel_group.launch_msg.dispatch_core_y = dispatch_core.y;
+        static_assert(sizeof(launch_msg_t) % sizeof(uint32_t) == 0);
+        uint32_t* launch_message_data = (uint32_t*)&kernel_group.launch_msg;
+        for (int i = 0; i < sizeof(launch_msg_t) / sizeof(uint32_t); i++) {
+            program_pages[program_page_idx + i] = launch_message_data[i];
+        }
+        program_page_idx += sizeof(launch_msg_t) / sizeof(uint32_t);
+    }
+
+    align_program_page_idx_to_new_page();
+    for (KernelGroup& kernel_group : kernel_group_unicast) {
+        if (kernel_group.get_core_type() == CoreType::ETH) {
+            const Kernel* kernel = detail::GetKernel(program, kernel_group.erisc_id.value());
+            for (const auto& logical_eth_core : kernel->logical_cores()) {
+                program_pages[program_page_idx] = 1;
+                program_page_idx += 4;  // 16 byte L1 alignment
+            }
+        } else {
+            TT_ASSERT(false, "All non-ethernet core go signals should be muticasted");
+        }
+    }
+
+    TT_ASSERT(
+        program_new_page_tracker == 0, "Number of new program pages not aligned between sizing and populating data.");
+
+    uint32_t num_workers = 0;
+    // Explicitly sum the worker and eth cores, since we don't have support for all core types
+    if (program.logical_cores().find(CoreType::WORKER) != program.logical_cores().end()) {
+        num_workers += program.logical_cores().at(CoreType::WORKER).size();
+    } else if (program.logical_cores().find(CoreType::ETH) != program.logical_cores().end()) {
+        num_workers += program.logical_cores().at(CoreType::ETH).size();
+    }
+    return {
+        .num_workers = num_workers,
+        .program_pages = std::move(program_pages),
+        .program_page_transfers = std::move(program_page_transfers),
+        .runtime_arg_page_transfers = std::move(runtime_arg_page_transfers),
+        .cb_config_page_transfers = std::move(cb_config_page_transfers),
+        .go_signal_page_transfers = std::move(go_signal_page_transfers),
+        .num_transfers_in_program_pages = std::move(num_transfers_in_program_pages),
+        .num_transfers_in_runtime_arg_pages = std::move(num_transfers_in_runtime_arg_pages),
+        .num_transfers_in_cb_config_pages = std::move(num_transfers_in_cb_config_pages),
+        .num_transfers_in_go_signal_pages = std::move(num_transfers_in_go_signal_pages),
+    };
+}
+
 void Program::compile( Device * device )
 {
     bool first_compile_on_device = compile_needed_.find(device->id()) == compile_needed_.end();
@@ -620,6 +1061,11 @@ void Program::compile( Device * device )
         f.wait();
 
     this->construct_core_range_set_for_worker_cores();
+
+    if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
+        this->program_device_map = ConstructProgramDeviceMap(device, *this);
+        this->buffer = std::make_unique<Buffer>(device, this->program_device_map.program_pages.size() * sizeof(uint32_t),  DeviceCommand::PROGRAM_PAGE_SIZE, BufferType::DRAM);
+    }
 
     if (detail::CompilationReporter::enabled()) {
         detail::CompilationReporter::inst().flush_program_entry(*this, enable_persistent_kernel_cache);

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -15,6 +15,7 @@
 #include "common/tt_backend_api_types.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include "tt_metal/impl/kernels/kernel_types.hpp"
+#include "tt_metal/impl/program/program_device_map.hpp"
 #include "dev_msgs.h"
 
 namespace tt {
@@ -103,6 +104,12 @@ class Program {
     void allocate_circular_buffers();
 
    private:
+    ProgramDeviceMap program_device_map;
+
+    // The buffer that holds the kernel/binaries/etc for this program
+    std::unique_ptr<Buffer> buffer;
+
+    bool loaded_onto_device;
     struct CircularBufferAllocator {
         CircularBufferAllocator(const CoreRange &core_range_) : core_range(core_range_) {}
 
@@ -173,6 +180,9 @@ class Program {
     void set_cb_data_fmt( Device *device, const std::vector<CoreRange> & crs, JitBuildOptions& build_options) const;
 
     void update_kernel_groups();
+
+    friend class CommandQueue;
+    friend class EnqueueProgramCommand;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/program/program_device_map.hpp
+++ b/tt_metal/impl/program/program_device_map.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <unordered_map>
+#include <cstdint>
+
+
+struct transfer_info {
+    std::uint32_t size_in_bytes;
+    std::uint32_t dst;
+    std::uint32_t dst_noc_encoding;
+    std::uint32_t num_receivers;
+    bool last_transfer_in_group;
+    bool linked;
+};
+
+enum class PageTransferType { MULTICAST, UNICAST };
+
+struct ProgramDeviceMap {
+    std::uint32_t num_workers;
+    vector<std::uint32_t> program_pages;
+    std::unordered_map<PageTransferType, vector<transfer_info>> program_page_transfers;
+    std::unordered_map<PageTransferType, vector<transfer_info>> runtime_arg_page_transfers;
+    std::unordered_map<PageTransferType, vector<transfer_info>> cb_config_page_transfers;
+    std::unordered_map<PageTransferType, vector<transfer_info>> go_signal_page_transfers;
+    std::unordered_map<PageTransferType, vector<std::uint32_t>> num_transfers_in_program_pages;
+    std::unordered_map<PageTransferType, vector<std::uint32_t>> num_transfers_in_runtime_arg_pages;
+    std::unordered_map<PageTransferType, vector<std::uint32_t>> num_transfers_in_cb_config_pages;
+    std::unordered_map<PageTransferType, vector<std::uint32_t>> num_transfers_in_go_signal_pages;
+};


### PR DESCRIPTION
Programs own their program data in fast dispatch, and on destruction they clear their program buffer. No more need to explicitly clear program buffer cache, since gets cleared on program destructor. Simplifies command queue code as well.