### PR TITLE
#5517: Add activation ops to ttnn

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 515
+personal_ws-1.1 en 519
 ABI
 ADDI
 API
@@ -271,10 +271,12 @@ funcs
 gcc
 gdb
 gdb's
+geglu
 gelu
 genindex
 getitem
 gez
+glu
 grayskull
 grey
 gte
@@ -395,6 +397,7 @@ rb
 rdiv
 recip
 reconfig
+reglu
 regs
 reigster
 relu
@@ -454,6 +457,7 @@ submodule
 subvec
 sudo
 svg
+swiglu
 sys
 tanh
 tanhshrink

--- a/docs/source/ttnn/api.rst
+++ b/docs/source/ttnn/api.rst
@@ -93,7 +93,9 @@ Pointwise Unary
    ttnn/exp
    ttnn/exp2
    ttnn/expm1
+   ttnn/geglu
    ttnn/gelu
+   ttnn/glu
    ttnn/hardshrink
    ttnn/hardsigmoid
    ttnn/hardswish
@@ -120,6 +122,7 @@ Pointwise Unary
    ttnn/multigammaln
    ttnn/neg
    ttnn/prelu
+   ttnn/reglu
    ttnn/relu
    ttnn/relu6
    ttnn/rsqrt
@@ -141,6 +144,7 @@ Pointwise Unary
    ttnn/reciprocal
    ttnn/sqrt
    ttnn/square
+   ttnn/swiglu
    ttnn/tril
    ttnn/triu
    ttnn/tanhshrink

--- a/docs/source/ttnn/ttnn/geglu.rst
+++ b/docs/source/ttnn/ttnn/geglu.rst
@@ -1,0 +1,6 @@
+.. _ttnn.geglu:
+
+ttnn.geglu
+###############
+
+.. autofunction:: ttnn.geglu

--- a/docs/source/ttnn/ttnn/glu.rst
+++ b/docs/source/ttnn/ttnn/glu.rst
@@ -1,0 +1,6 @@
+.. _ttnn.glu:
+
+ttnn.glu
+###############
+
+.. autofunction:: ttnn.glu

--- a/docs/source/ttnn/ttnn/reglu.rst
+++ b/docs/source/ttnn/ttnn/reglu.rst
@@ -1,0 +1,6 @@
+.. _ttnn.reglu:
+
+ttnn.reglu
+###############
+
+.. autofunction:: ttnn.reglu

--- a/docs/source/ttnn/ttnn/swiglu.rst
+++ b/docs/source/ttnn/ttnn/swiglu.rst
@@ -1,0 +1,6 @@
+.. _ttnn.swiglu:
+
+ttnn.swiglu
+###############
+
+.. autofunction:: ttnn.swiglu

--- a/tests/ttnn/sweep_tests/sweeps/geglu.py
+++ b/tests/ttnn/sweep_tests/sweeps/geglu.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [64, 1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def torch_geglu(input_tensor, *args, **kwargs):
+    split_size = input_tensor.size(-1) // 2
+    split_tensors = torch.split(input_tensor, split_size_or_sections=[split_size, split_size], dim=-1)
+    tensA, tensB = split_tensors[0], split_tensors[1]
+    return tensA * F.gelu(tensB)
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100.0
+    high = 100.0
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
+    torch_output_tensor = torch_geglu(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.geglu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/glu.py
+++ b/tests/ttnn/sweep_tests/sweeps/glu.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [64, 1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100.0
+    high = 100.0
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
+    torch_output_tensor = F.glu(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.glu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/reglu.py
+++ b/tests/ttnn/sweep_tests/sweeps/reglu.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [64, 1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def torch_reglu(input_tensor, *args, **kwargs):
+    split_size = input_tensor.size(-1) // 2
+    split_tensors = torch.split(input_tensor, split_size_or_sections=[split_size, split_size], dim=-1)
+    tensA, tensB = split_tensors[0], split_tensors[1]
+    return tensA * F.relu(tensB)
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100.0
+    high = 100.0
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
+    torch_output_tensor = torch_reglu(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.reglu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/swiglu.py
+++ b/tests/ttnn/sweep_tests/sweeps/swiglu.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [64, 1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def torch_swiglu(input_tensor, *args, **kwargs):
+    split_size = input_tensor.size(-1) // 2
+    split_tensors = torch.split(input_tensor, split_size_or_sections=[split_size, split_size], dim=-1)
+    tensA, tensB = split_tensors[0], split_tensors[1]
+    return tensA * F.silu(tensB)
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100.0
+    high = 100.0
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
+    torch_output_tensor = torch_swiglu(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    output_tensor = ttnn.swiglu(input_tensor, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/test_activation.py
@@ -106,6 +106,70 @@ def test_tanhshrink(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.tanhshrink, F.tanhshrink)
 
 
+def run_activation_unary_test_glu(device, batch_size, h, w, ttnn_function, torch_function, pcc=0.99):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16).unsqueeze(0)
+    torch_output_tensor = torch_function(torch_input_tensor)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn_function(input_tensor)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_glu(device, batch_size, h, w):
+    run_activation_unary_test_glu(device, batch_size, h, w, ttnn.glu, F.glu)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_reglu(device, batch_size, h, w):
+    run_activation_unary_test_glu(device, batch_size, h, w, ttnn.reglu, torch_reglu)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_swiglu(device, batch_size, h, w):
+    run_activation_unary_test_glu(device, batch_size, h, w, ttnn.swiglu, torch_swiglu)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_geglu(device, batch_size, h, w):
+    run_activation_unary_test_glu(device, batch_size, h, w, ttnn.geglu, torch_geglu)
+
+
+def torch_reglu(input_tensor, *args, **kwargs):
+    split_size = input_tensor.size(-1) // 2
+    split_tensors = torch.split(input_tensor, split_size_or_sections=[split_size, split_size], dim=-1)
+    tensA, tensB = split_tensors[0], split_tensors[1]
+    return tensA * F.relu(tensB)
+
+
+def torch_swiglu(input_tensor, *args, **kwargs):
+    split_size = input_tensor.size(-1) // 2
+    split_tensors = torch.split(input_tensor, split_size_or_sections=[split_size, split_size], dim=-1)
+    tensA, tensB = split_tensors[0], split_tensors[1]
+    return tensA * F.silu(tensB)
+
+
+def torch_geglu(input_tensor, *args, **kwargs):
+    split_size = input_tensor.size(-1) // 2
+    split_tensors = torch.split(input_tensor, split_size_or_sections=[split_size, split_size], dim=-1)
+    tensA, tensB = split_tensors[0], split_tensors[1]
+    return tensA * F.gelu(tensB)
+
+
 def torch_heaviside(x, *args, **kwargs):
     value = kwargs.pop("scalar")
     result = torch.heaviside(x, torch.tensor(value, dtype=x.dtype))

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -225,6 +225,10 @@ from ttnn.operations.activation import (
     softplus,
     tanhshrink,
     threshold,
+    glu,
+    geglu,
+    reglu,
+    swiglu,
 )
 
 from ttnn.operations.math import (

--- a/ttnn/ttnn/operations/activation.py
+++ b/ttnn/ttnn/operations/activation.py
@@ -267,6 +267,103 @@ def register_ttl_activation_function_with_two_float(name, ttl_activation_functio
     setattr(THIS_MODULE, name, activation_function)
 
 
+def torch_reglu(input_tensor, *args, **kwargs):
+    split_size = input_tensor.size(-1) // 2
+    split_tensors = torch.split(input_tensor, split_size_or_sections=[split_size, split_size], dim=-1)
+    tensA, tensB = split_tensors[0], split_tensors[1]
+    return tensA * F.relu(tensB)
+
+
+def torch_swiglu(input_tensor, *args, **kwargs):
+    split_size = input_tensor.size(-1) // 2
+    split_tensors = torch.split(input_tensor, split_size_or_sections=[split_size, split_size], dim=-1)
+    tensA, tensB = split_tensors[0], split_tensors[1]
+    return tensA * F.silu(tensB)
+
+
+def torch_geglu(input_tensor, *args, **kwargs):
+    split_size = input_tensor.size(-1) // 2
+    split_tensors = torch.split(input_tensor, split_size_or_sections=[split_size, split_size], dim=-1)
+    tensA, tensB = split_tensors[0], split_tensors[1]
+    return tensA * F.gelu(tensB)
+
+
+def register_ttl_activation_function_glu(name, ttl_activation_function, op_name, param):
+    def _torch_activation(input_tensor: ttnn.Tensor, dim: int = -1, **_):
+        name_to_torch_function = {
+            "glu": F.glu,
+            "reglu": torch_reglu,
+            "swiglu": torch_swiglu,
+            "geglu": torch_geglu,
+        }
+        torch_function = name_to_torch_function[name]
+        input_tensor = ttnn.to_torch(input_tensor)
+
+        return torch_function(input_tensor, dim=dim)
+
+    def _activation_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+
+    @ttnn.register_operation(
+        name=f"ttnn.{name}",
+        validate_input_tensors=_activation_validate_input_tensors,
+        torch_function=_torch_activation,
+    )
+    def activation_function(
+        input_tensor: ttnn.Tensor, dim: int = -1, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG
+    ) -> ttnn.Tensor:
+        input_shape = tuple(input_tensor.shape)
+        last_dim = input_shape[-1]
+        glu_shape = input_shape[:-1] + (int(last_dim / 2),)
+
+        input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+        ttl_input_tensor = input_tensor.value
+
+        if not isinstance(input_tensor, ttnn.Tensor):
+            raise TypeError("Expected first argument to be a ttnn.Tensor")
+
+        if not _is_scalar(dim):
+            raise TypeError("Expected second argument to be a float")
+
+        if not ttnn.has_storage_type_of(input_tensor, ttnn.DEVICE_STORAGE_TYPE):
+            raise RuntimeError("input_tensor must be on device!")
+        ttl_input_tensor = input_tensor.value
+
+        ttl_output_tensor = ttl_activation_function(ttl_input_tensor, dim, output_mem_config=memory_config)
+
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        output_tensor = ttnn.reshape(output_tensor, ttnn.Shape(glu_shape))
+        return output_tensor
+
+    activation_function.__name__ = f"ttnn.{(name)}"
+    activation_function.__doc__ = f"""{(name)}(input_tensor: ttnn.Tensor, dim: int = -1, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
+
+        Applies the {op_name} function to the elements of the input tensor :attr:`input_tensor` split along :attr:`{param}`.
+
+        .. math::
+            {(name)}(\\mathrm{{input\\_tensor}}_i  \\; , \\; {param})
+
+        Args:
+            * :attr:`input_tensor`
+            * :attr:`{param}`
+
+        Example::
+
+            >>> tensor = ttnn.from_torch(torch.tensor((32, 64), dtype=torch.bfloat16), device=device)
+            >>> output = ttnn.{(name)}(tensor, {param})
+
+        """
+    setattr(THIS_MODULE, name, activation_function)
+
+
 TTL_ACTIVATION_FUNCTIONS_UNARY = [
     ("hardsigmoid", ttl.tensor.hardsigmoid, "hardsigmoid"),
     ("hardswish", ttl.tensor.hardswish, "hardswish"),
@@ -296,6 +393,13 @@ TTL_ACTIVATION_FUNCTIONS_WITH_TWO_FLOAT_PARAM = [
     ("threshold", ttl.tensor.threshold, "threshold", "value", "threshold"),
 ]
 
+TTL_ACTIVATION_FUNCTIONS_GLU = [
+    ("glu", ttl.tensor.glu, "Gated Linear Units (GLU)", "dim"),
+    ("reglu", ttl.tensor.reglu, "Rectified Gated Linear Units (ReGLU)", "dim"),
+    ("swiglu", ttl.tensor.swiglu, "Swish Gated Linear Units (SwiGLU)", "dim"),
+    ("geglu", ttl.tensor.geglu, "Gaussian Error Gated Linear Units (GeGLU)", "dim"),
+]
+
 for activation_function_name, ttl_activation_function, name, param in TTL_ACTIVATION_FUNCTIONS_WITH_FLOAT_PARAM:
     register_ttl_activation_function_with_float(activation_function_name, ttl_activation_function, name, param)
 
@@ -312,5 +416,8 @@ for (
 
 for activation_function_name, ttl_activation_function, name in TTL_ACTIVATION_FUNCTIONS_UNARY:
     register_ttl_activation_function_unary(activation_function_name, ttl_activation_function, name)
+
+for activation_function_name, ttl_activation_function, op_name, param in TTL_ACTIVATION_FUNCTIONS_GLU:
+    register_ttl_activation_function_glu(activation_function_name, ttl_activation_function, op_name, param)
 
 __all__ = []


### PR DESCRIPTION
Add activation ops to ttnn
CI Test link:
[Slow](https://github.com/tenstorrent-metal/tt-metal/actions/runs/7994183946)
[Fast](https://github.com/tenstorrent-metal/tt-metal/actions/runs/7994181023)
Sweep tests:
[geglu.csv](https://github.com/tenstorrent-metal/tt-metal/files/14368273/geglu.csv)
[glu.csv](https://github.com/tenstorrent-metal/tt-metal/files/14368274/glu.csv)
[reglu.csv](https://github.com/tenstorrent-metal/tt-metal/files/14368275/reglu.csv)
[swiglu.csv](https://github.com/tenstorrent-metal/tt-metal/files/14368276/swiglu.csv)
