### PR TITLE
Add Events API/Support for tt_metal for host->CQ and CQ<->CQ synchronization #5529

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -58,6 +58,7 @@ ETH
 EltwiseUnary
 EnqueueProgram
 EnqueueQueueRecordEvent
+EnqueueQueueWaitForEvent
 EnqueueReadBuffer
 EnqueueWriteBuffer
 Enum

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -62,6 +62,7 @@ EnqueueReadBuffer
 EnqueueWriteBuffer
 Enum
 Enums
+EventSynchronize
 FW
 FileCopyrightText
 GGGG

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -57,6 +57,7 @@ ENDL
 ETH
 EltwiseUnary
 EnqueueProgram
+EnqueueQueueRecordEvent
 EnqueueReadBuffer
 EnqueueWriteBuffer
 Enum

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueQueueRecordEvent.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueQueueRecordEvent.rst
@@ -1,0 +1,4 @@
+EnqueueQueueRecordEvent
+=======================
+
+.. doxygenfunction:: EnqueueQueueRecordEvent(CommandQueue& cq, Event &event)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueQueueWaitForEvent.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueQueueWaitForEvent.rst
@@ -1,0 +1,4 @@
+EnqueueQueueWaitForEvent
+========================
+
+.. doxygenfunction:: EnqueueQueueWaitForEvent(CommandQueue& cq, Event &event)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EventSynchronize.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EventSynchronize.rst
@@ -1,0 +1,4 @@
+EventSynchronize
+================
+
+.. doxygenfunction:: EventSynchronize(Event &event)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
@@ -6,5 +6,6 @@ CommandQueue
   EnqueueReadBuffer
   EnqueueProgram
   EnqueueQueueRecordEvent
+  EnqueueQueueWaitForEvent
   EventSynchronize
   Finish

--- a/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
@@ -5,4 +5,5 @@ CommandQueue
   EnqueueWriteBuffer
   EnqueueReadBuffer
   EnqueueProgram
+  EnqueueQueueRecordEvent
   Finish

--- a/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
@@ -6,4 +6,5 @@ CommandQueue
   EnqueueReadBuffer
   EnqueueProgram
   EnqueueQueueRecordEvent
+  EventSynchronize
   Finish

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
@@ -33,3 +33,15 @@ TEST_F(CommandQueueFixture, TestEventsWrittenToCompletionQueueInOrder) {
         EXPECT_EQ(event, i);
     }
 }
+
+// Basic test, record events, check that Event struct was updated. Enough commands to trigger issue queue wrap.
+TEST_F(CommandQueueFixture, TestEventsEnqueueRecordEventIssueQueueWrap) {
+    size_t num_events = 100000; // Enough to wrap issue queue. 768MB and cmds are 22KB each, so 35k cmds.
+    for (size_t i = 0; i < num_events; i++) {
+        Event event;
+        EnqueueQueueRecordEvent(*this->cmd_queue, event);
+        EXPECT_EQ(event.event_id, i);
+        EXPECT_EQ(event.cq_id, this->cmd_queue->id());
+    }
+    Finish(*this->cmd_queue);
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueQueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueQueueWaitForEvent.cpp
@@ -10,6 +10,7 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
+#include "command_queue_test_utils.hpp"
 
 using namespace tt::tt_metal;
 
@@ -52,6 +53,258 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEventSynchronizeSanity) {
     }
 
     local_test_functions::FinishAllCqs(cqs);
+}
+
+// Simplest test to record and wait-for-events on same CQ.
+TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueQueueWaitForEventSanity) {
+    CommandQueue a(this->device_, 0);
+    CommandQueue b(this->device_, 1);
+    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+    size_t num_events = 10;
+
+    for (size_t j = 0; j < num_events; j++) {
+        for (uint i = 0; i < cqs.size(); i++) {
+            log_debug(tt::LogTest, "Recording and Device Syncing on event for CQ ID: {}", cqs[i].get().id());
+            Event event;
+            EnqueueQueueRecordEvent(cqs[i], event);
+            EXPECT_EQ(event.cq_id, cqs[i].get().id());
+            EXPECT_EQ(event.event_id, j * 2);
+            EnqueueQueueWaitForEvent(cqs[i], event);
+        }
+    }
+    local_test_functions::FinishAllCqs(cqs);
+}
+
+// Record event on one CQ, wait-for-that-event on another CQ. Then do the flip. Occasionally insert
+// syncs from Host per CQ, and verify completion queues per CQ are correct.
+TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueQueueWaitForEventCrossCQs) {
+    CommandQueue a(this->device_, 0);
+    CommandQueue b(this->device_, 1);
+    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+    size_t num_events_per_cq = 10;
+
+    // Currently hardcoded for 2 CQ. For 3+ CQ, can extend to record for CQ0, Wait for CQ1,CQ2,etc.
+    TT_ASSERT(cqs.size() == 2);
+    const int num_cmds_per_cq = 2;
+
+    // Store completion queue base address from initial rdptr, for later readback.
+    vector<uint32_t> completion_queue_base;
+    for (uint i = 0; i < cqs.size(); i++) {
+        completion_queue_base.push_back(this->device_->sysmem_manager().get_completion_queue_read_ptr(i));
+    }
+
+    // Issue a number of Event Record/Waits per CQ, with Record/Wait on alternate CQs
+    for (size_t j = 0; j < num_events_per_cq; j++) {
+        for (uint i = 0; i < cqs.size(); i++) {
+            auto &cq_record_event = cqs[i];
+            auto &cq_wait_event = cqs[(i + 1) % cqs.size()];
+            Event event;
+            log_debug(tt::LogTest, "Recording event on CQ ID: {} and Device Syncing on CQ ID: {}", cq_record_event.get().id(), cq_wait_event.get().id());
+
+            EnqueueQueueRecordEvent(cq_record_event, event);
+            EXPECT_EQ(event.cq_id, cq_record_event.get().id());
+            EXPECT_EQ(event.event_id, i + (j * num_cmds_per_cq));
+            EnqueueQueueWaitForEvent(cq_wait_event, event);
+
+            // Occasionally do host wait for extra coverage from both CQs.
+            if (j > 0 && ((j % 3) == 0)) {
+                EventSynchronize(event);
+            }
+        }
+    }
+
+    local_test_functions::FinishAllCqs(cqs);
+
+    // Check that completion queue per device is correct. Ensure expected event_ids seen in order.
+    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
+    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
+    constexpr uint32_t completion_queue_event_alignment = 32;
+    uint32_t event;
+
+    for (uint cq_id = 0; cq_id < cqs.size(); cq_id++) {
+        for (size_t i = 0; i < num_cmds_per_cq * num_events_per_cq; i++) {
+            uint32_t host_addr = completion_queue_base[cq_id] + i * completion_queue_event_alignment;
+            tt::Cluster::instance().read_sysmem(&event, 4, host_addr, mmio_device_id, channel);
+            EXPECT_EQ(event, i);
+        }
+    }
+}
+
+// Simple 2CQ test to mix reads, writes, record-event, wait-for-event in a basic way. It's simple because
+// the write, record-event, wait-event, read-event are all on the same CQ, but cover both CQ's.
+TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsReadWriteWithWaitForEventSameCQ) {
+    TestBufferConfig config = {.num_pages = 1, .page_size = 256, .buftype = BufferType::DRAM};
+    CommandQueue a(this->device_, 0);
+    CommandQueue b(this->device_, 1);
+    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+    size_t buf_size = config.num_pages * config.page_size;
+
+    size_t num_buffers_per_cq = 10;
+    bool pass = true;
+    std::unordered_map<uint, std::vector<Event>> sync_events;
+
+    for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
+        vector<std::unique_ptr<Buffer>> buffers;
+        vector<vector<uint32_t>> srcs;
+        for (uint i = 0; i < cqs.size(); i++) {
+            uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
+            buffers.push_back(std::make_unique<Buffer>(this->device_, buf_size, config.page_size, config.buftype));
+            srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
+            log_debug(tt::LogTest, "Doing Write to cq_id: {} of data: {}", i, srcs[i]);
+            EnqueueWriteBuffer(cqs[i], *buffers[i], srcs[i], false);
+            auto &event = sync_events[i].emplace_back(Event());
+            EnqueueQueueRecordEvent(cqs[i], event);
+        }
+
+        for (uint i = 0; i < cqs.size(); i++) {
+            auto &event = sync_events[i][buf_idx];
+            EnqueueQueueWaitForEvent(cqs[i], event);
+            vector<uint32_t> result;
+            EnqueueReadBuffer(cqs[i], *buffers[i], result, true);
+            log_debug(tt::LogTest, "Doing Read to cq_id: {} got data: {}", i, result);
+            bool local_pass = (srcs[i] == result);
+            pass &= local_pass;
+        }
+    }
+
+    local_test_functions::FinishAllCqs(cqs);
+    EXPECT_TRUE(pass);
+}
+
+// More interesting test where Blocking ReadBuffer, Non-Blocking WriteBuffer are on alternate CQs,
+// ordered via events. Do many loops, occasionally increasing size of buffers (page size, num pages).
+// Ensure read back data is correct, data is different for each write.
+TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsReadWriteWithWaitForEventCrossCQs) {
+    TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
+    CommandQueue a(this->device_, 0);
+    CommandQueue b(this->device_, 1);
+    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+
+    size_t num_buffers_per_cq = 50;
+    bool pass = true;
+
+    for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
+
+        // Increase number of pages and page size every 10 buffers, to change async timing betwen CQs.
+        if (buf_idx > 0 && ((buf_idx % 10) == 0)) {
+            config.page_size *= 2;
+            config.num_pages *= 2;
+        }
+
+        vector<std::unique_ptr<Buffer>> buffers;
+        vector<vector<uint32_t>> srcs;
+        size_t buf_size = config.num_pages * config.page_size;
+
+        for (uint i = 0; i < cqs.size(); i++) {
+
+            uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
+            auto &cq_write = cqs[i];
+            auto &cq_read = cqs[(i + 1) % cqs.size()];
+            Event event;
+            vector<uint32_t> result;
+
+            buffers.push_back(std::make_unique<Buffer>(this->device_, buf_size, config.page_size, config.buftype));
+            srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
+
+            // Blocking Read after Non-Blocking Write on alternate CQs, events ensure ordering.
+            log_debug(tt::LogTest, "Doing Write (page_size: {} num_pages: {}) to cq_id: {}", config.page_size, config.num_pages, cq_write.get().id());
+            EnqueueWriteBuffer(cq_write, *buffers[i], srcs[i], false);
+            EnqueueQueueRecordEvent(cq_write, event);
+            EnqueueQueueWaitForEvent(cq_read, event);
+            EnqueueReadBuffer(cq_read, *buffers[i], result, true);
+            pass &= (srcs[i] == result);
+        }
+    }
+
+    local_test_functions::FinishAllCqs(cqs);
+    EXPECT_TRUE(pass);
+}
+
+// 2 CQs with single Buffer, and a loop where each iteration has non-blocking Write to Buffer via CQ0 and non-blocking Read
+// to Bufffer via CQ1. Ping-Pongs between Writes and Reads to same buffer. Use events to synchronze read after write and
+// write after read before checking correct data read at the end after all cmds finished on device.
+TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsReadWriteWithWaitForEventCrossCQsPingPong) {
+    TestBufferConfig config = {.num_pages = 1, .page_size = 16, .buftype = BufferType::DRAM};
+    CommandQueue a(this->device_, 0);
+    CommandQueue b(this->device_, 1);
+    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+    size_t buf_size = config.num_pages * config.page_size;
+
+    bool pass = true;
+
+    // Some configuration, eventually refactor and spawn more tests.
+    int num_buffers = 20;
+    int num_wr_rd_per_buf = 5;
+    bool use_events = true; // Set to false to see failures.
+
+    TT_ASSERT(cqs.size() == 2);
+    auto &cq_write = cqs[0];
+    auto &cq_read = cqs[1];
+
+    // Another loop for increased testing. Repeat test multiple times for different buffers.
+    for (int i = 0; i < num_buffers; i++) {
+
+        vector<vector<uint32_t>> write_data;
+        vector<vector<uint32_t>> read_results;
+        vector<std::unique_ptr<Buffer>> buffers;
+
+        buffers.push_back(std::make_unique<Buffer>(this->device_, buf_size, config.page_size, config.buftype));
+
+        // Number of write-read combos per buffer. Fewer make RAW race without events easier to hit.
+        for (uint j = 0; j < num_wr_rd_per_buf; j++) {
+
+            // 2 Events to synchronize delaying the read after write, and delaying the next write after read.
+            Event event_sync_read_after_write;
+            Event event_sync_write_after_read;
+
+            // Add entry in resutls vector, and construct write data, unique per loop
+            read_results.emplace_back();
+            write_data.push_back(generate_arange_vector(buffers.back()->size(), j * 100));
+
+            // Issue non-blocking write via first CQ and record event to synchronize with read on other CQ.
+            log_debug(tt::LogTest, "Doing Write j: {} (page_size: {} num_pages: {}) to cq_id: {} write_data: {}", j, config.page_size, config.num_pages, cq_write.get().id(), write_data.back());
+            EnqueueWriteBuffer(cq_write, *buffers.back(), write_data.back(), false);
+            if (use_events) EnqueueQueueRecordEvent(cq_write, event_sync_read_after_write);
+
+            // Issue wait for write to complete, and non-blocking read from the second CQ.
+            if (use_events) EnqueueQueueWaitForEvent(cq_read, event_sync_read_after_write);
+            EnqueueReadBuffer(cq_read, *buffers.back(), read_results.back(), false);
+            log_debug(tt::LogTest, "Issued Read for j: {} got data: {}", j, read_results.back()); // Data not ready since non-blocking.
+
+            // If more loops, Record Event on second CQ and wait for it to complete on first CQ before next loop's write.
+            if (use_events && j < num_wr_rd_per_buf-1) {
+                EnqueueQueueRecordEvent(cq_read, event_sync_write_after_read);
+                EnqueueQueueWaitForEvent(cq_write, event_sync_write_after_read);
+            }
+        }
+
+        // Basically like Finish, but use host sync on event to ensure all read cmds are finished.
+        if (use_events) {
+            Event event_done_reads;
+            EnqueueQueueRecordEvent(cq_read, event_done_reads);
+            EventSynchronize(event_done_reads);
+        }
+
+        TT_ASSERT(write_data.size() == read_results.size());
+        TT_ASSERT(write_data.size() == num_wr_rd_per_buf);
+
+        for (uint j = 0; j < num_wr_rd_per_buf; j++) {
+            // Make copy of read results, helpful for comparison without events, since vector may be updated between comparison and debug log.
+            auto read_results_snapshot = read_results[j];
+            bool local_pass = write_data[j] == read_results_snapshot;
+            log_debug(tt::LogTest, "Checking j: {} local_pass: {} write_data: {} read_results: {}", j, local_pass, write_data[j], read_results_snapshot);
+            pass &= local_pass;
+        }
+
+        // Before starting test with another buffer, drain CQs. Without this, see segfaults after
+        // adding num_buffers loop.
+        local_test_functions::FinishAllCqs(cqs);
+
+    } // num_buffers
+
+    local_test_functions::FinishAllCqs(cqs);
+    EXPECT_TRUE(pass);
+
 }
 
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueQueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueQueueWaitForEvent.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+
+#include "command_queue_fixture.hpp"
+#include "common/logger.hpp"
+#include "gtest/gtest.h"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+
+using namespace tt::tt_metal;
+
+namespace local_test_functions {
+
+void FinishAllCqs(vector<std::reference_wrapper<CommandQueue>>& cqs) {
+    for (uint i = 0; i < cqs.size(); i++) {
+        Finish(cqs[i]);
+    }
+}
+
+}
+
+namespace basic_tests {
+
+// Simplest test to record Event per CQ and wait from host.
+TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEventSynchronizeSanity) {
+    CommandQueue a(this->device_, 0);
+    CommandQueue b(this->device_, 1);
+    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+    std::unordered_map<uint, std::vector<Event>> sync_events;
+    size_t num_events = 10;
+
+    for (size_t j = 0; j < num_events; j++) {
+        for (uint i = 0; i < cqs.size(); i++) {
+            log_debug(tt::LogTest, "Recording and Host Syncing on event for CQ ID: {}", cqs[i].get().id());
+            auto &event = sync_events[i].emplace_back(Event());
+            EnqueueQueueRecordEvent(cqs[i], event);
+            EXPECT_EQ(event.cq_id, cqs[i].get().id());
+            EXPECT_EQ(event.event_id, j); // 1 cmd per CQ
+            EventSynchronize(event);
+        }
+    }
+
+    // Sync on earlier events again per CQ just to show it works.
+    for (uint i = 0; i < cqs.size(); i++) {
+        for (size_t j = 0; j < num_events; j++) {
+            EventSynchronize(sync_events.at(i)[j]);
+        }
+    }
+
+    local_test_functions::FinishAllCqs(cqs);
+}
+
+
+}  // end namespace basic_tests

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "command_queue_fixture.hpp"
+#include "command_queue_test_utils.hpp"
 #include "gtest/gtest.h"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
@@ -12,36 +13,8 @@
 
 using namespace tt::tt_metal;
 
-struct TestBufferConfig {
-    uint32_t num_pages;
-    uint32_t page_size;
-    BufferType buftype;
-};
-
-struct BufferStressTestConfig {
-    // Used for normal write/read tests
-    uint32_t seed;
-    uint32_t num_pages_total;
-
-    uint32_t page_size;
-    uint32_t max_num_pages_per_buffer;
-
-    // Used for wrap test
-    uint32_t num_iterations;
-    uint32_t num_unique_vectors;
-};
 
 namespace local_test_functions {
-
-vector<uint32_t> generate_arange_vector(uint32_t size_bytes) {
-    TT_FATAL(size_bytes % sizeof(uint32_t) == 0);
-    vector<uint32_t> src(size_bytes / sizeof(uint32_t), 0);
-
-    for (uint32_t i = 0; i < src.size(); i++) {
-        src.at(i) = i;
-    }
-    return src;
-}
 
 bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(Device* device, vector<std::reference_wrapper<CommandQueue>>& cqs, const TestBufferConfig& config) {
     bool pass = true;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_test_utils.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// #pragma once
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/bfloat16.hpp"
+
+struct TestBufferConfig {
+    uint32_t num_pages;
+    uint32_t page_size;
+    BufferType buftype;
+};
+
+struct BufferStressTestConfig {
+    // Used for normal write/read tests
+    uint32_t seed;
+    uint32_t num_pages_total;
+
+    uint32_t page_size;
+    uint32_t max_num_pages_per_buffer;
+
+    // Used for wrap test
+    uint32_t num_iterations;
+    uint32_t num_unique_vectors;
+};
+
+
+inline vector<uint32_t> generate_arange_vector(uint32_t size_bytes, uint32_t start = 0) {
+    TT_FATAL(size_bytes % sizeof(uint32_t) == 0);
+    vector<uint32_t> src(size_bytes / sizeof(uint32_t), 0);
+
+    for (uint32_t i = 0; i < src.size(); i++) {
+        src.at(i) = start + i;
+    }
+    return src;
+}

--- a/tt_eager/queue/queue.cpp
+++ b/tt_eager/queue/queue.cpp
@@ -23,7 +23,6 @@ void EnqueueDeviceToHostTransfer(
 void QueueSynchronize(CommandQueue& q) { Finish(q); }
 
 void QueueWaitForEvent(CommandQueue& q, Event& e) {}
-void EventSynchronize(Event& e) {}
 
 std::vector<Tensor> EnqueueOperation(
     CommandQueue& queue,

--- a/tt_eager/queue/queue.cpp
+++ b/tt_eager/queue/queue.cpp
@@ -22,8 +22,6 @@ void EnqueueDeviceToHostTransfer(
 
 void QueueSynchronize(CommandQueue& q) { Finish(q); }
 
-void QueueWaitForEvent(CommandQueue& q, Event& e) {}
-
 std::vector<Tensor> EnqueueOperation(
     CommandQueue& queue,
     operation::DeviceOperation& devop,

--- a/tt_eager/queue/queue.cpp
+++ b/tt_eager/queue/queue.cpp
@@ -22,7 +22,6 @@ void EnqueueDeviceToHostTransfer(
 
 void QueueSynchronize(CommandQueue& q) { Finish(q); }
 
-void QueueRecordEvent(CommandQueue& q, Event& e) {}
 void QueueWaitForEvent(CommandQueue& q, Event& e) {}
 void EventSynchronize(Event& e) {}
 

--- a/tt_eager/queue/queue.hpp
+++ b/tt_eager/queue/queue.hpp
@@ -27,7 +27,7 @@ void EnqueueDeviceToHostTransfer(
     size_t src_offset = 0);
 
 void EnqueueQueueRecordEvent(CommandQueue&, Event&);
-void QueueWaitForEvent(CommandQueue&, Event&);
+void EnqueueQueueWaitForEvent(CommandQueue&, Event&);
 void EventSynchronize(Event&);
 void QueueSynchronize(CommandQueue&);
 

--- a/tt_eager/queue/queue.hpp
+++ b/tt_eager/queue/queue.hpp
@@ -26,7 +26,7 @@ void EnqueueDeviceToHostTransfer(
     const std::optional<std::size_t> transfer_size = std::nullopt,
     size_t src_offset = 0);
 
-void QueueRecordEvent(CommandQueue&, Event&);
+void EnqueueQueueRecordEvent(CommandQueue&, Event&);
 void QueueWaitForEvent(CommandQueue&, Event&);
 void EventSynchronize(Event&);
 void QueueSynchronize(CommandQueue&);

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -409,6 +409,17 @@ void DumpDeviceProfileResults(Device *device, const Program &program);
 void EnqueueQueueRecordEvent(CommandQueue& cq, Event &event);
 
 /**
+ * Enqueues a command on the device for a given CQ (non-blocking). The command on device will block and wait for completion of the specified event (which may be in another CQ).
+ * Return value: void
+ * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
+ * |              | and waits for the event to complete.                                   |                               |                                    |          |
+ * | event        | The event object that this CQ will wait on for completion.             | Event &                       |                                    | Yes      |
+ */
+void EnqueueQueueWaitForEvent(CommandQueue& cq, Event &event);
+
+/**
  * Blocking function for host to synchronize (wait) on an event completion on device.
  * Return value: void
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -408,6 +408,14 @@ void DumpDeviceProfileResults(Device *device, const Program &program);
  */
 void EnqueueQueueRecordEvent(CommandQueue& cq, Event &event);
 
+/**
+ * Blocking function for host to synchronize (wait) on an event completion on device.
+ * Return value: void
+ * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | event        | The event object that host will wait on for completion.                | Event &                       |                                    | Yes      |
+ */
+void EventSynchronize(Event &event);
 
 }  // namespace tt_metal
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -11,6 +11,7 @@
 #include "common/core_coord.h"
 #include "tt_metal/impl/program/program.hpp"
 #include "tt_metal/impl/buffers/buffer.hpp"
+#include "tt_metal/impl/event/event.hpp"
 
 /** @file */
 
@@ -397,15 +398,16 @@ void EnqueueTrace(Trace& trace, bool blocking);
  * */
 void DumpDeviceProfileResults(Device *device, const Program &program);
 
-// namespace experimental
-// {
-//     struct Event{
-//         uint32_t id;
-//         uint32_t cq_id;
-//     };
+/**
+ * Enqueues a command to record an Event on the device for a given CQ, and updates the Event object for the user.
+ * Return value: void
+ * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
+ * | event        | An event that will be populated by this function, and inserted in CQ   | Event &                       |                                    | Yes      |
+ */
+void EnqueueQueueRecordEvent(CommandQueue& cq, Event &event);
 
-//     void RecordEvent (Event & e);
-// }
 
 }  // namespace tt_metal
 

--- a/tt_metal/hostdevcommon/common_runtime_address_map.h
+++ b/tt_metal/hostdevcommon/common_runtime_address_map.h
@@ -90,6 +90,8 @@ constexpr static uint32_t CQ_ISSUE_READ_PTR = 110944;
 constexpr static uint32_t CQ_ISSUE_WRITE_PTR = CQ_ISSUE_READ_PTR + L1_ALIGNMENT;
 constexpr static uint32_t CQ_COMPLETION_WRITE_PTR = CQ_ISSUE_WRITE_PTR + L1_ALIGNMENT;
 constexpr static uint32_t CQ_COMPLETION_READ_PTR = CQ_COMPLETION_WRITE_PTR + L1_ALIGNMENT;
+constexpr static uint32_t CQ_COMPLETION_LAST_EVENT = CQ_COMPLETION_READ_PTR + L1_ALIGNMENT;
+constexpr static uint32_t CQ_COMPLETION_16B_SCRATCH = CQ_ISSUE_READ_PTR; // 16B unused in consumer core.
 
 // Host addresses for dispatch
 static constexpr uint32_t HOST_CQ_ISSUE_READ_PTR = 0;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -502,8 +502,10 @@ void Device::configure_command_queue_programs() {
                     uint32_t completion_queue_start_addr = CQ_START + issue_queue_size + get_absolute_cq_offset(curr_channel, cq_id, curr_cq_size);
                     uint32_t completion_queue_start_addr_16B = completion_queue_start_addr >> 4;
                     vector<uint32_t> completion_queue_wr_ptr = {completion_queue_start_addr_16B};
+                    vector<uint32_t> completion_queue_last_event = {0x0}; // Reset state in case L1 Clear is disabled.
                     detail::WriteToDeviceL1(this, completion_q_logical_core, CQ_COMPLETION_READ_PTR, completion_queue_wr_ptr);
                     detail::WriteToDeviceL1(this, completion_q_logical_core, CQ_COMPLETION_WRITE_PTR, completion_queue_wr_ptr);
+                    detail::WriteToDeviceL1(this, completion_q_logical_core, CQ_COMPLETION_LAST_EVENT, completion_queue_last_event);
                 }
             }
         }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -672,6 +672,47 @@ void EnqueueRecordEventCommand::process() {
     this->manager.issue_queue_push_back(cmd_size, detail::LAZY_COMMAND_QUEUE_MODE, this->command_queue_id);
 }
 
+EnqueueWaitForEventCommand::EnqueueWaitForEventCommand(
+    uint32_t command_queue_id, Device* device, SystemMemoryManager& manager, uint32_t event, const Event& sync_event):
+    command_queue_id(command_queue_id), device(device), manager(manager), event(event), sync_event(sync_event) {
+        // Should not be encountered under normal circumstances (record, wait) unless user is modifying sync event ID.
+        TT_ASSERT(command_queue_id != sync_event.cq_id || event != sync_event.event_id,
+            "EnqueueWaitForEventCommand cannot wait on it's own event id on the same CQ. Event ID: {} CQ ID: {}",
+            event, command_queue_id);
+}
+
+const DeviceCommand EnqueueWaitForEventCommand::assemble_device_command(uint32_t) {
+    DeviceCommand command;
+    command.set_issue_data_size(0); // No extra data just CMD.
+    command.set_completion_data_size(align(EVENT_PADDED_SIZE, 32));
+    command.set_event(this->event);
+
+    // #5529 - Cross chip sync needs to be implemented. Currently, we only support sync on the same chip.
+    TT_ASSERT(this->sync_event.device == this->device,
+            "EnqueueWaitForEvent() cross-chip sync not yet supported. Sync event device: {} this device: {}",
+            this->sync_event.device->id(), this->device->id());
+
+    auto &event_sync_hw_cq = this->sync_event.device->command_queue(this->sync_event.cq_id).hw_command_queue();
+    auto event_sync_core = this->sync_event.device->worker_core_from_logical_core(event_sync_hw_cq.completion_queue_writer_core);
+
+    // Let dispatcher know this is sync event, and what core/event_id to sync on.
+    command.set_is_event_sync(true);
+    command.set_event_sync_core_x(event_sync_core.x);
+    command.set_event_sync_core_y(event_sync_core.y);
+    command.set_event_sync_event_id(this->sync_event.event_id);
+
+    return command;
+}
+
+void EnqueueWaitForEventCommand::process() {
+    uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_id);
+    const DeviceCommand cmd = this->assemble_device_command(0);
+    uint32_t cmd_size = DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
+    this->manager.issue_queue_reserve_back(cmd_size, this->command_queue_id);
+    this->manager.cq_write(cmd.data(), DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND, write_ptr);
+    this->manager.issue_queue_push_back(cmd_size, detail::LAZY_COMMAND_QUEUE_MODE, this->command_queue_id);
+}
+
 // HWCommandQueue section
 HWCommandQueue::HWCommandQueue(Device* device, uint32_t id) : manager(device->sysmem_manager()), completion_queue_thread{} {
     ZoneScopedN("CommandQueue_constructor");
@@ -951,6 +992,19 @@ void HWCommandQueue::enqueue_record_event(std::reference_wrapper<Event> event) {
     this->manager.next_completion_queue_push_back(align(EVENT_PADDED_SIZE, 32), this->id);
 }
 
+void HWCommandQueue::enqueue_wait_for_event(std::reference_wrapper<Event> event) {
+    ZoneScopedN("HWCommandQueue_enqueue_wait_for_event");
+
+    uint32_t command_size = DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
+    if ((this->manager.get_issue_queue_write_ptr(this->id)) + command_size >= this->manager.get_issue_queue_limit(this->id)) {
+        this->issue_wrap();
+    }
+
+    auto command = EnqueueWaitForEventCommand(this->id, this->device, this->manager, this->manager.get_next_event(this->id), event.get());
+    this->enqueue_command(command, false);
+    this->manager.next_completion_queue_push_back(align(EVENT_PADDED_SIZE, 32), this->id);
+}
+
 
 void HWCommandQueue::copy_into_user_space(uint32_t event, uint32_t read_ptr, chip_id_t mmio_device_id, uint16_t channel) {
     const auto& [buffer_layout, page_size, padded_page_size, dev_page_to_host_page_mapping, dst, dst_offset, num_pages_read, cur_host_page_id] =
@@ -1212,6 +1266,27 @@ void EnqueueRecordEventImpl(CommandQueue& cq, std::reference_wrapper<Event> even
     cq.hw_command_queue().enqueue_record_event(event);
 }
 
+
+void EnqueueQueueWaitForEvent(CommandQueue& cq, Event &event) {
+    TT_ASSERT(event.device != nullptr, "EnqueueQueueRecordEvent expected to be given Event with initialized device ptr");
+    TT_ASSERT(event.event_id != -1, "EnqueueQueueWaitForEvent expected to be given Event with initialized event_id");
+    TT_ASSERT(event.cq_id != -1, "EnqueueQueueWaitForEvent expected to be given Event with initialized cq_id");
+    log_trace(tt::LogMetal, "EnqueueQueueWaitForEvent() issued on Event(device_id: {} cq_id: {} event_id: {}) from device_id: {} cq_id: {}",
+        event.device->id(), event.cq_id, event.event_id, cq.device()->id(), cq.id());
+
+    detail::DispatchStateCheck(true);
+    cq.run_command(CommandInterface{
+        .type = EnqueueCommandType::ENQUEUE_WAIT_FOR_EVENT,
+        .blocking = false,
+        .event = event,
+    });
+}
+
+void EnqueueWaitForEventImpl(CommandQueue& cq, std::reference_wrapper<Event> event) {
+    cq.hw_command_queue().enqueue_wait_for_event(event);
+}
+
+
 void EventSynchronize(Event& event) {
     detail::DispatchStateCheck(true);
     log_trace(tt::LogMetal, "Issuing host sync on Event(device_id: {} cq_id: {} event_id: {})", event.device->id(), event.cq_id, event.event_id);
@@ -1379,6 +1454,10 @@ void CommandQueue::run_command_impl(const CommandInterface& command) {
         case EnqueueCommandType::ENQUEUE_RECORD_EVENT:
             TT_ASSERT(command.event.has_value(), "Must provide an event!");
             EnqueueRecordEventImpl(*this, *command.event);
+            break;
+        case EnqueueCommandType::ENQUEUE_WAIT_FOR_EVENT:
+            TT_ASSERT(command.event.has_value(), "Must provide an event!");
+            EnqueueWaitForEventImpl(*this, *command.event);
             break;
         case EnqueueCommandType::FINISH:
             FinishImpl(*this);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1020,6 +1020,7 @@ void HWCommandQueue::read_completion_queue() {
                     }
                     this->manager.completion_queue_pop_front(align(EVENT_PADDED_SIZE, 32), this->id);
                 }
+                this->manager.set_last_completed_event(this->id, event);
             }
             this->num_completed_commands += num_events_to_read;
         } else if (this->exit_condition) {
@@ -1211,6 +1212,14 @@ void EnqueueRecordEventImpl(CommandQueue& cq, std::reference_wrapper<Event> even
     cq.hw_command_queue().enqueue_record_event(event);
 }
 
+void EventSynchronize(Event& event) {
+    detail::DispatchStateCheck(true);
+    log_trace(tt::LogMetal, "Issuing host sync on Event(device_id: {} cq_id: {} event_id: {})", event.device->id(), event.cq_id, event.event_id);
+
+    while (event.device->sysmem_manager().get_last_completed_event(event.cq_id) < event.event_id) {
+        std::this_thread::sleep_for(std::chrono::microseconds(10));
+    }
+}
 
 void Finish(CommandQueue& cq) {
     detail::DispatchStateCheck(true);

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -140,6 +140,7 @@ class SystemMemoryManager {
     uint32_t cq_size;
     uint32_t channel_offset;
     vector<int> cq_to_event;
+    vector<int> cq_to_last_completed_event;
     vector<std::mutex> cq_to_event_locks;
 
    public:
@@ -173,6 +174,7 @@ class SystemMemoryManager {
 
             this->cq_interfaces.push_back(SystemMemoryCQInterface(channel, cq_id, this->cq_size));
             this->cq_to_event.push_back(0);
+            this->cq_to_last_completed_event.push_back(0);
         }
         vector<std::mutex> temp_mutexes(num_hw_cqs);
         cq_to_event_locks.swap(temp_mutexes);
@@ -183,6 +185,20 @@ class SystemMemoryManager {
         uint32_t next_event = this->cq_to_event[cq_id]++;
         cq_to_event_locks[cq_id].unlock();
         return next_event;
+    }
+
+    void set_last_completed_event(const uint8_t cq_id, const uint32_t event_id) {
+        TT_ASSERT(event_id >= this->cq_to_last_completed_event[cq_id], "Event ID is expected to increase. Wrapping not supported for sync.");
+        cq_to_event_locks[cq_id].lock();
+        this->cq_to_last_completed_event[cq_id] = event_id;
+        cq_to_event_locks[cq_id].unlock();
+    }
+
+    uint32_t get_last_completed_event(const uint8_t cq_id) {
+        cq_to_event_locks[cq_id].lock();
+        uint32_t last_completed_event = this->cq_to_last_completed_event[cq_id];
+        cq_to_event_locks[cq_id].unlock();
+        return last_completed_event;
     }
 
     void reset(const uint8_t cq_id) {

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -103,6 +103,11 @@ void DeviceCommand::set_consumer_router_transfer_num_pages(const uint32_t consum
     this->packet.header.consumer_router_transfer_num_pages = consumer_router_transfer_num_pages;
 }
 
+void DeviceCommand::set_is_event_sync(const uint16_t is_event_sync) { this->packet.header.is_event_sync = is_event_sync; }
+void DeviceCommand::set_event_sync_core_x(const uint8_t event_sync_core_x) { this->packet.header.event_sync_core_x = event_sync_core_x; }
+void DeviceCommand::set_event_sync_core_y(const uint8_t event_sync_core_y) { this->packet.header.event_sync_core_y = event_sync_core_y; }
+void DeviceCommand::set_event_sync_event_id(const uint32_t event_sync_event_id) { this->packet.header.event_sync_event_id = event_sync_event_id; }
+
 void DeviceCommand::update_buffer_transfer_src(const uint8_t buffer_transfer_idx, const uint32_t new_src) {
     this->packet.data
         [DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER +

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -44,6 +44,10 @@ struct CommandHeader {
     uint32_t sharded_buffer_num_cores = 0;
     uint32_t new_issue_queue_size = 0;
     uint32_t new_completion_queue_size = 0;
+    uint16_t is_event_sync = 0;
+    uint8_t event_sync_core_x = 0;
+    uint8_t event_sync_core_y = 0;
+    uint32_t event_sync_event_id = 0;
 };
 
 static_assert((offsetof(CommandHeader, event) % 32) == 0);
@@ -139,6 +143,11 @@ class DeviceCommand {
     void set_producer_router_transfer_num_pages(const uint32_t producer_router_transfer_num_pages);
 
     void set_consumer_router_transfer_num_pages(const uint32_t consumer_router_transfer_num_pages);
+
+    void set_is_event_sync(const uint16_t is_event_sync);
+    void set_event_sync_core_x(const uint8_t event_sync_core_x);
+    void set_event_sync_core_y(const uint8_t event_sync_core_y);
+    void set_event_sync_event_id(const uint32_t event_sync_event_id);
 
     uint32_t get_issue_data_size() const;
 

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
+#include "hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/impl/dispatch/kernels/command_queue_common.hpp"
 
 CQWriteInterface cq_write_interface;
@@ -43,6 +44,15 @@ FORCE_INLINE volatile uint32_t* get_cq_completion_write_ptr() {
 
 FORCE_INLINE volatile uint32_t* get_cq_completion_read_ptr() {
     return reinterpret_cast<volatile uint32_t*>(CQ_COMPLETION_READ_PTR);
+}
+
+FORCE_INLINE volatile uint32_t* get_cq_completion_last_event() {
+    return reinterpret_cast<volatile uint32_t*>(CQ_COMPLETION_LAST_EVENT);
+}
+
+FORCE_INLINE volatile uint32_t* get_16b_scratch_l1() {
+    // 16B of space in L1 unused by dispatch core that can be used as scratch space for reads, etc.
+    return reinterpret_cast<volatile uint32_t*>(CQ_COMPLETION_16B_SCRATCH);
 }
 
 FORCE_INLINE
@@ -286,6 +296,20 @@ FORCE_INLINE void wait_for_program_completion(uint32_t num_workers) {
 
 
     DEBUG_STATUS('Q', 'D');
+}
+
+// Record last completed event ID in dedicated L1 space for future event syncs to rely on.
+FORCE_INLINE void record_last_completed_event(uint32_t event_id) {
+    volatile tt_l1_ptr uint32_t* last_event_id = get_cq_completion_last_event();
+    last_event_id[0] = event_id;
+}
+// Cross CQ sync by waiting for a given CQ to have completed up to a certain event id.
+FORCE_INLINE void wait_for_event(uint32_t event_id, uint32_t noc_x, uint32_t noc_y) {
+    uint64_t src_noc_addr = get_noc_addr(noc_x, noc_y, CQ_COMPLETION_LAST_EVENT);
+    do {
+        noc_async_read(src_noc_addr, CQ_COMPLETION_16B_SCRATCH, 4);
+        noc_async_read_barrier();
+    } while (*get_16b_scratch_l1() < event_id);
 }
 
 template <uint32_t host_finish_addr>

--- a/tt_metal/impl/event/event.hpp
+++ b/tt_metal/impl/event/event.hpp
@@ -4,13 +4,14 @@
 
 #pragma once
 
+#include <cstdint>
 namespace tt::tt_metal
 {
     class Device;
     struct Event
     {
-        Device * device;
-        uint32_t cq_id;
-        uint32_t event_id;
+        Device * device = nullptr;
+        uint32_t cq_id = -1;
+        uint32_t event_id = -1;
     };
 }


### PR DESCRIPTION
Changes are functional and cleaned up, got two things to follow up on

- [x] Still WIP a FIXME in code for known bug for 2 hw cq, and need to test it (will update this PR code tomorrow)
-  multi-device won't work in current implementation, no API exists for chip-to-chip reads from kernel, need to revisit soon (after this merge).

Tag @tooniz for initial review in the meantime if you have time.


