### PR TITLE
Revert "#0: skip MOREH Softmax tests from d5811b7edb55a1e7704b3860934…

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py
@@ -11,7 +11,6 @@ from loguru import logger
 import torch.nn.functional as F
 
 
-@pytest.mark.skip("Some of MOREH Softmax tests are failing from d5811b7edb55a1e7704b3860934554f3949d8dd7 on 02/07/24")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -53,7 +52,6 @@ def test_logsoftmax_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("Some of MOREH Softmax tests are failing from d5811b7edb55a1e7704b3860934554f3949d8dd7 on 02/07/24")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -94,7 +92,6 @@ def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("Some of MOREH Softmax tests are failing from d5811b7edb55a1e7704b3860934554f3949d8dd7 on 02/07/24")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -142,7 +139,6 @@ def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("Some of MOREH Softmax tests are failing from d5811b7edb55a1e7704b3860934554f3949d8dd7 on 02/07/24")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -186,7 +182,6 @@ def test_logsoftmax_for_dim_nc(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("Some of MOREH Softmax tests are failing from d5811b7edb55a1e7704b3860934554f3949d8dd7 on 02/07/24")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -237,7 +232,6 @@ def test_logsoftmax_backward_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("Some of MOREH Softmax tests are failing from d5811b7edb55a1e7704b3860934554f3949d8dd7 on 02/07/24")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -287,7 +281,6 @@ def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("Some of MOREH Softmax tests are failing from d5811b7edb55a1e7704b3860934554f3949d8dd7 on 02/07/24")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -350,7 +343,6 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("Some of MOREH Softmax tests are failing from d5811b7edb55a1e7704b3860934554f3949d8dd7 on 02/07/24")
 @pytest.mark.parametrize(
     "shape_dim",
     (

--- a/tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py
@@ -10,7 +10,6 @@ from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
 
 
-@pytest.mark.skip("MOREH softmax commit fails on 02/07/2024 for some of variations")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -52,7 +51,6 @@ def test_softmax_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("MOREH softmax commit fails on 02/07/2024 for some of variations")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -94,7 +92,6 @@ def test_softmax_large_algorithm_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("MOREH softmax commit fails on 02/07/2024 for some of variations")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -142,7 +139,6 @@ def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("MOREH softmax commit fails on 02/07/2024 for some of variations")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -186,7 +182,6 @@ def test_softmax_for_dim_nc(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("MOREH softmax commit fails on 02/07/2024 for some of variations")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -237,7 +232,6 @@ def test_softmax_backward_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("MOREH softmax commit fails on 02/07/2024 for some of variations")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -288,7 +282,6 @@ def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("MOREH softmax commit fails on 02/07/2024 for some of variations")
 @pytest.mark.parametrize(
     "shape_dim",
     (
@@ -350,7 +343,6 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@pytest.mark.skip("MOREH softmax commit fails on 02/07/2024 for some of variations")
 @pytest.mark.parametrize(
     "shape_dim",
     (


### PR DESCRIPTION
Revert "#0: skip MOREH Softmax tests from d5811b7edb55a1e7704b3860934554f3949d8dd7 commit on 02/07/24"

This reverts commit 28447d214c236c2ff0a0e15452d1b4285c550ac3.

============================================================================================ PASSES =============================================================================================
==================================================================================== short test summary info ====================================================================================
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_hw[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_hw[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_hw[shape_dim4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_hw[shape_dim5]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_hw[shape_dim6]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_hw[shape_dim7]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_large_algorithm_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_large_algorithm_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_not_multiple_of_32_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_not_multiple_of_32_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_not_multiple_of_32_for_dim_hw[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_not_multiple_of_32_for_dim_hw[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_nc[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_nc[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_nc[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_nc[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_nc[shape_dim4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_for_dim_nc[shape_dim5]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_hw[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_hw[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_hw[shape_dim4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_hw[shape_dim5]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_hw[shape_dim6]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_hw[shape_dim7]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_large_algorithm_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_large_algorithm_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_not_multiple_of_32_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_not_multiple_of_32_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_not_multiple_of_32_for_dim_hw[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_not_multiple_of_32_for_dim_hw[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_nc[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_nc[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_nc[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_nc[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_nc[shape_dim4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_logsoftmax.py::test_logsoftmax_backward_for_dim_nc[shape_dim5]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_hw[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_hw[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_hw[shape_dim4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_hw[shape_dim5]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_hw[shape_dim6]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_hw[shape_dim7]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_large_algorithm_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_large_algorithm_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_not_multiple_of_32_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_not_multiple_of_32_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_not_multiple_of_32_for_dim_hw[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_not_multiple_of_32_for_dim_hw[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_nc[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_nc[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_nc[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_nc[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_nc[shape_dim4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_for_dim_nc[shape_dim5]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_hw[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_hw[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_hw[shape_dim4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_hw[shape_dim5]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_hw[shape_dim6]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_hw[shape_dim7]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_large_algorithmfor_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_large_algorithmfor_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_not_multiple_of_32_for_dim_hw[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_not_multiple_of_32_for_dim_hw[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_not_multiple_of_32_for_dim_hw[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_not_multiple_of_32_for_dim_hw[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_nc[shape_dim0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_nc[shape_dim1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_nc[shape_dim2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_nc[shape_dim3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_nc[shape_dim4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_for_dim_nc[shape_dim5]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_callback[shape_dim_strategy0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_callback[shape_dim_strategy1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_callback[shape_dim_strategy2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_callback[shape_dim_strategy3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_callback[shape_dim_strategy4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_callback[shape_dim_strategy5]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_callback[shape_dim_strategy0]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_callback[shape_dim_strategy1]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_callback[shape_dim_strategy2]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_callback[shape_dim_strategy3]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_callback[shape_dim_strategy4]
PASSED tests/tt_eager/python_api_testing/unit_testing/test_moreh_softmax.py::test_softmax_backward_callback[shape_dim_strategy5]
================================================================================= 92 passed in 66.12s (0:01:06) =================================================================================
                 Device | INFO     | Closing user mode device drivers
(python_env) ubuntu@13c4b04b-65f5-4e03-957e-638871e2a23d:~/tt-metal-concat$ git commit -a -m '#0: revert the tests so 92 are passed'