### PR TITLE
#5244 enable multicore for upsample tilize untilize in unet

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/test_upsample.py
@@ -4,6 +4,7 @@
 
 import pytest
 import math
+from typing import Union, Tuple
 
 import torch
 import torch.nn as nn
@@ -11,6 +12,54 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import skip_for_wormhole_b0
+
+
+TILE_WIDTH = 32
+
+
+def get_shard_grid_from_num_cores(ncores: Union[int, Tuple[int, int]]) -> ttnn.experimental.tensor.CoreRangeSet:
+    max_grid_size = (9, 12)  ## (y, x)
+    if isinstance(ncores, int):
+        if ncores % max_grid_size[1] == 0:
+            core_grid = ttnn.CoreGrid(y=ncores // max_grid_size[1], x=max_grid_size[1])
+            grid_coord = ttnn.experimental.tensor.CoreCoord(core_grid.x - 1, core_grid.y - 1)
+            return ttnn.experimental.tensor.CoreRangeSet(
+                {ttnn.experimental.tensor.CoreRange(ttnn.experimental.tensor.CoreCoord(0, 0), grid_coord)}
+            )
+        else:
+            if ncores < max_grid_size[1]:
+                core_grid = ttnn.CoreGrid(y=1, x=ncores)
+                grid_coord = ttnn.experimental.tensor.CoreCoord(core_grid.x - 1, 0)
+                return ttnn.experimental.tensor.CoreRangeSet(
+                    {ttnn.experimental.tensor.CoreRange(ttnn.experimental.tensor.CoreCoord(0, 0), grid_coord)}
+                )
+            else:
+                core_grid_1 = ttnn.CoreGrid(y=ncores // max_grid_size[1], x=max_grid_size[1])
+                core_grid_2 = ttnn.CoreGrid(y=ncores // max_grid_size[1] + 1, x=ncores % max_grid_size[1])
+                grid_coord_1 = ttnn.experimental.tensor.CoreCoord(core_grid_1.x - 1, core_grid_1.y - 1)
+                grid_coord_2 = ttnn.experimental.tensor.CoreCoord(core_grid_2.x - 1, core_grid_2.y - 1)
+                return ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(ttnn.experimental.tensor.CoreCoord(0, 0), grid_coord_1),
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, grid_coord_2.y), grid_coord_2
+                        ),
+                    }
+                )
+    elif isinstance(ncores, tuple):
+        ncores_h, ncores_w = ncores
+        assert ncores_h <= max_grid_size[0]
+        assert ncores_w <= max_grid_size[1]
+        return ttnn.experimental.tensor.CoreRangeSet(
+            {
+                ttnn.experimental.tensor.CoreRange(
+                    ttnn.experimental.tensor.CoreCoord(0, 0),
+                    ttnn.experimental.tensor.CoreCoord(ncores_w - 1, ncores_h - 1),
+                )
+            }
+        )
+    else:
+        raise ValueError("Invalid ncores")
 
 
 @skip_for_wormhole_b0()
@@ -61,11 +110,10 @@ def test_upsample_single_core(device, input_shapes, scale_h, scale_w):
     "input_shape",
     [
         [2, 1280, 4, 4],  # 256x256
-        [2, 1280, 8, 8],
         [2, 640, 16, 16],
         [2, 1280, 8, 8],  # 512x512
         [2, 1280, 16, 16],
-        [2, 1280, 16, 16],
+        [1, 64, 132, 10],
     ],
 )
 @pytest.mark.parametrize("scale_h", [2])
@@ -81,14 +129,14 @@ def test_upsample_multi_core(device, input_shape, scale_h, scale_w, shard_strate
     scale_factor = (scale_h, scale_w)
     torch_upsample = nn.Upsample(scale_factor=scale_factor, mode="nearest")
     torch_result = torch_upsample(input)
-    output_shape = torch_result.shape
 
-    ## calculated ttnn result
-
-    ## permute to N H W C
+    ## permute to N H W C, which is what the upsample op expects
     tt_input = input.permute(0, 2, 3, 1)
 
+    num_bytes = 2  ## only BFLOAT16 is supported
+
     ## calculate ncores, corresponding grid_size and in_shard_shape based on the input_shape
+    ncores = None
     max_grid_size = (9, 12)  ## (y, x)
     if shard_strategy == ttnn.ShardStrategy.HEIGHT:
         ## nsticks per shard should be divisible by in_w
@@ -98,18 +146,7 @@ def test_upsample_multi_core(device, input_shape, scale_h, scale_w, shard_strate
             if batch_size * height % nshards == 0:
                 break
             nshards -= 1
-
         ncores = nshards
-        if ncores % max_grid_size[1] == 0:
-            grid_size = ttnn.CoreGrid(y=ncores // max_grid_size[1], x=max_grid_size[1])
-        else:
-            if ncores < max_grid_size[1]:
-                grid_size = ttnn.CoreGrid(y=1, x=ncores)
-            else:
-                grid1_size = ttnn.CoreGrid(y=ncores // max_grid_size[1], x=max_grid_size[1])
-                grid2_size = ttnn.CoreGrid(y=ncores // max_grid_size[1] + 1, x=ncores % max_grid_size[1])
-                grid_size = (grid1_size, grid2_size)
-
     elif shard_strategy == ttnn.ShardStrategy.BLOCK:
         max_nshards_h = min(batch_size * height, max_grid_size[0])  ## height along NHW
         max_nshards_w = min(num_channels, max_grid_size[1])  ## width along C
@@ -122,28 +159,54 @@ def test_upsample_multi_core(device, input_shape, scale_h, scale_w, shard_strate
         ## find nshards_w along C
         nshards_w = max_nshards_w
         while nshards_w > 0:
-            if num_channels % nshards_w == 0:
+            ## make sure: 1. nshards_w divides num_channels, and 2. shard_shape[1] is aligned to 32B
+            if num_channels % nshards_w == 0 and math.ceil(num_channels * num_bytes / nshards_w) % TILE_WIDTH == 0:
                 break
             nshards_w -= 1
-
         if nshards_w == 0 or nshards_h == 0:
             raise ValueError("nshards_h or nshards_w is 0")
+        ncores = (nshards_h, nshards_w)
 
-        ## calculate grid_size and shard_shape
-        grid_size = ttnn.CoreGrid(y=nshards_h, x=nshards_w)
+    # in_sharded_mem_config = ttnn.create_sharded_memory_config(
+    #     [batch_size, height, width, num_channels],
+    #     grid_size,
+    #     shard_strategy,
+    #     use_height_and_width_as_shard_shape=False   ##shard_strategy == ttnn.ShardStrategy.HEIGHT,
+    # )
+    # out_sharded_mem_config = ttnn.create_sharded_memory_config(
+    #     [batch_size, height * scale_h, width * scale_w, num_channels],
+    #     grid_size,
+    #     shard_strategy,
+    #     use_height_and_width_as_shard_shape=False   ##shard_strategy == ttnn.ShardStrategy.HEIGHT,
+    # )
 
-    in_sharded_mem_config = ttnn.create_sharded_memory_config(
-        [batch_size, height, width, num_channels],
-        grid_size,
-        shard_strategy,
-        use_height_and_width_as_shard_shape=shard_strategy == ttnn.ShardStrategy.HEIGHT,
-    )
-    out_sharded_mem_config = ttnn.create_sharded_memory_config(
-        [batch_size, height * scale_h, width * scale_w, num_channels],
-        grid_size,
-        shard_strategy,
-        use_height_and_width_as_shard_shape=shard_strategy == ttnn.ShardStrategy.HEIGHT,
-    )
+    shard_grid = get_shard_grid_from_num_cores(ncores)
+    shard_orientation = ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR
+
+    if shard_strategy == ttnn.ShardStrategy.BLOCK:
+        tensor_memory_layout = ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+    elif shard_strategy == ttnn.ShardStrategy.HEIGHT:
+        tensor_memory_layout = ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
+
+    ## input shard
+    if shard_strategy == ttnn.ShardStrategy.BLOCK:
+        shard_height = math.ceil(batch_size * height * width / ncores[0])
+        shard_width = math.ceil(num_channels / ncores[1])
+    elif shard_strategy == ttnn.ShardStrategy.HEIGHT:
+        shard_height = math.ceil(batch_size * height * width / ncores)
+        shard_width = num_channels
+    shard_shape = (shard_height, shard_width)
+    shard_spec = ttnn.experimental.tensor.ShardSpec(shard_grid, shard_shape, shard_orientation, False)
+    in_sharded_mem_config = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+
+    ## output shard
+    shard_height = shard_height * scale_h * scale_w
+    shard_shape = (shard_height, shard_width)
+    shard_spec = ttnn.experimental.tensor.ShardSpec(shard_grid, shard_shape, shard_orientation, False)
+    out_sharded_mem_config = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+
+    print(f"in_shard_mem_config: {in_sharded_mem_config}")
+    print(f"out_shard_mem_config: {out_sharded_mem_config}")
 
     ## ttnn uses NHWC, so need to set scale_factor_c = 1
     scale_factor = (scale_h, scale_w, 1)

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -316,9 +316,9 @@ Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layo
 
     uint32_t num_shards;
     uint32_t total_height = tt_metal::compute_volume(shape) / shape[-1];
-        uint32_t total_width = shape[-1];
+    uint32_t total_width = shape[-1];
     if (memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        TT_ASSERT(total_width == shard_shape[1], "Shard shape does not divide tensor shape correctly according to sharding scheme");
+        TT_ASSERT(total_width == shard_shape[1], "Shard shape {} does not divide tensor shape {} correctly according to sharding scheme", shard_shape[1], total_width);
         num_shards = div_up(total_height, shard_shape[0]);
     } else if (memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
         TT_ASSERT(total_height == shard_shape[0], "Shard shape does not divide tensor shape correctly according to sharding scheme");
@@ -329,7 +329,7 @@ Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layo
         TT_FATAL(false, "Unsupported sharding scheme");
     }
 
-    TT_ASSERT(num_shards == num_cores, "Number of shards must match number of cores");
+    TT_ASSERT(num_shards == num_cores, "Number of shards {} must match number of cores {}", num_shards, num_cores);
 
     if (layout == Layout::TILE) {
         TT_ASSERT((shard_shape[0] % TILE_HEIGHT == 0 && shard_shape[1] % TILE_WIDTH == 0), "Shard shape must be tile sized");

--- a/tt_eager/tt_dnn/op_library/upsample/single_core/upsample_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/upsample/single_core/upsample_op_single_core.cpp
@@ -20,7 +20,7 @@ namespace tt {
 
 namespace tt_metal {
 
-operation::ProgramWithCallbacks upsample_single_core(const Tensor &input, Tensor& output, int scale_factor_h, int scale_factor_w) {
+operation::ProgramWithCallbacks upsample_single_core(const Tensor &input, Tensor& output, uint32_t scale_factor_h, uint32_t scale_factor_w) {
     Program program{};
     CoreRange core({0, 0}, {0, 0});
 

--- a/tt_eager/tt_dnn/op_library/upsample/upsample_op.cpp
+++ b/tt_eager/tt_dnn/op_library/upsample/upsample_op.cpp
@@ -57,7 +57,7 @@ std::vector<Tensor> UpSample::create_output_tensors(const std::vector<Tensor> &i
             auto output_shape = compute_output_shapes(inputs).at(0);
             if (input.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
                 auto ncores = input_shard_spec.num_cores();
-                array<uint32_t, 2> output_shard_shape = {output_shape[0] * output_shape[1] * output_shape[2] / ncores, output_shape[-1]};
+                array<uint32_t, 2> output_shard_shape = {div_up(output_shape[0] * output_shape[1] * output_shape[2], ncores), output_shape[-1]};
                 auto output_shard_spec = input_shard_spec;
                 output_shard_spec.shape = output_shard_shape;
                 mem_config.shard_spec = output_shard_spec;

--- a/tt_eager/tt_dnn/op_library/upsample/upsample_op.hpp
+++ b/tt_eager/tt_dnn/op_library/upsample/upsample_op.hpp
@@ -42,7 +42,7 @@ Tensor upsample(const Tensor &input,
                   int scale_factor_w,
                   const MemoryConfig& out_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-operation::ProgramWithCallbacks upsample_single_core(const Tensor &a, Tensor& output, int scale_factor_h, int scale_factor_w);
+operation::ProgramWithCallbacks upsample_single_core(const Tensor &input, Tensor& output, uint32_t scale_factor_h, uint32_t scale_factor_w);
 operation::ProgramWithCallbacks upsample_multi_core(const Tensor &input, Tensor& output, uint32_t scale_factor_h, uint32_t scale_factor_w);
 
 }  // namespace tt_metal

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -399,7 +399,7 @@ const inline bool operator==(const CoreRangeSet &a, const CoreRangeSet &b) {
 inline std::vector<CoreCoord> grid_to_cores(uint32_t num_cores, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise=false) {
     std::vector<CoreCoord> cores;
     cores.reserve(num_cores);
-    TT_ASSERT(num_cores <= grid_size_x * grid_size_y);
+    TT_ASSERT(num_cores <= grid_size_x * grid_size_y, "Number of cores {} exceeds grid size {}x{}", num_cores, grid_size_x, grid_size_y);
     if (row_wise) {
         for(uint32_t i = 0; i < num_cores; ++i) {
             cores.push_back({i % grid_size_x, i / grid_size_x});


### PR DESCRIPTION
* Enable multicore by using incoming tensor shard strategy for upsample, tilize and untilize in ttnn when possible (default is single core)
* Add resharding to upsample if incoming sharding scheme is not compatible.