### PR TITLE
#5402: Add redesigned host-side sw command queue, it can be configured i…

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -325,9 +325,6 @@ TEST_F(CommandQueueFixture, TestAsyncCommandQueue) {
         EnqueueProgram(*this->cmd_queue, program, false);
         Finish(*this->cmd_queue);
     }
-
-    // Block until CQ is drained, without it it's unsafe to exit the scope
-    this->cmd_queue->wait_until_empty();
 }
 
 }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -6,6 +6,7 @@
 #include "command_queue_test_utils.hpp"
 #include "gtest/gtest.h"
 #include "tt_metal/common/bfloat16.hpp"
+#include "tt_metal/common/scoped_timer.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
@@ -300,6 +301,33 @@ TEST_F(CommandQueueFixture, TestArbiterDoesNotHang) {
 
     EnqueueProgram(*this->cmd_queue, program, false);
     Finish(*this->cmd_queue);
+}
+
+}
+
+namespace host_command_queue_tests {
+
+TEST_F(CommandQueueFixture, TestAsyncCommandQueue) {
+    Program program;
+
+    CoreRange cr({0, 0}, {0, 0});
+    CoreRangeSet cr_set({cr});
+    // Add an NCRISC blank manually, but in compile program, the BRISC blank will be
+    // added separately
+    auto dummy_reader_kernel = CreateKernel(
+        program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/arbiter_hang.cpp", cr_set, DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    this->cmd_queue->set_mode(CommandQueue::CommandQueueMode::ASYNC);
+
+    // Use scoper timer to benchmark time for pushing 2 commands
+    {
+        tt::ScopedTimer timer("AsyncCommandQueue");
+        EnqueueProgram(*this->cmd_queue, program, false);
+        Finish(*this->cmd_queue);
+    }
+
+    // Block until CQ is drained, without it it's unsafe to exit the scope
+    this->cmd_queue->wait_until_empty();
 }
 
 }

--- a/tt_metal/common/scoped_timer.hpp
+++ b/tt_metal/common/scoped_timer.hpp
@@ -9,7 +9,7 @@
 #include "logger.hpp"
 
 namespace tt {
-template <typename TimeUnit>
+template <typename TimeUnit = std::chrono::nanoseconds>
 struct ScopedTimer {
     using Clock = std::chrono::high_resolution_clock;
     using TimeInstant = std::chrono::time_point<Clock, std::chrono::nanoseconds>;
@@ -23,7 +23,7 @@ struct ScopedTimer {
         } else if constexpr (std::is_same_v<TimeUnit, std::chrono::seconds>) {
             return "s";
         } else {
-            return "time_unit";
+            return "ns";
         }
     }
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -518,9 +518,8 @@ class CommandQueue {
         TERMINATE = 2,
     };
     CommandQueueMode mode = CommandQueue::get_mode();
-    std::unique_ptr<std::thread> worker_thread;
     CommandQueueState worker_state = CommandQueueState::IDLE;
-
+    std::unique_ptr<std::thread> worker_thread;
     LockFreeQueue<CommandInterface> worker_queue;
     uint32_t cq_id;
     Device* device_ptr;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -534,7 +534,8 @@ class CommandQueue {
     bool passthrough_mode() { return this->mode == CommandQueueMode::PASSTHROUGH; }
 
     static CommandQueueMode get_mode() {
-        int value = parse_env<int>("TT_METAL_ASYNC_QUEUES", static_cast<int>(CommandQueueMode::PASSTHROUGH));
+        // Envvar is used for bringup and debug only. Will be removed in the future and should not be relied on in production.
+        int value = parse_env<int>("TT_METAL_CQ_ASYNC_MODE", static_cast<int>(CommandQueueMode::PASSTHROUGH));
         return static_cast<CommandQueue::CommandQueueMode>(value);
     }
 };

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <atomic>
+#include <memory>
+
+template<typename T>
+class LockFreeQueue {
+    private:
+        struct Node {
+            std::shared_ptr<T> data;
+            Node* next;
+        };
+
+        std::atomic<Node*> head;
+        std::atomic<Node*> tail;
+
+        Node* pop_head() {
+            Node* oldHead = head.load();
+            if (oldHead == tail.load()) {
+                return nullptr; // Queue is empty
+            }
+            head.store(oldHead->next);
+            return oldHead;
+        }
+
+    public:
+        LockFreeQueue() : head(new Node), tail(head.load()) {}
+
+        void push(const T& value) {
+            std::shared_ptr<T> newData(std::make_shared<T>(value));
+            Node* newNode = new Node;
+            newNode->data = newData;
+            newNode->next = nullptr;
+            Node* oldTail = tail.exchange(newNode);
+            oldTail->next = newNode;
+        }
+
+        std::shared_ptr<T> pop() {
+            Node* oldHead = pop_head();
+            if (!oldHead) {
+                throw std::runtime_error("Queue is empty");
+            }
+            std::shared_ptr<T> result(oldHead->data);
+            delete oldHead;
+            return result;
+        }
+
+        bool empty() const {
+            return head.load() == tail.load();
+        }
+};

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -31,10 +31,9 @@ class LockFreeQueue {
         void push(const T& value) {
             std::shared_ptr<T> newData(std::make_shared<T>(value));
             Node* newNode = new Node;
-            newNode->data = newData;
-            newNode->next = nullptr;
-            Node* oldTail = tail.exchange(newNode);
-            oldTail->next = newNode;
+            tail.load()->data = newData;
+            tail.load()->next = newNode;
+            tail.store(newNode);
         }
 
         std::shared_ptr<T> pop() {

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -5,6 +5,8 @@
 #include <atomic>
 #include <memory>
 
+#include "tt_metal/common/assert.hpp"
+
 template<typename T>
 class LockFreeQueue {
     private:
@@ -39,7 +41,7 @@ class LockFreeQueue {
         std::shared_ptr<T> pop() {
             Node* oldHead = pop_head();
             if (!oldHead) {
-                throw std::runtime_error("Queue is empty");
+                TT_THROW("Queue is empty");
             }
             std::shared_ptr<T> result(oldHead->data);
             delete oldHead;


### PR DESCRIPTION
The proposal is to remove taskflow based command queue and implement a dedicated host async command queue.

The main concern with taskflow is performance:
- it's feature rich and supports task dependencies (graph), however we only need a linear dependency (queue)
- it spawns a thread per task, whereas we only need a single thread for the whole command queue

The proposal is to create a SW command queue that supports async push and pop via a single worker thread. It can be configured in passthrough mode to support today's sequential exeuction, but can also be async to have an early return path for host as soon as the command in pushed (not blocked on command executed and pushed to device)

**Host SW CQ used in passthrough mode**

<img width="1409" alt="image" src="https://github.com/tenstorrent-metal/tt-metal/assets/1054713/51f110fb-5431-4f35-a420-246af0e3af86">

**Host SW CQ used in async mode**

<img width="1384" alt="image" src="https://github.com/tenstorrent-metal/tt-metal/assets/1054713/447718f4-a9e2-4461-90ee-58eb65b301c1">

fyi @davorchap @kmabeeTT @tt-asaigal 
