### PR TITLE
#5377: Avoid segfault by checking buffer !null before getting device

### DIFF
--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -93,7 +93,12 @@ class Tensor {
      Buffer *buffer() const { return std::get<DeviceStorage>(this->storage_).buffer.get(); }
      DeviceBuffer device_buffer() const { return std::get<DeviceStorage>(this->storage_).buffer; }
 
-     Device *device() const { return this->buffer()->device(); }
+     Device *device() const {
+         auto buffer = this->buffer();
+         if (buffer == nullptr)
+             TT_THROW("Cannot get the device from a tensor without an allocated buffer");
+         return buffer->device();
+     }
      const MemoryConfig memory_config() const {
          return std::visit(
              [](const auto &storage) -> MemoryConfig {

--- a/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
@@ -78,9 +78,9 @@ void EltwiseBinaryBroadcast::validate(const std::vector<Tensor> &input_tensors) 
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
 
+    TT_FATAL(input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr, "Operands to bcast need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.device() != nullptr and input_tensor_b.device() != nullptr, "Operands to bcast need to be on device!");
     TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to bcast need to be on the same device!");
-    TT_FATAL(input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr, "Operands to bcast need to be allocated in buffers on device!");
 
     const auto input_shape_a = input_tensor_a.shape();
     const auto input_shape_b = input_tensor_b.shape();

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -298,8 +298,8 @@ void Matmul::validate(const std::vector<Tensor>& input_tensors, const std::vecto
     // This requires sweeping across shapes with different dtypes/dataformats; for now, ignore dtype assertions here and uplift to actual matmul/bmm implementations
     TT_FATAL(input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE, "Operands to matmul need to be on device!");
-    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
 }
 
 std::vector<Shape> Matmul::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
@@ -573,8 +573,8 @@ void Matmul::validate(
 
     TT_FATAL(input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor_a.dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE, "Operands to matmul need to be on device!");
-    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
 
 
     TT_FATAL(optional_input_tensors.size() == 1);

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
@@ -112,8 +112,8 @@ void EltwiseBinary::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_b = input_tensors.at(1);
     TT_FATAL(input_tensor_a.shape() == input_tensor_b.shape(), "Input shapes must be the same!");
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE, "Operands to eltwise binary need to be on device!");
-    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to eltwise binary need to be on the same device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr, "Operands to eltwise binary need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to eltwise binary need to be on the same device!");
     TT_FATAL((input_tensor_a.layout() == Layout::TILE && input_tensor_b.layout() == Layout::TILE), "Inputs to eltwise binary must be tilized");
     if (this->in_place) {
         TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -37,6 +37,7 @@ namespace detail {
 static Device* get_device(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors = {}) {
     for (auto& input_tensor : input_tensors) {
         if (input_tensor.storage_type() == StorageType::DEVICE) {
+            TT_FATAL(input_tensor.buffer() != nullptr, "Operands need to be allocated in buffers on device");
             return input_tensor.device();
         }
     }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -161,8 +161,8 @@ void AttnMatmul::validate(const std::vector<Tensor>& input_tensors) const {
 
     // TODO: Uplift to support BFLOAT8_B and mixed precision
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE, "Operands to matmul need to be on device!");
-    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
 
     const auto ashape = input_tensor_a.shape();
     const auto bshape = input_tensor_b.shape();
@@ -259,8 +259,8 @@ void GroupAttnMatmul::validate(const std::vector<Tensor>& input_tensors) const {
 
     // TODO: Uplift to support BFLOAT8_B and mixed precision
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE, "Operands to matmul need to be on device!");
-    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
 
     const auto ashape = input_tensor_a.shape();
     const auto bshape = input_tensor_b.shape();


### PR DESCRIPTION
Just reordered some TT_FATAL lines, I think the only review really needed is the new one in [run_operation.cpp](https://github.com/tenstorrent-metal/tt-metal/compare/yieldthought/fix-deallocate-segfault?expand=1#diff-d12309db6d0d8fa367ca410e69d3361c0f618c6ede300f41c310ac19812e4366)

In general as a developer I'm a bit unhappy with this state of affairs. Do we really want an API that segfaults if you call `tensor.deallocate()` and then `tensor.device()`? Is there a reason we decided not to put a TT_FATAL in the ::device() implementation in the first place?