### PR TITLE
disable model perf measurements on VMs

### DIFF
--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         runner-info: [
-          {arch: grayskull, runs-on: ["model-runner-grayskull"], machine-type: "virtual_machine"},
+          # {arch: grayskull, runs-on: ["model-runner-grayskull"], machine-type: "virtual_machine"},
           {arch: grayskull, runs-on: ["perf-grayskull", "self-reset"], machine-type: "bare_metal"},
         ]
     env:


### PR DESCRIPTION
Measuring perf on VM has been very noisy and constantly failing. Let's just measure on BM instead 