### PR TITLE
add corerangeset to input args of create_sharded_memory_config

### DIFF
--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -70,7 +70,7 @@ def create_sharded_memory_config(
     if not isinstance(shape, (list, tuple, ttnn.Shape)):
         raise RuntimeError("Invalid input shape")
 
-    if not isinstance(core_grid, (ttnn.CoreGrid, tuple, list)):
+    if not isinstance(core_grid, (ttnn.CoreGrid, tuple, list, ttnn.experimental.tensor.CoreRangeSet)):
         raise RuntimeError("Invalid core_grid type")
 
     if strategy == ShardStrategy.BLOCK:
@@ -113,6 +113,10 @@ def create_sharded_memory_config(
                 ttnn.experimental.tensor.CoreRange(ttnn.experimental.tensor.CoreCoord(0, core_grid[0].y), grid_coord_2),
             }
         )
+    elif isinstance(core_grid, ttnn.experimental.tensor.CoreRangeSet):
+        shard_grid = core_grid
+        if not use_height_and_width_as_shard_shape:
+            raise RuntimeError("height and width must be shard shape with CoreRangeSet")
     else:
         raise RuntimeError("Invalid core_grid type")
 


### PR DESCRIPTION
For stable diffusion we need to insert a corerangeset for the shard_grid directly. 

For now the `create_sharded_memory_config` if it gets a CoreRangeSet will require the user to do the shard_shape calculation . I am making this explicit by asserting out otherwise.


This should be sufficient for stable diffusion, in a future PR we can look at modifying the shard_shape calculation to allow the user to not have to do the math to figure this out. 


CC: @tt-nshanker @mywoodstock 