### PR TITLE
#0: Change local tt_lib._C module install from symlink to copy

### DIFF
--- a/tt_eager/tt_lib/csrc/module.mk
+++ b/tt_eager/tt_lib/csrc/module.mk
@@ -29,7 +29,7 @@ $(TT_LIB_LIB): $(TT_LIB_OBJS) $(TT_DNN_LIB) $(TENSOR_LIB) $(DTX_LIB) $(TT_METAL_
 	$(CXX) $(TT_LIB_CFLAGS) $(CXXFLAGS) $(SHARED_LIB_FLAGS) -o $@ $(TT_LIB_OBJS) $(TT_LIB_LDFLAGS)
 
 $(TT_LIB_LIB_LOCAL_SO): $(TT_LIB_LIB)
-	ln -sf $^ $@
+	cp -fp $^ $@
 
 # Compile obj files
 $(OBJDIR)/tt_eager/tt_lib/csrc/%.o: tt_eager/tt_lib/csrc/%.cpp


### PR DESCRIPTION
Fixes error:
  ModuleNotFoundError: No module named 'tt_lib._C'