### PR TITLE
Bring stress test pipelines back to health

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_layernorm_sharded.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_layernorm_sharded.py
@@ -19,7 +19,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_equal,
     comp_pcc,
 )
-from models.utility_functions import is_wormhole_b0, skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, skip_for_wormhole_b0, skip_for_grayskull
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
 
 
@@ -35,6 +35,7 @@ seq_lens = [32, 256, 384]
 per_core_ks = [32, 64, 128]
 
 
+@skip_for_grayskull("disable due to watcher error, see issue #5797")
 @skip_for_wormhole_b0()
 @pytest.mark.parametrize(
     "grid_size",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_linear.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_linear.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import tt_lib as ttl
-from models.utility_functions import comp_allclose_and_pcc
+from models.utility_functions import comp_allclose_and_pcc, skip_for_wormhole_b0
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_moreh_matmul import get_tensors
 from loguru import logger
 
@@ -98,6 +98,7 @@ def test_moreh_linear(shapes, has_bias, device):
         ([2, 4, 4, 1024], [1, 1, 1300, 1024], [1, 1, 1, 1], [2, 4, 4, 1300]),
     ),
 )
+@skip_for_wormhole_b0("disabled due to watcher error, see issue #5868")
 @pytest.mark.parametrize(
     "requires_grads",
     (

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -7,9 +7,7 @@ from loguru import logger
 
 
 import tt_lib as ttl
-from models.utility_functions import (
-    comp_pcc,
-)
+from models.utility_functions import comp_pcc, skip_for_wormhole_b0
 import torch
 
 shapes = [
@@ -17,6 +15,7 @@ shapes = [
 ]
 
 
+@skip_for_wormhole_b0("disabled due to watcher error, see issue #5863")
 @pytest.mark.parametrize("shape", shapes)
 def test_move_op(shape, device):
     run_move_op(shape, device)


### PR DESCRIPTION
This requires disabling some tests (for now) and filing issues to track