### PR TITLE
#5301: Enforce code style described in .clang-format during CI pipelines

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -37,17 +37,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Install clang-format
         run: sudo apt-get install -y clang-format
       - name: Fetch merge target
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
         run: git fetch origin $GITHUB_BASE_REF --depth=1
       - name: Run formatter
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
         run: BASE_COMMIT_SHA=origin/$GITHUB_BASE_REF scripts/lint_clang_format.sh -m diff
       - name: Run formatter against previous commit (main only)
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: BASE_COMMIT_SHA=${{ github.event.before }} scripts/lint_clang_format.sh -m diff
   check-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -32,6 +32,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@23.10.1
+  check-clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Install clang-format
+        run: sudo apt-get install -y clang-format
+      - name: Fetch merge target
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: git fetch origin $GITHUB_BASE_REF --depth=1
+      - name: Run formatter
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: BASE_COMMIT_SHA=origin/$GITHUB_BASE_REF scripts/lint_clang_format.sh -m diff
+      - name: Run formatter against previous commit (main only)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: BASE_COMMIT_SHA=${{ github.event.before }} scripts/lint_clang_format.sh -m diff
   check-doc:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Table of Contents
     - [Debugging device hangs](#debugging-device-hangs)
   - [Contribution standards](#contribution-standards)
     - [File structure and formats](#file-structure-and-formats)
+    - [Code style](#code-style)
     - [CI/CD Principles](#cicd-principles)
     - [Using CI/CD for development](#using-cicd-for-development)
     - [Documentation](#documentation)
@@ -458,6 +459,16 @@ cat generated/watcher/watcher.log  # See k_ids field for each core in the last d
   //
   // SPDX-License-Identifier: Apache-2.0
   ```
+
+### Code style
+
+- All C++ code must comply with the code style described in the `.clang-format`
+  configuration file. The CI pipeline will check any files you have modified
+  against this format and fail if the style does not match. You can run
+  `clang-format` manually or using the script found in
+  [scripts/lint_clang_format.sh](./scripts/README.md).
+  - The CI pipeline is currently using `clang-format` 14.
+- All Python code must comply with the `black` code style.
 
 ### CI/CD Principles
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,21 @@
+# lint_clang_format.sh
+
+## Overview
+
+This bash script facilitates the process of applying `clang-format` across the repository. Users
+can select to format either all files within the repository (`all` mode) or only those files that
+have been modified (`diff` mode) compared to the main branch or a specified base commit.
+
+## Usage
+
+```bash
+./lint_clang_format.sh [-m <diff|all>] [-n] [-f]
+```
+
+Options:
+
+- `-m <diff|all>`: Choose to format all relevant C++ files in the repository (all) or only those
+  modified on your branch (diff).
+- `-n`: Perform a dry run, listing files that would be formatted without actually running
+  `clang-format`.
+- `-f`: Automatically fix formatting issues.

--- a/scripts/lint_clang_format.sh
+++ b/scripts/lint_clang_format.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Run clang-format over the entire repository and fix issues if specified by the user
+
+set -eu
+
+SUCCESS=0
+FAIL=1
+CLANG_FORMAT_BIN=${CLANG_FORMAT_BIN:-clang-format}
+
+usage() {
+    echo "-m | Select 'all' or 'diff': run formatter over all files or just modified ones"
+    echo "-n | If present, do a dry-run (don't actually run clang-format)"
+    echo "-f | If present, we should try to fix all issues automatically"
+    echo "Usage: $0 [-m <diff|all>] [-n] [-f]" 1>&2
+    exit $FAIL
+}
+
+log() {
+    BOLD="\033[1m"
+    DEFAULT="\e[0m"
+    echo -e "${BOLD}[$(basename $BASH_SOURCE)] $1$DEFAULT"
+}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/..
+log "Running from $PWD"
+
+MODE="diff"
+DRY_RUN=false
+SHOULD_FIX=false
+while getopts "fnm:" OPT; do
+    case "${OPT}" in
+        f)
+            SHOULD_FIX=true
+            log "Will attempt to fix changes"
+            ;;
+        n)
+            DRY_RUN=true
+            ;;
+        m)
+            MODE=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+log "Using '$MODE' mode"
+
+PATHSPEC=(
+        ":/*.cpp" \
+        ":/*.h" \
+        ":/*.hpp"
+    )
+
+# Either use all the files that match certain patterns or use a diff from master
+FILES=()
+if [ $MODE == "all" ]; then
+    mapfile -t FILES < <(git ls-files -- ${PATHSPEC[@]})
+elif [ $MODE == "diff" ]; then
+    # Use the base of our current branch if the user hasn't supplied one. If we are
+    # on CI, we have to pass this in.
+    BASE_COMMIT_SHA=${BASE_COMMIT_SHA:-$(git merge-base origin/main HEAD)}
+
+    # Get all files that are different from main
+    mapfile -t ALL_FILES < <(git diff --name-only $BASE_COMMIT_SHA -- ${PATHSPEC[@]})
+
+    # Filter out files that don't exist since we've deleted them
+    for FILE in ${ALL_FILES[@]}; do
+        if [[ -e "$FILE" ]]; then
+            FILES+=($FILE)
+        else
+            log "Could not find $FILE, it must have been deleted."
+        fi
+    done
+else
+    echo "Unexpected MODE encountered: $MODE"
+    exit $FAIL
+fi
+
+if $DRY_RUN; then
+    log "Dry run found ${#FILES[@]} file(s)..."
+    for FILE in ${FILES[@]}; do
+        echo "- $FILE"
+    done
+    exit $SUCCESS
+fi
+
+# Just succeed if there's no files to modify
+if (( ${#FILES[@]} )); then
+    FIX="-i"
+    CHECK="--dry-run -Werror"
+    log "Running formatter on ${#FILES[@]} file(s)..."
+    if $SHOULD_FIX; then
+        exit $($CLANG_FORMAT_BIN $FIX "${FILES[@]}")
+    else
+        exit $($CLANG_FORMAT_BIN $CHECK "${FILES[@]}")
+    fi
+else
+    log "There was nothing to do. Exiting."
+    exit $SUCCESS
+fi


### PR DESCRIPTION
See https://github.com/tenstorrent-metal/tt-metal/issues/5301 for the motivation behind the following fix.

I have added a new static check in CI that will verify all changed files meet the `.clang-format` configuration. The script used by CI also works locally so that developers can easily run the formatter locally, although using the script is not required.  

The new pipeline stage is fast (<1 min) so it can easily be run along with the rest of the static checks.

I also added documentation about the code formatting policy, and instructions on how to use the formatter script. A Slack announcement is also probably a good idea.

From the original issue:

> The main advantage to this solution is it can be gradually rolled out, without disrupting day-to-day development. Over time the repository will become more and more consistent. The downside is that code formatting changes may be noisy for reviewers, and some files that are very rarely (or never!) changed will never become reformatted.

If merged, everyone will need the to install `clang-format` on their machines. For most users it should be a simple `apt-get install`.

Question for reviewers:

- How do you typically test changes like this? Aside from making commits and manually verifying things are working.
- Mark the stage as optional, or hide it away so we can confirm everything is working correctly before accidentally blowing up CI 😅 
- If merged, everyone will need to install `clang-format` on their machines. For most users it should be a simple `apt-get install`.
- There can be slight format differences between major versions of LLVM, which is annoying for users if they happen to run the wrong version.  I've mentioned the correct version in the docs. Do you see any issues with this?
- How do we mark the stage as "Required"?

After feedback I'll clean up the commits. 