### PR TITLE
#5592: Add Falcon7b unit tests to post-commit B0 workflow

### DIFF
--- a/models/demos/falcon7b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon7b/tests/test_falcon_end_to_end.py
@@ -64,7 +64,7 @@ def run_test_FalconCausalLM_end_to_end(
     torch.manual_seed(0)
     base_url = ""
     max_position_embeddings = 2048
-    head_dim = configuration.hidden_size // configuration.n_head
+    head_dim = configuration.hidden_size // configuration.num_attention_heads
     use_cache = True
 
     if 1:

--- a/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
+++ b/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
@@ -68,7 +68,7 @@ def run_test_FalconCausalLM_inference(
     torch.manual_seed(0)
     base_url = ""
     max_position_embeddings = max_seq_len
-    head_dim = configuration.hidden_size // configuration.n_head
+    head_dim = configuration.hidden_size // configuration.num_attention_heads
     use_cache = True
     kv_cache_len = seq_len  # This will increment by one after each decode
 

--- a/tests/scripts/run_python_api_unit_tests.sh
+++ b/tests/scripts/run_python_api_unit_tests.sh
@@ -54,4 +54,12 @@ pytest $TT_METAL_HOME/models/demos/resnet/tests/test_resnet18.py
 pytest $TT_METAL_HOME/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py -k "seq_len_128 and in0_BFLOAT16-in1_BFLOAT8_B-out_BFLOAT16-weights_DRAM"
 pytest $TT_METAL_HOME/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py -k "seq_len_512 and in0_BFLOAT16-in1_BFLOAT8_B-out_BFLOAT16-weights_DRAM"
 pytest $TT_METAL_HOME/models/demos/falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
+else
+# wormhole_b0
+
+# Falcon tests
+# attn_matmul_from_cache is currently not used in falcon7b
+pytest $TT_METAL_HOME/models/demos/falcon7b/tests/unit_tests/test_falcon_attn_matmul.py -k "not attn_matmul_from_cache"
+# higher sequence lengths and different formats trigger memory issues
+pytest $TT_METAL_HOME/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py -k "(seq_len_128 or seq_len_512) and in0_BFLOAT16-in1_BFLOAT8_B-out_BFLOAT16-weights_DRAM"
 fi

--- a/tests/scripts/run_python_api_unit_tests.sh
+++ b/tests/scripts/run_python_api_unit_tests.sh
@@ -61,5 +61,5 @@ else
 # attn_matmul_from_cache is currently not used in falcon7b
 pytest $TT_METAL_HOME/models/demos/falcon7b/tests/unit_tests/test_falcon_attn_matmul.py -k "not attn_matmul_from_cache"
 # higher sequence lengths and different formats trigger memory issues
-pytest $TT_METAL_HOME/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py -k "(seq_len_128 or seq_len_512) and in0_BFLOAT16-in1_BFLOAT8_B-out_BFLOAT16-weights_DRAM"
+pytest $TT_METAL_HOME/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py -k "seq_len_128 and in0_BFLOAT16-in1_BFLOAT8_B-out_BFLOAT16-weights_DRAM"
 fi


### PR DESCRIPTION
This PR adds Falcon7b ops unit-tests to the B0 workflow; for GS we already run these tests. 

Additionally, some obsolete variables are updated in a couple of component tests (which are not run on the CI). 

post-commit unit-tests workflow: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8021831490; still running atm of the PR creation, will check it once it's done

cc @skhorasganiTT 