### PR TITLE
Don't assume user has one entry in their `$PYTHONPATH`

### DIFF
--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -271,7 +271,16 @@ validate_and_set_env_vars() {
 }
 
 set_up_chdir() {
-    cd $PYTHONPATH
+    # The user might have multiple entries in their PYTHONPATH so we should try to find the right one
+    IFS=':' read -ra ENTRIES <<< "$PYTHONPATH"
+    for ENTRY in "${ENTRIES[@]}"; do
+      if [[ $ENTRY == *"tt-metal" ]]; then
+        cd $ENTRY
+        return
+      fi
+    done
+    echo "Could not find the 'tt-metal' directory in your PYTHONPATH." 1>&2
+    exit 1
 }
 
 main() {


### PR DESCRIPTION
This PR updates `run_tests.sh` to allow for a user to have multiple entries in their `$PYTHONPATH`. 

Previously, the script would fail when trying into `cd` into `$PYTHONPATH` which could be a delimited set of paths. I have updated the script to search through all the entries and find the one ending in `tt-metal`. Alternatively, we could just `cd` into `$TT_METAL_HOME` which could be less brittle. Let me know if that is preferred.