### PR TITLE
#4982: Update remaining actions to use Node 20

### DIFF
--- a/.github/actions/stress-build-and-run/action.yml
+++ b/.github/actions/stress-build-and-run/action.yml
@@ -29,7 +29,7 @@ runs:
         ./tests/scripts/run_tests.sh --tt-arch ${{ arch }} --pipeline-type stress_post_commit --dispatch-mode ${{ dispatch }}
     - name: Upload watcher log
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: watcher-log-${{ arch }}-${{ machine }}
         path: built/watcher.log

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5.0.0
         with:
           python-version: '3.8'
           cache: 'pip'

--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -71,10 +71,10 @@ jobs:
         run: |
           touch gh_pages/index.html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: "gh_pages"
       - name: Deploy to GitHub Pages
         if: ${{ github.ref == 'refs/heads/main' }}
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4.0.4

--- a/.github/workflows/eager-package-main.yaml
+++ b/.github/workflows/eager-package-main.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: ./.github/actions/install-metal-deps
         with:
           os: ${{ matrix.os }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: eager-dist-${{ matrix.os }}-${{ matrix.arch }}
       - name: Set up end-to-end tests environment
@@ -73,7 +73,7 @@ jobs:
         with:
           submodules: recursive
           lfs: false
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: eager-dist-${{ matrix.os }}-${{ matrix.runner-hw-info.arch }}
       - name: Set up end-to-end tests environment

--- a/.github/workflows/eager-package.yaml
+++ b/.github/workflows/eager-package.yaml
@@ -32,7 +32,7 @@ jobs:
           os: ${{ inputs.os }}
       - name: Clean up dirty files
         run: git clean -f -d
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5.0.0
         with:
           python-version: '3.8'
           cache: 'pip'
@@ -49,7 +49,7 @@ jobs:
       - name: Build Python package distribution
         run: python -m build
       - name: Upload distribution as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: eager-dist-${{ inputs.os }}-${{ inputs.arch }}
           path: dist/

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -39,7 +39,7 @@ jobs:
         timeout-minutes: 45
         run: ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type microbenchmarks
       - name: Upload microbenchmark report csvs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: microbenchmark-report-csv-${{ matrix.runner-info.arch }}
           path: generated/profiler/.logs

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -38,7 +38,7 @@ jobs:
   create-tag:
     needs: get-params
     if: ${{ fromJSON(needs.get-params.outputs.should-create-release) }}
-    uses: tenstorrent-metal/metal-workflows/.github/workflows/release-verify-or-create-tag.yaml@main
+    uses: tenstorrent-metal/metal-workflows/.github/workflows/release-verify-or-create-tag.yaml@v2.0.1
     with:
       fetch_depth: 0
       bump_each_commit: false
@@ -59,7 +59,7 @@ jobs:
       - name: Output changelog
         run: cat CHANGELOG.txt
       - name: Upload changelog as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: changelog
           path: CHANGELOG.txt
@@ -100,13 +100,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Download eager Python packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: eager-dist-${{ matrix.os }}-${{ matrix.arch }}
       - name: Create VERSION
         run: echo ${{ needs.create-tag.outputs.version }} > VERSION
       - name : Download changelog
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: changelog
       - name: Assert wheels exist
@@ -115,7 +115,9 @@ jobs:
         # releases to allow for easier installing for Python users.
         run: ls -arhl metal_libs-*+*.whl
       - name: Release
-        uses: softprops/action-gh-release@v1
+        # A major release has not been tagged yet, so we need to do this to avoid
+        # Node 16 deprecation warning message
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
           tag_name: ${{ needs.create-tag.outputs.version }}
           name: ${{ needs.create-tag.outputs.version }}

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -49,7 +49,7 @@ jobs:
           ls -hal $DEVICE_PERF_REPORT_FILENAME
           echo "device_perf_report_filename=$DEVICE_PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
       - name: Upload device perf report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: device-perf-report-csv-${{ matrix.runner-info.arch }}-${{ matrix.runner-info.machine-type }}
           path: "${{ steps.check-device-perf-report.outputs.device_perf_report_filename }}"

--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -50,7 +50,7 @@ jobs:
           ls -hal $PERF_REPORT_FILENAME
           echo "perf_report_filename=$PERF_REPORT_FILENAME" >> "$GITHUB_OUTPUT"
       - name: Upload perf report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: perf-report-csv-${{ matrix.runner-info.arch }}-${{ matrix.runner-info.machine-type }}
           path: "${{ steps.check-perf-report.outputs.perf_report_filename }}"

--- a/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
@@ -40,7 +40,7 @@ jobs:
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type stress_post_commit --dispatch-mode fast
       - name: Upload watcher log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: watcher-log-${{ matrix.runner-info.arch }}-${{ matrix.runner-info.machine-type }}
           path: built/watcher.log

--- a/.github/workflows/stress-slow-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-slow-dispatch-build-and-unit-tests.yaml
@@ -39,7 +39,7 @@ jobs:
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type stress_post_commit --dispatch-mode slow
       - name: Upload watcher log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: watcher-log-${{ matrix.runner-info.arch }}-${{ matrix.runner-info.machine-type }}
           path: built/watcher.log

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Assert that csvs exist in expected ttnn results folder
         run: ls -hal tests/ttnn/sweep_tests/results/*.csv
       - name: Upload ttnn sweep reports csvs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ttnn-sweeps-report-csv-${{ matrix.arch }}
           path: tests/ttnn/sweep_tests/results/*.csv


### PR DESCRIPTION
 such as artifact       actions, docs actions, etc, specific for:
       - Static checks
       - Docs pipelines
       - Packaging and release pipelines
       - Perf + u-benchmark pipelines for results
       - Stress tests watcher logs
       - ttnn sweeps