### PR TITLE
#5326: Add tensor manip ops to ttnn

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 492
+personal_ws-1.1 en 494
 ABI
 ADDI
 API
@@ -324,6 +324,7 @@ maxdepth
 md
 mish
 modindex
+mse
 mul
 multicast
 multigammaln
@@ -419,6 +420,7 @@ skillset
 smi
 smsg
 softmax
+softplus
 softshrink
 softsign
 sqrt

--- a/docs/source/ttnn/api.rst
+++ b/docs/source/ttnn/api.rst
@@ -154,6 +154,29 @@ Activation
    ttnn/softsign
    ttnn/swish
    ttnn/hardsigmoid
+   ttnn/softplus
+
+Tensor Creation
+===============
+
+.. toctree::
+   :maxdepth: 1
+
+   ttnn/ones
+   ttnn/ones_like
+   ttnn/zeros
+   ttnn/zeros_like
+   ttnn/full
+   ttnn/full_like
+
+Losses
+======
+
+.. toctree::
+   :maxdepth: 1
+
+   ttnn/l1_loss
+   ttnn/mse_loss
 
 Reduction
 =========
@@ -162,6 +185,8 @@ Reduction
    :maxdepth: 1
 
    ttnn/mean
+   ttnn/std
+   ttnn/var
 
 Data Movement
 =============

--- a/docs/source/ttnn/ttnn/full.rst
+++ b/docs/source/ttnn/ttnn/full.rst
@@ -1,0 +1,6 @@
+.. _ttnn.full:
+
+ttnn.full
+###############
+
+.. autofunction:: ttnn.full

--- a/docs/source/ttnn/ttnn/full_like.rst
+++ b/docs/source/ttnn/ttnn/full_like.rst
@@ -1,0 +1,6 @@
+.. _ttnn.full_like:
+
+ttnn.full_like
+###############
+
+.. autofunction:: ttnn.full_like

--- a/docs/source/ttnn/ttnn/l1_loss.rst
+++ b/docs/source/ttnn/ttnn/l1_loss.rst
@@ -1,0 +1,6 @@
+.. _ttnn.l1_loss:
+
+ttnn.l1_loss
+###############
+
+.. autofunction:: ttnn.l1_loss

--- a/docs/source/ttnn/ttnn/mse_loss.rst
+++ b/docs/source/ttnn/ttnn/mse_loss.rst
@@ -1,0 +1,6 @@
+.. _ttnn.mse_loss:
+
+ttnn.mse_loss
+###############
+
+.. autofunction:: ttnn.mse_loss

--- a/docs/source/ttnn/ttnn/ones.rst
+++ b/docs/source/ttnn/ttnn/ones.rst
@@ -1,0 +1,6 @@
+.. _ttnn.ones:
+
+ttnn.ones
+###############
+
+.. autofunction:: ttnn.ones

--- a/docs/source/ttnn/ttnn/ones_like.rst
+++ b/docs/source/ttnn/ttnn/ones_like.rst
@@ -1,0 +1,6 @@
+.. _ttnn.ones_like:
+
+ttnn.ones_like
+###############
+
+.. autofunction:: ttnn.ones_like

--- a/docs/source/ttnn/ttnn/softplus.rst
+++ b/docs/source/ttnn/ttnn/softplus.rst
@@ -1,0 +1,6 @@
+.. _ttnn.softplus:
+
+ttnn.softplus
+###############
+
+.. autofunction:: ttnn.softplus

--- a/docs/source/ttnn/ttnn/std.rst
+++ b/docs/source/ttnn/ttnn/std.rst
@@ -1,0 +1,6 @@
+.. _ttnn.std:
+
+ttnn.std
+###############
+
+.. autofunction:: ttnn.std

--- a/docs/source/ttnn/ttnn/var.rst
+++ b/docs/source/ttnn/ttnn/var.rst
@@ -1,0 +1,6 @@
+.. _ttnn.var:
+
+ttnn.var
+###############
+
+.. autofunction:: ttnn.var

--- a/docs/source/ttnn/ttnn/zeros.rst
+++ b/docs/source/ttnn/ttnn/zeros.rst
@@ -1,0 +1,6 @@
+.. _ttnn.zeros:
+
+ttnn.zeros
+###############
+
+.. autofunction:: ttnn.zeros

--- a/docs/source/ttnn/ttnn/zeros_like.rst
+++ b/docs/source/ttnn/ttnn/zeros_like.rst
@@ -1,0 +1,6 @@
+.. _ttnn.zeros_like:
+
+ttnn.zeros_like
+###############
+
+.. autofunction:: ttnn.zeros_like

--- a/tests/ttnn/sweep_tests/sweeps/full.py
+++ b/tests/ttnn/sweep_tests/sweeps/full.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.ROW_MAJOR_LAYOUT],
+    "fill_value": [-5, 3],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    fill_value,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16).unsqueeze(0)
+    torch_output_tensor = torch.full(torch_input_tensor.shape, fill_value=fill_value)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.full(input_tensor.shape, fill_value=fill_value, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/full_like.py
+++ b/tests/ttnn/sweep_tests/sweeps/full_like.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.ROW_MAJOR_LAYOUT],
+    "fill_value": [-5, 7],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    fill_value,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16).unsqueeze(0)
+    torch_output_tensor = torch.full_like(torch_input_tensor, fill_value=fill_value)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.full_like(input_tensor, fill_value=fill_value, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/l1_loss.py
+++ b/tests/ttnn/sweep_tests/sweeps/l1_loss.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "loss_mode": ["none", "mean", "sum"],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+    loss_mode,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape_a = (*batch_sizes, height, width)
+    input_shape_b = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch.randn(input_shape_a, dtype=torch.float32).unsqueeze(0)
+    torch_input_tensor_b = torch.randn(input_shape_b, dtype=torch.float32).unsqueeze(0)
+    torch_output_tensor = torch.nn.L1Loss(reduction=loss_mode)(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+
+    output_tensor = ttnn.l1_loss(
+        input_tensor_a, input_tensor_b, loss_mode=loss_mode, memory_config=output_memory_config
+    )
+    output_tensor = ttnn.to_torch(output_tensor)
+    if loss_mode != "none":
+        output_tensor = output_tensor[0, 0, 0, 0]
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/mean.py
+++ b/tests/ttnn/sweep_tests/sweeps/mean.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16).unsqueeze(0)
+    torch_output_tensor = torch.mean(torch_input_tensor, [2, 3], keepdim=True)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.mean(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/mse_loss.py
+++ b/tests/ttnn/sweep_tests/sweeps/mse_loss.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "loss_mode": ["none", "mean", "sum"],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+    loss_mode,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape_a = (*batch_sizes, height, width)
+    input_shape_b = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch.randn(input_shape_a, dtype=torch.float32).unsqueeze(0)
+    torch_input_tensor_b = torch.randn(input_shape_b, dtype=torch.float32).unsqueeze(0)
+    torch_output_tensor = torch.nn.MSELoss(reduction=loss_mode)(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+
+    output_tensor = ttnn.mse_loss(
+        input_tensor_a, input_tensor_b, loss_mode=loss_mode, memory_config=output_memory_config
+    )
+    output_tensor = ttnn.to_torch(output_tensor)
+    if loss_mode != "none":
+        output_tensor = output_tensor[0, 0, 0, 0]
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/ones.py
+++ b/tests/ttnn/sweep_tests/sweeps/ones.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.ROW_MAJOR_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16).unsqueeze(0)
+    torch_output_tensor = torch.ones(torch_input_tensor.shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.ones(input_tensor.shape, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/softplus.py
+++ b/tests/ttnn/sweep_tests/sweeps/softplus.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.nn.functional.softplus(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
+    )
+
+    output_tensor = ttnn.softplus(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/std.py
+++ b/tests/ttnn/sweep_tests/sweeps/std.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 64],
+    "width": [64, 64],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+    "dim": [-1, -2],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    dim,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.std(torch_input_tensor, dim=dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.std(input_tensor, dim=dim, keepdim=True, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)

--- a/tests/ttnn/sweep_tests/sweeps/var.py
+++ b/tests/ttnn/sweep_tests/sweeps/var.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 64],
+    "width": [64, 64],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+    "dim": [-1, -2],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    dim,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.var(torch_input_tensor, dim=dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.var(input_tensor, dim=dim, keepdim=True, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)

--- a/tests/ttnn/sweep_tests/sweeps/zeros.py
+++ b/tests/ttnn/sweep_tests/sweeps/zeros.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.ROW_MAJOR_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16).unsqueeze(0)
+    torch_output_tensor = torch.zeros(torch_input_tensor.shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.zeros(input_tensor.shape, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/zeros_like.py
+++ b/tests/ttnn/sweep_tests/sweeps/zeros_like.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.ROW_MAJOR_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16).unsqueeze(0)
+    torch_output_tensor = torch.zeros_like(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.zeros_like(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/test_activation.py
@@ -94,6 +94,12 @@ def test_swish(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.swish, F.hardswish)
 
 
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_softplus(device, h, w):
+    run_activation_unary_test(device, h, w, ttnn.softplus, F.softplus)
+
+
 def torch_heaviside(x, *args, **kwargs):
     value = kwargs.pop("scalar")
     result = torch.heaviside(x, torch.tensor(value, dtype=x.dtype))

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+import torch.nn as nn
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1280, 4, 4],  # 256x256
+        [2, 1280, 8, 8],
+        [2, 640, 16, 16],
+        [2, 1280, 8, 8],  # 512x512
+        [2, 1280, 16, 16],
+        [2, 1280, 16, 16],
+    ],
+)
+def test_zeros_like(device, input_shapes):
+    torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.zeros_like(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    output_tensor = ttnn.zeros_like(input_tensor)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.allclose(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1280, 4, 4],  # 256x256
+        [2, 1280, 8, 8],
+        [2, 640, 16, 16],
+        [2, 1280, 8, 8],  # 512x512
+        [2, 1280, 16, 16],
+        [2, 1280, 16, 16],
+    ],
+)
+def test_ones_like(device, input_shapes):
+    torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.ones_like(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    output_tensor = ttnn.ones_like(input_tensor)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.allclose(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1280, 4, 4],  # 256x256
+        [2, 1280, 8, 8],
+        [2, 640, 16, 16],
+        [2, 1280, 8, 8],  # 512x512
+        [2, 1280, 16, 16],
+        [2, 1280, 16, 16],
+    ],
+)
+@pytest.mark.parametrize(
+    "fill_value",
+    [-5, 3, 15, 25],
+)
+def test_full_like(device, input_shapes, fill_value):
+    torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.full_like(torch_input_tensor, fill_value)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    output_tensor = ttnn.full_like(input_tensor, fill_value)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.allclose(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1, 4, 4],  # 256x256
+        [2, 1280, 8, 8],
+        [2, 640, 16, 16],
+        [2, 1280, 8, 8],  # 512x512
+        [2, 1280, 16, 16],
+        [2, 1280, 16, 16],
+    ],
+)
+def test_ones(device, input_shapes):
+    torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.ones(torch_input_tensor.shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.to_device(input_tensor, device)
+
+    output_tensor = ttnn.ones(input_tensor.shape)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.allclose(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1280, 4, 4],  # 256x256
+        [2, 1280, 8, 8],
+        [2, 640, 16, 16],
+        [2, 1280, 8, 8],  # 512x512
+        [2, 1280, 16, 16],
+        [2, 1280, 16, 16],
+    ],
+)
+def test_zeros(device, input_shapes):
+    torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.zeros(torch_input_tensor.shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.to_device(input_tensor, device)
+
+    output_tensor = ttnn.zeros(input_tensor.shape)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+    assert torch.allclose(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1280, 4, 4],  # 256x256
+        [2, 1280, 8, 8],
+        [2, 640, 16, 16],
+        [2, 1280, 8, 8],  # 512x512
+        [2, 1280, 16, 16],
+        [2, 1280, 16, 16],
+    ],
+)
+@pytest.mark.parametrize(
+    "fill_value",
+    [-5.3, 0, 3.6, 6.8, 10.1],
+)
+def test_full(device, input_shapes, fill_value):
+    torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.full(torch_input_tensor.shape, fill_value=fill_value, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.to_device(input_tensor, device)
+
+    output_tensor = ttnn.full(input_tensor.shape, fill_value=fill_value)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_losses.py
+++ b/tests/ttnn/unit_tests/operations/test_losses.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+import torch.nn as nn
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1280, 8, 8],
+        [2, 640, 16, 16],
+        [2, 1280, 8, 8],
+        [2, 1280, 16, 16],
+        [2, 1280, 16, 16],
+        [2, 1280, 32, 32],
+    ],
+)
+@pytest.mark.parametrize(
+    "loss_mode",
+    [
+        "none",
+        "mean",
+        "sum",
+    ],
+)
+def test_mse_loss(device, input_shapes, loss_mode):
+    torch_input_tensor_a = torch.randn((input_shapes), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.MSELoss(reduction=loss_mode)(
+        torch_input_tensor_a.to(torch.float32), torch_input_tensor_b.to(torch.float32)
+    )
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT)
+    input_tensor_a = ttnn.to_device(input_tensor_a, device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT)
+    input_tensor_b = ttnn.to_device(input_tensor_b, device)
+
+    output_tensor = ttnn.mse_loss(input_tensor_a, input_tensor_b, loss_mode=loss_mode)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    if loss_mode != "none":
+        output_tensor = output_tensor[0, 0, 0, 0]
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1280, 8, 8],
+        [2, 640, 16, 16],
+        [2, 1280, 8, 8],
+        [2, 1280, 16, 16],
+        [2, 1280, 16, 16],
+        [2, 1280, 32, 32],
+    ],
+)
+@pytest.mark.parametrize(
+    "loss_mode",
+    [
+        "none",
+        "mean",
+        "sum",
+    ],
+)
+def test_l1_loss(device, input_shapes, loss_mode):
+    torch_input_tensor_a = torch.randn((input_shapes), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.L1Loss(reduction=loss_mode)(
+        torch_input_tensor_a.to(torch.float32), torch_input_tensor_b.to(torch.float32)
+    )
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT)
+    input_tensor_a = ttnn.to_device(input_tensor_a, device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT)
+    input_tensor_b = ttnn.to_device(input_tensor_b, device)
+
+    output_tensor = ttnn.l1_loss(input_tensor_a, input_tensor_b, loss_mode=loss_mode)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    if loss_mode != "none":
+        output_tensor = output_tensor[0, 0, 0, 0]
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/test_reduction.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random
+
+
+@pytest.mark.parametrize("batch_size", [1, 16])
+@pytest.mark.parametrize("h", [32, 64])
+@pytest.mark.parametrize("w", [32, 64])
+@pytest.mark.parametrize("dim", [-1, -2])
+def test_std(device, batch_size, h, w, dim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.std(torch_input_tensor, dim=dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.std(input_tensor, dim=dim, keepdim=True)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+
+@pytest.mark.parametrize("batch_size", [1, 16])
+@pytest.mark.parametrize("h", [32, 64])
+@pytest.mark.parametrize("w", [32, 64])
+@pytest.mark.parametrize("dim", [-1, -2])
+def test_var(device, batch_size, h, w, dim):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.var(torch_input_tensor, dim=dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.var(input_tensor, dim=dim, keepdim=True)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -114,6 +114,25 @@ from ttnn.operations.others import (
     upsample,
 )
 
+from ttnn.operations.creation import (
+    ones,
+    ones_like,
+    zeros,
+    zeros_like,
+    full,
+    full_like,
+)
+
+from ttnn.operations.reduction import (
+    std,
+    var,
+)
+
+from ttnn.operations.losses import (
+    l1_loss,
+    mse_loss,
+)
+
 from ttnn.operations.data_movement import (
     concat,
     pad,
@@ -193,6 +212,7 @@ from ttnn.operations.activation import (
     softshrink,
     softsign,
     swish,
+    softplus,
 )
 
 from ttnn.operations.math import (

--- a/ttnn/ttnn/operations/activation.py
+++ b/ttnn/ttnn/operations/activation.py
@@ -33,6 +33,7 @@ def register_ttl_activation_function_unary(name, ttl_activation_function, op_nam
             "sign": torch.sign,
             "softsign": F.softsign,
             "swish": F.hardswish,
+            "softplus": F.softplus,
         }
         torch_function = name_to_torch_function[name]
         input_tensor = ttnn.to_torch(input_tensor)
@@ -289,6 +290,7 @@ TTL_ACTIVATION_FUNCTIONS_UNARY = [
     ("sign", ttl.tensor.sign, "sign"),
     ("softsign", ttl.tensor.softsign, "softsign"),
     ("swish", ttl.tensor.swish, "swish"),
+    ("softplus", ttl.tensor.softplus, "softplus"),
 ]
 
 TTL_ACTIVATION_FUNCTIONS_WITH_FLOAT_PARAM = [

--- a/ttnn/ttnn/operations/creation.py
+++ b/ttnn/ttnn/operations/creation.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Tuple, Union
+
+
+import tt_lib as ttl
+
+import ttnn
+
+
+def _zeros_like_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+    ttnn.validate_input_tensor(
+        operation_name,
+        input_tensor,
+        ranks=(2, 3, 4),
+        dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+        layouts=(ttnn.ROW_MAJOR_LAYOUT,),
+        can_be_on_device=True,
+        can_be_on_cpu=False,
+    )
+
+
+def _torch_zeros_like(input_tensor: ttnn.Tensor, **_):
+    import torch
+
+    input_tensor = ttnn.from_device(input_tensor)
+    input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    input_tensor = ttnn.to_torch(input_tensor)
+
+    return torch.zeros_like(input_tensor)
+
+
+@ttnn.register_operation(
+    name="ttnn.zeros_like",
+    validate_input_tensors=_zeros_like_validate_input_tensors,
+    torch_function=_torch_zeros_like,
+)
+def zeros_like(
+    input_tensor: ttnn.Tensor,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    r"""
+    Returns a new tensor filled with zero by taking input tensor shape as reference.
+
+    Args:
+        * :attr:`input_tensor`: the input tensor for reference shape
+    """
+
+    ttl_input_tensor = input_tensor.value
+    output_tensor = ttl.tensor.zeros_like(ttl_input_tensor, output_mem_config=memory_config)
+    output_tensor = ttnn.Tensor(output_tensor)
+
+    return output_tensor
+
+
+def _ones_like_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+    ttnn.validate_input_tensor(
+        operation_name,
+        input_tensor,
+        ranks=(2, 3, 4),
+        dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+        layouts=(ttnn.ROW_MAJOR_LAYOUT,),
+        can_be_on_device=True,
+        can_be_on_cpu=False,
+    )
+
+
+def _torch_ones_like(input_tensor: ttnn.Tensor, **_):
+    import torch
+
+    input_tensor = ttnn.from_device(input_tensor)
+    input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    input_tensor = ttnn.to_torch(input_tensor)
+
+    return torch.ones_like(input_tensor)
+
+
+@ttnn.register_operation(
+    name="ttnn.ones_like",
+    validate_input_tensors=_ones_like_validate_input_tensors,
+    torch_function=_torch_ones_like,
+)
+def ones_like(
+    input_tensor: ttnn.Tensor,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    r"""
+    Returns a new tensor filled with one by taking input tensor shape as reference.
+
+    Args:
+        * :attr:`input_tensor`: the input tensor for reference shape
+    """
+
+    ttl_input_tensor = input_tensor.value
+    output_tensor = ttl.tensor.ones_like(ttl_input_tensor, output_mem_config=memory_config)
+    output_tensor = ttnn.Tensor(output_tensor)
+
+    return output_tensor
+
+
+def _full_like_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+    ttnn.validate_input_tensor(
+        operation_name,
+        input_tensor,
+        ranks=(2, 3, 4),
+        dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+        layouts=(ttnn.ROW_MAJOR_LAYOUT,),
+        can_be_on_device=True,
+        can_be_on_cpu=False,
+    )
+
+
+def _torch_full_like(input_tensor: ttnn.Tensor, fill_value: float, **_):
+    import torch
+
+    input_tensor = ttnn.from_device(input_tensor)
+    input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    input_tensor = ttnn.to_torch(input_tensor)
+
+    return torch.full_like(input_tensor, fill_value)
+
+
+@ttnn.register_operation(
+    name="ttnn.full_like",
+    validate_input_tensors=_full_like_validate_input_tensors,
+    torch_function=_torch_full_like,
+)
+def full_like(
+    input_tensor: ttnn.Tensor,
+    fill_value: float,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    r"""
+    Returns a new tensor filled with scalar value by taking input tensor shape as reference.
+
+    Args:
+        * :attr:`input_tensor`: the input tensor for reference shape
+        * :attr:`fill_value`: the value to be filled
+    """
+
+    ttl_input_tensor = input_tensor.value
+    output_tensor = ttl.tensor.full_like(ttl_input_tensor, fill_value, output_mem_config=memory_config)
+    output_tensor = ttnn.Tensor(output_tensor)
+
+    return output_tensor
+
+
+def _torch_zeros(input_shape: ttnn.Shape, **_):
+    import torch
+
+    input_shape = ttnn.from_device(input_shape)
+    input_shape = ttnn.to_layout(input_shape, ttnn.ROW_MAJOR_LAYOUT)
+    input_shape = ttnn.to_torch(input_shape)
+
+    return torch.zeros(input_shape)
+
+
+def _zeros_validate_input_tensors(operation_name, input_shape, *args, **kwargs):
+    if len(input_shape) == 4:
+        return True
+
+
+@ttnn.register_operation(
+    name="ttnn.zeros",
+    validate_input_tensors=_zeros_validate_input_tensors,
+    torch_function=_torch_zeros,
+)
+def zeros(
+    input_shape: ttnn.Shape,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    r"""
+    Returns a new tensor filled with zeros by taking input tensor shape as reference.
+
+    Args:
+        * :attr:`input_shape`: the input shape for reference
+    """
+    output_tensor = ttl.tensor.zeros(input_shape, output_mem_config=memory_config)
+    output_tensor = ttnn.Tensor(output_tensor)
+
+    return output_tensor
+
+
+def _torch_ones(input_shape: ttnn.Shape, **_):
+    import torch
+
+    input_shape = ttnn.from_device(input_shape)
+    input_shape = ttnn.to_layout(input_shape, ttnn.ROW_MAJOR_LAYOUT)
+    input_shape = ttnn.to_torch(input_shape)
+
+    return torch.ones(input_shape)
+
+
+def _ones_validate_input_tensors(operation_name, input_shape, *args, **kwargs):
+    if len(input_shape) == 4:
+        return True
+
+
+@ttnn.register_operation(
+    name="ttnn.ones",
+    validate_input_tensors=_ones_validate_input_tensors,
+    torch_function=_torch_ones,
+)
+def ones(
+    input_shape: ttnn.Shape,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    r"""
+    Returns a new tensor filled with ones by taking input tensor shape as reference.
+
+    Args:
+        * :attr:`input_shape`: the input shape for reference
+    """
+    output_tensor = ttl.tensor.ones(input_shape, output_mem_config=memory_config)
+    output_tensor = ttnn.Tensor(output_tensor)
+
+    return output_tensor
+
+
+def _torch_full(input_shape: ttnn.Shape, fill_value: float, **_):
+    import torch
+
+    input_shape = ttnn.from_device(input_shape)
+    input_shape = ttnn.to_layout(input_shape, ttnn.ROW_MAJOR_LAYOUT)
+    input_shape = ttnn.to_torch(input_shape)
+
+    return torch.full(input_shape, fill_value=fill_value)
+
+
+def _full_validate_input_tensors(operation_name, input_shape, *args, **kwargs):
+    if len(input_shape) == 4:
+        return True
+
+
+@ttnn.register_operation(
+    name="ttnn.full",
+    validate_input_tensors=_full_validate_input_tensors,
+    torch_function=_torch_full,
+)
+def full(
+    input_shape: ttnn.Shape,
+    fill_value: float,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    r"""
+    Returns a new tensor filled with fill_value by taking input tensor shape as reference.
+
+    Args:
+        * :attr:`input_shape`: the input shape for reference
+        * :attr:`fill_value`: the value to be filled
+    """
+    output_tensor = ttl.tensor.full(input_shape, fill_value=fill_value, output_mem_config=memory_config)
+    output_tensor = ttnn.Tensor(output_tensor)
+
+    return output_tensor
+
+
+__all__ = []

--- a/ttnn/ttnn/operations/losses.py
+++ b/ttnn/ttnn/operations/losses.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import tt_lib as ttl
+
+import ttnn
+
+
+THIS_MODULE = sys.modules[__name__]
+
+__all__ = []
+
+
+def register_ttl_loss_function(name, ttl_loss_function):
+    def _torch_loss(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, loss_mode: str, **_):
+        import torch
+
+        name_to_torch_function = {
+            "mse_loss": torch.nn.MSELoss,
+            "l1_loss": torch.nn.L1Loss,
+        }
+        torch_function = name_to_torch_function[name]
+        input_tensor = ttnn.to_torch(input_tensor)
+        return torch_function(reduction=loss_mode)(input_tensor_a, input_tensor_b)
+
+    def _loss_validate_input_tensors(operation_name, input_tensor_a, input_tensor_b, *args, **kwargs):
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor_a,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor_b,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+
+    @ttnn.register_operation(
+        name=f"ttnn.{name}",
+        validate_input_tensors=_loss_validate_input_tensors,
+        torch_function=_torch_loss,
+    )
+    def loss_function(
+        input_tensor_a: ttnn.Tensor,
+        input_tensor_b: ttnn.Tensor,
+        loss_mode: str,
+        *,
+        memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    ) -> ttnn.Tensor:
+        input_tensor_a = ttnn.unsqueeze_to_4D(input_tensor_a)
+        input_tensor_b = ttnn.unsqueeze_to_4D(input_tensor_b)
+        ttl_input_tensor_a = input_tensor_a.value
+        ttl_input_tensor_b = input_tensor_b.value
+
+        if not isinstance(input_tensor_a, ttnn.Tensor) or not isinstance(input_tensor_b, ttnn.Tensor):
+            raise TypeError("Expected both arguments to be a ttnn.Tensor")
+
+        if not ttnn.has_storage_type_of(input_tensor_a, ttnn.DEVICE_STORAGE_TYPE) or not ttnn.has_storage_type_of(
+            input_tensor_b, ttnn.DEVICE_STORAGE_TYPE
+        ):
+            raise RuntimeError("Both input_tensor must be on device!")
+
+        if loss_mode == "none":
+            mode = ttl.tensor.LossReductionMode.NONE
+        if loss_mode == "sum":
+            mode = ttl.tensor.LossReductionMode.SUM
+        if loss_mode == "mean":
+            mode = ttl.tensor.LossReductionMode.MEAN
+
+        ttl_output_tensor = ttl_loss_function(
+            ttl_input_tensor_a, ttl_input_tensor_b, mode, output_mem_config=memory_config
+        )
+
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        output_tensor = ttnn.unsqueeze_to_4D(output_tensor)
+        return output_tensor
+
+    loss_function.__name__ = f"ttnn.{name}"
+    loss_function.__doc__ = f"""{name}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, loss_mode: str, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
+
+        Applies {name} to :attr:`input_tensor_a` and :attr:`input_tensor_b` with loss_mode :attr:`loss_mode`.
+
+        .. math::
+            {name.replace('_',' ')}(\\mathrm{{input\\_tensor}}_i)
+
+        Args:
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+            * :attr:`loss_mode`
+
+        Example::
+
+            >>> tensor1 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> tensor2 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> output = ttnn.{name}(tensor1, tensor2, mode)
+
+        {loss_function.__doc__}
+
+        """
+    setattr(THIS_MODULE, name, loss_function)
+
+
+TTL_UNARY_FUNCTIONS = [
+    ("mse_loss", ttl.tensor.mseloss),
+    ("l1_loss", ttl.tensor.maeloss),
+]
+
+
+for unary_function_name, ttl_unary_function in TTL_UNARY_FUNCTIONS:
+    register_ttl_loss_function(unary_function_name, ttl_unary_function)
+
+
+__all__ = []

--- a/ttnn/ttnn/operations/reduction.py
+++ b/ttnn/ttnn/operations/reduction.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Tuple, Union
+
+
+import tt_lib as ttl
+
+import ttnn
+
+
+def _torch_std(input_tensor: ttnn.Tensor, dim: int, keepdim=False, **_):
+    import torch
+
+    input_tensor = ttnn.from_device(input_tensor)
+    input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    input_tensor = ttnn.to_torch(input_tensor)
+
+    return torch.std(input_tensor, dim=dim, keepdim=keepdim)
+
+
+def _std_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+    ttnn.validate_input_tensor(
+        operation_name,
+        input_tensor,
+        ranks=(2, 3, 4),
+        dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+        layouts=(ttnn.TILE_LAYOUT,),
+        can_be_on_device=True,
+        can_be_on_cpu=False,
+    )
+
+
+@ttnn.register_operation(
+    name="ttnn.std",
+    validate_input_tensors=_std_validate_input_tensors,
+    torch_function=_torch_std,
+)
+def std(
+    input_tensor: ttnn.Tensor,
+    dim: Union[int, Tuple[int]],
+    keepdim: bool = False,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    """
+    std(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int]], keepdim: bool = False) -> ttnn.Tensor
+    """
+
+    input_shape = tuple(input_tensor.shape)
+    rank = len(input_shape)
+
+    if isinstance(dim, int):
+        if dim < 0:
+            dim = rank + dim
+        dim = (dim,)
+
+    if isinstance(dim, tuple):
+        if dim == (rank - 1,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.W
+        elif dim == (rank - 2,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.H
+        elif dim == (rank - 1, rank - 2):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.HW
+        else:
+            raise RuntimeError("Unsupported dim")
+    else:
+        raise RuntimeError("Invalid dim")
+
+    output_shape = []
+    padded_output_shape = []
+    for axis, size in enumerate(input_shape):
+        if axis in dim:
+            if keepdim:
+                output_shape.append(1)
+                padded_output_shape.append(ttnn.TILE_SIZE)
+        else:
+            output_shape.append(size)
+            padded_output_shape.append(size)
+    output_shape = tuple(output_shape)
+    padded_output_shape = tuple(padded_output_shape)
+
+    input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+    ttl_input_tensor = input_tensor.value
+
+    mean_tensor = ttl.tensor.reduce(ttl_input_tensor, ttl.tensor.ReduceOpMath.SUM, reduce_op_dim, 1 / input_shape[-1])
+    mean_square_tensor = ttl.tensor.reduce(
+        ttl.tensor.pow(ttl_input_tensor, 2.0), ttl.tensor.ReduceOpMath.SUM, reduce_op_dim, 1 / input_shape[-1]
+    )
+    std_tensor = ttl.tensor.sqrt(ttl.tensor.sub(mean_square_tensor, (ttl.tensor.pow(mean_tensor, 2.0))))
+
+    output_tensor = ttnn.Tensor(std_tensor)
+    output_tensor = ttnn.reshape(output_tensor, ttnn.Shape(output_shape, padded_output_shape))
+
+    return output_tensor
+
+
+def _torch_var(input_tensor: ttnn.Tensor, dim: int, keepdim=False, **_):
+    import torch
+
+    input_tensor = ttnn.from_device(input_tensor)
+    input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    input_tensor = ttnn.to_torch(input_tensor)
+
+    return torch.var(input_tensor, dim=dim, keepdim=keepdim)
+
+
+def _var_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+    ttnn.validate_input_tensor(
+        operation_name,
+        input_tensor,
+        ranks=(2, 3, 4),
+        dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+        layouts=(ttnn.TILE_LAYOUT,),
+        can_be_on_device=True,
+        can_be_on_cpu=False,
+    )
+
+
+@ttnn.register_operation(
+    name="ttnn.var",
+    validate_input_tensors=_var_validate_input_tensors,
+    torch_function=_torch_var,
+)
+def var(
+    input_tensor: ttnn.Tensor,
+    dim: Union[int, Tuple[int]],
+    keepdim: bool = False,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    """
+    var(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int]], keepdim: bool = False) -> ttnn.Tensor
+    """
+
+    input_shape = tuple(input_tensor.shape)
+    rank = len(input_shape)
+
+    if isinstance(dim, int):
+        if dim < 0:
+            dim = rank + dim
+        dim = (dim,)
+
+    if isinstance(dim, tuple):
+        if dim == (rank - 1,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.W
+        elif dim == (rank - 2,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.H
+        elif dim == (rank - 1, rank - 2):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.HW
+        else:
+            raise RuntimeError("Unsupported dim")
+    else:
+        raise RuntimeError("Invalid dim")
+
+    output_shape = []
+    padded_output_shape = []
+    for axis, size in enumerate(input_shape):
+        if axis in dim:
+            if keepdim:
+                output_shape.append(1)
+                padded_output_shape.append(ttnn.TILE_SIZE)
+        else:
+            output_shape.append(size)
+            padded_output_shape.append(size)
+    output_shape = tuple(output_shape)
+    padded_output_shape = tuple(padded_output_shape)
+
+    input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+    ttl_input_tensor = input_tensor.value
+
+    mean_tensor = ttl.tensor.reduce(ttl_input_tensor, ttl.tensor.ReduceOpMath.SUM, reduce_op_dim, 1 / input_shape[-1])
+    mean_square_tensor = ttl.tensor.reduce(
+        ttl.tensor.pow(ttl_input_tensor, 2.0), ttl.tensor.ReduceOpMath.SUM, reduce_op_dim, 1 / input_shape[-1]
+    )
+    variance_tensor = ttl.tensor.sub(mean_square_tensor, ttl.tensor.pow(mean_tensor, 2.0))
+
+    output_tensor = ttnn.Tensor(variance_tensor)
+    output_tensor = ttnn.reshape(output_tensor, ttnn.Shape(output_shape, padded_output_shape))
+
+    return output_tensor
+
+
+__all__ = []


### PR DESCRIPTION
Add tensor manip ops to ttnn
Sweep Test Results:
[full_like.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296286/full_like.csv)
[full.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296287/full.csv)
[maeloss.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296288/maeloss.csv)
[mean_hw.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296290/mean_hw.csv)
[mseloss.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296291/mseloss.csv)
[normalize_global.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296292/normalize_global.csv)
[normalize_hw.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296293/normalize_hw.csv)
[ones.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296294/ones.csv)
[softplus.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296295/softplus.csv)
[std_hw.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296296/std_hw.csv)
[var_hw.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296297/var_hw.csv)
[zeros_like.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296298/zeros_like.csv)
[zeros.csv](https://github.com/tenstorrent-metal/tt-metal/files/14296299/zeros.csv)
