### PR TITLE
Add ethernet datamover (EDM) - a foundational ethernet transfer engine

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Build tests
         run: make tests
       - name: Run microbenchmark tests
-        timeout-minutes: 45
+        timeout-minutes: 90
         run: ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type microbenchmarks
       - name: Upload microbenchmark report csvs
         uses: actions/upload-artifact@v4

--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_send_data_microbenchmark.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_send_data_microbenchmark.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from loguru import logger
+import pytest
+from tt_metal.tools.profiler.process_device_log import import_log_run_stats
+import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
+
+
+def report_results(test_case_name, total_data_transferred):
+    print("reporting results...")
+    setup = device_post_proc_config.default_setup()
+    setup.timerAnalysis = {
+        "LATENCY": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "ERISC", "timerID": 80},
+            "end": {"risc": "ERISC", "timerID": 3},
+        },
+    }
+
+    throughput_GB_per_second = -1
+    os.system("sed -i '/^[[:space:]]*$/d' ./generated/profiler/.logs/profile_log_device.csv")
+    try:
+        setup.deviceInputLog = "./generated/profiler/.logs/profile_log_device.csv"
+        stats = import_log_run_stats(setup)
+        core = [key for key in stats["devices"][1]["cores"].keys() if key != "DEVICE"][0]
+        # test_cycles = stats["devices"][1]["cores"][core]["riscs"]["ERISC"]["analysis"]["LATENCY"]["stats"]["First"]
+        test_cycles = stats["devices"][1]["cores"][core]["riscs"]["TENSIX"]["analysis"]["LATENCY"]["stats"]["First"]
+        total_bytes = total_data_transferred
+        cycles_per_second = 1000000000
+        throughput_bytes_per_second = total_bytes / (test_cycles / 1000000000)
+        throughput_GB_per_second = throughput_bytes_per_second / (1000 * 1000 * 1000)
+        print(
+            f"Cycles: {test_cycles}, Total Data Sent(B): {total_data_transferred}, Throughput: {throughput_GB_per_second} GB/s"
+        )
+    except:
+        print("Error in results parsing")
+        assert False
+
+    os.system(f"rm -rf ./generated/profiler/.logs/{test_case_name}/")
+    os.system(f"mkdir -p ./generated/profiler/.logs/{test_case_name}/")
+    os.system(
+        f"cp ./generated/profiler/.logs/profile_log_device.csv ./generated/profiler/.logs/{test_case_name}/profile_log_device.csv"
+    )
+
+    return throughput_GB_per_second
+
+
+@pytest.mark.parametrize(
+    "input_buffer_size_bytes",
+    [16384, 64 * 1024, 128 * 1024, 256 * 1024, 835584, 16711680, 680 * 32768],
+)
+@pytest.mark.parametrize(
+    "eth_buffer_size_bytes",
+    [8192, 12 * 1024, 16 * 1024, 24 * 1024, 32 * 1024, 50 * 1024],
+)
+@pytest.mark.parametrize("num_transaction_buffers", [3, 4, 5])
+@pytest.mark.parametrize("input_buffer_page_size", [1024, 2048, 4096])
+# @pytest.mark.parametrize("precomputed_address_buffer_size", [0, 16, 32])
+@pytest.mark.skip("Some cases are flaky")
+def test_ethernet_send_data_microbenchmark_concurrent_with_dram_read_and_write(
+    input_buffer_size_bytes, eth_buffer_size_bytes, num_transaction_buffers, input_buffer_page_size
+):
+    if eth_buffer_size_bytes < input_buffer_page_size:
+        pytest.skip("eth_buffer_size_bytes < input_buffer_page_size")
+        return
+
+    if input_buffer_size_bytes < input_buffer_page_size:
+        pytest.skip("input_buffer_size_bytes < input_buffer_page_size")
+        return
+
+    test_string_name = f"test_ethernet_send_data_microbenchmark - \
+            input_buffer_page_size: {input_buffer_page_size}, \
+                num_transaction_buffers: {num_transaction_buffers}, \
+                    eth_buffer_size_bytes: {eth_buffer_size_bytes} \
+                        input_buffer_size_bytes: {input_buffer_size_bytes}"
+    print(
+        f"test_ethernet_send_data_microbenchmark - \
+            input_buffer_page_size: {input_buffer_page_size}, \
+                num_transaction_buffers: {num_transaction_buffers}, \
+                    eth_buffer_size_bytes: {eth_buffer_size_bytes} \
+                        input_buffer_size_bytes: {input_buffer_size_bytes}"
+    )
+    os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
+    rc = os.system(
+        f"TT_METAL_SLOW_DISPATCH_MODE=1 TT_METAL_DEVICE_PROFILER=1 \
+            {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data \
+            \"tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_forward_local_chip_data_looping_multi_channel.cpp\" \
+            \"tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_non_blocking_receive_fwd_to_dram.cpp\" \
+            {eth_buffer_size_bytes} \
+            {num_transaction_buffers} \
+            {input_buffer_page_size} \
+            {input_buffer_size_bytes} \
+            {1} \
+            {1} \
+            0 \
+            "
+        # > /dev/null 2>&1"
+    )
+    if rc != 0:
+        print("Error in running the test")
+        assert False
+
+    test_string_name = f"test_ethernet_send_data_microbenchmark_concurrent_with_dram_read_"
+    test_string_name += f"{input_buffer_page_size}_"
+    test_string_name += f"{num_transaction_buffers}_"
+    test_string_name += f"{eth_buffer_size_bytes}_"
+    test_string_name += f"{input_buffer_size_bytes}"  # _"
+    # test_string_name += f"{precomputed_address_buffer_size}"
+    return report_results(test_string_name, input_buffer_size_bytes)
+
+
+@pytest.mark.parametrize(
+    "input_buffer_size_bytes",
+    [16384, 64 * 1024, 128 * 1024, 256 * 1024, 835584],
+)
+@pytest.mark.parametrize(
+    "eth_buffer_size_bytes",
+    [8192, 16 * 1024, 20 * 1024, 32 * 1024, 50 * 1024],
+)
+@pytest.mark.parametrize("num_transaction_buffers", [1, 2, 3])
+@pytest.mark.parametrize("input_buffer_page_size", [1024, 2048, 4096])
+# @pytest.mark.parametrize("precomputed_address_buffer_size", [0, 16, 32])
+def test_decoupled_worker_and_erisc_data_mover_single_direction(
+    input_buffer_size_bytes, eth_buffer_size_bytes, num_transaction_buffers, input_buffer_page_size
+):
+    if eth_buffer_size_bytes * num_transaction_buffers > 100000:
+        pytest.skip("not enough erisc L1 for configuration")
+        return
+    if eth_buffer_size_bytes < input_buffer_page_size:
+        pytest.skip("eth_buffer_size_bytes < input_buffer_page_size")
+        return
+
+    if input_buffer_size_bytes < input_buffer_page_size:
+        pytest.skip("input_buffer_size_bytes < input_buffer_page_size")
+        return
+
+    if num_transaction_buffers > 1:
+        pytest.skip("This unit test doesn't support multi-channel yet")
+
+    test_string_name = f"test_ethernet_send_data_microbenchmark - \
+            input_buffer_page_size: {input_buffer_page_size}, \
+                num_transaction_buffers: {num_transaction_buffers}, \
+                    eth_buffer_size_bytes: {eth_buffer_size_bytes} \
+                        input_buffer_size_bytes: {input_buffer_size_bytes}"
+    print(
+        f"test_ethernet_send_data_microbenchmark - \
+            input_buffer_page_size: {input_buffer_page_size}, \
+                num_transaction_buffers: {num_transaction_buffers}, \
+                    eth_buffer_size_bytes: {eth_buffer_size_bytes} \
+                        input_buffer_size_bytes: {input_buffer_size_bytes}"
+    )
+    os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
+    rc = os.system(
+        f"TT_METAL_SLOW_DISPATCH_MODE=1 TT_METAL_DEVICE_PROFILER=1 \
+            {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional \
+            \"tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_sender_worker_reader.cpp\" \
+            \"tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_sender_worker_sender.cpp\" \
+            \"tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_receiver_worker_reader.cpp\" \
+            \"tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_receiver_worker_sender.cpp\" \
+            {eth_buffer_size_bytes} \
+            {num_transaction_buffers} \
+            {input_buffer_page_size} \
+            {input_buffer_size_bytes} \
+            {1} \
+            {1} \
+            0 \
+            "
+        # > /dev/null 2>&1"
+    )
+    if rc != 0:
+        print("Error in running the test")
+        assert False
+
+    return True
+    # test_string_name = f"test_ethernet_send_data_microbenchmark_concurrent_with_dram_read_"
+    # test_string_name += f"{input_buffer_page_size}_"
+    # test_string_name += f"{num_transaction_buffers}_"
+    # test_string_name += f"{eth_buffer_size_bytes}_"
+    # test_string_name += f"{input_buffer_size_bytes}"  # _"
+    # # test_string_name += f"{precomputed_address_buffer_size}"
+    # return report_results(test_string_name, input_buffer_size_bytes)
+
+
+@pytest.mark.skip("Some cases are flaky")
+def test_run_ethernet_send_data_microbenchmark_sweep():
+    input_buffer_size_bytes = [16384, 64 * 1024, 256 * 1024, 16711680]  # , 680*32768]
+    eth_buffer_size_bytes = [8192, 12 * 1024, 14 * 1024, 16 * 1024]
+    # num_transaction_buffers = [1, 2, 3, 4, 8]
+    # num_transaction_buffers = [2, 3, 4, 8]
+    num_transaction_buffers = [2, 3, 4, 5]
+    input_buffer_page_size = [1024, 2048, 4096]
+
+    recorded_throughput_slow_mode = {}
+    recorded_throughput_concurrent = {}
+    recorded_throughputs = {}
+
+    for page_size in input_buffer_page_size:
+        for input_size_bytes in input_buffer_size_bytes:
+            for eth_l1_buffer_size in eth_buffer_size_bytes:
+                for max_concurrent_transfers in num_transaction_buffers:
+                    if max_concurrent_transfers > 1 and (
+                        eth_l1_buffer_size * (max_concurrent_transfers - 1) > input_size_bytes
+                    ):
+                        continue
+
+                    if eth_buffer_size_bytes < input_buffer_page_size:
+                        continue
+
+                    if input_buffer_size_bytes < input_buffer_page_size:
+                        continue
+
+                    if eth_l1_buffer_size * max_concurrent_transfers > 160000:
+                        continue
+
+                    attempts = 0
+                    max_attempts = 10
+                    successful = False
+                    throughput = -1
+                    while not successful and attempts < max_attempts:
+                        try:
+                            throughput = test_ethernet_send_data_microbenchmark_concurrent_with_dram_read_and_write(
+                                input_size_bytes, eth_l1_buffer_size, max_concurrent_transfers, page_size
+                            )
+
+                            os.system(
+                                f'echo "{page_size},{input_size_bytes},{eth_l1_buffer_size},{num_concurrent_transfers},{throughput}\n" >> throughputs.txt'
+                            )
+                            successful = True
+                        except:
+                            attempts += 1
+                            continue
+
+                    if page_size not in recorded_throughputs:
+                        recorded_throughputs[page_size] = {}
+
+                    if input_size_bytes not in recorded_throughputs[page_size]:
+                        recorded_throughputs[page_size][input_size_bytes] = {}
+
+                    if eth_l1_buffer_size not in recorded_throughputs[page_size][input_size_bytes]:
+                        recorded_throughputs[page_size][input_size_bytes][eth_l1_buffer_size] = {}
+
+                    recorded_throughputs[page_size][input_size_bytes][eth_l1_buffer_size][
+                        max_concurrent_transfers
+                    ] = throughput
+
+    ## Print out the results
+
+    COLUMN_WIDTH = 10
+    for page_size in recorded_throughputs:
+        print(f"##############################################")
+        print(f"##############################################")
+        print(f"PAGE_SIZE: {page_size}")
+        for input_size_bytes in recorded_throughputs[page_size]:
+            print(f"||----------------------------------------------")
+            print(f"|| INPUT_SIZE: {input_size_bytes}")
+            print(f"||\t NUM_TRANSACTIONS:")
+
+            space = ""
+            top_row = f"||{space:^{COLUMN_WIDTH}}"
+            for num_concurrent_transfers in num_transaction_buffers:
+                top_row += f"|{num_concurrent_transfers:^{COLUMN_WIDTH}}"
+            print(top_row)
+
+            for eth_l1_buffer_size in recorded_throughputs[page_size][input_size_bytes]:
+                row = f"||{eth_l1_buffer_size:<{COLUMN_WIDTH}}"
+                for num_concurrent_transfers in num_transaction_buffers:
+                    if (
+                        num_concurrent_transfers
+                        not in recorded_throughputs[page_size][input_size_bytes][eth_l1_buffer_size]
+                    ):
+                        row += f"|{'N/A':<{COLUMN_WIDTH}}"
+                        continue
+                    else:
+                        throughput = recorded_throughputs[page_size][input_size_bytes][eth_l1_buffer_size][
+                            num_concurrent_transfers
+                        ]
+                        row += f"|{throughput:<{COLUMN_WIDTH}.2f}"
+
+                print(row)
+
+    print(f"##############################################")
+    print(f"page_size,input_size_bytes,eth_l1_buffer_size,num_concurrent_transfers,throughput(GBps)")
+    for page_size, throughputs_input_size_bytes in recorded_throughputs.items():
+        for input_size_bytes, throughputs_eth_1l_buf_size_bytes in throughputs_input_size_bytes.items():
+            for eth_l1_buffer_size, throughputs_max_concurrent_transfers in throughputs_eth_1l_buf_size_bytes.items():
+                for num_concurrent_transfers, throughput in throughputs_max_concurrent_transfers.items():
+                    print(
+                        f"{page_size},{input_size_bytes},{eth_l1_buffer_size},{num_concurrent_transfers},{throughput}"
+                    )

--- a/tests/tt_metal/tt_metal/module.mk
+++ b/tests/tt_metal/tt_metal/module.mk
@@ -15,6 +15,8 @@ TT_METAL_TESTS += \
 		 tests/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency \
 		 tests/tt_metal/perf_microbenchmark/dispatch/test_dispatcher \
 		 tests/tt_metal/perf_microbenchmark/dispatch/test_prefetcher \
+		 tests/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data \
+		 tests/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional \
 		 tests/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1 \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1 \

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
@@ -1,0 +1,367 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <random>
+
+#include "tt_metal/common/core_coord.h"
+#include "tt_metal/common/math.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/kernels/kernel.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/df/df.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+
+using namespace tt;
+using namespace tt::test_utils;
+using namespace tt::test_utils::df;
+
+class N300TestDevice {
+   public:
+    N300TestDevice() : device_open(false) {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (not slow_dispatch) {
+            TT_THROW("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
+        }
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+
+        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 2 and
+            tt::tt_metal::GetNumPCIeDevices() == 1) {
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                auto* device = tt::tt_metal::CreateDevice(id);
+                devices_.push_back(device);
+            }
+            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+
+        } else {
+            TT_THROW("This suite can only be run on N300 Wormhole devices");
+        }
+        device_open = true;
+    }
+    ~N300TestDevice() {
+        if (device_open) {
+            TearDown();
+        }
+    }
+
+    void TearDown() {
+        device_open = false;
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+        for (unsigned int id = 0; id < devices_.size(); id++) {
+            tt::tt_metal::CloseDevice(devices_.at(id));
+        }
+    }
+
+    std::vector<tt::tt_metal::Device*> devices_;
+    tt::ARCH arch_;
+    size_t num_devices_;
+
+   private:
+    bool device_open;
+};
+
+struct BankedConfig {
+    size_t num_pages;
+    size_t size_bytes;
+    size_t page_size_bytes;
+    BufferType input_buffer_type;// = BufferType::L1;
+    BufferType output_buffer_type;// = BufferType::L1;
+    tt::DataFormat l1_data_format;// = tt::DataFormat::Float16_b;
+};
+
+bool RunWriteBWTest(
+    std::string const& sender_kernel_path,
+    std::string const& receiver_kernel_path,
+    tt_metal::Device* sender_device,
+    tt_metal::Device* receiver_device,
+
+    const CoreCoord& eth_sender_core,
+    const CoreCoord& eth_receiver_core,
+
+    const size_t src_eth_l1_byte_address,
+    const size_t dst_eth_l1_byte_address,
+
+    const size_t precomputed_source_addresses_buffer_address,
+    const size_t precomputed_source_addresses_buffer_size,
+
+    const uint32_t eth_l1_staging_buffer_size,
+    const uint32_t eth_max_concurrent_sends,
+    const uint32_t input_buffer_page_size,
+    const uint32_t input_buffer_size_bytes,
+    bool source_is_dram,
+    bool dest_is_dram
+
+) {
+    // number of bytes to send per eth send (given that eth l1 buf size not
+    // guaranteed to be multiple of page size, we won't send the left over
+    // bytes at the end
+    const uint32_t pages_per_send = eth_l1_staging_buffer_size / input_buffer_page_size;
+    const uint32_t num_bytes_per_send = pages_per_send * input_buffer_page_size;
+    const uint32_t num_pages = ((input_buffer_size_bytes - 1) / input_buffer_page_size) + 1;  // includes padding
+    const uint32_t num_messages_to_send = ((input_buffer_size_bytes - 1) / num_bytes_per_send) + 1;
+
+    TT_ASSERT(precomputed_source_addresses_buffer_address < std::numeric_limits<uint32_t>::max(), "precomputed_source_addresses_buffer_address is too large");
+
+    bool pass = true;
+    log_debug(
+        tt::LogTest,
+        "Sending {} bytes from device {} eth core {} addr {} to device {} eth core {} addr {}",
+        input_buffer_size_bytes,
+        sender_device->id(),
+        eth_sender_core.str(),
+        src_eth_l1_byte_address,
+        receiver_device->id(),
+        eth_receiver_core.str(),
+        dst_eth_l1_byte_address);
+    std::cout << "num_messages_to_send: " << num_messages_to_send << std::endl;
+    // Generate inputs
+    ////////////////////////////////////////////////////////////////////////////
+    //   SETUP THE INPUT CB
+    ////////////////////////////////////////////////////////////////////////////
+    std::cout << "Generating vector" << std::endl;
+    auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, input_buffer_size_bytes / sizeof(uint32_t));
+
+    // Clear expected value at ethernet L1 address
+
+    BankedConfig test_config =
+        BankedConfig{
+            .num_pages = num_pages,
+            .size_bytes = input_buffer_size_bytes,
+            .page_size_bytes = input_buffer_page_size,
+            .input_buffer_type = source_is_dram ? BufferType::DRAM : BufferType::L1,
+            .output_buffer_type = dest_is_dram ? BufferType::DRAM : BufferType::L1,
+            .l1_data_format = tt::DataFormat::Float16_b};
+    auto input_buffer =
+            CreateBuffer(
+                InterleavedBufferConfig{sender_device, test_config.size_bytes, test_config.page_size_bytes, test_config.input_buffer_type});
+
+    bool input_is_dram = test_config.input_buffer_type == BufferType::DRAM;
+    tt_metal::detail::WriteToBuffer(input_buffer, inputs);
+    const uint32_t dram_input_buf_base_addr = input_buffer->address();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //   EMPTY INITIALIZE THE OUTPUT CB
+    ////////////////////////////////////////////////////////////////////////////
+
+    // Clear expected value at ethernet L1 address
+    std::vector<uint32_t> all_zeros(inputs.size(), 0);
+
+    auto output_buffer =
+            CreateBuffer(
+                InterleavedBufferConfig{receiver_device, test_config.size_bytes, test_config.page_size_bytes, test_config.output_buffer_type});
+
+    bool output_is_dram = test_config.output_buffer_type == BufferType::DRAM;
+    tt_metal::detail::WriteToBuffer(output_buffer, all_zeros);
+    const uint32_t dram_output_buffer_base_addr = output_buffer->address();
+
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Sender Device
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program sender_program = tt_metal::Program();
+
+    uint32_t num_pages_per_l1_buffer = num_bytes_per_send / input_buffer_page_size;
+    TT_ASSERT(num_messages_to_send * num_pages_per_l1_buffer >= num_pages);
+    std::cout << "eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE: " << eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE << std::endl;
+    std::cout << "src_eth_l1_byte_address: " << src_eth_l1_byte_address << std::endl;
+    auto eth_sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        sender_kernel_path,
+        eth_sender_core,
+        tt_metal::EthernetConfig{
+            .noc = tt_metal::NOC::NOC_0,
+            .compile_args = {
+                uint32_t(num_bytes_per_send),         // 0
+                uint32_t(num_bytes_per_send >> 4),    // 1
+                uint32_t(num_messages_to_send),       // 2
+                uint32_t(eth_max_concurrent_sends),   // 3
+                uint32_t(source_is_dram)              // 4
+                }
+            // .compile_args = {uint32_t(256), uint32_t(256 >> 4)}
+            });
+
+    tt_metal::SetRuntimeArgs(
+        sender_program,
+        eth_sender_kernel,
+        eth_sender_core,
+        {
+            uint32_t(src_eth_l1_byte_address),
+            uint32_t(dst_eth_l1_byte_address),
+            uint32_t(dram_input_buf_base_addr),
+            uint32_t(input_buffer_page_size),
+            uint32_t(num_pages),
+            uint32_t(precomputed_source_addresses_buffer_address),
+            uint32_t(precomputed_source_addresses_buffer_size)
+        });
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                           Receiver Device
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program receiver_program = tt_metal::Program();
+
+    auto eth_receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        receiver_kernel_path,
+        eth_receiver_core,
+        tt_metal::EthernetConfig{
+            .noc = tt_metal::NOC::NOC_0,
+            .compile_args = {
+                uint32_t(num_bytes_per_send),         // 0
+                uint32_t(num_bytes_per_send >> 4),    // 1
+                uint32_t(num_messages_to_send),       // 2
+                uint32_t(eth_max_concurrent_sends),   // 3
+                uint32_t(dest_is_dram)                // 4
+            }});  // probably want to use NOC_1 here
+            // .compile_args = {uint32_t(256), uint32_t(256 >> 4)}});  // probably want to use NOC_1 here
+
+    tt_metal::SetRuntimeArgs(
+        receiver_program,
+        eth_receiver_kernel,
+        eth_receiver_core,
+        {
+            uint32_t(dst_eth_l1_byte_address),
+            uint32_t(src_eth_l1_byte_address),
+            dram_output_buffer_base_addr,
+            input_buffer_page_size,
+            num_pages
+        });
+
+    std::cout << "dram_output_buffer_base_addr: " << dram_output_buffer_base_addr << std::endl;
+    std::cout << "dram_input_buf_base_addr: " << dram_input_buf_base_addr << std::endl;
+    std::cout << "input_buffer_page_size: " << input_buffer_page_size << std::endl;
+    std::cout << "num_pages: " << num_pages << std::endl;
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Compile and Execute Application
+    ////////////////////////////////////////////////////////////////////////////
+
+    try {
+    tt::tt_metal::detail::CompileProgram(sender_device, sender_program);
+    tt::tt_metal::detail::CompileProgram(receiver_device, receiver_program);
+    } catch (std::exception& e) {
+        std::cout << "Failed compile: " << e.what() << std::endl;
+        throw e;
+    }
+
+    std::cout << "Running..." << std::endl;
+
+    std::thread th2 = std::thread([&] {
+        tt_metal::detail::LaunchProgram(receiver_device, receiver_program);
+    });
+    std::thread th1 = std::thread([&] {
+        tt_metal::detail::LaunchProgram(sender_device, sender_program);
+    });
+
+    th2.join();
+    std::cout << "receiver done" << std::endl;
+    th1.join();
+    std::cout << "sender done" << std::endl;
+
+    std::vector<uint32_t> readback_data_vec = std::vector<uint32_t>(all_zeros.size(), -1); // init to 0 data for easier debug
+    tt_metal::detail::ReadFromBuffer(output_buffer, readback_data_vec);
+    pass &= (readback_data_vec == inputs);
+    TT_ASSERT(std::any_of(inputs.begin(), inputs.end(), [](uint32_t x) { return x != 0; }), "Input buffer expected to not be all 0");
+    if (not pass) {
+        std::cout << "Mismatch output mismatch" << std::endl;
+        std::size_t num_printed_mismatches = 0;
+        for (size_t i = 0; i < readback_data_vec.size() && num_printed_mismatches < 64; i++) {
+            if (readback_data_vec[i] != inputs[i]) {
+                std::cout << "[" << i << "]: expected " << inputs[i] << " got " << readback_data_vec[i] << std::endl;
+                num_printed_mismatches++;
+            }
+        }
+        std::cout << "... (remaining mismatches omitted)" << std::endl;
+    }
+    return pass;
+}
+
+
+int main(int argc, char** argv) {
+    // argv[0]: program
+    // argv[1]: buffer_size_bytes
+    // argv[2]: num_loops
+    assert (argc == 10);
+    std::string const& sender_kernel_path = argv[1];
+    std::string const& receiver_kernel_path = argv[2];
+    const uint32_t eth_l1_staging_buffer_size = std::stoi(argv[3]);
+    const uint32_t eth_max_concurrent_sends = std::stoi(argv[4]);
+    const uint32_t input_buffer_page_size = std::stoi(argv[5]);
+    const uint32_t input_buffer_size_bytes = std::stoi(argv[6]);
+    const bool source_is_dram = std::stoi(argv[7]) == 1;
+    const bool dest_is_dram = std::stoi(argv[8]) == 1;
+    const uint32_t precomputed_source_addresses_buffer_size = std::stoi(argv[9]);
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    if (num_devices != 2) {
+        std::cout << "Need at least 2 devices to run this test" << std::endl;
+        return 0;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        std::cout << "Test must be run on WH" << std::endl;
+        return 0;
+    }
+    N300TestDevice test_fixture;
+
+    std::cout << "precomputed_source_addresses_buffer_size: " << precomputed_source_addresses_buffer_size << std::endl;
+    const auto& device_0 = test_fixture.devices_.at(0);
+    const auto& device_1 = test_fixture.devices_.at(1);
+    const size_t precomputed_source_addresses_buffer_address = (size_t)nullptr;
+    const size_t src_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 32;
+    const size_t dst_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 32;
+
+    auto const& active_eth_cores = device_0->get_active_ethernet_cores(true);
+    assert (active_eth_cores.size() > 0);
+    auto eth_sender_core_iter = active_eth_cores.begin();
+    assert (eth_sender_core_iter != active_eth_cores.end());
+    // eth_sender_core_iter++;
+    // assert (eth_sender_core_iter != active_eth_cores.end());
+    const auto& eth_sender_core = *eth_sender_core_iter;
+    auto [device_id, eth_receiver_core] = device_0->get_connected_ethernet_core(eth_sender_core);
+
+    // std::cout << "SENDER CORE: (x=" << eth_sender_core.x << ", y=" << eth_sender_core.y << ")" << std::endl;
+    // std::cout << "RECEIVER CORE: (x=" << eth_receiver_core.x << ", y=" << eth_receiver_core.y << ")" << std::endl;
+
+    // std::cout << "BW TEST: " << 64 << ", num_messages_to_send: " << num_messages_to_send << std::endl;
+    bool success = false;
+    try {
+        success = RunWriteBWTest(
+            sender_kernel_path,
+            receiver_kernel_path,
+            device_0,
+            device_1,
+            eth_sender_core,
+            eth_receiver_core,
+            src_eth_l1_byte_address,
+            dst_eth_l1_byte_address,
+            precomputed_source_addresses_buffer_address,
+            precomputed_source_addresses_buffer_size,
+            eth_l1_staging_buffer_size,
+            eth_max_concurrent_sends,
+            input_buffer_page_size,
+            input_buffer_size_bytes,
+            source_is_dram,
+            dest_is_dram
+            );
+    } catch (std::exception& e) {
+        std::cout << "Caught exception: " << e.what() << std::endl;
+        test_fixture.TearDown();
+        return -1;
+    }
+
+
+    test_fixture.TearDown();
+
+    return success ? 0 : -1;
+
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_send_data_looping.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_send_data_looping.cpp
@@ -1,0 +1,285 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <random>
+
+#include "tt_metal/common/core_coord.h"
+#include "tt_metal/common/math.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/kernels/kernel.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/df/df.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+
+using namespace tt;
+using namespace tt::test_utils;
+using namespace tt::test_utils::df;
+
+class N300TestDevice {
+   public:
+    N300TestDevice() : device_open(false) {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (not slow_dispatch) {
+            TT_THROW("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
+        }
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+
+        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 2 and
+            tt::tt_metal::GetNumPCIeDevices() == 1) {
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                auto* device = tt::tt_metal::CreateDevice(id);
+                devices_.push_back(device);
+            }
+            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+
+        } else {
+            TT_THROW("This suite can only be run on N300 Wormhole devices");
+        }
+        device_open = true;
+    }
+    ~N300TestDevice() {
+        if (device_open) {
+            TearDown();
+        }
+    }
+
+    void TearDown() {
+        device_open = false;
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+        for (unsigned int id = 0; id < devices_.size(); id++) {
+            tt::tt_metal::CloseDevice(devices_.at(id));
+        }
+    }
+
+    std::vector<tt::tt_metal::Device*> devices_;
+    tt::ARCH arch_;
+    size_t num_devices_;
+
+   private:
+    bool device_open;
+};
+
+bool RunWriteBWTest(
+    std::string const& sender_kernel_path,
+    std::string const& receiver_kernel_path,
+    tt_metal::Device* sender_device,
+    tt_metal::Device* receiver_device,
+
+    bool source_is_dram,
+    bool dest_is_dram,
+
+    const uint32_t size_in_bytes,
+    const size_t src_eth_l1_byte_address,
+    const size_t dst_eth_l1_byte_address,
+    const CoreCoord& eth_sender_core,
+    const CoreCoord& eth_receiver_core,
+    const uint32_t num_messages_to_send,
+    const uint32_t max_num_transaction_buffers,
+    uint32_t num_bytes_per_send = 16
+
+    ) {
+    bool pass = true;
+    log_debug(
+        tt::LogTest,
+        "Sending {} bytes from device {} eth core {} addr {} to device {} eth core {} addr {}",
+        size_in_bytes,
+        sender_device->id(),
+        eth_sender_core.str(),
+        src_eth_l1_byte_address,
+        receiver_device->id(),
+        eth_receiver_core.str(),
+        dst_eth_l1_byte_address);
+
+    // Initialize L1s:
+    std::vector<uint32_t> zeros = std::vector<uint32_t>(32, 0);
+    llrt::write_hex_vec_to_core(
+        sender_device->id(),
+        sender_device->ethernet_core_from_logical_core(eth_sender_core),
+        zeros,
+        src_eth_l1_byte_address);
+    llrt::write_hex_vec_to_core(
+        receiver_device->id(),
+        receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
+        zeros,
+        dst_eth_l1_byte_address);
+
+    // Generate inputs
+    auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, size_in_bytes / sizeof(uint32_t));
+    llrt::write_hex_vec_to_core(
+        sender_device->id(),
+        sender_device->ethernet_core_from_logical_core(eth_sender_core),
+        inputs,
+        src_eth_l1_byte_address);
+
+    // Clear expected value at ethernet L1 address
+    std::vector<uint32_t> all_zeros(inputs.size(), 0);
+    llrt::write_hex_vec_to_core(
+        receiver_device->id(),
+        receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
+        all_zeros,
+        dst_eth_l1_byte_address);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Sender Device
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program sender_program = tt_metal::Program();
+
+    auto eth_sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        sender_kernel_path,
+        eth_sender_core,
+        tt_metal::EthernetConfig{
+            .noc = tt_metal::NOC::NOC_0,
+            .compile_args = {
+                uint32_t(num_bytes_per_send),         // 0
+                uint32_t(num_bytes_per_send >> 4),    // 1
+                uint32_t(num_messages_to_send),       // 2
+                uint32_t(max_num_transaction_buffers),// 3
+                uint32_t(source_is_dram)              // 4
+                }
+            });
+
+    tt_metal::SetRuntimeArgs(
+        sender_program,
+        eth_sender_kernel,
+        eth_sender_core,
+        {
+            uint32_t(src_eth_l1_byte_address),
+            uint32_t(dst_eth_l1_byte_address)
+        });
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                           Receiver Device
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program receiver_program = tt_metal::Program();
+
+    auto eth_receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        receiver_kernel_path,
+        eth_receiver_core,
+        tt_metal::EthernetConfig{
+            .noc = tt_metal::NOC::NOC_0,
+            .compile_args = {
+                uint32_t(num_bytes_per_send),         // 0
+                uint32_t(num_bytes_per_send >> 4),    // 1
+                uint32_t(num_messages_to_send),       // 2
+                uint32_t(max_num_transaction_buffers),// 3
+                uint32_t(dest_is_dram)                // 4
+            }});  // probably want to use NOC_1 here
+
+    tt_metal::SetRuntimeArgs(
+        receiver_program,
+        eth_receiver_kernel,
+        eth_receiver_core,
+        {
+            uint32_t(src_eth_l1_byte_address),
+            uint32_t(dst_eth_l1_byte_address)
+        });
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Compile and Execute Application
+    ////////////////////////////////////////////////////////////////////////////
+
+    tt::tt_metal::detail::CompileProgram(sender_device, sender_program);
+    tt::tt_metal::detail::CompileProgram(receiver_device, receiver_program);
+
+    std::cout << "Running..." << std::endl;
+
+    std::thread th2 = std::thread([&] {
+        tt_metal::detail::LaunchProgram(receiver_device, receiver_program);
+    });
+    std::thread th1 = std::thread([&] {
+        tt_metal::detail::LaunchProgram(sender_device, sender_program);
+    });
+
+    th2.join();
+    std::cout << "receiver done" << std::endl;
+    th1.join();
+    std::cout << "sender done" << std::endl;
+
+    auto readback_vec = llrt::read_hex_vec_from_core(
+        receiver_device->id(),
+        receiver_device->ethernet_core_from_logical_core(eth_receiver_core),
+        dst_eth_l1_byte_address,
+        size_in_bytes);
+    pass &= (readback_vec == inputs);
+    if (not pass) {
+        std::cout << "Mismatch at Core: " << eth_receiver_core.str() << std::endl;
+        std::cout << readback_vec[0] << std::endl;
+    }
+    return pass;
+}
+
+
+int main(int argc, char** argv) {
+    // argv[0]: program
+    // argv[1]: buffer_size_bytes
+    // argv[2]: num_loops
+    assert (argc == 6);
+    const uint32_t buffer_size_bytes = std::stoi(argv[1]);
+    const uint32_t num_messages_to_send = std::stoi(argv[2]);
+    const uint32_t max_num_transaction_buffers = std::stoi(argv[3]);
+    std::string const& sender_kernel_path = argv[4];
+    std::string const& receiver_kernel_path = argv[5];
+
+    bool source_is_dram = true;
+    bool dest_is_dram = true;
+
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    if (num_devices != 2) {
+        std::cout << "Need at least 2 devices to run this test" << std::endl;
+        return 0;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        std::cout << "Test must be run on WH" << std::endl;
+        return 0;
+    }
+    N300TestDevice test_fixture;
+
+    const auto& device_0 = test_fixture.devices_.at(0);
+    const auto& device_1 = test_fixture.devices_.at(1);
+    const size_t src_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+    const size_t dst_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+
+    auto const& active_eth_cores = device_0->get_active_ethernet_cores(true);
+    assert (active_eth_cores.size() > 0);
+    auto eth_sender_core_iter = active_eth_cores.begin();
+    assert (eth_sender_core_iter != active_eth_cores.end());
+    eth_sender_core_iter++;
+    assert (eth_sender_core_iter != active_eth_cores.end());
+    const auto& eth_sender_core = *eth_sender_core_iter;
+    auto [device_id, eth_receiver_core] = device_0->get_connected_ethernet_core(eth_sender_core);
+
+    // std::cout << "SENDER CORE: (x=" << eth_sender_core.x << ", y=" << eth_sender_core.y << ")" << std::endl;
+    // std::cout << "RECEIVER CORE: (x=" << eth_receiver_core.x << ", y=" << eth_receiver_core.y << ")" << std::endl;
+
+    // std::cout << "BW TEST: " << 64 << ", num_messages_to_send: " << num_messages_to_send << std::endl;
+    RunWriteBWTest(
+        sender_kernel_path,
+        receiver_kernel_path,
+        device_0,
+        device_1,
+        source_is_dram,
+        dest_is_dram,
+        buffer_size_bytes,
+        src_eth_l1_byte_address,
+        dst_eth_l1_byte_address,
+        eth_sender_core,
+        eth_receiver_core,
+        num_messages_to_send,
+        max_num_transaction_buffers,
+        buffer_size_bytes);
+
+    test_fixture.TearDown();
+
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
@@ -1,0 +1,633 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <random>
+
+#include "device/tt_arch_types.h"
+#include "tt_backend_api_types.hpp"
+#include "tt_metal/common/core_coord.h"
+#include "tt_metal/common/math.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/kernels/kernel.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/df/df.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+// #include "impl/kernels/kernel_types.hpp"
+
+using namespace tt;
+using namespace tt::test_utils;
+using namespace tt::test_utils::df;
+
+class N300TestDevice {
+   public:
+    N300TestDevice() : device_open(false) {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (not slow_dispatch) {
+            TT_THROW("This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
+        }
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+
+        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 2 and
+            tt::tt_metal::GetNumPCIeDevices() == 1) {
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                auto* device = tt::tt_metal::CreateDevice(id);
+                devices_.push_back(device);
+            }
+            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+
+        } else {
+            TT_THROW("This suite can only be run on N300 Wormhole devices");
+        }
+        device_open = true;
+    }
+    ~N300TestDevice() {
+        if (device_open) {
+            TearDown();
+        }
+    }
+
+    void TearDown() {
+        device_open = false;
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+        for (unsigned int id = 0; id < devices_.size(); id++) {
+            tt::tt_metal::CloseDevice(devices_.at(id));
+        }
+    }
+
+    std::vector<tt::tt_metal::Device*> devices_;
+    tt::ARCH arch_;
+    size_t num_devices_;
+
+   private:
+    bool device_open;
+};
+
+struct BankedConfig {
+    size_t num_pages;
+    size_t size_bytes;
+    size_t page_size_bytes;
+    BufferType input_buffer_type;   // = BufferType::L1;
+    BufferType output_buffer_type;  // = BufferType::L1;
+    tt::DataFormat l1_data_format;  // = tt::DataFormat::Float16_b;
+};
+
+struct KernelXY {
+    uint16_t x;
+    uint16_t y;
+
+    uint32_t to_uint32() const { return y << 16 | x; }
+};
+
+bool RunWriteBWTest(
+    std::string const &sender_side_reader_worker_kernel_path,
+    std::string const &sender_side_writer_worker_kernel_path,
+    std::string const &receiver_side_reader_worker_kernel_path,
+    std::string const &receiver_side_writer_worker_kernel_path,
+
+    tt_metal::Device* sender_device,
+    tt_metal::Device* receiver_device,
+
+    const CoreCoord& eth_sender_core,
+    const CoreCoord& eth_receiver_core,
+
+    const size_t src_eth_l1_byte_address,
+    const size_t dst_eth_l1_byte_address,
+
+    const size_t precomputed_source_addresses_buffer_address,
+    const size_t precomputed_source_addresses_buffer_size,
+
+    const uint32_t eth_l1_staging_buffer_size,
+    const uint32_t eth_max_concurrent_sends,
+    const uint32_t input_buffer_page_size,
+    const uint32_t input_buffer_size_bytes,
+    bool source_is_dram,
+    bool dest_is_dram
+
+) {
+    // number of bytes to send per eth send (given that eth l1 buf size not
+    // guaranteed to be multiple of page size, we won't send the left over
+    // bytes at the end
+    const uint32_t pages_per_send = eth_l1_staging_buffer_size / input_buffer_page_size;
+    const uint32_t num_bytes_per_send = pages_per_send * input_buffer_page_size;
+    const uint32_t num_pages = ((input_buffer_size_bytes - 1) / input_buffer_page_size) + 1;  // includes padding
+    const uint32_t num_messages_to_send = ((input_buffer_size_bytes - 1) / num_bytes_per_send) + 1;
+
+    TT_ASSERT(
+        precomputed_source_addresses_buffer_address < std::numeric_limits<uint32_t>::max(),
+        "precomputed_source_addresses_buffer_address is too large");
+
+    bool pass = true;
+    log_debug(
+        tt::LogTest,
+        "Sending {} bytes from device {} eth core {} addr {} to device {} eth core {} addr {}",
+        input_buffer_size_bytes,
+        sender_device->id(),
+        eth_sender_core.str(),
+        src_eth_l1_byte_address,
+        receiver_device->id(),
+        eth_receiver_core.str(),
+        dst_eth_l1_byte_address);
+    // Generate inputs
+    ////////////////////////////////////////////////////////////////////////////
+    //   SETUP THE INPUT CB
+    ////////////////////////////////////////////////////////////////////////////
+    auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, input_buffer_size_bytes / sizeof(uint32_t));
+
+    // Clear expected value at ethernet L1 address
+
+    BankedConfig test_config = BankedConfig{
+        .num_pages = num_pages,
+        .size_bytes = input_buffer_size_bytes,
+        .page_size_bytes = input_buffer_page_size,
+        .input_buffer_type = source_is_dram ? BufferType::DRAM : BufferType::L1,
+        .output_buffer_type = dest_is_dram ? BufferType::DRAM : BufferType::L1,
+        .l1_data_format = tt::DataFormat::Float16_b};
+    auto input_buffer = CreateBuffer(InterleavedBufferConfig{
+        sender_device, test_config.size_bytes, test_config.page_size_bytes, test_config.input_buffer_type});
+
+    bool input_is_dram = test_config.input_buffer_type == BufferType::DRAM;
+    tt_metal::detail::WriteToBuffer(input_buffer, inputs);
+    const uint32_t dram_input_buf_base_addr = input_buffer->address();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //   EMPTY INITIALIZE THE OUTPUT CB
+    ////////////////////////////////////////////////////////////////////////////
+
+    // Clear expected value at ethernet L1 address
+    std::vector<uint32_t> all_zeros(inputs.size(), 0);
+
+    auto output_buffer = CreateBuffer(InterleavedBufferConfig{
+        receiver_device, test_config.size_bytes, test_config.page_size_bytes, test_config.output_buffer_type});
+
+    bool output_is_dram = test_config.output_buffer_type == BufferType::DRAM;
+    tt_metal::detail::WriteToBuffer(output_buffer, all_zeros);
+    const uint32_t dram_output_buffer_base_addr = output_buffer->address();
+
+    // TODO(snijjar): Find a cleaner way to do this
+    uint32_t erisc_handshake_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+
+    // MAKE GLOBAL FOR NOW
+    auto chip0_sender_worker_core = CoreCoord(0, 0);
+
+    uint32_t chip0_next_buffer_address = erisc_handshake_address + 16;
+    std::vector<uint32_t> chip0_edm_args = {erisc_handshake_address};
+    uint32_t chip0_sender_channels_offset = 0;
+    uint32_t chip0_arg_sender_num_channels = 1;
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                  WORKER CB CONFIG
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t src0_cb_index = CB::c_in0;
+
+    // Just want a dummy DF
+    tt::DataFormat df = input_buffer_page_size == 1024 ? tt::DataFormat::Bfp8 :
+                        input_buffer_page_size == 2048 ? tt::DataFormat::Float16 :
+                                                         tt::DataFormat::Float32;
+    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(2 * pages_per_send * input_buffer_page_size, {{src0_cb_index, df}})
+		.set_page_size(src0_cb_index, input_buffer_page_size);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                               Device 0
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program sender_program = tt_metal::Program();
+    uint32_t chip0_worker_semaphores_base_address = tt::tt_metal::CreateSemaphore(sender_program, chip0_sender_worker_core, 0);
+
+    chip0_edm_args.push_back(chip0_sender_channels_offset);
+
+    // 3) sender num channels (How many erisc channels to use. ALso how many buffers to instantiate)
+    log_debug(tt::LogTest, "------------------ Device 0 args ----------------");
+    //---------------------
+    //                              Device 0 - SENDER
+    log_debug(tt::LogTest, "\t-- sender --");
+    log_debug(tt::LogTest, "\tchip0_sender_channels_offset: {}", chip0_sender_channels_offset);
+    uint32_t chip0_sender_num_channels = chip0_arg_sender_num_channels;
+    chip0_edm_args.push_back(chip0_sender_num_channels);
+    log_debug(tt::LogTest, "\tchip0_sender_num_channels: {}", chip0_sender_num_channels);
+    uint32_t chip0_receiver_channels_offset = chip0_sender_channels_offset + chip0_sender_num_channels;
+    uint32_t chip0_sender_erisc_sender_buffer_address = chip0_next_buffer_address;
+    uint32_t chip0_eth_sender_l1_base_addr = 0;
+    uint32_t chip0_eth_sender_l1_sem_addr = 0;
+    for (uint32_t sc = 0; sc < chip0_sender_num_channels; sc++) {
+        //    Informs how many times to iterate through the next group of args
+        //    4) sender_buffer_address
+        chip0_edm_args.push_back(chip0_next_buffer_address);
+        chip0_eth_sender_l1_base_addr = chip0_next_buffer_address;
+        log_debug(tt::LogTest, "\t\tsender_buffer_address: {}", chip0_next_buffer_address);
+        //    5) sender_num_messages_to_send
+        chip0_edm_args.push_back(num_messages_to_send);
+        log_debug(tt::LogTest, "\t\tchip0_sender_num_messages_to_send: {}", num_messages_to_send);
+        //    6) sender_channel_size
+        chip0_edm_args.push_back(eth_l1_staging_buffer_size);
+        log_debug(tt::LogTest, "\t\tchip0_sender_channel_size: {}", eth_l1_staging_buffer_size);
+        chip0_next_buffer_address =
+            chip0_next_buffer_address + eth_l1_staging_buffer_size + 16 - (eth_l1_staging_buffer_size % 16);
+        //    7) sender_semaphores_base_address
+        // ... Any off by one errors and I'm toast :)
+        //     erisc local copy of semaphore that workers update remotely
+        chip0_edm_args.push_back(chip0_next_buffer_address);
+        log_debug(tt::LogTest, "\t\tsender erisc l1 semaphore address: {}", chip0_next_buffer_address);
+        chip0_eth_sender_l1_sem_addr = chip0_next_buffer_address;
+        chip0_next_buffer_address += 16;
+        //    8) worker_semaphore_address
+        //       worker local L1 semaphores that erisc updates
+        chip0_edm_args.push_back(chip0_worker_semaphores_base_address);
+        log_debug(tt::LogTest, "\t\tworker_semaphores_base_address: {}", chip0_worker_semaphores_base_address);
+        //    9) sender_num_workers
+        //       Informs how many worker X/Y coords to accept in the next loop. Each X/Y pair is 2 uint16s
+        const uint32_t chip0_num_workers_on_channel = 1;
+        chip0_edm_args.push_back(chip0_num_workers_on_channel);
+        log_debug(tt::LogTest, "\t\tchip0_num_workers_on_channel: {}", chip0_num_workers_on_channel);
+        for (uint32_t w = 0; w < chip0_num_workers_on_channel; w++) {
+            //       10) worker_coord(s)
+            auto worker_noc_coord = sender_device->physical_core_from_logical_core(chip0_sender_worker_core, CoreType::WORKER);
+            chip0_edm_args.push_back(KernelXY{
+                static_cast<uint16_t>(worker_noc_coord.x), static_cast<uint16_t>(worker_noc_coord.y)}
+                                         .to_uint32());
+            log_debug(
+                tt::LogTest,
+                "\t\t\tchip0_sender_noc_xy: x={},y={}",
+                worker_noc_coord.x,
+                worker_noc_coord.y);
+        }
+    }
+    TT_ASSERT(chip0_eth_sender_l1_sem_addr != 0);
+    TT_ASSERT(chip0_eth_sender_l1_base_addr != 0);
+
+    //---------------------
+    //                              Device 0 - RECEIVER
+    log_debug(tt::LogTest, "\t-- receiver --");
+    log_debug(tt::LogTest, "\tchip0_receiver_channels_offset: {}", chip0_receiver_channels_offset);
+    chip0_edm_args.push_back(chip0_receiver_channels_offset);
+    uint32_t chip0_receiver_num_channels = 0;
+    chip0_edm_args.push_back(chip0_receiver_num_channels);
+    log_debug(tt::LogTest, "\tchip0_receiver_num_channels: {}", chip0_receiver_num_channels);
+    //---------------------
+
+    uint32_t num_pages_per_l1_buffer = num_bytes_per_send / input_buffer_page_size;
+    TT_ASSERT(num_messages_to_send * num_pages_per_l1_buffer >= num_pages);
+
+    auto eth_sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover.cpp",
+        eth_sender_core,
+        tt_metal::EthernetConfig{
+            .noc = tt_metal::NOC::NOC_0,
+            .compile_args = {
+                uint32_t(1),  // enable sender side
+                uint32_t(0)   // enable receiver side
+            }});
+
+    // chip 0 sender_worker_sender
+    std::vector<uint32_t> chip0_sender_worker_sender_compile_args{
+        pages_per_send,
+        num_pages,
+        input_buffer_page_size};
+    std::vector<uint32_t> chip0_sender_worker_sender_runtime_args{
+        chip0_sender_erisc_sender_buffer_address,
+        // ERISC's semaphore address
+        chip0_eth_sender_l1_sem_addr,
+        // worker L1 semaphore address. Sender writes to this address to signal the worker
+        // that the buffer is empty and available to write into
+        chip0_worker_semaphores_base_address,
+        uint32_t(sender_device->ethernet_core_from_logical_core(eth_sender_core).x),
+        uint32_t(sender_device->ethernet_core_from_logical_core(eth_sender_core).y)
+        };
+    // TODO
+    std::vector<uint32_t> chip0_sender_worker_reader_compile_args{
+        input_is_dram,
+        num_pages,
+        input_buffer_page_size
+        };
+    // TODO
+    std::vector<uint32_t> chip0_sender_worker_reader_runtime_args{
+        dram_input_buf_base_addr};
+
+    CBHandle cb_src0_sender_workers = CreateCircularBuffer(sender_program, chip0_sender_worker_core, cb_src0_config);
+    auto device_0_edm_sender_worker_reader_kernel = tt_metal::CreateKernel(
+        sender_program,
+        sender_side_reader_worker_kernel_path,
+        chip0_sender_worker_core,
+        tt_metal::DataMovementConfig {
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = chip0_sender_worker_reader_compile_args});
+    auto device_0_edm_sender_worker_sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        sender_side_writer_worker_kernel_path,
+        chip0_sender_worker_core,
+        tt_metal::DataMovementConfig {
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = tt_metal::NOC::NOC_0,//  ::RISCV_1_default,
+            .compile_args = chip0_sender_worker_sender_compile_args});
+
+    tt_metal::SetRuntimeArgs(sender_program, eth_sender_kernel, eth_sender_core, chip0_edm_args);
+    tt_metal::SetRuntimeArgs(
+        sender_program,
+        device_0_edm_sender_worker_sender_kernel,
+        chip0_sender_worker_core,
+        chip0_sender_worker_sender_runtime_args);
+    tt_metal::SetRuntimeArgs(
+        sender_program, device_0_edm_sender_worker_reader_kernel, chip0_sender_worker_core, chip0_sender_worker_reader_runtime_args);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                              Device 1
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program receiver_program = tt_metal::Program();
+    auto chip1_receiver_worker_core = CoreCoord(0, 0);
+    uint32_t chip1_worker_semaphores_base_address = tt::tt_metal::CreateSemaphore(receiver_program, chip1_receiver_worker_core, 0);
+
+    auto eth_receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover.cpp",
+        eth_receiver_core,
+        tt_metal::EthernetConfig{
+            .noc = tt_metal::NOC::NOC_0,
+            .compile_args = {
+                uint32_t(0),  // enable sender side
+                uint32_t(1)   // enable receiver side
+            }});
+
+    //                              Device 1 - RECEIVER
+    log_debug(tt::LogTest, "------------------ Device 1 args ----------------");
+    uint32_t chip1_sender_num_channels = 0;
+    uint32_t chip1_next_buffer_address = erisc_handshake_address + 16;
+    std::vector<uint32_t> chip1_edm_args = {erisc_handshake_address};
+    uint32_t chip1_receiver_num_channels = chip0_arg_sender_num_channels;
+
+    //                              Device 1 - SENDER
+    uint32_t chip1_sender_channel_size = 0;
+    uint32_t chip1_sender_num_messages_to_send = 0;
+    uint32_t chip1_sender_channels_offset = chip1_receiver_num_channels;
+    log_debug(tt::LogTest, "\t-- sender --");
+    chip1_edm_args.push_back(chip1_sender_channels_offset);
+    log_debug(tt::LogTest, "\tchip1_sender_channels_offset: {}", chip1_sender_channels_offset);
+    chip1_edm_args.push_back(chip1_sender_num_channels);
+    log_debug(tt::LogTest, "\tchip1_sender_num_channels: {}", chip1_sender_num_channels);
+    CoreCoord chip1_sender_noc_xy(0,0);
+    for (uint32_t sc = 0; sc < chip1_sender_num_channels; sc++) {
+        TT_ASSERT(chip1_sender_noc_xy.x != 0 && chip1_sender_noc_xy.y != 0);
+        //    Informs how many times to iterate through the next group of args
+        //    4) sender_buffer_address
+        chip1_edm_args.push_back(chip1_next_buffer_address);
+        log_debug(tt::LogTest, "\t\tsender_buffer_address: {}", chip1_next_buffer_address);
+        //    5) sender_num_messages_to_send
+        chip1_edm_args.push_back(chip1_sender_num_messages_to_send);
+        log_debug(tt::LogTest, "\t\tchip1_sender_num_messages_to_send: {}", chip1_sender_num_messages_to_send);
+        //    6) sender_channel_size
+        chip1_edm_args.push_back(chip1_sender_channel_size);
+        log_debug(tt::LogTest, "\t\tchip1_sender_channel_size: {}", chip1_sender_channel_size);
+        chip1_next_buffer_address =
+            chip1_next_buffer_address + chip1_sender_channel_size + 16 - (chip1_sender_channel_size % 16);
+        //    7) sender_semaphores_base_address
+        // ... Any off by one errors and I'm toast :)
+        chip1_edm_args.push_back(chip1_next_buffer_address);
+        log_debug(tt::LogTest, "\t\tsender_semaphores_base_address: {}", chip1_next_buffer_address);
+        chip1_next_buffer_address += 16;
+        //    8) worker_semaphore_address
+        chip1_edm_args.push_back(chip1_worker_semaphores_base_address);
+        log_debug(tt::LogTest, "\t\tworker_semaphores_base_address: {}", chip1_worker_semaphores_base_address);
+        //    9) sender_num_workers
+        //       Informs how many worker X/Y coords to accept in the next loop. Each X/Y pair is 2 uint16s
+        const uint32_t chip1_num_workers_on_channel = 1;
+        chip1_edm_args.push_back(chip1_num_workers_on_channel);
+        log_debug(tt::LogTest, "\t\tchip1_num_workers_on_channel: {}", chip1_num_workers_on_channel);
+        for (uint32_t w = 0; w < chip1_num_workers_on_channel; w++) {
+            //       10) worker_coord(s)
+            auto worker_noc_coord = receiver_device->physical_core_from_logical_core(chip1_sender_noc_xy, CoreType::WORKER);
+            chip1_edm_args.push_back(
+                KernelXY{static_cast<uint16_t>(worker_noc_coord.x), static_cast<uint16_t>(worker_noc_coord.y)}
+                    .to_uint32());
+            log_debug(
+                tt::LogTest,
+                "\t\t\tchip1_num_workers_on_channel: x={},y={}",
+                worker_noc_coord.x,
+                worker_noc_coord.y);
+        }
+    }
+
+
+    log_debug(tt::LogTest, "\t-- receiver --");
+    uint32_t chip1_receiver_channels_offset = chip0_sender_channels_offset;
+    uint32_t chip1_eth_receiver_l1_base_addr = 0;
+    uint32_t chip1_eth_receiver_l1_sem_addr = 0;
+    chip1_edm_args.push_back(chip1_receiver_channels_offset);
+    log_debug(tt::LogTest, "\tchip1_receiver_channels_offset: {}", chip1_receiver_channels_offset);
+    chip1_edm_args.push_back(chip1_receiver_num_channels);
+    log_debug(tt::LogTest, "\tchip1_receiver_num_channels: {}", chip1_receiver_num_channels);
+    for (uint32_t sc = 0; sc < chip1_receiver_num_channels; sc++) {
+        //    Informs how many times to iterate through the next group of args
+        //    4) sender_buffer_address
+        chip1_edm_args.push_back(chip1_next_buffer_address);
+        chip1_eth_receiver_l1_base_addr = chip1_next_buffer_address;
+        log_debug(tt::LogTest, "\t\tchip1_next_buffer_address: {}", chip1_next_buffer_address);
+        //    5) sender_num_messages_to_send
+        chip1_edm_args.push_back(num_messages_to_send);
+        log_debug(tt::LogTest, "\t\tchip1_receiver_num_messages_to_send: {}", num_messages_to_send);
+        //    6) sender_channel_size
+        chip1_edm_args.push_back(eth_l1_staging_buffer_size);
+        log_debug(tt::LogTest, "\t\tchip1_receiver_channel_size: {}", eth_l1_staging_buffer_size);
+        chip1_next_buffer_address =
+            chip1_next_buffer_address + eth_l1_staging_buffer_size + 16 - (eth_l1_staging_buffer_size % 16);
+        //    7) sender_semaphores_base_address
+        // ... Any off by one errors and I'm toast :)
+        chip1_edm_args.push_back(chip1_next_buffer_address);
+        log_debug(tt::LogTest, "\t\treceiver erisc semaphores_base_address: {}", chip1_next_buffer_address);
+        chip1_eth_receiver_l1_sem_addr = chip1_next_buffer_address;
+        chip1_next_buffer_address += 16;
+        //    8) worker_semaphore_address
+        chip1_edm_args.push_back(chip1_worker_semaphores_base_address);
+        log_debug(tt::LogTest, "\t\tworker_semaphores_base_address: {}", chip1_worker_semaphores_base_address);
+        //    9) sender_num_workers
+        //       Informs how many worker X/Y coords to accept in the next loop. Each X/Y pair is 2 uint16s
+        const uint32_t chip1_num_workers_on_channel = 1;
+        chip1_edm_args.push_back(chip1_num_workers_on_channel);
+        log_debug(tt::LogTest, "\t\tnum_workers: {}", chip1_num_workers_on_channel);
+        for (uint32_t w = 0; w < chip1_num_workers_on_channel; w++) {
+            //       10) worker_coord(s)
+            auto worker_noc_coord = receiver_device->physical_core_from_logical_core(chip1_receiver_worker_core, CoreType::WORKER);
+            chip1_edm_args.push_back(
+                KernelXY{static_cast<uint16_t>(worker_noc_coord.x), static_cast<uint16_t>(worker_noc_coord.y)}
+                    .to_uint32());
+            log_debug(
+                tt::LogTest, "\t\t\tchip1_receiver_noc_xy: x={},y={}", worker_noc_coord.x, worker_noc_coord.y);
+        }
+    }
+    TT_ASSERT(chip1_eth_receiver_l1_base_addr != 0);
+    TT_ASSERT(chip1_eth_receiver_l1_sem_addr != 0);
+
+
+    tt_metal::SetRuntimeArgs(receiver_program, eth_receiver_kernel, eth_receiver_core, chip1_edm_args);
+    std::vector<uint32_t> chip1_receiver_worker_sender_compile_args{
+        dest_is_dram,  //
+        num_pages,     //
+        input_buffer_page_size};
+    std::vector<uint32_t> chip1_receiver_worker_sender_runtime_args{dram_output_buffer_base_addr};
+    std::vector<uint32_t> chip1_receiver_worker_receiver_compile_args{
+        chip1_eth_receiver_l1_base_addr,  //
+        chip1_eth_receiver_l1_sem_addr    //
+    };
+    std::vector<uint32_t> chip1_receiver_worker_receiver_runtime_args{
+        num_pages_per_l1_buffer,
+        num_pages,
+        input_buffer_page_size,
+        (uint32_t)receiver_device->ethernet_core_from_logical_core(eth_receiver_core).x,
+        (uint32_t)receiver_device->ethernet_core_from_logical_core(eth_receiver_core).y,
+        chip1_worker_semaphores_base_address};
+
+    CBHandle cb_src0_receiver_workers = CreateCircularBuffer(receiver_program, chip1_receiver_worker_core, cb_src0_config);
+    auto device_1_edm_receiver_worker_receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        receiver_side_reader_worker_kernel_path,
+        chip1_receiver_worker_core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = chip1_receiver_worker_receiver_compile_args});
+    auto device_1_edm_receiver_worker_sender_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        receiver_side_writer_worker_kernel_path,
+        chip1_receiver_worker_core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt_metal::NOC::RISCV_1_default,
+            .compile_args = chip1_receiver_worker_sender_compile_args});
+    tt_metal::SetRuntimeArgs(
+        receiver_program,
+        device_1_edm_receiver_worker_receiver_kernel,
+        chip1_receiver_worker_core,
+        chip1_receiver_worker_receiver_runtime_args);
+    tt_metal::SetRuntimeArgs(
+        receiver_program,
+        device_1_edm_receiver_worker_sender_kernel,
+        chip1_receiver_worker_core,
+        chip1_receiver_worker_sender_runtime_args);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Compile and Execute Application
+    ////////////////////////////////////////////////////////////////////////////
+
+    try {
+        tt::tt_metal::detail::CompileProgram(sender_device, sender_program);
+        tt::tt_metal::detail::CompileProgram(receiver_device, receiver_program);
+    } catch (std::exception& e) {
+        std::cout << "Failed compile: " << e.what() << std::endl;
+        throw e;
+    }
+
+    std::cout << "Running..." << std::endl;
+
+    std::thread th2 = std::thread([&] { tt_metal::detail::LaunchProgram(receiver_device, receiver_program); });
+    std::thread th1 = std::thread([&] { tt_metal::detail::LaunchProgram(sender_device, sender_program); });
+
+    th2.join();
+    th1.join();
+
+    std::vector<uint32_t> readback_data_vec =
+        std::vector<uint32_t>(all_zeros.size(), -1);  // init to 0 data for easier debug
+    tt_metal::detail::ReadFromBuffer(output_buffer, readback_data_vec);
+    pass &= (readback_data_vec == inputs);
+    TT_ASSERT(
+        std::any_of(inputs.begin(), inputs.end(), [](uint32_t x) { return x != 0; }),
+        "Input buffer expected to not be all 0");
+    if (not pass) {
+        std::cout << "Mismatch output mismatch" << std::endl;
+        std::size_t num_printed_mismatches = 0;
+        for (size_t i = 0; i < readback_data_vec.size() && num_printed_mismatches < 64; i++) {
+            if (readback_data_vec[i] != inputs[i]) {
+                std::cout << "[" << i << "]: expected " << inputs[i] << " got " << readback_data_vec[i] << std::endl;
+                num_printed_mismatches++;
+            }
+        }
+        std::cout << "... (remaining mismatches omitted)" << std::endl;
+    }
+    return pass;
+}
+
+int main(int argc, char** argv) {
+    // argv[0]: program
+    // argv[1]: buffer_size_bytes
+    // argv[2]: num_loops
+    assert(argc == 12);
+    std::string const& sender_side_reader_worker_kernel_path = argv[1];
+    std::string const& sender_side_writer_worker_kernel_path = argv[2];
+    std::string const& receiver_side_reader_worker_kernel_path = argv[3];
+    std::string const& receiver_side_writer_worker_kernel_path = argv[4];
+    const uint32_t eth_l1_staging_buffer_size = std::stoi(argv[5]);
+    const uint32_t eth_max_concurrent_sends = std::stoi(argv[6]);
+    const uint32_t input_buffer_page_size = std::stoi(argv[7]);
+    const uint32_t input_buffer_size_bytes = std::stoi(argv[8]);
+    const bool source_is_dram = std::stoi(argv[9]) == 1;
+    const bool dest_is_dram = std::stoi(argv[10]) == 1;
+    const uint32_t precomputed_source_addresses_buffer_size = std::stoi(argv[9]);
+
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    if (num_devices != 2) {
+        std::cout << "Need at least 2 devices to run this test" << std::endl;
+        return 0;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        std::cout << "Test must be run on WH" << std::endl;
+        return 0;
+    }
+
+    N300TestDevice test_fixture;
+
+
+    const auto& device_0 = test_fixture.devices_.at(0);
+    const auto& device_1 = test_fixture.devices_.at(1);
+    const size_t precomputed_source_addresses_buffer_address = (size_t) nullptr;
+    const size_t src_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 32;
+    const size_t dst_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 32;
+
+    auto const& active_eth_cores = device_0->get_active_ethernet_cores(true);
+    assert(active_eth_cores.size() > 0);
+    auto eth_sender_core_iter = active_eth_cores.begin();
+    assert(eth_sender_core_iter != active_eth_cores.end());
+    const auto& eth_sender_core = *eth_sender_core_iter;
+    auto [device_id, eth_receiver_core] = device_0->get_connected_ethernet_core(eth_sender_core);
+
+    bool success = false;
+    try {
+        success = RunWriteBWTest(
+            sender_side_reader_worker_kernel_path,
+            sender_side_writer_worker_kernel_path,
+            receiver_side_reader_worker_kernel_path,
+            receiver_side_writer_worker_kernel_path,
+            device_0,
+            device_1,
+            eth_sender_core,
+            eth_receiver_core,
+            src_eth_l1_byte_address,
+            dst_eth_l1_byte_address,
+            precomputed_source_addresses_buffer_address,
+            precomputed_source_addresses_buffer_size,
+            eth_l1_staging_buffer_size,
+            eth_max_concurrent_sends,
+            input_buffer_page_size,
+            input_buffer_size_bytes,
+            source_is_dram,
+            dest_is_dram);
+    } catch (std::exception& e) {
+        std::cout << "Caught exception: " << e.what() << std::endl;
+        test_fixture.TearDown();
+        return -1;
+    }
+
+    test_fixture.TearDown();
+
+    return success ? 0 : -1;
+}
+
+
+// EnablePersistentKernelCache

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_async_datamover.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_async_datamover.hpp
@@ -1,0 +1,622 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdint>
+#include <type_traits>
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "ethernet/dataflow_api.h"
+#include "tt_metal/hw/inc/wormhole/noc/noc.h"
+
+namespace erisc {
+namespace datamover {
+
+/*
+ * Worker coordinate, used by EDM to know which workers to signal
+ */
+struct WorkerXY {
+    uint16_t x;
+    uint16_t y;
+};
+
+/*
+ * The `ChannelBuffer` is a building block of the Erisc Data Mover (EDM). For every concurrent transaction
+ * channel managed by the EDM, there is a `ChannelBuffer` associated with the. The `ChannelBuffer` manages
+ * state for the transaction channel, holds information such as buffer and semaphore addresses, and has helper
+ * functions to more easily check semaphore and ack statuses and to send/receive data and/or semaphore updates.
+ */
+class ChannelBuffer final {
+   public:
+    enum STATE : uint8_t {
+        DONE = 0,
+
+        // For sender: means we are ready to tell the worker(s) that the buffer is available for writing into
+        //
+        SIGNALING_WORKER,
+
+        // For sender: we are waiting for the payload to arrive in L1; we are checking local semaphore for worker
+        // completion For receiver: we are waiting for worker to complete pull of payload from L1; we are checking local
+        // semaphore for worker completion
+        WAITING_FOR_WORKER,
+
+        // For sender: means workers have signalled (via semaphores) that the buffer payload is
+        //             ready in L1
+        // For receiver:
+        READY_FOR_ETH_TRANSFER,
+
+        // For sender: means we are waiting for ack from receiver that payload was received
+        // For receiver: means we are waitinf for a payload from sender
+        WAITING_FOR_ETH,
+    };
+
+    // for default initialization in arrays
+    ChannelBuffer() :
+        local_semaphore_address(0),
+        worker_coords(0),
+        address(0),
+        remote_eth_buffer_address(0),
+        size_in_bytes(0),
+        worker_semaphore_l1_address(0),
+        num_workers(0),
+        num_messages_moved(0),
+        total_num_messages_to_move(0),
+        state(STATE::DONE) {}
+
+    ChannelBuffer(
+        uint32_t eth_transaction_channel,
+        size_t address,
+        size_t size_in_bytes,
+        uint32_t worker_semaphore_l1_address,
+        uint32_t num_workers,
+        uint32_t total_num_messages_to_move,
+        uint32_t remote_eth_buffer_address,
+        volatile tt_l1_ptr uint32_t *const local_semaphore_address,
+        tt_l1_ptr const WorkerXY *worker_coords,
+        bool is_sender_side) :
+        eth_transaction_channel(eth_transaction_channel),
+        local_semaphore_address(local_semaphore_address),
+        worker_coords(worker_coords),
+        address(address),
+        remote_eth_buffer_address(remote_eth_buffer_address),
+        size_in_bytes(size_in_bytes),
+        worker_semaphore_l1_address(worker_semaphore_l1_address),
+        num_workers(num_workers),
+        num_messages_moved(0),
+        total_num_messages_to_move(total_num_messages_to_move),
+        state(is_sender_side ? STATE::WAITING_FOR_WORKER : STATE::WAITING_FOR_ETH),
+        is_sender_side(is_sender_side) {
+        clear_local_semaphore();
+        if (is_sender_side) {
+            // Tell the sender side workers that we're ready to accept data on this channel
+            increment_worker_semaphores();
+        }
+    };
+
+    // Resets the semaphore in local L1, which workers write to remotely.
+    FORCE_INLINE void clear_local_semaphore() { noc_semaphore_set(local_semaphore_address, 0); }
+
+    // Increment the semaphore in the remote L1s of every worker associated with this ChannelBuffer
+    FORCE_INLINE void increment_worker_semaphores() {
+        // We have to be careful that the worker x/y matches for the `noc_index`
+        // active on the erisc
+        for (std::size_t i = 0; i < this->num_workers; i++) {
+            WorkerXY worker_xy = this->worker_coords[i];
+            uint64_t worker_semaphore_address =
+                get_noc_addr((uint32_t)worker_xy.x, (uint32_t)worker_xy.y, this->worker_semaphore_l1_address);
+            noc_semaphore_inc(worker_semaphore_address, 1);
+        }
+    }
+
+    [[nodiscard]] FORCE_INLINE bool is_local_semaphore_full() const {
+        return *(this->local_semaphore_address) == this->num_workers;
+    }
+
+    [[nodiscard]] FORCE_INLINE bool is_active() const {
+        return this->num_messages_moved < this->total_num_messages_to_move;
+    }
+
+    FORCE_INLINE void goto_state(STATE s) { this->state = s; }
+    [[nodiscard]] FORCE_INLINE bool is_waiting_for_workers_core() const {
+        return this->state == STATE::WAITING_FOR_WORKER;
+    }
+    [[nodiscard]] FORCE_INLINE bool is_ready_to_signal_workers() const {
+        return this->state == STATE::SIGNALING_WORKER;
+    }
+    [[nodiscard]] FORCE_INLINE bool is_waiting_for_remote_eth_core() const {
+        return this->state == STATE::WAITING_FOR_ETH;
+    }
+    [[nodiscard]] FORCE_INLINE bool is_ready_for_eth_transfer() const {
+        return this->state == STATE::READY_FOR_ETH_TRANSFER;
+    }
+    [[nodiscard]] FORCE_INLINE bool is_done() const { return this->state == STATE::DONE; }
+
+    [[nodiscard]] FORCE_INLINE uint8_t get_eth_transaction_channel() const { return this->eth_transaction_channel; }
+    [[nodiscard]] FORCE_INLINE std::size_t get_remote_eth_buffer_address() const {
+        return this->remote_eth_buffer_address;
+    }
+    [[nodiscard]] FORCE_INLINE std::size_t get_size_in_bytes() const { return this->size_in_bytes; }
+    [[nodiscard]] FORCE_INLINE std::size_t get_current_payload_size() const { return this->get_size_in_bytes(); }
+
+    [[nodiscard]] FORCE_INLINE std::size_t get_buffer_address() const { return this->address; }
+
+    FORCE_INLINE void increment_messages_moved() { this->num_messages_moved++; }
+
+    [[nodiscard]] FORCE_INLINE bool all_messages_moved() {
+        return this->num_messages_moved == this->total_num_messages_to_move;
+    }
+
+   private:
+    uint32_t eth_transaction_channel;  //
+    volatile tt_l1_ptr uint32_t *const local_semaphore_address;
+    WorkerXY const *const worker_coords;
+    std::size_t const address;
+    std::size_t const remote_eth_buffer_address;
+    std::size_t const size_in_bytes;
+    // Even for multiple workers, this address will be the same
+    std::size_t const worker_semaphore_l1_address;
+    uint32_t const num_workers;
+    uint32_t num_messages_moved;
+    const uint32_t total_num_messages_to_move;
+    STATE state;
+    bool is_sender_side;
+};
+
+template <typename T = uint8_t>
+class QueueIndexPointer {
+   public:
+    QueueIndexPointer(uint8_t queue_size) : ptr(0), size(queue_size), wrap_around(queue_size * 2) {
+        // FWASSERT(queue_size < 128);
+    }
+
+    [[nodiscard("index was called without consuming the result. Did you mean to call it?")]] T index() const {
+        return this->ptr >= this->size ? this->ptr - this->size : this->ptr;
+    }
+    [[nodiscard("raw_index was called without consuming the result. Did you mean to call it?")]] inline T raw_index()
+        const {
+        return this->ptr;
+    }
+    [[nodiscard("distance was called without consuming the result. Did you mean to call it?")]] inline static T
+    distance(QueueIndexPointer ptr, QueueIndexPointer ackptr) {
+        // FWASSERT(ptr.size == ackptr.size);
+        return ackptr.ptr > ptr.ptr ? (ptr.wrap_around - ackptr.ptr) + ptr.ptr : ptr.ptr - ackptr.ptr;
+    }
+    [[nodiscard("full was called without consuming the result. Did you mean to call it?")]] inline static T full(
+        QueueIndexPointer ptr, QueueIndexPointer ackptr) {
+        // FWASSERT(ptr.size == ackptr.size);
+        return distance(ptr.ptr, ackptr.ptr) >= ptr.size;
+    }
+    [[nodiscard("empty was called without consuming the result. Did you mean to call it?")]] inline static T empty(
+        QueueIndexPointer ptr, QueueIndexPointer ackptr) {
+        // FWASSERT(ptr.size == ackptr.size);
+        return ptr.ptr == ackptr.ptr;
+    }
+    inline void increment() { this->ptr = this->next_pointer(); }
+    [[nodiscard(
+        "next_index was called without consuming the result. Did you mean to call it?")]] inline QueueIndexPointer
+    next_index() const {
+        return QueueIndexPointer(this->next_pointer(), this->size);
+    }
+    // Compares indices since the raw index is not visible to the user
+    inline bool operator==(const QueueIndexPointer &other) const { return this->ptr == other.ptr; }
+    inline bool operator!=(const QueueIndexPointer &other) const { return this->ptr != other.ptr; }
+
+   private:
+    inline T next_pointer() {
+        T next_ptr = (this->ptr + 1);
+        next_ptr = next_ptr == wrap_around ? 0 : next_ptr;
+        return next_ptr;
+    }
+    QueueIndexPointer(T ptr, uint8_t queue_size) : ptr(ptr), size(queue_size), wrap_around(queue_size * 2) {}
+    T ptr;
+    uint8_t size;
+    uint8_t wrap_around;
+};
+
+void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        eth_wait_for_receiver_done();
+    } else {
+        eth_wait_for_bytes(16);
+        eth_receiver_done();
+    }
+}
+
+template <uint32_t NUM_CHANNELS>
+void initialize_transaction_buffer_addresses(
+    uint32_t max_concurrent_transactions,
+    uint32_t first_buffer_base_address,
+    uint32_t num_bytes_per_send,
+    std::array<uint32_t, NUM_CHANNELS> &transaction_channel_buffer_addresses) {
+    uint32_t buffer_address = first_buffer_base_address;
+    for (uint32_t i = 0; i < max_concurrent_transactions; i++) {
+        transaction_channel_buffer_addresses[i] = buffer_address;
+
+// ENABLE_L1_BUFFER_OVERLAP mode overlaps buffers to enable benchmarking of larger
+// buffering scenarios than are currently possible on erisc (due to L1 being allocated
+// for other purposes).
+// #if ENABLE_L1_BUFFER_OVERLAP == 0
+        buffer_address += num_bytes_per_send;
+// #endif
+    }
+}
+
+/////////////////////////////////////////////
+//   SENDER SIDE HELPERS
+/////////////////////////////////////////////
+
+FORCE_INLINE bool sender_eth_send_data_sequence(ChannelBuffer &sender_buffer_channel) {
+    bool did_something = false;
+    bool data_ready_for_send = sender_buffer_channel.is_ready_for_eth_transfer();
+    if (data_ready_for_send) {
+        bool consumer_ready_to_accept =
+            eth_is_receiver_channel_send_done(sender_buffer_channel.get_eth_transaction_channel());
+        if (consumer_ready_to_accept) {
+            // kernel_profiler::mark_time(14);
+            // Queue up another send
+            // because eth word size is 16B. -> 4bits shift to get words from bytes
+            static constexpr std::size_t ETH_BYTES_TO_WORDS_SHIFT = 4;
+            eth_send_bytes_over_channel(
+                sender_buffer_channel.get_buffer_address(),
+                sender_buffer_channel.get_remote_eth_buffer_address(),
+                sender_buffer_channel.get_current_payload_size(),
+                sender_buffer_channel.get_eth_transaction_channel(),
+                sender_buffer_channel.get_current_payload_size(),
+                sender_buffer_channel.get_current_payload_size() >> ETH_BYTES_TO_WORDS_SHIFT);
+            sender_buffer_channel.goto_state(ChannelBuffer::WAITING_FOR_ETH);
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+FORCE_INLINE bool sender_notify_workers_if_buffer_available_sequence(
+    ChannelBuffer &sender_buffer_channel, uint32_t &num_senders_complete) {
+    bool did_something = false;
+
+    bool ready_to_notify_workers_that_buffer_is_available = sender_buffer_channel.is_ready_to_signal_workers();
+
+    if (ready_to_notify_workers_that_buffer_is_available) {
+        sender_buffer_channel.increment_worker_semaphores();
+
+        if (!sender_buffer_channel.all_messages_moved()) {
+            sender_buffer_channel.goto_state(ChannelBuffer::WAITING_FOR_WORKER);
+        } else {
+            sender_buffer_channel.goto_state(ChannelBuffer::DONE);
+            num_senders_complete++;
+        }
+        did_something = true;
+    }
+
+    return did_something;
+}
+
+FORCE_INLINE bool sender_eth_check_receiver_ack_sequence(ChannelBuffer &sender_buffer_channel) {
+    bool did_something = false;
+
+    bool is_waiting_for_receiver_ack = sender_buffer_channel.is_waiting_for_remote_eth_core();
+    if (is_waiting_for_receiver_ack) {
+        bool transimission_acked_by_receiver =
+            eth_is_receiver_channel_send_acked(sender_buffer_channel.get_eth_transaction_channel()) ||
+            eth_is_receiver_channel_send_done(sender_buffer_channel.get_eth_transaction_channel());
+        if (transimission_acked_by_receiver) {
+            kernel_profiler::mark_time(15);
+
+            eth_clear_sender_channel_ack(sender_buffer_channel.get_eth_transaction_channel());
+            sender_buffer_channel.increment_messages_moved();
+            sender_buffer_channel.goto_state(ChannelBuffer::SIGNALING_WORKER);
+
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+/*
+ *
+ */
+FORCE_INLINE bool sender_noc_receive_payload_ack_check_sequence(ChannelBuffer &sender_channel_buffer) {
+    bool did_something = false;
+
+    bool noc_read_is_in_progress = sender_channel_buffer.is_waiting_for_workers_core();
+    if (noc_read_is_in_progress) {
+        bool read_finished = sender_channel_buffer.is_local_semaphore_full();
+        if (read_finished) {
+            // kernel_profiler::mark_time(13);
+            // We can clear the semaphore, and wait for space on receiver
+            sender_channel_buffer.clear_local_semaphore();
+            sender_channel_buffer.goto_state(ChannelBuffer::READY_FOR_ETH_TRANSFER);
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+/////////////////////////////////////////////
+//   RECEIVER SIDE HELPERS
+/////////////////////////////////////////////
+
+/*
+ * If payload received, notify (send ack to) sender so sender knows it can free up its local buffer
+ *
+ */
+bool receiver_eth_accept_payload_sequence(ChannelBuffer &buffer_channel) {
+    bool did_something = false;
+    bool waiting_for_next_payload_from_sender = buffer_channel.is_waiting_for_remote_eth_core();
+
+    if (waiting_for_next_payload_from_sender &&
+        eth_bytes_are_available_on_channel(buffer_channel.get_eth_transaction_channel())) {
+        eth_receiver_channel_ack(buffer_channel.get_eth_transaction_channel());
+        buffer_channel.goto_state(ChannelBuffer::SIGNALING_WORKER);
+        did_something = true;
+    }
+
+    return did_something;
+}
+
+/*
+ *
+ */
+FORCE_INLINE bool receiver_eth_notify_workers_payload_available_sequence(ChannelBuffer &buffer_channel) {
+    bool did_something = false;
+
+    if (buffer_channel.is_ready_to_signal_workers()) {
+        buffer_channel.increment_worker_semaphores();
+        buffer_channel.goto_state(ChannelBuffer::WAITING_FOR_WORKER);
+        did_something = true;
+    }
+
+    return did_something;
+}
+
+/*
+ * Does something if we are waiting for workers to complete their read and the read is complete:
+ * - increment messages moved (that transfer is done)
+ * - notifies sender it is safe to send next payload
+ * - clear local semaphore
+ */
+FORCE_INLINE bool receiver_noc_read_worker_completion_check_sequence(
+    ChannelBuffer &buffer_channel, uint32_t &num_receivers_complete) {
+    bool did_something = false;
+
+    bool workers_are_reading_buffer = buffer_channel.is_waiting_for_workers_core();
+    bool workers_are_finished_reading = buffer_channel.is_local_semaphore_full();
+    bool can_notify_sender_of_buffer_available = workers_are_reading_buffer && workers_are_finished_reading;
+    if (can_notify_sender_of_buffer_available) {
+        eth_receiver_channel_done(buffer_channel.get_eth_transaction_channel());
+        buffer_channel.increment_messages_moved();
+        buffer_channel.goto_state(ChannelBuffer::WAITING_FOR_ETH);
+        buffer_channel.clear_local_semaphore();
+
+        if (!buffer_channel.all_messages_moved()) {
+            buffer_channel.goto_state(ChannelBuffer::WAITING_FOR_ETH);
+        } else {
+            buffer_channel.goto_state(ChannelBuffer::DONE);
+            num_receivers_complete++;
+        }
+
+        did_something = true;
+
+        kernel_profiler::mark_time(13);
+    }
+
+    return did_something;
+}
+
+////////////////////////////
+//  DEPRECATED
+////////////////////////////
+namespace deprecated {
+// This namespace exists to support non-decoupled mode microbenchmarks until those are available
+// in decoupled mode
+
+FORCE_INLINE bool sender_buffer_pool_full(
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_wrptr,
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_ackptr,
+    const QueueIndexPointer<uint8_t> eth_sender_rdptr,
+    const QueueIndexPointer<uint8_t> eth_sender_ackptr) {
+    return QueueIndexPointer<uint8_t>::full(noc_reader_buffer_wrptr, eth_sender_ackptr);
+}
+
+FORCE_INLINE bool sender_buffer_pool_empty(
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_wrptr,
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_ackptr,
+    const QueueIndexPointer<uint8_t> eth_sender_rdptr,
+    const QueueIndexPointer<uint8_t> eth_sender_ackptr) {
+    return QueueIndexPointer<uint8_t>::empty(eth_sender_rdptr, noc_reader_buffer_wrptr);
+}
+
+FORCE_INLINE bool sender_buffer_available_for_eth_send(
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_wrptr,
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_ackptr,
+    const QueueIndexPointer<uint8_t> eth_sender_rdptr,
+    const QueueIndexPointer<uint8_t> eth_sender_ackptr) {
+    return eth_sender_rdptr != noc_reader_buffer_ackptr;
+}
+
+template <uint32_t MAX_NUM_CHANNELS>
+FORCE_INLINE bool sender_eth_send_data_sequence(
+    std::array<uint32_t, MAX_NUM_CHANNELS> &transaction_channel_sender_buffer_addresses,
+    std::array<uint32_t, MAX_NUM_CHANNELS> &transaction_channel_receiver_buffer_addresses,
+    uint32_t local_eth_l1_src_addr,
+    uint32_t remote_eth_l1_dst_addr,
+    uint32_t num_bytes,
+    uint32_t num_bytes_per_send,
+    uint32_t num_bytes_per_send_word_size,
+    QueueIndexPointer<uint8_t> noc_reader_buffer_wrptr,
+    QueueIndexPointer<uint8_t> noc_reader_buffer_ackptr,
+    QueueIndexPointer<uint8_t> &eth_sender_rdptr,
+    QueueIndexPointer<uint8_t> &eth_sender_ackptr) {
+    bool did_something = false;
+    bool data_ready_for_send = sender_buffer_available_for_eth_send(
+        noc_reader_buffer_wrptr, noc_reader_buffer_ackptr, eth_sender_rdptr, eth_sender_ackptr);
+    if (data_ready_for_send) {
+        bool consumer_ready_to_accept = eth_is_receiver_channel_send_done(eth_sender_rdptr.index());
+        if (consumer_ready_to_accept) {
+            // kernel_profiler::mark_time(14);
+            // Queue up another send
+            uint32_t sender_buffer_address = transaction_channel_sender_buffer_addresses[eth_sender_rdptr.index()];
+            uint32_t receiver_buffer_address = transaction_channel_receiver_buffer_addresses[eth_sender_rdptr.index()];
+
+            eth_send_bytes_over_channel(
+                sender_buffer_address,
+                receiver_buffer_address,
+                num_bytes,
+                eth_sender_rdptr.index(),
+                num_bytes_per_send,
+                num_bytes_per_send_word_size);
+            eth_sender_rdptr.increment();
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+FORCE_INLINE bool sender_eth_check_receiver_ack_sequence(
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_wrptr,
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_ackptr,
+    QueueIndexPointer<uint8_t> &eth_sender_rdptr,
+    QueueIndexPointer<uint8_t> &eth_sender_ackptr,
+    uint32_t &num_eth_sends_acked) {
+    bool did_something = false;
+    bool eth_sends_unacknowledged = QueueIndexPointer<uint8_t>::distance(eth_sender_rdptr, eth_sender_ackptr) > 0;
+    if (eth_sends_unacknowledged) {
+        bool transimission_acked_by_receiver = eth_is_receiver_channel_send_acked(eth_sender_ackptr.index()) ||
+                                               eth_is_receiver_channel_send_done(eth_sender_ackptr.index());
+        if (transimission_acked_by_receiver) {
+            num_eth_sends_acked++;
+            eth_sender_ackptr.increment();
+
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+FORCE_INLINE bool sender_is_noc_read_in_progress(
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_wrptr,
+    const QueueIndexPointer<uint8_t> noc_reader_buffer_ackptr) {
+    return noc_reader_buffer_wrptr != noc_reader_buffer_ackptr;
+}
+
+FORCE_INLINE bool sender_noc_receive_payload_ack_check_sequence(
+    QueueIndexPointer<uint8_t> &noc_reader_buffer_wrptr,
+    QueueIndexPointer<uint8_t> &noc_reader_buffer_ackptr,
+    const uint8_t noc_index) {
+    bool did_something = false;
+
+    bool noc_read_is_in_progress = sender_is_noc_read_in_progress(noc_reader_buffer_wrptr, noc_reader_buffer_ackptr);
+    if (noc_read_is_in_progress) {
+#if EMULATE_DRAM_READ_CYCLES == 1
+        bool read_finished = emulated_dram_read_cycles_finished();
+#else
+        bool read_finished = ncrisc_noc_reads_flushed(noc_index);
+#endif
+        if (read_finished) {
+            noc_reader_buffer_ackptr.increment();
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+/////////////////////////////////////////////
+//   RECEIVER SIDE HELPERS
+/////////////////////////////////////////////
+
+FORCE_INLINE bool receiver_is_noc_write_in_progress(
+    const QueueIndexPointer<uint8_t> noc_writer_buffer_wrptr,
+    const QueueIndexPointer<uint8_t> noc_writer_buffer_ackptr) {
+    return noc_writer_buffer_wrptr != noc_writer_buffer_ackptr;
+}
+
+bool receiver_eth_accept_payload_sequence(
+    QueueIndexPointer<uint8_t> noc_writer_buffer_wrptr,
+    QueueIndexPointer<uint8_t> noc_writer_buffer_ackptr,
+    QueueIndexPointer<uint8_t> &eth_receiver_ptr,
+    QueueIndexPointer<uint8_t> &eth_receiver_ackptr) {
+    bool did_something = false;
+    bool receive_pointers_full = QueueIndexPointer<uint8_t>::full(eth_receiver_ptr, eth_receiver_ackptr);
+
+    if (!receive_pointers_full) {
+        if (eth_bytes_are_available_on_channel(eth_receiver_ptr.index())) {
+            // DPRINT << "rx: accepting payload, sending receive ack on channel " << (uint32_t)eth_receiver_ptr << "\n";
+            eth_receiver_channel_ack(eth_receiver_ptr.index());
+            eth_receiver_ptr.increment();
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+FORCE_INLINE bool receiver_noc_read_worker_completion_check_sequence(
+    QueueIndexPointer<uint8_t> &noc_writer_buffer_wrptr,
+    QueueIndexPointer<uint8_t> &noc_writer_buffer_ackptr,
+    const uint8_t noc_index) {
+    bool did_something = false;
+
+    bool noc_write_is_in_progress =
+        receiver_is_noc_write_in_progress(noc_writer_buffer_wrptr, noc_writer_buffer_ackptr);
+    if (noc_write_is_in_progress) {
+#if EMULATE_DRAM_READ_CYCLES == 1
+        bool write_finished = emulated_dram_write_cycles_finished();
+#else
+        bool writes_finished = ncrisc_noc_nonposted_writes_sent(noc_index);
+#endif
+        if (writes_finished) {
+            // DPRINT << "rx: accepting payload, sending receive ack on channel " << (uint32_t)noc_writer_buffer_ackptr
+            // << "\n";
+            kernel_profiler::mark_time(13);
+            noc_writer_buffer_ackptr.increment();
+
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+FORCE_INLINE bool receiver_eth_send_ack_to_sender_sequence(
+    const QueueIndexPointer<uint8_t> noc_writer_buffer_wrptr,
+    const QueueIndexPointer<uint8_t> noc_writer_buffer_ackptr,
+    QueueIndexPointer<uint8_t> &eth_receiver_rdptr,
+    QueueIndexPointer<uint8_t> &eth_receiver_ackptr,
+    uint32_t &num_eth_sends_acked) {
+    bool did_something = false;
+    bool eth_sends_unacknowledged = eth_receiver_rdptr != eth_receiver_ackptr;
+    if (eth_sends_unacknowledged) {
+        // If data is done being sent out of this local l1 buffer and to the destination(s),
+        // then we can safely send the ack and increment the ackptr
+        bool buffer_writes_flushed = ncrisc_noc_nonposted_writes_sent(noc_index);
+        // bool buffer_writes_flushed = ncrisc_noc_nonposted_writes_flushed(noc_index);
+        if (buffer_writes_flushed) {
+            // kernel_profiler::mark_time(15);
+            // DPRINT << "rx: accepting payload, sending receive ack on channel " << (uint32_t)noc_writer_buffer_wrptr
+            // << "\n";
+            eth_receiver_channel_done(eth_receiver_ackptr.index());
+            num_eth_sends_acked++;
+            eth_receiver_ackptr.increment();
+            // DPRINT << "rx: Sending eth ack. ackptr incrementing to " << (uint32_t)eth_receiver_ackptr.index() <<
+            // "\n";
+
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+};  // namespace deprecated
+
+};  // namespace datamover
+};  // namespace erisc

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover.cpp
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "eth_l1_address_map.h"
+#include "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_async_datamover.hpp"
+
+// Args Schema:
+// 1) handshake addr
+// 2) sender channels offset (indicates for the erisc channels, where the senders start
+//    so sender and receivers don't clash when paired with sender/receiver on the other
+//    end of the link.)
+// 3) sender num channels (How many erisc channels to use. ALso how many buffers to instantiate)
+//    Informs how many times to iterate through the next group of args
+//    4) sender_buffer_address
+//    5) sender_num_messages_to_send
+//    6) sender_channel_size
+//    7) sender_semaphores_base_address
+//    8) worker_semaphore_address
+//    9) sender_num_workers
+//       Informs how many worker X/Y coords to accept in the next loop. Each X/Y pair is 2 uint16s
+//       10) worker_coord(s)
+// ...
+// Repeat from step 2 for receiver side
+
+// Intended only for (performance) test use cases
+void eth_setup_handshake2(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        DPRINT << "eth_send_bytes\n";
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        DPRINT << "eth_wait_for_receiver_done\n";
+        eth_wait_for_receiver_done();
+    } else {
+        DPRINT << "eth_wait_for_bytes\n";
+        eth_wait_for_bytes(16);
+        DPRINT << "wait eth_receiver_done\n";
+        eth_receiver_done();
+    }
+}
+
+void kernel_main() {
+    // COMPILE TIME ARGS
+    // If true, will enable this erisc's sender functionality
+    constexpr bool enable_sender_side = get_compile_time_arg_val(0) != 0;
+
+    // If true, will enable this erisc's receiver functionality
+    constexpr bool enable_receiver_side = get_compile_time_arg_val(1) != 0;
+
+    std::array<erisc::datamover::ChannelBuffer, eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS> sender_buffer_channels;
+    std::array<erisc::datamover::ChannelBuffer, eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS> receiver_buffer_channels;
+
+    // SENDER ARGS
+    uint32_t args_offset = 0;
+    uint32_t handshake_addr = get_arg_val<uint32_t>(args_offset++);
+
+    DPRINT << "EDM handshaking with other eth. enable_sender_side " << (uint32_t)enable_sender_side << "\n";
+
+    kernel_profiler::mark_time(80);
+
+    uint8_t sender_channels_start = get_arg_val<uint32_t>(args_offset++);
+    uint32_t sender_num_channels = get_arg_val<uint32_t>(args_offset++);
+    DPRINT << "EDM args(" << (uint32_t)enable_sender_side << "): sender_channels_start "
+           << (uint32_t)sender_channels_start << "\n";
+    DPRINT << "EDM args(" << (uint32_t)enable_sender_side << "): sender_num_channels " << sender_num_channels << "\n";
+    for (uint32_t channel = 0; channel < sender_num_channels; channel++) {
+        uint32_t sender_buffer_address = get_arg_val<uint32_t>(args_offset++);
+        uint32_t sender_num_messages_to_send = get_arg_val<uint32_t>(args_offset++);
+        // Each channel buffer is at buffer_base + (channel_id * sender_channel_size)
+        // Each channel currently constrained to the same buffer size
+        std::uint32_t sender_channel_size = get_arg_val<uint32_t>(args_offset++);
+        // TODO(snijjar): we can consider computing this instead using a helper in erisc_datamover_api.h
+        // The erisc's local l1 copy of the semaphore workers remotely increment
+        uint32_t sender_semaphores_base_address = get_arg_val<uint32_t>(args_offset++);
+        uint32_t worker_semaphore_address = get_arg_val<uint32_t>(args_offset++);
+        uint32_t sender_num_workers = get_arg_val<uint32_t>(args_offset++);
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side
+               << "): \tsender_num_messages_to_send=" << sender_num_messages_to_send << "\n";
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side << "): \tsender_channel_size=" << sender_channel_size
+               << "\n";
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side
+               << "): \tsender_semaphores_base_address=" << sender_semaphores_base_address << "\n";
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side
+               << "): \tworker_semaphore_address=" << worker_semaphore_address << "\n";
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side << "): \tsender_num_workers=" << sender_num_workers
+               << "\n";
+        uint32_t workers_xy_list_addr = get_arg_addr(args_offset);
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side
+               << "): \tsender workers_xy_list_addr=" << workers_xy_list_addr << "\n";
+        args_offset += sender_num_workers;
+        new (&sender_buffer_channels[sender_channels_start + channel]) erisc::datamover::ChannelBuffer(
+            sender_channels_start + channel,
+            sender_buffer_address,
+            sender_channel_size,
+            worker_semaphore_address,
+            sender_num_workers,
+            sender_num_messages_to_send,
+            sender_buffer_address,
+            (volatile tt_l1_ptr uint32_t *const)sender_semaphores_base_address,
+            (const erisc::datamover::WorkerXY *)workers_xy_list_addr,
+            true);
+    }
+
+    // Receiver args
+    uint8_t receiver_channels_start = get_arg_val<uint32_t>(args_offset++);
+    uint32_t receiver_num_channels = get_arg_val<uint32_t>(args_offset++);
+    DPRINT << "EDM args(" << (uint32_t)enable_sender_side << "): receiver_channels_start "
+           << (uint32_t)receiver_channels_start << "\n";
+    DPRINT << "EDM args(" << (uint32_t)enable_sender_side << "): receiver_num_channels " << receiver_num_channels
+           << "\n";
+    for (uint32_t channel = 0; channel < receiver_num_channels; channel++) {
+        uint32_t receiver_buffers_base_address = get_arg_val<uint32_t>(args_offset++);
+        uint32_t receiver_num_messages_to_send = get_arg_val<uint32_t>(args_offset++);
+        // Each channel buffer is at buffer_base + (channel_id * sender_channel_size)
+        // Each channel currently constrained to the same buffer size
+        uint32_t receiver_channel_size = get_arg_val<uint32_t>(args_offset++);
+        // TODO(snijjar): we can consider computing this instead using a helper in erisc_datamover_api.h
+        uint32_t receiver_semaphores_base_address = get_arg_val<uint32_t>(args_offset++);
+        uint32_t worker_semaphore_address = get_arg_val<uint32_t>(args_offset++);
+        uint32_t receiver_num_workers = get_arg_val<uint32_t>(args_offset++);
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side
+               << "): \treceiver_num_messages_to_send=" << receiver_num_messages_to_send << "\n";
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side << "): \treceiver_channel_size=" << receiver_channel_size
+               << "\n";
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side
+               << "): \treceiver_semaphores_base_address=" << receiver_semaphores_base_address << "\n";
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side
+               << "): \tworker_semaphore_address=" << worker_semaphore_address << "\n";
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side << "): \treceiver_num_workers=" << receiver_num_workers
+               << "\n";
+        uint32_t workers_xy_list_addr = get_arg_addr(args_offset);
+        DPRINT << "EDM arg (" << (uint32_t)enable_sender_side
+               << "): \treceiver workers_xy_list_addr=" << workers_xy_list_addr << "\n";
+        args_offset += receiver_num_workers;
+        new (&receiver_buffer_channels[receiver_channels_start + channel]) erisc::datamover::ChannelBuffer(
+            receiver_channels_start + channel,
+            receiver_buffers_base_address,
+            receiver_channel_size,
+            worker_semaphore_address,
+            receiver_num_workers,
+            receiver_num_messages_to_send,
+            receiver_buffers_base_address,  // remote_eth_buffer_address,
+            (volatile tt_l1_ptr uint32_t *const)receiver_semaphores_base_address,
+            (const erisc::datamover::WorkerXY *)workers_xy_list_addr,
+            false);
+    }
+
+    // Handshake with other erisc to make sure it's safe to start sending/receiving
+    // Chose an arbitrary ordering mechanism to guarantee one of the erisc's will always be "sender" and the other
+    // will always be "receiver" (only for handshake purposes)
+    bool act_as_sender_in_handshake =
+        (sender_channels_start < receiver_channels_start || receiver_num_channels == 0) && sender_num_channels > 0;
+    erisc::datamover::eth_setup_handshake(handshake_addr, enable_sender_side);
+
+    uint32_t eth_sends_completed = 0;
+
+    constexpr uint32_t SWITCH_INTERVAL = 100000;
+    uint32_t did_nothing_count = 0;
+
+    uint32_t num_senders_complete = !enable_sender_side ? sender_num_channels : 0;
+    uint32_t num_receivers_complete = !enable_receiver_side ? receiver_num_channels : 0;
+    uint32_t curr_sender = 0;
+    uint32_t curr_receiver = 0;
+    DPRINT << "EDM arg (" << (uint32_t)enable_sender_side << "): \tNOC_INDEX " << (uint32_t)noc_index << "\n";
+    DPRINT << "EDM arg (" << (uint32_t)enable_sender_side << "): \tnum_senders_complete " << num_senders_complete
+           << "\n";
+    DPRINT << "EDM arg (" << (uint32_t)enable_sender_side << "): \tsender_num_channels " << sender_num_channels << "\n";
+    DPRINT << "EDM arg (" << (uint32_t)enable_sender_side << "): \tnum_receivers_complete " << num_receivers_complete
+           << "\n";
+    DPRINT << "EDM arg (" << (uint32_t)enable_sender_side << "): \treceiver_num_channels " << receiver_num_channels
+           << "\n";
+    while ((enable_sender_side && num_senders_complete != sender_num_channels) ||
+           (enable_receiver_side && num_receivers_complete != receiver_num_channels)) {
+        bool did_something = false;
+
+        // Note, may want to interleave the sender and receiver calls to reduce latency for each
+        //////////////////////////////////////
+        // SENDER
+        //////////////////////////////////////
+        if constexpr (enable_sender_side) {
+            erisc::datamover::ChannelBuffer &current_sender =
+                sender_buffer_channels[sender_channels_start + curr_sender];
+            if (!current_sender.is_done()) {
+                did_something =
+                    erisc::datamover::sender_noc_receive_payload_ack_check_sequence(current_sender) || did_something;
+
+                did_something = erisc::datamover::sender_eth_send_data_sequence(current_sender) || did_something;
+
+                did_something = erisc::datamover::sender_notify_workers_if_buffer_available_sequence(
+                                    current_sender, num_senders_complete) ||
+                                did_something;
+
+                did_something =
+                    erisc::datamover::sender_eth_check_receiver_ack_sequence(current_sender) || did_something;
+            }
+
+            curr_sender += 1;
+            curr_sender = (curr_sender == sender_num_channels) ? 0 : curr_sender;
+        }
+        //////////////////////////////////////
+        // RECEIVER
+        //////////////////////////////////////
+
+        if constexpr (enable_receiver_side) {
+            erisc::datamover::ChannelBuffer &current_receiver =
+                receiver_buffer_channels[receiver_channels_start + curr_receiver];
+            if (!current_receiver.is_done()) {
+                bool received = erisc::datamover::receiver_eth_accept_payload_sequence(current_receiver);
+                did_something = received || did_something;
+
+                did_something =
+                    erisc::datamover::receiver_eth_notify_workers_payload_available_sequence(current_receiver) ||
+                    did_something;
+
+                did_something = erisc::datamover::receiver_noc_read_worker_completion_check_sequence(
+                                    current_receiver, num_receivers_complete) ||
+                                did_something;
+            }
+
+            curr_receiver += 1;
+            curr_receiver = (curr_receiver == receiver_num_channels) ? 0 : curr_receiver;
+        }
+        //////////////////////////////////////
+
+        if (!did_something) {
+            if (did_nothing_count++ > SWITCH_INTERVAL) {
+                did_nothing_count = 0;
+                // kernel_profiler::mark_time(15);
+                run_routing();
+            } else {
+                did_nothing_count++;
+            }
+        } else {
+            did_nothing_count = 0;
+        }
+    }
+
+    kernel_profiler::mark_time(16);
+    if (enable_sender_side) {
+        DPRINT << "1 ERISC DATAMOVER DONE!\n";
+    } else {
+        DPRINT << "0 ERISC DATAMOVER DONE!\n";
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_receiver_worker_reader.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_receiver_worker_reader.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+// #include "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+FORCE_INLINE void fetch_chunk(
+    const uint32_t max_pages_per_chunk,
+    const uint32_t total_pages_to_read,
+    uint32_t& num_pages_read,
+    const uint32_t& cb_id,
+    const uint32_t& page_size,
+    uint64_t remote_l1_read_addr) {
+    const uint32_t num_pages_this_chunk = std::min(total_pages_to_read - num_pages_read, max_pages_per_chunk);
+
+    for (uint32_t i = 0; i < num_pages_this_chunk; ++i) {
+        cb_reserve_back(cb_id, 1);
+        uint32_t l1_write_addr = get_write_ptr(cb_id);
+        noc_async_read(remote_l1_read_addr, l1_write_addr, page_size);
+        remote_l1_read_addr += page_size;
+        noc_async_read_barrier();
+        cb_push_back(cb_id, 1);
+    }
+
+    num_pages_read += num_pages_this_chunk;
+}
+
+void kernel_main() {
+    const uint32_t eth_receiver_l1_base_addr = get_compile_time_arg_val(0);
+    const uint32_t eth_receiver_l1_sem_addr = get_compile_time_arg_val(1);
+    const uint32_t num_pages_per_read_chunk = get_arg_val<uint32_t>(0);
+    const uint32_t total_pages_to_read = get_arg_val<uint32_t>(1);
+    const uint32_t page_size = get_arg_val<uint32_t>(2);
+    const uint32_t receiver_erisc_datamover_noc_x = get_arg_val<uint32_t>(3);
+    const uint32_t receiver_erisc_datamover_noc_y = get_arg_val<uint32_t>(4);
+    // Worker local L1 semaphore that erisc datamover signals to
+    const uint32_t receiver_read_sem_addr = get_arg_val<uint32_t>(5);
+
+    DPRINT << " rwr: args: eth_receiver_l1_base_addr="<<
+        eth_receiver_l1_base_addr<<
+        "\n\teth_receiver_l1_sem_addr="<<eth_receiver_l1_sem_addr<<
+        "\n\tnum_pages_per_read_chunk="<<num_pages_per_read_chunk<<
+        "\n\ttotal_pages_to_read="<<total_pages_to_read<<
+        "\n\tpage_size="<<page_size<<
+        "\n\treceiver_erisc_datamover_noc_x="<<receiver_erisc_datamover_noc_x<<
+        "\n\treceiver_erisc_datamover_noc_y="<<receiver_erisc_datamover_noc_y<<
+        "\n\treceiver_read_sem_addr="<<receiver_read_sem_addr<<
+        "\n";
+
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
+
+    // Eth receiver will set this semaphore when data is available
+    volatile tt_l1_ptr uint32_t* receiver_read_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_read_sem_addr);
+
+    // Address of the buffer on the eth receiver, this is different per receiver worker core
+    const uint64_t eth_receiver_l1_base_noc_addr =
+        get_noc_addr(receiver_erisc_datamover_noc_x, receiver_erisc_datamover_noc_y, eth_receiver_l1_base_addr);
+    // Address of the semaphore on the eth receiver, this is the same per receiver worker core
+    const uint64_t eth_receiver_l1_semaphore_noc_addr =
+        get_noc_addr(receiver_erisc_datamover_noc_x, receiver_erisc_datamover_noc_y, eth_receiver_l1_sem_addr);
+
+    DPRINT << " rwr: noc_index " << (uint32_t)noc_index << "\n";
+    DPRINT << " rwr: my_x[0],my_y[0] " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "\n";
+    DPRINT << " rwr: my_x[1],my_y[1] " << (uint32_t)my_x[1] << "," << (uint32_t)my_y[1] << "\n";
+    uint32_t num_pages_read = 0;
+    while (num_pages_read < total_pages_to_read) {
+        DPRINT << " rwr: page " << num_pages_read << " waiting for semaphore at " << (uint32_t)receiver_read_sem_addr << "\n";
+        noc_semaphore_wait(receiver_read_semaphore_addr_ptr, 1);
+        DPRINT << " rwr: got semaphore signal from sender erisc\n";
+        noc_semaphore_set(receiver_read_semaphore_addr_ptr, 0);
+        // Read page by page so that writer can be kicked off instead of being blocked waiting for full chunk to be read
+        // Look into perf/optimizations for this
+        DPRINT << " rwr: fetch chunk\n";
+        fetch_chunk(
+            num_pages_per_read_chunk,
+            total_pages_to_read,
+            num_pages_read,
+            cb_id_in0,
+            page_size,
+            eth_receiver_l1_base_noc_addr);
+        DPRINT << " rwr: increment semaphore on eth core at address " << eth_receiver_l1_sem_addr << "\n";
+        noc_semaphore_inc(eth_receiver_l1_semaphore_noc_addr, 1);
+    }
+
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_receiver_worker_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_receiver_worker_sender.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+// #include "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t num_pages_total = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
+    InterleavedAddrGen<dst_is_dram> dest_addr_generator = {
+        .bank_base_address = dst_addr, .page_size = page_size};
+    DPRINT << " rws: args: " <<
+        "\n\tdst_addr="<<dst_addr<<
+        "\n\tdst_is_dram="<<(dst_is_dram ? "T" : "F")<<
+        "\n\tnum_pages_total="<<num_pages_total<<
+        "\n\tpage_size="<<page_size << "\n";
+
+    DPRINT << " rws: noc_index " << (uint32_t)noc_index << "\n";
+    DPRINT << " rws: my_x[0],my_y[0] " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "\n";
+    DPRINT << " rws: my_x[1],my_y[1] " << (uint32_t)my_x[1] << "," << (uint32_t)my_y[1] << "\n";
+    for (uint32_t p = 0; p < num_pages_total; ++p) {
+        DPRINT << "rws: cb_wait_front\n";
+        cb_wait_front(cb_id_in0, 1);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_in0);
+        DPRINT << *reinterpret_cast<uint32_t*>(l1_read_addr) << "\n";
+        uint64_t dst_noc_addr = get_noc_addr(p, dest_addr_generator);
+        noc_async_write(l1_read_addr, dst_noc_addr, page_size);
+        DPRINT << "rws: write barrier complete\n";
+        noc_async_write_barrier();
+        DPRINT << "rws: cb_pop_front\n";
+        cb_pop_front(cb_id_in0, 1);
+    }
+
+    // DPRINT << "rws: DONE\n";
+    // ncrisc_noc_full_sync();
+    // DPRINT << "rws: DONE DONE\n";
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_sender_worker_reader.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_sender_worker_reader.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+// #include "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t num_pages_to_read_total = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
+    const InterleavedAddrGen<src_is_dram> source_address_generator = {
+        .bank_base_address = src_addr, .page_size = page_size};
+
+    DPRINT << "swr: args " <<
+        "\n\tsrc_addr="<<src_addr<<
+        "\n\tsrc_is_dram="<<(src_is_dram?"T":"F")<<
+        "\n\tnum_pages_to_read_total="<<num_pages_to_read_total<<
+        "\n\tpage_size="<<page_size<<"\n";
+
+    for (uint32_t num_pages_read = 0; num_pages_read < num_pages_to_read_total; num_pages_read++) {
+        // How can I read ahead into the circular buffer so I don't have to do an async read barrier for
+        // every page? I only want to block when the CB is full
+        DPRINT << "swr: cb_reserve_back on page " << num_pages_read << "\n";
+        cb_reserve_back(cb_id_in0, 1);
+        uint32_t local_l1_read_addr = get_write_ptr(cb_id_in0);
+        uint64_t src_noc_addr = get_noc_addr(num_pages_read, source_address_generator);
+        DPRINT << "swr: async_read\n";
+        noc_async_read(src_noc_addr, local_l1_read_addr, page_size);
+        DPRINT << "swr: read_barrier\n";
+        noc_async_read_barrier();
+        DPRINT << "swr: cb_push_back\n";
+        cb_push_back(cb_id_in0, 1);
+    }
+
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_sender_worker_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_sender_worker_sender.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "noc_nonblocking_api.h"
+#include "noc_parameters.h"
+
+FORCE_INLINE void send_chunk(
+    const uint32_t max_pages_per_chunk,
+    const uint32_t total_pages_to_send,
+    uint32_t& num_pages_sent,
+    const uint32_t& cb_id,
+    const uint32_t& page_size,
+    uint64_t remote_l1_write_addr,
+    volatile tt_l1_ptr uint32_t* writer_send_semaphore_addr_ptr
+    ) {
+
+    const uint32_t num_pages_this_chunk = std::min(total_pages_to_send - num_pages_sent, max_pages_per_chunk);
+    for (uint32_t i = 0; i < num_pages_this_chunk; ++i) {
+        cb_wait_front(cb_id, 1);
+        uint32_t l1_read_addr = get_read_ptr(cb_id);
+        noc_async_write(l1_read_addr, remote_l1_write_addr, page_size);
+        remote_l1_write_addr += page_size;
+        noc_async_write_barrier();
+        cb_pop_front(cb_id, 1);
+    }
+    num_pages_sent += num_pages_this_chunk;
+}
+
+// Worker core - Data Movement Writer -> Sends to Erisc Data Mover (sender side).
+// -> takes input from local cb and pushes to erisc L1
+void kernel_main() {
+    const uint32_t eth_l1_base_addr = get_arg_val<uint32_t>(0);
+    // erisc l1 semaphore address
+    const uint32_t eth_sender_l1_sem_addr = get_arg_val<uint32_t>(1);
+    const uint32_t writer_send_sem_addr = get_arg_val<uint32_t>(2);
+    const uint32_t eth_sender_noc_x = get_arg_val<uint32_t>(3);
+    const uint32_t eth_sender_noc_y = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t num_pages_per_send = get_compile_time_arg_val(0);
+    constexpr uint32_t total_pages_to_send = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+
+    DPRINT << " sws: args:" <<
+        "\n\teth_sender_l1_base_addr="<<eth_l1_base_addr<<
+        "\n\teth_sender_l1_sem_addr="<<eth_sender_l1_sem_addr<<
+        "\n\twriter_send_sem_addr="<<writer_send_sem_addr<<
+        "\n\teth_sender_noc_x="<<eth_sender_noc_x<<
+        "\n\teth_sender_noc_y="<<eth_sender_noc_y<<
+        "\n\tnum_pages_per_send="<<num_pages_per_send<<
+        "\n\ttotal_pages_to_send="<<total_pages_to_send<<
+        "\n\tpage_size="<<page_size<<"\n";
+
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
+
+    // Used to wait until eth sender has space available
+    volatile tt_l1_ptr uint32_t* writer_send_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(writer_send_sem_addr);
+
+    // This is different per writer core
+    const uint64_t eth_l1_sender_base_noc_addr =
+        get_noc_addr(eth_sender_noc_x, eth_sender_noc_y, eth_l1_base_addr);
+    // Used to signal eth sender that data is available. This is different per writer core
+    const uint64_t eth_l1_sender_semaphore_addr =
+        get_noc_addr(eth_sender_noc_x, eth_sender_noc_y, eth_sender_l1_sem_addr);
+
+    // num_transfers = num_devices - 1
+    uint32_t num_pages_sent = 0;
+    DPRINT << " sws: noc_index " << (uint32_t)noc_index << "\n";
+    DPRINT << " sws: my_x[0],my_y[0] " << (uint32_t)my_x[0] << "," << (uint32_t)my_y[0] << "\n";
+    DPRINT << " sws: my_x[1],my_y[1] " << (uint32_t)my_x[1] << "," << (uint32_t)my_y[1] << "\n";
+
+    uint32_t old_val_NIU_SLV_CMD_ACCEPTED = NOC_STATUS_READ_REG(noc_index, NIU_SLV_REQ_ACCEPTED);
+    uint32_t old_val_NIU_SLV_ATOMIC_RESP_SENT = NOC_STATUS_READ_REG(noc_index, NIU_SLV_ATOMIC_RESP_SENT);
+    uint32_t old_val_NIU_SLV_POSTED_ATOMIC_RECEIVED = NOC_STATUS_READ_REG(noc_index, NIU_SLV_POSTED_ATOMIC_RECEIVED);
+    uint32_t old_val_NIU_SLV_NONPOSTED_ATOMIC_SENT = NOC_STATUS_READ_REG(noc_index, NIU_SLV_NONPOSTED_ATOMIC_RECEIVED);
+
+    bool diffed_NIU_SLV_CMD_ACCEPTED = false;
+    bool diffed_NIU_SLV_ATOMIC_RESP_SENT = false;
+    bool diffed_NIU_SLV_POSTED_ATOMIC_RECEIVED = false;
+    bool diffed_NIU_SLV_NONPOSTED_ATOMIC_SENT = false;
+    while (num_pages_sent < total_pages_to_send) {
+        noc_semaphore_wait(writer_send_semaphore_addr_ptr, 1);
+
+        noc_semaphore_set(writer_send_semaphore_addr_ptr, 0);
+        send_chunk(num_pages_per_send, total_pages_to_send, num_pages_sent, cb_id_in0, page_size, eth_l1_sender_base_noc_addr, writer_send_semaphore_addr_ptr);
+        noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_l1_data_forward.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_l1_data_forward.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+enum RX_MODE {
+    FWD_L1 = 0,
+    RX_ETH = 1,
+    RX_TENSIX = 2
+};
+
+enum TX_MODE {
+    PARK_L1 = 0,
+    TX_ETH = 1,
+    TX_TENSIX = 2
+};
+
+void kernel_main() {
+    std::uint32_t num_bytes = get_arg_val<uint32_t>(0);
+    RX_MODE rx_mode = get_arg_val<uint32_t>(1);
+    TX_MODE tx_mode = get_arg_val<uint32_t>(2);
+
+    std::uint32_t bytes_sent = 0;
+
+    for (std::uint32_t i = 0; i < num_bytes; i += 64) {
+        switch  (rx_mode) {
+            case RX_MODE::RX_ETH:
+                noc_semaphore_inc(sender_semaphore_noc_addr, 1);
+                eth_noc_semaphore_wait(receiver_semaphore_addr_ptr, 1);
+                noc_semaphore_set(receiver_semaphore_addr_ptr, 0);(64);
+                break;
+            case RX_MODE::RX_TENSIX:
+                tensix_wait_for_bytes(64);
+                break;
+            case RX_MODE::FWD_L1:
+                break;
+        }
+
+        if (tx_mode == TX_MODE::TX_ETH) {
+            eth_send_bytes(src_addr, dst_addr, send_size);
+            eth_wait_for_bytes(num_bytes); // Waits for write to complete
+        } else if (tx_mode == TX_MODE::TX_TENSIX) {
+            tensix_send_bytes(0, 64);
+        }
+
+        bytes_sent += 64;
+    }
+
+    std::uint32_t local_eth_l1_src_addr = get_arg_val<uint32_t>(0);
+    std::uint32_t remote_eth_l1_dst_addr = get_arg_val<uint32_t>(1);
+    std::uint32_t num_bytes = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t num_bytes_per_send = get_compile_time_arg_val(0);
+    constexpr uint32_t num_bytes_per_send_word_size = get_compile_time_arg_val(1);
+
+
+    eth_wait_for_bytes(num_bytes);
+    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
+
+    eth_noc_semaphore_wait(receiver_semaphore_addr_ptr, 1);
+    noc_semaphore_set(receiver_semaphore_addr_ptr, 0);
+
+    eth_send_bytes(
+        local_eth_l1_src_addr, remote_eth_l1_dst_addr, num_bytes, num_bytes_per_send, num_bytes_per_send_word_size);
+    eth_wait_for_receiver_done();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_receive_looping.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_receive_looping.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <algorithm>
+
+/**
+ * Any two RISC processors cannot use the same CMD_BUF
+ * non_blocking APIs shouldn't be mixed with slow noc.h APIs
+ * explicit flushes need to be used since the calls are non-blocking
+ * */
+
+
+void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        eth_send_bytes(handshake_register_address,handshake_register_address, 16);
+        eth_wait_for_receiver_done();
+
+        // eth_wait_for_bytes(16);
+        // eth_receiver_done();
+    } else {
+        eth_wait_for_bytes(16);
+        eth_receiver_done();
+
+        // eth_send_bytes(handshake_register_address,handshake_register_address, 16);
+        // eth_wait_for_receiver_done();
+    }
+}
+
+void kernel_main() {
+    std::uint32_t local_eth_l1_src_addr = get_arg_val<uint32_t>(0);
+    std::uint32_t remote_eth_l1_dst_addr = get_arg_val<uint32_t>(1);
+    std::size_t num_bytes_ = get_arg_val<uint32_t>(2);
+    std::uint32_t num_loops_ = get_arg_val<uint32_t>(3);
+    std::uint32_t num_sends_per_loop_ = get_arg_val<uint32_t>(4);
+
+
+    constexpr uint32_t num_bytes_per_send = get_compile_time_arg_val(0);
+    constexpr uint32_t num_bytes_per_send_word_size = get_compile_time_arg_val(1);
+
+    constexpr std::uint32_t num_bytes = get_compile_time_arg_val(2);
+    constexpr std::uint32_t num_loops = get_compile_time_arg_val(3);
+    constexpr std::uint32_t num_sends_per_loop = get_compile_time_arg_val(4);
+
+    // Handshake first before timestamping to make sure we aren't measuring any
+    // dispatch/setup times for the kernels on both sides of the link.
+    eth_setup_handshake(remote_eth_l1_dst_addr, false);
+
+    uint32_t wrap_mask = num_sends_per_loop - 1;
+    kernel_profiler::mark_time(100 + num_sends_per_loop);
+    uint32_t j = 0;
+    kernel_profiler::mark_time(12);
+    for (uint32_t i = 0; i < num_loops; i += num_sends_per_loop) {
+        kernel_profiler::mark_time(15);
+        eth_wait_for_bytes(num_bytes * std::min<uint32_t>(num_loops - i, num_sends_per_loop));
+        kernel_profiler::mark_time(16);
+
+        eth_receiver_done();
+
+        kernel_profiler::mark_time(17);
+
+        j = (j + 1) & wrap_mask;
+    }
+
+    if (j != 0) {
+        eth_receiver_done();
+    }
+    kernel_profiler::mark_time(13);
+    kernel_profiler::mark_time(100);
+
+    for (int i = 0; i < 3000000; i++);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_send_looping_multi_channel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_direct_send_looping_multi_channel.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdint>
+
+void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        eth_wait_for_receiver_done();
+
+        // eth_wait_for_bytes(16);
+        // eth_receiver_done();
+    } else {
+        eth_wait_for_bytes(16);
+        eth_receiver_done();
+
+        // eth_send_bytes(handshake_register_address,handshake_register_address, 16);
+        // eth_wait_for_receiver_done();
+    }
+}
+
+void kernel_main() {
+    std::uint32_t local_eth_l1_src_addr = get_arg_val<uint32_t>(0);
+    std::uint32_t remote_eth_l1_dst_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t num_bytes_per_send = get_compile_time_arg_val(0);
+    constexpr uint32_t num_bytes_per_send_word_size = get_compile_time_arg_val(1);
+    constexpr std::uint32_t total_num_message_sends = get_compile_time_arg_val(2);
+    constexpr std::uint32_t NUM_TRANSACTION_BUFFERS = get_compile_time_arg_val(3);
+    constexpr bool src_is_dram = get_compile_time_arg_val(4) == 1;
+
+    constexpr uint32_t MAX_NUM_CHANNELS = NUM_TRANSACTION_BUFFERS;
+    static_assert(MAX_NUM_CHANNELS % 2 == 0, "MAX_NUM_CHANNELS must be <= 8");
+    constexpr uint32_t CHANNEL_MASK = (MAX_NUM_CHANNELS - 1);
+    std::array<std::uint32_t, MAX_NUM_CHANNELS> channels_active;
+    for (uint8_t i = 0; i < NUM_TRANSACTION_BUFFERS; i++) {
+        channels_active[i] = 0;
+    }
+
+    eth_setup_handshake(remote_eth_l1_dst_addr, true);
+
+    kernel_profiler::mark_time(10);
+    uint32_t j = 0;
+    for (uint32_t i = 0; i < total_num_message_sends; i++) {
+        kernel_profiler::mark_time(20);
+        if (channels_active[j] != 0) {
+            kernel_profiler::mark_time(21);
+            eth_wait_for_receiver_channel_done(j);
+            channels_active[j] = 0;
+        }
+        kernel_profiler::mark_time(22);
+        eth_send_bytes_over_channel(
+            local_eth_l1_src_addr,
+            remote_eth_l1_dst_addr,
+            num_bytes_per_send,
+            j,
+            num_bytes_per_send,
+            num_bytes_per_send_word_size);
+        channels_active[j] = 1;
+        kernel_profiler::mark_time(23);
+        j = (j + 1) & CHANNEL_MASK;
+    }
+
+    for (uint32_t j = 0; j < MAX_NUM_CHANNELS; j++) {
+        kernel_profiler::mark_time(24);
+        if (channels_active[j] != 0) {
+            eth_wait_for_receiver_channel_done(j);
+        }
+        kernel_profiler::mark_time(25);
+    }
+    kernel_profiler::mark_time(11);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_forward_local_chip_data_looping_multi_channel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_forward_local_chip_data_looping_multi_channel.cpp
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_async_datamover.hpp"
+
+#define ENABLE_L1_BUFFER_OVERLAP 0
+// #define ENABLE_L1_BUFFER_OVERLAP 1
+// #define EMULATE_DRAM_READ_CYCLES 1
+#define EMULATE_DRAM_READ_CYCLES 0
+// #define DONT_STRIDE_IN_ETH_BUFFER 1
+#define DONT_STRIDE_IN_ETH_BUFFER 0
+
+template <bool src_is_dram>
+void read_chunk(
+    uint32_t eth_l1_buffer_address_base,
+    uint32_t num_pages,
+    uint32_t num_pages_per_l1_buffer,
+    uint32_t page_size,
+    uint32_t &page_index,
+    const InterleavedAddrGen<src_is_dram> &source_address_generator
+)
+{
+    uint32_t local_eth_l1_curr_src_addr = eth_l1_buffer_address_base;
+    uint32_t end_page_index = std::min(page_index + num_pages_per_l1_buffer, num_pages);
+    for (; page_index < end_page_index; ++page_index) {
+        // read source address
+        uint64_t src_noc_addr = get_noc_addr(page_index, source_address_generator);
+        noc_async_read(src_noc_addr, local_eth_l1_curr_src_addr, page_size);
+        // read dest addr
+        #if DONT_STRIDE_IN_ETH_BUFFER == 0
+        local_eth_l1_curr_src_addr += page_size;
+        #endif
+    }
+}
+
+
+template <uint8_t MAX_CONCURRENT_TRANSACTIONS, bool src_is_dram>
+FORCE_INLINE  bool noc_read_data_sequence(
+    std::array<uint32_t, MAX_CONCURRENT_TRANSACTIONS> &transaction_channel_sender_buffer_addresses,
+    uint32_t num_bytes_per_send,
+    erisc::datamover::QueueIndexPointer<uint8_t> &noc_reader_buffer_wrptr,
+    erisc::datamover::QueueIndexPointer<uint8_t> &noc_reader_buffer_ackptr,
+    const erisc::datamover::QueueIndexPointer<uint8_t> eth_sender_rdptr,
+    const erisc::datamover::QueueIndexPointer<uint8_t> eth_sender_ackptr,
+    const uint8_t noc_index,
+    const InterleavedAddrGen<src_is_dram> &source_address_generator,
+    const uint32_t page_size,
+    const uint32_t num_pages_per_l1_buffer,
+    const uint32_t num_pages,
+    uint32_t &page_index
+    ) {
+    bool did_something = false;
+
+    bool noc_read_is_in_progress =
+        erisc::datamover::deprecated::sender_is_noc_read_in_progress(noc_reader_buffer_wrptr, noc_reader_buffer_ackptr);
+    bool more_data_to_read = page_index < num_pages;
+    if (!noc_read_is_in_progress && more_data_to_read) {
+        // We can only If a noc read is in progress, we can't issue another noc read
+        bool next_buffer_available = !erisc::datamover::deprecated::sender_buffer_pool_full(
+            noc_reader_buffer_wrptr, noc_reader_buffer_ackptr, eth_sender_rdptr, eth_sender_ackptr);
+        if (next_buffer_available) {
+
+            // Queue up another read
+            // non blocking - issues noc_async_read
+            // issue_read_chunk(noc_reader_buffer_wrptr, ...);
+            // kernel_profiler::mark_time(12);
+            #if EMULATE_DRAM_READ_CYCLES == 1
+            issue_read_chunk();
+            #else
+
+            // DPRINT << "tx: reading data into L1 buffer on channel " << (uint32_t)noc_reader_buffer_wrptr << "\n";
+            read_chunk<src_is_dram>(
+                transaction_channel_sender_buffer_addresses[noc_reader_buffer_wrptr.index()], // eth_l1_buffer_address_base
+                num_pages,
+                num_pages_per_l1_buffer,
+                page_size,
+                page_index,
+                source_address_generator
+            );
+            #endif
+            noc_reader_buffer_wrptr.increment();
+
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+
+void kernel_main() {
+    // COMPILE TIME ARGS
+    constexpr uint32_t num_bytes_per_send = get_compile_time_arg_val(0);
+    constexpr uint32_t num_bytes_per_send_word_size = get_compile_time_arg_val(1);
+    constexpr std::uint32_t total_num_message_sends = get_compile_time_arg_val(2);
+    constexpr std::uint32_t NUM_TRANSACTION_BUFFERS = get_compile_time_arg_val(3);
+    constexpr bool src_is_dram = get_compile_time_arg_val(4) == 1;
+
+    constexpr uint32_t MAX_NUM_CHANNELS = NUM_TRANSACTION_BUFFERS;
+
+    // COMPILE TIME ARG VALIDATION
+    static_assert(MAX_NUM_CHANNELS > 1, "Implementation currently doesn't support single buffering");
+
+    // RUNTIME ARGS
+    std::uint32_t local_eth_l1_src_addr = get_arg_val<uint32_t>(0);
+    std::uint32_t remote_eth_l1_dst_addr = get_arg_val<uint32_t>(1);
+
+    std::uint32_t src_addr = get_arg_val<uint32_t>(2);
+    std::uint32_t page_size = get_arg_val<uint32_t>(3);
+    std::uint32_t num_pages = get_arg_val<uint32_t>(4);
+
+    erisc::datamover::QueueIndexPointer<uint8_t> noc_reader_buffer_ackptr(MAX_NUM_CHANNELS);
+    erisc::datamover::QueueIndexPointer<uint8_t> noc_reader_buffer_wrptr(MAX_NUM_CHANNELS);
+    erisc::datamover::QueueIndexPointer<uint8_t> eth_sender_rdptr(MAX_NUM_CHANNELS);
+    erisc::datamover::QueueIndexPointer<uint8_t> eth_sender_ackptr(MAX_NUM_CHANNELS);
+
+    // Handshake with the other erisc first so we don't include dispatch time
+    // in our measurements
+    erisc::datamover::eth_setup_handshake(local_eth_l1_src_addr, true);
+
+    // const InterleavedAddrGenFast<src_is_dram> s = {
+    //     .bank_base_address = src_addr, .page_size = page_size, .data_format = df};
+
+    const InterleavedAddrGen<src_is_dram> source_address_generator = {
+        .bank_base_address = src_addr, .page_size = page_size};
+
+    kernel_profiler::mark_time(10);
+
+    // SETUP DATASTRUCTURES
+    std::array<uint32_t, MAX_NUM_CHANNELS> transaction_channel_sender_buffer_addresses;
+    std::array<uint32_t, MAX_NUM_CHANNELS> transaction_channel_receiver_buffer_addresses;\
+    erisc::datamover::initialize_transaction_buffer_addresses<MAX_NUM_CHANNELS>(
+        MAX_NUM_CHANNELS,
+        local_eth_l1_src_addr,
+        num_bytes_per_send,
+        transaction_channel_sender_buffer_addresses);
+    erisc::datamover::initialize_transaction_buffer_addresses<MAX_NUM_CHANNELS>(
+        MAX_NUM_CHANNELS,
+        remote_eth_l1_dst_addr,
+        num_bytes_per_send,
+        transaction_channel_receiver_buffer_addresses);
+
+    uint32_t eth_sends_completed = 0;
+
+    kernel_profiler::mark_time(11);
+    constexpr uint32_t SWITCH_INTERVAL = 100000;
+    uint32_t count = 0;
+    uint32_t page_index = 0;
+    uint32_t num_pages_per_l1_buffer = num_bytes_per_send / page_size;
+    uint32_t num_context_switches = 0;
+    uint32_t max_num_context_switches = 10000;
+    bool printed_hang = false;
+    uint32_t total_eth_sends = 0;
+    while (eth_sends_completed < total_num_message_sends) {
+        bool did_something = false;
+
+        did_something = erisc::datamover::deprecated::sender_noc_receive_payload_ack_check_sequence(
+                            noc_reader_buffer_wrptr,
+                            noc_reader_buffer_ackptr,
+                            noc_index) || did_something;
+
+        did_something = noc_read_data_sequence<MAX_NUM_CHANNELS, src_is_dram>(
+                            transaction_channel_sender_buffer_addresses,
+                            num_bytes_per_send,
+                            noc_reader_buffer_wrptr,
+                            noc_reader_buffer_ackptr,
+                            eth_sender_rdptr,
+                            eth_sender_ackptr,
+                            noc_index,
+                            source_address_generator,
+                            page_size,
+                            num_pages_per_l1_buffer,
+                            num_pages,
+                            page_index) || did_something;
+
+        bool sent_eth_data = erisc::datamover::deprecated::sender_eth_send_data_sequence<MAX_NUM_CHANNELS>(
+                            transaction_channel_sender_buffer_addresses,
+                            transaction_channel_receiver_buffer_addresses,
+                            local_eth_l1_src_addr,
+                            remote_eth_l1_dst_addr,
+                            num_bytes_per_send,  // bytes to send from this buffer over eth link
+                            num_bytes_per_send,  // break the end-to-end send into messages of this size
+                            num_bytes_per_send_word_size,
+                            noc_reader_buffer_wrptr,
+                            noc_reader_buffer_ackptr,
+                            eth_sender_rdptr,
+                            eth_sender_ackptr);
+        total_eth_sends = sent_eth_data ? total_eth_sends + 1 : total_eth_sends;
+        did_something = sent_eth_data || did_something;
+
+
+        did_something = erisc::datamover::deprecated::sender_eth_check_receiver_ack_sequence(
+                            noc_reader_buffer_wrptr,
+                            noc_reader_buffer_ackptr,
+                            eth_sender_rdptr,
+                            eth_sender_ackptr,
+                            eth_sends_completed) ||
+                        did_something;
+
+        if (!did_something) {
+            if (count++ > SWITCH_INTERVAL) {
+                count = 0;
+                // kernel_profiler::mark_time(15);
+                run_routing();
+                num_context_switches++;
+                if (num_context_switches > max_num_context_switches) {
+                    if (!printed_hang) {
+                        DPRINT << "tx: HANG\n";
+                        DPRINT << "tx: HANG eth_sends_completed " << eth_sends_completed << "\n";
+                        DPRINT << "tx: HANG noc_reader_buffer_wrptr " << (uint32_t)noc_reader_buffer_ackptr.index() << "\n";
+                        DPRINT << "tx: HANG (raw) noc_reader_buffer_wrptr " << (uint32_t)noc_reader_buffer_ackptr.raw_index() << "\n";
+                        DPRINT << "tx: HANG noc_reader_buffer_ackptr " << (uint32_t)noc_reader_buffer_wrptr.index() << "\n";
+                        DPRINT << "tx: HANG (raw) noc_reader_buffer_ackptr " << (uint32_t)noc_reader_buffer_wrptr.raw_index() << "\n";
+                        DPRINT << "tx: HANG eth_sender_rdptr " << (uint32_t)eth_sender_rdptr.index() << "\n";
+                        DPRINT << "tx: HANG (raw) eth_sender_rdptr " << (uint32_t)eth_sender_rdptr.raw_index() << "\n";
+                        DPRINT << "tx: HANG eth_sender_ackptr " << (uint32_t)eth_sender_ackptr.index() << "\n";
+                        DPRINT << "tx: HANG (raw) eth_sender_ackptr " << (uint32_t)eth_sender_ackptr.raw_index() << "\n";
+                        DPRINT << "tx: HANG total_eth_sends " << (uint32_t)total_eth_sends << "\n";
+                        for (uint32_t i = 0; i < MAX_NUM_CHANNELS; i++) {
+                            DPRINT << "tx: HANG channel [" << i << "] bytes_sent " << erisc_info->channels[0].bytes_sent << "\n";
+                            DPRINT << "tx: HANG channel [" << i << "] bytes_receiver_ack " << erisc_info->channels[0].receiver_ack << "\n";
+                            DPRINT << "tx: HANG eth_is_receiver_channel_send_acked (" << i << ") " << (eth_is_receiver_channel_send_acked(i) ? "true" : "false") << "\n";
+                            DPRINT << "tx: HANG eth_is_receiver_channel_send_done(" << i << ") " << (eth_is_receiver_channel_send_done(i) ? "true" : "false") << "\n";
+                        }
+                        // bool noc_read_is_in_progress =
+                        //     is_noc_read_in_progress(noc_reader_buffer_wrptr, noc_reader_buffer_ackptr);
+                        // bool more_data_to_read = page_index < num_pages;
+                        // bool next_buffer_available = !buffer_pool_full<MAX_NUM_CHANNELS>(
+                        //     noc_reader_buffer_wrptr, noc_reader_buffer_ackptr, eth_sender_rdptr, eth_sender_ackptr);
+                        // DPRINT << "tx: HANG noc_read_is_in_progress " << (noc_read_is_in_progress ? "true" : "false") << "\n";
+                        // DPRINT << "tx: HANG more_data_to_read " << (more_data_to_read ? "true" : "false") << "\n";
+                        // DPRINT << "tx: HANG next_buffer_available " << (next_buffer_available ? "true" : "false") << "\n";
+                        num_context_switches = 0;
+                        printed_hang = true;
+                    }
+                }
+            } else {
+                count++;
+            }
+        } else {
+            num_context_switches = 0;
+        }
+    }
+
+
+    DPRINT << "tx: DONE\n";
+    DPRINT << "tx: DONE eth_sends_completed " << (uint32_t)eth_sends_completed << "\n";
+    DPRINT << "tx: DONE total_num_message_sends " << (uint32_t)total_num_message_sends << "\n";
+    kernel_profiler::mark_time(16);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_non_blocking_receive_fwd_to_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_non_blocking_receive_fwd_to_dram.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdint>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_async_datamover.hpp"
+
+#define DONT_STRIDE_IN_ETH_BUFFER 0
+
+/**
+ * Any two RISC processors cannot use the same CMD_BUF
+ * non_blocking APIs shouldn't be mixed with slow noc.h APIs
+ * explicit flushes need to be used since the calls are non-blocking
+ * */
+
+
+// Initiate DRAM write -> advances  write pointer
+template <bool dest_is_dram>
+void write_chunk(
+    const uint32_t eth_l1_buffer_address_base,
+    const uint32_t num_pages,
+    const uint32_t num_pages_per_l1_buffer,
+    const uint32_t page_size,
+    uint32_t &page_index,
+    const InterleavedAddrGen<dest_is_dram> &dest_address_generator) {
+    uint32_t local_eth_l1_curr_src_addr = eth_l1_buffer_address_base;
+    uint32_t end_page_index = std::min(page_index + num_pages_per_l1_buffer, num_pages);
+    for (; page_index < end_page_index; ++page_index) {
+        // read source address
+        uint64_t dest_noc_addr = get_noc_addr(page_index, dest_address_generator);
+        noc_async_write(local_eth_l1_curr_src_addr, dest_noc_addr, page_size);
+        // read dest addr
+        #if DONT_STRIDE_IN_ETH_BUFFER == 0
+        local_eth_l1_curr_src_addr += page_size;
+        #endif
+    }
+}
+
+
+template <uint32_t MAX_NUM_CHANNELS, bool dest_is_dram>
+bool eth_initiate_noc_write_sequence(
+    std::array<uint32_t, MAX_NUM_CHANNELS> &transaction_channel_receiver_buffer_addresses,
+    erisc::datamover::QueueIndexPointer<uint8_t> &noc_writer_buffer_wrptr,
+    erisc::datamover::QueueIndexPointer<uint8_t> &noc_writer_buffer_ackptr,
+    const erisc::datamover::QueueIndexPointer<uint8_t> eth_receiver_wrptr,
+    const erisc::datamover::QueueIndexPointer<uint8_t> eth_receiver_ackptr,
+
+    const uint32_t num_pages,
+    const uint32_t num_pages_per_l1_buffer,
+    const uint32_t page_size,
+    uint32_t &page_index,
+    const InterleavedAddrGen<dest_is_dram> &dest_address_generator) {
+    bool did_something = false;
+    bool noc_write_is_in_progress = erisc::datamover::deprecated::receiver_is_noc_write_in_progress(noc_writer_buffer_wrptr, noc_writer_buffer_ackptr);
+
+    if (!noc_write_is_in_progress) {
+        bool next_payload_received = noc_writer_buffer_wrptr != eth_receiver_wrptr;
+        if (next_payload_received) {
+            // Can initialize a new write if data is at this buffer location (eth num_bytes != 0)
+            // and the receiver ackptr != next write pointer
+            // // DPRINT << "rx: accepting payload, sending receive ack on channel " << (uint32_t)noc_writer_buffer_wrptr << "\n";
+            write_chunk<dest_is_dram>(
+                transaction_channel_receiver_buffer_addresses[noc_writer_buffer_wrptr.index()],
+                num_pages,
+                num_pages_per_l1_buffer,
+                page_size,
+                page_index,
+                dest_address_generator);
+            noc_writer_buffer_wrptr.increment();
+            did_something = true;
+        }
+    }
+
+    return did_something;
+}
+
+void kernel_main() {
+    constexpr uint32_t num_bytes_per_send = get_compile_time_arg_val(0);
+    constexpr uint32_t num_bytes_per_send_word_size = get_compile_time_arg_val(1);
+    constexpr std::uint32_t total_num_message_sends = get_compile_time_arg_val(2);
+    constexpr std::uint32_t NUM_TRANSACTION_BUFFERS = get_compile_time_arg_val(3);
+    constexpr bool dest_is_dram = get_compile_time_arg_val(4) == 1;
+
+    constexpr uint32_t MAX_NUM_CHANNELS = NUM_TRANSACTION_BUFFERS;
+    // Handshake first before timestamping to make sure we aren't measuring any
+    // dispatch/setup times for the kernels on both sides of the link.
+
+    const std::uint32_t local_eth_l1_src_addr = get_arg_val<uint32_t>(0);
+    const std::uint32_t remote_eth_l1_dst_addr = get_arg_val<uint32_t>(1);
+    const std::uint32_t dest_addr = get_arg_val<uint32_t>(2);
+    const std::uint32_t page_size = get_arg_val<uint32_t>(3);
+    const std::uint32_t num_pages = get_arg_val<uint32_t>(4);
+    erisc::datamover::eth_setup_handshake(remote_eth_l1_dst_addr, false);
+
+    const InterleavedAddrGen<dest_is_dram> dest_address_generator = {
+        .bank_base_address = dest_addr, .page_size = page_size};
+
+    erisc::datamover::QueueIndexPointer<uint8_t> noc_writer_buffer_ackptr(MAX_NUM_CHANNELS);
+    erisc::datamover::QueueIndexPointer<uint8_t> noc_writer_buffer_wrptr(MAX_NUM_CHANNELS);
+    erisc::datamover::QueueIndexPointer<uint8_t> eth_receiver_rdptr(MAX_NUM_CHANNELS);
+    erisc::datamover::QueueIndexPointer<uint8_t> eth_receiver_ackptr(MAX_NUM_CHANNELS);
+
+    kernel_profiler::mark_time(80);
+
+    std::array<uint32_t, NUM_TRANSACTION_BUFFERS> transaction_channel_remote_buffer_addresses;
+    erisc::datamover::initialize_transaction_buffer_addresses<NUM_TRANSACTION_BUFFERS>(
+        MAX_NUM_CHANNELS,
+        remote_eth_l1_dst_addr,
+        num_bytes_per_send,
+        transaction_channel_remote_buffer_addresses);
+    std::array<uint32_t, NUM_TRANSACTION_BUFFERS> transaction_channel_local_buffer_addresses;
+    erisc::datamover::initialize_transaction_buffer_addresses<NUM_TRANSACTION_BUFFERS>(
+        MAX_NUM_CHANNELS,
+        local_eth_l1_src_addr,
+        num_bytes_per_send,
+        transaction_channel_local_buffer_addresses);
+
+    constexpr uint32_t SWITCH_INTERVAL = 100000;
+    uint32_t page_index = 0;
+    const uint32_t num_pages_per_l1_buffer = num_bytes_per_send / page_size;
+
+    bool write_in_flight = false;
+    uint32_t num_eth_sends_acked = 0;
+    uint32_t count = 0;
+    uint32_t num_context_switches = 0;
+    uint32_t max_num_context_switches = 1000;
+    bool printed_hang = false;
+    uint32_t num_receives_acked = 0;
+
+    while (num_eth_sends_acked < total_num_message_sends && page_index < num_pages) {
+        bool did_something = false;
+        // kernel_profiler::mark_time(90);
+
+        bool received = erisc::datamover::deprecated::receiver_eth_accept_payload_sequence(
+                            noc_writer_buffer_wrptr, noc_writer_buffer_ackptr, eth_receiver_rdptr, eth_receiver_ackptr);
+        num_receives_acked = received ? num_receives_acked + 1 : num_receives_acked;
+        did_something = received || did_something;
+
+        did_something = eth_initiate_noc_write_sequence<MAX_NUM_CHANNELS, dest_is_dram>(
+                            transaction_channel_local_buffer_addresses,
+                            noc_writer_buffer_wrptr,
+                            noc_writer_buffer_ackptr,
+                            eth_receiver_rdptr,
+                            eth_receiver_ackptr,
+
+                            num_pages,
+                            num_pages_per_l1_buffer,
+                            page_size,
+                            page_index,
+                            dest_address_generator) ||
+                        did_something;
+
+        did_something = erisc::datamover::deprecated::receiver_noc_read_worker_completion_check_sequence(
+                            noc_writer_buffer_wrptr, noc_writer_buffer_ackptr, noc_index) ||
+                        did_something;
+
+        did_something =
+            erisc::datamover::deprecated::receiver_eth_send_ack_to_sender_sequence(
+                noc_writer_buffer_wrptr, noc_writer_buffer_ackptr, eth_receiver_rdptr, eth_receiver_ackptr, num_eth_sends_acked) ||
+            did_something;
+
+        if (!did_something) {
+
+            if (count++ > SWITCH_INTERVAL) {
+                count = 0;
+                // kernel_profiler::mark_time(15);
+                run_routing();
+                num_context_switches++;
+                if (num_context_switches > max_num_context_switches) {
+                    if (!printed_hang) {
+                        DPRINT << "rx: HANG\n";
+                        DPRINT << "rx: HANG num_eth_sends_acked " << (uint32_t)num_eth_sends_acked << "\n";
+                        DPRINT << "rx: HANG total_num_message_sends " << (uint32_t)total_num_message_sends << "\n";
+                        for (uint32_t i = 0; i < MAX_NUM_CHANNELS; i++) {
+
+                            DPRINT << "rx: HANG channel [" << i << "] bytes_sent " << erisc_info->channels[0].bytes_sent << "\n";
+                            DPRINT << "rx: HANG channel [" << i << "] bytes_receiver_ack " << erisc_info->channels[0].receiver_ack << "\n";
+                            DPRINT << "rx: HANG eth_is_receiver_channel_send_acked (" << i << ") " << (eth_is_receiver_channel_send_acked(i) ? "true" : "false") << "\n";
+                            DPRINT << "rx: HANG eth_is_receiver_channel_send_done(" << i << ") " << (eth_is_receiver_channel_send_done(i) ? "true" : "false") << "\n";
+                        }
+                        DPRINT << "rx: HANG noc_writer_buffer_ackptr " << (uint32_t)noc_writer_buffer_ackptr.index() << "\n";
+                        DPRINT << "rx: HANG (raw) noc_writer_buffer_ackptr " << (uint32_t)noc_writer_buffer_ackptr.raw_index() << "\n";
+                        DPRINT << "rx: HANG noc_writer_buffer_wrptr " << (uint32_t)noc_writer_buffer_wrptr.index() << "\n";
+                        DPRINT << "rx: HANG (raw) noc_writer_buffer_wrptr " << (uint32_t)noc_writer_buffer_wrptr.raw_index() << "\n";
+                        DPRINT << "rx: HANG eth_receiver_rdptr " << (uint32_t)eth_receiver_rdptr.index() << "\n";
+                        DPRINT << "rx: HANG (raw) eth_receiver_rdptr " << (uint32_t)eth_receiver_rdptr.raw_index() << "\n";
+                        DPRINT << "rx: HANG eth_receiver_ackptr " << (uint32_t)eth_receiver_ackptr.index() << "\n";
+                        DPRINT << "rx: HANG (raw) eth_receiver_ackptr " << (uint32_t)eth_receiver_ackptr.raw_index() << "\n";
+                        DPRINT << "rx: HANG num_receives_acked " << (uint32_t)num_receives_acked << "\n";
+                        printed_hang = true;
+                        num_context_switches = 0;
+                    }
+                }
+            } else {
+                count++;
+            }
+        } else {
+            num_context_switches = 0;
+        }
+    }
+
+    while (!ncrisc_noc_nonposted_writes_sent(noc_index));
+    while (!ncrisc_noc_nonposted_writes_flushed(noc_index));
+
+    DPRINT << "rx: DONE\n";
+    DPRINT << "rx: DONE eth_sends_completed " << (uint32_t)num_eth_sends_acked << "\n";
+    DPRINT << "rx: DONE total_num_message_sends " << (uint32_t)total_num_message_sends << "\n";
+
+    DPRINT << "rx: DONE num_eth_sends_acked " << (uint32_t)num_eth_sends_acked << "\n";
+    DPRINT << "rx: DONE total_num_message_sends " << (uint32_t)total_num_message_sends << "\n";
+    for (uint32_t i = 0; i < MAX_NUM_CHANNELS; i++) {
+
+        DPRINT << "rx: DONE channel [" << i << "] bytes_sent " << erisc_info->channels[0].bytes_sent << "\n";
+        DPRINT << "rx: DONE channel [" << i << "] bytes_receiver_ack " << erisc_info->channels[0].receiver_ack << "\n";
+        DPRINT << "rx: DONE eth_is_receiver_channel_send_acked (" << i << ") " << (eth_is_receiver_channel_send_acked(i) ? "true" : "false") << "\n";
+        DPRINT << "rx: DONE eth_is_receiver_channel_send_done(" << i << ") " << (eth_is_receiver_channel_send_done(i) ? "true" : "false") << "\n";
+    }
+    DPRINT << "rx: DONE noc_writer_buffer_ackptr " << (uint32_t)noc_writer_buffer_ackptr.index() << "\n";
+    DPRINT << "rx: DONE (raw) noc_writer_buffer_ackptr " << (uint32_t)noc_writer_buffer_ackptr.raw_index() << "\n";
+    DPRINT << "rx: DONE noc_writer_buffer_wrptr " << (uint32_t)noc_writer_buffer_wrptr.index() << "\n";
+    DPRINT << "rx: DONE (raw) noc_writer_buffer_wrptr " << (uint32_t)noc_writer_buffer_wrptr.raw_index() << "\n";
+    DPRINT << "rx: DONE eth_receiver_rdptr " << (uint32_t)eth_receiver_rdptr.index() << "\n";
+    DPRINT << "rx: DONE (raw) eth_receiver_rdptr " << (uint32_t)eth_receiver_rdptr.raw_index() << "\n";
+    DPRINT << "rx: DONE eth_receiver_ackptr " << (uint32_t)eth_receiver_ackptr.index() << "\n";
+    DPRINT << "rx: DONE (raw) eth_receiver_ackptr " << (uint32_t)eth_receiver_ackptr.raw_index() << "\n";
+    DPRINT << "rx: DONE num_receives_acked " << (uint32_t)num_receives_acked << "\n";
+
+    kernel_profiler::mark_time(81);
+
+    kernel_profiler::mark_time(100);
+
+}

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -40,9 +40,10 @@ struct address_map {
   //    -   1 * 1024 misc args
   //    -  53 * 1024 eth app reserved buffer space
   //    - 106 * 1024 L1 unreserved buffer space
+  static constexpr std::int32_t MAX_NUM_CONCURRENT_TRANSACTIONS = 8;
   static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
   static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 48;
-  static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 32;
+  static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 160 + 16 * MAX_NUM_CONCURRENT_TRANSACTIONS;
 
   static constexpr std::int32_t ERISC_BARRIER_BASE = TILE_HEADER_BUFFER_BASE;
   static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = ERISC_BARRIER_BASE + ERISC_BARRIER_SIZE;


### PR DESCRIPTION
# What's Included
- Added "channel" concept to ethernet dataflow_api: @aliuTT 
- Added two level ack to ethernet channels: @aliuTT 
   - First to indicate message received by receiver
   - Second to indicate receiver buffer available
- Added EDM
- Added multichannel ethernet microbenchmark sweep with erisc doing DRAM read/write
- Added decoupled worker <-> EDM functional sweep
  - Currently we are prevented from collecting perf measurements here due to reporting bug
    - Will address in future changes
    - Why I kept non-decoupled benchmarks around



# Description

The EDM is the foundational building block for communication over ethernet. It is "dumb" data mover that is decoupled from the data I/O access pattern. It is up to worker cores to push data to and pull data from the EDM and is designed to be bidirectional and non-blocking.

Workers can interact with EDM by pushing to or pulling from EDM, for each direction, the interface is the same. `ChannelBuffers` are channels (and corresponding L1 buffering on erisc) that make independent progress relative to each other. They can be filled and drained at different rates relative to one another. Additionally, `ChannelBuffer`s can be written to or read by multiple workers; in that case it is up to workers to ensure they are accessing data with the correct offsets into the buffers.

For every `ChannelBuffer`, a pair of semaphores are used to facilitate synchronization. One of the semaphores for the `ChannelBuffer` lives on the erisc in L1 and the other lives in each worker's L1 (a copy). EDM will notify each worker when update occur.

# Arg Setup Schema (EDM) 

1) Handshake L1 Address: will be removed in the future. 16 B 
2) Sender channels start: Which ethernet dataflow channels to start the
   sender side channels at. Valid values: (0-7)
3) Sender num channels: Number of sender channels to instantiate.
   Informs how many times to run the following arg fetch loop:
   4) sender_buffer_address: EDM L1 start offset of the `ChannelBuffer`
   5) sender_num_messages_to_send: Number of eth sends before completion
      - in other words, how many worker completion worth of transfers 
   6) sender_channel_size (B): Size of the L1 buffer on EDM 
   7) sender_semaphores_address: EDM local L1 address of semaphore 
   8) worker_semaphore_address: Worker L1 address of semaphore 
   9) sender num workers: semaphore threshold, also how many XY pairs to fetch in the next loop. 
        10) Worker X/Y (16bits each)

11) receiver channel start: same as sender channel start but for
    receiver side
12) receiver num channels:
    <Same loop structure as sender side>

# Transaction States (Worker -> EDM): 

## Worker 
1) Worker first waits for a semaphore increment on its local semaphore
   copy
   - The semaphore must be initialized to 0 by dispatcher/runtime 2) Upon receipt of (local) semaphore increment, the worker knows that it
   is safe to write into the destination.
3) Worker clears the (local) semaphore
4) Worker writes into the EDM sender buffer
   - How much data to writer and at which offset(s) into the buffer are up to the worker kernel
   - **NOTE**: Make sure to flush the writes because the following semaphore inc could race ahead 5) Worker increments the semaphore on the EDM (sender) `ChannelBuffer` 6) Worker goes back to 1 if not done, else finishes

## EDM (sender side) 
(**NOTE**: the below is per `ChannelBuffer` and direction. It doesn't block)
1) Initializes(increments) the worker L1 semaphore, for all workers 2) Waits (checks) for worker completion to know when buffer payload is
   ready
   - Indicated by the `ChannelBuffer`'s local semaphore value equaling the number of workers 3) Waits (checks) if receiver is ready
   - Indicated by receiver channel done message which tells sender the receiver side buffer was consumed 4) Waits (checks) for receiver erisc to ack indicating message received
   - EDM sender can now clear its buffer and signal to workers that they can send again
   - Go to step 1 if not complete, else exit

EDM receiver <-> Worker code path is the same except that EDM receiver semaphore increments each reader worker's semaphore when data is available. It waits for a semaphore inc from each worker to indicate that the payload was consumed and the EDM receiver's buffer can be reused again.

Added microbenchmarks. Currently only enabled on old, non-decoupled EDM and I/O logic (due to issue reading back timestamps on host in decoupled mode).

To run non-decoupled microbenchmarks:
`pytest tests/tt_metal/microbenchmarks/ethernet/test_ethernet_send_data_microbenchmark.py -k "test_run_ethernet_send_data_microbenchmark_sweep"`

With the above command, throughput from low GBps to 12GBps were observed, depending on tensor side.

For functional sweep test for decoupled mode, run the pytest: `test_decoupled_worker_and_erisc_data_mover_single_direction` from
`tests/tt_metal/microbenchmarks/ethernet/test_ethernet_send_data_microbenchmark.py`