### PR TITLE
#0: Speedup incremental builds

### DIFF
--- a/module.mk
+++ b/module.mk
@@ -127,8 +127,7 @@ LIBS_TO_BUILD =
 ifdef TT_METAL_ENV_IS_DEV
 LIBS_TO_BUILD += \
 	python_env/dev \
-	git_hooks \
-	ttnn/dev_install
+	git_hooks
 endif
 
 LIBS_TO_BUILD += \
@@ -145,7 +144,6 @@ include $(UMD_HOME)/device/module.mk
 include $(TT_METAL_HOME)/tt_metal/common/common.mk
 include $(TT_METAL_HOME)/tt_metal/module.mk
 include $(TT_METAL_HOME)/tt_eager/module.mk
-include $(TT_METAL_HOME)/ttnn/module.mk
 include $(TT_METAL_HOME)/tt_metal/python_env/module.mk
 include $(TT_METAL_HOME)/tests/module.mk
 

--- a/tt_eager/module.mk
+++ b/tt_eager/module.mk
@@ -20,7 +20,7 @@ TT_LIBS_TO_BUILD = tt_eager/tensor \
 
 ifdef TT_METAL_ENV_IS_DEV
 TT_LIBS_TO_BUILD += \
-	tt_eager/tt_lib/dev_install
+	$(TT_LIB_LIB_LOCAL_SO)
 endif
 
 tt_eager: $(TT_LIBS_TO_BUILD)

--- a/tt_eager/tt_lib/csrc/module.mk
+++ b/tt_eager/tt_lib/csrc/module.mk
@@ -1,4 +1,5 @@
 TT_LIB_LIB = $(LIBDIR)/libtt_lib_csrc.so
+TT_LIB_LIB_LOCAL_SO = tt_eager/tt_lib/_C.so
 TT_LIB_DEFINES =
 TT_LIB_INCLUDES = $(TT_EAGER_INCLUDES) $(shell python3-config --includes) -Itt_metal/third_party/pybind11/include
 TT_LIB_LDFLAGS = -ltt_dnn -ldtx -ltensor -ltt_metal -lyaml-cpp $(LDFLAGS)
@@ -27,10 +28,8 @@ $(TT_LIB_LIB): $(TT_LIB_OBJS) $(TT_DNN_LIB) $(TENSOR_LIB) $(DTX_LIB) $(TT_METAL_
 	@mkdir -p $(LIBDIR)
 	$(CXX) $(TT_LIB_CFLAGS) $(CXXFLAGS) $(SHARED_LIB_FLAGS) -o $@ $(TT_LIB_OBJS) $(TT_LIB_LDFLAGS)
 
-.PHONY: tt_lib/csrc/setup_local_so
-tt_lib/csrc/setup_local_so: $(TT_LIB_LIB)
-	rm -f tt_eager/tt_lib/_C.so
-	cp $^ tt_eager/tt_lib/_C.so
+$(TT_LIB_LIB_LOCAL_SO): $(TT_LIB_LIB)
+	ln -sf $^ $@
 
 # Compile obj files
 $(OBJDIR)/tt_eager/tt_lib/csrc/%.o: tt_eager/tt_lib/csrc/%.cpp

--- a/tt_eager/tt_lib/module.mk
+++ b/tt_eager/tt_lib/module.mk
@@ -1,7 +1,3 @@
 include tt_eager/tt_lib/csrc/module.mk
 
 tt_eager/tt_lib: tt_lib/csrc
-
-tt_eager/tt_lib/dev_install: tt_lib/csrc/setup_local_so
-	echo "Installing editable dev version of tt_eager packages..."
-	bash -c "source $(PYTHON_ENV)/bin/activate && pip install -e ."

--- a/tt_metal/python_env/module.mk
+++ b/tt_metal/python_env/module.mk
@@ -20,7 +20,11 @@ $(PYTHON_ENV)/.installed:
 $(PYTHON_ENV)/%: $(PYTHON_ENV)/.installed
 	bash -c "source $(PYTHON_ENV)/bin/activate"
 
-$(PYTHON_ENV)/.installed-dev: tt_eager/tt_lib/dev_install python_env tt_metal/python_env/requirements-dev.txt
+$(PYTHON_ENV)/.installed-dev: $(PYTHON_ENV)/.installed $(TT_LIB_LIB_LOCAL_SO) tt_metal/python_env/requirements-dev.txt
 	echo "Installing dev environment packages..."
 	bash -c "source $(PYTHON_ENV)/bin/activate && python -m pip install -r tt_metal/python_env/requirements-dev.txt"
+	echo "Installing editable dev version of tt_eager packages..."
+	bash -c "source $(PYTHON_ENV)/bin/activate && pip install -e ."
+	echo "Installing editable dev version of ttnn package..."
+	bash -c "source $(PYTHON_ENV)/bin/activate && pip install -e ttnn"
 	touch $@

--- a/ttnn/module.mk
+++ b/ttnn/module.mk
@@ -1,7 +1,0 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-
-# SPDX-License-Identifier: Apache-2.0
-
-ttnn/dev_install: python_env/dev
-	echo "Installing editable dev version of ttnn package..."
-	bash -c "source $(PYTHON_ENV)/bin/activate && pip install -e ttnn"


### PR DESCRIPTION
This change removed the use of phony targets and also refactored things in the python_env makefiles to avoid rebuilding the python env for incremental builds, which takes a significant amount of time.  Largely this involved ensuring that a file is produced for each target so that make can track the target's state.