### PR TITLE
#5442: Add math ops to ttnn

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 494
+personal_ws-1.1 en 497
 ABI
 ADDI
 API
@@ -281,6 +281,7 @@ hpp
 hs
 html
 hw
+hypot
 icb
 idst
 ie
@@ -292,6 +293,7 @@ intrinsics
 iomanip
 ios
 ipynb
+isclose
 isfinite
 isinf
 isinstance
@@ -304,6 +306,7 @@ iy
 jupyter
 labelled
 ld
+lerp
 lez
 lgamma
 linenos

--- a/docs/source/ttnn/api.rst
+++ b/docs/source/ttnn/api.rst
@@ -111,6 +111,7 @@ Pointwise Relational
    ttnn/lte
    ttnn/eq
    ttnn/ne
+   ttnn/isclose
 
 Pointwise Math
 ==============
@@ -139,6 +140,10 @@ Pointwise Math
    ttnn/erfinv
    ttnn/exp2
    ttnn/expm1
+   ttnn/atan2
+   ttnn/hypot
+   ttnn/lerp
+   ttnn/squared_difference
 
 Activation
 ==========

--- a/docs/source/ttnn/ttnn/atan2.rst
+++ b/docs/source/ttnn/ttnn/atan2.rst
@@ -1,0 +1,6 @@
+.. _ttnn.atan2:
+
+ttnn.atan2
+###############
+
+.. autofunction:: ttnn.atan2

--- a/docs/source/ttnn/ttnn/hypot.rst
+++ b/docs/source/ttnn/ttnn/hypot.rst
@@ -1,0 +1,6 @@
+.. _ttnn.hypot:
+
+ttnn.hypot
+###############
+
+.. autofunction:: ttnn.hypot

--- a/docs/source/ttnn/ttnn/isclose.rst
+++ b/docs/source/ttnn/ttnn/isclose.rst
@@ -1,0 +1,6 @@
+.. _ttnn.isclose:
+
+ttnn.isclose
+###############
+
+.. autofunction:: ttnn.isclose

--- a/docs/source/ttnn/ttnn/lerp.rst
+++ b/docs/source/ttnn/ttnn/lerp.rst
@@ -1,0 +1,6 @@
+.. _ttnn.lerp:
+
+ttnn.lerp
+###############
+
+.. autofunction:: ttnn.lerp

--- a/docs/source/ttnn/ttnn/squared_difference.rst
+++ b/docs/source/ttnn/ttnn/squared_difference.rst
@@ -1,0 +1,6 @@
+.. _ttnn.squared_difference:
+
+ttnn.squared_difference
+########################
+
+.. autofunction:: ttnn.squared_difference

--- a/tests/ttnn/sweep_tests/sweeps/atan2.py
+++ b/tests/ttnn/sweep_tests/sweeps/atan2.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_YX": [[20, 40, 40, 80], [-1, 1, -1, 1]],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+    input_YX,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+    a1, a2, b1, b2 = input_YX
+
+    torch_input_tensor_a = torch.linspace(a1, a2, steps=height * width, dtype=torch.bfloat16).reshape(input_shape)
+    torch_input_tensor_b = torch.linspace(b1, b2, steps=height * width, dtype=torch.bfloat16).reshape(input_shape)
+
+    torch_output_tensor = torch.atan2(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.atan2(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/hypot.py
+++ b/tests/ttnn/sweep_tests/sweeps/hypot.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [32, 1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100
+    high = 100
+
+    torch_input_tensor_a = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_output_tensor = torch.hypot(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.hypot(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/isclose.py
+++ b/tests/ttnn/sweep_tests/sweeps/isclose.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [32, 1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "isclose_params": [[1e-5, 1e-8, False], [1e-15, 1e-12, True]],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+    isclose_params,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    rtol, atol, equal_nan = isclose_params
+
+    torch_input_tensor_a = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn(input_shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.isclose(
+        torch_input_tensor_a, torch_input_tensor_b, rtol=rtol, atol=atol, equal_nan=equal_nan
+    )
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.isclose(
+        input_tensor_a, input_tensor_b, rtol, atol, equal_nan, memory_config=output_memory_config
+    )
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/lerp.py
+++ b/tests/ttnn/sweep_tests/sweeps/lerp.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_w_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "weight_is_tensor": [True, False],
+    "weight": [0.3, 0.5],
+    "end": [100],
+    "low": [-10, 10],
+    "high": [40, 80],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    input_w_memory_config,
+    output_memory_config,
+    weight_is_tensor,
+    weight,
+    end,
+    low,
+    high,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch.linspace(low, high, steps=height * width, dtype=torch.bfloat16).reshape(input_shape)
+    torch_input_tensor_b = torch.full(input_shape, end, dtype=torch.bfloat16)
+
+    torch_weight = weight
+    if weight_is_tensor:
+        torch_weight = torch.full(input_shape, weight, dtype=torch.bfloat16)
+
+    torch_output_tensor = torch.lerp(torch_input_tensor_a, torch_input_tensor_b, torch_weight)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    input_weight = weight
+    if weight_is_tensor:
+        input_weight = ttnn.from_torch(
+            torch_weight,
+            dtype=input_a_dtype,
+            device=device,
+            layout=input_a_layout,
+            memory_config=input_w_memory_config,
+        )
+    output_tensor = ttnn.lerp(input_tensor_a, input_tensor_b, input_weight, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/squared_difference.py
+++ b/tests/ttnn/sweep_tests/sweeps/squared_difference.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [32, 1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def torch_squared_difference(x, y, *args, **kwargs):
+    return torch.square(torch.sub(x, y))
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100
+    high = 100
+
+    torch_input_tensor_a = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_output_tensor = torch_squared_difference(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.squared_difference(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_lerp.py
+++ b/tests/ttnn/unit_tests/operations/test_lerp.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from math import pi
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def run_lerp_test_float(device, h, w, low, high, end, weight, ttnn_function, torch_function, pcc=0.9999):
+    torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
+    torch_input_tensor_b = torch.full((h, w), end, dtype=torch.bfloat16)
+
+    torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b, weight)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn_function(input_tensor_a, input_tensor_b, weight)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("weight", [0.5])
+def test_lerp_float_a(device, h, w, weight):
+    run_lerp_test_float(device, h, w, 0, 90, 100, weight, ttnn.lerp, torch.lerp)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("weight", [0.75])
+def test_lerp_float_b(device, h, w, weight):
+    run_lerp_test_float(device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, pcc=0.999)
+
+
+def run_lerp_test_tensor(device, h, w, low, high, end, weight, ttnn_function, torch_function, pcc=0.9999):
+    torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
+    torch_input_tensor_b = torch.full((h, w), end, dtype=torch.bfloat16)
+    torch_weight = torch.full((h, w), weight, dtype=torch.bfloat16)
+
+    torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b, torch_weight)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+    input_weight = ttnn.from_torch(torch_weight, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn_function(input_tensor_a, input_tensor_b, input_weight)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("weight", [0.5])
+def test_lerp_tensor_a(device, h, w, weight):
+    run_lerp_test_tensor(device, h, w, 0, 90, 100, weight, ttnn.lerp, torch.lerp)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("weight", [0.75])
+def test_lerp_tensor_b(device, h, w, weight):
+    run_lerp_test_tensor(device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, pcc=0.999)

--- a/tests/ttnn/unit_tests/operations/test_math_binary.py
+++ b/tests/ttnn/unit_tests/operations/test_math_binary.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from math import pi
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random
+
+
+def run_math_binary_test(device, h, w, ttnn_function, torch_function, pcc=0.9999):
+    torch.manual_seed(0)
+    torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
+    torch.manual_seed(42)
+    torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
+
+    torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn_function(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_hypot_a(device, h, w):
+    run_math_binary_test(device, h, w, ttnn.hypot, torch.hypot)
+
+
+def run_math_binary_test_atan2(device, h, w, a1, a2, b1, b2, ttnn_function, torch_function, pcc=0.9999):
+    torch_input_tensor_a = torch.linspace(a1, a2, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
+    torch_input_tensor_b = torch.linspace(b1, b2, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
+
+    torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn_function(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_atan2_a(device, h, w):
+    run_math_binary_test_atan2(device, h, w, 20, 40, 40, 80, ttnn.atan2, torch.atan2)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_atan2_b(device, h, w):
+    run_math_binary_test_atan2(device, h, w, -1, 1, -1, 1, ttnn.atan2, torch.atan2)
+
+
+def run_math_binary_test_range(device, h, w, ttnn_function, torch_function, low, high, pcc=0.9999):
+    torch.manual_seed(0)
+    torch_input_tensor_a = torch_random((h, w), low, high, dtype=torch.bfloat16)
+    torch.manual_seed(42)
+    torch_input_tensor_b = torch_random((h, w), low, high, dtype=torch.bfloat16)
+
+    torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn_function(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+def torch_squared_difference(x, y, *args, **kwargs):
+    return torch.square(torch.sub(x, y))
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_squared_difference(device, h, w):
+    run_math_binary_test_range(device, h, w, ttnn.squared_difference, torch_squared_difference, -100, 100)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_hypot_b(device, h, w):
+    run_math_binary_test_range(device, h, w, ttnn.hypot, torch.hypot, 0, 100)

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -190,6 +190,7 @@ from ttnn.operations.relational import (
     lte,
     eq,
     ne,
+    isclose,
 )
 
 from ttnn.operations.activation import (
@@ -237,6 +238,10 @@ from ttnn.operations.math import (
     erfinv,
     exp2,
     expm1,
+    atan2,
+    hypot,
+    squared_difference,
+    lerp,
 )
 
 from ttnn.operations.normalization import (

--- a/ttnn/ttnn/operations/math.py
+++ b/ttnn/ttnn/operations/math.py
@@ -145,4 +145,262 @@ def torch_multigammaln(x, *args, **kwargs):
     return result
 
 
+def register_ttl_math_binary_function(name, ttl_math_binary_function, op_name):
+    def _torch_math_binary(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, **_):
+        name_to_torch_function = {
+            "atan2": torch.atan2,
+            "hypot": torch.hypot,
+            "squared_difference": torch_squared_difference,
+        }
+
+        input_shape_a = input_tensor_a.shape
+        slices = [slice(0, dim) for dim in input_shape_a]
+        input_tensor_a = ttnn.from_device(input_tensor_a)
+        input_tensor_a = ttnn.to_layout(input_tensor_a, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_a = ttnn.to_torch(input_tensor_a)
+        input_tensor_a = input_tensor_a[slices]
+
+        input_shape_b = input_tensor_b.shape
+        slices = [slice(0, dim) for dim in input_shape_b]
+        input_tensor_b = ttnn.from_device(input_tensor_b)
+        input_tensor_b = ttnn.to_layout(input_tensor_b, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_b = ttnn.to_torch(input_tensor_b)
+        input_tensor_b = input_tensor_b[slices]
+
+        torch_function = name_to_torch_function[name]
+        return torch_function(input_tensor_a, input_tensor_b)
+
+    def _math_binary_validate_input_tensors(operation_name, input_tensor_a, input_tensor_b, *args, **kwargs):
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor_a,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor_b,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+
+    @ttnn.register_operation(
+        name=f"ttnn.{name}",
+        validate_input_tensors=_math_binary_validate_input_tensors,
+        torch_function=_torch_math_binary,
+    )
+    def math_binary_function(
+        input_tensor_a: ttnn.Tensor,
+        input_tensor_b: Union[ttnn.Tensor, int, float],
+        *,
+        memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    ) -> ttnn.Tensor:
+        if not (input_tensor_a.shape == input_tensor_b.shape):
+            raise RuntimeError("input_tensors must be of same size!")
+
+        if not isinstance(input_tensor_a, ttnn.Tensor) or not isinstance(input_tensor_b, ttnn.Tensor):
+            raise TypeError("Expected both arguments to be a ttnn.Tensor")
+
+        if not ttnn.has_storage_type_of(input_tensor_a, ttnn.DEVICE_STORAGE_TYPE) or not ttnn.has_storage_type_of(
+            input_tensor_b, ttnn.DEVICE_STORAGE_TYPE
+        ):
+            raise RuntimeError("input_tensors must be on device!")
+
+        original_shape = input_tensor_a.shape
+
+        input_tensor_a = ttnn.unsqueeze_to_4D(input_tensor_a)
+        ttl_input_tensor_a = input_tensor_a.value
+
+        input_tensor_b = ttnn.unsqueeze_to_4D(input_tensor_b)
+        ttl_input_tensor_b = input_tensor_b.value
+
+        ttl_output_tensor = ttl_math_binary_function(
+            ttl_input_tensor_a, ttl_input_tensor_b, output_mem_config=memory_config
+        )
+
+        ttl_input_tensor_a = input_tensor_a.value
+        ttl_input_tensor_b = input_tensor_b.value
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        output_tensor = ttnn.reshape(output_tensor, original_shape)
+        return output_tensor
+
+    math_binary_function.__name__ = f"ttnn.{name}"
+    math_binary_function.__doc__ = f"""{name}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
+
+        Performs eltwise-binary {op_name} operation on two tensors :attr:`input_a` and :attr:`input_b`.
+
+        .. math::
+            {name.replace('_',' ')}(\\mathrm{{input\\_tensor\\_a}}_i \\; , \\; \\mathrm{{input\\_tensor\\_b}}_i  \\; \\; or \\; \\; \\mathrm{{scalar}})
+
+        Args:
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+
+        Example::
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 2], [3, 4]]), dtype=torch.bfloat16)), device)
+            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 1], [4, 4]]), dtype=torch.bfloat16)), device)
+            >>> output = ttnn.{name}(tensor1, tensor2)
+        """
+
+    setattr(THIS_MODULE, name, math_binary_function)
+
+
+TTL_BINARY_MATH_FUNCTIONS = [
+    ("atan2", ttl.tensor.atan2, "atan2"),
+    ("hypot", ttl.tensor.hypot, "hypotenuse"),
+    ("squared_difference", ttl.tensor.squared_difference, "squared_difference (input_a - input_b)^2"),
+]
+
+
+for math_binary_function_name, ttl_math_binary_function, op_name in TTL_BINARY_MATH_FUNCTIONS:
+    register_ttl_math_binary_function(math_binary_function_name, ttl_math_binary_function, op_name)
+
+
+def torch_squared_difference(x, y, *args, **kwargs):
+    return torch.square(torch.sub(x, y))
+
+
+def register_ttl_lerp_function(name, ttl_lerp_function, op_name):
+    def _is_scalar(value):
+        return isinstance(value, (int, float))
+
+    def _torch_math_binary(
+        input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, weight: Union[ttnn.Tensor, int, float], **_
+    ):
+        name_to_torch_function = {
+            "lerp": torch.lerp,
+        }
+
+        input_shape_a = input_tensor_a.shape
+        slices = [slice(0, dim) for dim in input_shape_a]
+        input_tensor_a = ttnn.from_device(input_tensor_a)
+        input_tensor_a = ttnn.to_layout(input_tensor_a, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_a = ttnn.to_torch(input_tensor_a)
+        input_tensor_a = input_tensor_a[slices]
+
+        input_shape_b = input_tensor_b.shape
+        slices = [slice(0, dim) for dim in input_shape_b]
+        input_tensor_b = ttnn.from_device(input_tensor_b)
+        input_tensor_b = ttnn.to_layout(input_tensor_b, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_b = ttnn.to_torch(input_tensor_b)
+        input_tensor_b = input_tensor_b[slices]
+
+        if not _is_scalar(weight):
+            weight_shape = weight.shape
+            slices = [slice(0, dim) for dim in weight_shape]
+            weight = ttnn.from_device(weight)
+            weight = ttnn.to_layout(weight, ttnn.ROW_MAJOR_LAYOUT)
+            weight = ttnn.to_torch(weight)
+            weight = weight[slices]
+
+        torch_function = name_to_torch_function[name]
+        return torch_function(input_tensor_a, input_tensor_b)
+
+    def _math_binary_validate_input_tensors(operation_name, input_tensor_a, input_tensor_b, *args, **kwargs):
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor_a,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor_b,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+
+    @ttnn.register_operation(
+        name=f"ttnn.{name}",
+        validate_input_tensors=_math_binary_validate_input_tensors,
+        torch_function=_torch_math_binary,
+    )
+    def lerp_function(
+        input_tensor_a: ttnn.Tensor,
+        input_tensor_b: ttnn.Tensor,
+        weight: Union[ttnn.Tensor, int, float],
+        *,
+        memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    ) -> ttnn.Tensor:
+        if not (input_tensor_a.shape == input_tensor_b.shape):
+            raise RuntimeError("input_tensors must be of same size!")
+
+        if not isinstance(input_tensor_a, ttnn.Tensor) or not isinstance(input_tensor_b, ttnn.Tensor):
+            raise TypeError("Expected both arguments to be a ttnn.Tensor")
+
+        if not ttnn.has_storage_type_of(input_tensor_a, ttnn.DEVICE_STORAGE_TYPE) or not ttnn.has_storage_type_of(
+            input_tensor_b, ttnn.DEVICE_STORAGE_TYPE
+        ):
+            raise RuntimeError("input_tensors must be on device!")
+
+        if isinstance(weight, ttnn.Tensor) and not (input_tensor_a.shape == weight.shape):
+            raise RuntimeError("weight tensor must be of same size!")
+
+        if isinstance(weight, ttnn.Tensor) and not ttnn.has_storage_type_of(weight, ttnn.DEVICE_STORAGE_TYPE):
+            raise RuntimeError("weight tensor must be on device!")
+
+        original_shape = input_tensor_a.shape
+        ttl_weight = weight
+
+        input_tensor_a = ttnn.unsqueeze_to_4D(input_tensor_a)
+        ttl_input_tensor_a = input_tensor_a.value
+
+        input_tensor_b = ttnn.unsqueeze_to_4D(input_tensor_b)
+        ttl_input_tensor_b = input_tensor_b.value
+
+        if isinstance(weight, ttnn.Tensor):
+            weight = ttnn.unsqueeze_to_4D(weight)
+            ttl_weight = weight.value
+
+        ttl_output_tensor = ttl_lerp_function(
+            ttl_input_tensor_a, ttl_input_tensor_b, ttl_weight, output_mem_config=memory_config
+        )
+
+        ttl_input_tensor_a = input_tensor_a.value
+        ttl_input_tensor_b = input_tensor_b.value
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        output_tensor = ttnn.reshape(output_tensor, original_shape)
+        return output_tensor
+
+    lerp_function.__name__ = f"ttnn.{name}"
+    lerp_function.__doc__ = f"""{name}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
+
+        Performs eltwise-binary {op_name} operation on two tensors :attr:`input_a` and :attr:`input_b`.
+
+        .. math::
+            {name.replace('_',' ')}(\\mathrm{{input\\_tensor\\_a}}_i \\; , \\; \\mathrm{{input\\_tensor\\_b}}_i  \\; \\; or \\; \\; \\mathrm{{scalar}})
+
+        Args:
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+
+        Example::
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 2], [3, 4]]), dtype=torch.bfloat16)), device)
+            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 1], [4, 4]]), dtype=torch.bfloat16)), device)
+            >>> output = ttnn.{name}(tensor1, tensor2)
+        """
+
+    setattr(THIS_MODULE, name, lerp_function)
+
+
+TTL_LERP_FUNCTION = [
+    ("lerp", ttl.tensor.lerp, "linear interpolation"),
+]
+
+
+for lerp_function_name, ttl_lerp_function, op_name in TTL_LERP_FUNCTION:
+    register_ttl_lerp_function(lerp_function_name, ttl_lerp_function, op_name)
+
 __all__ = []

--- a/ttnn/ttnn/operations/relational.py
+++ b/ttnn/ttnn/operations/relational.py
@@ -261,4 +261,140 @@ ttnn.Tensor.__ge__ = getattr(THIS_MODULE, "gte")
 ttnn.Tensor.__lt__ = getattr(THIS_MODULE, "lt")
 ttnn.Tensor.__le__ = getattr(THIS_MODULE, "lte")
 
+
+def register_ttl_isclose_function(name, ttl_isclose_function, op_name, param1, param2):
+    def _torch_relational(
+        input_tensor_a: ttnn.Tensor,
+        input_tensor_b: ttnn.Tensor,
+        param1: float = 1e-05,
+        param2: float = 1e-08,
+        equal_nan: bool = False,
+        **_,
+    ):
+        import torch
+
+        name_to_torch_function = {
+            "isclose": torch.isclose,
+        }
+
+        input_shape_a = input_tensor_a.shape
+        slices = [slice(0, dim) for dim in input_shape_a]
+        input_tensor_a = ttnn.from_device(input_tensor_a)
+        input_tensor_a = ttnn.to_layout(input_tensor_a, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_a = ttnn.to_torch(input_tensor_a)
+        input_tensor_a = input_tensor_a[slices]
+
+        input_shape_b = input_tensor_b.shape
+        slices = [slice(0, dim) for dim in input_shape_b]
+        input_tensor_b = ttnn.from_device(input_tensor_b)
+        input_tensor_b = ttnn.to_layout(input_tensor_b, ttnn.ROW_MAJOR_LAYOUT)
+        input_tensor_b = ttnn.to_torch(input_tensor_b)
+        input_tensor_b = input_tensor_b[slices]
+
+        torch_function = name_to_torch_function[name]
+        return torch_function(input_tensor_a, input_tensor_b, rtol=param1, atol=param2, equal_nan=equal_nan)
+
+    def _relational_validate_input_tensors(operation_name, input_tensor_a, input_tensor_b, *args, **kwargs):
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor_a,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor_b,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+
+    @ttnn.register_operation(
+        name=f"ttnn.{name}",
+        validate_input_tensors=_relational_validate_input_tensors,
+        torch_function=_torch_relational,
+    )
+    def isclose_function(
+        input_tensor_a: ttnn.Tensor,
+        input_tensor_b: ttnn.Tensor,
+        rtol: float = 1e-05,
+        atol: float = 1e-08,
+        equal_nan: bool = False,
+        *,
+        memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    ) -> ttnn.Tensor:
+        if not (input_tensor_a.shape == input_tensor_b.shape):
+            raise RuntimeError("input_tensors must be of same size!")
+
+        if not isinstance(input_tensor_a, ttnn.Tensor) or not isinstance(input_tensor_b, ttnn.Tensor):
+            raise TypeError("Expected both arguments to be a ttnn.Tensor")
+
+        if not ttnn.has_storage_type_of(input_tensor_a, ttnn.DEVICE_STORAGE_TYPE) or not ttnn.has_storage_type_of(
+            input_tensor_b, ttnn.DEVICE_STORAGE_TYPE
+        ):
+            raise RuntimeError("input_tensors must be on device!")
+
+        if not _is_scalar(atol) or not _is_scalar(rtol):
+            raise TypeError("Expected float parameters!")
+
+        original_shape = input_tensor_a.shape
+
+        input_tensor_a = ttnn.unsqueeze_to_4D(input_tensor_a)
+        ttl_input_tensor_a = input_tensor_a.value
+
+        input_tensor_b = ttnn.unsqueeze_to_4D(input_tensor_b)
+        ttl_input_tensor_b = input_tensor_b.value
+
+        ttl_output_tensor = ttl_isclose_function(
+            ttl_input_tensor_a, ttl_input_tensor_b, rtol, atol, equal_nan, output_mem_config=memory_config
+        )
+
+        ttl_input_tensor_a = input_tensor_a.value
+        ttl_input_tensor_b = input_tensor_b.value
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        output_tensor = ttnn.reshape(output_tensor, original_shape)
+        return output_tensor
+
+    isclose_function.__name__ = f"ttnn.{name}"
+    isclose_function.__doc__ = f"""{name}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
+
+        Applies the {name} function to the elements of the input tensor :attr:`input_a` and :attr:`input_b`.
+        {op_name}
+
+        .. math::
+            {name.replace('_',' ')}(\\mathrm{{input\\_tensor\\_a}}_i \\; , \\; \\mathrm{{input\\_tensor\\_b}}_i  \\; , \\; \\mathrm{{atol}}\\; , \\; \\mathrm{{rtol}})
+
+        Args:
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+
+        Example::
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 2], [3, 4]]), dtype=torch.bfloat16)), device)
+            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1 + 1e-10, 1], [4, 4 + 1e-10]]), dtype=torch.bfloat16)), device)
+            >>> output = ttnn.{name}(tensor1, tensor2, {param2}, {param1})
+        """
+
+    setattr(THIS_MODULE, name, isclose_function)
+
+
+TTL_ISCLOSE_FUNCTION = [
+    (
+        "isclose",
+        ttl.tensor.isclose,
+        "isclose(input_a, input_b, rtol, atol) = ∣input_a−input_B∣ ≤ atol+rtol×∣input_b∣.",
+        "atol",
+        "rtol",
+    ),
+]
+
+
+for isclose_function_name, ttl_isclose_function, op_name, param1, param2 in TTL_ISCLOSE_FUNCTION:
+    register_ttl_isclose_function(isclose_function_name, ttl_isclose_function, op_name, param1, param2)
+
+
 __all__ = []


### PR DESCRIPTION
Add math ops to ttnn
CI test: 
[Fast Dispatch](https://github.com/tenstorrent-metal/tt-metal/actions/runs/7942556974)
[Slow Dispatch](https://github.com/tenstorrent-metal/tt-metal/actions/runs/7942559616)
Sweep tests: 
[atan2.csv](https://github.com/tenstorrent-metal/tt-metal/files/14319453/atan2.csv)
[hypot.csv](https://github.com/tenstorrent-metal/tt-metal/files/14319454/hypot.csv)
[isclose.csv](https://github.com/tenstorrent-metal/tt-metal/files/14319455/isclose.csv)
[lerp.csv](https://github.com/tenstorrent-metal/tt-metal/files/14319456/lerp.csv)
[squared_difference.csv](https://github.com/tenstorrent-metal/tt-metal/files/14319457/squared_difference.csv)
