### PR TITLE
[Falcon7b] Fix bugs with attention computation and rename obsolete variables in tests

### DIFF
--- a/models/demos/falcon7b/tests/test_falcon_attention.py
+++ b/models/demos/falcon7b/tests/test_falcon_attention.py
@@ -67,7 +67,7 @@ def run_test_FalconAttention_inference(
     layer_num = 0
     base_url = "transformer.h"
     max_position_embeddings = 2048
-    head_dim = configuration.hidden_size // configuration.n_head
+    head_dim = configuration.hidden_size // configuration.num_attention_heads
 
     # Generate input, attention_mask, and kv_cache --------------------------------------
     # TODO: Generate attention_mask on device
@@ -83,7 +83,7 @@ def run_test_FalconAttention_inference(
 
         tt_attention_input = torch2tt_tensor(attention_input.unsqueeze(1), device)
         tt_attention_mask = torch2tt_tensor(
-            (attention_mask_bool * -100000).expand(-1, configuration.n_head, -1, -1),
+            (attention_mask_bool * -100000).expand(-1, configuration.num_attention_heads, -1, -1),
             device,
         )
         tt_k_cache = torch.zeros(batch, max_position_embeddings, head_dim)
@@ -118,7 +118,7 @@ def run_test_FalconAttention_inference(
         tt_attention_mask = torch2tt_tensor(
             (attention_mask_bool_padded.transpose(0, 2) * -100000).expand(
                 -1,
-                configuration.n_head,
+                configuration.num_attention_heads,
                 -1,
                 -1
                 # -1, 71, -1, -1
@@ -154,7 +154,7 @@ def run_test_FalconAttention_inference(
         base_url,
         layer_num,
         configuration.hidden_size,
-        configuration.n_head,
+        configuration.num_attention_heads,
         # 4544,
         # 71,
         max_position_embeddings,

--- a/models/demos/falcon7b/tests/test_falcon_attention.py
+++ b/models/demos/falcon7b/tests/test_falcon_attention.py
@@ -100,7 +100,6 @@ def run_test_FalconAttention_inference(
         attention_input = (torch.rand(batch, q_len, configuration.hidden_size) * 2) - 1
         # attention_input = (torch.rand(batch, q_len, 4544) * 2) - 1
         attention_mask_bool = torch.zeros(batch, 1, q_len, kv_len, dtype=bool)
-        attention_mask_bool[:, :, :, -1] = True
         k_cache = torch.rand(batch, kv_cache_len, head_dim)
         v_cache = torch.rand(batch, kv_cache_len, head_dim)
         layer_past = (k_cache, v_cache)

--- a/models/demos/falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon7b/tests/test_falcon_causallm.py
@@ -57,7 +57,7 @@ def run_test_FalconCausalLM_inference(
     tt_cache_path,
     model_location_generator,
 ):
-    model_name = model_location_generator(model_version, model_subdir="Falcon", low_cpu_mem_usage=True)
+    model_name = model_location_generator(model_version, model_subdir="Falcon")
 
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name)
 
@@ -69,7 +69,7 @@ def run_test_FalconCausalLM_inference(
     torch.manual_seed(0)
     base_url = ""
     max_position_embeddings = 2048
-    head_dim = configuration.hidden_size // configuration.n_head
+    head_dim = configuration.hidden_size // configuration.num_attention_heads
     use_cache = True
 
     if 1:

--- a/models/demos/falcon7b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon7b/tests/test_falcon_decoder.py
@@ -100,7 +100,6 @@ def run_test_FalconDecoder_inference(
 
         decoder_input = (torch.rand(batch, q_len, configuration.hidden_size) * 2) - 1
         attention_mask_bool = torch.zeros(batch, 1, q_len, kv_len, dtype=bool)
-        attention_mask_bool[:, :, :, -1] = True
         k_cache = torch.rand(batch, kv_cache_len, head_dim)
         v_cache = torch.rand(batch, kv_cache_len, head_dim)
         layer_past = (k_cache, v_cache)

--- a/models/demos/falcon7b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon7b/tests/test_falcon_decoder.py
@@ -54,7 +54,7 @@ def run_test_FalconDecoder_inference(
     tt_cache_path,
     model_location_generator,
 ):
-    model_name = model_location_generator(model_version, model_subdir="Falcon", low_cpu_mem_usage=True)
+    model_name = model_location_generator(model_version, model_subdir="Falcon")
 
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name)
     hugging_face_reference_model.eval()
@@ -66,7 +66,7 @@ def run_test_FalconDecoder_inference(
     decoder_input = (torch.rand(batch, seq_len, configuration.hidden_size) * 2) - 1
     base_url = "transformer.h"
     max_position_embeddings = 2048
-    head_dim = configuration.hidden_size // configuration.n_head
+    head_dim = configuration.hidden_size // configuration.num_attention_heads
     use_cache = True
     user_id = 0
 
@@ -84,7 +84,7 @@ def run_test_FalconDecoder_inference(
 
         tt_decoder_input = torch2tt_tensor(decoder_input.unsqueeze(1), device)
         tt_attention_mask = torch2tt_tensor(
-            (attention_mask_bool * -100000).expand(-1, configuration.n_head, -1, -1),
+            (attention_mask_bool * -100000).expand(-1, configuration.num_attention_heads, -1, -1),
             device,
         )
         tt_k_cache = torch.zeros(batch, max_position_embeddings, head_dim)
@@ -116,7 +116,9 @@ def run_test_FalconDecoder_inference(
             dim=-1,
         )
         tt_attention_mask = torch2tt_tensor(
-            (attention_mask_bool_padded.transpose(0, 2) * -100000).expand(-1, configuration.n_head, -1, -1),
+            (attention_mask_bool_padded.transpose(0, 2) * -100000).expand(
+                -1, configuration.num_attention_heads, -1, -1
+            ),
             device,
         )
         tt_k_cache = torch.zeros(batch, max_position_embeddings, head_dim)

--- a/models/demos/falcon7b/tests/test_falcon_model.py
+++ b/models/demos/falcon7b/tests/test_falcon_model.py
@@ -217,8 +217,8 @@ def run_test_FalconModel_inference(
 )
 @pytest.mark.parametrize(
     "num_layers, pcc",
-    ((2, 0.98), (32, 0.98)),
-    ids=["layers_2", "layers_32"],
+    ((1, 0.98), (2, 0.98), (32, 0.98)),
+    ids=["layers_1", "layers_2", "layers_32"],
 )
 @pytest.mark.parametrize(
     "model_version",

--- a/models/demos/falcon7b/tests/test_falcon_model.py
+++ b/models/demos/falcon7b/tests/test_falcon_model.py
@@ -62,7 +62,7 @@ def run_test_FalconModel_inference(
     torch.manual_seed(0)
     base_url = "transformer"
     max_position_embeddings = 2048
-    head_dim = configuration.hidden_size // configuration.n_head
+    head_dim = configuration.hidden_size // configuration.num_attention_heads
     use_cache = True
 
     if 1:

--- a/models/demos/falcon7b/tt/falcon_attention.py
+++ b/models/demos/falcon7b/tt/falcon_attention.py
@@ -124,7 +124,6 @@ class TtFalconAttention(nn.Module):
         self.device = device
         self.state_dict = state_dict
         self.model_config = model_config
-        self.temperature = 0.92
 
         if (self.head_dim * num_heads) != self.hidden_size:
             raise ValueError(
@@ -330,7 +329,6 @@ class TtFalconAttention(nn.Module):
         ### SOFTMAX ###
         ###############
         # TODO: Replace with scaled_softmax_attention_mask from BERT
-        attn_weights = tt_lib.tensor.mul_unary(attn_weights, 1 / self.temperature)
         attn_weights = tt_lib.operations.primary.softmax_in_place(
             attn_weights,
         )

--- a/models/demos/falcon7b/tt/falcon_model.py
+++ b/models/demos/falcon7b/tt/falcon_model.py
@@ -151,7 +151,6 @@ class TtFalconModelShared(torch.nn.Module):
             )
 
             attention_mask_bool = torch.zeros(batch_size, 1, sequence_size, num_input_tokens, dtype=bool)
-            attention_mask_bool[:, :, :, -1] = True
 
             num_max_tokens = nearest_32(
                 kv_cache_len + 1


### PR DESCRIPTION
- Remove hardcoded temperature param in attention and fix bug with attention mask (input token index should not be masked) to improve single layer pcc from 0.87 to 0.996
- Fix obsolete variables in model tests which are not regularly tested
- Log top 1/5 accuracy in perf test