### PR TITLE
#0: Fix watcher interval timing to include polling time

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
@@ -50,7 +50,7 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
     // The kernels need arguments to be passed in: the number of cycles to delay while syncing,
     // and an L1 buffer to use for the syncing.
     uint32_t clk_mhz = tt::Cluster::instance().get_device_aiclk(device->id());
-    uint32_t delay_cycles = clk_mhz * 1000000; // 1 second
+    uint32_t delay_cycles = clk_mhz * 2000000; // 2 seconds
     tt_metal::InterleavedBufferConfig l1_config {
         .device = device,
         .size = sizeof(uint32_t),


### PR DESCRIPTION
The intermittent issue we're seeing on CI is due to the fact that on VM-22 the watcher polling time can be a little variable (perhaps this machine slows down when loaded), and so sometimes didn't poll quickly enough to catch the waypoint updates in TestWatcherWaypoints.

Two issues fixed here
(1) Fix the watcher polling interval to include the actual polling time. Previously we would poll and then wait the set interval time, but now we include the polling time when waiting between intervals.
(2) The timing was a bit tight on the TestWatcherWaypoints, which uses hard-coded delays and assumes the set watcher polling interval for the test is fast enough to catch them. The timing was a bit tight here so bump up the devices wait times for this test.

Running CI here:
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8012343263
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8012340965
Verified this fix works on VM-22 (running 100 times in a row all passing, previously failed within 30 runs)