### PR TITLE
Cleanup compiler errors for newer versions of GCC and Clang

### DIFF
--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -10,12 +10,12 @@
 #include <vector>
 
 #include "common/bfloat16.hpp"
+#include "common/tt_backend_api_types.hpp"
 #include "tensor/borrowed_buffer.hpp"
 #include "tensor/owned_buffer.hpp"
 #include "tt_metal/impl/buffers/buffer.hpp"
 #include "tt_metal/impl/device/device.hpp"
 #include "tt_metal/tt_stl/concepts.hpp"
-#include "tt_metal/tt_stl/reflection.hpp"
 
 namespace tt {
 
@@ -40,10 +40,7 @@ enum class StorageType {
     BORROWED,  // for storing torch/numpy/etc tensors
 };
 
-
-
 tt::DataFormat datatype_to_dataformat_converter(DataType datatype);
-
 
 static constexpr std::size_t MAX_NUM_DIMENSIONS = 8;
 

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -4,15 +4,9 @@
 
 #pragma once
 
-#include "common/tt_backend_api_types.hpp"
 #include "common/core_coord.h"
-#include "hostdevcommon/common_values.hpp"
-#include "tt_metal/common/constants.hpp"
-#include "tt_metal/tt_stl/concepts.hpp"
 #include "tt_metal/tt_stl/reflection.hpp"
-#include <map>
 #include <optional>
-
 
 namespace tt {
 

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -12,8 +12,6 @@
 #include "tt_metal/impl/buffers/semaphore.hpp"
 #include "tt_metal/impl/device/device.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
-#include "common/tt_backend_api_types.hpp"
-#include "hostdevcommon/common_values.hpp"
 #include "tt_metal/impl/kernels/kernel_types.hpp"
 #include "tt_metal/impl/program/program_device_map.hpp"
 #include "dev_msgs.h"

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -2,17 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-#include <filesystem>
-#include <mutex>
 #include <unordered_set>
 #include <string>
 
 #include "tt_metal/host_api.hpp"
-#include "impl/debug/dprint_server.hpp"
 #include "dev_msgs.h"
 
-#include "tools/profiler/profiler.hpp"
 #include "tools/cpuprof/cpuprof.h"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/detail/program.hpp"
@@ -232,10 +227,6 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
         }
     }
 
-    void WriteToBuffer( std::shared_ptr<const Buffer> buffer, const std::vector<uint32_t> &host_buffer){
-        WriteToBuffer ( *buffer, host_buffer );
-    }
-
     void WriteToBuffer(const Buffer &buffer, const std::vector<uint32_t> &host_buffer) {
         switch (buffer.buffer_type()) {
             case BufferType::DRAM:
@@ -247,6 +238,10 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
             } break;
             default: TT_FATAL(false && "Unsupported buffer type!");
         }
+    }
+
+    void WriteToBuffer( std::shared_ptr<const Buffer> buffer, const std::vector<uint32_t> &host_buffer){
+        WriteToBuffer ( *buffer, host_buffer );
     }
 
     void ReadFromDeviceInterleavedContiguous(const Buffer &buffer, std::vector<uint32_t> &host_buffer) {
@@ -376,11 +371,6 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
         }
     }
 
-    void ReadFromBuffer(std::shared_ptr<const Buffer> buffer, std::vector<uint32_t> &host_buffer, bool shard_order)
-    {
-        ReadFromBuffer(*buffer, host_buffer, shard_order);
-    }
-
     void ReadFromBuffer(const Buffer &buffer, std::vector<uint32_t> &host_buffer, bool shard_order) {
         Device *device = buffer.device();
         switch (buffer.buffer_type()) {
@@ -398,6 +388,11 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
             } break;
             default: TT_FATAL(false && "Unsupported buffer type!");
         }
+    }
+
+    void ReadFromBuffer(std::shared_ptr<const Buffer> buffer, std::vector<uint32_t> &host_buffer, bool shard_order)
+    {
+        ReadFromBuffer(*buffer, host_buffer, shard_order);
     }
 
     void ReadShard(const Buffer &buffer, std::vector<uint32_t> &host_buffer, const uint32_t & core_id) {

--- a/tt_metal/tt_stl/concepts.hpp
+++ b/tt_metal/tt_stl/concepts.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
 namespace tt {
 namespace stl {
 namespace concepts {

--- a/tt_metal/tt_stl/reflection.hpp
+++ b/tt_metal/tt_stl/reflection.hpp
@@ -15,6 +15,7 @@
 #include <variant>
 #include <vector>
 
+#include "tt_metal/tt_stl/concepts.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
 
 namespace tt {


### PR DESCRIPTION
This PR contains several minor fixes to reduce the amount of compiler errors/warnings on newer versions of Clang and GCC. This should improve the experience for those trying to use a language server like `clangd` during development. 

I also removed some unused headers where possible.

Let me know if you prefer a multiple commits or a single squashed commit. 