### PR TITLE
#5233: updated resnet18 to run residual connections

### DIFF
--- a/models/experimental/functional_resnet/tt/ttnn_functional_resnet.py
+++ b/models/experimental/functional_resnet/tt/ttnn_functional_resnet.py
@@ -29,12 +29,12 @@ class BasicBlock:
         ttnn.deallocate(conv1)
 
         if self.downsample is not None:
+            x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
             identity = self.downsample(x)
             ttnn.deallocate(x)
 
-        out = ttnn.add_and_apply_activation(
-            conv2, identity, activation="relu", memory_config=ttnn.get_memory_config(conv2)
-        )
+        identity = ttnn.reshape(identity, conv2.shape)
+        out = ttnn.add_and_apply_activation(conv2, identity, activation="relu", memory_config=ttnn.DRAM_MEMORY_CONFIG)
         ttnn.deallocate(conv2)
         if x != identity:
             ttnn.deallocate(identity)

--- a/tests/ttnn/unit_tests/test_model_preprocessing.py
+++ b/tests/ttnn/unit_tests/test_model_preprocessing.py
@@ -510,36 +510,36 @@ def test_resnet(device):
     assert "maxpool" in parameters
 
     assert "layer1" in parameters
-    assert "0" in parameters["layer1"]
-    assert "conv1" in parameters["layer1"]["0"]
-    assert "conv2" in parameters["layer1"]["0"]
-    assert "1" in parameters["layer1"]
-    assert "conv1" in parameters["layer1"]["1"]
-    assert "conv2" in parameters["layer1"]["1"]
+    assert 0 in parameters["layer1"]
+    assert "conv1" in parameters["layer1"][0]
+    assert "conv2" in parameters["layer1"][0]
+    assert 1 in parameters["layer1"]
+    assert "conv1" in parameters["layer1"][1]
+    assert "conv2" in parameters["layer1"][1]
 
     assert "layer2" in parameters
-    assert "0" in parameters["layer3"]
-    assert "conv1" in parameters["layer2"]["0"]
-    assert "conv2" in parameters["layer2"]["0"]
-    assert "1" in parameters["layer2"]
-    assert "conv1" in parameters["layer2"]["1"]
-    assert "conv2" in parameters["layer2"]["1"]
+    assert 0 in parameters["layer3"]
+    assert "conv1" in parameters["layer2"][0]
+    assert "conv2" in parameters["layer2"][0]
+    assert 1 in parameters["layer2"]
+    assert "conv1" in parameters["layer2"][1]
+    assert "conv2" in parameters["layer2"][1]
 
     assert "layer3" in parameters
-    assert "0" in parameters["layer3"]
-    assert "conv1" in parameters["layer3"]["0"]
-    assert "conv2" in parameters["layer3"]["0"]
-    assert "1" in parameters["layer3"]
-    assert "conv1" in parameters["layer3"]["1"]
-    assert "conv2" in parameters["layer3"]["1"]
+    assert 0 in parameters["layer3"]
+    assert "conv1" in parameters["layer3"][0]
+    assert "conv2" in parameters["layer3"][0]
+    assert 1 in parameters["layer3"]
+    assert "conv1" in parameters["layer3"][1]
+    assert "conv2" in parameters["layer3"][1]
 
     assert "layer4" in parameters
-    assert "0" in parameters["layer4"]
-    assert "conv1" in parameters["layer4"]["0"]
-    assert "conv2" in parameters["layer4"]["0"]
-    assert "1" in parameters["layer4"]
-    assert "conv1" in parameters["layer4"]["1"]
-    assert "conv2" in parameters["layer4"]["1"]
+    assert 0 in parameters["layer4"]
+    assert "conv1" in parameters["layer4"][0]
+    assert "conv2" in parameters["layer4"][0]
+    assert 1 in parameters["layer4"]
+    assert "conv1" in parameters["layer4"][1]
+    assert "conv2" in parameters["layer4"][1]
 
     assert "fc" in parameters
     assert "weight" in parameters["fc"]


### PR DESCRIPTION
- Use ttnn_functional_resnet.BasicBlock to run resnet18
- Updated model_preprocessing to use integer keys for ttnn_module_args of torch.nn.ModuleList objects.
- Delete ttnn_module_args for the parameters that were dropped by custom_preprocessor