### PR TITLE
#5539: Migrate ops to ttnn

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 519
+personal_ws-1.1 en 521
 ABI
 ADDI
 API
@@ -350,6 +350,7 @@ ncrisc
 nd
 ne
 networkx
+nextafter
 nez
 noc
 noconvert
@@ -376,6 +377,7 @@ phiyodr
 phyiscally
 png
 polygamma
+polyval
 pragma
 pre
 prelu

--- a/docs/source/ttnn/api.rst
+++ b/docs/source/ttnn/api.rst
@@ -49,6 +49,7 @@ Tensor Creation
    :maxdepth: 1
 
    ttnn/arange
+   ttnn/empty
    ttnn/zeros
    ttnn/zeros_like
    ttnn/ones
@@ -183,6 +184,8 @@ Pointwise Binary
    ttnn/eq
    ttnn/ne
    ttnn/isclose
+   ttnn/polyval
+   ttnn/nextafter
 
 Pointwise Ternary
 =================
@@ -225,6 +228,7 @@ Data Movement
    ttnn/permute
    ttnn/reshape
    ttnn/split
+   ttnn/repeat
    ttnn/repeat_interleave
 
 Normalization

--- a/docs/source/ttnn/ttnn/empty.rst
+++ b/docs/source/ttnn/ttnn/empty.rst
@@ -1,0 +1,6 @@
+.. _ttnn.empty:
+
+ttnn.empty
+###############
+
+.. autofunction:: ttnn.empty

--- a/docs/source/ttnn/ttnn/nextafter.rst
+++ b/docs/source/ttnn/ttnn/nextafter.rst
@@ -1,0 +1,6 @@
+.. _ttnn.nextafter:
+
+ttnn.nextafter
+###############
+
+.. autofunction:: ttnn.nextafter

--- a/docs/source/ttnn/ttnn/polyval.rst
+++ b/docs/source/ttnn/ttnn/polyval.rst
@@ -1,0 +1,6 @@
+.. _ttnn.polyval:
+
+ttnn.polyval
+###############
+
+.. autofunction:: ttnn.polyval

--- a/docs/source/ttnn/ttnn/repeat.rst
+++ b/docs/source/ttnn/ttnn/repeat.rst
@@ -1,0 +1,6 @@
+.. _ttnn.repeat:
+
+ttnn.repeat
+###############
+
+.. autofunction:: ttnn.repeat

--- a/tests/ttnn/sweep_tests/sweeps/empty.py
+++ b/tests/ttnn/sweep_tests/sweeps/empty.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.empty(torch_input_tensor.shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
+    )
+
+    output_tensor = ttnn.empty(input_tensor.shape, device=device, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    if torch_output_tensor.shape != output_tensor.shape:
+        return (
+            False,
+            f"list(torch_output_tensor.shape)={list(torch_output_tensor.shape)} vs list(output_tensor.shape)={list(output_tensor.shape)}",
+        )
+    else:
+        return True, "passed"

--- a/tests/ttnn/sweep_tests/sweeps/nextafter.py
+++ b/tests/ttnn/sweep_tests/sweeps/nextafter.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1, 2)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch.randn(input_shape, dtype=torch.float32)
+    torch_input_tensor_b = torch.randn(input_shape, dtype=torch.float32)
+
+    torch_output_tensor = torch.nextafter(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
+    )
+
+    output_tensor = ttnn.nextafter(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/polyval.py
+++ b/tests/ttnn/sweep_tests/sweeps/polyval.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1, 2)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+    "coeff": [(3.6, 23.6, 1.7, 4.6), (9.4, 4.2, 3.3, 9.0)],
+}
+
+
+def torch_polyval(input_tensor, coeff):
+    curVal = 0
+    for curValIndex in range(len(coeff) - 1):
+        curVal = (curVal + coeff[curValIndex]) * input_tensor[0]
+    return curVal + coeff[len(coeff) - 1]
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    coeff,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch_polyval(torch_input_tensor, coeff)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
+    )
+
+    output_tensor = ttnn.polyval(input_tensor, coeff, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor).squeeze(0)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/repeat.py
+++ b/tests/ttnn/sweep_tests/sweeps/repeat.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1, 2)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+    "repeat_shape": [(2, 4, 1, 1), (1, 2, 1, 1)],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    repeat_shape,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    repeat_shape = torch.randn(repeat_shape, dtype=torch.float32)
+
+    torch_output_tensor = torch_input_tensor.repeat(repeat_shape.shape)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
+    )
+    repeat_shape = ttnn.from_torch(
+        repeat_shape, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
+    )
+
+    output_tensor = ttnn.repeat(input_tensor, repeat_shape.shape, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -164,3 +164,28 @@ def test_arange(device, start, end, step):
     output_tensor = output_tensor[-1, -1, -1, :]
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [2, 1, 4, 4],  # 256x256
+        [2, 1280, 8, 8],
+        [2, 640, 16, 16],
+        [2, 1280, 8, 8],  # 512x512
+        [2, 1280, 16, 16],
+        [2, 1280, 16, 16],
+    ],
+)
+def test_empty(device, input_shapes):
+    torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.empty(torch_input_tensor.shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    output_tensor = ttnn.empty(input_tensor.shape, device=device)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert list(torch_output_tensor.shape) == list(output_tensor.shape)

--- a/tests/ttnn/unit_tests/operations/test_nextafter.py
+++ b/tests/ttnn/unit_tests/operations/test_nextafter.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
+def test_nextafter(device, shape):
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = torch.rand(shape, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand(shape, dtype=torch.bfloat16)
+
+    torch_output_tensor = torch.nextafter(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.nextafter(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/unit_tests/operations/test_polyval.py
+++ b/tests/ttnn/unit_tests/operations/test_polyval.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def torch_polyval(input_tensor, coeff):
+    curVal = 0
+    for curValIndex in range(len(coeff) - 1):
+        curVal = (curVal + coeff[curValIndex]) * input_tensor[0]
+    return curVal + coeff[len(coeff) - 1]
+
+
+@pytest.mark.parametrize("shape", [(1, 1, 32, 32)])
+@pytest.mark.parametrize("coeff", [(1.5, 2.4, 6.7, 9.1)])
+def test_polyval(device, shape, coeff):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
+
+    torch_output_tensor = torch_polyval(torch_input_tensor, coeff)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output_tensor = ttnn.polyval(input_tensor_a, coeff)
+    output_tensor = ttnn.to_torch(output_tensor).squeeze(0)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def test_repeat(device):
+    torch_input_tensor = torch.randn((1, 2, 4, 4), dtype=torch.bfloat16)
+    repeat_shape = torch.randn((1, 2, 1, 1), dtype=torch.bfloat16)
+
+    input_tensor1 = ttnn.from_torch(repeat_shape, layout=ttnn.TILE_LAYOUT)
+    input_tensor1 = ttnn.to_device(input_tensor1, device)
+    torch_result = torch_input_tensor.repeat(repeat_shape.shape)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.repeat(input_tensor, input_tensor1.shape)
+    output = ttnn.to_torch(output)
+
+    assert_with_pcc(torch_result, output, 0.9999)

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -113,6 +113,7 @@ from ttnn.operations.others import (
 
 from ttnn.operations.creation import (
     arange,
+    empty,
     full,
     full_like,
     ones,
@@ -137,6 +138,7 @@ from ttnn.operations.data_movement import (
     permute,
     split,
     repeat_interleave,
+    repeat,
 )
 
 from ttnn.operations.unary import (
@@ -179,6 +181,8 @@ from ttnn.operations.binary import (
     xlogy,
     add_and_apply_activation,
     add_and_apply_activation_,
+    nextafter,
+    polyval,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/operations/creation.py
+++ b/ttnn/ttnn/operations/creation.py
@@ -342,4 +342,40 @@ def arange(
     return output_tensor
 
 
+def _torch_empty(input_shape: ttnn.Shape, **_):
+    import torch
+
+    input_shape = ttnn.from_device(input_shape)
+    input_shape = ttnn.to_layout(input_shape, ttnn.ROW_MAJOR_LAYOUT)
+    input_shape = ttnn.to_torch(input_shape)
+
+    return torch.empty(input_shape)
+
+
+def _empty_validate_input_tensors(operation_name, input_shape, *args, **kwargs):
+    ...
+
+
+@ttnn.register_operation(
+    name="ttnn.empty",
+    validate_input_tensors=_empty_validate_input_tensors,
+    torch_function=_torch_empty,
+)
+def empty(
+    input_shape: ttnn.Shape,
+    device: ttnn.Device,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    r"""
+    Returns a new empty tensor by taking input shape as reference.
+
+    Args:
+        * :attr:`input_shape`: the input shape for reference
+    """
+
+    output_tensor = ttnn.experimental.tensor.empty(input_shape, device=device, output_mem_config=memory_config)
+
+    return output_tensor
+
+
 __all__ = []


### PR DESCRIPTION
Add support for nextafter, repeat, empty, polyval op to TTNN
Sweep test results:
[empty.csv](https://github.com/tenstorrent-metal/tt-metal/files/14384352/empty.csv)
[nextafter.csv](https://github.com/tenstorrent-metal/tt-metal/files/14384353/nextafter.csv)
[polyval.csv](https://github.com/tenstorrent-metal/tt-metal/files/14384354/polyval.csv)
[repeat.csv](https://github.com/tenstorrent-metal/tt-metal/files/14384355/repeat.csv)

Slow Dispatch Test: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8015693376
Fast Dispatch Test: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8016679190