### PR TITLE
[Falcon7b] Fix remaining bugs and pcc issues for decode and add assert in perf test

### DIFF
--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -36,6 +36,7 @@ from models.utility_functions import (
     disable_persistent_kernel_cache,
     disable_compilation_reports,
     is_e75,
+    is_wormhole_b0,
 )
 from models.perf.perf_utils import prep_perf_report
 
@@ -344,6 +345,13 @@ def run_test_FalconCausalLM_end_to_end(
     logger.info(f"falcon {comment} inference time: {second_iter_time}")
     logger.info(f"falcon {comment} compile time: {compile_time}")
 
+    if does_pass:
+        logger.info("Falcon PCC Check Passed!")
+    else:
+        logger.warning("Falcon PCC Check Failed!")
+        if is_wormhole_b0():  # only assert for pcc on wormhole until grayskull pcc is fixed
+            assert does_pass, f"PCC value is lower than {pcc}"
+
 
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
@@ -365,7 +373,7 @@ def run_test_FalconCausalLM_end_to_end(
 )
 @pytest.mark.parametrize(
     "num_layers, pcc",
-    ((32, 0.86),),
+    ((32, 0.89),),
     ids=["layers_32"],
 )
 @pytest.mark.parametrize(
@@ -433,7 +441,7 @@ def test_perf_bare_metal(
 )
 @pytest.mark.parametrize(
     "num_layers, pcc",
-    ((32, 0.86),),
+    ((32, 0.89),),
     ids=["layers_32"],
 )
 @pytest.mark.parametrize(

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -712,7 +712,9 @@ Tensor falcon_dense_h_to_4h_matmul(const Tensor &input_tensor_a, const Tensor &i
         return operation::run_with_autoformat(Matmul{.bcast_batch=true, .output_mem_config=mem_config, .output_dtype=output_dtype.value_or(input_tensor_a.dtype())}, {input_tensor_a, input_tensor_b}).at(0);
     } else {
         auto program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, true, fused_activation, true, mem_config.is_sharded());
-        return operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype);
+        std::optional<const DeviceComputeKernelConfig> config = std::nullopt;
+        auto compute_kernel_config = init_device_compute_kernel_config(input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true, false, true);
+        return operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype, compute_kernel_config);
     }
 }
 

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -713,7 +713,7 @@ Tensor falcon_dense_h_to_4h_matmul(const Tensor &input_tensor_a, const Tensor &i
     } else {
         auto program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, true, fused_activation, true, mem_config.is_sharded());
         std::optional<const DeviceComputeKernelConfig> config = std::nullopt;
-        auto compute_kernel_config = init_device_compute_kernel_config(input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true, false, true);
+        auto compute_kernel_config = init_device_compute_kernel_config(input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true /* math_approx_mode */, false /* fp32_dest_acc_en */, true /* packer_l1_acc */);
         return operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype, compute_kernel_config);
     }
 }
@@ -731,7 +731,7 @@ Tensor falcon_lm_head_matmul(const Tensor &input_tensor_a, const Tensor &input_t
     } else {
         auto program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, true, std::nullopt, true, mem_config.is_sharded());
         std::optional<const DeviceComputeKernelConfig> config = std::nullopt;
-        auto compute_kernel_config = init_device_compute_kernel_config(input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true, false, true);
+        auto compute_kernel_config = init_device_compute_kernel_config(input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true /* math_approx_mode */, false /* fp32_dest_acc_en */, true /* packer_l1_acc */);
         return operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype, compute_kernel_config);
     }
 }

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -730,7 +730,9 @@ Tensor falcon_lm_head_matmul(const Tensor &input_tensor_a, const Tensor &input_t
         return operation::run_with_autoformat(Matmul{.bcast_batch=true, .output_mem_config=mem_config, .output_dtype=output_dtype.value_or(input_tensor_a.dtype())}, {input_tensor_a, input_tensor_b}, {bias}).at(0);
     } else {
         auto program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, true, std::nullopt, true, mem_config.is_sharded());
-        return operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype);
+        std::optional<const DeviceComputeKernelConfig> config = std::nullopt;
+        auto compute_kernel_config = init_device_compute_kernel_config(input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true, false, true);
+        return operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype, compute_kernel_config);
     }
 }
 


### PR DESCRIPTION
- Enable packer_l1_acc for h-to-4h matmul and lm-head matmul to fix remaining pcc drops (rest of drop comes from gelu [issue #5578](https://github.com/tenstorrent-metal/tt-metal/issues/5578), which if removed from both HF and tt-metal models, results in pcc=0.999 for decode with kv cache size 2047)
- Fix bug where cached cos/sin tensors were loaded and used even if shapes did not match
- Add assert to check pcc in falcon7b perf test to prevent future regressions (only enabled on wormhole for now)