### PR TITLE
More optimizations for group_attn_matmul

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_attn_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_attn_matmul.py
@@ -211,7 +211,9 @@ def test_group_attn_matmul_with_program_cache(in0_dtype, in1_dtype, output_dtype
     q_len = 1
     batch = 32
     num_cache_entries = 0  # Only track cache entries of group_attn_matmul
-    for K, seq_len, q_heads, kv_heads in ((96, 512 + 64, 10, 2), (64, 128, 50, 5)):
+    # NOTE: Program is cached on out_subblock_w as well, so only seq_len >= 256 (out_subblock_w = 8) will share cache
+    # For seq_len < = 256, recompile at worst 8 times.
+    for K, seq_len, q_heads, kv_heads in ((96, 512 + 64, 10, 2), (64, 256, 50, 5)):
         input_shape_a = [q_len, q_heads, batch, K]
         input_shape_b = [batch, kv_heads, K, seq_len]
 

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
@@ -24,7 +24,6 @@ void kernel_main() {
 
     // matmul params
     uint32_t in0_block_w                      = get_arg_val<uint32_t>(i++);
-    uint32_t out_subblock_w                   = get_arg_val<uint32_t>(i++);
     uint32_t out_block_w                      = get_arg_val<uint32_t>(i++);
     uint32_t in1_num_subblocks                = get_arg_val<uint32_t>(i++);
     uint32_t in1_num_blocks                   = get_arg_val<uint32_t>(i++);
@@ -58,6 +57,7 @@ void kernel_main() {
     constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
     #define transpose_hw_bool get_compile_time_arg_val(2) == 1
     constexpr bool row_major = (bool) get_compile_time_arg_val(3);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(4);
 
 
     constexpr uint32_t cb_id_in1 = 1; // mcast receive all kv_heads; compute chooses which kv_heads to use for matmul
@@ -136,7 +136,6 @@ void kernel_main() {
     uint32_t in1_block_addr_skip = 0; // Skip padded subblocks to prevent reading from undefined memory
     uint32_t out_subblock_w_ = out_subblock_w;
     #endif
-
 
     for (uint32_t b = 0; b < blocks; b++) { // TODO: Must be 1
         #ifndef IN1_SHARDED

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -372,12 +372,13 @@ operation::ProgramWithCallbacks GroupAttnMatmul::create_program(const std::vecto
     auto device_compute_with_storage_grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
     TT_ASSERT((this->compute_with_storage_grid_size.x <= device_compute_with_storage_grid_size.x && this->compute_with_storage_grid_size.y <= device_compute_with_storage_grid_size.y), "Unsupported grid shape");
 
-    return multi_core_group_attn_matmul(input_tensor_a, input_tensor_b, output_tensor, this->num_tokens, this->transpose_hw, this->compute_with_storage_grid_size, this->row_major);
+    return multi_core_group_attn_matmul(input_tensor_a, input_tensor_b, output_tensor, this->num_tokens, this->transpose_hw, this->out_subblock_w, this->compute_with_storage_grid_size, this->row_major);
 }
 
 tt::stl::reflection::Attributes GroupAttnMatmul::attributes() const {
     return {
         {"transpose_hw", this->transpose_hw},
+        {"out_subblock_w", this->out_subblock_w},
         {"compute_with_storage_grid_size", this->compute_with_storage_grid_size.str()},
         {"output_mem_config", this->output_mem_config},
         {"output_dtype", this->output_dtype},
@@ -392,6 +393,7 @@ const operation::Hash GroupAttnMatmul::compute_program_hash(const std::vector<Te
 
     return operation::hash_operation<GroupAttnMatmul>(
         this->transpose_hw,
+        this->out_subblock_w,
         this->compute_with_storage_grid_size.str(),
         this->output_mem_config.memory_layout,
         this->output_mem_config.buffer_type,


### PR DESCRIPTION
- Skip local copy if seq_len <= 256 (ie. we don't have blocking along N)
- Switch to pack_untilize which does the extra untilize we need for free