### PR TITLE
#5666: Adding more kernel info to op reports

### DIFF
--- a/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.cpp
@@ -101,7 +101,7 @@ std::vector<Tensor> all_gather(const std::vector<Tensor>& input_tensors, const u
                 if (profiler_info.parallelization_strategy.has_value()) {
                     op_profiler::set_parallelization_strategy(profiler_info.parallelization_strategy.value());
                 }
-                op_profiler::append_math_fidelities(program);
+                op_profiler::append_kernel_info(program);
                 op_profiler::append_meta_data(fmt::format("{}", operation.attributes()));
             }
             op_profiler::dump_device_profiler_results(input_tensors[i].device(), program);

--- a/tt_metal/tools/profiler/common.py
+++ b/tt_metal/tools/profiler/common.py
@@ -61,7 +61,7 @@ def get_log_locations():
         with open(PROFILER_LOG_LOCATIONS_RECORD, "r") as recordFile:
             for line in recordFile.readlines():
                 logLocation = line.strip()
-                if os.path.isdir(f"{TT_METAL_HOME}/{logLocation}"):
+                if os.path.isdir(f"{logLocation}") or os.path.isdir(f"{TT_METAL_HOME}/{logLocation}"):
                     logLocations.add(logLocation)
                     tmpSplit = logLocation.rsplit("_", 1)
                     if tmpSplit[-1] == "device":

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -56,6 +56,10 @@ OPS_CSV_HEADER = [
     "INPUTS",
     "OUTPUTS",
     "CALL DEPTH",
+    "COMPUTE KERNEL PATH",
+    "COMPUTE KERNEL HASH",
+    "DATA MOVEMENT KERNEL PATH",
+    "DATA MOVEMENT KERNEL HASH",
 ]
 
 SORT_KEY = OPS_CSV_HEADER[2]
@@ -296,6 +300,10 @@ def parse_ops_logs(opsFolder):
                             maxOutputCount = len(outputs.keys())
 
                         mathFidelity = row[" Math Fidelity"].strip()
+                        computeKernelPaths = row[" Compute Kernel Paths"].strip()
+                        computeKernelHashes = row[" Compute Kernel Hashes"].strip()
+                        datamovementKernelPaths = row[" Data Movement Kernel Paths"].strip()
+                        datamovementKernelHashes = row[" Data Movement Kernel Hashes"].strip()
                         parallelizationStrategy = row[" Parallelization Strategy"].strip()
                         preferredName = row[" Preferred Name"].strip().split("tt::tt_metal::")[-1]
                         metadata = row[" Meta Data"].strip()
@@ -333,6 +341,10 @@ def parse_ops_logs(opsFolder):
                             "INPUTS": inputs,
                             "OUTPUTS": outputs,
                             "MATH FIDELITY": mathFidelity,
+                            "COMPUTE KERNEL PATH": computeKernelPaths,
+                            "COMPUTE KERNEL HASH": computeKernelHashes,
+                            "DATA MOVEMENT KERNEL PATH": datamovementKernelPaths,
+                            "DATA MOVEMENT KERNEL HASH": datamovementKernelHashes,
                             "PARALLELIZATION STRATEGY": parallelizationStrategy,
                             "HOST DURATION [ns]": delta_time,
                             "ATTRIBUTES": metadata,


### PR DESCRIPTION
Kernel hash and build paths are added to op report

example :
[ops_perf_results_2024_02_27_14_54_27.csv](https://github.com/tenstorrent-metal/tt-metal/files/14422752/ops_perf_results_2024_02_27_14_54_27.csv)
