### PR TITLE
#5529: Change Events APIs to use shared_ptr<Event> instead of Event&

### DIFF
--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueRecordEvent.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueRecordEvent.rst
@@ -1,4 +1,4 @@
 EnqueueRecordEvent
 ==================
 
-.. doxygenfunction:: EnqueueRecordEvent(CommandQueue& cq, Event &event)
+.. doxygenfunction:: EnqueueRecordEvent(CommandQueue& cq, std::shared_ptr<Event> event)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueWaitForEvent.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EnqueueWaitForEvent.rst
@@ -1,4 +1,4 @@
 EnqueueWaitForEvent
 ===================
 
-.. doxygenfunction:: EnqueueWaitForEvent(CommandQueue& cq, Event &event)
+.. doxygenfunction:: EnqueueWaitForEvent(CommandQueue& cq, std::shared_ptr<Event> event)

--- a/docs/source/tt_metal/apis/host_apis/command_queue/EventSynchronize.rst
+++ b/docs/source/tt_metal/apis/host_apis/command_queue/EventSynchronize.rst
@@ -1,4 +1,4 @@
 EventSynchronize
 ================
 
-.. doxygenfunction:: EventSynchronize(Event &event)
+.. doxygenfunction:: EventSynchronize(std::shared_ptr<Event> event)

--- a/tt_eager/queue/queue.hpp
+++ b/tt_eager/queue/queue.hpp
@@ -26,9 +26,9 @@ void EnqueueDeviceToHostTransfer(
     const std::optional<std::size_t> transfer_size = std::nullopt,
     size_t src_offset = 0);
 
-void EnqueueRecordEvent(CommandQueue&, Event&);
-void EnqueueWaitForEvent(CommandQueue&, Event&);
-void EventSynchronize(Event&);
+void EnqueueRecordEvent(CommandQueue&, std::shared_ptr<Event>);
+void EnqueueWaitForEvent(CommandQueue&, std::shared_ptr<Event>);
+void EventSynchronize(std::shared_ptr<Event>);
 void QueueSynchronize(CommandQueue&);
 
 std::vector<Tensor> EnqueueOperation(

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -421,9 +421,9 @@ void DumpDeviceProfileResults(Device *device, const Program &program);
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
  * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
- * | event        | An event that will be populated by this function, and inserted in CQ   | Event &                       |                                    | Yes      |
+ * | event        | An event that will be populated by this function, and inserted in CQ   | std::shared_ptr<Event>        |                                    | Yes      |
  */
-void EnqueueRecordEvent(CommandQueue& cq, Event &event);
+void EnqueueRecordEvent(CommandQueue& cq, std::shared_ptr<Event> event);
 
 /**
  * Enqueues a command on the device for a given CQ (non-blocking). The command on device will block and wait for completion of the specified event (which may be in another CQ).
@@ -432,18 +432,18 @@ void EnqueueRecordEvent(CommandQueue& cq, Event &event);
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
  * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
  * |              | and waits for the event to complete.                                   |                               |                                    |          |
- * | event        | The event object that this CQ will wait on for completion.             | Event &                       |                                    | Yes      |
+ * | event        | The event object that this CQ will wait on for completion.             | std::shared_ptr<Event>        |                                    | Yes      |
  */
-void EnqueueWaitForEvent(CommandQueue& cq, Event &event);
+void EnqueueWaitForEvent(CommandQueue& cq, std::shared_ptr<Event> event);
 
 /**
  * Blocking function for host to synchronize (wait) on an event completion on device.
  * Return value: void
  * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
- * | event        | The event object that host will wait on for completion.                | Event &                       |                                    | Yes      |
+ * | event        | The event object that host will wait on for completion.                | std::shared_ptr<Event>        |                                    | Yes      |
  */
-void EventSynchronize(Event &event);
+void EventSynchronize(std::shared_ptr<Event> event);
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -490,9 +490,9 @@ class HWCommandQueue {
     void enqueue_write_buffer(std::shared_ptr<const Buffer> buffer, const void* src, bool blocking);
     void enqueue_write_buffer(const Buffer& buffer, const void* src, bool blocking);
     void enqueue_program(Program& program, std::optional<std::reference_wrapper<Trace>> trace, bool blocking);
-    void enqueue_record_event(std::reference_wrapper<Event> event);
-    void populate_record_event(std::reference_wrapper<Event> event);
-    void enqueue_wait_for_event(std::reference_wrapper<Event> event);
+    void enqueue_record_event(std::shared_ptr<Event> event);
+    void populate_record_event(std::shared_ptr<Event> event);
+    void enqueue_wait_for_event(std::shared_ptr<Event> event);
     void enqueue_trace();
     void finish();
     void issue_wrap();
@@ -502,10 +502,10 @@ class HWCommandQueue {
     friend void EnqueueProgramImpl(CommandQueue& cq, std::variant < std::reference_wrapper<Program>, std::shared_ptr<Program> > program, bool blocking);
     friend void EnqueueReadBufferImpl(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, bool blocking);
     friend void EnqueueWriteBufferImpl(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, const void* src, bool blocking);
-    friend void EnqueueRecordEventImpl(CommandQueue& cq, std::reference_wrapper<Event> event);
-    friend void EnqueueWaitForEventImpl(CommandQueue& cq, std::reference_wrapper<Event> event);
+    friend void EnqueueRecordEventImpl(CommandQueue& cq, std::shared_ptr<Event> event);
+    friend void EnqueueWaitForEventImpl(CommandQueue& cq, std::shared_ptr<Event> event);
     friend void FinishImpl(CommandQueue & cq);
-    friend void EnqueueRecordEvent(CommandQueue& cq, Event &event);
+    friend void EnqueueRecordEvent(CommandQueue& cq, std::shared_ptr<Event> event);
     friend class Trace;
 };
 
@@ -518,7 +518,7 @@ struct CommandInterface {
     std::optional<std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program>>> program;
     std::optional<const void*> src;
     std::optional<void*> dst;
-    std::optional<std::reference_wrapper<Event>> event;
+    std::optional<std::shared_ptr<Event>> event;
 };
 
 class CommandQueue {


### PR DESCRIPTION
A follow up to #5529

 - Safer for when async CQs (upcoming change) are enabled. Was too easy for tests to have Events objects go out of scope in main thread before worker async cq thread could use the Event and dispatch cmd to device.


 Want to make this change sooner rather than later before folks starting using Events APIs
