### PR TITLE
#5901: Add CB wait front and reserve back total times to op report

### DIFF
--- a/docs/source/ttnn/profiling_ttnn_operations.rst
+++ b/docs/source/ttnn/profiling_ttnn_operations.rst
@@ -83,6 +83,18 @@ The headers of the columns with their descriptions is below:
 
 - **DEVICE TRISC2 KERNEL DURATION [ns]**: Kernel duration on the device for the OP, calculated as (last Kernel end cycle - first Kernel start cycle)/core_frequency with cycle markers chosen across TRISC2s of all cores
 
+- **DEVICE COMPUTE CB WAIT FRONT [ns]**: Total time spent on ``cb_wait_front`` on TRISC0, averaged across all cores
+
+- **DEVICE COMPUTE CB RESERVE BACK [ns]**: Total time spent on ``cb_reserve_back`` on TRISC2, averaged across all cores
+
+- **COMPUTE KERNEL PATH**: Path of the compute kernels in the program
+
+- **COMPUTE KERNEL HASH**: Kernel hash for compute kernel cache
+
+- **DATAMOVEMENT KERNEL PATH**: Path of the datamovement kernels in the program
+
+- **DATAMOVEMENT KERNEL HASH**: Kernel hash for datamovement kernel cache
+
 - **Input & Output Tensor Headers**: Header template is {Input/Output}_{IO Number}_{Field}. e.g. INPUT_0_MEMORY
 
     - *W*: Tensor batch count

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -34,7 +34,6 @@ run_post_proc_test(){
     export PYTHONPATH=$TT_METAL_HOME
 
     pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_logs.py -vvv
-    pytest $PROFILER_TEST_SCRIPTS_ROOT/test_unaryop_profiler.py -vvv
 }
 
 run_tracy_test(){

--- a/tt_metal/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/profiler_common.h
@@ -14,6 +14,11 @@
 #define CC_KERNEL_MAIN_END     3U
 #define CC_MAIN_END            4U
 
+#define GLOBAL_SUM_MARKER      3000U
+#define GLOBAL_SUM_COUNT       2U
+#define CB_WAIT_FRONT_MARKER   0U
+#define CB_RESERVE_BACK_MARKER 1U
+
 namespace kernel_profiler{
 /**
  * L1 buffer structure for profiler markers

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_pack.h
@@ -23,7 +23,7 @@ inline void llk_setup_outputs() {
 // Blocking call to wait for free space needed to pack N tiles
 template <bool skip_sync = false, bool wait_for_blocks = false, bool brisc_pack = false>
 inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
-
+    kernel_profiler::mark_function_sum_start(CB_RESERVE_BACK_MARKER);
     std::uint32_t output = operand;
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
@@ -43,6 +43,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         std::uint16_t free_tiles_wrap = cb_interface[output].fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t) free_tiles_wrap;
     } while (free_tiles < num_tiles);
+    kernel_profiler::mark_function_sum_end(CB_RESERVE_BACK_MARKER);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_unpack.h
@@ -37,7 +37,7 @@ inline void llk_setup_operands() {
 
 // Wait for N tiles available in the incoming stream
 inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
-
+    kernel_profiler::mark_function_sum_start(CB_WAIT_FRONT_MARKER);
     std::uint32_t input = operand;
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
@@ -49,7 +49,7 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
         tiles_received = (std::uint16_t) reg_read((std::uint32_t)tiles_received_ptr);
         num_tiles_recv = tiles_received - cb_interface[input].tiles_acked;
     } while (num_tiles_recv < num_tiles_u);
-
+    kernel_profiler::mark_function_sum_end(CB_WAIT_FRONT_MARKER);
 }
 
 // Pop N tiles from the incoming stream

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -43,7 +43,7 @@ inline void llk_setup_outputs() {
 // Blocking call to wait for free space needed to pack N tiles
 template <bool skip_sync = false, bool wait_for_blocks = false, bool brisc_pack = false>
 inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
-
+    kernel_profiler::mark_function_sum_start(CB_RESERVE_BACK_MARKER);
     std::uint32_t output = operand;
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
@@ -63,6 +63,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         std::uint32_t free_tiles_wrap = cb_interface[output].fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t) free_tiles_wrap;
     } while (free_tiles < num_tiles);
+    kernel_profiler::mark_function_sum_end(CB_RESERVE_BACK_MARKER);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -38,7 +38,7 @@ inline void llk_setup_operands() {
 
 // Wait for N tiles available in the incoming stream
 inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
-
+    kernel_profiler::mark_function_sum_start(CB_WAIT_FRONT_MARKER);
     std::uint32_t input = operand;
     volatile tt_l1_ptr std::uint32_t * tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
@@ -50,7 +50,7 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
         tiles_received = (std::uint16_t) reg_read((std::uint32_t)tiles_received_ptr);
         num_tiles_recv = tiles_received - cb_interface[input].tiles_acked;
     } while (num_tiles_recv < num_tiles_u);
-
+    kernel_profiler::mark_function_sum_end(CB_WAIT_FRONT_MARKER);
 }
 
 // Pop N tiles from the incoming stream

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -60,6 +60,8 @@ CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
 namespace kernel_profiler {
 uint32_t wIndex __attribute__((used));
+uint32_t device_function_sums[GLOBAL_SUM_COUNT] __attribute__((used)) = {0};
+uint64_t device_function_starts[GLOBAL_SUM_COUNT] __attribute__((used)) = {0};
 }
 
 void enable_power_management() {
@@ -345,6 +347,7 @@ int main() {
 
         mailboxes->launch.run = RUN_MSG_DONE;
 
+        kernel_profiler::store_function_sums();
         // Not including any dispatch related code
         kernel_profiler::mark_time(CC_MAIN_END);
 

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -28,6 +28,8 @@ void ApplicationHandler(void) __attribute__((__section__(".init")));
 
 namespace kernel_profiler {
 uint32_t wIndex __attribute__((used));
+uint32_t device_function_sums[GLOBAL_SUM_COUNT] __attribute__((used)) = {0};
+uint64_t device_function_starts[GLOBAL_SUM_COUNT] __attribute__((used)) = {0};
 }
 
 uint8_t noc_index = 0;  // TODO: remove hardcoding
@@ -124,6 +126,7 @@ void __attribute__((section("erisc_l1_code"))) Application(void) {
             kernel_profiler::init_profiler();
             kernel_profiler::mark_time(CC_MAIN_START);
             kernel_init();
+            kernel_profiler::store_function_sums();
             kernel_profiler::mark_time(CC_MAIN_END);
             DEBUG_STATUS('D');
         }

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -30,6 +30,8 @@ CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
 namespace kernel_profiler {
 uint32_t wIndex __attribute__((used));
+uint32_t device_function_sums[GLOBAL_SUM_COUNT] __attribute__((used)) = {0};
+uint64_t device_function_starts[GLOBAL_SUM_COUNT] __attribute__((used)) = {0};
 }
 
 extern "C" void ncrisc_resume(void);
@@ -61,7 +63,7 @@ int main(int argc, char *argv[]) {
       DEBUG_STATUS('R');
       kernel_init();
       DEBUG_STATUS('D');
-
+      kernel_profiler::store_function_sums();
       kernel_profiler::mark_time(CC_MAIN_END);
   }
 

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -16,6 +16,8 @@
 
 namespace kernel_profiler {
 uint32_t wIndex __attribute__((used));
+uint32_t device_function_sums[GLOBAL_SUM_COUNT] __attribute__((used)) = {0};
+uint64_t device_function_starts[GLOBAL_SUM_COUNT] __attribute__((used)) = {0};
 }
 
 namespace ckernel
@@ -107,6 +109,7 @@ int main(int argc, char *argv[])
         tensix_sync();
         *trisc_run = RUN_SYNC_MSG_DONE;
 
+        kernel_profiler::store_function_sums();
         kernel_profiler::mark_time(CC_MAIN_END);
     }
 }

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -283,6 +283,7 @@ inline void wait_for_sync_register_value(uint32_t addr, int32_t val) {
  */
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
+    kernel_profiler::mark_function_sum_start(CB_RESERVE_BACK_MARKER);
     uint32_t pages_acked_ptr = (uint32_t) get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
@@ -306,6 +307,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
         free_space_pages = (int32_t)free_space_pages_wrap;
     } while (free_space_pages < num_pages);
     DEBUG_STATUS('C', 'R', 'B', 'D');
+    kernel_profiler::mark_function_sum_end(CB_RESERVE_BACK_MARKER);
 }
 
 /**
@@ -332,6 +334,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
  * */
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
+    kernel_profiler::mark_function_sum_start(CB_WAIT_FRONT_MARKER);
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
     uint32_t pages_received_ptr = (uint32_t) get_cb_tiles_received_ptr(operand);
 
@@ -342,6 +345,7 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
         pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     } while (pages_received < num_pages);
     DEBUG_STATUS('C', 'W', 'F', 'D');
+    kernel_profiler::mark_function_sum_end(CB_WAIT_FRONT_MARKER);
 }
 
 // NOC transfers

--- a/tt_metal/hw/inc/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/ethernet/dataflow_api.h
@@ -10,6 +10,7 @@
 #include "tt_eth_api.h"
 #include "erisc.h"
 
+#include "tools/profiler/kernel_profiler.hpp"
 #include "../dataflow_api.h"
 
 #define FORCE_INLINE inline __attribute__((always_inline))

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -52,6 +52,8 @@ OPS_CSV_HEADER = [
     "DEVICE TRISC1 KERNEL DURATION [ns]",
     "DEVICE TRISC2 KERNEL DURATION [ns]",
     "DEVICE ERISC KERNEL DURATION [ns]",
+    "DEVICE COMPUTE CB WAIT FRONT [ns]",
+    "DEVICE COMPUTE CB RESERVE BACK [ns]",
     # "CALL COUNT",
     "INPUTS",
     "OUTPUTS",
@@ -164,6 +166,16 @@ def append_device_time_data(opCandidatePath, call_count, timeDataDict, deviceLog
                 "start": {"core": "ANY", "risc": "ERISC", "timerID": 2},
                 "end": {"core": "ANY", "risc": "ERISC", "timerID": 3},
             },
+            "CB_COMPUTE_WAIT_FRONT": {
+                "across": "device",
+                "type": "sum",
+                "marker": {"risc": "TRISC_0", "timerID": 3000},
+            },
+            "CB_COMPUTE_RESERVE_BACK": {
+                "across": "device",
+                "type": "sum",
+                "marker": {"risc": "TRISC_2", "timerID": 3001},
+            },
         }
 
         devicesData = import_log_run_stats(setup)
@@ -188,6 +200,8 @@ def append_device_time_data(opCandidatePath, call_count, timeDataDict, deviceLog
         t1_kernel_delta_time_ns = 0
         t2_kernel_delta_time_ns = 0
         er_kernel_delta_time_ns = 0
+        cb_wait_compute_delta_time_ns = 0
+        cb_reserve_compute_delta_time_ns = 0
 
         if "BR_KERNEL_START->BR_KERNEL_END" in deviceLevelStats.keys():
             br_kernel_delta_time_ns = (
@@ -213,6 +227,12 @@ def append_device_time_data(opCandidatePath, call_count, timeDataDict, deviceLog
             er_kernel_delta_time_ns = (
                 deviceLevelStats["ER_KERNEL_START->ER_KERNEL_END"]["stats"]["Average"] * 1000 / freq
             )
+        if "CB_COMPUTE_WAIT_FRONT" in deviceLevelStats.keys():
+            cb_wait_compute_delta_time_ns = deviceLevelStats["CB_COMPUTE_WAIT_FRONT"]["stats"]["Average"] * 1000 / freq
+        if "CB_COMPUTE_RESERVE_BACK" in deviceLevelStats.keys():
+            cb_reserve_compute_delta_time_ns = (
+                deviceLevelStats["CB_COMPUTE_RESERVE_BACK"]["stats"]["Average"] * 1000 / freq
+            )
 
         timeDataDict["DEVICE FW START CYCLE"] = start_ts
         timeDataDict["DEVICE FW END CYCLE"] = end_ts
@@ -224,6 +244,8 @@ def append_device_time_data(opCandidatePath, call_count, timeDataDict, deviceLog
         timeDataDict["DEVICE TRISC1 KERNEL DURATION [ns]"] = round(t1_kernel_delta_time_ns)
         timeDataDict["DEVICE TRISC2 KERNEL DURATION [ns]"] = round(t2_kernel_delta_time_ns)
         timeDataDict["DEVICE ERISC KERNEL DURATION [ns]"] = round(er_kernel_delta_time_ns)
+        timeDataDict["DEVICE COMPUTE CB WAIT FRONT [ns]"] = round(cb_wait_compute_delta_time_ns)
+        timeDataDict["DEVICE COMPUTE CB RESERVE BACK [ns]"] = round(cb_reserve_compute_delta_time_ns)
         timeDataDict["CORE COUNT"] = len(cores)
 
     else:
@@ -237,6 +259,8 @@ def append_device_time_data(opCandidatePath, call_count, timeDataDict, deviceLog
         timeDataDict["DEVICE TRISC1 KERNEL DURATION [ns]"] = "-"
         timeDataDict["DEVICE TRISC2 KERNEL DURATION [ns]"] = "-"
         timeDataDict["DEVICE ERISC KERNEL DURATION [ns]"] = "-"
+        timeDataDict["DEVICE COMPUTE CB WAIT FRONT [ns]"] = "-"
+        timeDataDict["DEVICE COMPUTE CB RESERVE BACK [ns]"] = "-"
         timeDataDict["CORE COUNT"] = "-"
 
 


### PR DESCRIPTION
Adding CB input and output wait times for compute cores to the op_report.

[cb_time_op_report.csv](https://github.com/tenstorrent-metal/tt-metal/files/14466179/cb_time_op_report.csv)
