### PR TITLE
#3122: Use device grid size in falcon_attention to be genereric...

### DIFF
--- a/models/demos/falcon7b/tt/falcon_attention.py
+++ b/models/demos/falcon7b/tt/falcon_attention.py
@@ -293,7 +293,7 @@ class TtFalconAttention(nn.Module):
             attn_weights = tt_lib.operations.primary.transformers.attn_matmul(
                 query_layer,
                 key_layer_transposed,
-                compute_with_storage_grid_size=tt_lib.tensor.CoreCoord(12, 9),
+                compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
                 output_mem_config=self.model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"],
                 output_dtype=self.model_config["PRE_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
             )
@@ -356,7 +356,7 @@ class TtFalconAttention(nn.Module):
             attn_output = tt_lib.operations.primary.transformers.attn_matmul(
                 attn_weights,
                 value_layer,
-                compute_with_storage_grid_size=tt_lib.tensor.CoreCoord(12, 9),
+                compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
                 output_mem_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
                 output_dtype=self.model_config["POST_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
             )


### PR DESCRIPTION
Use device grid size in falcon_attention to be genereric across GS and WH.

The test referenced in [this issue](https://github.com/tenstorrent-metal/tt-metal/commit/f061fecdcad675a3f28f0a9160b6e214982a77d2) seems to have been moved to:

`pytest models/demos/falcon7b/tests/test_perf_falcon.py`

This test passes now on GS and WH for some configurations but fails for a test with larger sequence length (2048) which does not seem to be related to this specific issue.

This change also fixes the falcon7b demo on WH:

`pytest --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/falcon7b/demo/demo.py`