### PR TITLE
#0: Add support for typecast float <-> uint

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_typecast.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_typecast.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 from functools import partial
 import tt_lib as ttl
+from collections import defaultdict
 
 
 from tests.tt_eager.python_api_testing.sweep_tests import (
@@ -28,6 +29,10 @@ mem_configs = [
         (torch.float16, ttl.tensor.DataType.FLOAT32),
         (torch.float32, ttl.tensor.DataType.BFLOAT8_B),
         (torch.bfloat16, ttl.tensor.DataType.BFLOAT16),
+        (
+            torch.int,
+            ttl.tensor.DataType.BFLOAT16,
+        ),  # we can't keep int for tt input because input will be of bfloat16 in ckernel.
         (torch.int, ttl.tensor.DataType.UINT32),
     ),
 )
@@ -36,6 +41,9 @@ mem_configs = [
     (
         (torch.bfloat16, ttl.tensor.DataType.BFLOAT16),
         (torch.float32, ttl.tensor.DataType.BFLOAT8_B),
+        (torch.int32, ttl.tensor.DataType.UINT16),
+        (torch.int32, ttl.tensor.DataType.UINT32),
+        (torch.float32, ttl.tensor.DataType.FLOAT32),
     ),
 )
 @pytest.mark.parametrize(
@@ -74,8 +82,23 @@ class TestTypecast:
             pytest.skip(f"{tt_input_dtype} cannot be converted yet. Skip")
         if tt_input_dtype == tt_output_dtype:
             pytest.skip("Same I/O data types. Skip.")
+        if tt_input_dtype in [ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.UINT32, ttl.tensor.DataType.FLOAT32]:
+            if tt_output_dtype in [ttl.tensor.DataType.UINT16, ttl.tensor.DataType.UINT32, ttl.tensor.DataType.FLOAT32]:
+                pytest.skip(f"{tt_input_dtype} cannot be converted yet. Skip")
+
+        options = defaultdict(lambda: (-100, 100))
+        options[ttl.tensor.DataType.FLOAT32] = (0, 2137483647)
+        options[ttl.tensor.DataType.UINT16] = (0, 65535)
+        options[ttl.tensor.DataType.UINT32] = (
+            0,
+            2137483647,
+        )  # uint max value is 4294967295, as torch dont have uint32
+
         datagen_func = [
-            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=0, high=10), pt_input_dtype)
+            generation_funcs.gen_func_with_cast(
+                partial(generation_funcs.gen_rand, low=options[tt_output_dtype][0], high=options[tt_output_dtype][1]),
+                pt_input_dtype,
+            )
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args["pt_input_dtype"] = [pt_input_dtype]

--- a/tt_eager/tensor/tensor_impl.cpp
+++ b/tt_eager/tensor/tensor_impl.cpp
@@ -160,8 +160,8 @@ void validate_on_device_dtype_and_layout(Device *device, DataType dtype, Layout 
     // TODO: Get supported layout and dtypes from device
     auto supported_dtype = [&dtype]() {
         TT_ASSERT(
-            (dtype == DataType::BFLOAT16 || dtype == DataType::BFLOAT8_B || dtype == DataType::UINT32 || dtype == DataType::UINT16) &&
-            "Only BFLOAT16, BFLOAT8_B, UINT32, or UINT16 is supported on device!"
+            (dtype == DataType::BFLOAT16 || dtype == DataType::BFLOAT8_B || dtype == DataType::UINT32 || dtype == DataType::UINT16 || dtype == DataType::FLOAT32) &&
+            "Only BFLOAT16, BFLOAT8_B, UINT32, Float32 or UINT16 is supported on device!"
         );
     };
     auto supported_layout = [&dtype, &layout]() {

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -1552,7 +1552,30 @@ Tensor argmax(
     return operation::decorate_as_composite(__func__, _argmax)(input_a, dim, all, output_mem_config);
 }
 
+
+Tensor _typecast(const Tensor& input_a, const DataType& dtype, const MemoryConfig& output_mem_config) {
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(dtype);
+    if(cb_data_format == tt::DataFormat::UInt16)
+    {
+        return to_uint16(input_a,output_mem_config);
+    }
+    else if(cb_data_format == tt::DataFormat::UInt32 || cb_data_format == tt::DataFormat::Float32)
+    {
+        return to_uint32(input_a,output_mem_config);
+    }
+    else{
+        return to_bfloat(input_a, dtype, output_mem_config);
+    }
+}
+
+Tensor typecast(const Tensor& input_tensors, const DataType& dtype, const MemoryConfig& output_mem_config ) {
+    return operation::decorate_as_composite(__func__, _typecast)(input_tensors, dtype, output_mem_config);
+}
+
+
 Tensor _argmin(const Tensor& input_a, int64_t _dim, bool all, const MemoryConfig& output_mem_config) {
+    auto& input_shape = input_a.shape();
+    TT_FATAL(input_shape.rank() == 4,"supported for rank-4 tensors at this time");
 
     Tensor neg_input =  neg(input_a, output_mem_config);
     return (argmax(neg_input, _dim, all, output_mem_config));

--- a/tt_eager/tt_dnn/op_library/copy/copy_op.cpp
+++ b/tt_eager/tt_dnn/op_library/copy/copy_op.cpp
@@ -87,8 +87,8 @@ Tensor clone(const Tensor& input, const MemoryConfig& output_mem_config, std::op
     return operation::run(Copy{output_mem_config, output_dtype.value_or(input.dtype())}, {input}).at(0);
 }
 
-Tensor typecast(const Tensor& input_tensor, const DataType& dtype, const MemoryConfig& output_mem_config ) {
-    return operation::run(Copy{output_mem_config, dtype}, {input_tensor}).at(0);
+Tensor to_bfloat(const Tensor& input_tensor, const DataType& dtype, const MemoryConfig& output_mem_config ) {
+        return operation::run(Copy{output_mem_config, dtype}, {input_tensor}).at(0);
 }
 
 //unary assign

--- a/tt_eager/tt_dnn/op_library/copy/copy_op.hpp
+++ b/tt_eager/tt_dnn/op_library/copy/copy_op.hpp
@@ -43,6 +43,7 @@ Tensor clone(const Tensor& input, const MemoryConfig& output_mem_config = operat
 
 Tensor typecast(const Tensor& input_tensor, const DataType& dtype, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+Tensor to_bfloat(const Tensor& input_tensor, const DataType& dtype, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 //unary assign
 Tensor assign(const Tensor& input, const MemoryConfig& output_mem_config, std::optional<const DataType> output_dtype = std::nullopt);
 

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -145,6 +145,8 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, stri
         case UnaryOpType::LOG: op_init_and_name = {"log_tile_init();", fmt::format("log_tile({});", idst)}; break;
         case UnaryOpType::TANH: op_init_and_name = {"tanh_tile_init();", fmt::format("tanh_tile({});", idst)}; break;
         case UnaryOpType::SIGNBIT: op_init_and_name = {"signbit_tile_init();", fmt::format("signbit_tile({});", idst)}; break;
+        case UnaryOpType::TO_UINT16: op_init_and_name = {"to_uint16_tile_init();", fmt::format("to_uint16_tile({});", idst)}; break;
+        case UnaryOpType::TO_UINT32: op_init_and_name = {"to_uint32_tile_init();", fmt::format("to_uint32_tile({});", idst)}; break;
         case UnaryOpType::SIN: op_init_and_name = {"sin_tile_init();", fmt::format("sin_tile({});", idst)}; break;
         case UnaryOpType::COS: op_init_and_name = {"cos_tile_init();", fmt::format("cos_tile({});", idst)}; break;
         case UnaryOpType::ISFINITE: op_init_and_name = {"isfinite_tile_init();", fmt::format("isfinite_tile({});", idst)}; break;

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -73,7 +73,9 @@ enum class UnaryOpType {
     ADD_UNARY_SFPU = 55,
     SUB_UNARY_SFPU = 56,
     MUL_UNARY_SFPU = 57,
-    DIV_UNARY_SFPU = 58
+    DIV_UNARY_SFPU = 58,
+    TO_UINT16 = 59,
+    TO_UINT32 = 60
 };
 
 template <typename T>
@@ -251,6 +253,8 @@ constexpr auto isneginf = make_eltwise_unary<UnaryOpType::ISNEGINF>{};
 constexpr auto isnan = make_eltwise_unary<UnaryOpType::ISNAN>{};
 constexpr auto sign = make_eltwise_unary<UnaryOpType::SIGN>{};
 constexpr auto signbit = make_eltwise_unary<UnaryOpType::SIGNBIT>{};
+constexpr auto to_uint16 = make_eltwise_unary<UnaryOpType::TO_UINT16>{};
+constexpr auto to_uint32 = make_eltwise_unary<UnaryOpType::TO_UINT32>{};
 constexpr auto square = make_eltwise_unary<UnaryOpType::SQUARE>{};
 constexpr auto atan = make_eltwise_unary<UnaryOpType::ATAN>{};
 constexpr auto eqz = make_eltwise_unary<UnaryOpType::EQZ>{};

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -82,6 +82,26 @@ inline void llk_math_eltwise_unary_sfpu_signbit_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::signbit, APPROXIMATE>();
 }
 
+template <bool APPROXIMATE, DstSync dst_sync = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_to_uint16(uint dst_index, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu<SfpuType::to_uint16, APPROXIMATE, dst_sync>(dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_to_uint16_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::to_uint16, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE, DstSync dst_sync = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_to_uint32(uint dst_index, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu<SfpuType::to_uint32, APPROXIMATE, dst_sync>(dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_to_uint32_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::to_uint32, APPROXIMATE>();
+}
+
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_tanh_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::tanh, APPROXIMATE>();

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_common_includes.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_common_includes.h
@@ -101,7 +101,11 @@ inline void llk_math_calculate_sfpu(
         calculate_atan<APPROXIMATION_MODE, ITERATIONS>();
     } else if constexpr (operation == SfpuType::signbit) {
         calculate_signbit<APPROXIMATION_MODE, ITERATIONS>();
-    } else if constexpr (operation == SfpuType::silu) {
+    }else if constexpr (operation == SfpuType::to_uint16) {
+        calculate_to_uint16<APPROXIMATION_MODE, ITERATIONS>();
+    }else if constexpr (operation == SfpuType::to_uint32) {
+        calculate_to_uint32<APPROXIMATION_MODE, ITERATIONS>();
+    }else if constexpr (operation == SfpuType::silu) {
         calculate_silu<APPROXIMATION_MODE, ITERATIONS>();
     }
     //erf, erfc are dispatched directly.

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/metal_ckernel_sfpu.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/metal_ckernel_sfpu.h
@@ -236,6 +236,104 @@ inline void calculate_signbit()
 
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_to_uint16()
+{
+
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vFloat val = dst_reg[0];
+        vFloat result = 0;
+
+        for(int i=0; i<47 ; i++)
+        {
+                v_if ( val >= 10000.0f  ){
+                result += 10000;
+                val -= 10000.0f;
+                }
+                v_elseif ( val >= 1000.0f  ){
+                    result += 1000;
+                    val -= 1000.0f;
+                }
+                v_elseif ( val >= 100.0f  ){
+                    result += 100;
+                    val -= 100.0f;
+                }
+                v_elseif ( val >= 10.0f ){
+                    result += 10;
+                    val -= 10.0f;
+                }
+                v_elseif ( val >= 1.0f){
+                    result += 1;
+                    val -= 1.0f;
+                }v_elseif ( val < 0.0f){
+                    result = 0;
+                    val = 0.0f;
+                }
+                v_endif;
+
+        }
+        dst_reg[0] = result;
+
+        dst_reg++;
+    }
+
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_to_uint32()
+{
+
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vFloat result = 0;
+        vFloat val = dst_reg[0];
+
+        for(int i = 0; i < 95; i++)
+        {
+                v_if ( val >= 100000000.0f){
+                    result += 100000000;
+                    val -= 100000000.0f;
+                } v_elseif ( val >= 10000000.0f){
+                    result += 10000000;
+                    val -= 10000000.0f;
+                } v_elseif ( val >= 10000000.0f){
+                    result += 10000000;
+                    val -= 10000000.0f;
+                } v_elseif ( val >= 1000000.0f){
+                    result += 1000000;
+                    val -= 1000000.0f;
+                } v_elseif ( val >= 100000.0f){
+                    result += 100000;
+                    val -= 100000.0f;
+                } v_elseif ( val >= 10000.0f){
+                    result += 10000;
+                    val -= 10000.0f;
+                }v_elseif ( val >= 1000.0f){
+                    result += 1000;
+                    val -= 1000.0f;
+                } v_elseif ( val >= 100.0f){
+                    result += 100;
+                    val -= 100.0f;
+                } v_elseif ( val >= 10.0f){
+                    result += 10;
+                    val -= 10.0f;
+                } v_elseif ( val >= 1.0f){
+                    result += 1;
+                    val -= 1.0f;
+                } v_elseif ( val < 0.0f){
+                    result = 0;
+                    val = 0.0f;
+                }
+                v_endif;
+        }
+        dst_reg[0] = result;
+
+        dst_reg++;
+    }
+
+}
+
 template <bool APPROXIMATION_MODE,int ITERATIONS>
 inline void calculate_power_iterative(const uint exponent)
 {

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu_types.h
@@ -60,5 +60,7 @@ enum SfpuType {
   silu,
   mask,
   negative,
+  to_uint16,
+  to_uint32,
   unused,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -279,6 +279,27 @@ inline void llk_math_eltwise_unary_sfpu_acos_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::acos, APPROXIMATE>();
 }
 
+// uint16
+template <bool APPROXIMATE, DstSync dst_sync = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_to_uint16(uint dst_index, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu<SfpuType::to_uint16, APPROXIMATE, dst_sync>(dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_to_uint16_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::to_uint16, APPROXIMATE>();
+}
+// uint32
+template <bool APPROXIMATE, DstSync dst_sync = DstSync::SyncFull>
+inline void llk_math_eltwise_unary_sfpu_to_uint32(uint dst_index, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu<SfpuType::to_uint32, APPROXIMATE, dst_sync>(dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_to_uint32_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::to_uint32, APPROXIMATE>();
+}
+
 //silu
 template <bool APPROXIMATE, DstSync dst_sync = DstSync::SyncFull>
 inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_common_includes.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_common_includes.h
@@ -100,6 +100,10 @@ inline void llk_math_calculate_sfpu(
         calculate_signbit<APPROXIMATION_MODE, ITERATIONS>();
     } else if constexpr (operation == SfpuType::silu) {
         calculate_silu<APPROXIMATION_MODE, ITERATIONS>();
+    }else if constexpr (operation == SfpuType::to_uint16) {
+        calculate_to_uint16<APPROXIMATION_MODE, ITERATIONS>();
+    }else if constexpr (operation == SfpuType::to_uint32) {
+        calculate_to_uint32<APPROXIMATION_MODE, ITERATIONS>();
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/metal_ckernel_sfpu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/metal_ckernel_sfpu.h
@@ -761,5 +761,104 @@ inline void calculate_silu()
     }
 }
 
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_to_uint16()
+{
+
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vFloat val = dst_reg[0];
+        vFloat result = 0;
+
+        for(int i=0; i<47 ; i++)
+        {
+                v_if ( val >= 10000.0f  ){
+                result += 10000;
+                val -= 10000.0f;
+                }
+                v_elseif ( val >= 1000.0f  ){
+                    result += 1000;
+                    val -= 1000.0f;
+                }
+                v_elseif ( val >= 100.0f  ){
+                    result += 100;
+                    val -= 100.0f;
+                }
+                v_elseif ( val >= 10.0f ){
+                    result += 10;
+                    val -= 10.0f;
+                }
+                v_elseif ( val >= 1.0f){
+                    result += 1;
+                    val -= 1.0f;
+                }v_elseif ( val < 0.0f){
+                    result = 0;
+                    val = 0.0f;
+                }
+                v_endif;
+
+        }
+        dst_reg[0] = result;
+
+        dst_reg++;
+    }
+
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_to_uint32()
+{
+
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vFloat result = 0;
+        vFloat val = dst_reg[0];
+
+        for(int i = 0; i < 95; i++)
+        {
+                v_if ( val >= 100000000.0f){
+                    result += 100000000;
+                    val -= 100000000.0f;
+                } v_elseif ( val >= 10000000.0f){
+                    result += 10000000;
+                    val -= 10000000.0f;
+                } v_elseif ( val >= 10000000.0f){
+                    result += 10000000;
+                    val -= 10000000.0f;
+                } v_elseif ( val >= 1000000.0f){
+                    result += 1000000;
+                    val -= 1000000.0f;
+                } v_elseif ( val >= 100000.0f){
+                    result += 100000;
+                    val -= 100000.0f;
+                } v_elseif ( val >= 10000.0f){
+                    result += 10000;
+                    val -= 10000.0f;
+                }v_elseif ( val >= 1000.0f){
+                    result += 1000;
+                    val -= 1000.0f;
+                } v_elseif ( val >= 100.0f){
+                    result += 100;
+                    val -= 100.0f;
+                } v_elseif ( val >= 10.0f){
+                    result += 10;
+                    val -= 10.0f;
+                } v_elseif ( val >= 1.0f){
+                    result += 1;
+                    val -= 1.0f;
+                } v_elseif ( val < 0.0f){
+                    result = 0;
+                    val = 0.0f;
+                }
+                v_endif;
+        }
+        dst_reg[0] = result;
+
+        dst_reg++;
+    }
+
+}
+
 } // namespace sfpu
 } // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -65,5 +65,7 @@ enum SfpuType {
     dequant_int32,
     requant_int32,
     quant_int32,
+    to_uint16,
+    to_uint32,
     unused,
 };

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -206,8 +206,21 @@ ALWI void signbit_tile(uint32_t idst) {
     MATH(( llk_math_eltwise_unary_sfpu_signbit<APPROX, SyncHalf>(idst) ));
 }
 
+ALWI void to_uint16_tile_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_to_uint16_init<APPROX>() ));
+}
 
+ALWI void to_uint16_tile(uint32_t idst) {
+    MATH(( llk_math_eltwise_unary_sfpu_to_uint16<APPROX, SyncHalf>(idst) ));
+}
 
+ALWI void to_uint32_tile_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_to_uint32_init<APPROX>() ));
+}
+
+ALWI void to_uint32_tile(uint32_t idst) {
+    MATH(( llk_math_eltwise_unary_sfpu_to_uint32<APPROX, SyncHalf>(idst) ));
+}
 /**
  * Performs element-wise computation of absolute value on each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in


### PR DESCRIPTION
It have the support for following typecast conversion using ladder method in GS and WhB0

- bf16 -> uint16
- bf16 -> uint32
- uint16 -> float32(as kernel don't have support other than bf16 input dtype I actually perform bf16->float conversion)

Muthu we don't have a separate for uint to float conversion because float to uint and uint to float conversion are almost same. so to avoid code duplication I have called float to uint32 conversion.