### PR TITLE
#5876: pytest & c++ test logging cleanup

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -25,6 +25,7 @@ jobs:
       ARCH_NAME: ${{ matrix.runner-info.arch }}
       CONFIG: ci
       TT_METAL_SLOW_DISPATCH_MODE: 1
+      LOGURU_LEVEL: INFO
     environment: dev
     runs-on: ${{ matrix.runner-info.runs-on }}
     steps:

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -25,6 +25,7 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.runner-info.arch }}
       CONFIG: ci
+      LOGURU_LEVEL: INFO
     environment: dev
     runs-on: ${{ matrix.runner-info.runs-on }}
     steps:
@@ -80,6 +81,7 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.runner-info.arch }}
       CONFIG: ci
+      LOGURU_LEVEL: INFO
     environment: dev
     runs-on: ${{ matrix.runner-info.runs-on }}
     steps:
@@ -113,6 +115,7 @@ jobs:
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.runner-info.arch }}
+      LOGURU_LEVEL: INFO
     environment: dev
     runs-on: ${{ matrix.runner-info.runs-on }}
     steps:
@@ -146,6 +149,7 @@ jobs:
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.runner-info.arch }}
+      LOGURU_LEVEL: INFO
     environment: dev
     runs-on: ${{ matrix.runner-info.runs-on }}
     steps:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -24,6 +24,7 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.runner-info.arch }}
       CONFIG: ci
+      LOGURU_LEVEL: INFO
     environment: dev
     runs-on: ${{ matrix.runner-info.runs-on }}
     steps:

--- a/models/demos/falcon40b/tests/test_falcon_model_single_chip.py
+++ b/models/demos/falcon40b/tests/test_falcon_model_single_chip.py
@@ -538,16 +538,16 @@ def test_sharded_nlp_create_qkv_heads_test(
         pcc = 1.0
 
     passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, pcc)
-    logger.info(f"Q passing={passing_pcc_q}")
-    logger.info(f"Q output pcc={output_pcc_q}")
+    logger.debug(f"Q passing={passing_pcc_q}")
+    logger.debug(f"Q output pcc={output_pcc_q}")
 
     passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, pcc)
-    logger.info(f"K passing={passing_pcc_k}")
-    logger.info(f"K output pcc={output_pcc_k}")
+    logger.debug(f"K passing={passing_pcc_k}")
+    logger.debug(f"K output pcc={output_pcc_k}")
 
     passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, pcc)
-    logger.info(f"V passing={passing_pcc_v}")
-    logger.info(f"V output pcc={output_pcc_v}")
+    logger.debug(f"V passing={passing_pcc_v}")
+    logger.debug(f"V output pcc={output_pcc_v}")
     assert passing_pcc_q
     assert passing_pcc_k
     assert passing_pcc_v

--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
@@ -108,8 +108,8 @@ def run_falcon_attn_matmul_test(
     ref_bmm = torch.matmul(A.transpose(0, 2), B).transpose(0, 2)
 
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, pcc)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -134,8 +134,8 @@ def run_falcon_matmul_test(
     ref_bmm = torch.matmul(A, B)
 
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, pcc)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/demos/resnet/tests/test_resnet50_conv.py
+++ b/models/demos/resnet/tests/test_resnet50_conv.py
@@ -813,6 +813,6 @@ def test_resnet50_conv(
         # Compare against golden
         assert out_result.shape == out_golden.shape
         passing_pcc, output_pcc = comp_pcc(out_golden, out_result, 0.99)
-        logger.info(f"Passing={passing_pcc}")
-        logger.info(f"Output pcc={output_pcc}")
+        logger.debug(f"Passing={passing_pcc}")
+        logger.debug(f"Output pcc={output_pcc}")
         assert passing_pcc

--- a/models/demos/ttnn_falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
+++ b/models/demos/ttnn_falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
@@ -108,8 +108,8 @@ def run_falcon_attn_matmul_test(
     ref_bmm = torch.matmul(A.transpose(0, 2), B).transpose(0, 2)
 
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, pcc)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/demos/ttnn_falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/ttnn_falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -134,8 +134,8 @@ def run_falcon_matmul_test(
     ref_bmm = torch.matmul(A, B)
 
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, pcc)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
@@ -49,8 +49,8 @@ def run_bert_large_concatenate_heads_test(device, batch, dtype, in0_mem_config, 
 
     ref_out = torch.transpose(A, -3, -2).reshape([batch, 1, 384, 1024])
     passing_pcc, output_pcc = comp_pcc(pyt_got_back_rm_out, ref_out, 0.99)
-    logger.info(f"passing={passing_pcc}")
-    logger.info(f"output pcc={output_pcc}")
+    logger.debug(f"passing={passing_pcc}")
+    logger.debug(f"output pcc={output_pcc}")
     assert passing_pcc
 
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
@@ -127,8 +127,8 @@ def run_bert_large_ff1_matmul_test(
         else:
             assert False, "Unknown activation"
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
@@ -90,8 +90,8 @@ def run_bert_large_ff2_matmul_test(device, dtype, in0_mem_config, in1_mem_config
     if bias_mem_config is not None:
         ref_bmm = ref_bmm + BIAS
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
@@ -90,8 +90,8 @@ def run_bert_large_fused_qkv_matmul_test(
     if bias_mem_config is not None:
         ref_bmm = ref_bmm + BIAS
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
@@ -144,8 +144,8 @@ def run_bert_large_matmul_test(
         ref_bmm = torch.nn.functional.gelu(ref_bmm)
 
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 
@@ -234,8 +234,8 @@ def run_bert_large_bmm_test(
         ref_bmm = torch.matmul(A.reshape([a_shape[0], 16, 384, 384]), B)
 
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
@@ -71,8 +71,8 @@ def run_bert_large_post_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_
 
     ref_bmm = torch.matmul(A.reshape([9, 16, 384, 384]), B)
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_pre_softmax_bmm.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_pre_softmax_bmm.py
@@ -64,8 +64,8 @@ def run_bert_large_pre_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_c
 
     ref_bmm = torch.matmul(A, B)
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
@@ -89,8 +89,8 @@ def run_bert_large_selfout_matmul_test(device, dtype, in0_mem_config, in1_mem_co
     if bias_mem_config is not None:
         ref_bmm = ref_bmm + BIAS
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
@@ -69,16 +69,16 @@ def run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem
     ref_v = ref_v.reshape([batch, 384, 16, 64]).transpose(-3, -2)
 
     passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, 0.99)
-    logger.info(f"Q passing={passing_pcc_q}")
-    logger.info(f"Q output pcc={output_pcc_q}")
+    logger.debug(f"Q passing={passing_pcc_q}")
+    logger.debug(f"Q output pcc={output_pcc_q}")
     assert passing_pcc_q
     passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, 0.99)
-    logger.info(f"K passing={passing_pcc_k}")
-    logger.info(f"K output pcc={output_pcc_k}")
+    logger.debug(f"K passing={passing_pcc_k}")
+    logger.debug(f"K output pcc={output_pcc_k}")
     assert passing_pcc_k
     passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, 0.99)
-    logger.info(f"V passing={passing_pcc_v}")
-    logger.info(f"V output pcc={output_pcc_v}")
+    logger.debug(f"V passing={passing_pcc_v}")
+    logger.debug(f"V output pcc={output_pcc_v}")
     assert passing_pcc_v
 
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
@@ -69,16 +69,16 @@ def run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem
     ref_v = ref_v.reshape([batch, 384, 16, 64]).transpose(-3, -2)
 
     passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, 0.99)
-    logger.info(f"Q passing={passing_pcc_q}")
-    logger.info(f"Q output pcc={output_pcc_q}")
+    logger.debug(f"Q passing={passing_pcc_q}")
+    logger.debug(f"Q output pcc={output_pcc_q}")
     assert passing_pcc_q
     passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, 0.99)
-    logger.info(f"K passing={passing_pcc_k}")
-    logger.info(f"K output pcc={output_pcc_k}")
+    logger.debug(f"K passing={passing_pcc_k}")
+    logger.debug(f"K output pcc={output_pcc_k}")
     assert passing_pcc_k
     passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, 0.99)
-    logger.info(f"V passing={passing_pcc_v}")
-    logger.info(f"V output pcc={output_pcc_v}")
+    logger.debug(f"V passing={passing_pcc_v}")
+    logger.debug(f"V output pcc={output_pcc_v}")
     assert passing_pcc_v
 
 

--- a/tests/tt_eager/dtx/collapse_transformations.cpp
+++ b/tests/tt_eager/dtx/collapse_transformations.cpp
@@ -29,8 +29,7 @@ using namespace std;
 bool run_DataTransformation_test_0(bool DEBUG) {
     bool pass = true;
 
-    if (DEBUG) cout << "======================================\nrun_DataTransformation_test_0\n======================================" << endl;
-
+    if (DEBUG) tt::log_debug(tt::LogDTX, "======================================\nrun_DataTransformation_test_0\n======================================");
     TransformationNode * node0 = new TransformationNode("producer", 1);
     TransformationNode * node1 = new TransformationNode("tx1", 1);
     TransformationNode * node2 = new TransformationNode("consumer", 1);
@@ -67,7 +66,7 @@ bool run_DataTransformation_test_0(bool DEBUG) {
     if (DEBUG) golden->print(0);
 
     pass = compare_two_groups(golden->groups[0], node2->groups[0]);
-    if (DEBUG) cout << "PASS = " << pass << endl;
+    if (DEBUG) tt::log_debug(tt::LogDTX, "PASS = {}", pass);
 
     return pass;
 }
@@ -75,7 +74,7 @@ bool run_DataTransformation_test_0(bool DEBUG) {
 bool run_DataTransformation_test_1(bool DEBUG) {
     bool pass = true;
 
-    if (DEBUG) cout << "======================================\nrun_DataTransformation_test_1\n======================================" << endl;
+    if (DEBUG) tt::log_debug(tt::LogDTX, "======================================\nrun_DataTransformation_test_1\n======================================");
 
     TransformationNode * node0 = new TransformationNode("producer", 1);
     TransformationNode * node1 = new TransformationNode("tx1", 1);
@@ -114,7 +113,7 @@ bool run_DataTransformation_test_1(bool DEBUG) {
     if (DEBUG) golden->print(0);
 
     pass = compare_two_groups(golden->groups[0], node2->groups[0]);
-    if (DEBUG) cout << "PASS = " << pass << endl;
+    if (DEBUG) tt::log_debug(tt::LogDTX, "PASS = {}", pass);
 
 
     return pass;
@@ -230,9 +229,9 @@ int main(int argc, char** argv) {
     bool pass = true;
 
     pass &= test_DataTransformations();
-    printf("test_DataTransformations - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_DataTransformations - {}", pass);
 
-    if (pass == true) cout << "\nTESTS PASSED\n\n\n" << endl;
-    else cout << "TESTS FAILED\n\n\n" << endl;
+    if (pass == true) tt::log_debug(tt::LogDTX, "TESTS PASSED");
+    else tt::log_error(tt::LogDTX, "TESTS FAILED");
 
 }

--- a/tests/tt_eager/dtx/overlap.cpp
+++ b/tests/tt_eager/dtx/overlap.cpp
@@ -105,11 +105,11 @@ int main(int argc, char** argv) {
     bool pass = true;
 
     pass &= test_calculate_line_segment_overlap_in_1d();
-    printf("test_calculate_line_segment_overlap_in_1d - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_calculate_line_segment_overlap_in_1d - {}", pass);
 
     pass &= test_calculate_nd_tensor_overlap();
-    printf("test_calculate_nd_tensor_overlap - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_calculate_nd_tensor_overlap - {}", pass);
 
-    if (pass == true) cout << "\nTESTS PASSED\n\n\n" << endl;
-    else cout << "TESTS FAILED\n\n\n" << endl;
+    if (pass == true) tt::log_debug(tt::LogDTX, "TESTS PASSED");
+    else tt::log_error(tt::LogDTX, "TESTS FAILED");
 }

--- a/tests/tt_eager/dtx/tensor.cpp
+++ b/tests/tt_eager/dtx/tensor.cpp
@@ -81,11 +81,9 @@ bool test_golden_comparisons() {
 }
 
 void run_tensor_data_test(vector<int> shape, string filename){
-    cout << endl;
     TensorData * t = new TensorData(shape);
     t->print();
     //t->generate_csv(filename);
-    cout << endl;
 }
 
 
@@ -112,9 +110,9 @@ int main(int argc, char** argv) {
     printf("test_DataTransformations - %d\n\n", pass);
     */
     pass &= test_tensor_data_class();
-    printf("test_tensor_data_class - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_tensor_data_class - {}", pass);
 
-    if (pass == true) cout << "\nTESTS PASSED\n\n\n" << endl;
-    else cout << "TESTS FAILED\n\n\n" << endl;
+    if (pass == true) tt::log_debug(tt::LogDTX, "TESTS PASSED");
+    else tt::log_error(tt::LogDTX, "TESTS FAILED");
 
 }

--- a/tests/tt_eager/dtx/test_dtx.cpp
+++ b/tests/tt_eager/dtx/test_dtx.cpp
@@ -57,11 +57,9 @@ int main(int argc, char **argv) {
             address_map.push_back(transfer->dst_address*2);
             address_map.push_back(transfer->size*2);
         }
-        std::cout << "Address Map - " << std::endl;
+        tt::log_debug(tt::LogDTX, "Address Map - {}", address_map);
         for(auto i = 0; i < address_map.size(); i+=3) {
-            std::cout << "Source address - " << address_map[i];
-            std::cout << ", Destination address - " << address_map[i+1];
-            std::cout << ", Size to transfer in bytes - " << address_map[i+2] << std::endl;
+            tt::log_debug(tt::LogDTX, "Source address - {} , Destination address - {} , Size to transfer in bytes - {}", address_map[i], address_map[i+1], address_map[i+2]);
         }
 
         tt_metal::Program program = tt_metal::CreateProgram();

--- a/tests/tt_eager/dtx/test_dtx_tilized_row_to_col_major.cpp
+++ b/tests/tt_eager/dtx/test_dtx_tilized_row_to_col_major.cpp
@@ -62,11 +62,9 @@ int main(int argc, char **argv) {
             address_map.push_back(transfer->dst_address*2);
             address_map.push_back(transfer->size*2);
         }
-        std::cout << "Address Map - " << std::endl;
+        tt::log_debug(tt::LogDTX, "Address Map - {}", address_map);
         for(auto i = 0; i < address_map.size(); i+=3) {
-            std::cout << "Source address - " << address_map[i];
-            std::cout << ", Destination address - " << address_map[i+1];
-            std::cout << ", Size to transfer in bytes - " << address_map[i+2] << std::endl;
+            tt::log_debug(tt::LogDTX, "Source address - {} , Destination address - {} , Size to transfer in bytes - {}", address_map[i], address_map[i+1], address_map[i+2]);
         }
         tt_metal::Program program = tt_metal::CreateProgram();
 

--- a/tests/tt_eager/dtx/unit_tests.cpp
+++ b/tests/tt_eager/dtx/unit_tests.cpp
@@ -464,7 +464,7 @@ bool test_channels_last_to_2D_matrix() {
     pass &= convert_tensor_layout_3d_conv_act_to_2Dmatrix(dtx_right, {1,1,1,1,0,0});
     pass &= row_major_memory_store(dtx_right);
 
-    cout << "\n\nDTX_RIGHT" << endl;
+    tt::log_debug(tt::LogDTX, "DTX_RIGHT");
     dtx_right->print();
 
 
@@ -475,19 +475,19 @@ bool test_channels_last_to_2D_matrix() {
     dtx_left->transformations.push_back(node1);
     pass &= convert_abstract_tensor_to_channels_last_layout(dtx_left);
 
-    cout << "\n\nDTX_LEFT" << endl;
+    log_debug(tt::LogDTX, "DTX_LEFT");
     dtx_left->print();
 
     DataTransformations * combined = reverse_and_combine_transformations(dtx_left, dtx_right);
-    cout << "\n\nDTX_COMBINED" << endl;
+    log_debug(tt::LogDTX, "DTX_COMBINED");
     combined->print();
 
     pass &= optimize_away_transpose(combined);
-    cout << "\n\nDTX_OPTIMIZED" << endl;
+    log_debug(tt::LogDTX, "DTX_OPTIMIZED");
     combined->print();
 
     pass &= collapse_transformations(combined);
-    cout << "\n\nDTX_COLLAPSED" << endl;
+    log_debug(tt::LogDTX, "DTX_COLLAPSED");
     combined->print();
     pass &= generate_transfer_addresses(combined);
     combined->print();
@@ -513,7 +513,7 @@ bool test_channels_last_to_2D_matrix_conv1x1() {
     pass &= convert_tensor_layout_3d_conv_act_to_2Dmatrix(dtx_right, {1,1,1,1,0,0});
     pass &= row_major_memory_store(dtx_right);
 
-    cout << "\n\nDTX_RIGHT" << endl;
+    tt::log_debug(tt::LogDTX, "DTX_RIGHT");
     dtx_right->print();
 
 
@@ -524,19 +524,19 @@ bool test_channels_last_to_2D_matrix_conv1x1() {
     dtx_left->transformations.push_back(node1);
     pass &= convert_abstract_tensor_to_channels_last_layout(dtx_left);
 
-    cout << "\n\nDTX_LEFT" << endl;
+    tt::log_debug(tt::LogDTX, "DTX_LEFT");
     dtx_left->print();
 
     DataTransformations * combined = reverse_and_combine_transformations(dtx_left, dtx_right);
-    cout << "\n\nDTX_COMBINED" << endl;
+    tt:log_debug(tt::LogDTX, "DTX_COMBINED");
     combined->print();
 
     pass &= optimize_away_transpose(combined);
-    cout << "\n\nDTX_OPTIMIZED" << endl;
+    tt::log_debug(tt::LogDTX, "DTX_OPTIMIZED");
     combined->print();
 
     pass &= collapse_transformations(combined);
-    cout << "\n\nDTX_COLLAPSED" << endl;
+    tt::log_debug(tt::LogDTX, "DTX_COLLAPSED");
     combined->print();
     pass &= generate_transfer_addresses(combined);
     combined->print();
@@ -616,12 +616,11 @@ bool test_padding_pass() {
         auto golden_data = std::get<1>(t);
         pass &= test_padding_pass_(shape, pad_to_nearest, input_data_2_2, golden_data);
         if(pass) {
-            std::cout << "Passed test with shape = ";
+            tt::log_debug(tt::LogDTX, "Passed test with shape = {} , pad to nearest = {}", v2s(shape), v2s(pad_to_nearest));
         }
         else {
-            std::cout << "Failed test with shape = ";
+            tt::log_error(tt::LogDTX, "Failed test with shape = {} , pad to nearest = {}", v2s(shape), v2s(pad_to_nearest));
         }
-        std::cout << v2s(shape) << " , pad to nearest = " << v2s(pad_to_nearest) << std::endl;
         if(!pass) exit(1);
     }
     return pass;
@@ -675,12 +674,11 @@ bool test_block_2d_matrix_pass() {
         auto golden_data = std::get<2>(t);
         pass &= test_block_2d_matrix_pass_(shape, block_shape, dim_order, input_data_4_4, golden_data);
         if(pass) {
-            std::cout << "Passed test with shape = ";
+            tt::log_debug(tt::LogDTX, "Passed test with shape = {} , block shape = {} , dim_order = {}", v2s(shape), v2s(block_shape), v2s(dim_order));
         }
         else {
-            std::cout << "Failed test with shape = ";
+            tt::log_error(tt::LogDTX, "Failed test with shape = {} , block shape = {} , dim_order = {}", v2s(shape), v2s(block_shape), v2s(dim_order));
         }
-        std::cout << v2s(shape) << " , block shape = " << v2s(block_shape) << " , dim order = " << v2s(dim_order) << std::endl;
     }
     // Testing shape with x != y
     shape = {1, 2, 6};
@@ -701,12 +699,11 @@ bool test_block_2d_matrix_pass() {
         auto golden_data = std::get<2>(t);
         pass &= test_block_2d_matrix_pass_(shape, block_shape, dim_order, input_data_2_6, golden_data);
         if(pass) {
-            std::cout << "Passed test with shape = ";
+            tt::log_debug(tt::LogDTX, "Passed test with shape = {} , block shape = {} , dim order = {}", v2s(shape), v2s(block_shape), v2s(dim_order));
         }
         else {
-            std::cout << "Failed test with shape = ";
+            tt::log_error(tt::LogDTX, "Failed test with shape = {} , block shape = {} , dim order = {}", v2s(shape), v2s(block_shape), v2s(dim_order));
         }
-        std::cout << v2s(shape) << " , block shape = " << v2s(block_shape) << " , dim order = " << v2s(dim_order) << std::endl;
     }
     return pass;
 
@@ -769,12 +766,11 @@ bool test_block_2d_matrix_group_pass() {
         auto golden_data = std::get<2>(t);
         pass &= test_block_2d_matrix_group_pass_(shape, block_shape, dim_order, input_data_4_4, golden_data);
         if(pass) {
-            std::cout << "Passed test with shape = ";
+            tt::log_debug(tt::LogDTX, "Passed test with shape = {} , block shape = {} , dim order = {}", v2s(shape), v2s(block_shape), v2s(dim_order));
         }
         else {
-            std::cout << "Failed test with shape = ";
+            tt::log_error(tt::LogDTX, "Failed test with shape = {} , block shape = {} , dim order = {}", v2s(shape), v2s(block_shape), v2s(dim_order));
         }
-        std::cout << v2s(shape) << " , block shape = " << v2s(block_shape) << " , dim order = " << v2s(dim_order) << std::endl;
     }
     return pass;
 
@@ -829,16 +825,11 @@ bool test_pad_and_block_passes() {
         auto golden_data = std::get<3>(t);
         pass &= test_pad_and_block_passes_(shape, pad_to_nearest, block_shape, dim_order, input_data_2_2, golden_data);
         if(pass) {
-            std::cout << "Passed test with shape = ";
+            tt::log_debug(tt::LogDTX, "Passed test with shape = {} , pad to nearest = {} , block shape = {} , dim order = {}", v2s(shape), v2s(pad_to_nearest), v2s(block_shape), v2s(dim_order));
         }
         else {
-            std::cout << "Failed test with shape = ";
+            tt::log_error(tt::LogDTX, "Failed test with shape = {} , pad to nearest = {} , block shape = {} , dim order = {}", v2s(shape), v2s(pad_to_nearest), v2s(block_shape), v2s(dim_order));
         }
-        std::cout << v2s(shape) <<
-            " , pad to nearest = " << v2s(pad_to_nearest) <<
-            " , block shape = " << v2s(block_shape) <<
-            " , dim order = " << v2s(dim_order) <<
-            std::endl;
         if (!pass) exit(1);
     }
     return pass;
@@ -847,9 +838,9 @@ bool test_pad_and_block_passes() {
 void run_dtx_tests() {
     bool pass = true;
 
-    cout << "==================================================================" << endl;
-    cout << "                         Starting DTX TESTs                       " << endl;
-    cout << "==================================================================" << endl;
+    tt::log_info(tt::LogDTX, "==================================================================");
+    tt::log_info(tt::LogDTX, "                         Starting DTX TESTs                       ");
+    tt::log_info(tt::LogDTX, "==================================================================");
 
     // pass &= test_GenerateAddresses();
     // printf("test_GenerateAddresses - %d\n\n", pass);
@@ -885,31 +876,31 @@ void run_dtx_tests() {
     //printf("test_pass_convert_abstract_tensor_to_channels_last_layout - %d\n\n", pass);
 
     pass &= test_channels_last_to_2D_matrix();
-    printf("test_channels_last_to_2D_matrix - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_channels_last_to_2D_matrix - {}", pass);
 
     pass &= test_channels_last_to_2D_matrix_conv1x1();
-    printf("test_channels_last_to_2D_matrix_conv1x1 - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_channels_last_to_2D_matrix_conv1x1 - {}", pass);
 
     pass &= test_high_level_pass_and_evaluate();
-    printf("test_high_level_pass_and_evaluate - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_high_level_pass_and_evaluate - {}", pass);
 
     pass &= test_block_2d_matrix_pass();
-    printf("test_block_2d_matrix_pass - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_block_2d_matrix_pass - {}", pass);
 
     pass &= test_block_2d_matrix_group_pass();
-    printf("test_block_2d_matrix_group_pass - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_block_2d_matrix_group_pass - {}", pass);
 
     pass &= test_padding_pass();
-    printf("test_pad_2d_matrix_pass - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_pad_2d_matrix_pass - {}", pass);
 
     pass &= test_pad_and_block_passes();
-    printf("test_pad_and_block_passes - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_pad_and_block_passes - {}", pass);
 
     pass &= test_run_conv_transform_no_evaluate();
-    printf("test_run_conv_transform_no_evaluate - %d\n\n", pass);
+    tt::log_info(tt::LogDTX, "test_run_conv_transform_no_evaluate - {}", pass);
 
-    if (pass == true) cout << "\nTESTS PASSED\n\n\n" << endl;
-    else cout << "TESTS FAILED\n\n\n" << endl;
+    if (pass == true) tt::log_info(tt::LogDTX, "TESTS PASSED");
+    else tt::log_error(tt::LogDTX, "TESTS FAILED");
 }
 
 // ===============================================================

--- a/tests/tt_eager/integration_tests/test_bert.cpp
+++ b/tests/tt_eager/integration_tests/test_bert.cpp
@@ -190,8 +190,6 @@ void test_bert() {
     using tt::tt_metal::Layout;
     using tt::tt_metal::Tensor;
 
-    tt::log_info(tt::LogTest, "Running {}", __func__);
-
     int device_id = 0;
     auto device = tt::tt_metal::CreateDevice(device_id);
     CoreCoord compute_grid_size = device->compute_with_storage_grid_size();
@@ -232,7 +230,7 @@ void test_bert() {
     parameters.emplace("qa_head_bias", tt::numpy::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), {1, 1, TILE_HEIGHT, TILE_WIDTH}, Layout::TILE).to(device, dram_memory_config));
 
     auto run_bert = [&]() {
-        tt::log_info(tt::LogTest, "run_bert started");
+        tt::log_debug(tt::LogTest, "run_bert started");
         auto begin = std::chrono::steady_clock::now();
         auto hidden_states = tt::numpy::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), {batch_size, 1, sequence_size, hidden_size}, Layout::TILE).to(device, l1_memory_config);
         for (auto encoder_index = 0; encoder_index < num_encoders; encoder_index++) {

--- a/tests/tt_eager/ops/test_tilize_op.cpp
+++ b/tests/tt_eager/ops/test_tilize_op.cpp
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
-        std::cout << "Moving src data to host to validate" << std::endl;
+        log_debug(LogTest, "Moving src data to host to validate");
         Tensor host_a = a.cpu(); // Move tensor a to host to validate
         Tensor golden = host_a.to(Layout::TILE);
         auto golden_vec = owned_buffer::get_as<bfloat16>(golden);

--- a/tests/tt_eager/ops/test_tilize_op_channels_last.cpp
+++ b/tests/tt_eager/ops/test_tilize_op_channels_last.cpp
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
-        std::cout << "Moving src data to host to validate" << std::endl;
+        log_debug(LogTest, "Moving src data to host to validate");
         Tensor host_a = a.cpu(); // Move tensor a to host to validate
         Tensor g = Tensor(host_a.storage(), shape, DataType::BFLOAT16, Layout::ROW_MAJOR);
         Tensor golden = g.to(Layout::TILE);

--- a/tests/tt_eager/ops/test_tilize_zero_padding.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
-        std::cout << "Moving src data to host to validate" << std::endl;
+        log_debug(LogTest, "Moving src data to host to validate");
         Tensor host_a = a.cpu(); // Move tensor a to host to validate
         // TODO: Update when tensor.pad_to_tile() function is added
         auto padded_shape = a.get_legacy_shape();
@@ -57,14 +57,12 @@ int main(int argc, char **argv) {
         Tensor golden = padded_host_a.to(Layout::TILE);
         auto golden_vec =  owned_buffer::get_as<bfloat16>(golden);
         auto result_vec = owned_buffer::get_as<bfloat16>(c);
-        std::cout << "Validating " << std::endl;
-         std::cout << "golden vec size " << golden_vec.size() << std::endl;
-        std::cout << "result vec size " << result_vec.size() << std::endl;
+        log_debug(LogTest, "Validating - golden vec size: {} , result vec size {}", golden_vec.size(), result_vec.size());
         uint32_t num_errors = 0;
         for(uint32_t i = 0; i < result_vec.size() ; i++) {
             if(result_vec[i] != golden_vec[i]) {
                 if(num_errors < 10)
-                    std::cout << "Error at i=" << i << " result=" <<result_vec[i]<< " golden=" <<golden_vec[i] << std::endl;
+                    log_error(LogTest, "Error at i={} result={} golden={}", i, result_vec[i], golden_vec[i]);
                 num_errors++;
             }
         }

--- a/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
-        std::cout << "Moving src data to host to validate" << std::endl;
+        log_debug(LogTest, "Moving src data to host to validate");
         Tensor host_a = a.cpu(); // Move tensor a to host to validate
         Tensor g = Tensor(host_a.storage(), shape, DataType::BFLOAT16, Layout::ROW_MAJOR);
         // TODO: Update when tensor.pad_to_tile() function is added
@@ -58,14 +58,12 @@ int main(int argc, char **argv) {
         Tensor golden = padded_g.to(Layout::TILE);
         auto golden_vec =  owned_buffer::get_as<bfloat16>(golden);
         auto result_vec = owned_buffer::get_as<bfloat16>(c);
-        std::cout << "Validating " << std::endl;
-         std::cout << "golden vec size " << golden_vec.size() << std::endl;
-        std::cout << "result vec size " << result_vec.size() << std::endl;
+        log_debug(LogTest, "Validating - golden vec size: {} , result vec size {}", golden_vec.size(), result_vec.size());
         uint32_t num_errors = 0;
         for(uint32_t i = 0; i < result_vec.size() ; i++) {
             if(result_vec[i] != golden_vec[i]) {
                 if(num_errors < 10)
-                    std::cout << "Error at i=" << i << " result=" <<result_vec[i]<< " golden=" <<golden_vec[i] << std::endl;
+                    log_error(LogTest, "Error at i={} result={} golden={}", i, result_vec[i], golden_vec[i]);
                 num_errors++;
             }
         }

--- a/tests/tt_eager/python_api_testing/conv/conv_op_trace_config.py
+++ b/tests/tt_eager/python_api_testing/conv/conv_op_trace_config.py
@@ -136,8 +136,8 @@ def traced_conv_reference(pad_metadata, data_top_left_indices, conv_params, inpu
 
     # compare to pytorch
     passing_pcc, output_pcc = comp_equal(out_golden_pyt_tensor, output_pyt_tensor)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     assert passing_pcc
 
     return

--- a/tests/tt_eager/python_api_testing/sweep_tests/common.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/common.py
@@ -39,7 +39,7 @@ def run_tt_lib_test(
     device=None,
     plot_func=None,
 ):
-    logger.info(f"Running with args: {test_args}")
+    logger.debug(f"Running with args: {test_args}")
 
     tensor_inputs = []
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/test_sweep_conv.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/test_sweep_conv.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
+from loguru import logger
 
 import numpy as np
 import tt_lib as ttl
@@ -95,8 +95,8 @@ def run_conv_as_large_matmul(conv_op_test_params, pytorch_inputs_and_golden, dev
     out_golden = pytorch_inputs_and_golden[2]
     assert out_result.shape == out_golden.shape
     passing_pcc, output_pcc = comp_pcc(out_golden, out_result, 0.99)
-    print("Passing=", passing_pcc)
-    print("Output pcc=", output_pcc)
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     return passing_pcc
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/test_sweep_conv_with_address_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/test_sweep_conv_with_address_map.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
+from loguru import logger
 
 import numpy as np
 import tt_lib as ttl
@@ -97,8 +97,8 @@ def run_conv_as_large_matmul(conv_op_test_params, pytorch_inputs_and_golden, dev
     out_golden = pytorch_inputs_and_golden[2]
     assert out_result.shape == out_golden.shape
     passing_pcc, output_pcc = comp_pcc(out_golden, out_result, 0.99)
-    print("Passing=", passing_pcc)
-    print("Output pcc=", output_pcc)
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     return passing_pcc
 
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_conv_with_dtx_cpu_sweep.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_conv_with_dtx_cpu_sweep.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
+from loguru import logger
 import numpy as np
 import tt_lib as ttl
 from tt_lib.utils import blocked_mm_with_conv_act, _nearest_32, _nearest_y
@@ -112,8 +112,8 @@ def run_conv_as_large_matmul_dtx_cpu(conv_op_test_params, pytorch_inputs_and_gol
     out_golden = pytorch_inputs_and_golden[2]
     assert out_result.shape == out_golden.shape
     passing_pcc, output_pcc = comp_pcc(out_golden, out_result, 0.99)
-    print("Passing=", passing_pcc)
-    print("Output pcc=", output_pcc)
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     return passing_pcc
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_embedding.py
@@ -59,5 +59,5 @@ def test_embedding_bw(input_shapes, device):
 
     comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(golden_output_tensor_a, tt_output_tensor_a)
 
-    logger.info(comp_out_a)
+    logger.debug(comp_out_a)
     assert comp_pass_a

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -27,8 +27,8 @@ def compare_results(tt_tensor, golden_tensor, pcc=0.99):
         pt_out_tensor = golden_tensor[i]
         comp_pass, comp_out = comparison_funcs.comp_pcc(pt_out_tensor, tt_out_tensor, pcc=pcc)
         comp_all, _ = comparison_funcs.comp_allclose(pt_out_tensor, tt_out_tensor, atol=4, rtol=1e-1)
-        logger.info(comp_pass)
-        logger.info(comp_all)
-        logger.info(comp_out)
+        logger.debug(comp_pass)
+        logger.debug(comp_all)
+        logger.debug(comp_out)
         status = status & (comp_pass | comp_all)
     return status

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_adaptiveavgpool2d.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_adaptiveavgpool2d.py
@@ -50,5 +50,5 @@ def test_AdaptiveAvgPool2d_fallback(
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_argmax_min_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_argmax_min_op.py
@@ -47,5 +47,5 @@ class TestArgMaxMinOps:
 
         output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, comp_out = comparison_funcs.comp_equal(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_batch_norm2d.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_batch_norm2d.py
@@ -117,5 +117,5 @@ def test_BatchNorm_fallback(
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_ops.py
@@ -52,7 +52,7 @@ class TestBitwiseOps:
         output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comparison_funcs.comp_equal(pt_out, output)
         _, comp_out = comparison_funcs.comp_allclose_and_pcc(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass
 
     @pytest.mark.parametrize("op_kind", ["or", "and", "xor"])
@@ -88,5 +88,5 @@ class TestBitwiseOps:
         output = tout.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comparison_funcs.comp_equal(pt_out, output)
         _, comp_out = comparison_funcs.comp_allclose_and_pcc(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_shift_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_bitwise_shift_ops.py
@@ -45,7 +45,7 @@ class TestBitwiseShiftOps:
         output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comparison_funcs.comp_equal(pt_out, output)
         _, comp_out = comparison_funcs.comp_allclose_and_pcc(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass
 
     def test_bitwise_binary_shift_fallback(self, input_shapes, shift_kind, on_device, device):
@@ -79,5 +79,5 @@ class TestBitwiseShiftOps:
         output = tout.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comparison_funcs.comp_equal(pt_out, output)
         _, comp_out = comparison_funcs.comp_allclose_and_pcc(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_ceil_floor_mod_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_ceil_floor_mod_ops.py
@@ -40,7 +40,7 @@ class TestMathOps:
         output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
         _, comp_out = comp_allclose_and_pcc(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass
 
     def test_floor_fallbackop(self, input_shape, on_device, device):
@@ -64,7 +64,7 @@ class TestMathOps:
         output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
         _, comp_out = comp_allclose_and_pcc(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass
 
     @pytest.mark.parametrize("other", [1.5, 2.0, 3.0])
@@ -89,7 +89,7 @@ class TestMathOps:
         output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
         _, comp_out = comp_allclose_and_pcc(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass
 
     def test_binary_fmod_fallbackop(self, input_shape, on_device, device):
@@ -122,5 +122,5 @@ class TestMathOps:
         output = tout.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
         _, comp_out = comp_allclose_and_pcc(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_chunk_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_chunk_op.py
@@ -40,5 +40,5 @@ def test_chunk_fallback(input_shape, chunks, dim, on_device, device):
         tt_output = tt_out[i].cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comp_pcc(pt_output, tt_output, 0.9999)
         _, comp_out = comp_allclose_and_pcc(pt_output, tt_output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_concat_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_concat_op.py
@@ -62,5 +62,5 @@ def test_concat_fallback(input_shapes, dim, on_device, device):
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_conv2d_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_conv2d_op.py
@@ -120,7 +120,7 @@ def test_conv2d_fallback(
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
 
 
 @pytest.mark.parametrize(
@@ -279,5 +279,5 @@ def test_Conv2d_fallback(
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_full_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_full_op.py
@@ -26,5 +26,5 @@ def test_full_fallback(input_shape, fill_value, device):
     output = t0.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_group_norm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_group_norm.py
@@ -141,7 +141,7 @@ def test_group_norm_fallback(input_shape, weight_shape, bias_shape, num_groups, 
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass
 
 
@@ -253,5 +253,5 @@ def test_GroupNorm_fallback(
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_interpolate_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_interpolate_op.py
@@ -55,5 +55,5 @@ def test_pad_fallback(
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_layer_norm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_layer_norm.py
@@ -135,7 +135,7 @@ def test_layer_norm_fallback(input_shape, weight_shape, bias_shape, normalized_s
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass
 
 
@@ -234,5 +234,5 @@ def test_LayerNorm_fallback(
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_maxpool2d.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_maxpool2d.py
@@ -62,5 +62,5 @@ def test_MaxPool2d_fallback(
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_pad_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_pad_op.py
@@ -44,5 +44,5 @@ def test_pad_fallback(input_shape, pad, mode, value, on_device, device):
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_repeat_interleave_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_repeat_interleave_op.py
@@ -38,5 +38,5 @@ def test_repeat_interleave_fallback(input_shape, repeats, dim, on_device, device
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_repeat_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_repeat_op.py
@@ -40,5 +40,5 @@ def test_repeat_fallback(input_shape, sizes, on_device, device):
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_reshape_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_reshape_op.py
@@ -43,5 +43,5 @@ def test_reshape_fallback(input_shape, output_shape, on_device, device):
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_silu_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_silu_op.py
@@ -44,5 +44,5 @@ def test_silu_fallback(input_shape, on_device, device):
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_softmax_op.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_softmax_op.py
@@ -45,5 +45,5 @@ def test_softmax_fallback(input_shape, dim, on_device, device):
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_tensor_slice.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_tensor_slice.py
@@ -50,5 +50,5 @@ def test_tensor_slice_fallback(input_shape, slices, on_device, device):
     output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     comp_pass, _ = comp_pcc(pt_out, output, 0.9999)
     _, comp_out = comp_allclose_and_pcc(pt_out, output)
-    logger.info(comp_out)
+    logger.debug(comp_out)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_trunc_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/fallback_ops/test_trunc_ops.py
@@ -40,5 +40,5 @@ class TestTruncOp:
         output = t1.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         comp_pass, _ = comp_equal(pt_out, output)
         _, comp_out = comp_allclose_and_pcc(pt_out, output)
-        logger.info(comp_out)
+        logger.debug(comp_out)
         assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/loss_ops/test_loss_mae.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/loss_ops/test_loss_mae.py
@@ -49,7 +49,7 @@ class TestMAELoss:
         pt_mae_output = loss(ref_data.to(torch.float32), pred_data.to(torch.float32))
         comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(pt_mae_output, tt_mae_output)
 
-        logger.info(comp_out_a)
+        logger.debug(comp_out_a)
         assert comp_pass_a
 
     def test_loss_mae_sum(self, input_shapes, memcfg, device):
@@ -77,7 +77,7 @@ class TestMAELoss:
             pt_mae_output, torch.tensor(tt_mae_output[0, 0, 0, 0]), atol=4, rtol=1e-1
         )
 
-        logger.info(comp_out_a)
+        logger.debug(comp_out_a)
         assert comp_pass_a
 
     def test_loss_mae_mean(self, input_shapes, memcfg, device):
@@ -107,5 +107,5 @@ class TestMAELoss:
             pt_mae_output, torch.tensor(tt_mae_output[0, 0, 0, 0]), atol=4, rtol=1e-1
         )
 
-        logger.info(comp_out_a)
+        logger.debug(comp_out_a)
         assert comp_pass_a

--- a/tests/tt_eager/python_api_testing/unit_testing/loss_ops/test_loss_mse.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/loss_ops/test_loss_mse.py
@@ -49,7 +49,7 @@ class TestMSELoss:
         pt_mse_output = loss(ref_data.to(torch.float32), pred_data.to(torch.float32))
         comp_pass_a, comp_out_a = comparison_funcs.comp_pcc(pt_mse_output, tt_mse_output)
 
-        logger.info(comp_out_a)
+        logger.debug(comp_out_a)
         assert comp_pass_a
 
     def test_loss_mse_sum(self, input_shapes, memcfg, device):
@@ -76,7 +76,7 @@ class TestMSELoss:
             pt_mse_output, torch.tensor(tt_mse_output[0, 0, 0, 0]), atol=4, rtol=1e-1
         )
 
-        logger.info(comp_out_a)
+        logger.debug(comp_out_a)
         assert comp_pass_a
 
     def test_loss_mse_mean(self, input_shapes, memcfg, device):
@@ -105,5 +105,5 @@ class TestMSELoss:
             pt_mse_output, torch.tensor(tt_mse_output[0, 0, 0, 0]), atol=4, rtol=1e-1
         )
 
-        logger.info(comp_out_a)
+        logger.debug(comp_out_a)
         assert comp_pass_a

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_conv_new_activation_reader_function_cpu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_conv_new_activation_reader_function_cpu.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
+from loguru import logger
 import tt_lib as ttl
 from tt_lib.utils import (
     blocked_mm_with_conv_act,
@@ -247,6 +247,6 @@ def test_run_conv_as_large_matmul_cpu(K, C, H, W, R, S, stride_h, stride_w, pad_
     out_golden = torch.nn.functional.conv2d(A_pyt, B_pyt, stride=(stride_h, stride_w), padding=(pad_h, pad_w))
     assert out_result.shape == out_golden.shape
     passing_pcc, output_pcc = comp_pcc(out_golden, out_result, 0.99)
-    print("Passing=", passing_pcc)
-    print("Output pcc=", output_pcc)
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     assert passing_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_conv_with_dtx_cpu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_conv_with_dtx_cpu.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
+from loguru import logger
 
 import numpy as np
 
@@ -128,6 +128,6 @@ def test_run_conv_as_large_matmul_cpu(K, C, H, W, R, S, stride_h, stride_w, pad_
     out_golden = torch.nn.functional.conv2d(A_pyt, B_pyt, stride=(stride_h, stride_w), padding=(pad_h, pad_w))
     assert out_result.shape == out_golden.shape
     passing_pcc, output_pcc = comp_pcc(out_golden, out_result, 0.99)
-    print("Passing=", passing_pcc)
-    print("Output pcc=", output_pcc)
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     assert passing_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_downsample.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_downsample.py
@@ -109,8 +109,8 @@ def test_run_downsample(
     input_shard_height = (int)(input_2d_height_padded / num_cores_height_slices)
     output_2d_height_padded = _nearest_y(batch_size * output_height * output_width, num_cores_height_slices * 32)
     output_shard_height = (int)(output_2d_height_padded / num_cores_height_slices)
-    logger.info(f"input_2d_height={input_2d_height}")
-    logger.info(f"input_2d_width={input_2d_width}")
+    logger.debug(f"input_2d_height={input_2d_height}")
+    logger.debug(f"input_2d_width={input_2d_width}")
     sharded_memory_layout = (
         ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED if height_sharded else ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED
     )
@@ -118,9 +118,9 @@ def test_run_downsample(
         ttl.tensor.ShardOrientation.ROW_MAJOR if height_sharded else ttl.tensor.ShardOrientation.COL_MAJOR
     )
     input_shard_width = input_2d_width if height_sharded else ((int)(input_2d_width / grid_size[1]))
-    logger.info(f"grid_size={grid_size}")
-    logger.info(f"shard_memory_layout={sharded_memory_layout}")
-    logger.info(f"input_shard_height={input_shard_height}, input_shard_width={input_shard_width}")
+    logger.debug(f"grid_size={grid_size}")
+    logger.debug(f"shard_memory_layout={sharded_memory_layout}")
+    logger.debug(f"input_shard_height={input_shard_height}, input_shard_width={input_shard_width}")
 
     A_sharded = ttl.tensor.interleaved_to_sharded(
         A_interleaved,
@@ -211,6 +211,4 @@ def test_run_downsample(
         )  # For LowFi we need 0.99976
     else:
         passing, output_info = comp_equal(out_golden, out_result)
-    logger.info(f"Passing={passing}")
-    logger.info(f"Output info={output_info}")
     assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_embedding.py
@@ -46,8 +46,8 @@ def run_embeddings_tests(
     ).reshape((batch_size, 1, num_rows, embedding_dim))
 
     passing_pcc, output_pcc = comp_equal(t_ref, tt_got_back)
-    logger.info(f"Out passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     assert passing_pcc
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_generic_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_generic_conv.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
+from loguru import logger
 import numpy as np
 
 import tt_lib as ttl
@@ -224,8 +224,8 @@ def test_run_generic_conv(
         passing_allclose_and_pcc, output_info = comp_allclose_and_pcc(
             out_golden, out_result, rtol=1e-1, atol=1e-3, pcc=0.999
         )
-        print("Passing=", passing_allclose_and_pcc)
-        print("Output info=", output_info)
+        logger.debug(f"Passing={passing_allclose_and_pcc}")
+        logger.debug(f"Output info={output_info}")
         passing_pcc, _ = comp_pcc(out_golden, out_result, pcc=0.999)
         assert passing_pcc
         # assert passing_allclose_and_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adam.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adam.py
@@ -143,21 +143,21 @@ def test_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, device):
 
     rtol = atol = 0.01
     passing, out = comp_allclose_and_pcc(model.weight, param_result, pcc=0.999, rtol=rtol, atol=atol)
-    logger.info(f"Out passing (param)={passing}")
-    logger.info(f"Output pcc={out}")
+    logger.debug(f"Out passing (param)={passing}")
+    logger.debug(f"Output pcc={out}")
 
     passing, out = comp_allclose_and_pcc(cpu_exp_avg_result, exp_avg_result, pcc=0.999, rtol=rtol, atol=atol)
-    logger.info(f"Out passing (exp_avg)={passing}")
-    logger.info(f"Output pcc={out}")
+    logger.debug(f"Out passing (exp_avg)={passing}")
+    logger.debug(f"Output pcc={out}")
 
     passing, out = comp_allclose_and_pcc(cpu_exp_avg_sq_result, exp_avg_sq_result, pcc=0.999, rtol=rtol, atol=atol)
-    logger.info(f"Out passing (exp_avg_sq)={passing}")
-    logger.info(f"Output pcc={out}")
+    logger.debug(f"Out passing (exp_avg_sq)={passing}")
+    logger.debug(f"Output pcc={out}")
 
     if "max_exp_avg_sq" in optimizer_state_dict["state"][0]:
         passing, out = comp_allclose_and_pcc(
             cpu_max_exp_avg_sq_result, max_exp_avg_sq_result, pcc=0.999, rtol=rtol, atol=atol
         )
-        logger.info(f"Out passing (max_exp_avg_sq)={passing}")
-        logger.info(f"Output pcc={out}")
+        logger.debug(f"Out passing (max_exp_avg_sq)={passing}")
+        logger.debug(f"Output pcc={out}")
     assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_bmm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_bmm.py
@@ -49,8 +49,8 @@ def test_moreh_bmm(shape, device):
 
     ## test for equivalance
     passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_out, pcc=0.999)
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing
 
@@ -108,8 +108,8 @@ def test_moreh_bmm_backward(shape, requires_grad, device):
 
         torch_input_grad = torch.unsqueeze(torch_input.grad, dim=0)
         passing, output_pcc = comp_allclose_and_pcc(torch_input_grad, ttcpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
-        logger.info(f"input_grad passing={passing}")
-        logger.info(f"input_grad pcc={output_pcc}")
+        logger.debug(f"input_grad passing={passing}")
+        logger.debug(f"input_grad pcc={output_pcc}")
         assert passing
 
     if require_mat2_grad:
@@ -117,6 +117,6 @@ def test_moreh_bmm_backward(shape, requires_grad, device):
 
         torch_mat2_grad = torch.unsqueeze(torch_mat2.grad, dim=0)
         passing, output_pcc = comp_allclose_and_pcc(torch_mat2_grad, ttcpu_mat2_grad, pcc=0.999, rtol=rtol, atol=atol)
-        logger.info(f"mat2_grad passing={passing}")
-        logger.info(f"mat2_grad pcc={output_pcc}")
+        logger.debug(f"mat2_grad passing={passing}")
+        logger.debug(f"mat2_grad pcc={output_pcc}")
         assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_clip_grad_norm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_clip_grad_norm.py
@@ -103,7 +103,7 @@ def test_moreh_clip_grad_norm(
         pass_total_norm, out_total_norm = comp_allclose_and_pcc(
             actual_total_norm.double(), expected_total_norm.double(), rtol=rtol, atol=atol
         )
-        logger.info(f"total_norm's {out_total_norm}")
+        logger.debug(f"total_norm's {out_total_norm}")
         assert pass_total_norm
 
         # Check inputs
@@ -111,7 +111,7 @@ def test_moreh_clip_grad_norm(
             expected_input_i = cpu_inputs[i].grad.double()
             actual_input_i = to_cpu(npu_inputs[i], input_shapes[i]).double()
             pass_input_i, out_input_i = comp_allclose_and_pcc(expected_input_i, actual_input_i, rtol=rtol, atol=atol)
-            logger.info(f"inputs[{i}]-shape[{input_shapes[i]}]'s {out_input_i}")
+            logger.debug(f"inputs[{i}]-shape[{input_shapes[i]}]'s {out_input_i}")
             assert pass_input_i
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_cumsum.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_cumsum.py
@@ -86,8 +86,8 @@ def test_moreh_cumsum_dim(input_shape, dim, device):
     rtol = atol = 0.1
     passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
 
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing
 
@@ -137,7 +137,7 @@ def test_moreh_cumsumsum_backward(input_shape, dim, device):
     rtol = atol = 0.1
     passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_cpu, pcc=0.999, rtol=rtol, atol=atol)
 
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_groupnorm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_groupnorm.py
@@ -215,17 +215,17 @@ def test_moreh_groupnorm(N, C_num_groups, H, W, eps, affine, device):
 
     # Check output
     pass_output, out_output = comp_allclose(expected_output, actual_output, rtol=rtol, atol=atol)
-    logger.info(f"output's {out_output}")
+    logger.debug(f"output's {out_output}")
     assert pass_output
 
     # Check mean
     pass_mean, out_mean = comp_allclose(expected_mean, actual_mean, rtol=rtol, atol=atol)
-    logger.info(f"mean's {out_mean}")
+    logger.debug(f"mean's {out_mean}")
     assert pass_mean
 
     # Check rstd
     pass_rstd, out_rstd = comp_allclose(expected_rstd, actual_rstd, rtol=rtol, atol=atol)
-    logger.info(f"rstd's {out_rstd}")
+    logger.debug(f"rstd's {out_rstd}")
     assert pass_rstd
 
 
@@ -292,7 +292,7 @@ def test_moreh_groupnorm_backward(N, C_num_groups, H, W, eps, affine, device):
 
     # Check input_grad
     pass_input_grad, out_input_grad = comp_allclose(expected_input_grad, actual_input_grad, rtol=rtol, atol=atol)
-    logger.info(f"input_grad's {out_input_grad}")
+    logger.debug(f"input_grad's {out_input_grad}")
     assert pass_input_grad
 
     # I divide gamma_grad and beta_grad by (N * C * Ht * Wt), because the error of bf16 sum increases.
@@ -305,7 +305,7 @@ def test_moreh_groupnorm_backward(N, C_num_groups, H, W, eps, affine, device):
         pass_gamma_grad, out_gamma_grad = comp_allclose(
             expected_gamma_grad / divisor, actual_gamma_grad / divisor, rtol=rtol, atol=atol
         )
-        logger.info(f"gamma_grad's {out_gamma_grad}")
+        logger.debug(f"gamma_grad's {out_gamma_grad}")
         assert pass_gamma_grad
 
     # Check beta_grad
@@ -313,5 +313,5 @@ def test_moreh_groupnorm_backward(N, C_num_groups, H, W, eps, affine, device):
         pass_beta_grad, out_beta_grad = comp_allclose(
             expected_beta_grad / divisor, actual_beta_grad / divisor, rtol=rtol, atol=atol
         )
-        logger.info(f"beta_grad's {out_beta_grad}")
+        logger.debug(f"beta_grad's {out_beta_grad}")
         assert pass_beta_grad

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_layernorm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_layernorm.py
@@ -271,7 +271,7 @@ def test_moreh_layernorm(input_shape, normalized_dims, elementwise_affine, eps, 
     pass_output, out_output = comp_allclose_and_pcc(
         expected_output, actual_output, rtol=rtol, atol=atol, pcc=output_pcc
     )
-    logger.info(f"output's {out_output}")
+    logger.debug(f"output's {out_output}")
     assert pass_output
 
     # Set rtol and atol and pcc for mean and rstd
@@ -284,11 +284,11 @@ def test_moreh_layernorm(input_shape, normalized_dims, elementwise_affine, eps, 
 
     # Check mean and rstd
     pass_mean, out_mean = comp_allclose_and_pcc(expected_mean, actual_mean, rtol=rtol, atol=atol, pcc=mean_pcc)
-    logger.info(f"mean's {out_mean}")
+    logger.debug(f"mean's {out_mean}")
     assert pass_mean
 
     pass_rstd, out_rstd = comp_allclose_and_pcc(expected_rstd, actual_rstd, rtol=rtol, atol=atol, pcc=rstd_pcc)
-    logger.info(f"rstd's {out_rstd}")
+    logger.debug(f"rstd's {out_rstd}")
     assert pass_rstd
 
 
@@ -337,7 +337,7 @@ def test_moreh_layernorm_backward(input_shape, normalized_dims, elementwise_affi
 
     # Check input_grad
     pig, oig = comp_allclose_and_pcc(expected_input_grad, actual_input_grad, rtol=rtol, atol=atol, pcc=pcc)
-    logger.info(f"input_grad's {oig}")
+    logger.debug(f"input_grad's {oig}")
     assert pig
 
     # I divide gamma_grad and beta_grad by (N * C * Ht * Wt), because the error of bf16 sum increases.
@@ -351,7 +351,7 @@ def test_moreh_layernorm_backward(input_shape, normalized_dims, elementwise_affi
         pgg, ogg = comp_allclose_and_pcc(
             expected_gamma_grad / numerator, actual_gamma_grad / numerator, rtol=rtol, atol=atol, pcc=pcc
         )
-        logger.info(f"gamma_grad's {ogg}")
+        logger.debug(f"gamma_grad's {ogg}")
         assert pgg
     else:
         assert actual_gamma_grad is None
@@ -361,7 +361,7 @@ def test_moreh_layernorm_backward(input_shape, normalized_dims, elementwise_affi
         pbg, obg = comp_allclose_and_pcc(
             expected_beta_grad / numerator, actual_beta_grad / numerator, rtol=rtol, atol=atol, pcc=pcc
         )
-        logger.info(f"beta_grad's {obg}")
+        logger.debug(f"beta_grad's {obg}")
         assert pbg
     else:
         assert actual_beta_grad is None

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_linear.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_linear.py
@@ -71,8 +71,8 @@ def test_moreh_linear(shapes, has_bias, device):
     cpu_layout = ttl.tensor.Layout.ROW_MAJOR
     ttcpu_output = tt_output.cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
     passing, output_pcc = comp_allclose_and_pcc(torch_output, ttcpu_output, pcc=0.999, rtol=rtol, atol=atol)
-    logger.info(f"Passing = {passing}")
-    logger.info(f"Output PCC = {output_pcc}")
+    logger.debug(f"Passing = {passing}")
+    logger.debug(f"Output PCC = {output_pcc}")
 
     assert passing
 
@@ -146,7 +146,7 @@ def test_moreh_linear_backward(shapes, requires_grads, requires_bias_grad, devic
     if requires_input_grad:
         ttcpu_input_grad = tt_input_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
         passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, ttcpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
-        logger.info(f"input_grad passing={passing} pcc={output_pcc}")
+        logger.debug(f"input_grad passing={passing} pcc={output_pcc}")
         assert passing
 
     if requires_weight_grad:
@@ -154,12 +154,12 @@ def test_moreh_linear_backward(shapes, requires_grads, requires_bias_grad, devic
         passing, output_pcc = comp_allclose_and_pcc(
             torch_weight.grad, ttcpu_weight_grad, pcc=0.999, rtol=rtol, atol=atol
         )
-        logger.info(f"weight_grad passing={passing} pcc={output_pcc}")
+        logger.debug(f"weight_grad passing={passing} pcc={output_pcc}")
         assert passing
 
     if requires_bias_grad:
         ttcpu_bias_grad = tt_bias_grad.cpu().to(cpu_layout).unpad_from_tile(bias_shape).to_torch()
 
         passing, output_pcc = comp_allclose_and_pcc(torch_bias.grad, ttcpu_bias_grad, pcc=0.999, rtol=rtol, atol=atol)
-        logger.info(f"bias_grad passing={passing} pcc={output_pcc}")
+        logger.debug(f"bias_grad passing={passing} pcc={output_pcc}")
         assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
@@ -47,7 +47,7 @@ def test_logsoftmax_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.1
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -86,7 +86,7 @@ def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.1
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -127,7 +127,7 @@ def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.1
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -167,7 +167,7 @@ def test_logsoftmax_for_dim_nc(shape_dim, device):
 
     rtol = atol = 0.1
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -215,7 +215,7 @@ def test_logsoftmax_backward_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.5
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -262,7 +262,7 @@ def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.5
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -317,7 +317,7 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.1
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -373,7 +373,7 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, device):
 
     rtol = atol = 0.5
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_matmul.py
@@ -83,8 +83,8 @@ def test_moreh_matmul_1d(input_shape, device):
     # test for equivalance
     rtol = atol = 0.1
     passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_out[0][0][0][0], pcc=0.999, rtol=rtol, atol=atol)
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing
 
@@ -140,8 +140,8 @@ def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
         passing, output_pcc = comp_allclose_and_pcc(
             torch_input.grad, ttcpu_input_grad.reshape(-1), pcc=0.999, rtol=rtol, atol=atol
         )
-        logger.info(f"input_grad passing={passing}")
-        logger.info(f"input_grad pcc={output_pcc}")
+        logger.debug(f"input_grad passing={passing}")
+        logger.debug(f"input_grad pcc={output_pcc}")
         assert passing
 
     if require_other_grad:
@@ -150,8 +150,8 @@ def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
         passing, output_pcc = comp_allclose_and_pcc(
             torch_other.grad, ttcpu_other_grad.reshape(-1), pcc=0.999, rtol=rtol, atol=atol
         )
-        logger.info(f"other_grad passing={passing}")
-        logger.info(f"other_grad pcc={output_pcc}")
+        logger.debug(f"other_grad passing={passing}")
+        logger.debug(f"other_grad pcc={output_pcc}")
         assert passing
 
 
@@ -218,16 +218,16 @@ def test_moreh_matmul_backward(params, input_b1, input_b2, other_b1, other_b2, r
             atol = 1
 
         passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, ttcpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
-        logger.info(f"input_grad passing={passing}")
-        logger.info(f"input_grad pcc={output_pcc}")
+        logger.debug(f"input_grad passing={passing}")
+        logger.debug(f"input_grad pcc={output_pcc}")
         assert passing
 
     if require_other_grad:
         ttcpu_other_grad = tt_other_grad.cpu().to(cpu_layout).unpad_from_tile(other_shape).to_torch()
 
         passing, output_pcc = comp_allclose_and_pcc(torch_other.grad, ttcpu_other_grad, pcc=0.999, rtol=rtol, atol=atol)
-        logger.info(f"other_grad passing={passing}")
-        logger.info(f"other_grad pcc={output_pcc}")
+        logger.debug(f"other_grad passing={passing}")
+        logger.debug(f"other_grad pcc={output_pcc}")
         assert passing
 
 
@@ -269,8 +269,8 @@ def test_moreh_matmul(params, device):
     # test for equivalance
     rtol = atol = 0.1
     passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_output, pcc=0.999, rtol=rtol, atol=atol)
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing
 
@@ -327,7 +327,7 @@ def test_primary_moreh_matmul(params, device):
 
     # test for equivalance
     passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_output, pcc=0.999, rtol=rtol, atol=atol)
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_mean.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_mean.py
@@ -118,8 +118,8 @@ def test_moreh_mean_dims(input_shape, dims, use_randint, device):
     else:
         passing, output_pcc = comp_pcc(torch_output, tt_output_cpu, pcc=0.999)
 
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing
 
@@ -196,7 +196,7 @@ def test_moreh_mean_backward(input_shape, dims, use_randint, device):
     else:
         passing, output_pcc = comp_pcc(torch_input.grad, tt_input_grad_cpu, pcc=0.999)
 
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
@@ -159,8 +159,8 @@ def test_moreh_nll_loss_4d(shape, ignore_index, reduction_mean, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(torch_loss, tt_loss_to_cpu, pcc=0.999, rtol=rtol, atol=atol)
-    logger.info(f"Out passing (param)={passing}")
-    logger.info(f"Output pcc={out}")
+    logger.debug(f"Out passing (param)={passing}")
+    logger.debug(f"Output pcc={out}")
 
     assert passing
 
@@ -187,8 +187,8 @@ def test_moreh_nll_loss_2d(shape, ignore_index, reduction_mean, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(torch_loss, tt_loss_to_cpu, pcc=0.999, rtol=rtol, atol=atol)
-    logger.info(f"Out passing (param)={passing}")
-    logger.info(f"Output pcc={out}")
+    logger.debug(f"Out passing (param)={passing}")
+    logger.debug(f"Output pcc={out}")
 
     assert passing
 
@@ -247,8 +247,8 @@ def test_moreh_nll_loss_4d_backward(shape, ignore_index, reduction_mean, device)
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_to_cpu, pcc=0.999, rtol=rtol, atol=atol)
 
-    logger.info(f"Out passing (param)={passing}")
-    logger.info(f"Output pcc={out}")
+    logger.debug(f"Out passing (param)={passing}")
+    logger.debug(f"Output pcc={out}")
 
     assert passing
 
@@ -306,7 +306,7 @@ def test_moreh_nll_loss_2d_backward(shape, ignore_index, reduction_mean, device)
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_to_cpu, pcc=0.999, rtol=rtol, atol=atol)
 
-    logger.info(f"Out passing (param)={passing}")
-    logger.info(f"Output pcc={out}")
+    logger.debug(f"Out passing (param)={passing}")
+    logger.debug(f"Output pcc={out}")
 
     assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_norm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_norm.py
@@ -149,7 +149,7 @@ def test_moreh_norm(input_shape, p, dim_rtol_atol, device):
 
     # Check output
     pass_y, out_y = comp_allclose(expected_y, actual_y, rtol=rtol, atol=atol)
-    logger.info(f"output's {out_y}")
+    logger.debug(f"output's {out_y}")
     assert pass_y
 
 
@@ -215,5 +215,5 @@ def test_moreh_norm_backward(input_shape, p, dim_rtol_atol, device):
 
     # Check input_grad
     pass_dx, out_dx = comp_allclose(expected_dx, actual_dx, rtol=rtol, atol=atol)
-    logger.info(f"input_grad's {out_dx}")
+    logger.debug(f"input_grad's {out_dx}")
     assert pass_dx

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sgd.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sgd.py
@@ -134,8 +134,8 @@ def test_moreh_sgd(shape, lr, momentum, dampening, weight_decay, nesterov, momen
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(model.weight, param_result, pcc=0.99, rtol=rtol, atol=atol)
 
-    logger.info(f"Out passing (param)={passing}")
-    logger.info(f"Output pcc={out}")
+    logger.debug(f"Out passing (param)={passing}")
+    logger.debug(f"Output pcc={out}")
 
     assert passing
 
@@ -146,7 +146,7 @@ def test_moreh_sgd(shape, lr, momentum, dampening, weight_decay, nesterov, momen
         )
 
         passing, out = comp_allclose_and_pcc(cpu_momentum_out, momentum_buffer_result, pcc=0.99, rtol=rtol, atol=atol)
-        logger.info(f"Momentum_out passing (param)={passing}")
-        logger.info(f"Momentum_out pcc={out}")
+        logger.debug(f"Momentum_out passing (param)={passing}")
+        logger.debug(f"Momentum_out pcc={out}")
 
         assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
@@ -46,7 +46,7 @@ def test_softmax_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -86,7 +86,7 @@ def test_softmax_large_algorithm_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -127,7 +127,7 @@ def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -167,7 +167,7 @@ def test_softmax_for_dim_nc(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -215,7 +215,7 @@ def test_softmax_backward_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -263,7 +263,7 @@ def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -318,7 +318,7 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -374,7 +374,7 @@ def test_softmax_backward_for_dim_nc(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -413,7 +413,7 @@ def test_softmax_callback(shape_dim_strategy, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -460,7 +460,7 @@ def test_softmax_backward_callback(shape_dim_strategy, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
@@ -47,7 +47,7 @@ def test_softmin_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -86,7 +86,7 @@ def test_softmin_large_algorithm_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -127,7 +127,7 @@ def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -167,7 +167,7 @@ def test_softmin_for_dim_nc(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -215,7 +215,7 @@ def test_softmin_backward_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -262,7 +262,7 @@ def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -317,7 +317,7 @@ def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 
@@ -373,7 +373,7 @@ def test_softmin_backward_for_dim_nc(shape_dim, device):
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(x.grad, tt_dev, rtol=rtol, atol=atol)
-    logger.info(out)
+    logger.debug(out)
     assert passing
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sum.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sum.py
@@ -103,8 +103,8 @@ def test_moreh_sum_dims(input_shape, dims, device):
     rtol = atol = 0.12
     passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
 
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing
 
@@ -168,7 +168,7 @@ def test_moreh_sum_backward(input_shape, dims, device):
     rtol = atol = 0.1
     passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_cpu, pcc=0.999, rtol=rtol, atol=atol)
 
-    logger.info(f"Out passing={passing}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move.py
@@ -43,8 +43,8 @@ def run_move_op(test_id, shape, layout, dtype, in0_mem_config, output_mem_config
     pyt_got_back_rm = tt_host_rm.to_torch()
 
     passing_pcc, output_pcc = comp_pcc(pyt_got_back_rm, torch_tensor, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -107,7 +107,7 @@ def run_move_op(shape, device):
     pyt_got_back_rm = tt_host_rm.to_torch()
 
     passing_pcc, output_pcc = comp_pcc(pyt_got_back_rm, torch_tensor, 0.99)
-    logger.info(f"Passing={passing_pcc}")
-    logger.info(f"Output pcc={output_pcc}")
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
 
     assert passing_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads.py
@@ -42,8 +42,8 @@ def run_nlp_concat_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem_con
         pcc = 1.0
 
     passing_pcc, output_pcc = comp_pcc(pyt_got_back_rm_out, ref_out, pcc)
-    logger.info(f"passing={passing_pcc}")
-    logger.info(f"output pcc={output_pcc}")
+    logger.debug(f"passing={passing_pcc}")
+    logger.debug(f"output pcc={output_pcc}")
     assert passing_pcc
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py
@@ -54,16 +54,16 @@ def run_nlp_create_qkv_heads_falcon7b_test(batch, seq_len, dtype, in0_mem_config
         pcc = 1.0
 
     passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, pcc)
-    logger.info(f"Q passing={passing_pcc_q}")
-    logger.info(f"Q output pcc={output_pcc_q}")
+    logger.debug(f"Q passing={passing_pcc_q}")
+    logger.debug(f"Q output pcc={output_pcc_q}")
     assert passing_pcc_q
     passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, pcc)
-    logger.info(f"K passing={passing_pcc_k}")
-    logger.info(f"K output pcc={output_pcc_k}")
+    logger.debug(f"K passing={passing_pcc_k}")
+    logger.debug(f"K output pcc={output_pcc_k}")
     assert passing_pcc_k
     passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, pcc)
-    logger.info(f"V passing={passing_pcc_v}")
-    logger.info(f"V output pcc={output_pcc_v}")
+    logger.debug(f"V passing={passing_pcc_v}")
+    logger.debug(f"V output pcc={output_pcc_v}")
     assert passing_pcc_v
 
 
@@ -204,16 +204,16 @@ def run_nlp_create_qkv_heads_test(
         pcc = 1.0
 
     passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, pcc)
-    logger.info(f"Q passing={passing_pcc_q}")
-    logger.info(f"Q output pcc={output_pcc_q}")
+    logger.debug(f"Q passing={passing_pcc_q}")
+    logger.debug(f"Q output pcc={output_pcc_q}")
 
     passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, pcc)
-    logger.info(f"K passing={passing_pcc_k}")
-    logger.info(f"K output pcc={output_pcc_k}")
+    logger.debug(f"K passing={passing_pcc_k}")
+    logger.debug(f"K output pcc={output_pcc_k}")
 
     passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, pcc)
-    logger.info(f"V passing={passing_pcc_v}")
-    logger.info(f"V output pcc={output_pcc_v}")
+    logger.debug(f"V passing={passing_pcc_v}")
+    logger.debug(f"V output pcc={output_pcc_v}")
     assert passing_pcc_q
     assert passing_pcc_k
     assert passing_pcc_v
@@ -399,16 +399,16 @@ def run_sharded_nlp_create_qkv_heads_test(
         pcc = 1.0
 
     passing_pcc_q, output_pcc_q = comp_pcc(pyt_got_back_rm_q, ref_q, pcc)
-    logger.info(f"Q passing={passing_pcc_q}")
-    logger.info(f"Q output pcc={output_pcc_q}")
+    logger.debug(f"Q passing={passing_pcc_q}")
+    logger.debug(f"Q output pcc={output_pcc_q}")
 
     passing_pcc_k, output_pcc_k = comp_pcc(pyt_got_back_rm_k, ref_k, pcc)
-    logger.info(f"K passing={passing_pcc_k}")
-    logger.info(f"K output pcc={output_pcc_k}")
+    logger.debug(f"K passing={passing_pcc_k}")
+    logger.debug(f"K output pcc={output_pcc_k}")
 
     passing_pcc_v, output_pcc_v = comp_pcc(pyt_got_back_rm_v, ref_v, pcc)
-    logger.info(f"V passing={passing_pcc_v}")
-    logger.info(f"V output pcc={output_pcc_v}")
+    logger.debug(f"V passing={passing_pcc_v}")
+    logger.debug(f"V output pcc={output_pcc_v}")
     assert passing_pcc_q
     assert passing_pcc_k
     assert passing_pcc_v

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv.py
@@ -5,6 +5,7 @@
 import pytest
 from pathlib import Path
 import sys
+from loguru import logger
 
 import numpy as np
 
@@ -211,8 +212,8 @@ def test_run_optimized_conv(
         passing_allclose_and_pcc, output_info = comp_allclose_and_pcc(
             out_golden, out_result, rtol=1e-1, atol=1e-3, pcc=0.9999
         )  # For LowFi we need 0.99976
-        print("Passing=", passing_allclose_and_pcc)
-        print("Output info=", output_info)
+        logger.debug(f"Passing={passing_allclose_and_pcc}")
+        logger.debug(f"Output info={output_info}")
         passing_pcc, _ = comp_pcc(out_golden, out_result, pcc=0.9998)  # For LowFi we need 0.99976
         assert passing_pcc
         # assert passing_allclose_and_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_multi_core.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_multi_core.py
@@ -5,6 +5,7 @@
 import pytest
 from pathlib import Path
 import sys
+from loguru import logger
 
 import numpy as np
 
@@ -218,8 +219,8 @@ def test_run_optimized_conv(
         passing_allclose_and_pcc, output_info = comp_allclose_and_pcc(
             out_golden, out_result, rtol=1e-1, atol=1e-3, pcc=0.9999
         )  # For LowFi we need 0.99976
-        print("Passing=", passing_allclose_and_pcc)
-        print("Output info=", output_info)
+        logger.debug(f"Passing={passing_allclose_and_pcc}")
+        logger.debug(f"Output info={output_info}")
         passing_pcc, _ = comp_pcc(out_golden, out_result, pcc=0.9998)  # For LowFi we need 0.99976
         assert passing_pcc
         # assert passing_allclose_and_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_v2.py
@@ -213,6 +213,6 @@ def test_optimized_conv_v2(
     else:
         pcc = 0.999
     passing_pcc, info = comp_pcc(out_golden, out_result, pcc=pcc)
-    print("Passing=", passing_pcc)
-    print("Info=", info)
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Info={info}")
     assert passing_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_first_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_first_conv.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
+from loguru import logger
 import numpy as np
 
 import tt_lib as ttl
@@ -273,6 +273,6 @@ def test_resnet50_first_conv(
         golden_pcc = 0.9999
 
         passing_pcc, output_pcc = comp_pcc(out_golden, out_result, golden_pcc)
-        print("Passing=", passing_pcc)
-        print("Output pcc=", output_pcc)
+        logger.debug(f"Passing={passing_pcc}")
+        logger.debug(f"Output pcc={output_pcc}")
         assert passing_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_first_conv_folding_on_host.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_first_conv_folding_on_host.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from loguru import logger
 
 import numpy as np
 
@@ -96,6 +97,6 @@ def test_resnet50_first_conv(
     golden_pcc = 0.9999999999999847
 
     passing_pcc, output_pcc = comp_pcc(out_golden, out_result, golden_pcc)
-    print("Passing=", passing_pcc)
-    print("Output pcc=", output_pcc)
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     assert passing_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv.py
@@ -677,14 +677,14 @@ def test_resnet50_conv(
         # Compare baseline against golden
         assert out_result_baseline.shape == out_golden.shape
         passing_pcc_baseline, output_pcc_baseline = comp_pcc(out_golden, out_result_baseline, 0.99)
-        logger.info(f"Passing baseline={passing_pcc_baseline}")
-        logger.info(f"Output pcc baseline={output_pcc_baseline}")
+        logger.debug(f"Passing baseline={passing_pcc_baseline}")
+        logger.debug(f"Output pcc baseline={output_pcc_baseline}")
 
         # Compare out result against golden
         assert out_result.shape == out_golden.shape
         passing_pcc, output_pcc = comp_pcc(out_golden, out_result, 0.99)
-        logger.info(f"Passing={passing_pcc}")
-        logger.info(f"Output pcc={output_pcc}")
+        logger.debug(f"Passing={passing_pcc}")
+        logger.debug(f"Output pcc={output_pcc}")
         assert passing_pcc
 
         # Compare baseline to output (should be identical)
@@ -694,4 +694,4 @@ def test_resnet50_conv(
             eq = torch.equal(out_result_baseline, out_result)
             assert eq, "Output should be identical to old conv!"
             assert passing_pcc == passing_pcc_baseline, "Output pcc should be identical to old conv pcc!"
-            logger.info(f"Output pcc passes and matches old conv pcc")
+            logger.debug(f"Output pcc passes and matches old conv pcc")

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv_v2.py
@@ -739,14 +739,14 @@ def test_resnet50_conv(
         # Compare baseline against golden
         assert out_result_baseline.shape == out_golden.shape
         passing_pcc_baseline, output_pcc_baseline = comp_pcc(out_golden, out_result_baseline, 0.99)
-        logger.info(f"Passing baseline={passing_pcc_baseline}")
-        logger.info(f"Output pcc baseline={output_pcc_baseline}")
+        logger.debug(f"Passing baseline={passing_pcc_baseline}")
+        logger.debug(f"Output pcc baseline={output_pcc_baseline}")
 
         # Compare out result against golden
         assert out_result.shape == out_golden.shape
         passing_pcc, output_pcc = comp_pcc(out_golden, out_result, 0.99)
-        logger.info(f"Passing={passing_pcc}")
-        logger.info(f"Output pcc={output_pcc}")
+        logger.debug(f"Passing={passing_pcc}")
+        logger.debug(f"Output pcc={output_pcc}")
         assert passing_pcc
 
         # Compare baseline to output (should be identical)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_two_chunks_tiled.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_two_chunks_tiled.py
@@ -147,6 +147,6 @@ def test_split_tiled_w(dim, refshape, in_mem_config, out_mem_config, device, dty
     for index, pyt_buff in enumerate(pyt_buff_list):
         golden_buff = golden_buffers[index]
         passing_pcc, output_pcc = comp_pcc(pyt_buff, golden_buff, 1.0)
-        logger.info(f"Out passing={passing_pcc}")
-        logger.info(f"Output pcc={output_pcc}")
+        logger.debug(f"Out passing={passing_pcc}")
+        logger.debug(f"Output pcc={output_pcc}")
         assert passing_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_last_dim_two_chunks_tiled.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_last_dim_two_chunks_tiled.py
@@ -145,6 +145,6 @@ def test_split_tiled_w(shape, in_mem_config, out_mem_config, device, dtype=ttl.t
     for index, pyt_buff in enumerate(pyt_buff_list):
         golden_buff = golden_buffers[index]
         passing_pcc, output_pcc = comp_pcc(pyt_buff, golden_buff, 1.0)
-        logger.info(f"Out passing={passing_pcc}")
-        logger.info(f"Output pcc={output_pcc}")
+        logger.debug(f"Out passing={passing_pcc}")
+        logger.debug(f"Output pcc={output_pcc}")
         assert passing_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_hpadding_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_hpadding_matmul.py
@@ -4,6 +4,7 @@
 
 
 import tt_lib as ttl
+from loguru import logger
 from tt_lib.utils import (
     tilize_to_list,
     tilize,
@@ -55,9 +56,8 @@ def run_tilize_matmul_test(M, K, N, device):
     ref_bmm = torch.matmul(A_padded.reshape(a_shape_padded[1:]), B.reshape(b_shape[1:]))
     ref_bmm = ref_bmm.reshape(output_shape)
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    print("Passing=", passing_pcc)
-    print("Output pcc=", output_pcc)
-
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     assert passing_pcc
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_tilize_matmul.py
@@ -4,6 +4,7 @@
 
 
 import tt_lib as ttl
+from loguru import logger
 
 from models.utility_functions import (
     untilize,
@@ -44,9 +45,8 @@ def run_tilize_matmul_test(M, K, N, device):
     ref_bmm = torch.matmul(A.reshape(1, M, K), B.reshape(1, K, N))
     ref_bmm = ref_bmm.reshape(1, 1, M, N)
     passing_pcc, output_pcc = comp_pcc(ref_bmm, pyt_got_back_rm, 0.99)
-    print("Passing=", passing_pcc)
-    print("Output pcc=", output_pcc)
-
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     assert passing_pcc
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_v2.py
@@ -537,8 +537,8 @@ def test_generate_all_configs_and_references(
             atol=1e-3,
             pcc=0.9999,
         )
-        logger.info(f"Passing={passing_allclose_and_pcc}")
-        logger.info(f"Output info={output_info}")
+        logger.debug(f"Passing={passing_allclose_and_pcc}")
+        logger.debug(f"Output info={output_info}")
         passing_pcc, _ = comp_pcc(
             golden_untilize_with_halo_output_pyt_tensor, untilize_with_halo_output_pyt_tensor, pcc=0.999
         )

--- a/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
@@ -233,8 +233,10 @@ int main(int argc, char **argv) {
 
         vector<uint32_t> golden = gold_standard_untilize(src0_vec, {num_tiles_r * 32, num_tiles_c * 32});
 
-        print_vec_of_uint32_as_packed_bfloat16(result_vec, num_tiles, "result");
-        print_vec_of_uint32_as_packed_bfloat16(golden, num_tiles, "golden");
+        if (not pass){
+            print_vec_of_uint32_as_packed_bfloat16(result_vec, num_tiles, "result");
+            print_vec_of_uint32_as_packed_bfloat16(golden, num_tiles, "golden");
+        }
 
         pass &= (golden == result_vec);
 

--- a/tests/tt_metal/tt_metal/unit_tests/buffer/test_simple_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/buffer/test_simple_l1_buffer.cpp
@@ -101,9 +101,9 @@ namespace tt::test::buffer::detail {
         writeL1Backdoor(device, core, input_local_address, inputs);
         tt_metal::detail::LaunchProgram(device, program);
         readL1Backdoor(device, core, input_local_address, byte_size, outputs);
-        tt::log_info("input readback inputs[0]={} == readback[0]={}", inputs[0], outputs[0]);
+        tt::log_debug("input readback inputs[0]={} == readback[0]={}", inputs[0], outputs[0]);
         readL1Backdoor(device, core, output_local_address, byte_size, outputs);
-        tt::log_info("inputs[0]={} == outputs[0]={}", inputs[0], outputs[0]);
+        tt::log_debug("inputs[0]={} == outputs[0]={}", inputs[0], outputs[0]);
         bool pass = (inputs == outputs);
         if (not pass) {
             tt::log_info("Mismatch at Core={}, phys_core={}, Packet Size(in Bytes)={}", core.str(), phys_core.str(), byte_size);

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -49,10 +49,10 @@ protected:
         // Skip for slow dispatch for now
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
-            tt::log_info(tt::LogTest, "Running test using Slow Dispatch");
+            tt::log_debug(tt::LogTest, "Running test using Slow Dispatch");
             slow_dispatch_ = true;
         } else {
-            tt::log_info(tt::LogTest, "Running test using Fast Dispatch");
+            tt::log_debug(tt::LogTest, "Running test using Fast Dispatch");
             slow_dispatch_ = false;
         }
         // Set up all available devices

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -357,7 +357,7 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::Device *device){
                                                     in0_block_w, out_subblock_h, out_subblock_w,
                                                     per_core_M, per_core_N);
 
-    log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
+    log_debug(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
     auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
     auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
@@ -367,7 +367,7 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::Device *device){
     auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
     pass &= move_tiles_to_dram(device, weights, K, N, in1_dram_addr);
-    log_info(LogTest, "Copying inputs to dram complete");
+    log_debug(LogTest, "Copying inputs to dram complete");
 
     for(int i = 0; i < num_cores_r; i++) {
         for(int j = 0; j < num_cores_c; j++) {
@@ -378,7 +378,7 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::Device *device){
         }
     }
 
-    log_info(LogTest, "Writing kernel runtime args to device");
+    log_debug(LogTest, "Writing kernel runtime args to device");
     pass &= write_runtime_args_to_device(
         device,
         program,
@@ -393,14 +393,14 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::Device *device){
         in0_dram_addr, in1_dram_addr, out_dram_addr,
         in0_mcast_sender_semaphore_noc_addr, in1_mcast_sender_semaphore_noc_addr, in0_mcast_receiver_semaphore_noc_addr, in1_mcast_receiver_semaphore_noc_addr
     );
-    log_info(LogTest, "Writing kernel runtime args to device complete");
+    log_debug(LogTest, "Writing kernel runtime args to device complete");
 
-    log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
+    log_debug(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
     tt_metal::detail::LaunchProgram(device, program);
-    log_info(LogTest, "Matmul test done");
+    log_debug(LogTest, "Matmul test done");
 
-    log_info(LogTest, "Gathering data back from dram and checking against golden");
+    log_debug(LogTest, "Gathering data back from dram and checking against golden");
 
     for(int i = 0; i < M; i++) {
         auto row = get_row_slice(golden, M, i, M * 32, N * 32);
@@ -419,7 +419,7 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::Device *device){
             pass &= (golden_tile == result_flat_layout);
         }
     }
-    log_info(LogTest, "Golden check complete");
+    log_debug(LogTest, "Golden check complete");
     return pass;
 }
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -296,7 +296,7 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::Device *device, int in1_or
                                                                                                     in0_block_w, out_subblock_h, out_subblock_w,
                                                                                                     per_core_M, per_core_N);
 
-    log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
+    log_debug(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
     auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
     auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
@@ -306,7 +306,7 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::Device *device, int in1_or
     auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
     pass &= move_tiles_to_dram(device, weights, K, N, in1_dram_addr);
-    log_info(LogTest, "Copying inputs to dram complete");
+    log_debug(LogTest, "Copying inputs to dram complete");
 
     for(int i = 0; i < num_cores_r; i++) {
         for(int j = 0; j < num_cores_c; j++) {
@@ -316,7 +316,7 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::Device *device, int in1_or
         }
     }
 
-    log_info(LogTest, "Writing kernel runtime args to device");
+    log_debug(LogTest, "Writing kernel runtime args to device");
     pass &= write_runtime_args_to_device(
         in1_or_in0,
         device,
@@ -331,14 +331,14 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::Device *device, int in1_or
         in0_dram_addr, in1_dram_addr, out_dram_addr,
         in_mcast_sender_semaphore_addr, in_mcast_receiver_semaphore_addr
     );
-    log_info(LogTest, "Writing kernel runtime args to device complete");
+    log_debug(LogTest, "Writing kernel runtime args to device complete");
 
-    log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
+    log_debug(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
     tt_metal::detail::LaunchProgram(device, program);
-    log_info(LogTest, "Matmul test done");
+    log_debug(LogTest, "Matmul test done");
 
-    log_info(LogTest, "Gathering data back from dram and checking against golden");
+    log_debug(LogTest, "Gathering data back from dram and checking against golden");
 
     for(int i = 0; i < M; i++) {
         auto row = get_row_slice(golden, M, i, M * 32, N * 32);
@@ -357,7 +357,7 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::Device *device, int in1_or
             pass &= (golden_tile == result_flat_layout);
         }
     }
-    log_info(LogTest, "Golden check complete");
+    log_debug(LogTest, "Golden check complete");
     return pass;
 }
 } // namespace unit_tests_common::matmul::test_matmul_multi_core

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_single_core.cpp
@@ -194,9 +194,9 @@ bool matmul_single_core(CommonFixture *fixture, tt_metal::Device *device, int M,
         core,
         writer_rt_args);
 
-    log_info(LogTest, "Launching kernels");
+    log_debug(LogTest, "Launching kernels");
     fixture->RunProgram(device, program);
-    log_info(LogTest, "Kernels done");
+    log_debug(LogTest, "Kernels done");
 
     std::vector<uint32_t> result_vec;
     fixture->ReadBuffer(device, dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
@@ -108,7 +108,7 @@ bool dram_single_core (CommonFixture* fixture, tt_metal::Device *device, const D
 
     auto input_dram_noc_xy = input_dram_buffer->noc_coordinates();
     auto output_dram_noc_xy = output_dram_buffer->noc_coordinates();
-    log_info(tt::LogVerif, "Creating kernel");
+    log_debug(tt::LogVerif, "Creating kernel");
     // Create the kernel
     auto dram_kernel = tt_metal::CreateKernel(
         program,

--- a/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram_to_l1_multicast.cpp
@@ -66,8 +66,8 @@ bool dram_to_l1_multicast(CommonFixture* fixture, tt_metal::Device *device, cons
         (std::uint32_t)core_start_physical.y,
         (std::uint32_t)(grid_size.x * grid_size.y) - cfg.target_grid_offset}; // Note: exclude src from acks, since we are not setting NOC_CMD_BRCST_SRC_INCLUDE
 
-    log_info(LogTest, "Start = {}, {}", core_start_physical.x, core_start_physical.y);
-    log_info(LogTest, "End = {}, {}", core_end_physical.x, core_end_physical.y);
+    log_debug(LogTest, "Start = {}, {}", core_start_physical.x, core_start_physical.y);
+    log_debug(LogTest, "End = {}, {}", core_end_physical.x, core_end_physical.y);
     auto mcast_reader_kernel = tt_metal::CreateKernel(
         program,
         cfg.kernel_file,
@@ -81,9 +81,9 @@ bool dram_to_l1_multicast(CommonFixture* fixture, tt_metal::Device *device, cons
 
     tt_metal::SetRuntimeArgs(program, mcast_reader_kernel, core, mcast_reader_args);
 
-    log_info(LogTest, "Launching kernels");
+    log_debug(LogTest, "Launching kernels");
     fixture->RunProgram(device, program);
-    log_info(LogTest, "Kernels done");
+    log_debug(LogTest, "Kernels done");
 
     for(int i = 0 ; i < grid_size.y; i++) {
         for(int j = 0 ; j < grid_size.x; j++) {

--- a/tt_eager/dtx/dtx.cpp
+++ b/tt_eager/dtx/dtx.cpp
@@ -27,12 +27,11 @@ TensorData::TensorData(vector<int> shape) {
 
 void TensorData::print() {
     bool DEBUG = true;
-    if (DEBUG) tt::log_info(tt::LogDTX, "Printing TensorData");
+    if (DEBUG) tt::log_debug(tt::LogDTX, "Printing TensorData");
 
     vector<int> counter = zeros(this->rank);
     for (int i=0; i<this->volume; i++){
-
-        if (DEBUG) cout << s(2) << "i = " << i << ".  counter = " << v2s(counter) << endl;
+        if (DEBUG) tt::log_debug(tt::LogDTX, "i = {}.  counter = {}", i, v2s(counter));
 
         int index = 0;   // = y*this->shape[0] + x;
         for (int d=0; d<rank; d++) {
@@ -170,24 +169,24 @@ string Transfer::get_string() {
 
 void TransformationNode::print(int spaces) {
 
-    tt::log_info(tt::LogDTX, "{}Transformation Node: opcode = {}", s(spaces), this->opcode);
+    tt::log_debug(tt::LogDTX, "{}Transformation Node: opcode = {}", s(spaces), this->opcode);
 
     int group_index = 0;
     for (TensorPairGroup * group : this->groups) {
 
-        tt::log_info(tt::LogDTX, "{}Group = {}; shape = {}, core = {}", s(2 + spaces), group_index, v2s(group->shape), v2s(group->core));
+        tt::log_debug(tt::LogDTX, "{}Group = {}; shape = {}, core = {}", s(2 + spaces), group_index, v2s(group->shape), v2s(group->core));
 
-        tt::log_info(tt::LogDTX, "{}TensorPairs ({}):", s(4+spaces), group->tensor_pairs.size());
+        tt::log_debug(tt::LogDTX, "{}TensorPairs ({}):", s(4+spaces), group->tensor_pairs.size());
         int tp_index = 0;
         for (TensorPair * tp : group->tensor_pairs) {
-            tt::log_info(tt::LogDTX, "{}TensorPair[{}]{}", s(6+spaces), tp_index, tp->get_string());
+            tt::log_debug(tt::LogDTX, "{}TensorPair[{}]{}", s(6+spaces), tp_index, tp->get_string());
             tp_index++;
         }
 
-        tt::log_info(tt::LogDTX, "{}Transactions:", s(4+spaces));
+        tt::log_debug(tt::LogDTX, "{}Transactions:", s(4+spaces));
         int tx_index = 0;
         for (Transfer * tx : group->transfers) {
-            tt::log_info(tt::LogDTX, "{}, Transaction[{}]  {}", s(6+spaces), tx_index, tx->get_string());
+            tt::log_debug(tt::LogDTX, "{}, Transaction[{}]  {}", s(6+spaces), tx_index, tx->get_string());
             tx_index++;
         }
         group_index++;
@@ -199,8 +198,8 @@ void DataTransformations::print() {
 }
 
 void DataTransformations::print(int spaces) {
-    tt::log_info(tt::LogDTX, "{} DataTransformations -- nodes = {}", s(spaces), this->transformations.size());
-    tt::log_info(tt::LogDTX, "{} ----------------------------------------------------", s(spaces));
+    tt::log_debug(tt::LogDTX, "{} DataTransformations -- nodes = {}", s(spaces), this->transformations.size());
+    tt::log_debug(tt::LogDTX, "{} ----------------------------------------------------", s(spaces));
     for (int t=0; t<this->transformations.size(); t++) {
         this->transformations[t]->print(spaces+3);
     }

--- a/tt_eager/dtx/dtx_evaluate.cpp
+++ b/tt_eager/dtx/dtx_evaluate.cpp
@@ -43,7 +43,7 @@ vector<uint32_t> generate_address_map(DataTransformations * dtx, bool in_bytes, 
 vector<vector<float>> evaluate(vector<float> data, std::vector<uint32_t> address_map, vector<vector<int>> output_shape) {
     uint32_t address_map_index = 0;
     uint32_t num_groups = address_map[address_map_index];
-    std::cout << "num_groups = " << num_groups << std::endl;
+    log_debug(tt::LogDTX, "num_groups = {}", num_groups);
     assert(output_shape.size() == num_groups);
     address_map_index += 1;
     vector<vector<float>> data_transformed_groups;

--- a/tt_eager/dtx/pass_tilize.cpp
+++ b/tt_eager/dtx/pass_tilize.cpp
@@ -43,7 +43,7 @@ vector<vector<int>> dim_order_counting(vector<int> shape, vector<int> dim_order)
         end[rank-1]--;
         end[rank-2]--;
 
-        cout << s(3) << "counter = " << v2s(counter) << ", reorderd = " << v2s(counter_reordered) << ";   " << v2s(str) << " => " << v2s(end) << endl;
+        tt::log_debug(tt::LogDTX, "   counter = {} , reordered = {};   {} => {}", v2s(counter), v2s(counter_reordered), v2s(str), v2s(end));
         list_of_counted_dims.push_back(counter_reordered);
 
         counter.back()++;
@@ -54,8 +54,6 @@ vector<vector<int>> dim_order_counting(vector<int> shape, vector<int> dim_order)
             }
         }
     }
-    cout << endl;
-    cout << endl;
 
     return list_of_counted_dims;
 }
@@ -64,7 +62,7 @@ vector<vector<int>> dim_order_counting(vector<int> shape, vector<int> dim_order)
 bool tilize_and_store(DataTransformations * dtx, vector<int> dim_order) {
     bool DEBUG = true;
 
-    if (DEBUG) cout << "\n\nPASS: Tilize and Store" << endl;
+    if (DEBUG) tt::log_info(tt::LogDTX, "PASS: Tilize and Store");
 
     // Identify producer TX & Consumer
     TransformationNode * producer = dtx->transformations.back();
@@ -72,7 +70,7 @@ bool tilize_and_store(DataTransformations * dtx, vector<int> dim_order) {
     dtx->transformations.push_back(consumer);
 
     for (int group_idx=0; group_idx<producer->groups.size(); group_idx++) {
-        cout << "\n\n" << s(2) << "Group = " << group_idx << endl;
+        tt::log_debug(tt::LogDTX, "Group = {}", group_idx);
 
         TensorPairGroup * consumer_group = consumer->groups[group_idx];
         TensorPairGroup * producer_group = producer->groups[group_idx];
@@ -86,21 +84,18 @@ bool tilize_and_store(DataTransformations * dtx, vector<int> dim_order) {
 
         vector<int> consumer_str = zeros(rank);
         vector<int> consumer_end = vector_addition(consumer_str, tile_shape, -1);
-        cout << s(4) << "tile shape      = " << v2s(tile_shape) << endl;
+        tt::log_debug(tt::LogDTX, "    tile_shape = {}", v2s(tile_shape));
 
         if (shape.size() != dim_order.size()) throw std::runtime_error("shape and dim_order dont have the same rank!");
 
         int shape_x = list_of_counted_dims.size() * 32;
         consumer_group->shape = {32, shape_x};
 
-        cout << s(4) << "Tensor Pairs: " << list_of_counted_dims.size() << endl;
+        tt::log_debug("    Tensor Pairs: {}", list_of_counted_dims.size());
         for (int i=0; i< list_of_counted_dims.size(); i++) {
-            std::cout <<  std::endl;
             for(int j = 0; j < list_of_counted_dims[i].size(); j++) {
-
-                std::cout << "dim " << list_of_counted_dims[i][j] << std::endl;
+                tt::log_debug(tt::LogDTX, "dim {}", list_of_counted_dims[i][j]);
             }
-            std::cout <<  std::endl;
             // Source Tensor: within the ND tensor from producer
             vector<int> str;
             vector<int> end;
@@ -112,7 +107,7 @@ bool tilize_and_store(DataTransformations * dtx, vector<int> dim_order) {
                                             new DTXTensor({consumer_str}, {consumer_end}));
             consumer_group->tensor_pairs.push_back(tp);
 
-            cout << s(6) << i << ".  " << tp->get_string() << endl;
+            tt::log_debug(tt::LogDTX, "      {}. {}", i, tp->get_string());
 
             // Prepare for the next itteration
             consumer_str.back() = (i+1) * 32;

--- a/tt_eager/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm.cpp
@@ -113,10 +113,10 @@ operation::ProgramWithCallbacks moreh_groupnorm_impl(
          num_rows_per_core_group_1,
          num_rows_per_core_group_2] = tt_metal::split_work_to_cores(core_grid_coord, num_rows);
 
-    log_info(LogTest, fmt::format("num_cores_to_be_used: {}", num_cores_to_be_used).c_str());
-    log_info(LogTest, fmt::format("num_rows_per_core_group_1: {}", num_rows_per_core_group_1).c_str());
-    log_info(LogTest, fmt::format("num_rows_per_core_group_2: {}", num_rows_per_core_group_2).c_str());
-    log_info(LogTest, fmt::format("block_size: {}", block_size).c_str());
+    log_debug(LogTest, fmt::format("num_cores_to_be_used: {}", num_cores_to_be_used).c_str());
+    log_debug(LogTest, fmt::format("num_rows_per_core_group_1: {}", num_rows_per_core_group_1).c_str());
+    log_debug(LogTest, fmt::format("num_rows_per_core_group_2: {}", num_rows_per_core_group_2).c_str());
+    log_debug(LogTest, fmt::format("block_size: {}", block_size).c_str());
 
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup

--- a/tt_eager/tt_dnn/op_library/moreh_groupnorm_backward/gamma_beta_grad/moreh_groupnorm_backward_gamma_beta_grad.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_groupnorm_backward/gamma_beta_grad/moreh_groupnorm_backward_gamma_beta_grad.cpp
@@ -88,9 +88,9 @@ operation::ProgramWithCallbacks moreh_groupnorm_backward_gamma_beta_grad_impl(
          num_channels_per_core_group_1,
          num_channels_per_core_group_2] = tt_metal::split_work_to_cores(core_grid_coord, num_channels);
 
-    log_info(LogTest, fmt::format("num_cores_to_be_used: {}", num_cores_to_be_used).c_str());
-    log_info(LogTest, fmt::format("num_channels_per_core_group_1: {}", num_channels_per_core_group_1).c_str());
-    log_info(LogTest, fmt::format("num_channels_per_core_group_2: {}", num_channels_per_core_group_2).c_str());
+    log_debug(LogTest, fmt::format("num_cores_to_be_used: {}", num_cores_to_be_used).c_str());
+    log_debug(LogTest, fmt::format("num_channels_per_core_group_1: {}", num_channels_per_core_group_1).c_str());
+    log_debug(LogTest, fmt::format("num_channels_per_core_group_2: {}", num_channels_per_core_group_2).c_str());
 
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup

--- a/tt_eager/tt_dnn/op_library/moreh_groupnorm_backward/input_grad/moreh_groupnorm_backward_input_grad.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_groupnorm_backward/input_grad/moreh_groupnorm_backward_input_grad.cpp
@@ -83,9 +83,9 @@ operation::ProgramWithCallbacks moreh_groupnorm_backward_input_grad_impl(
          num_rows_per_core_group_1,
          num_rows_per_core_group_2] = tt_metal::split_work_to_cores(core_grid_coord, num_rows);
 
-    log_info(LogTest, fmt::format("num_cores_to_be_used: {}", num_cores_to_be_used).c_str());
-    log_info(LogTest, fmt::format("num_rows_per_core_group_1: {}", num_rows_per_core_group_1).c_str());
-    log_info(LogTest, fmt::format("num_rows_per_core_group_2: {}", num_rows_per_core_group_2).c_str());
+    log_debug(LogTest, fmt::format("num_cores_to_be_used: {}", num_cores_to_be_used).c_str());
+    log_debug(LogTest, fmt::format("num_rows_per_core_group_1: {}", num_rows_per_core_group_1).c_str());
+    log_debug(LogTest, fmt::format("num_rows_per_core_group_2: {}", num_rows_per_core_group_2).c_str());
 
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup

--- a/tt_eager/tt_dnn/op_library/moreh_helper_functions.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_helper_functions.cpp
@@ -68,16 +68,16 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
     {
         auto iter = core_group_1.ranges();
         for_each(
-            iter.begin(), iter.end(), [](CoreRange core) { log_info(LogTest, "Use core_group_1 {}", core.str()); });
+            iter.begin(), iter.end(), [](CoreRange core) { log_debug(LogTest, "Use core_group_1 {}", core.str()); });
     }
-    log_info(LogTest, "num_tiles_per_core_group_1 {}", num_tiles_per_core_group_1);
+    log_debug(LogTest, "num_tiles_per_core_group_1 {}", num_tiles_per_core_group_1);
 
     {
         auto iter = core_group_2.ranges();
         for_each(
-            iter.begin(), iter.end(), [](CoreRange core) { log_info(LogTest, "Use core_group_2 {}", core.str()); });
+            iter.begin(), iter.end(), [](CoreRange core) { log_debug(LogTest, "Use core_group_2 {}", core.str()); });
     }
-    log_info(LogTest, "num_tiles_per_core_group_2 {}", num_tiles_per_core_group_2);
+    log_debug(LogTest, "num_tiles_per_core_group_2 {}", num_tiles_per_core_group_2);
 
     return std::make_tuple(
         num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2);

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward.cpp
@@ -58,7 +58,7 @@ operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output
     if (ht_need_bcast) num_dim *= input_grad_origin_h;
     if (wt_need_bcast) num_dim *= input_grad_origin_w;
 
-    log_info(LogOp, "num_dim {}", num_dim);
+    log_debug(LogOp, "num_dim {}", num_dim);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup

--- a/tt_eager/tt_dnn/op_library/sliding_window_op_infra/untilize_with_halo_config_generation_and_validation.py
+++ b/tt_eager/tt_dnn/op_library/sliding_window_op_infra/untilize_with_halo_config_generation_and_validation.py
@@ -4,6 +4,7 @@
 
 import torch
 import numpy as np
+from loguru import logger
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_allclose_and_pcc
 
@@ -118,8 +119,8 @@ def validate_input_padded_tensor_and_data_top_left_indices_and_pad_metadata(
     out_golden_pyt_tensor_cnhw = torch.permute(out_golden_pyt_tensor, (1, 0, 2, 3))
     # compare to pytorch
     passing_pcc, output_pcc = comp_equal(out_golden_pyt_tensor_cnhw.reshape(-1), output_pyt_tensor.reshape(-1))
-    print("Passing=", passing_pcc)
-    print("Output pcc=", output_pcc)
+    logger.debug(f"Passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
     assert passing_pcc
 
 


### PR DESCRIPTION
Reduce the amount of spam in post-commit CI logs. **This would result in ~2-3 mins improvement in post-commit time.**

Pytests and c++ tests use two different loggers. The same methodology was used for both, where only `info` level would get printed to the CI logs along with any failures. 
For pytests, the LOGURU_LEVEL env variable was set so in local runs all logging would still get printed. For c++ it defaults to only printing at info level, so any logging changed to `debug` level can only be seen now by manually setting `TT_METAL_LOGGER_LEVEL="DEBUG"`

I've also tried to replace any `print` or `cout` with the logger as much as possible

Much of info level logs have been moved to debug level 

Debug level logging now includes: 

- any parametrization or output result prints that spams the terminal, examples include:
`Max ATOL Delta: 2.379291534423828, Max RTOL Delta: inf, PCC: 0.9997987717052998`
`num_cores_to_be_used:` or similar
- `TEST PASSED` and `PCC=..` similar prints 
- prints that serve as intermediary checkpoints between functions calls such as:
`Slicing input tensors and copying them to dram along with sending runtime args to device`
`Scattering inputs (activation & weights) to dram channels using tiled layout`