### PR TITLE
#5449: Metal Trace Host API with stub functionality

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 525
+personal_ws-1.1 en 528
 ABI
 ADDI
 API
@@ -10,6 +10,7 @@ BRISC
 BRISCs
 BUF
 BUFs
+BeginTrace
 BertIntermediate
 BinaryOpType
 BorrowedStorage
@@ -56,10 +57,13 @@ DumpDeviceProfileResults
 ENDL
 ETH
 EltwiseUnary
+EndTrace
 EnqueueProgram
 EnqueueReadBuffer
 EnqueueRecordEvent
 EnqueueWaitForEvent
+EnqueueReadBuffer
+EnqueueTrace
 EnqueueWriteBuffer
 Enum
 Enums
@@ -75,6 +79,7 @@ GetRuntimeArgs
 Grayskull
 HW
 HiFi
+InstantiateTrace
 InterleavedBufferConfig
 Jupyter
 KernelHandle

--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 528
+personal_ws-1.1 en 529
 ABI
 ADDI
 API
@@ -61,9 +61,8 @@ EndTrace
 EnqueueProgram
 EnqueueReadBuffer
 EnqueueRecordEvent
-EnqueueWaitForEvent
-EnqueueReadBuffer
 EnqueueTrace
+EnqueueWaitForEvent
 EnqueueWriteBuffer
 Enum
 Enums

--- a/docs/source/tt_metal/apis/host_apis/command_queue/BeginTrace.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/BeginTrace.rst
@@ -1,0 +1,4 @@
+BeginTrace
+==========
+
+.. doxygenfunction:: BeginTrace(Trace &trace)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EndTrace.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EndTrace.rst
@@ -1,0 +1,4 @@
+EndTrace
+========
+
+.. doxygenfunction:: EndTrace(Trace &trace)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueProgram.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueProgram.rst
@@ -1,4 +1,4 @@
 EnqueueProgram
 ==============
 
-void EnqueueProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program> > program, bool blocking, std::optional<std::reference_wrapper<Trace>> trace);
+.. doxygenfunction:: EnqueueProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program> > program, bool blocking)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueTrace.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueTrace.rst
@@ -1,0 +1,4 @@
+EnqueueTrace
+============
+
+.. doxygenfunction:: EnqueueTrace(CommandQueue &cq, uint32_t trace_id, bool blocking)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/InstantiateTrace.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/InstantiateTrace.rst
@@ -1,0 +1,4 @@
+InstantiateTrace
+================
+
+.. doxygenfunction:: InstantiateTrace(Trace &trace, CommandQueue &cq)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
@@ -8,4 +8,8 @@ CommandQueue
   EnqueueRecordEvent
   EnqueueWaitForEvent
   EventSynchronize
+  BeginTrace
+  EndTrace
+  InstantiateTrace
+  EnqueueTrace
   Finish

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
@@ -128,7 +128,7 @@ TEST_F(CommandQueueFixture, EnqueueTwoProgramTrace) {
             EnqueueProgram(command_queue, op1, blocking);
             EnqueueReadBuffer(command_queue, output, eager_output_data.data(), blocking);
         }
-        if (!blocking) {
+        if (not blocking) {
             // (Optional) wait for the last non-blocking command to finish
             Finish(command_queue);
         }
@@ -210,7 +210,7 @@ TEST_F(CommandQueueFixture, EnqueueMultiProgramTraceBenchmark) {
             }
             EnqueueReadBuffer(command_queue, output, eager_output_data.data(), blocking);
         }
-        if (!blocking) {
+        if (not blocking) {
             // (Optional) wait for the last non-blocking command to finish
             Finish(command_queue);
         }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueTrace.cpp
@@ -105,7 +105,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTrace) {
     EnqueueWriteBuffer(data_movement_queue, input, input_data.data(), true);
 
     BeginTrace(trace);
-    EnqueueProgram(trace.trace_queue(), simple_program, false);
+    EnqueueProgram(trace.queue(), simple_program, false);
     EndTrace(trace);
     // Instantiate a trace on a device queue
     uint32_t trace_id = InstantiateTrace(trace, command_queue);
@@ -148,9 +148,9 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTraceLoops) {
     for (auto i = 0; i < num_loops; i++) {
         EnqueueWriteBuffer(data_movement_queue, input, input_data.data(), true);
 
-        if (!trace_captured) {
+        if (not trace_captured) {
             BeginTrace(trace);
-            EnqueueProgram(trace.trace_queue(), simple_program, false);
+            EnqueueProgram(trace.queue(), simple_program, false);
             EndTrace(trace);
             // Instantiate a trace on a device queue
             trace_id = InstantiateTrace(trace, command_queue);
@@ -214,7 +214,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTraceBenchmark) {
             EnqueueProgram(command_queue, simple_program, blocking);
             EnqueueReadBuffer(command_queue, output, eager_output_data.data(), blocking);
         }
-        if (!blocking) {
+        if (not blocking) {
             // (Optional) wait for the last non-blocking command to finish
             Finish(command_queue);
         }

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -351,8 +351,8 @@ void EnqueueProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Progra
 void Finish(CommandQueue& cq);
 
 /**
- * Begins capture on a trace, when the trace is in capture mode all programs push into the trace queue will not be executed.
- * The capture must be later ended via EndTrace, and can be instantiated via InstantiateTrace on a device command queue.
+ * Begins capture on a trace, when the trace is in capture mode all programs pushed into the trace queue will have their execution delayed until the trace is instantiated and enqueued.
+ * The capture must be later ended via EndTrace, and can be instantiated via InstantiateTrace on a device command queue, and finally scheduled to be executed via EnqueueTrace.
  *
  * Return value: CommandQueue&
  *
@@ -364,7 +364,7 @@ CommandQueue& BeginTrace(Trace &trace);
 
 /**
  * Completes capture on a trace, if captured commands do not conform to the rules of the trace, the trace will be invalidated.
- * This trace can later be instantiated via InstantiateTrace on a device command queue, and executed via EnqueueTrace on the same device command queue.
+ * This trace can later be instantiated via InstantiateTrace on a device command queue, and enqueued for execution via EnqueueTrace on the same device command queue.
  *
  * Return value: void
  *
@@ -376,7 +376,7 @@ void EndTrace(Trace &trace);
 
 /**
  * Instantiates a trace on a device command queue, triggering the staging of traced commands and data to the device.
- * Staging is a blocking operation and must be completed before the trace can be enqueued. A unique trace instance id is returned
+ * Staging is a blocking operation and must be completed before the trace can be enqueued for exeuction. A unique trace instance id is returned
  *
  * Return value: uint32_t
  *

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -353,7 +353,9 @@ void Finish(CommandQueue& cq);
 /**
  * Begins capture on a trace, when the trace is in capture mode all programs push into the trace queue will not be executed.
  * The capture must be later ended via EndTrace, and can be instantiated via InstantiateTrace on a device command queue.
+ *
  * Return value: CommandQueue&
+ *
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
  * | trace        | Trace in which to initiate the capture                                 | Trace &                       |                                    | Yes      |
@@ -363,7 +365,9 @@ CommandQueue& BeginTrace(Trace &trace);
 /**
  * Completes capture on a trace, if captured commands do not conform to the rules of the trace, the trace will be invalidated.
  * This trace can later be instantiated via InstantiateTrace on a device command queue, and executed via EnqueueTrace on the same device command queue.
+ *
  * Return value: void
+ *
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
  * | trace        | Trace in which to end the capture                                      | Trace &                       |                                    | Yes      |
@@ -371,19 +375,23 @@ CommandQueue& BeginTrace(Trace &trace);
 void EndTrace(Trace &trace);
 
 /**
-* Instantiates a trace on a device command queue, triggering the staging of traced commands and data to the device.
-* Staging is a blocking operation and must be completed before the trace can be enqueued. A unique trace instance id is returned
-* Return value: uint32_t
-* | Argument     | Description                                                             | Type                          | Valid Range                        | Required |
-* |--------------|-------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
-* | trace        | The trace object to instantiate                                         | Trace &                       |                                    | Yes      |
-* | cq           | The device command queue on which to instantiate the trace              | CommandQueue &                |                                    | Yes      |
+ * Instantiates a trace on a device command queue, triggering the staging of traced commands and data to the device.
+ * Staging is a blocking operation and must be completed before the trace can be enqueued. A unique trace instance id is returned
+ *
+ * Return value: uint32_t
+ *
+ * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | trace        | The trace object to instantiate                                        | Trace &                       |                                    | Yes      |
+ * | cq           | The device command queue on which to instantiate the trace             | CommandQueue &                |                                    | Yes      |
 */
 uint32_t InstantiateTrace(Trace &trace, CommandQueue &cq);
 
 /**
  * Enqueues a trace of previously generated commands and data.
+ *
  * Return value: void
+ *
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
  * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1552,6 +1552,8 @@ std::ostream& operator<<(std::ostream& os, EnqueueCommandType const& type) {
         case EnqueueCommandType::ENQUEUE_WRITE_BUFFER: os << "ENQUEUE_WRITE_BUFFER"; break;
         case EnqueueCommandType::ENQUEUE_PROGRAM: os << "ENQUEUE_PROGRAM"; break;
         case EnqueueCommandType::ENQUEUE_TRACE: os << "ENQUEUE_TRACE"; break;
+        case EnqueueCommandType::ENQUEUE_RECORD_EVENT: os << "ENQUEUE_RECORD_EVENT"; break;
+        case EnqueueCommandType::ENQUEUE_WAIT_FOR_EVENT: os << "ENQUEUE_WAIT_FOR_EVENT"; break;
         case EnqueueCommandType::FINISH: os << "FINISH"; break;
         case EnqueueCommandType::FLUSH: os << "FLUSH"; break;
         default: tt::log_fatal("Invalid command type!");

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -29,11 +29,18 @@ using std::tuple;
 using std::unique_ptr;
 
 // Only contains the types of commands which are enqueued onto the device
-<<<<<<< HEAD
-enum class EnqueueCommandType { ENQUEUE_READ_BUFFER, ENQUEUE_WRITE_BUFFER, ENQUEUE_PROGRAM, FINISH, ENQUEUE_WRAP, FLUSH, ENQUEUE_RECORD_EVENT, ENQUEUE_WAIT_FOR_EVENT, INVALID };
-=======
-enum class EnqueueCommandType { ENQUEUE_READ_BUFFER, ENQUEUE_WRITE_BUFFER, ENQUEUE_PROGRAM, FINISH, ENQUEUE_WRAP, ENQUEUE_TRACE, FLUSH, INVALID };
->>>>>>> #5449: Implemented Host API based on 3-stage Metal Trace proposal. Stub functionality brought up with test_EnqueueTrace unit test
+enum class EnqueueCommandType {
+    ENQUEUE_READ_BUFFER,
+    ENQUEUE_WRITE_BUFFER,
+    ENQUEUE_PROGRAM,
+    ENQUEUE_TRACE,
+    ENQUEUE_RECORD_EVENT,
+    ENQUEUE_WAIT_FOR_EVENT,
+    ENQUEUE_WRAP,
+    FINISH,
+    FLUSH,
+    INVALID
+};
 
 string EnqueueCommandTypeToString(EnqueueCommandType ctype);
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -375,7 +375,7 @@ class Trace {
 
    public:
     Trace();
-    CommandQueue& trace_queue() const { return *cq; };
+    CommandQueue& queue() const { return *cq; };
     uint32_t instantiate(CommandQueue& cq);  // return a unique trace id
 };
 
@@ -499,8 +499,6 @@ class HWCommandQueue {
     void completion_wrap(uint32_t event);
     void launch(launch_msg_t& msg);
     friend void EnqueueTraceImpl(CommandQueue& cq);
-    // friend void EndTrace(Trace& trace);
-    // friend Trace BeginTrace(CommandQueue& cq);
     friend void EnqueueProgramImpl(CommandQueue& cq, std::variant < std::reference_wrapper<Program>, std::shared_ptr<Program> > program, bool blocking);
     friend void EnqueueReadBufferImpl(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, bool blocking);
     friend void EnqueueWriteBufferImpl(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, const void* src, bool blocking);
@@ -568,7 +566,6 @@ class CommandQueue {
         RUNNING = 1,
         TERMINATE = 2,
     };
-    constexpr static uint32_t TRACE_QUEUE_CQ_ID = 401;
     friend class Trace;
     friend void EnqueueTraceImpl(CommandQueue& cq);
     friend uint32_t InstantiateTrace(Trace& trace, CommandQueue& cq);

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -51,4 +51,25 @@ class LockFreeQueue {
         bool empty() const {
             return head.load() == tail.load();
         }
+        class Iterator : public std::iterator<std::forward_iterator_tag, T> {
+           private:
+            Node* current;
+
+           public:
+            Iterator(Node* start) : current(start) {}
+
+            Iterator& operator++() {
+                if (current != nullptr) {
+                    current = current->next;
+                }
+                return *this;
+            }
+
+            bool operator!=(const Iterator& other) const { return current != other.current; }
+
+            const T& operator*() const { return *(current->data); }
+        };
+
+        Iterator begin() { return Iterator(head.load()); }
+        Iterator end() { return Iterator(tail.load()); }
 };


### PR DESCRIPTION
Implemented metal trace host APIs according to the proposal #5449

The following are implemented properly:
- BeginTrace
- EndTrace

The following are implement with stubs:
- InstantiateTrace
- EnqueueTrace

EnqueueProgram with tracing also needs work but is not needed for the stub. Sending the current stub version as PR for review, plus with stub it's functional (just no trace speed up)