### PR TITLE
#5639: Update fill_cache for prefill for Falcon40B

### DIFF
--- a/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
@@ -23,4 +23,4 @@ TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="D
 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueuePCIDevicesFixture.*"
 pytest tests/tt_eager/python_api_testing/unit_testing/test_all_gather.py
 pytest models/demos/falcon40b/tests/test_falcon_decoder.py
-pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-4]

--- a/tests/tt_eager/python_api_testing/unit_testing/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_update_cache.py
@@ -14,40 +14,74 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 @pytest.mark.parametrize("head_dim", [64])
 @pytest.mark.parametrize("max_seq_len", [2048])
 @pytest.mark.parametrize("num_users", [32, 64])
+@pytest.mark.parametrize("num_heads", [1, 2])
+@pytest.mark.parametrize("in_sharded", [True, False])
+@pytest.mark.parametrize("input_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
 class TestUpdateCache:
-    @pytest.mark.parametrize("seq_len", [128, 512, 1024])
-    def test_fill_cache(self, seq_len, head_dim, max_seq_len, num_users, device):
-        input_shape = [1, 1, seq_len, head_dim]
-        cache_shape = [num_users, 1, max_seq_len, head_dim]
+    @pytest.mark.parametrize("seq_len", [32, 512, 2048])
+    def test_fill_cache(
+        self, seq_len, head_dim, max_seq_len, num_users, num_heads, in_sharded, input_dtype, device, use_program_cache
+    ):
+        if not in_sharded and num_heads > 1 and seq_len == 2048:
+            pytest.skip(
+                "For interleaved, each core can only have 1 tile along seq_len if num_heads > 1, so there is a restriction on max seq_len!"
+            )
+
+        cache_dtype = input_dtype
+
+        input_shape = [1, num_heads, seq_len, head_dim]
+        cache_shape = [num_users, num_heads, max_seq_len, head_dim]
         cache = torch.randn(cache_shape).bfloat16().float()
-        cachett = ttl.tensor.Tensor(cache, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+        cachett = ttl.tensor.Tensor(cache, cache_dtype).to(ttl.tensor.Layout.TILE).to(device)
         for i in range(num_users):
             x = torch.randn(input_shape).bfloat16().float()
-            xt = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
+            xt = ttl.tensor.Tensor(x, input_dtype).to(ttl.tensor.Layout.TILE)
+            if in_sharded:
+                compute_grid_size = device.compute_with_storage_grid_size()
+                num_cores = min(seq_len // 32 * num_heads, 32)  # Always use max 32 cores for testing
+                shard_grid = ttl.tensor.CoreRangeSet(
+                    ttl.tensor.num_cores_to_corerange_set(num_cores, compute_grid_size, True)
+                )
+                input_shard_spec = ttl.tensor.ShardSpec(
+                    shard_grid,
+                    [
+                        xt.volume() // xt.shape()[-1] // num_cores,
+                        xt.shape()[-1],
+                    ],
+                    ttl.tensor.ShardOrientation.ROW_MAJOR,
+                    False,
+                )
+                input_mem_config = ttl.tensor.MemoryConfig(
+                    ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1, input_shard_spec
+                )
+                xt = xt.to(device, input_mem_config)
+            else:
+                xt = xt.to(device)
+
             cachett = ttl.tensor.fill_cache(cachett, xt, i)
-            cache[i : i + 1, 0:1, 0 : x.shape[-2], 0 : x.shape[-1]] = x
+            cache[i : i + 1, :, : x.shape[-2], :] = x
 
         tt_got_back = cachett.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-
-        eq = torch.equal(tt_got_back, cache)
+        if input_dtype == ttl.tensor.DataType.BFLOAT16 and cache_dtype == input_dtype:
+            eq, output = comp_equal(cache, tt_got_back)
+        else:
+            eq, output = comp_pcc(cache, tt_got_back)
+        logger.info(output)
         assert eq
 
-    @pytest.mark.parametrize("num_heads", [1, 2])
     @pytest.mark.parametrize("cache_idx", [0, 1, 127, 1057])
-    @pytest.mark.parametrize("in_sharded", [True, False])
-    @pytest.mark.parametrize("input_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
     @pytest.mark.parametrize("cache_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
     def test_update_cache_decode(
         self,
+        cache_idx,
         head_dim,
         max_seq_len,
         num_users,
         num_heads,
-        cache_idx,
-        device,
         in_sharded,
         input_dtype,
         cache_dtype,
+        device,
         use_program_cache,
     ):
         input_shape = [num_users, num_heads, 1, head_dim]

--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    #ifdef INPUT_SHARDED
+    cb_reserve_back(cb_id_in0, num_tiles);
+    cb_push_back(cb_id_in0, num_tiles);
+    #else
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    #ifdef BACKWARDS
+    uint32_t end_id = start_id - num_tiles;
+    for (uint32_t i = start_id; i != end_id; -- i) {
+    #else
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+    #endif
+        cb_reserve_back(cb_id_in0, onetile);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, onetile);
+    }
+    #endif
+}

--- a/tt_eager/tt_dnn/op_library/update_cache/update_cache_op.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/update_cache_op.cpp
@@ -24,15 +24,33 @@ void UpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor.buffer() != nullptr and cache_tensor.buffer() != nullptr, "Operands to update_cache need to be allocated in buffers on device!");
     TT_FATAL((input_tensor.layout() == Layout::TILE && cache_tensor.layout() == Layout::TILE), "Inputs to update_cache must be tilized");
     TT_FATAL(input_tensor.dtype() == DataType::BFLOAT16 || input_tensor.dtype() == DataType::BFLOAT8_B);
+    TT_FATAL(cache_tensor.dtype() == DataType::BFLOAT16 || cache_tensor.dtype() == DataType::BFLOAT8_B);
 
     TT_FATAL(input_tensor.shape()[-1] == cache_tensor.shape()[-1]);
     TT_FATAL(input_tensor.shape()[0] == 1);
     TT_FATAL(input_tensor.shape()[1] == cache_tensor.shape()[1]);
     TT_FATAL(cache_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
     if (this->op_type == UpdateCacheOpType::FILL) {
-        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        TT_FATAL(input_tensor.shape()[1] == 1);
-        TT_FATAL(cache_tensor.shape()[1] == 1);
+        // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion
+        TT_FATAL(input_tensor.dtype() == cache_tensor.dtype(), "Input and cache tensors must have same dtype!");
+
+        // TODO: For interleaved, assume each core handles 1 tile of seq_len if kv_heads > 1
+        // For 56 cores and 2 heads, this effectively caps max seq len at 56 / 2 * 32 = 896
+        // Can generalize interleaved to infer and check arbitrary number of tiles along seq_len per core; or, add more robust logic in reader/writer loops to handle generic blocking of work
+        // For sharded, we infer number of tiles each core handles from shard so no issues there
+        if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED and input_tensor.shape()[1] > 1) {
+            const uint32_t num_blocks_of_work = input_tensor.shape()[1] * input_tensor.shape()[-2] / TILE_HEIGHT;
+            const auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+            TT_FATAL((num_blocks_of_work <= compute_with_storage_grid_size.x * compute_with_storage_grid_size.y));
+        }
+
+        if (input_tensor.is_sharded()) {
+            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.shape()[-1]);
+            // Require even work division along seq_len and also only 1 head per core
+            TT_FATAL(input_tensor.shape()[-2] % input_tensor.shard_spec().value().shape[0] == 0, "Seq len must be divisible by shard height!");
+        }
+
         TT_FATAL(this->batch_idx < cache_tensor.shape()[0]);
         TT_FATAL(input_tensor.shape()[-2] <= cache_tensor.shape()[-2]);
     } else if (this->op_type == UpdateCacheOpType::UPDATE) {
@@ -84,13 +102,8 @@ operation::ProgramWithCallbacks UpdateCache::create_program(const std::vector<Te
 UpdateCacheOpParallelizationStrategy UpdateCache::get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors.at(1);
     if (this->op_type == UpdateCacheOpType::FILL) {
-        uint32_t num_tiles = input_tensor.volume() / TILE_HW;
-        if (num_tiles > 1) {
-            return UpdateCacheOpParallelizationStrategy::MULTI_CORE;
-        }
-        else{
-            return UpdateCacheOpParallelizationStrategy::SINGLE_CORE;
-        }
+        // TODO: Deprecate SINGLE_CORE? Is there a reason to keep it around or can it just be handled by MULTI_CORE version
+        return UpdateCacheOpParallelizationStrategy::MULTI_CORE;
     } else {
         uint32_t num_batch_heads = input_tensor.shape()[1] * input_tensor.shape()[-2] / TILE_HEIGHT;
         if (num_batch_heads > 1 || input_tensor.is_sharded()) {


### PR DESCRIPTION
- Add num_heads, dtype and sharded input for fill_cache unit tests
- Add assert for input and cache tensors being same dtype for prefill
- Add assert for maximum seq_len for interleaved and num_heads > 1
- Add support for generic num_heads for fill_cache
- Add support for sharded kv_heads for fill_cache
- Default fill_cache to MULTI_CORE implementation which also supports single core cases