### PR TITLE
Move watcher out of llrt -> now adjacent with dprint

### DIFF
--- a/docs/source/tools/watcher.rst
+++ b/docs/source/tools/watcher.rst
@@ -77,7 +77,7 @@ to commands have been removed for brevity.  After attaching to the program and s
 
     thread 1   # make sure the main thread is present
     up         # repeat until in the "tt" namespace (not in, e.g., template library code)
-    call tt::llrt::watcher::dump(stderr, true) # the "true" at the end enables dumping HW registers
+    call tt::watcher::dump(stderr, true) # the "true" at the end enables dumping HW registers
 
 Example
 -------

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
@@ -5,7 +5,7 @@
 #include <chrono>
 #include <thread>
 #include "common_fixture.hpp"
-#include "llrt/watcher.hpp"
+#include "impl/debug/watcher_server.hpp"
 
 // A version of CommonFixture with watcher enabled
 class WatcherFixture: public CommonFixture {
@@ -40,7 +40,7 @@ protected:
         tt::llrt::OptionsG.set_watcher_dump_all(false);
         tt::llrt::OptionsG.set_watcher_append(false);
         tt::llrt::OptionsG.set_test_mode_enabled(true);
-        tt::llrt::watcher_clear_log();
+        tt::watcher_clear_log();
 
         // Parent class initializes devices and any necessary flags
         CommonFixture::SetUp();
@@ -59,7 +59,7 @@ protected:
         tt::llrt::OptionsG.set_watcher_dump_all(watcher_previous_dump_all);
         tt::llrt::OptionsG.set_watcher_append(watcher_previous_append);
         tt::llrt::OptionsG.set_test_mode_enabled(test_mode_previous);
-        tt::llrt::watcher_server_clear_error_flag();
+        tt::watcher_server_clear_error_flag();
     }
 
     void RunTestOnDevice(
@@ -72,6 +72,6 @@ protected:
         CommonFixture::RunTestOnDevice(run_function_no_args, device);
         // Wait for a final watcher poll and then clear the log.
         std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
-        tt::llrt::watcher_clear_log();
+        tt::watcher_clear_log();
     }
 };

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -97,7 +97,7 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
         fixture->RunProgram(device, program);
     } catch (std::runtime_error& e) {
         string expected = "Command Queue could not finish: device hang due to illegal NoC transaction. See {} for details.\n";
-        expected += tt::llrt::watcher_get_log_file_name();
+        expected += tt::watcher_get_log_file_name();
         const string error = string(e.what());
         log_info(tt::LogTest, "Caught exception (one is expected in this test)");
         EXPECT_TRUE(error.find(expected) != string::npos);
@@ -137,7 +137,7 @@ static void RunTestEth(WatcherFixture* fixture, Device* device) {
     RunTestOnCore(fixture, device, core, true);
 }
 
-// Run tests for host-side sanitization (uses functions that are from watcher.hpp).
+// Run tests for host-side sanitization (uses functions that are from watcher_server.hpp).
 void CheckHostSanitization(Device *device) {
     // Try reading from a core that doesn't exist
     constexpr CoreCoord core = {16, 16};

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -13,7 +13,6 @@
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 #include "tt_metal/detail/program.hpp"
-#include "tt_metal/llrt/watcher.hpp"
 #include "tt_metal/jit_build/genfiles.hpp"
 #include "tt_metal/host_api.hpp"
 

--- a/tt_metal/impl/debug/sanitize_noc_host.hpp
+++ b/tt_metal/impl/debug/sanitize_noc_host.hpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "noc/noc_parameters.h"
+#include "noc/noc_overlay_parameters.h"
+
+#pragma once
+
+namespace tt {
+
+#define DEBUG_VALID_L1_ADDR(a, l) (((a) >= MEM_L1_BASE) && ((a) + (l) <= MEM_L1_BASE + MEM_L1_SIZE))
+
+// what's the size of the NOC<n> address space?  using 0x1000 for now
+#define DEBUG_VALID_REG_ADDR(a)                                                        \
+    (                                                                                  \
+     (((a) >= NOC_OVERLAY_START_ADDR) && ((a) < NOC_OVERLAY_START_ADDR + NOC_STREAM_REG_SPACE_SIZE * NOC_NUM_STREAMS)) || \
+     (((a) >= NOC0_REGS_START_ADDR) && ((a) < NOC0_REGS_START_ADDR + 0x1000)) || \
+     (((a) >= NOC1_REGS_START_ADDR) && ((a) < NOC1_REGS_START_ADDR + 0x1000)) || \
+     ((a) == RISCV_DEBUG_REG_SOFT_RESET_0))
+#define DEBUG_VALID_WORKER_ADDR(a, l) (DEBUG_VALID_L1_ADDR(a, l) || (DEBUG_VALID_REG_ADDR(a) && (l) == 4))
+#define DEBUG_VALID_DRAM_ADDR(a, l, b, e) (((a) >= b) && ((a) + (l) <= e))
+
+#define DEBUG_VALID_ETH_ADDR(a, l) (((a) >= MEM_ETH_BASE) && ((a) + (l) <= MEM_ETH_BASE + MEM_ETH_SIZE))
+
+static bool coord_found_p(vector<CoreCoord>coords, CoreCoord core) {
+    for (CoreCoord item : coords) {
+        if (item == core) return true;
+    }
+    return false;
+}
+
+static bool coord_found_p(CoreCoord range, CoreCoord core) {
+    return
+        core.x >= 1 && core.x <= range.x &&
+        core.y >= 1 && core.y <= range.y;
+}
+
+static string noc_address(CoreCoord core, uint64_t a, uint32_t l) {
+    std::stringstream ss;
+    ss << "noc{" << core.str() << ", 0x" << std::setfill('0') << std::setw(8) << std::hex << a << ", " << std::dec << l << "}";
+    return ss.str();
+}
+
+static void print_stack_trace (void) {
+    void *array[15];
+
+    int size = backtrace (array, 15);
+    char **strings = backtrace_symbols(array, size);
+    if (strings != NULL) {
+        fprintf(stderr, "Obtained %d stack frames.\n", size);
+        for (int i = 0; i < size; i++) fprintf(stderr, "%s\n", strings[i]);
+    }
+
+    free (strings);
+}
+
+static void watcher_sanitize_host_noc(const char* what,
+                                      const metal_SocDescriptor& soc_d,
+                                      CoreCoord core,
+                                      uint64_t addr,
+                                      uint32_t lbytes) {
+
+    if (coord_found_p(soc_d.get_pcie_cores(), core)) {
+        TT_THROW("Host watcher: bad {} NOC coord {}", what, core.str());
+    } else if (coord_found_p(soc_d.get_dram_cores(), core)) {
+        uint64_t dram_addr_base = 0;
+        uint64_t dram_addr_size = soc_d.dram_core_size;
+        uint64_t dram_addr_end = dram_addr_size - dram_addr_base;
+        if (!DEBUG_VALID_DRAM_ADDR(addr, lbytes, dram_addr_base, dram_addr_end)) {
+            print_stack_trace();
+            TT_THROW("Host watcher: bad {} dram address {}", what, noc_address(core, addr, lbytes));
+        }
+    } else if (coord_found_p(soc_d.get_physical_ethernet_cores(), core)) {
+        if (!DEBUG_VALID_ETH_ADDR(addr, lbytes)) {
+            print_stack_trace();
+            TT_THROW("Host watcher: bad {} eth address {}", what, noc_address(core, addr, lbytes));
+        }
+    } else if (coord_found_p(soc_d.grid_size, core)) {
+        if (!DEBUG_VALID_WORKER_ADDR(addr, lbytes)) {
+            print_stack_trace();
+            TT_THROW("Host watcher: bad {} worker address {}", what, noc_address(core, addr, lbytes));
+        }
+    } else {
+        // Bad COORD
+        print_stack_trace();
+        TT_THROW("Host watcher: bad {} NOC coord {}", what, core.str());
+    }
+}
+
+void watcher_sanitize_host_noc_read(const metal_SocDescriptor& soc_d, CoreCoord core, uint64_t addr, uint32_t lbytes) {
+    watcher_sanitize_host_noc("read", soc_d, core, addr, lbytes);
+}
+
+void watcher_sanitize_host_noc_write(const metal_SocDescriptor& soc_d, CoreCoord core, uint64_t addr, uint32_t lbytes) {
+    watcher_sanitize_host_noc("write", soc_d, core, addr, lbytes);
+}
+
+} // namespace tt

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -24,33 +24,13 @@
 namespace tt {
 namespace watcher {
 
-
-class WatcherDevice {
-  public:
-    int device_id_;
-    std::function<CoreCoord ()>get_grid_size_;
-    std::function<CoreCoord (CoreCoord)>worker_from_logical_;
-    std::function<const std::set<CoreCoord> &()> storage_only_cores_;
-    std::function<const std::unordered_set<CoreCoord> ()> ethernet_cores_;
-    std::function<CoreCoord (CoreCoord)>ethernet_from_logical_;
-
-    WatcherDevice(
-        int device_id,
-        std::function<CoreCoord ()>get_grid_size,
-        std::function<CoreCoord (CoreCoord)>worker_from_logical,
-        std::function<const std::set<CoreCoord> &()>storage_only_cores,
-        std::function<const std::unordered_set<CoreCoord> ()>ethernet_cores,
-        std::function<CoreCoord (CoreCoord)>ethernet_from_logical
-    );
-};
-
 constexpr uint64_t DEBUG_SANITIZE_NOC_SENTINEL_OK_64 = 0xbadabadabadabada;
 constexpr uint32_t DEBUG_SANITIZE_NOC_SENTINEL_OK_32 = 0xbadabada;
 constexpr uint16_t DEBUG_SANITIZE_NOC_SENTINEL_OK_16 = 0xbada;
 
 static std::atomic<bool> enabled = false;
 static std::mutex watch_mutex;
-static std::unordered_map<void *, std::shared_ptr<WatcherDevice>> devices;
+static std::unordered_set<Device *> devices;
 static string logfile_path = "";
 static string logfile_name = "watcher.log";
 static FILE *logfile = nullptr;
@@ -59,23 +39,6 @@ static std::vector<string> kernel_names;
 
 // Flag to signal whether the watcher server has been killed due to a thrown exception.
 static std::atomic<bool> watcher_killed_due_to_error = false;
-
-WatcherDevice::WatcherDevice(
-    int device_id,
-    std::function<CoreCoord ()>get_grid_size,
-    std::function<CoreCoord (CoreCoord)>worker_from_logical,
-    std::function<const std::set<CoreCoord> &()> storage_only_cores,
-    std::function<const std::unordered_set<CoreCoord> ()>ethernet_cores,
-    std::function<CoreCoord (CoreCoord)>ethernet_from_logical
-):
-    device_id_(device_id),
-    get_grid_size_(get_grid_size),
-    worker_from_logical_(worker_from_logical),
-    storage_only_cores_(storage_only_cores),
-    ethernet_cores_(ethernet_cores),
-    ethernet_from_logical_(ethernet_from_logical)
-{
-}
 
 static double get_elapsed_secs() {
     std::chrono::time_point now_time = std::chrono::system_clock::now();
@@ -125,11 +88,11 @@ static void log_running_kernels(const launch_msg_t *launch_msg) {
     log_info(" triscs: {}", kernel_names[launch_msg->triscs_watcher_kernel_id]);
 }
 
-static void dump_l1_status(FILE *f, WatcherDevice *wdev, CoreCoord core, const launch_msg_t *launch_msg) {
+static void dump_l1_status(FILE *f, Device *device, CoreCoord core, const launch_msg_t *launch_msg) {
 
     // Read L1 address 0, looking for memory corruption
     std::vector<uint32_t> data;
-    data = tt::llrt::read_hex_vec_from_core(wdev->device_id_, core, MEM_L1_BASE, sizeof(uint32_t));
+    data = tt::llrt::read_hex_vec_from_core(device->id(), core, MEM_L1_BASE, sizeof(uint32_t));
     // XXXX TODO(pgk): get this const from llrt (jump to fw insn)
     if (data[0] != 0x2010006f) {
         log_running_kernels(launch_msg);
@@ -375,7 +338,7 @@ static void dump_debug_status(FILE *f, CoreCoord core, const launch_msg_t *launc
     fprintf(f, "%s ", out.c_str());
 }
 
-static void dump_sync_regs(FILE *f, WatcherDevice *wdev, CoreCoord core) {
+static void dump_sync_regs(FILE *f, Device *device, CoreCoord core) {
 
     // Read back all of the stream state, most of it is unused
     std::vector<uint32_t> data;
@@ -385,11 +348,11 @@ static void dump_sync_regs(FILE *f, WatcherDevice *wdev, CoreCoord core) {
         uint32_t base = NOC_OVERLAY_START_ADDR + (OPERAND_START_STREAM + operand) * NOC_STREAM_REG_SPACE_SIZE;
 
         uint32_t rcvd_addr = base + STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX * sizeof(uint32_t);
-        data = tt::llrt::read_hex_vec_from_core(wdev->device_id_, core, rcvd_addr, sizeof(uint32_t));
+        data = tt::llrt::read_hex_vec_from_core(device->id(), core, rcvd_addr, sizeof(uint32_t));
         uint32_t rcvd = data[0];
 
         uint32_t ackd_addr = base + STREAM_REMOTE_DEST_BUF_START_REG_INDEX * sizeof(uint32_t);
-        data = tt::llrt::read_hex_vec_from_core(wdev->device_id_, core, ackd_addr, sizeof(uint32_t));
+        data = tt::llrt::read_hex_vec_from_core(device->id(), core, ackd_addr, sizeof(uint32_t));
         uint32_t ackd = data[0];
 
         if (rcvd != ackd) {
@@ -422,21 +385,21 @@ static void validate_kernel_ids(FILE *f,
     used_kernel_names[launch->triscs_watcher_kernel_id] = true;
 }
 
-static void dump_core(FILE *f, std::map<int, bool>& used_kernel_names, WatcherDevice *wdev, CoreCoord core, bool dump_all) {
+static void dump_core(FILE *f, std::map<int, bool>& used_kernel_names, Device *device, CoreCoord core, bool dump_all) {
 
     string pad(11 - core.str().length(), ' ');
-    fprintf(f, "Device %i, ", wdev->device_id_);
+    fprintf(f, "Device %i, ", device->id());
     fprintf(f, "Core %s:%s  ", core.str().c_str(), pad.c_str());
 
     // Ethernet cores have a different mailbox base addr
-    bool is_eth_core = tt::llrt::is_ethernet_core(core, wdev->device_id_);
+    bool is_eth_core = tt::llrt::is_ethernet_core(core, device->id());
     uint64_t mailbox_addr = MEM_MAILBOX_BASE;
     if (is_eth_core) {
         mailbox_addr = eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE;
     }
 
     std::vector<uint32_t> data;
-    data = tt::llrt::read_hex_vec_from_core(wdev->device_id_, core, mailbox_addr, sizeof(mailboxes_t));
+    data = tt::llrt::read_hex_vec_from_core(device->id(), core, mailbox_addr, sizeof(mailboxes_t));
     mailboxes_t *mbox_data = (mailboxes_t *)(&data[0]);
 
     // Validate these first since they are used in diagnostic messages below.
@@ -448,7 +411,7 @@ static void dump_core(FILE *f, std::map<int, bool>& used_kernel_names, WatcherDe
         // Ethernet cores have firmware that starts at address 0, so no need to check it for a
         // magic value.
         if (!is_eth_core)
-            dump_l1_status(f, wdev, core,  &mbox_data->launch);
+            dump_l1_status(f, device, core,  &mbox_data->launch);
         dump_noc_sanity_status(f, core, &mbox_data->launch, mbox_data->sanitize_noc, mbox_data->debug_status);
     }
 
@@ -459,7 +422,7 @@ static void dump_core(FILE *f, std::map<int, bool>& used_kernel_names, WatcherDe
         if (dump_all || tt::llrt::OptionsG.get_watcher_dump_all()) {
             // Reading registers while running can cause hangs, only read if
             // requested explicitly
-            dump_sync_regs(f, wdev, core);
+            dump_sync_regs(f, device, core);
         }
     }
 
@@ -480,28 +443,26 @@ static void dump_core(FILE *f, std::map<int, bool>& used_kernel_names, WatcherDe
 
 // noinline so that this fn exists to be called from dgb
 static void  __attribute__((noinline)) dump(FILE *f, bool dump_all) {
-    for (auto const& dev_pair : devices) {
-        std::shared_ptr<WatcherDevice>wdev = dev_pair.second;
-
+    for (Device* device : devices) {
         if (f != stdout && f != stderr) {
-            log_info(LogLLRuntime, "Watcher checking device {}", wdev->device_id_);
+            log_info(LogLLRuntime, "Watcher checking device {}", device->id());
         }
 
         std::map<int, bool> used_kernel_names;
-        CoreCoord grid_size = wdev->get_grid_size_();
+        CoreCoord grid_size = device->logical_grid_size();
         for (uint32_t y = 0; y < grid_size.y; y++) {
             for (uint32_t x = 0; x < grid_size.x; x++) {
                 CoreCoord logical_core(x, y);
-                CoreCoord worker_core = wdev->worker_from_logical_(logical_core);
-                if (wdev->storage_only_cores_().find(logical_core) == wdev->storage_only_cores_().end()) {
-                    dump_core(f, used_kernel_names, wdev.get(), worker_core, dump_all);
+                CoreCoord worker_core = device->worker_core_from_logical_core(logical_core);
+                if (device->storage_only_cores().find(logical_core) == device->storage_only_cores().end()) {
+                    dump_core(f, used_kernel_names, device, worker_core, dump_all);
                 }
             }
         }
 
-        for (const CoreCoord &eth_core : wdev->ethernet_cores_()) {
-            CoreCoord physical_core = wdev->ethernet_from_logical_(eth_core);
-            dump_core(f, used_kernel_names, wdev.get(), physical_core, dump_all);
+        for (const CoreCoord &eth_core : device->get_active_ethernet_cores()) {
+            CoreCoord physical_core = device->ethernet_core_from_logical_core(eth_core);
+            dump_core(f, used_kernel_names, device, physical_core, dump_all);
         }
 
         for (auto k_id : used_kernel_names) {
@@ -562,12 +523,7 @@ static void watcher_loop(int sleep_usecs) {
 
 } // namespace watcher
 
-void watcher_init(int device_id,
-                  std::function<CoreCoord ()>get_grid_size,
-                  std::function<CoreCoord (CoreCoord)>worker_from_logical,
-                  const std::function<const std::unordered_set<CoreCoord> ()> &ethernet_cores,
-                  const std::function<CoreCoord (CoreCoord)> &ethernet_from_logical
-                  ) {
+void watcher_init(Device *device) {
 
     // Initialize debug status values to "unknown"
     std::vector<uint32_t> debug_status_init_val = { 'X', 'X', 'X', 'X', 'X' };
@@ -585,44 +541,37 @@ void watcher_init(int device_id,
     }
 
     // Initialize worker cores debug values
-    CoreCoord grid_size = get_grid_size();
+    CoreCoord grid_size = device->logical_grid_size();
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord logical_core(x, y);
-            CoreCoord worker_core = worker_from_logical(logical_core);
-            tt::llrt::write_hex_vec_to_core(device_id, worker_core, debug_status_init_val, GET_MAILBOX_ADDRESS_HOST(debug_status));
-            tt::llrt::write_hex_vec_to_core(device_id, worker_core, debug_sanity_init_val, GET_MAILBOX_ADDRESS_HOST(sanitize_noc));
+            CoreCoord worker_core = device->worker_core_from_logical_core(logical_core);
+            tt::llrt::write_hex_vec_to_core(device->id(), worker_core, debug_status_init_val, GET_MAILBOX_ADDRESS_HOST(debug_status));
+            tt::llrt::write_hex_vec_to_core(device->id(), worker_core, debug_sanity_init_val, GET_MAILBOX_ADDRESS_HOST(sanitize_noc));
         }
     }
 
     // Initialize ethernet cores debug values
-    for (const CoreCoord &eth_core : ethernet_cores()) {
-        CoreCoord physical_core = ethernet_from_logical(eth_core);
+    for (const CoreCoord &eth_core : device->get_active_ethernet_cores()) {
+        CoreCoord physical_core = device->ethernet_core_from_logical_core(eth_core);
         tt::llrt::write_hex_vec_to_core(
-            device_id,
+            device->id(),
             physical_core,
             debug_status_init_val,
             GET_ETH_MAILBOX_ADDRESS_HOST(debug_status)
         );
         tt::llrt::write_hex_vec_to_core(
-            device_id,
+            device->id(),
             physical_core,
             debug_sanity_init_val,
             GET_ETH_MAILBOX_ADDRESS_HOST(sanitize_noc)
         );
     }
 
-    log_debug(LogLLRuntime, "Watcher initialized device {}", device_id);
+    log_debug(LogLLRuntime, "Watcher initialized device {}", device->id());
 }
 
-void watcher_attach(void *dev,
-                    int device_id,
-                    const std::function<CoreCoord ()>& get_grid_size,
-                    const std::function<CoreCoord (CoreCoord)>& worker_from_logical,
-                    const std::function<const std::set<CoreCoord> &()>& storage_only_cores,
-                    const std::function<const std::unordered_set<CoreCoord> ()>& ethernet_cores,
-                    const std::function<CoreCoord (CoreCoord)> &ethernet_from_logical,
-                    const string& log_path) {
+void watcher_attach(Device *device, const string& log_path) {
 
     const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
 
@@ -641,28 +590,26 @@ void watcher_attach(void *dev,
     }
 
     if (watcher::logfile != nullptr) {
-        fprintf(watcher::logfile, "At %.3lfs attach device %d\n", watcher::get_elapsed_secs(), device_id);
+        fprintf(watcher::logfile, "At %.3lfs attach device %d\n", watcher::get_elapsed_secs(), device->id());
     }
 
     if (watcher::enabled) {
-        log_info(LogLLRuntime, "Watcher attached device {}", device_id);
+        log_info(LogLLRuntime, "Watcher attached device {}", device->id());
     }
 
     // Always register the device w/ watcher, even if disabled
     // This allows dump() to be called from debugger
-    std::shared_ptr<watcher::WatcherDevice> wdev(new watcher::WatcherDevice(device_id, get_grid_size, worker_from_logical, storage_only_cores, ethernet_cores, ethernet_from_logical));
-    watcher::devices.insert(pair<void *, std::shared_ptr<watcher::WatcherDevice>>(dev, wdev));
+    watcher::devices.insert(device);
 }
 
-void watcher_detach(void *old) {
+void watcher_detach(Device *old) {
 
     const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
 
-    auto pair = watcher::devices.find(old);
-    TT_ASSERT(pair != watcher::devices.end());
+    TT_ASSERT(watcher::devices.find(old) != watcher::devices.end());
     if (watcher::enabled && watcher::logfile != nullptr) {
-        log_info(LogLLRuntime, "Watcher detached device {}", pair->second->device_id_);
-        fprintf(watcher::logfile, "At %.3lfs detach device %d\n", watcher::get_elapsed_secs(), pair->second->device_id_);
+        log_info(LogLLRuntime, "Watcher detached device {}", old->id());
+        fprintf(watcher::logfile, "At %.3lfs detach device %d\n", watcher::get_elapsed_secs(), old->id());
     }
     watcher::devices.erase(old);
     if (watcher::enabled && watcher::devices.empty()) {

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include "tt_cluster.hpp"
-
 namespace tt {
-namespace llrt {
 
 void watcher_init(int device_id,
                   std::function<CoreCoord ()>get_grid_size,
@@ -45,5 +42,4 @@ void watcher_clear_log();
 // Helper function to get the current watcher log file name/path
 string watcher_get_log_file_name();
 
-} // namespace llrt
 } // namespace tt

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -4,25 +4,13 @@
 
 #pragma once
 
+#include "tt_metal/impl/device/device.hpp"
+
 namespace tt {
 
-void watcher_init(int device_id,
-                  std::function<CoreCoord ()>get_grid_size,
-                  std::function<CoreCoord (CoreCoord)>worker_from_logical,
-                  const std::function<const std::unordered_set<CoreCoord> ()> &ethernet_cores,
-                  const std::function<CoreCoord (CoreCoord)> &ethernet_from_logical
-                  );
-void watcher_attach(
-    void *dev,
-    int device_id,
-    const std::function<CoreCoord ()>& get_grid_size,
-    const std::function<CoreCoord (CoreCoord)>& worker_from_logical,
-    const std::function<const std::set<CoreCoord> &()>& storage_only_cores,
-    const std::function<const std::unordered_set<CoreCoord> ()> &ethernet_cores,
-    const std::function<CoreCoord (CoreCoord)> &ethernet_from_logical,
-    const string& log_path
-);
-void watcher_detach(void *dev);
+void watcher_init(Device *device);
+void watcher_attach(Device *device, const string& log_path);
+void watcher_detach(Device *dev);
 
 void watcher_sanitize_host_noc_read(const metal_SocDescriptor &soc_d, CoreCoord core, uint64_t addr, uint32_t len);
 void watcher_sanitize_host_noc_write(const metal_SocDescriptor &soc_d, CoreCoord core, uint64_t addr, uint32_t len);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -8,6 +8,7 @@
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "impl/debug/dprint_server.hpp"
+#include "impl/debug/watcher_server.hpp"
 #include "tt_metal/third_party/umd/device/util.hpp"
 
 
@@ -548,7 +549,7 @@ bool Device::initialize(const std::vector<uint32_t>& l1_bank_remap) {
     }
 
     DprintServerAttach(this);
-    llrt::watcher_init(this->id(),
+    watcher_init(this->id(),
                        [&, this]() { return this->logical_grid_size(); },
                        [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); },
                        [&, this]() -> const std::unordered_set<CoreCoord> { return this->get_active_ethernet_cores(); },
@@ -557,7 +558,7 @@ bool Device::initialize(const std::vector<uint32_t>& l1_bank_remap) {
 
     this->initialize_and_launch_firmware();
 
-    llrt::watcher_attach(this, this->id(),
+    watcher_attach(this, this->id(),
                          [&, this]() { return this->logical_grid_size(); },
                          [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); },
                          [&, this]() -> const std::set<CoreCoord>& { return this->storage_only_cores(); },
@@ -587,7 +588,7 @@ bool Device::close() {
         TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
     }
     this->deallocate_buffers();
-    llrt::watcher_detach(this);
+    watcher_detach(this);
     DprintServerDetach(this);
 
     // Assert worker cores

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -549,23 +549,11 @@ bool Device::initialize(const std::vector<uint32_t>& l1_bank_remap) {
     }
 
     DprintServerAttach(this);
-    watcher_init(this->id(),
-                       [&, this]() { return this->logical_grid_size(); },
-                       [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); },
-                       [&, this]() -> const std::unordered_set<CoreCoord> { return this->get_active_ethernet_cores(); },
-                       [&, this](CoreCoord core) { return this->ethernet_core_from_logical_core(core); }
-                       );
+    watcher_init(this);
 
     this->initialize_and_launch_firmware();
 
-    watcher_attach(this, this->id(),
-                         [&, this]() { return this->logical_grid_size(); },
-                         [&, this](CoreCoord core) { return this->worker_core_from_logical_core(core); },
-                         [&, this]() -> const std::set<CoreCoord>& { return this->storage_only_cores(); },
-                         [&, this]() -> const std::unordered_set<CoreCoord> { return this->get_active_ethernet_cores(); },
-                         [&, this](CoreCoord core) { return this->ethernet_core_from_logical_core(core); },
-                         build_env_.get_out_root_path()
-                         );
+    watcher_attach(this, build_env_.get_out_root_path());
 
     // Mark initialized before compiling and sending dispatch kernels to device because compilation expects device to be initialized
     this->initialized_ = true;

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -10,7 +10,6 @@
 
 #include "debug_tools.hpp"
 #include "dev_msgs.h"
-#include "llrt/watcher.hpp"
 #include "logger.hpp"
 #include "noc/noc_parameters.h"
 #include "tt_metal/detail/program.hpp"
@@ -18,6 +17,7 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/impl/buffers/semaphore.hpp"
 #include "tt_metal/impl/debug/dprint_server.hpp"
+#include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 #include "tt_metal/third_party/umd/device/tt_xy_pair.h"
 
@@ -989,11 +989,11 @@ void HWCommandQueue::finish() {
             if (DPrintServerHangDetected()) {
                 this->exit_condition = true;
                 TT_THROW("Command Queue could not finish: device hang due to unanswered DPRINT WAIT.");
-            } else if (tt::llrt::watcher_server_killed_due_to_error()) {
+            } else if (tt::watcher_server_killed_due_to_error()) {
                 this->exit_condition = true;
                 TT_THROW(
                     "Command Queue could not finish: device hang due to illegal NoC transaction. See {} for details.",
-                    tt::llrt::watcher_get_log_file_name()
+                    tt::watcher_get_log_file_name()
                 );
             }
         }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -13,14 +13,14 @@
 
 #include "third_party/magic_enum/magic_enum.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
-#include "llrt/watcher.hpp"
+#include "tt_metal/impl/debug/watcher_server.hpp"
 
 namespace tt {
 
 namespace tt_metal {
 
 Kernel::Kernel(const std::string &kernel_path_file_name, const CoreRangeSet &core_range_set, const std::vector<uint32_t> &compile_args, const std::map<std::string, std::string> &defines) :
-    watcher_kernel_id_(llrt::watcher_register_kernel(kernel_path_file_name)),
+    watcher_kernel_id_(watcher_register_kernel(kernel_path_file_name)),
     kernel_path_file_name_(kernel_path_file_name),
     core_range_set_(core_range_set),
     binary_size16_(0),

--- a/tt_metal/impl/module.mk
+++ b/tt_metal/impl/module.mk
@@ -17,7 +17,8 @@ TT_METAL_IMPL_SRCS = \
 	tt_metal/impl/dispatch/device_command.cpp \
 	tt_metal/impl/dispatch/debug_tools.cpp \
 	tt_metal/impl/dispatch/command_queue.cpp \
-	tt_metal/impl/debug/dprint_server.cpp
+	tt_metal/impl/debug/dprint_server.cpp \
+	tt_metal/impl/debug/watcher_server.cpp
 
 TT_METAL_IMPL_OBJS = $(addprefix $(OBJDIR)/, $(TT_METAL_IMPL_SRCS:.cpp=.o))
 TT_METAL_IMPL_DEPS = $(addprefix $(OBJDIR)/, $(TT_METAL_IMPL_SRCS:.cpp=.d))

--- a/tt_metal/llrt/module.mk
+++ b/tt_metal/llrt/module.mk
@@ -6,7 +6,6 @@ LLRT_CFLAGS = $(CFLAGS) -Werror -Wno-int-to-pointer-cast
 LLRT_SRCS_RELATIVE = \
 	llrt/tt_cluster.cpp \
 	llrt/llrt.cpp \
-	llrt/watcher.cpp \
 	llrt/rtoptions.cpp \
 	llrt/tt_memory.cpp \
 	llrt/tt_hexfile.cpp

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -16,7 +16,7 @@
 #include "third_party/umd/device/tt_silicon_driver_common.hpp"
 #include "tools/profiler/profiler.hpp"
 #include "tt_metal/third_party/umd/device/util.hpp"
-#include "watcher.hpp"
+#include "tt_metal/impl/debug/sanitize_noc_host.hpp"
 
 #ifdef ARCH_GRAYSKULL
 static constexpr uint32_t DYNAMIC_TLB_COUNT = 16;
@@ -438,7 +438,7 @@ void Cluster::write_core(
     chip_id_t chip_id = core.chip;
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(chip_id);
     if (tt::llrt::OptionsG.get_watcher_enabled()) {
-        tt::llrt::watcher_sanitize_host_noc_write(
+        tt::watcher_sanitize_host_noc_write(
             soc_desc, {core.x, core.y}, addr, sz_in_bytes);
     }
     tt_cxy_pair virtual_core = soc_desc.convert_to_umd_coordinates(core);
@@ -455,7 +455,7 @@ void Cluster::read_core(
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(chip_id);
 
     if (tt::llrt::OptionsG.get_watcher_enabled()) {
-        tt::llrt::watcher_sanitize_host_noc_read(
+        tt::watcher_sanitize_host_noc_read(
             soc_desc, {core.x, core.y}, addr, size_in_bytes);
     }
 
@@ -475,7 +475,7 @@ void Cluster::write_reg(const std::uint32_t *mem_ptr, tt_cxy_pair target, uint64
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(chip_id);
 
     if (tt::llrt::OptionsG.get_watcher_enabled()) {
-        tt::llrt::watcher_sanitize_host_noc_write(soc_desc, {target.x, target.y}, addr, size_in_bytes);
+        tt::watcher_sanitize_host_noc_write(soc_desc, {target.x, target.y}, addr, size_in_bytes);
     }
     tt_cxy_pair virtual_target = soc_desc.convert_to_umd_coordinates(target);
     this->get_driver(chip_id).write_to_device(mem_ptr, size_in_bytes, virtual_target, addr, "REG_TLB");
@@ -491,7 +491,7 @@ void Cluster::read_reg(std::uint32_t *mem_ptr, tt_cxy_pair target, uint64_t addr
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(chip_id);
 
     if (tt::llrt::OptionsG.get_watcher_enabled()) {
-        tt::llrt::watcher_sanitize_host_noc_read(soc_desc, {target.x, target.y}, addr, size_in_bytes);
+        tt::watcher_sanitize_host_noc_read(soc_desc, {target.x, target.y}, addr, size_in_bytes);
     }
     tt_cxy_pair virtual_target = soc_desc.convert_to_umd_coordinates(target);
     this->get_driver(chip_id).read_from_device(mem_ptr, virtual_target, addr, size_in_bytes, "REG_TLB");


### PR DESCRIPTION
Pull the watcher out of llrt (like we did with DPRINT a couple months ago) to (1) give it access to Device, and (2) make it easier to add features moving forwards.

CI passing (perf hasn't run yet, but watcher is disabled for perf so don't expect any issues there): https://github.com/tenstorrent-metal/tt-metal/actions/runs/8069195811