### PR TITLE
#4947: Add noc alignment checks to watcher

### DIFF
--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -41,7 +41,10 @@ extern uint8_t noc_index;
 #include "noc_parameters.h"
 #include "noc_overlay_parameters.h"
 
-#define DEBUG_VALID_L1_ADDR(a, l) ((a >= MEM_L1_BASE) && (a + l <= MEM_L1_BASE + MEM_L1_SIZE) && ((a) + (l) > (a)))
+#define DEBUG_VALID_L1_ADDR(a, l) ((a >= MEM_L1_BASE) && \
+                                   (a + l <= MEM_L1_BASE + MEM_L1_SIZE) && \
+                                   ((a) + (l) > (a)) && \
+                                   ((a % 16) == 0))
 
 // TODO(PGK): remove soft reset when fw is downloaded at init
 #define DEBUG_VALID_REG_ADDR(a)                                                        \
@@ -49,10 +52,18 @@ extern uint8_t noc_index;
       ((a) < NOC_OVERLAY_START_ADDR + NOC_STREAM_REG_SPACE_SIZE * NOC_NUM_STREAMS)) || \
      ((a) == RISCV_DEBUG_REG_SOFT_RESET_0))
 #define DEBUG_VALID_WORKER_ADDR(a, l) (DEBUG_VALID_L1_ADDR(a, l) || (DEBUG_VALID_REG_ADDR(a) && (l) == 4))
-#define DEBUG_VALID_PCIE_ADDR(a, l) (((a) >= NOC_PCIE_ADDR_BASE) && ((a) + (l) <= NOC_PCIE_ADDR_END) && ((a) + (l) > (a)))
-#define DEBUG_VALID_DRAM_ADDR(a, l) (((a) >= NOC_DRAM_ADDR_BASE) && ((a) + (l) <= NOC_DRAM_ADDR_END) && ((a) + (l) > (a)))
+#define DEBUG_VALID_PCIE_ADDR(a, l) (((a) >= NOC_PCIE_ADDR_BASE) && \
+                                     ((a) + (l) <= NOC_PCIE_ADDR_END) && \
+                                     ((a) + (l) > (a)) && \
+                                     ((a % 32) == 0))
+#define DEBUG_VALID_DRAM_ADDR(a, l) (((a) >= NOC_DRAM_ADDR_BASE) && \
+                                     ((a) + (l) <= NOC_DRAM_ADDR_END) && \
+                                     ((a) + (l) > (a)) && \
+                                     ((a % 32) == 0))
 
-#define DEBUG_VALID_ETH_ADDR(a, l) (((a) >= MEM_ETH_BASE) && ((a) + (l) <= MEM_ETH_BASE + MEM_ETH_SIZE))
+#define DEBUG_VALID_ETH_ADDR(a, l) (((a) >= MEM_ETH_BASE) && \
+                                    ((a) + (l) <= MEM_ETH_BASE + MEM_ETH_SIZE) && \
+                                    ((a % 16) == 0))
 
 inline uint32_t debug_sanitize_get_which_riscv()
 {

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -44,7 +44,7 @@ extern uint8_t noc_index;
 #define DEBUG_VALID_L1_ADDR(a, l) ((a >= MEM_L1_BASE) && \
                                    (a + l <= MEM_L1_BASE + MEM_L1_SIZE) && \
                                    ((a) + (l) > (a)) && \
-                                   ((a % 16) == 0))
+                                   ((a % NOC_L1_ALIGNMENT_BYTES) == 0))
 
 // TODO(PGK): remove soft reset when fw is downloaded at init
 #define DEBUG_VALID_REG_ADDR(a)                                                        \
@@ -55,15 +55,15 @@ extern uint8_t noc_index;
 #define DEBUG_VALID_PCIE_ADDR(a, l) (((a) >= NOC_PCIE_ADDR_BASE) && \
                                      ((a) + (l) <= NOC_PCIE_ADDR_END) && \
                                      ((a) + (l) > (a)) && \
-                                     ((a % 32) == 0))
+                                     ((a % NOC_PCIE_ALIGNMENT_BYTES) == 0))
 #define DEBUG_VALID_DRAM_ADDR(a, l) (((a) >= NOC_DRAM_ADDR_BASE) && \
                                      ((a) + (l) <= NOC_DRAM_ADDR_END) && \
                                      ((a) + (l) > (a)) && \
-                                     ((a % 32) == 0))
+                                     ((a % NOC_DRAM_ALIGNMENT_BYTES) == 0))
 
 #define DEBUG_VALID_ETH_ADDR(a, l) (((a) >= MEM_ETH_BASE) && \
                                     ((a) + (l) <= MEM_ETH_BASE + MEM_ETH_SIZE) && \
-                                    ((a % 16) == 0))
+                                    ((a % NOC_L1_ALIGNMENT_BYTES) == 0))
 
 inline uint32_t debug_sanitize_get_which_riscv()
 {

--- a/tt_metal/hw/inc/grayskull/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/grayskull/noc/noc_parameters.h
@@ -18,4 +18,9 @@
 
 #define NOC_XY_ADDR2(xy, addr) ((((uint64_t)(xy)) << NOC_ADDR_LOCAL_BITS) | ((uint64_t)(addr)))
 
+// Alignment restrictions
+#define NOC_L1_ALIGNMENT_BYTES   16
+#define NOC_PCIE_ALIGNMENT_BYTES 32
+#define NOC_DRAM_ALIGNMENT_BYTES 32
+
 #endif

--- a/tt_metal/hw/inc/wormhole/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/wormhole/noc/noc_parameters.h
@@ -24,4 +24,9 @@
    ((((uint64_t)(xy)) << NOC_ADDR_LOCAL_BITS) |                        \
    ((uint64_t)(addr)))
 
+// Alignment restrictions
+#define NOC_L1_ALIGNMENT_BYTES   16
+#define NOC_PCIE_ALIGNMENT_BYTES 32
+#define NOC_DRAM_ALIGNMENT_BYTES 32
+
 #endif

--- a/tt_metal/impl/debug/sanitize_noc_host.hpp
+++ b/tt_metal/impl/debug/sanitize_noc_host.hpp
@@ -9,6 +9,7 @@
 
 namespace tt {
 
+// Host MMIO reads/writes don't have alignment restrictions, so no need to check alignment here.
 #define DEBUG_VALID_L1_ADDR(a, l) (((a) >= MEM_L1_BASE) && ((a) + (l) <= MEM_L1_BASE + MEM_L1_SIZE))
 
 // what's the size of the NOC<n> address space?  using 0x1000 for now

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -178,7 +178,7 @@ static void dump_noc_sanity_status(FILE *f,
         fprintf(f, "%s using noc%d reading L1[addr=0x%08lx,len=%d]\n", get_sanity_riscv_name(core, launch_msg, san->which), noc, san->addr, san->len);
         fflush(f);
         log_running_kernels(launch_msg);
-        log_info("Watcher stopped the device due to bad NOC L1/reg address");
+        log_warning("Watcher stopped the device due to bad NOC L1/reg address");
         log_waypoint(core, launch_msg, debug_status);
         snprintf(buf, sizeof(buf), "On core %s: %s using noc%d reading L1[addr=0x%08lx,len=%d]",
                  core.str().c_str(), get_sanity_riscv_name(core, launch_msg, san->which), noc, san->addr, san->len);
@@ -192,7 +192,7 @@ static void dump_noc_sanity_status(FILE *f,
                 NOC_UNICAST_ADDR_Y(san->addr),
                 NOC_LOCAL_ADDR_OFFSET(san->addr), san->len);
         fflush(f);
-        log_info("Watcher stopped the device due to bad NOC unicast transaction");
+        log_warning("Watcher stopped the device due to bad NOC unicast transaction");
         log_running_kernels(launch_msg);
         log_waypoint(core, launch_msg, debug_status);
         snprintf(buf, sizeof(buf), "On core %s: %s using noc%d tried to accesss core (%02ld,%02ld) L1[addr=0x%08lx,len=%d]",
@@ -214,7 +214,7 @@ static void dump_noc_sanity_status(FILE *f,
                 NOC_MCAST_ADDR_END_Y(san->addr),
                 NOC_LOCAL_ADDR_OFFSET(san->addr), san->len);
         fflush(f);
-        log_info("Watcher stopped the device due to bad NOC multicast transaction");
+        log_warning("Watcher stopped the device due to bad NOC multicast transaction");
         log_running_kernels(launch_msg);
         log_waypoint(core, launch_msg, debug_status);
         snprintf(buf, sizeof(buf), "On core %s: %s using noc%d tried to access core range (%02ld,%02ld)-(%02ld,%02ld) L1[addr=0x%08lx,len=%d]}",


### PR DESCRIPTION
This current implementation forces absolute alignment (as opposed to relative alignment which is what the actual requirement is). Waiting to hear back from Andrew and Davor to see if they think relative alignment only is helpful).

CI passes: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8147412598