### PR TITLE
#0: Add an envvar parser with value detection and default value setti…

### DIFF
--- a/tt_metal/common/env_lib.hpp
+++ b/tt_metal/common/env_lib.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <map>
+#include <vector>
+#include <string>
+#include <tuple>
+
+namespace tt {
+
+template <class T>
+constexpr std::false_type false_type_t{};
+
+template <typename T>
+T parse_env(const char *env_name, const T &default_value) {
+    char* env_value = std::getenv(env_name);
+    if (env_value == nullptr)
+        return default_value;
+
+    if constexpr (std::is_same_v<T, bool>) {
+        return static_cast<bool>(std::stoi(env_value, 0, 0));
+    } else if constexpr (std::is_same_v<T, std::string>) {
+        return std::string{env_value};
+    } else if constexpr (std::is_same_v<T, int>) {
+        return std::stoi(env_value, 0, 0);
+    } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+        return std::stoul(env_value, 0, 0);
+    } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+        return std::stoull(env_value, 0, 0);
+    } else {
+        static_assert(false_type_t<T>, "No specialization for type");
+    }
+}
+
+}  // namespace tt
+
+// Explicit specializations
+template bool tt::parse_env<bool>(const char *, const bool &);
+template std::string tt::parse_env<std::string>(const char *, const std::string &);
+template int tt::parse_env<int>(const char *, const int &);
+template uint32_t tt::parse_env<uint32_t>(const char *, const uint32_t &);
+template uint64_t tt::parse_env<uint64_t>(const char *, const uint64_t &);


### PR DESCRIPTION
Current code base uses `std::getenv`, and it assumes the existence means the value is true.

This can be error-prone when user sets `TT_METAL_MODE=0`, it will still be picked up as a true setting

The proper parsing for value is quite a bit of code to type up:
```
  bool env_setting;
  char* env_value = std::getenv("TT_METAL_MODE");
  if (env_value == nullptr)
    env_setting = static_cast<bool>(std::stoi(env_value, 0, 0));
  else
    env_setting = false; // default value
```

Using the proposed library simplifies all of that with
```
  bool env_setting = tt::parse_env("TT_METAL_MODE", false);
```