### PR TITLE
#2875: Package all build artifacts, while removing unnecessary stuff for reusable artifacts from build folder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,15 +37,10 @@ jobs:
         # Does not work yet
         if: ${{ matrix.config != 'release' }}
         run: make tests
+      - name: Remove unnecessary artifacts
+        run: rm -rf build/python_env build/obj build/git_hooks
       - name: Upload libraries as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: metal-libraries-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.config }}
-          path: build/lib
-      - name: Upload tests as artifacts
-        uses: actions/upload-artifact@v4
-        # Does not work yet
-        if: ${{ matrix.config != 'release' }}
-        with:
-          name: metal-tests-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.config }}
-          path: build/test
+          name: metal-build-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.config }}
+          path: build


### PR DESCRIPTION
excluding python_env, objs, and g…it_hooks, into one artifact