### PR TITLE
#5099: Add dprint/watcher enabled to kernel hash

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
@@ -140,8 +140,6 @@ bool dram_single_core (CommonFixture* fixture, tt_metal::Device *device, const D
 }
 
 TEST_F(CommonFixture, DRAMLoopbackSingleCore){
-    // disabled since it seems to corrupt the WatcherSanitize tests ..
-    GTEST_SKIP();
     uint32_t buffer_size = 2 * 1024 * 50;
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -47,11 +47,15 @@ namespace{
         // Account for device id in hash because generated headers are dependent on harvesting config, which can differ per device
         // This can be removed with https://github.com/tenstorrent-metal/tt-metal/issues/3381
 
+        // Also account for watcher/dprint enabled in hash because they enable additional code to
+        // be compiled into the kernel.
         string compile_hash_str = fmt::format(
-            "{}_{}_{}",
+            "{}_{}_{}_{}_{}",
             device_id,
             std::to_string(std::hash<tt_hlk_desc>{}(build_options.hlk_desc)),
-            kernel->compute_hash()
+            kernel->compute_hash(),
+            tt::llrt::OptionsG.get_watcher_enabled(),
+            tt::llrt::OptionsG.get_dprint_enabled()
         );
         size_t compile_hash = std::hash<std::string>{}(compile_hash_str);
 


### PR DESCRIPTION
Need to do this because these flags change what code gets compiled, previous issue was due to skipping compilation when enabling watcher on a kernel that was already compiled.

CI passing: https://github.com/tenstorrent-metal/tt-metal/actions/runs/7981012406