### PR TITLE
#5529: Rename recently added Events APIs (EnqueueQueue_* -> Enqueue_*)

### DIFF
--- a/docs/aspell-dictionary.pws
+++ b/docs/aspell-dictionary.pws
@@ -57,8 +57,8 @@ ENDL
 ETH
 EltwiseUnary
 EnqueueProgram
-EnqueueQueueRecordEvent
-EnqueueQueueWaitForEvent
+EnqueueRecordEvent
+EnqueueWaitForEvent
 EnqueueReadBuffer
 EnqueueWriteBuffer
 Enum

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueQueueRecordEvent.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueQueueRecordEvent.rst
@@ -1,4 +1,0 @@
-EnqueueQueueRecordEvent
-=======================
-
-.. doxygenfunction:: EnqueueQueueRecordEvent(CommandQueue& cq, Event &event)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueQueueWaitForEvent.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueQueueWaitForEvent.rst
@@ -1,4 +1,0 @@
-EnqueueQueueWaitForEvent
-========================
-
-.. doxygenfunction:: EnqueueQueueWaitForEvent(CommandQueue& cq, Event &event)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueRecordEvent.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueRecordEvent.rst
@@ -1,0 +1,4 @@
+EnqueueRecordEvent
+==================
+
+.. doxygenfunction:: EnqueueRecordEvent(CommandQueue& cq, Event &event)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueWaitForEvent.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueWaitForEvent.rst
@@ -1,0 +1,4 @@
+EnqueueWaitForEvent
+===================
+
+.. doxygenfunction:: EnqueueWaitForEvent(CommandQueue& cq, Event &event)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/command_queue.rst
@@ -5,7 +5,7 @@ CommandQueue
   EnqueueWriteBuffer
   EnqueueReadBuffer
   EnqueueProgram
-  EnqueueQueueRecordEvent
-  EnqueueQueueWaitForEvent
+  EnqueueRecordEvent
+  EnqueueWaitForEvent
   EventSynchronize
   Finish

--- a/tt_eager/queue/queue.hpp
+++ b/tt_eager/queue/queue.hpp
@@ -26,8 +26,8 @@ void EnqueueDeviceToHostTransfer(
     const std::optional<std::size_t> transfer_size = std::nullopt,
     size_t src_offset = 0);
 
-void EnqueueQueueRecordEvent(CommandQueue&, Event&);
-void EnqueueQueueWaitForEvent(CommandQueue&, Event&);
+void EnqueueRecordEvent(CommandQueue&, Event&);
+void EnqueueWaitForEvent(CommandQueue&, Event&);
 void EventSynchronize(Event&);
 void QueueSynchronize(CommandQueue&);
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -406,7 +406,7 @@ void DumpDeviceProfileResults(Device *device, const Program &program);
  * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
  * | event        | An event that will be populated by this function, and inserted in CQ   | Event &                       |                                    | Yes      |
  */
-void EnqueueQueueRecordEvent(CommandQueue& cq, Event &event);
+void EnqueueRecordEvent(CommandQueue& cq, Event &event);
 
 /**
  * Enqueues a command on the device for a given CQ (non-blocking). The command on device will block and wait for completion of the specified event (which may be in another CQ).
@@ -417,7 +417,7 @@ void EnqueueQueueRecordEvent(CommandQueue& cq, Event &event);
  * |              | and waits for the event to complete.                                   |                               |                                    |          |
  * | event        | The event object that this CQ will wait on for completion.             | Event &                       |                                    | Yes      |
  */
-void EnqueueQueueWaitForEvent(CommandQueue& cq, Event &event);
+void EnqueueWaitForEvent(CommandQueue& cq, Event &event);
 
 /**
  * Blocking function for host to synchronize (wait) on an event completion on device.

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1248,10 +1248,10 @@ void EnqueueProgramImpl(CommandQueue& cq, std::variant < std::reference_wrapper<
     }, program);
 }
 
-void EnqueueQueueRecordEvent(CommandQueue& cq, Event &event) {
-    TT_ASSERT(event.device == nullptr, "EnqueueQueueRecordEvent expected to be given an uninitialized event");
-    TT_ASSERT(event.event_id == -1, "EnqueueQueueRecordEvent expected to be given an uninitialized event");
-    TT_ASSERT(event.cq_id == -1, "EnqueueQueueRecordEvent expected to be given an uninitialized event");
+void EnqueueRecordEvent(CommandQueue& cq, Event &event) {
+    TT_ASSERT(event.device == nullptr, "EnqueueRecordEvent expected to be given an uninitialized event");
+    TT_ASSERT(event.event_id == -1, "EnqueueRecordEvent expected to be given an uninitialized event");
+    TT_ASSERT(event.cq_id == -1, "EnqueueRecordEvent expected to be given an uninitialized event");
 
     detail::DispatchStateCheck(true);
     cq.hw_command_queue().populate_record_event(event);
@@ -1267,11 +1267,11 @@ void EnqueueRecordEventImpl(CommandQueue& cq, std::reference_wrapper<Event> even
 }
 
 
-void EnqueueQueueWaitForEvent(CommandQueue& cq, Event &event) {
-    TT_ASSERT(event.device != nullptr, "EnqueueQueueRecordEvent expected to be given Event with initialized device ptr");
-    TT_ASSERT(event.event_id != -1, "EnqueueQueueWaitForEvent expected to be given Event with initialized event_id");
-    TT_ASSERT(event.cq_id != -1, "EnqueueQueueWaitForEvent expected to be given Event with initialized cq_id");
-    log_trace(tt::LogMetal, "EnqueueQueueWaitForEvent() issued on Event(device_id: {} cq_id: {} event_id: {}) from device_id: {} cq_id: {}",
+void EnqueueWaitForEvent(CommandQueue& cq, Event &event) {
+    TT_ASSERT(event.device != nullptr, "EnqueueRecordEvent expected to be given Event with initialized device ptr");
+    TT_ASSERT(event.event_id != -1, "EnqueueWaitForEvent expected to be given Event with initialized event_id");
+    TT_ASSERT(event.cq_id != -1, "EnqueueWaitForEvent expected to be given Event with initialized cq_id");
+    log_trace(tt::LogMetal, "EnqueueWaitForEvent() issued on Event(device_id: {} cq_id: {} event_id: {}) from device_id: {} cq_id: {}",
         event.device->id(), event.cq_id, event.event_id, cq.device()->id(), cq.id());
 
     detail::DispatchStateCheck(true);

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -487,7 +487,7 @@ class HWCommandQueue {
     friend void EnqueueRecordEventImpl(CommandQueue& cq, std::reference_wrapper<Event> event);
     friend void EnqueueWaitForEventImpl(CommandQueue& cq, std::reference_wrapper<Event> event);
     friend void FinishImpl(CommandQueue & cq);
-    friend void EnqueueQueueRecordEvent(CommandQueue& cq, Event &event);
+    friend void EnqueueRecordEvent(CommandQueue& cq, Event &event);
     friend class Trace;
 };
 


### PR DESCRIPTION
 - EnqueueQueueRecordEvent()  is now EnqueueRecordEvent()
 - EnqueueQueueWaitForEvent() is now EnqueueWaitForEvent()
 - Late request after previous merge.
 - Update functions, comments, filenames, etc.
 
 regenerated html docs and viewed in web, look good.  Events tests continue to pass. Probably won't run much more since was simple search and replace.
 
 Also ran this, all passing as expected (this includes my Events tests):
 
 ```
./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type post_commit --dispatch-mode fast-multi-queue-single-device |& tee post_commit_fd_multi_queue_tests.log
./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type post_commit --dispatch-mode fast |& tee post_commit_fd_test.log 
 ```