### PR TITLE
#0: Add timeout in profiler regression workflow

### DIFF
--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -34,5 +34,6 @@ jobs:
         run: |
           ./scripts/build_scripts/build_with_profiler_opt.sh
       - name: Run profiler regression tests
+        timeout-minutes: 30
         run: |
           ./tests/scripts/run_profiler_regressions.sh


### PR DESCRIPTION
No timeout on profiler regression workflows.
Some workflows have been running for hours when normal runs take ~15mins

Sample Successful Pipelines
https://github.com/tenstorrent-metal/tt-metal/actions/runs/7888031695 (~15 min runs) 
Lots of passed workflows for profiler regression specifically take ~15 mins

Sample Failed Pipelines
https://github.com/tenstorrent-metal/tt-metal/actions/runs/7883420932/job/21510346995
Took 6 hours but only took 6hours because user cancelled the run.

Sample Workflow running new changes
https://github.com/tenstorrent-metal/tt-metal/actions/runs/7913988842