### PR TITLE
#4438: Simplify Buffer creation API

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/buffer/test_sharded_l1.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/buffer/test_sharded_l1.cpp
@@ -61,30 +61,17 @@ namespace local_test_functions {
 bool l1_buffer_read_write(Device* device, const L1Config& test_config) {
     bool pass = true;
 
-
-    std::variant<BufferConfig, ShardedBufferConfig> config;
-
-    if (test_config.sharded) {
-        config = tt::tt_metal::ShardedBufferConfig{
-                    .device=device,
-                    .size = test_config.size_bytes,
-                    .page_size = test_config.page_size_bytes,
-                    .buffer_layout = test_config.buffer_layout,
-                    .shard_parameters = test_config.shard_spec()
-        };
-    }
-    else {
-        config = tt::tt_metal::BufferConfig{
-                    .device=device,
-                    .size = test_config.size_bytes,
-                    .page_size = test_config.page_size_bytes,
-                    .buffer_layout = test_config.buffer_layout
-        };
-
-    }
-
-    auto buffer = CreateBuffer(config);
-
+    auto buffer = test_config.sharded ? CreateBuffer(tt::tt_metal::ShardedBufferConfig{
+                                            .device = device,
+                                            .size = test_config.size_bytes,
+                                            .page_size = test_config.page_size_bytes,
+                                            .buffer_layout = test_config.buffer_layout,
+                                            .shard_parameters = test_config.shard_spec()})
+                                      : CreateBuffer(tt::tt_metal::BufferConfig{
+                                            .device = device,
+                                            .size = test_config.size_bytes,
+                                            .page_size = test_config.page_size_bytes,
+                                            .buffer_layout = test_config.buffer_layout});
 
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, test_config.size_bytes / sizeof(uint32_t));
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -191,15 +191,26 @@ void UpdateDynamicCircularBufferAddress(Program &program, CBHandle cb_handle, co
 uint32_t CreateSemaphore(Program &program, const std::variant<CoreRange,CoreRangeSet> &core_spec, uint32_t initial_value);
 
 /**
-*  Allocates a DRAM or L1 buffer on device
+*  Allocates an interleaved DRAM or L1 buffer on device
 *
 *  Return value: std::shared_ptr<Buffer>
 *
 *  | Argument        | Description                             | Type                     | Valid Range | Required |
 *  |-----------------|---------------------------------------- |--------------------------|-------------|----------|
-*  | config          | config for buffer                       | BufferConfig             |             | Yes      |
+*  | config          | config for buffer                       | InterleavedBufferConfig  |             | Yes      |
 */
-std::shared_ptr<Buffer> CreateBuffer(const std::variant<InterleavedBufferConfig, ShardedBufferConfig> & config);
+std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config);
+
+/**
+*  Allocates a sharded DRAM or L1 buffer on device
+*
+*  Return value: std::shared_ptr<Buffer>
+*
+*  | Argument        | Description                             | Type                     | Valid Range | Required |
+*  |-----------------|---------------------------------------- |--------------------------|-------------|----------|
+*  | config          | config for buffer                       | ShardedBufferConfig      |             | Yes      |
+*/
+std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config);
 
 /**
 *  Deallocates buffer from device by marking its memory as free.

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -681,22 +681,19 @@ uint32_t CreateSemaphore(Program &program, const std::variant<CoreRange,CoreRang
 }
 
 
-std::shared_ptr<Buffer> CreateBuffer(const std::variant<InterleavedBufferConfig, ShardedBufferConfig> &config)
-{
-    if  (std::holds_alternative<InterleavedBufferConfig>(config)) {
-        auto buff_config = std::get<InterleavedBufferConfig>(config);
-        return std::make_shared<Buffer> (
-                    buff_config.device, buff_config.size, buff_config.page_size,
-                    buff_config.buffer_type, buff_config.buffer_layout
-                    );
-    }
-    else {
-        auto buff_config = std::get<ShardedBufferConfig>(config);
-        return std::make_shared<Buffer>(
-                        buff_config.device, buff_config.size, buff_config.page_size,
-                        buff_config.buffer_type, buff_config.buffer_layout, buff_config.shard_parameters
-                    );
-    }
+std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config) {
+    return std::make_shared<Buffer>(
+        config.device, config.size, config.page_size, config.buffer_type, config.buffer_layout);
+}
+
+std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config) {
+    return std::make_shared<Buffer>(
+        config.device,
+        config.size,
+        config.page_size,
+        config.buffer_type,
+        config.buffer_layout,
+        config.shard_parameters);
 }
 
 void DeallocateBuffer(Buffer &buffer) { buffer.deallocate(); }


### PR DESCRIPTION
The type of requested buffer config is known at compile time. Converting it to a temporary variant followed by a runtime check of the stored type penalizes performance for no benefit.