### PR TITLE
#5949: Add backward support for subalpha

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -974,6 +974,7 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.binary_lt_bw
 
+.. autofunction:: tt_lib.tensor.subalpha_bw
 
 Loss Functions
 ==============

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_subalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_subalpha.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("alpha", [0.05, 1.0, -0.5, -10.0])
+def test_bw_subalpha(input_shapes, alpha, device):
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.subalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    pyt_y = torch.sub(in_data, other_data, alpha=alpha)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad, other_data.grad]
+
+    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -171,6 +171,8 @@ std::vector<Tensor> celu_bw(const Tensor& grad, const Tensor& input, float alpha
 
 std::vector<Tensor> binary_lt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> subalpha_bw(const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 } //namespace tt_metal
 
 } //namespace tt

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -466,7 +466,7 @@ namespace tt::tt_metal::detail{
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
                 "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor add is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
@@ -1271,5 +1271,24 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+
+    m_tensor.def("subalpha_bw", &tt::tt_metal::subalpha_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            
+            Performs backward operations for subraction of ``other`` and ``input`` tensors with alpha for the given ``grad``.
+            
+            Input tensors must have BFLOAT16 data type.
+            
+            Output tensors will have BFLOAT16 data type.
+            
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+                
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "alpha", "Alpha value", "float", "default to 1.0f", "No"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
     }
 }


### PR DESCRIPTION
Subalpha backward support
[[post-commit] all - Slow Dispatch post-commit main build and unit tests](https://github.com/tenstorrent-metal/tt-metal/actions/runs/8136657138) - Passed 

[[post-commit] all - Fast dispatch post-commit main build and unit tests](https://github.com/tenstorrent-metal/tt-metal/actions/runs/8136654207) - Passed
