### PR TITLE
#5531: Remove ppa registration for Git

### DIFF
--- a/.github/actions/install-metal-dev-deps/action.yml
+++ b/.github/actions/install-metal-dev-deps/action.yml
@@ -28,7 +28,6 @@ runs:
       run: |
         DEPENDENCIES=$(jq -r --arg os "${{ inputs.os }}" '.[$os] | .[]' $GITHUB_ACTION_PATH/dependencies.json)
         echo $DEPENDENCIES
-        sudo add-apt-repository ppa:git-core/ppa
         sudo apt update
         sudo apt install $DEPENDENCIES
     - name: Install doxygen

--- a/.github/actions/install-metal-dev-deps/dependencies.json
+++ b/.github/actions/install-metal-dev-deps/dependencies.json
@@ -1,4 +1,5 @@
 {
+  "_comments": "We do not include git and git-lfs here along with the PPA command 'sudo add-apt-repository ppa:git-core/ppa' for registering the apt repository to install those packages because we were timing out the GPG fetching by hammering it",
   "ubuntu-20.04": [
     "git",
     "git-lfs",


### PR DESCRIPTION
… because we already have Git stuff on the runner + we're timing on GPG fetching. Also add a comment in dependencies.json explaining what happened