### PR TITLE
#5198: Fix moreh softmax related bug

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py
@@ -403,3 +403,92 @@ def test_softmax_backward_for_dim_nc(shape_dim, device):
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
     logger.info(out)
     assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim_strategy",
+    (
+        ((1, 1, 32, 32), 3, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.SMALL_W),
+        ((1, 1, 32, 32), 2, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.SMALL_H),
+        ((1, 1, 32, 32), 3, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_W),
+        ((1, 1, 32, 32), 2, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_H),
+        ((1, 1, 32, 32), 1, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_C),
+        ((1, 1, 32, 32), 0, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_C),
+    ),
+)
+def test_softmax_callback(shape_dim_strategy, device):
+    ttl.program_cache.enable()
+
+    shape, dim, strategy = shape_dim_strategy
+    torch.manual_seed(0)
+
+    N = shape[0]
+    C = shape[1]
+    H = shape[2]
+    W = shape[3]
+
+    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+
+    dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+    dev_y = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+
+    tt_cpu = torch.softmax(x, dim)
+    for i in range(2):
+        tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dev_y, dim, strategy)
+
+    assert list(tt_npu.shape()) == list(tt_cpu.shape)
+    tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.05
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
+    logger.info(out)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_dim_strategy",
+    (
+        ((1, 1, 32, 32), 3, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.SMALL_W),
+        ((1, 1, 32, 32), 2, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.SMALL_H),
+        ((1, 1, 32, 32), 3, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_W),
+        ((1, 1, 32, 32), 2, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_H),
+        ((1, 1, 32, 32), 1, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_C),
+        ((1, 1, 32, 32), 0, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_C),
+    ),
+)
+def test_softmax_backward_callback(shape_dim_strategy, device):
+    ttl.program_cache.enable()
+    shape, dim, strategy = shape_dim_strategy
+    torch.manual_seed(0)
+
+    N = shape[0]
+    C = shape[1]
+    H = shape[2]
+    W = shape[3]
+
+    x = (
+        torch.randint(low=0, high=4, size=(N * C * H * W,))
+        .reshape((N, C, H, W))
+        .to(torch.bfloat16)
+        .requires_grad_(True)
+    )
+
+    y = torch.softmax(x, dim)
+    dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+
+    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+
+    dev_dx = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+
+    y.backward(dy)
+    for i in range(2):
+        tt_npu = ttl.operations.primary.moreh_softmax_backward(dev_y, dev_dy, dev_dx, dim, strategy)
+
+    assert list(tt_npu.shape()) == list(x.grad.shape)
+    tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
+
+    rtol = atol = 0.05
+    passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
+    logger.info(out)
+    assert passing

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
@@ -140,11 +140,10 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 2);
 
         auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
+        auto dst_dram_buffer = input_buffers.at(1);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
@@ -125,11 +125,10 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 2);
 
         auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
+        auto dst_dram_buffer = input_buffers.at(1);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
@@ -147,11 +147,10 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 2);
 
         auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
+        auto dst_dram_buffer = input_buffers.at(1);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
@@ -125,11 +125,10 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 2);
 
         auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
+        auto dst_dram_buffer = input_buffers.at(1);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
@@ -146,11 +146,10 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 2);
 
         auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
+        auto dst_dram_buffer = input_buffers.at(1);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -147,12 +147,11 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 3);
 
         auto output_dram_buffer = input_buffers.at(0);
         auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
+        auto input_grad_dram_buffer = input_buffers.at(2);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -132,12 +132,11 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 3);
 
         auto output_dram_buffer = input_buffers.at(0);
         auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
+        auto input_grad_dram_buffer = input_buffers.at(2);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -154,12 +154,11 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 3);
 
         auto output_dram_buffer = input_buffers.at(0);
         auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
+        auto input_grad_dram_buffer = input_buffers.at(2);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -131,12 +131,11 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 3);
 
         auto output_dram_buffer = input_buffers.at(0);
         auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
+        auto input_grad_dram_buffer = input_buffers.at(2);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -154,12 +154,11 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_small(const Tensor &out
         const std::vector<Buffer*>& input_buffers,
         const std::vector<Buffer*>& output_buffers
     ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
+        TT_ASSERT(input_buffers.size() == 3);
 
         auto output_dram_buffer = input_buffers.at(0);
         auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
+        auto input_grad_dram_buffer = input_buffers.at(2);
 
         for (uint32_t icore = 0; icore < num_cores; icore++) {
             CoreCoord core = {icore / core_h, icore % core_h};

--- a/ttnn/ttnn/operations/others.py
+++ b/ttnn/ttnn/operations/others.py
@@ -350,9 +350,8 @@ def softmax(
         input_tensor = ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT)
         ttl_input_tensor = input_tensor.value
 
-        ttl_output_tensor = ttl.operations.primary.moreh_softmax(
-            ttl_input_tensor, dim=dim_4D, output_mem_config=memory_config
-        )
+        ttl_output_tensor = ttnn.Tensor(ttl_input_tensor).value
+        ttl.operations.primary.moreh_softmax(ttl_input_tensor, ttl_output_tensor, dim=dim_4D)
     output_tensor = ttnn.Tensor(ttl_output_tensor)
     output_tensor = ttnn.reshape(output_tensor, input_shape)
     return output_tensor


### PR DESCRIPTION
I fixed the bug that occurred after merging the logsoftmax PR(https://github.com/tenstorrent-metal/tt-metal/pull/4961)

In the PR, `moreh_softmax` was modified to accept the output tensor as input, but this change was not reflected in the test code, leading to a bug

Also, I discovered that the callback implementation in test_moreh_softmax was not being tested, so I added tests for it and fixed related bugs

I plan to apply the https://tenstorrent-metal.github.io/tt-metal/latest/ttnn/dependencies/tt_lib.html#new-device-operation-with-optional-output-tensors  link after this PR


I ran the `pytest tests/ttnn/integration_tests` tests and confirmed that they all passed.