### PR TITLE
#5592: Adjust cache path for ttnn falcon7b demo

### DIFF
--- a/models/demos/ttnn_falcon7b/tt/model_config.py
+++ b/models/demos/ttnn_falcon7b/tt/model_config.py
@@ -143,8 +143,8 @@ def get_tt_cache_path(model_version):
     if tt_cache_path.exists():
         return tt_cache_path
     else:
-        Path(f"models/demos/falcon7b/datasets/{model_version}").mkdir(parents=True, exist_ok=True)
-        return Path(f"models/demos/falcon7b/datasets/{model_version}")
+        Path(f"models/demos/ttnn_falcon7b/datasets/{model_version}").mkdir(parents=True, exist_ok=True)
+        return Path(f"models/demos/ttnn_falcon7b/datasets/{model_version}")
 
 
 model_config_entries = {


### PR DESCRIPTION
Currently ttlib and ttnn version of falcon7b use same cache path, and endup clasing with each other. In order to be able to run both version of the demo in same repo, cache paths need to be decoupled.