### PR TITLE
#5247: Add unary ops to ttnn

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 490
+personal_ws-1.1 en 492
 ABI
 ADDI
 API
@@ -191,6 +191,7 @@ brisc
 cachable
 cb
 cbid
+cbrt
 cd
 cin
 ckernel
@@ -225,6 +226,7 @@ dest
 dev
 devs
 dfb
+digamma
 dir
 dnn
 doxygendefine

--- a/docs/source/ttnn/api.rst
+++ b/docs/source/ttnn/api.rst
@@ -119,6 +119,15 @@ Pointwise Math
    ttnn/log2
    ttnn/multigammaln
    ttnn/neg
+   ttnn/abs
+   ttnn/cbrt
+   ttnn/deg2rad
+   ttnn/digamma
+   ttnn/erf
+   ttnn/erfc
+   ttnn/erfinv
+   ttnn/exp2
+   ttnn/expm1
 
 Activation
 ==========
@@ -144,6 +153,7 @@ Activation
    ttnn/softshrink
    ttnn/softsign
    ttnn/swish
+   ttnn/hardsigmoid
 
 Reduction
 =========

--- a/docs/source/ttnn/ttnn/abs.rst
+++ b/docs/source/ttnn/ttnn/abs.rst
@@ -1,0 +1,6 @@
+.. _ttnn.abs:
+
+ttnn.abs
+###############
+
+.. autofunction:: ttnn.abs

--- a/docs/source/ttnn/ttnn/cbrt.rst
+++ b/docs/source/ttnn/ttnn/cbrt.rst
@@ -1,0 +1,6 @@
+.. _ttnn.cbrt:
+
+ttnn.cbrt
+###############
+
+.. autofunction:: ttnn.cbrt

--- a/docs/source/ttnn/ttnn/deg2rad.rst
+++ b/docs/source/ttnn/ttnn/deg2rad.rst
@@ -1,0 +1,6 @@
+.. _ttnn.deg2rad:
+
+ttnn.deg2rad
+###############
+
+.. autofunction:: ttnn.deg2rad

--- a/docs/source/ttnn/ttnn/digamma.rst
+++ b/docs/source/ttnn/ttnn/digamma.rst
@@ -1,0 +1,6 @@
+.. _ttnn.digamma:
+
+ttnn.digamma
+###############
+
+.. autofunction:: ttnn.digamma

--- a/docs/source/ttnn/ttnn/erf.rst
+++ b/docs/source/ttnn/ttnn/erf.rst
@@ -1,0 +1,6 @@
+.. _ttnn.erf:
+
+ttnn.erf
+###############
+
+.. autofunction:: ttnn.erf

--- a/docs/source/ttnn/ttnn/erfc.rst
+++ b/docs/source/ttnn/ttnn/erfc.rst
@@ -1,0 +1,6 @@
+.. _ttnn.erfc:
+
+ttnn.erfc
+###############
+
+.. autofunction:: ttnn.erfc

--- a/docs/source/ttnn/ttnn/erfinv.rst
+++ b/docs/source/ttnn/ttnn/erfinv.rst
@@ -1,0 +1,6 @@
+.. _ttnn.erfinv:
+
+ttnn.erfinv
+###############
+
+.. autofunction:: ttnn.erfinv

--- a/docs/source/ttnn/ttnn/exp2.rst
+++ b/docs/source/ttnn/ttnn/exp2.rst
@@ -1,0 +1,6 @@
+.. _ttnn.exp2:
+
+ttnn.exp2
+###############
+
+.. autofunction:: ttnn.exp2

--- a/docs/source/ttnn/ttnn/expm1.rst
+++ b/docs/source/ttnn/ttnn/expm1.rst
@@ -1,0 +1,6 @@
+.. _ttnn.expm1:
+
+ttnn.expm1
+###############
+
+.. autofunction:: ttnn.expm1

--- a/docs/source/ttnn/ttnn/hardsigmoid.rst
+++ b/docs/source/ttnn/ttnn/hardsigmoid.rst
@@ -1,0 +1,6 @@
+.. _ttnn.hardsigmoid:
+
+ttnn.hardsigmoid
+################
+
+.. autofunction:: ttnn.hardsigmoid

--- a/tests/ttnn/sweep_tests/sweeps/abs.py
+++ b/tests/ttnn/sweep_tests/sweeps/abs.py
@@ -44,17 +44,14 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.abs(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.abs(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/cbrt.py
+++ b/tests/ttnn/sweep_tests/sweeps/cbrt.py
@@ -44,17 +44,14 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.sgn(torch_input_tensor) * torch.pow(torch.abs(torch_input_tensor), 1.0 / 3)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.cbrt(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/deg2rad.py
+++ b/tests/ttnn/sweep_tests/sweeps/deg2rad.py
@@ -44,17 +44,14 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.deg2rad(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.deg2rad(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/digamma.py
+++ b/tests/ttnn/sweep_tests/sweeps/digamma.py
@@ -44,17 +44,15 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_input_tensor += 10.0
+    torch_output_tensor = torch.digamma(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.digamma(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/erf.py
+++ b/tests/ttnn/sweep_tests/sweeps/erf.py
@@ -44,17 +44,14 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.erf(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.erf(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/erfc.py
+++ b/tests/ttnn/sweep_tests/sweeps/erfc.py
@@ -44,17 +44,14 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.erfc(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.erfc(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/erfinv.py
+++ b/tests/ttnn/sweep_tests/sweeps/erfinv.py
@@ -44,17 +44,14 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.erfinv(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.erfinv(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.98)

--- a/tests/ttnn/sweep_tests/sweeps/exp.py
+++ b/tests/ttnn/sweep_tests/sweeps/exp.py
@@ -19,6 +19,7 @@ parameters = {
     "input_dtype": [ttnn.bfloat16],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
 }
 
 
@@ -37,6 +38,7 @@ def run(
     input_dtype,
     input_memory_config,
     output_memory_config,
+    layout,
     *,
     device,
 ) -> Tuple[bool, Optional[str]]:
@@ -49,7 +51,7 @@ def run(
     torch_output_tensor = torch.exp(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
-        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
     output_tensor = ttnn.exp(input_tensor, memory_config=output_memory_config)

--- a/tests/ttnn/sweep_tests/sweeps/exp2.py
+++ b/tests/ttnn/sweep_tests/sweeps/exp2.py
@@ -44,17 +44,14 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.exp2(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.exp2(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/expm1.py
+++ b/tests/ttnn/sweep_tests/sweeps/expm1.py
@@ -44,17 +44,14 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.expm1(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.expm1(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/hardsigmoid.py
+++ b/tests/ttnn/sweep_tests/sweeps/hardsigmoid.py
@@ -44,17 +44,14 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
-
-    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
-    torch_output_tensor = torch.nn.functional.gelu(torch_input_tensor)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.nn.functional.hardsigmoid(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.gelu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.hardsigmoid(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/unit_tests/operations/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/test_activation.py
@@ -60,6 +60,18 @@ def test_relu6(device, h, w):
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
+def test_gelu(device, h, w):
+    run_activation_unary_test(device, h, w, ttnn.gelu, F.gelu)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_hardsigmoid(device, h, w):
+    run_activation_unary_test(device, h, w, ttnn.hardsigmoid, F.hardsigmoid)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
 def test_sigmoid(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.sigmoid, torch.sigmoid)
 

--- a/tests/ttnn/unit_tests/operations/test_math.py
+++ b/tests/ttnn/unit_tests/operations/test_math.py
@@ -16,6 +16,8 @@ def run_math_unary_test(device, h, w, ttnn_function, torch_function, pcc=0.9999)
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    if "digamma" in str(torch_function):
+        torch_input_tensor += 100.0
     torch_output_tensor = torch_function(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
@@ -93,6 +95,60 @@ def test_neg(device, h, w):
     run_math_unary_test(device, h, w, ttnn.neg, torch.neg)
 
 
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_abs(device, h, w):
+    run_math_unary_test(device, h, w, ttnn.abs, torch.abs)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_cbrt(device, h, w):
+    run_math_unary_test(device, h, w, ttnn.cbrt, torch_cbrt, pcc=0.999)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_deg2rad(device, h, w):
+    run_math_unary_test(device, h, w, ttnn.deg2rad, torch.deg2rad)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_digamma(device, h, w):
+    run_math_unary_test(device, h, w, ttnn.digamma, torch.digamma)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_erf(device, h, w):
+    run_math_unary_test(device, h, w, ttnn.erf, torch.erf)
+
+
+@pytest.mark.parametrize("h", [2])
+@pytest.mark.parametrize("w", [3])
+def test_erfc(device, h, w):
+    run_math_unary_test(device, h, w, ttnn.erfc, torch.erfc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_erfinv(device, h, w):
+    run_math_unary_test(device, h, w, ttnn.erfinv, torch.erfinv, pcc=0.999)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_exp2(device, h, w):
+    run_math_unary_test(device, h, w, ttnn.exp2, torch.exp2, pcc=0.98)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_expm1(device, h, w):
+    run_math_unary_test(device, h, w, ttnn.expm1, torch.expm1, pcc=0.99)
+
+
 def run_math_unary_test_range(device, h, w, ttnn_function, torch_function, pcc=0.9999):
     torch.manual_seed(0)
     low = 1.6
@@ -108,6 +164,10 @@ def run_math_unary_test_range(device, h, w, ttnn_function, torch_function, pcc=0
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+def torch_cbrt(x, *args, **kwargs):
+    return torch.sgn(x) * torch.pow(torch.abs(x), 1.0 / 3)
 
 
 def torch_multigammaln(x, *args, **kwargs):

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -177,6 +177,7 @@ from ttnn.operations.activation import (
     clip,
     elu,
     hardshrink,
+    hardsigmoid,
     hardswish,
     hardtanh,
     heaviside,
@@ -207,6 +208,15 @@ from ttnn.operations.math import (
     log2,
     multigammaln,
     neg,
+    abs,
+    cbrt,
+    deg2rad,
+    digamma,
+    erf,
+    erfc,
+    erfinv,
+    exp2,
+    expm1,
 )
 
 from ttnn.operations.normalization import (

--- a/ttnn/ttnn/operations/activation.py
+++ b/ttnn/ttnn/operations/activation.py
@@ -23,6 +23,7 @@ __all__ = []
 def register_ttl_activation_function_unary(name, ttl_activation_function, op_name):
     def _torch_activation(input_tensor: ttnn.Tensor, **_):
         name_to_torch_function = {
+            "hardsigmoid": F.hardsigmoid,
             "hardswish": F.hardswish,
             "hardtanh": F.hardtanh,
             "log_sigmoid": F.logsigmoid,
@@ -278,6 +279,7 @@ def register_ttl_activation_function_with_two_float(name, ttl_activation_functio
 
 
 TTL_ACTIVATION_FUNCTIONS_UNARY = [
+    ("hardsigmoid", ttl.tensor.hardsigmoid, "hardsigmoid"),
     ("hardswish", ttl.tensor.hardswish, "hardswish"),
     ("hardtanh", ttl.tensor.hardtanh, "hardtanh"),
     ("log_sigmoid", ttl.tensor.log_sigmoid, "log sigmoid"),

--- a/ttnn/ttnn/operations/math.py
+++ b/ttnn/ttnn/operations/math.py
@@ -33,6 +33,15 @@ def register_ttl_math_op_function_unary(name, ttl_math_op_function, op_name):
             "log2": torch.log2,
             "multigammaln": torch_multigammaln,
             "neg": torch.neg,
+            "abs": torch.abs,
+            "cbrt": torch_cbrt,
+            "deg2rad": torch.deg2rad,
+            "digamma": torch.digamma,
+            "erf": torch.erf,
+            "erfc": torch.erfc,
+            "erfinv": torch.erfinv,
+            "exp2": torch.exp2,
+            "expm1": torch.expm1,
         }
         torch_function = name_to_torch_function[name]
         input_tensor = ttnn.to_torch(input_tensor)
@@ -107,11 +116,24 @@ TTL_MATH_OP_FUNCTIONS_UNARY = [
     ("log2", ttl.tensor.log2, "log2"),
     ("multigammaln", ttl.tensor.multigammaln, "multigammaln"),
     ("neg", ttl.tensor.neg, "neg"),
+    ("abs", ttl.tensor.abs, "abs"),
+    ("cbrt", ttl.tensor.cbrt, "cbrt"),
+    ("deg2rad", ttl.tensor.deg2rad, "deg2rad"),
+    ("digamma", ttl.tensor.digamma, "digamma"),
+    ("erf", ttl.tensor.erf, "erf"),
+    ("erfc", ttl.tensor.erfc, "erfc"),
+    ("erfinv", ttl.tensor.erfinv, "erfinv"),
+    ("exp2", ttl.tensor.exp2, "exp2"),
+    ("expm1", ttl.tensor.expm1, "expm1"),
 ]
 
 
 for math_op_function_name, ttl_math_op_function, op_name in TTL_MATH_OP_FUNCTIONS_UNARY:
     register_ttl_math_op_function_unary(math_op_function_name, ttl_math_op_function, op_name)
+
+
+def torch_cbrt(x, *args, **kwargs):
+    return torch.sgn(x) * torch.pow(torch.abs(x), 1.0 / 3)
 
 
 def torch_multigammaln(x, *args, **kwargs):


### PR DESCRIPTION
Add support to unary math ops to TTNN
Sweep Test Results:
[abs.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227855/abs.csv)
[cbrt.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227856/cbrt.csv)
[clone.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227857/clone.csv)
[deg2rad.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227858/deg2rad.csv)
[digamma.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227859/digamma.csv)
[erf.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227860/erf.csv)
[erfc.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227861/erfc.csv)
[erfinv.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227862/erfinv.csv)
[exp.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227863/exp.csv)
[exp2.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227864/exp2.csv)
[expm1.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227865/expm1.csv)
[gelu.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227866/gelu.csv)
[hardsigmoid.csv](https://github.com/tenstorrent-metal/tt-metal/files/14227867/hardsigmoid.csv)
