### PR TITLE
#5483: Add reduction ops to ttnn

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 522
+personal_ws-1.1 en 525
 ABI
 ADDI
 API
@@ -57,9 +57,9 @@ ENDL
 ETH
 EltwiseUnary
 EnqueueProgram
+EnqueueReadBuffer
 EnqueueRecordEvent
 EnqueueWaitForEvent
-EnqueueReadBuffer
 EnqueueWriteBuffer
 Enum
 Enums

--- a/docs/source/ttnn/api.rst
+++ b/docs/source/ttnn/api.rst
@@ -187,6 +187,8 @@ Pointwise Binary
    ttnn/isclose
    ttnn/polyval
    ttnn/nextafter
+   ttnn/maximum
+   ttnn/minimum
 
 Pointwise Ternary
 =================
@@ -214,8 +216,11 @@ Reduction
 .. toctree::
    :maxdepth: 1
 
+   ttnn/max
    ttnn/mean
+   ttnn/min
    ttnn/std
+   ttnn/sum
    ttnn/var
 
 Data Movement

--- a/docs/source/ttnn/ttnn/max.rst
+++ b/docs/source/ttnn/ttnn/max.rst
@@ -1,0 +1,6 @@
+.. _ttnn.max:
+
+ttnn.max
+###############
+
+.. autofunction:: ttnn.max

--- a/docs/source/ttnn/ttnn/maximum.rst
+++ b/docs/source/ttnn/ttnn/maximum.rst
@@ -1,0 +1,6 @@
+.. _ttnn.maximum:
+
+ttnn.maximum
+###############
+
+.. autofunction:: ttnn.maximum

--- a/docs/source/ttnn/ttnn/min.rst
+++ b/docs/source/ttnn/ttnn/min.rst
@@ -1,0 +1,6 @@
+.. _ttnn.min:
+
+ttnn.min
+###############
+
+.. autofunction:: ttnn.min

--- a/docs/source/ttnn/ttnn/minimum.rst
+++ b/docs/source/ttnn/ttnn/minimum.rst
@@ -1,0 +1,6 @@
+.. _ttnn.minimum:
+
+ttnn.minimum
+###############
+
+.. autofunction:: ttnn.minimum

--- a/docs/source/ttnn/ttnn/sum.rst
+++ b/docs/source/ttnn/ttnn/sum.rst
@@ -1,0 +1,6 @@
+.. _ttnn.sum:
+
+ttnn.sum
+###############
+
+.. autofunction:: ttnn.sum

--- a/tests/ttnn/sweep_tests/sweeps/max.py
+++ b/tests/ttnn/sweep_tests/sweeps/max.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 64],
+    "width": [64, 64],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+    "dim": [
+        -1,
+        -2,
+        None,
+    ],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    dim,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100
+    high = 100
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+
+    if dim == None:
+        torch_output_tensor = torch.max(torch_input_tensor)
+    else:
+        torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    if dim == None:
+        output_tensor = ttnn.max(input_tensor)
+    else:
+        output_tensor = ttnn.max(input_tensor, dim=dim, memory_config=output_memory_config)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    if dim == None:
+        output_tensor = output_tensor[0, 0, 0, 0]
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/maximum.py
+++ b/tests/ttnn/sweep_tests/sweeps/maximum.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [32, 1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100
+    high = 100
+
+    torch_input_tensor_a = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_output_tensor = torch.maximum(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.maximum(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/min.py
+++ b/tests/ttnn/sweep_tests/sweeps/min.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 64],
+    "width": [64, 64],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+    "dim": [
+        -1,
+        -2,
+        None,
+    ],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    dim,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100
+    high = 100
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+
+    if dim == None:
+        torch_output_tensor = torch.min(torch_input_tensor)
+    else:
+        torch_output_tensor, _ = torch.min(torch_input_tensor, dim=dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+
+    if dim == None:
+        output_tensor = ttnn.min(input_tensor)
+    else:
+        output_tensor = ttnn.min(input_tensor, dim=dim, memory_config=output_memory_config)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    if dim == None:
+        output_tensor = output_tensor[0, 0, 0, 0]
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/minimum.py
+++ b/tests/ttnn/sweep_tests/sweeps/minimum.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [32, 1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100
+    high = 100
+
+    torch_input_tensor_a = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_output_tensor = torch.minimum(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.minimum(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/sum.py
+++ b/tests/ttnn/sweep_tests/sweeps/sum.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 64],
+    "width": [64, 64],
+    "input_dtype": [ttnn.bfloat16],
+    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "layout": [ttnn.TILE_LAYOUT],
+    "dim": [
+        -1,
+        -2,
+        (2, 1),
+        None,
+    ],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    dim,
+    layout,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -100
+    high = 100
+
+    torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    if dim == None:
+        torch_output_tensor = torch.sum(torch_input_tensor)
+    else:
+        torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=True)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
+    )
+    if dim == None:
+        output_tensor = ttnn.sum(input_tensor)
+    else:
+        output_tensor = ttnn.sum(input_tensor, dim=dim, memory_config=output_memory_config)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    if dim == None:
+        output_tensor = output_tensor[0, 0, 0, 0]
+
+    return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_max.py
+++ b/tests/ttnn/unit_tests/operations/test_max.py
@@ -15,37 +15,39 @@ from models.utility_functions import torch_random
 @pytest.mark.parametrize("h", [32, 64])
 @pytest.mark.parametrize("w", [32, 64])
 @pytest.mark.parametrize("dim", [-1, -2])
-def test_std(device, batch_size, h, w, dim):
+def test_max(device, batch_size, h, w, dim):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.std(torch_input_tensor, dim=dim, keepdim=True)
+    torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
+    torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim, keepdim=True)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.std(input_tensor, dim=dim)
+    output_tensor = ttnn.max(input_tensor, dim=dim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+
+    assert_with_pcc(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
 @pytest.mark.parametrize("h", [32, 64])
 @pytest.mark.parametrize("w", [32, 64])
-@pytest.mark.parametrize("dim", [-1, -2])
-def test_var(device, batch_size, h, w, dim):
+def test_max_global(device, batch_size, h, w):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.var(torch_input_tensor, dim=dim, keepdim=True)
+    torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
+    torch_output_tensor = torch.max(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.var(input_tensor, dim=dim)
+    output_tensor = ttnn.max(input_tensor)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    output_tensor = output_tensor[0, 0, 0, 0]
+
+    assert_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_min.py
+++ b/tests/ttnn/unit_tests/operations/test_min.py
@@ -15,37 +15,38 @@ from models.utility_functions import torch_random
 @pytest.mark.parametrize("h", [32, 64])
 @pytest.mark.parametrize("w", [32, 64])
 @pytest.mark.parametrize("dim", [-1, -2])
-def test_std(device, batch_size, h, w, dim):
+def test_min(device, batch_size, h, w, dim):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.std(torch_input_tensor, dim=dim, keepdim=True)
+    torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
+    torch_output_tensor, _ = torch.min(torch_input_tensor, dim=dim, keepdim=True)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.std(input_tensor, dim=dim)
+    output_tensor = ttnn.min(input_tensor, dim=dim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    assert_with_pcc(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
 @pytest.mark.parametrize("h", [32, 64])
 @pytest.mark.parametrize("w", [32, 64])
-@pytest.mark.parametrize("dim", [-1, -2])
-def test_var(device, batch_size, h, w, dim):
+def test_min_global(device, batch_size, h, w):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.var(torch_input_tensor, dim=dim, keepdim=True)
+    torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
+    torch_output_tensor = torch.min(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.var(input_tensor, dim=dim)
+    output_tensor = ttnn.min(input_tensor)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    output_tensor = output_tensor[0, 0, 0, 0]
+
+    assert_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/test_sum.py
@@ -14,38 +14,39 @@ from models.utility_functions import torch_random
 @pytest.mark.parametrize("batch_size", [1, 16])
 @pytest.mark.parametrize("h", [32, 64])
 @pytest.mark.parametrize("w", [32, 64])
-@pytest.mark.parametrize("dim", [-1, -2])
-def test_std(device, batch_size, h, w, dim):
+@pytest.mark.parametrize("dim", [-1, -2, (2, 1)])
+def test_sum(device, batch_size, h, w, dim):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.std(torch_input_tensor, dim=dim, keepdim=True)
+    torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=True)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.std(input_tensor, dim=dim)
+    output_tensor = ttnn.sum(input_tensor, dim=dim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    assert_with_pcc(torch_output_tensor, output_tensor)
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
 @pytest.mark.parametrize("h", [32, 64])
 @pytest.mark.parametrize("w", [32, 64])
-@pytest.mark.parametrize("dim", [-1, -2])
-def test_var(device, batch_size, h, w, dim):
+def test_sum_global(device, batch_size, h, w):
     torch.manual_seed(0)
 
-    torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.var(torch_input_tensor, dim=dim, keepdim=True)
+    torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
+    torch_output_tensor = torch.sum(torch_input_tensor)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.var(input_tensor, dim=dim)
+    output_tensor = ttnn.sum(input_tensor)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+    output_tensor = output_tensor[0, 0, 0, 0]
+
+    assert_with_pcc(torch_output_tensor, output_tensor)

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -138,6 +138,9 @@ from ttnn.operations.creation import (
 from ttnn.operations.reduction import (
     std,
     var,
+    max,
+    min,
+    sum,
 )
 
 from ttnn.operations.losses import (
@@ -196,6 +199,8 @@ from ttnn.operations.binary import (
     add_and_apply_activation_,
     nextafter,
     polyval,
+    maximum,
+    minimum,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -586,6 +586,8 @@ def register_ttl_elt_binary_function(name, ttl_elt_binary_function, op_name):
             "logical_or": torch.logical_or,
             "logical_xor": torch.logical_xor,
             "xlogy": torch.xlogy,
+            "maximum": torch.maximum,
+            "minimum": torch.minimum,
         }
         input_shape_a = input_tensor_a.shape
         slices = [slice(0, dim) for dim in input_shape_a]
@@ -693,6 +695,8 @@ TTL_BINARY_ELTWISE_FUNCTIONS = [
     ("logical_or", ttl.tensor.logical_or, "logical OR (input_a || input_b)"),
     ("logical_xor", ttl.tensor.logical_xor, "logical XOR (input_a ^ input_b) "),
     ("xlogy", ttl.tensor.xlogy, "xlogy (input_a * log( input_b ))"),
+    ("maximum", ttl.tensor.max, "maximum "),
+    ("minimum", ttl.tensor.min, "minimum "),
 ]
 
 

--- a/ttnn/ttnn/operations/reduction.py
+++ b/ttnn/ttnn/operations/reduction.py
@@ -40,11 +40,10 @@ def _std_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
 def std(
     input_tensor: ttnn.Tensor,
     dim: Union[int, Tuple[int]],
-    keepdim: bool = False,
     memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
 ) -> ttnn.Tensor:
     """
-    std(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int]], keepdim: bool = False) -> ttnn.Tensor
+    std(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int]]) -> ttnn.Tensor
     """
 
     input_shape = tuple(input_tensor.shape)
@@ -71,9 +70,8 @@ def std(
     padded_output_shape = []
     for axis, size in enumerate(input_shape):
         if axis in dim:
-            if keepdim:
-                output_shape.append(1)
-                padded_output_shape.append(ttnn.TILE_SIZE)
+            output_shape.append(1)
+            padded_output_shape.append(ttnn.TILE_SIZE)
         else:
             output_shape.append(size)
             padded_output_shape.append(size)
@@ -125,11 +123,10 @@ def _var_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
 def var(
     input_tensor: ttnn.Tensor,
     dim: Union[int, Tuple[int]],
-    keepdim: bool = False,
     memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
 ) -> ttnn.Tensor:
     """
-    var(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int]], keepdim: bool = False) -> ttnn.Tensor
+    var(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int]]) -> ttnn.Tensor
     """
 
     input_shape = tuple(input_tensor.shape)
@@ -156,9 +153,8 @@ def var(
     padded_output_shape = []
     for axis, size in enumerate(input_shape):
         if axis in dim:
-            if keepdim:
-                output_shape.append(1)
-                padded_output_shape.append(ttnn.TILE_SIZE)
+            output_shape.append(1)
+            padded_output_shape.append(ttnn.TILE_SIZE)
         else:
             output_shape.append(size)
             padded_output_shape.append(size)
@@ -175,6 +171,269 @@ def var(
     variance_tensor = ttl.tensor.sub(mean_square_tensor, ttl.tensor.pow(mean_tensor, 2.0))
 
     output_tensor = ttnn.Tensor(variance_tensor)
+    output_tensor = ttnn.reshape(output_tensor, ttnn.Shape(output_shape, padded_output_shape))
+
+    return output_tensor
+
+
+def _torch_max(input_tensor: ttnn.Tensor, dim: Union[int, None], keepdim=False, **_):
+    import torch
+
+    input_tensor = ttnn.from_device(input_tensor)
+    input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    input_tensor = ttnn.to_torch(input_tensor)
+
+    if dim == None:
+        return torch.max(input_tensor)
+    else:
+        return torch.max(input_tensor, dim=dim, keepdim=keepdim)
+
+
+def _max_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+    ttnn.validate_input_tensor(
+        operation_name,
+        input_tensor,
+        ranks=(2, 3, 4),
+        dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+        layouts=(ttnn.TILE_LAYOUT,),
+        can_be_on_device=True,
+        can_be_on_cpu=False,
+    )
+
+
+@ttnn.register_operation(
+    name="ttnn.max",
+    validate_input_tensors=_max_validate_input_tensors,
+    torch_function=_torch_max,
+)
+def max(
+    input_tensor: ttnn.Tensor,
+    dim: Union[int, Tuple[int], None] = None,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    """
+    max(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int], None]) -> ttnn.Tensor
+    """
+
+    input_shape = tuple(input_tensor.shape)
+    rank = len(input_shape)
+
+    if dim == None:
+        input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+        ttl_input_tensor = input_tensor.value
+        ttl_output_tensor = ttl.tensor.global_max(ttl_input_tensor)
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        return output_tensor
+
+    if isinstance(dim, int):
+        if dim < 0:
+            dim = rank + dim
+        dim = (dim,)
+
+    if isinstance(dim, tuple):
+        if dim == (rank - 1,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.W
+        elif dim == (rank - 2,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.H
+        elif dim == (rank - 1, rank - 2):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.HW
+        else:
+            raise RuntimeError("Unsupported dim")
+    else:
+        raise RuntimeError("Invalid dim")
+
+    output_shape = []
+    padded_output_shape = []
+    for axis, size in enumerate(input_shape):
+        if axis in dim:
+            output_shape.append(1)
+            padded_output_shape.append(ttnn.TILE_SIZE)
+        else:
+            output_shape.append(size)
+            padded_output_shape.append(size)
+    output_shape = tuple(output_shape)
+    padded_output_shape = tuple(padded_output_shape)
+
+    input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+    ttl_input_tensor = input_tensor.value
+    ttl_output_tensor = ttl.tensor.reduce(ttl_input_tensor, ttl.tensor.ReduceOpMath.MAX, reduce_op_dim, 1.0)
+
+    output_tensor = ttnn.Tensor(ttl_output_tensor)
+    output_tensor = ttnn.reshape(output_tensor, ttnn.Shape(output_shape, padded_output_shape))
+
+    return output_tensor
+
+
+def _torch_min(input_tensor: ttnn.Tensor, dim: Union[int, None], keepdim=False, **_):
+    import torch
+
+    input_tensor = ttnn.from_device(input_tensor)
+    input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    input_tensor = ttnn.to_torch(input_tensor)
+
+    if dim == None:
+        return torch.min(input_tensor)
+    else:
+        return torch.min(input_tensor, dim=dim, keepdim=keepdim)
+
+
+def _min_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+    ttnn.validate_input_tensor(
+        operation_name,
+        input_tensor,
+        ranks=(2, 3, 4),
+        dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+        layouts=(ttnn.TILE_LAYOUT,),
+        can_be_on_device=True,
+        can_be_on_cpu=False,
+    )
+
+
+@ttnn.register_operation(
+    name="ttnn.min",
+    validate_input_tensors=_min_validate_input_tensors,
+    torch_function=_torch_min,
+)
+def min(
+    input_tensor: ttnn.Tensor,
+    dim: Union[int, Tuple[int], None] = None,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    """
+    min(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int], None]) -> ttnn.Tensor
+    """
+
+    input_shape = tuple(input_tensor.shape)
+    rank = len(input_shape)
+
+    if dim == None:
+        input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+        ttl_input_tensor = input_tensor.value
+        ttl_output_tensor = ttl.tensor.global_min(ttl_input_tensor)
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        return output_tensor
+
+    if isinstance(dim, int):
+        if dim < 0:
+            dim = rank + dim
+        dim = (dim,)
+
+    if isinstance(dim, tuple):
+        if dim == (rank - 1,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.W
+        elif dim == (rank - 2,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.H
+        elif dim == (rank - 1, rank - 2):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.HW
+        else:
+            raise RuntimeError("Unsupported dim")
+    else:
+        raise RuntimeError("Invalid dim")
+
+    output_shape = []
+    padded_output_shape = []
+    for axis, size in enumerate(input_shape):
+        if axis in dim:
+            output_shape.append(1)
+            padded_output_shape.append(ttnn.TILE_SIZE)
+        else:
+            output_shape.append(size)
+            padded_output_shape.append(size)
+    output_shape = tuple(output_shape)
+    padded_output_shape = tuple(padded_output_shape)
+
+    input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+    ttl_input_tensor = input_tensor.value
+    ttl_output_tensor = ttl.tensor.reduce(ttl_input_tensor, ttl.tensor.ReduceOpMath.MIN, reduce_op_dim, 1.0)
+
+    output_tensor = ttnn.Tensor(ttl_output_tensor)
+    output_tensor = ttnn.reshape(output_tensor, ttnn.Shape(output_shape, padded_output_shape))
+
+    return output_tensor
+
+
+def _torch_sum(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int], None] = None, keepdim=False, **_):
+    import torch
+
+    input_tensor = ttnn.from_device(input_tensor)
+    input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    input_tensor = ttnn.to_torch(input_tensor)
+    if dim == None:
+        return torch.sum(input_tensor)
+    else:
+        return torch.sum(input_tensor, dim=dim, keepdim=keepdim)
+
+
+def _sum_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+    ttnn.validate_input_tensor(
+        operation_name,
+        input_tensor,
+        ranks=(2, 3, 4),
+        dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+        layouts=(ttnn.TILE_LAYOUT,),
+        can_be_on_device=True,
+        can_be_on_cpu=False,
+    )
+
+
+@ttnn.register_operation(
+    name="ttnn.sum",
+    validate_input_tensors=_sum_validate_input_tensors,
+    torch_function=_torch_sum,
+)
+def sum(
+    input_tensor: ttnn.Tensor,
+    dim: Union[int, Tuple[int], None] = None,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    """
+    sum(input_tensor: ttnn.Tensor, dim: Union[int, Tuple[int], None]) -> ttnn.Tensor
+    """
+
+    input_shape = tuple(input_tensor.shape)
+    rank = len(input_shape)
+
+    if dim == None:
+        input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+        ttl_input_tensor = input_tensor.value
+        ttl_output_tensor = ttl.tensor.global_sum(ttl_input_tensor)
+        output_tensor = ttnn.Tensor(ttl_output_tensor)
+        return output_tensor
+
+    if isinstance(dim, int):
+        if dim < 0:
+            dim = rank + dim
+        dim = (dim,)
+
+    if isinstance(dim, tuple):
+        if dim == (rank - 1,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.W
+        elif dim == (rank - 2,):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.H
+        elif dim == (rank - 1, rank - 2):
+            reduce_op_dim = ttl.tensor.ReduceOpDim.HW
+        else:
+            raise RuntimeError("Unsupported dim")
+    else:
+        raise RuntimeError("Invalid dim")
+
+    output_shape = []
+    padded_output_shape = []
+    for axis, size in enumerate(input_shape):
+        if axis in dim:
+            output_shape.append(1)
+            padded_output_shape.append(ttnn.TILE_SIZE)
+        else:
+            output_shape.append(size)
+            padded_output_shape.append(size)
+    output_shape = tuple(output_shape)
+    padded_output_shape = tuple(padded_output_shape)
+
+    input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
+    ttl_input_tensor = input_tensor.value
+    ttl_output_tensor = ttl.tensor.reduce(ttl_input_tensor, ttl.tensor.ReduceOpMath.SUM, reduce_op_dim, 1.0)
+
+    output_tensor = ttnn.Tensor(ttl_output_tensor)
     output_tensor = ttnn.reshape(output_tensor, ttnn.Shape(output_shape, padded_output_shape))
 
     return output_tensor


### PR DESCRIPTION
Add reduction ops to ttnn
Fixed unit tests

CI tests: 
Fast Dispatch: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8094776165
Slow Dispatch: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8094785050

Sweep tests: 
[max.csv](https://github.com/tenstorrent-metal/tt-metal/files/14447348/max.csv)
[maximum.csv](https://github.com/tenstorrent-metal/tt-metal/files/14447349/maximum.csv)
[min.csv](https://github.com/tenstorrent-metal/tt-metal/files/14447350/min.csv)
[minimum.csv](https://github.com/tenstorrent-metal/tt-metal/files/14447351/minimum.csv)
[sum.csv](https://github.com/tenstorrent-metal/tt-metal/files/14447352/sum.csv)
