### PR TITLE
 fix for sharded allocater when num banks == num cores

### DIFF
--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -38,7 +38,7 @@ class BankManager {
 
     int64_t bank_offset(uint32_t bank_id) const;
 
-    uint64_t allocate_buffer(uint32_t size, uint32_t page_size, bool bottom_up, std::optional<uint32_t> num_shards);
+    uint64_t allocate_buffer(uint32_t size, uint32_t page_size, bool bottom_up, CoreCoord compute_grid_size, std::optional<uint32_t> num_shards);
 
     void deallocate_buffer(uint64_t address);
     void deallocate_all();

--- a/tt_metal/impl/allocator/allocator_types.hpp
+++ b/tt_metal/impl/allocator/allocator_types.hpp
@@ -43,6 +43,7 @@ struct AllocatorConfig {
     std::unordered_map<int, int> worker_log_to_physical_routing_x = {};
     std::unordered_map<int, int> worker_log_to_physical_routing_y = {};
     BankMapping l1_bank_remap = {}; // for remapping which l1 bank points to which bank if we assume normal row-major assignment
+    CoreCoord compute_grid_size = {};
     void reset();
     ~AllocatorConfig() { reset(); }
 };

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -91,6 +91,7 @@ void Device::initialize_allocator(const std::vector<uint32_t>& l1_bank_remap) {
         .worker_log_to_physical_routing_x=soc_desc.worker_log_to_physical_routing_x,
         .worker_log_to_physical_routing_y=soc_desc.worker_log_to_physical_routing_y,
         .l1_bank_remap = l1_bank_remap,
+        .compute_grid_size = this->compute_with_storage_grid_size()
     });
     // Initialize dram_offsets from soc_descriptor
     for (auto channel = 0; channel < soc_desc.get_num_dram_channels(); channel++) {


### PR DESCRIPTION
Use compute_cores when determining how many banks we have available to shard. 