### PR TITLE
Alex/metal/enable conv tests on b0

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_max_pool.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_max_pool.py
@@ -163,10 +163,16 @@ def test_run_max_pool(
     # Resnet specific config pulled from max_pool_multi_core.cpp:get_num_cores
     is_resnet_shape = out_nhw in (3136, 6272, 12544, 25088)
     ncores_for_resnet_shape = 98
+    ncores_on_n300 = 56
 
     if is_resnet_shape and (compute_grid_size.x * compute_grid_size.y < ncores_for_resnet_shape):
         pytest.skip(
             f"Skipping over Resnet specific config where parallelization does not fit on core grid {compute_grid_size}"
+        )
+
+    if (compute_grid_size.x * compute_grid_size.y) == ncores_on_n300:
+        pytest.skip(
+            f"Skipping on N300 (8x7 core grid) due to bug https://github.com/tenstorrent-metal/tt-metal/issues/5458"
         )
 
     torch.set_printoptions(precision=3, sci_mode=False, linewidth=500, threshold=10000, edgeitems=32)

--- a/tests/tt_eager/python_api_testing/unit_testing/test_optimized_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_optimized_conv.py
@@ -17,7 +17,7 @@ from tt_lib.utils import (
     _nearest_y,
     convert_weights_2d_matrix,
 )
-from models.utility_functions import print_diff_argmax, is_close, comp_pcc, comp_allclose_and_pcc, skip_for_wormhole_b0
+from models.utility_functions import print_diff_argmax, is_close, comp_pcc, comp_allclose_and_pcc
 from tests.tt_eager.python_api_testing.conv.conv_unit_test_utils import (
     create_conv_act_tensor,
     create_conv_weight_tensor,
@@ -27,7 +27,6 @@ from tests.tt_eager.python_api_testing.conv.conv_unit_test_utils import (
 import torch
 
 
-@skip_for_wormhole_b0()
 @pytest.mark.parametrize("untilize_out", (False,))
 @pytest.mark.parametrize("has_bias", (True,))
 @pytest.mark.parametrize("fuse_relu", (True,))

--- a/tests/tt_eager/python_api_testing/unit_testing/test_optimized_conv_multi_core.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_optimized_conv_multi_core.py
@@ -17,7 +17,7 @@ from tt_lib.utils import (
     _nearest_y,
     convert_weights_2d_matrix,
 )
-from models.utility_functions import print_diff_argmax, is_close, comp_pcc, comp_allclose_and_pcc, skip_for_wormhole_b0
+from models.utility_functions import print_diff_argmax, is_close, comp_pcc, comp_allclose_and_pcc
 from tests.tt_eager.python_api_testing.conv.conv_unit_test_utils import (
     create_conv_act_tensor,
     create_conv_weight_tensor,
@@ -27,7 +27,6 @@ from tests.tt_eager.python_api_testing.conv.conv_unit_test_utils import (
 import torch
 
 
-@skip_for_wormhole_b0()
 @pytest.mark.parametrize("untilize_out", (False,))
 @pytest.mark.parametrize("has_bias", (False,))
 @pytest.mark.parametrize("fuse_relu", (False,))

--- a/tests/tt_eager/python_api_testing/unit_testing/test_resnet50_first_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_resnet50_first_conv.py
@@ -19,7 +19,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose_and_pcc,
     comp_pcc,
 )
-from models.utility_functions import is_wormhole_b0, skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0
 from tests.tt_eager.python_api_testing.conv.conv_unit_test_utils import (
     create_conv_act_tensor,
     create_conv_act_tensor_special,
@@ -30,7 +30,6 @@ from tests.tt_eager.python_api_testing.conv.conv_unit_test_utils import (
 import torch
 
 
-@skip_for_wormhole_b0()
 @pytest.mark.parametrize("untilize_out", (False,))
 @pytest.mark.parametrize("has_bias", (True,))
 @pytest.mark.parametrize("fuse_relu", (True,))
@@ -60,8 +59,8 @@ def test_resnet50_first_conv(
         pytest.skip(
             f"Skipping batch 8 on E75 because expected grid size is 12x9 but E75 grid size is {compute_grid_size}"
         )
-    if N != 8:
-        pytest.skip("Skipping non-batch 8 tests due to potential non-determinism")
+    if N == 2:
+        pytest.skip("Skipping batch 2 due to pcc error!")
     if N == 8 and is_wormhole_b0():
         pytest.skip("Parallelization unsupported for WH B0")
     if sharded_out and N != 8:

--- a/tests/tt_eager/python_api_testing/unit_testing/test_resnet50_first_conv_folding_on_host.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_resnet50_first_conv_folding_on_host.py
@@ -20,8 +20,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
 from models.utility_functions import (
-    is_wormhole_b0,
-    skip_for_wormhole_b0,
     pad_and_fold_conv_activation_for_unity_stride,
     pad_and_fold_conv_filters_for_unity_stride,
 )
@@ -35,7 +33,6 @@ from tests.tt_eager.python_api_testing.conv.conv_unit_test_utils import (
 import torch
 
 
-@skip_for_wormhole_b0()
 @pytest.mark.parametrize("has_bias", (True,))
 @pytest.mark.parametrize("fuse_relu", (True,))
 @pytest.mark.parametrize(
@@ -57,8 +54,6 @@ def test_resnet50_first_conv(
         )
     if N != 8:
         pytest.skip("Skipping non-batch 8 tests due to potential non-determinism")
-    if N == 8 and is_wormhole_b0():
-        pytest.skip("Parallelization unsupported for WH B0")
 
     (K, C, padded_C, H, W, R, S, padded_S, stride_h, stride_w, pad_h, pad_w) = (
         64,

--- a/tests/tt_eager/python_api_testing/unit_testing/test_untilize_with_halo_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_untilize_with_halo_v2.py
@@ -29,8 +29,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 from tt_lib.utils import _nearest_y
 import tt_lib as ttl
 
-from models.utility_functions import skip_for_wormhole_b0
-
 from loguru import logger
 
 
@@ -48,7 +46,6 @@ def plot_diff(vals, fid, nsticks, stick_len):
     plt.close()
 
 
-@skip_for_wormhole_b0()
 # conv params - output_channels, input_channels, filter_h, filter_w, stride_h, stride_w, pad_h, pad_w, dilation, groups
 @pytest.mark.parametrize(
     "conv_params, batch_size, input_chw_shape, num_cores_nhw, grid_size, test_max_pool",
@@ -282,6 +279,10 @@ def test_generate_all_configs_and_references(
 
     if test_max_pool and batch_size > 8:
         pytest.skip(f"Skipping maxpool config with batch_size = {batch_size} due to mem limitations")
+
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
+        pytest.skip(f"Need {grid_size} grid size to run this test but core grid is {compute_grid_size}")
 
     torch.set_printoptions(threshold=10000, edgeitems=50, linewidth=400)  ##, sci_mode=False)
 

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -21,7 +21,7 @@ inline void llk_math_eltwise_unary_datacopy(uint dst_index) {
 }
 
 template <DataCopyType type, BroadcastType src_b_bcast_type = BroadcastType::NONE, DstSync Dst = DstSync::SyncFull, bool is_fp32_dest_acc_en = false>
-inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles) {
+inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint ntiles, uint operand = 0 /*not used*/) {
 
     for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
         llk_math_eltwise_unary_datacopy<type, src_b_bcast_type, Dst>(dst_index);

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -211,14 +211,22 @@ ALWI void add_bcast_rows_init_short(uint32_t icb0 = 0, uint32_t icb1 = 1)
  */
 ALWI void add_bcast_rows_init_short_post_matmul(uint32_t icb0 = 0, uint32_t icb1 = 1)
 {
+    #ifdef ARCH_GRAYSKULL
+    // math
     MATH(( llk_math_eltwise_binary_init<ELWADD, BroadcastType::ROW, MATH_FIDELITY>() ));
+    MATH(( llk_math_pack_sync_init<SYNC>()  ));
+
+    // unpacker
     UNPACK(( llk_unpack_AB_init<BroadcastType::ROW>(icb0, icb1) ));
 
-    #ifdef ARCH_GRAYSKULL
-    MATH(( llk_math_pack_sync_init<SYNC>()  ));
+    // packer
     PACK(( llk_pack_init<false, false, DstTileFaceLayout::RowMajor>()  ));
     PACK(( llk_pack_dest_init<SYNC, DstTileFaceLayout::RowMajor, false>()  ));
     PACK(( llk_init_packer_dest_offset_registers<SyncHalf,DstTileFaceLayout::RowMajor,false>()  ));
+    #else
+    MATH(( llk_math_eltwise_binary_init<ELWADD, BroadcastType::ROW>() ));
+    // FIXME: API Update needed in compute kernel?
+    UNPACK(( llk_unpack_AB_init<BroadcastType::ROW>(icb0, icb1) ));
     #endif
 }
 

--- a/tt_metal/include/compute_kernel_api/tile_move_copy.h
+++ b/tt_metal/include/compute_kernel_api/tile_move_copy.h
@@ -138,7 +138,7 @@ ALWI void copy_block_matmul_partials(uint32_t icb, uint32_t start_itile, uint32_
     UNPACK(( llk_unpack_A_block<BroadcastType::NONE, false>(icb, start_itile, ntiles, false)  ));
     #endif
 
-    MATH(( llk_math_eltwise_unary_datacopy_block<A2D, BroadcastType::NONE, SyncHalf, DST_ACCUM_MODE>(start_idst, ntiles)  ));
+    MATH(( llk_math_eltwise_unary_datacopy_block<A2D, BroadcastType::NONE, SyncHalf, DST_ACCUM_MODE>(start_idst, ntiles, icb)  ));
 }
 
 }


### PR DESCRIPTION
Enable following conv unit tests to run on b0:

tests/tt_eager/python_api_testing/unit_testing/test_optimized_conv.py
tests/tt_eager/python_api_testing/unit_testing/test_resnet50_first_conv.py
tests/tt_eager/python_api_testing/unit_testing/test_optimized_conv_multi_core.py
tests/tt_eager/python_api_testing/unit_testing/test_untilize_with_halo_v2.py
tests/tt_eager/python_api_testing/unit_testing/test_resnet50_first_conv_folding_on_host.py
tests/tt_eager/python_api_testing/unit_testing/test_resnet50_untilize_with_halo_and_conv_v2.py

skip test_max_pool.py on N300 (8x7 core grid) as workaround for bug https://github.com/tenstorrent-metal/tt-metal/issues/5458
