### PR TITLE
#5323: Convolutions of small size fail during parallelization calculations

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_optimized_conv_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_optimized_conv_v2.py
@@ -45,6 +45,9 @@ from tt_eager.tt_dnn.op_library.sliding_window_op_infra.tt_py_composite_conv imp
         (8, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False),
         # sd conv
         (1, 320, 320, 32, 32, 3, 3, 1, 1, 1, 1, False),
+        # Small conv
+        (1, 32, 32, 16, 16, 3, 3, 2, 2, 1, 1, True),
+        # (1, 32, 32, 16, 16, 3, 3, 2, 2, 1, 1, False), # Asserts #5323
     ),
 )
 @pytest.mark.parametrize(

--- a/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_composite_conv.py
+++ b/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_composite_conv.py
@@ -120,7 +120,7 @@ def determine_parallel_config(
         ]  # for 1d systolic array, we don't need to provide actual grid size because tensor sharding deterimines that automatically
         num_cores_nhw = actual_num_cores
         grid_size = [
-            max_grid_size["x"],
+            max_grid_size["x"] if num_cores_nhw >= max_grid_size["x"] else num_cores_nhw,
             math.ceil(num_cores_nhw / max_grid_size["x"]),
         ]  # for 1d systolic array, grid size is the tightest bound of num_cores_nhw as a rectangle (x,y)
     else:
@@ -666,7 +666,7 @@ class TTPyCompositeConv(TTPyOp):
                 bias_untiled = bias_untiled.to_torch()
                 bias_ = ttl.tensor.Tensor(bias_untiled, weights_dtype).to(ttl.tensor.Layout.TILE)
                 bias_on_device = bias_.to(device) if move_weights_to_device else bias_
-                self.bias = bias_on_device
+            self.bias = bias_on_device
         else:
             self.weight = weight
             self.bias = bias

--- a/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_untilize_with_halo.py
+++ b/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_untilize_with_halo.py
@@ -161,23 +161,29 @@ class TTPyUntilizeWithHalo(TTPyOp):
             block_sharding = num_cores_nhw == num_cores_w
             if not block_sharding:
                 assert num_cores_w == 12
-                num_cores_height_excluding_remainder_last_row = num_cores_nhw // num_cores_w
-                assert num_cores_h >= num_cores_height_excluding_remainder_last_row
-                core_range_1 = ttl.tensor.CoreRange(
-                    ttl.tensor.CoreCoord(0, 0),
-                    ttl.tensor.CoreCoord(num_cores_w - 1, num_cores_height_excluding_remainder_last_row - 1),
-                )
-                num_cores_last = num_cores_nhw % num_cores_w
-                core_range_2 = None
-                if num_cores_last > 0:
-                    assert num_cores_h == num_cores_height_excluding_remainder_last_row + 1
-                    core_range_2 = ttl.tensor.CoreRange(
-                        ttl.tensor.CoreCoord(0, num_cores_height_excluding_remainder_last_row),
-                        ttl.tensor.CoreCoord(num_cores_last - 1, num_cores_height_excluding_remainder_last_row),
+                if num_cores_nhw >= num_cores_w:
+                    num_cores_height_excluding_remainder_last_row = num_cores_nhw // num_cores_w
+                    assert num_cores_h >= num_cores_height_excluding_remainder_last_row
+                    core_range_1 = ttl.tensor.CoreRange(
+                        ttl.tensor.CoreCoord(0, 0),
+                        ttl.tensor.CoreCoord(num_cores_w - 1, num_cores_height_excluding_remainder_last_row - 1),
                     )
-                    shard_grid = ttl.tensor.CoreRangeSet({core_range_1, core_range_2})
+                    num_cores_last = num_cores_nhw % num_cores_w
+                    if num_cores_last > 0:
+                        assert num_cores_h == num_cores_height_excluding_remainder_last_row + 1
+                        core_range_2 = ttl.tensor.CoreRange(
+                            ttl.tensor.CoreCoord(0, num_cores_height_excluding_remainder_last_row),
+                            ttl.tensor.CoreCoord(num_cores_last - 1, num_cores_height_excluding_remainder_last_row),
+                        )
+                        shard_grid = ttl.tensor.CoreRangeSet({core_range_1, core_range_2})
+                    else:
+                        assert num_cores_h == num_cores_height_excluding_remainder_last_row
+                        shard_grid = ttl.tensor.CoreRangeSet({core_range_1})
                 else:
-                    assert num_cores_h == num_cores_height_excluding_remainder_last_row
+                    core_range_1 = ttl.tensor.CoreRange(
+                        ttl.tensor.CoreCoord(0, 0),
+                        ttl.tensor.CoreCoord(num_cores_nhw - 1, 0),
+                    )
                     shard_grid = ttl.tensor.CoreRangeSet({core_range_1})
             else:
                 core_range = ttl.tensor.CoreRange(


### PR DESCRIPTION
    Height Sharded fails because the code assumes the parallelization to be
    at least 12 cores and then special-cases the overflow if it's not a
    multiple of 12. But if the total number of par cores is < 12 to begin
    with the code still assumes at least 12 cores and we end up with
    rounding errors. The fix is to special case par for < 12 cores.