### PR TITLE
#5509: Add ternary ops to ttnn

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 516
+personal_ws-1.1 en 519
 ABI
 ADDI
 API
@@ -166,12 +166,15 @@ abovementioned
 acc
 acos
 acosh
+addcdiv
+addcmul
 addexp
 addr
 agrebenisan
 andi
 api
 apis
+arange
 arg
 args
 asin

--- a/docs/source/ttnn/api.rst
+++ b/docs/source/ttnn/api.rst
@@ -48,6 +48,7 @@ Tensor Creation
 .. toctree::
    :maxdepth: 1
 
+   ttnn/arange
    ttnn/zeros
    ttnn/zeros_like
    ttnn/ones
@@ -182,6 +183,17 @@ Pointwise Binary
    ttnn/eq
    ttnn/ne
    ttnn/isclose
+
+Pointwise Ternary
+=================
+
+.. toctree::
+   :maxdepth: 1
+
+   ttnn/addcdiv
+   ttnn/addcmul
+   ttnn/mac
+   ttnn/where
 
 Losses
 ======

--- a/docs/source/ttnn/ttnn/addcdiv.rst
+++ b/docs/source/ttnn/ttnn/addcdiv.rst
@@ -1,0 +1,6 @@
+.. _ttnn.addcdiv:
+
+ttnn.addcdiv
+###############
+
+.. autofunction:: ttnn.addcdiv

--- a/docs/source/ttnn/ttnn/addcmul.rst
+++ b/docs/source/ttnn/ttnn/addcmul.rst
@@ -1,0 +1,6 @@
+.. _ttnn.addcmul:
+
+ttnn.addcmul
+###############
+
+.. autofunction:: ttnn.addcmul

--- a/docs/source/ttnn/ttnn/arange.rst
+++ b/docs/source/ttnn/ttnn/arange.rst
@@ -1,0 +1,6 @@
+.. _ttnn.arange:
+
+ttnn.arange
+###############
+
+.. autofunction:: ttnn.arange

--- a/docs/source/ttnn/ttnn/mac.rst
+++ b/docs/source/ttnn/ttnn/mac.rst
@@ -1,0 +1,6 @@
+.. _ttnn.mac:
+
+ttnn.mac
+###############
+
+.. autofunction:: ttnn.mac

--- a/docs/source/ttnn/ttnn/where.rst
+++ b/docs/source/ttnn/ttnn/where.rst
@@ -1,0 +1,6 @@
+.. _ttnn.where:
+
+ttnn.where
+###############
+
+.. autofunction:: ttnn.where

--- a/tests/ttnn/sweep_tests/sweeps/addcdiv.py
+++ b/tests/ttnn/sweep_tests/sweeps/addcdiv.py
@@ -20,7 +20,7 @@ parameters = {
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "layout": [ttnn.TILE_LAYOUT],
-    "dim": [-1, -2],
+    "value": [5.5, 15.8],
 }
 
 
@@ -39,21 +39,29 @@ def run(
     input_dtype,
     input_memory_config,
     output_memory_config,
-    dim,
     layout,
+    value,
     *,
     device,
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
-    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=True)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+    torch_input_tensor1 = torch.randn(input_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+    torch_input_tensor2 = torch.randn(input_shape, dtype=torch.bfloat16).uniform_(-100, 100)
+    torch_output_tensor = torch.addcdiv(torch_input_tensor, torch_input_tensor1, torch_input_tensor2, value=value)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
     )
+    input_tensor1 = ttnn.from_torch(
+        torch_input_tensor1, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+    input_tensor2 = ttnn.from_torch(
+        torch_input_tensor2, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
 
-    output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=True)
+    output_tensor = ttnn.addcdiv(input_tensor, input_tensor1, input_tensor2, value, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/mac.py
+++ b/tests/ttnn/sweep_tests/sweeps/mac.py
@@ -20,7 +20,9 @@ parameters = {
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "layout": [ttnn.TILE_LAYOUT],
-    "dim": [-1, -2],
+    "type": ["TensorTensorTensor", "TensorScalarScalar"],
+    "float1": [15.5, -6.8],
+    "float2": [-4.2, 11.4],
 }
 
 
@@ -39,21 +41,37 @@ def run(
     input_dtype,
     input_memory_config,
     output_memory_config,
-    dim,
     layout,
+    type,
+    float1,
+    float2,
     *,
     device,
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
     torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
-    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=True)
+    if type == "TensorTensorTensor":
+        torch_input_tensor1 = torch.randn(input_shape, dtype=torch.bfloat16)
+        torch_input_tensor2 = torch.randn(input_shape, dtype=torch.bfloat16)
+        input_tensor1 = ttnn.from_torch(
+            torch_input_tensor1, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+        )
+        input_tensor2 = ttnn.from_torch(
+            torch_input_tensor2, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+        )
+    elif type == "TensorScalarScalar":
+        torch_input_tensor1 = float1
+        torch_input_tensor2 = float2
+        input_tensor1 = torch_input_tensor1
+        input_tensor2 = torch_input_tensor2
+    torch_output_tensor = torch.add(torch.mul(torch_input_tensor, torch_input_tensor1), torch_input_tensor2)
 
     input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
     )
 
-    output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=True)
+    output_tensor = ttnn.mac(input_tensor, input_tensor1, input_tensor2, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/where.py
+++ b/tests/ttnn/sweep_tests/sweeps/where.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+    "value1": [5.5, 15.8],
+    "value2": [3.7, 12.3],
+    "type": ["TensorTensorTensor", "TensorTensorScalar", "TensorScalarTensor", "TensorScalarScalar"],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    value1,
+    value2,
+    type,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_predicate = torch.rand(input_shape, dtype=torch.bfloat16)
+    predicate = ttnn.from_torch(
+        torch_predicate, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+    if type == "TensorTensorTensor":
+        torch_true_value = torch.rand(input_shape, dtype=torch.bfloat16)
+        torch_false_value = torch.rand(input_shape, dtype=torch.bfloat16)
+        true_value = ttnn.from_torch(
+            torch_true_value, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+        )
+        false_value = ttnn.from_torch(
+            torch_false_value, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+        )
+    elif type == "TensorTensorScalar":
+        torch_true_value = torch.rand(input_shape, dtype=torch.bfloat16)
+        torch_false_value = value2
+        true_value = ttnn.from_torch(
+            torch_true_value, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+        )
+        false_value = torch_false_value
+    elif type == "TensorScalarTensor":
+        torch_true_value = value1
+        torch_false_value = torch.rand(input_shape, dtype=torch.bfloat16)
+        true_value = torch_true_value
+        false_value = ttnn.from_torch(
+            torch_false_value, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+        )
+    elif type == "TensorScalarScalar":
+        torch_true_value = value1
+        torch_false_value = value2
+        true_value = torch_true_value
+        false_value = torch_false_value
+
+    torch_output_tensor = torch.where(torch_predicate.to(torch.bool), torch_true_value, torch_false_value)
+
+    output_tensor = ttnn.where(predicate, true_value, false_value, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -136,3 +136,31 @@ def test_full(device, input_shape, fill_value):
 
     assert_with_pcc(torch_tensor, tensor, 0.9999)
     assert torch.allclose(torch_tensor, tensor)
+
+
+@pytest.mark.parametrize(
+    "start",
+    [4, 8, 16, 32],
+)
+@pytest.mark.parametrize(
+    "end",
+    [100, 200, 300],
+)
+@pytest.mark.parametrize(
+    "step",
+    [1, 2],
+)
+def test_arange(device, start, end, step):
+    torch_input_tensor = torch.rand((start, end, step), dtype=torch.bfloat16)
+    torch_output_tensor = torch.arange(start, end, step)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.to_device(input_tensor, device)
+
+    output_tensor = ttnn.arange(input_tensor.shape[0], input_tensor.shape[1], input_tensor.shape[2], device)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = output_tensor[-1, -1, -1, :]
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)

--- a/tests/ttnn/unit_tests/operations/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/test_ternary.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def torch_mac(input, tensor1, tensor2):
+    return torch.add(torch.mul(input, tensor1), tensor2)
+
+
+def run_ternary_test_mac_TTT(device, h, w, ttnn_function, torch_function, pcc=0.9999):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_input_tensor1 = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_input_tensor2 = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch_function(torch_input_tensor, torch_input_tensor1, torch_input_tensor2)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    input_tensor1 = ttnn.from_torch(torch_input_tensor1, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor1 = ttnn.to_device(input_tensor1, device)
+    input_tensor2 = ttnn.from_torch(torch_input_tensor2, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.to_device(input_tensor2, device)
+    output_tensor = ttnn_function(input_tensor, input_tensor1, input_tensor2)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_mac_ttt(device, h, w):
+    run_ternary_test_mac_TTT(device, h, w, ttnn.mac, torch_mac)
+
+
+def run_ternary_test_mac_TSS(device, h, w, scalar1, scalar2, ttnn_function, torch_function, pcc=0.9999):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_input_tensor1 = scalar1
+    torch_input_tensor2 = scalar2
+    torch_output_tensor = torch_function(torch_input_tensor, torch_input_tensor1, torch_input_tensor2)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.to_device(input_tensor, device)
+
+    output_tensor = ttnn_function(input_tensor, scalar1, scalar2)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("scalar1", [5.5])
+@pytest.mark.parametrize("scalar2", [-13.2])
+def test_mac_tss(device, h, w, scalar1, scalar2):
+    run_ternary_test_mac_TSS(device, h, w, scalar1, scalar2, ttnn.mac, torch_mac)
+
+
+def run_ternary_test_where_TTT(device, h, w, ttnn_function, torch_function, pcc=0.9999):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_input_tensor1 = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_input_tensor2 = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch_function(torch_input_tensor.to(torch.bool), torch_input_tensor1, torch_input_tensor2)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    input_tensor1 = ttnn.from_torch(torch_input_tensor1, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor1 = ttnn.to_device(input_tensor1, device)
+    input_tensor2 = ttnn.from_torch(torch_input_tensor2, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.to_device(input_tensor2, device)
+    output_tensor = ttnn_function(input_tensor, input_tensor1, input_tensor2)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_where_ttt(device, h, w):
+    run_ternary_test_where_TTT(device, h, w, ttnn.where, torch.where)
+
+
+def run_ternary_test_where_TTS(device, h, w, scalar, ttnn_function, torch_function, pcc=0.9999):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_input_tensor1 = torch.rand((h, w), dtype=torch.bfloat16)
+
+    torch_output_tensor = torch_function(torch_input_tensor.to(torch.bool), torch_input_tensor1, scalar)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    input_tensor1 = ttnn.from_torch(torch_input_tensor1, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor1 = ttnn.to_device(input_tensor1, device)
+
+    output_tensor = ttnn_function(input_tensor, input_tensor1, scalar)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("scalar", [15.5])
+def test_where_tts(device, h, w, scalar):
+    run_ternary_test_where_TTS(device, h, w, scalar, ttnn.where, torch.where)
+
+
+def run_ternary_test_where_TST(device, h, w, scalar, ttnn_function, torch_function, pcc=0.9999):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_input_tensor1 = torch.rand((h, w), dtype=torch.bfloat16)
+
+    torch_output_tensor = torch_function(torch_input_tensor.to(torch.bool), scalar, torch_input_tensor1)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    input_tensor1 = ttnn.from_torch(torch_input_tensor1, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor1 = ttnn.to_device(input_tensor1, device)
+
+    output_tensor = ttnn_function(input_tensor, scalar, input_tensor1)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("scalar", [15.5])
+def test_where_tst(device, h, w, scalar):
+    run_ternary_test_where_TST(device, h, w, scalar, ttnn.where, torch.where)
+
+
+def run_ternary_test_where_TSS(device, h, w, scalar1, scalar2, ttnn_function, torch_function, pcc=0.9999):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+
+    torch_output_tensor = torch_function(torch_input_tensor.to(torch.bool), scalar1, scalar2)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.to_device(input_tensor, device)
+
+    output_tensor = ttnn_function(input_tensor, scalar1, scalar2)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("scalar1", [15.5])
+@pytest.mark.parametrize("scalar2", [31.2])
+def test_where_tss(device, h, w, scalar1, scalar2):
+    run_ternary_test_where_TSS(device, h, w, scalar1, scalar2, ttnn.where, torch.where)
+
+
+def run_ternary_test_value(device, h, w, value, ttnn_function, torch_function, pcc=0.9999):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16).uniform_(-100, 100)
+    torch_input_tensor1 = torch.rand((h, w), dtype=torch.bfloat16).uniform_(-100, 100)
+    torch_input_tensor2 = torch.rand((h, w), dtype=torch.bfloat16).uniform_(-100, 100)
+    torch_output_tensor = torch_function(torch_input_tensor, torch_input_tensor1, torch_input_tensor2, value=value)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    input_tensor1 = ttnn.from_torch(torch_input_tensor1, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor1 = ttnn.to_device(input_tensor1, device)
+    input_tensor2 = ttnn.from_torch(torch_input_tensor2, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.to_device(input_tensor2, device)
+    output_tensor = ttnn_function(input_tensor, input_tensor1, input_tensor2, value)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("value", [15.5])
+def test_addcmul(device, h, w, value):
+    run_ternary_test_value(device, h, w, value, ttnn.addcmul, torch.addcmul)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("value", [15.5])
+def test_addcdiv(device, h, w, value):
+    run_ternary_test_value(device, h, w, value, ttnn.addcdiv, torch.addcdiv)

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -112,12 +112,13 @@ from ttnn.operations.others import (
 )
 
 from ttnn.operations.creation import (
+    arange,
+    full,
+    full_like,
     ones,
     ones_like,
     zeros,
     zeros_like,
-    full,
-    full_like,
 )
 
 from ttnn.operations.reduction import (
@@ -180,6 +181,12 @@ from ttnn.operations.binary import (
     add_and_apply_activation_,
 )
 
+from ttnn.operations.ternary import (
+    addcdiv,
+    addcmul,
+    mac,
+    where,
+)
 
 from ttnn.operations.relational import (
     gtz,

--- a/ttnn/ttnn/operations/creation.py
+++ b/ttnn/ttnn/operations/creation.py
@@ -300,4 +300,46 @@ def full(
     return output_tensor
 
 
+def _is_int(value):
+    return isinstance(value, (int))
+
+
+def _torch_arange(start: int, end: int, step: int, **_):
+    import torch
+
+    return torch.arange(start, end, step)
+
+
+def _arange_validate_input_tensors(operation_name, input_shape, *args, **kwargs):
+    return True
+
+
+@ttnn.register_operation(
+    name="ttnn.arange",
+    validate_input_tensors=_arange_validate_input_tensors,
+    torch_function=_torch_arange,
+)
+def arange(
+    start: int,
+    end: int,
+    step: int,
+    device,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    r"""
+    Returns a new 1D tensor with the incremented values in size specified by inputs start, end and step.
+
+    Args:
+        * :attr:`start`
+        * :attr:`end`
+        * :attr:`step`
+    """
+    if not _is_int(start) or not _is_int(end) or not _is_int(step):
+        raise TypeError("Expected three arguments to be a int")
+
+    output_tensor = ttnn.experimental.tensor.arange(start, end, step, device, output_mem_config=memory_config)
+
+    return output_tensor
+
+
 __all__ = []

--- a/ttnn/ttnn/operations/ternary.py
+++ b/ttnn/ttnn/operations/ternary.py
@@ -1,0 +1,391 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import tt_lib as ttl
+
+import ttnn
+
+
+THIS_MODULE = sys.modules[__name__]
+
+__all__ = []
+
+
+def torch_mac(input, tensor1, tensor2):
+    import torch
+
+    return torch.add(torch.mul(input, tensor1), tensor2)
+
+
+def register_ttl_ternary_function(name, ttl_ternary_function):
+    def _torch_ternary(input_tensor: ttnn.Tensor, **_):
+        import torch
+
+        name_to_torch_function = {
+            "mac": torch_mac,
+        }
+        torch_function = name_to_torch_function[name]
+        input_tensor = ttnn.to_torch(input_tensor)
+        return torch_function(input_tensor)
+
+    def _ternary_validate_input_tensors(operation_name, input, input1, input2, *args, **kwargs):
+        ttnn.validate_input_tensor(
+            operation_name,
+            input,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input1,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+            can_be_a_scalar=True,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input2,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+            can_be_a_scalar=True,
+        )
+
+    @ttnn.register_operation(
+        name=f"ttnn.{name}",
+        validate_input_tensors=_ternary_validate_input_tensors,
+        torch_function=_torch_ternary,
+    )
+    def ternary_function(
+        input: ttnn.Tensor,
+        input1: [ttnn.Tensor, float],
+        input2: [ttnn.Tensor, float],
+        *,
+        memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    ) -> ttnn.Tensor:
+        original_shape = input.shape
+        input_tensor = ttnn.unsqueeze_to_4D(input)
+        if not _is_scalar(input1) and not _is_scalar(input2):
+            input_tensor1 = ttnn.unsqueeze_to_4D(input1)
+            input_tensor2 = ttnn.unsqueeze_to_4D(input2)
+            ttl_input_tensor1 = input_tensor1.value
+            ttl_input_tensor2 = input_tensor2.value
+        elif _is_scalar(input1) and _is_scalar(input2):
+            input_tensor1 = input1
+            input_tensor2 = input2
+            ttl_input_tensor1 = input_tensor1
+            ttl_input_tensor2 = input_tensor2
+
+        ttl_input_tensor = input_tensor.value
+
+        if not isinstance(input_tensor, ttnn.Tensor):
+            raise TypeError("Expected input argument to be a ttnn.Tensor")
+
+        if (isinstance(input_tensor1, ttnn.Tensor) and not isinstance(input_tensor2, ttnn.Tensor)) or (
+            not isinstance(input_tensor1, ttnn.Tensor) and isinstance(input_tensor2, ttnn.Tensor)
+        ):
+            raise TypeError("Expected other two inputs as either both tensor or scalar")
+
+        if not ttnn.has_storage_type_of(input_tensor, ttnn.DEVICE_STORAGE_TYPE):
+            raise RuntimeError("input_tensor must be on device!")
+
+        ttl_output_tensor = ttl_ternary_function(
+            ttl_input_tensor, ttl_input_tensor1, ttl_input_tensor2, output_mem_config=memory_config
+        )
+
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        output_tensor = ttnn.reshape(output_tensor, original_shape)
+        return output_tensor
+
+    ternary_function.__name__ = f"ttnn.{name}"
+    ternary_function.__doc__ = f"""{name}(input_tensor: ttnn.Tensor, input_tensor1: ttnn.Tensor, input_tensor2: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
+
+        Returns tensor with the {name} of all of elements of the input tensors input, tensor1, tensor2.
+
+        .. math::
+            {name.replace('_',' ')}(\\mathrm{{input\\_tensor}}_i)
+
+        Args:
+            * :attr:`input_tensor`
+            * :attr:`input_tensor1`
+            * :attr:`input_tensor2`
+
+        Example::
+
+            >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> tensor1 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> tensor2 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> output = ttnn.{name}(tensor, tensor1, tensor2)
+
+        {ternary_function.__doc__}
+
+        """
+    setattr(THIS_MODULE, name, ternary_function)
+
+
+TTL_TERNARY_FUNCTIONS = [
+    ("mac", ttl.tensor.mac),
+]
+
+
+for ternary_function_name, ttl_ternary_function in TTL_TERNARY_FUNCTIONS:
+    register_ttl_ternary_function(ternary_function_name, ttl_ternary_function)
+
+
+def _is_scalar(value):
+    return isinstance(value, (float))
+
+
+def register_ttl_ternary_function_with_float(name, ttl_ternary_function, op_name, param):
+    def _torch_ternary(input_tensor: ttnn.Tensor, parameter, **_):
+        import torch
+
+        name_to_torch_function = {
+            "addcmul": torch.addcmul,
+            "addcdiv": torch.addcdiv,
+        }
+        torch_function = name_to_torch_function[name]
+        input_tensor = ttnn.to_torch(input_tensor)
+
+        return torch_function(input_tensor, parameter)
+
+    def _ternary_validate_input_tensors(operation_name, input_tensor, input_tensor1, input_tensor2, *args, **kwargs):
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16,),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor1,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16,),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor2,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16,),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+
+    @ttnn.register_operation(
+        name=f"ttnn.{name}",
+        validate_input_tensors=_ternary_validate_input_tensors,
+        torch_function=_torch_ternary,
+    )
+    def ternary_function(
+        input_tensor: ttnn.Tensor,
+        input_tensor1: ttnn.Tensor,
+        input_tensor2: ttnn.Tensor,
+        parameter: float,
+        *,
+        memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    ) -> ttnn.Tensor:
+        original_shape = input_tensor.shape
+        input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+        input_tensor1 = ttnn.unsqueeze_to_4D(input_tensor1)
+        input_tensor2 = ttnn.unsqueeze_to_4D(input_tensor2)
+
+        ttl_input_tensor = input_tensor.value
+        ttl_input_tensor1 = input_tensor1.value
+        ttl_input_tensor2 = input_tensor2.value
+
+        if (
+            not isinstance(input_tensor, ttnn.Tensor)
+            or not isinstance(input_tensor1, ttnn.Tensor)
+            or not isinstance(input_tensor2, ttnn.Tensor)
+        ):
+            raise TypeError("Expected 3 arguments to be a ttnn.Tensor")
+
+        if not _is_scalar(parameter):
+            raise TypeError("Expected one argument to be a float")
+
+        if (
+            not ttnn.has_storage_type_of(input_tensor, ttnn.DEVICE_STORAGE_TYPE)
+            or not ttnn.has_storage_type_of(input_tensor1, ttnn.DEVICE_STORAGE_TYPE)
+            or not ttnn.has_storage_type_of(input_tensor2, ttnn.DEVICE_STORAGE_TYPE)
+        ):
+            raise RuntimeError("input_tensor must be on device!")
+
+        ttl_output_tensor = ttl_ternary_function(
+            ttl_input_tensor, ttl_input_tensor1, ttl_input_tensor2, value=parameter, output_mem_config=memory_config
+        )
+
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        output_tensor = ttnn.reshape(output_tensor, original_shape)
+        return output_tensor
+
+    ternary_function.__name__ = f"ttnn.{(name)}"
+    ternary_function.__doc__ = f"""{(name)}(input_tensor: ttnn.Tensor, input_tensor1: ttnn.Tensor, input_tensor2: ttnn.Tensor, parameter, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
+
+        Performs the element-wise {op_name} of tensor1 by tensor2, multiplies the result by the scalar value and adds it to input input.
+
+        .. math::
+            {(op_name)}(\\mathrm{{input\\_tensor}}_i  \\; , \\; {param})
+
+        Args:
+            * :attr:`input_tensor`
+            * :attr:`input_tensor1`
+            * :attr:`input_tensor2`
+            * :attr:`{param}`
+
+        Example::
+
+            >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> tensor1 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> tensor2 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> output = ttnn.{(name)}(tensor, tensor1, tensor2, {param})
+
+        """
+    setattr(THIS_MODULE, name, ternary_function)
+
+
+TTL_TERNARY_FUNCTIONS_WITH_FLOAT_PARAM = [
+    ("addcmul", ttl.tensor.addcmul, "addcmul", "value"),
+    ("addcdiv", ttl.tensor.addcdiv, "addcdiv", "value"),
+]
+
+for ternary_function_name, ttl_ternary_function, name, param in TTL_TERNARY_FUNCTIONS_WITH_FLOAT_PARAM:
+    register_ttl_ternary_function_with_float(ternary_function_name, ttl_ternary_function, name, param)
+
+
+def register_ttl_ternary_function_where(name, ttl_ternary_function):
+    def _torch_ternary(input_tensor: ttnn.Tensor, **_):
+        import torch
+
+        name_to_torch_function = {
+            "where": torch.where,
+        }
+        torch_function = name_to_torch_function[name]
+        input_tensor = ttnn.to_torch(input_tensor)
+        return torch_function(input_tensor)
+
+    def _ternary_validate_input_tensors(operation_name, input_tensor, input1, input2, *args, **kwargs):
+        ttnn.validate_input_tensor(
+            operation_name,
+            input_tensor,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input1,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+            can_be_a_scalar=True,
+        )
+        ttnn.validate_input_tensor(
+            operation_name,
+            input2,
+            ranks=(2, 3, 4),
+            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            layouts=(ttnn.TILE_LAYOUT,),
+            can_be_on_device=True,
+            can_be_on_cpu=False,
+            can_be_a_scalar=True,
+        )
+
+    @ttnn.register_operation(
+        name=f"ttnn.{name}",
+        validate_input_tensors=_ternary_validate_input_tensors,
+        torch_function=_torch_ternary,
+    )
+    def ternary_function(
+        predicate: ttnn.Tensor,
+        true_value: [ttnn.Tensor, float],
+        false_value: [ttnn.Tensor, float],
+        *,
+        memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    ) -> ttnn.Tensor:
+        original_shape = predicate.shape
+        predicate = ttnn.unsqueeze_to_4D(predicate)
+        if not _is_scalar(true_value):
+            true_value = ttnn.unsqueeze_to_4D(true_value)
+            ttl_true_value = true_value.value
+        else:
+            ttl_true_value = true_value
+        if not _is_scalar(false_value):
+            false_value = ttnn.unsqueeze_to_4D(false_value)
+            ttl_false_value = false_value.value
+        else:
+            ttl_false_value = false_value
+
+        ttl_predicate = predicate.value
+
+        if not isinstance(predicate, ttnn.Tensor):
+            raise TypeError("Expected input_tensor arguments to be a ttnn.Tensor")
+
+        if not ttnn.has_storage_type_of(predicate, ttnn.DEVICE_STORAGE_TYPE):
+            raise RuntimeError("input_tensor must be on device!")
+
+        ttl_output_tensor = ttl_ternary_function(
+            ttl_predicate, ttl_true_value, ttl_false_value, output_mem_config=memory_config
+        )
+
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        output_tensor = ttnn.reshape(output_tensor, original_shape)
+        return output_tensor
+
+    ternary_function.__name__ = f"ttnn.{name}"
+    ternary_function.__doc__ = f"""{name}(predicate_tensor: ttnn.Tensor, true_value: [ttnn.Tensor,float], false_value: [ttnn.Tensor,float], *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
+
+        Perform an ternary {name} operation on two tensors based on predicate input tensor.
+
+        .. math::
+            {name.replace('_',' ')}(\\mathrm{{input\\_tensor}}_i)
+
+        Args:
+            * :attr:`predicate_tensor`
+            * :attr:`true_value`
+            * :attr:`false_value`
+
+        Example::
+
+            >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> tensor1 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> tensor2 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> output = ttnn.{name}(tensor, tensor1, tensor2)
+
+        {ternary_function.__doc__}
+
+        """
+    setattr(THIS_MODULE, name, ternary_function)
+
+
+TTL_TERNARY_FUNCTIONS_WHERE = [
+    ("where", ttl.tensor.where),
+]
+
+
+for ternary_function_name, ttl_ternary_function in TTL_TERNARY_FUNCTIONS_WHERE:
+    register_ttl_ternary_function_where(ternary_function_name, ttl_ternary_function)
+
+
+__all__ = []


### PR DESCRIPTION
Add support to ternary ops for TTNN
Slow Dispatch test: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8014570243
Fast Dispatch test: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8015527690

Renamed ttnn.ttl to ttnn.experimental 