### PR TITLE
#5397: Noc sanitization hang recovery on eth cores

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -170,9 +170,6 @@ TEST_F(WatcherFixture, TestWatcherSanitize) {
 }
 
 TEST_F(WatcherFixture, TestWatcherSanitizeEth) {
-    // Skip this test for now until we add a way to recover from the hang.
-    log_info(LogTest, "Skip this test until we can recover from the hang on an eth core.");
-    GTEST_SKIP();
     if (this->slow_dispatch_)
         GTEST_SKIP();
     this->RunTestOnDevice(RunTestEth, this->devices_[0]);

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -32,6 +32,7 @@ enum debug_sanitize_which_riscv {
 
 #if defined(COMPILE_FOR_ERISC)
 #include "erisc.h"
+extern "C" void erisc_early_exit(std::int32_t stack_save_addr);
 #endif
 
 extern uint8_t noc_index;
@@ -79,8 +80,12 @@ inline void debug_sanitize_post_noc_addr_and_hang(uint64_t a, uint32_t l, uint32
         v[noc_index].which = debug_sanitize_get_which_riscv();
         v[noc_index].invalid = invalid;
     }
+
 #if defined(COMPILE_FOR_ERISC)
+    // For erisc, we can't hang the kernel/fw, because the core doesn't get restarted when a new
+    // kernel is written. In this case we'll do an early exit back to base FW.
     internal_::disable_erisc_app();
+    erisc_early_exit(eth_l1_mem::address_map::ERISC_MEM_MAILBOX_STACK_SAVE);
 #endif
 
     while(1) {

--- a/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
@@ -15,6 +15,7 @@ struct address_map {
   // Base addresses
   static constexpr std::int32_t FIRMWARE_BASE = 0;
   static constexpr std::int32_t ERISC_MEM_MAILBOX_BASE = 0;
+  static constexpr std::int32_t ERISC_MEM_MAILBOX_STACK_SAVE = 0;
 
   static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 0;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 0;

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -28,6 +28,8 @@ struct address_map {
   static constexpr std::int32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
   static constexpr std::int32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
   static constexpr std::int32_t ERISC_MEM_MAILBOX_BASE = COMMAND_Q_BASE - 204 - 128;
+  // erisc early exit functionality re-uses mailboxes_t::ncrisc_halt_msg_t::stack_save memory
+  static constexpr std::int32_t ERISC_MEM_MAILBOX_STACK_SAVE = ERISC_MEM_MAILBOX_BASE + 4;
 
   // TT Metal Specific
   static constexpr std::int32_t ERISC_FIRMWARE_SIZE = 2 * 1024;

--- a/tt_metal/hw/toolchain/erisc-early-exit.S
+++ b/tt_metal/hw/toolchain/erisc-early-exit.S
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+.section .text
+
+.global erisc_save_sp_and_ra
+.global erisc_early_exit
+
+/*
+    This file contains an early exit function for use in erisc kernels + erisc metal fw (not base
+    layer fw). This needs to exist so that when watcher detects an illegal noc transaction it can
+    exit from the kernel or metal fw. On brisc/ncrisc, watcher will hang the core, whichwill then
+    be recovered when a new program is written. Because erisc doesn't get deasserted when a new
+    program is written, we instead need to early exit to ensure no hang. We accomplish this by
+    saving registers to the stack when metal fw starts and saving the stack pointer to a known
+    address. Then in this early exit function we restore all registers and return to the base fw
+    layer.
+*/
+
+/* save 13 registers */
+#define CONTEXT_SIZE (13 * 4)
+
+.align 4
+.func
+erisc_early_exit:
+	lw  sp, 0( x10 )
+	/* Restore context */
+	lw  x1, 0 * 4( sp )
+	lw  x8, 1 * 4( sp )
+	lw  x9, 2 * 4( sp )
+	lw  x18, 3 * 4( sp )
+	lw  x19, 4 * 4( sp )
+	lw  x20, 5 * 4( sp )
+	lw  x21, 6 * 4( sp )
+	lw  x22, 7 * 4( sp )
+	lw  x23, 8 * 4( sp )
+	lw  x24, 9 * 4( sp )
+	lw  x25, 10 * 4( sp )
+	lw  x26, 11 * 4( sp )
+	lw  x27, 12 * 4( sp )
+
+	addi sp, sp, CONTEXT_SIZE
+
+    /* Directly return to the new return address. */
+    ret
+.endfunc

--- a/tt_metal/hw/toolchain/ncrisc-halt.S
+++ b/tt_metal/hw/toolchain/ncrisc-halt.S
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
 #include <dev_mem_map.h>
 
 .section .text

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -331,6 +331,7 @@ JitBuildEthernet::JitBuildEthernet(const JitBuildEnv& env, int which, bool is_fw
     this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
     if (this->is_fw_) {
         this->srcs_.push_back("tt_metal/hw/firmware/src/erisc.cc");
+        this->srcs_.push_back("tt_metal/hw/toolchain/erisc-early-exit.S");
     } else {
         this->srcs_.push_back("tt_metal/hw/firmware/src/erisck.cc");
         this->srcs_.push_back("tt_metal/hw/toolchain/tmu-crt0k.S");


### PR DESCRIPTION
Re-enabled the previously failing test, it passes and doesn't break subsequent tests like it used to. CI green: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8084755113