### PR TITLE
#0: Fix WatcherSanitize test for N150X2 machines

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -122,7 +122,8 @@ TEST_F(WatcherFixture, TestWatcherSanitize) {
         GTEST_SKIP();
 
     CheckHostSanitization(this->devices_[0]);
-    for (Device* device : this->devices_) {
-        this->RunTestOnDevice(RunTest, device);
-    }
+
+    // Only run the main test on device 0, because it brings the watcher server down and we don't
+    // have a way to recover fromt hat between runs here.
+    this->RunTestOnDevice(RunTest, this->devices_[0]);
 }


### PR DESCRIPTION
See comment for why this was a problem. Tested locally on an N150x2 machine so should be very low risk to just merge. Wasn't a problem on Ci because it doesn't affect GS and N300, as well as N150X1