### PR TITLE
#0: Add fail-fast: false for build-and-upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-upload:
     strategy:
+      fail-fast: false
       matrix:
         config: [debug, assert, release]
         arch: [grayskull, wormhole_b0]


### PR DESCRIPTION
 because GPG key fetchin…g timeout is causing immediate reds, which we don't necessarily want all the time, which is skewing our results into thinking compiles fail