### PR TITLE
#5985: Splitting out trace code from dispatch/command_queue

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1211,54 +1211,12 @@ void HWCommandQueue::completion_wrap(uint32_t event) {
     this->enqueue_command(command, false);
 }
 
-Trace::Trace() : trace_complete(false), num_data_bytes(0) {
-    this->cq = std::make_unique<CommandQueue>(this);
-}
-
 volatile bool HWCommandQueue::is_dprint_server_hung() {
     return dprint_server_hang;
 }
 
 volatile bool HWCommandQueue::is_noc_hung() {
     return illegal_noc_txn_hang;
-}
-
-
-void Trace::record(const TraceNode& trace_node) {
-    TT_FATAL(not this->trace_complete, "Cannot record any more for a completed trace");
-    this->num_data_bytes += trace_node.num_data_bytes;
-    this->history.push_back(trace_node);
-}
-
-void Trace::validate() {
-    for (const auto& cmd : this->queue().worker_queue) {
-        if (cmd.blocking.has_value()) {
-            TT_FATAL(cmd.blocking.value() == false, "Blocking commands are not supported in traces");
-        }
-    }
-}
-
-uint32_t Trace::next_trace_id() {
-    static uint32_t global_trace_id = 0;
-    return global_trace_id++;
-}
-
-uint32_t Trace::instantiate(CommandQueue& cq) {
-    uint32_t trace_id = next_trace_id();
-    cq.trace_ptr = this;
-
-    // Stage the trace commands into device DRAM that the command queue will read from
-    // - flatten commands into tightly packed data structure
-    // - allocate the data into a DRAM interleaved buffer using 2KB page size
-    // - commit the DRAM buffer via an enqueue WB command
-    // - map the trace id to the DRAM buffer for later enqueue Trace
-
-    if (trace_instances.count(trace_id)) {
-        TT_THROW("Trace ID " + std::to_string(trace_id) + " already exists");
-    }
-
-    trace_instances.insert(trace_id);
-    return trace_id;
 }
 
 void EnqueueAddBufferToProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program>> program, bool blocking) {

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -13,6 +13,7 @@
 
 #include "tt_metal/impl/dispatch/command_queue_interface.hpp"
 #include "tt_metal/impl/dispatch/lock_free_queue.hpp"
+#include "tt_metal/impl/trace/trace.hpp"
 #include "tt_metal/common/base.hpp"
 #include "tt_metal/impl/program/program.hpp"
 #include "common/env_lib.hpp"
@@ -352,37 +353,6 @@ class EnqueueWaitForEventCommand : public Command {
     EnqueueCommandType type() { return EnqueueCommandType::ENQUEUE_WAIT_FOR_EVENT; }
 
     constexpr bool has_side_effects() { return false; }
-};
-
-
-class Trace {
-   // TODO: delete the extra bloat not needed once implementation is complete
-   private:
-    struct TraceNode {
-        DeviceCommand command;
-        const vector<uint32_t> data;
-        EnqueueCommandType command_type;
-        uint32_t num_data_bytes;
-    };
-    bool trace_complete;
-    vector<TraceNode> history;
-    uint32_t num_data_bytes;
-    std::set<uint32_t> trace_instances;
-    std::unique_ptr<CommandQueue> cq;
-    static uint32_t next_trace_id();
-    void record(const TraceNode& trace_node);
-    void validate();
-
-    friend class CommandQueue;
-    friend class EnqueueProgramCommand;
-    friend CommandQueue& BeginTrace(Trace& trace);
-    friend void EndTrace(Trace& trace);
-    friend void EnqueueTrace(CommandQueue& cq, uint32_t trace_id, bool blocking);
-
-   public:
-    Trace();
-    CommandQueue& queue() const { return *cq; };
-    uint32_t instantiate(CommandQueue& cq);  // return a unique trace id
 };
 
 namespace detail {

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <atomic>
 #include <memory>
 #include "tt_metal/common/assert.hpp"

--- a/tt_metal/impl/module.mk
+++ b/tt_metal/impl/module.mk
@@ -18,7 +18,8 @@ TT_METAL_IMPL_SRCS = \
 	tt_metal/impl/dispatch/debug_tools.cpp \
 	tt_metal/impl/dispatch/command_queue.cpp \
 	tt_metal/impl/debug/dprint_server.cpp \
-	tt_metal/impl/debug/watcher_server.cpp
+	tt_metal/impl/debug/watcher_server.cpp \
+	tt_metal/impl/trace/trace.cpp
 
 TT_METAL_IMPL_OBJS = $(addprefix $(OBJDIR)/, $(TT_METAL_IMPL_SRCS:.cpp=.o))
 TT_METAL_IMPL_DEPS = $(addprefix $(OBJDIR)/, $(TT_METAL_IMPL_SRCS:.cpp=.d))

--- a/tt_metal/impl/trace/trace.cpp
+++ b/tt_metal/impl/trace/trace.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>  // for copy() and assign()
+#include <iterator>   // for back_inserter
+#include <memory>
+#include <string>
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/dispatch/command_queue.hpp"
+
+namespace tt::tt_metal {
+
+Trace::Trace() : trace_complete(false), num_data_bytes(0) { this->cq = std::make_unique<CommandQueue>(this); }
+
+void Trace::record(const TraceNode& trace_node) {
+    TT_FATAL(not this->trace_complete, "Cannot record any more for a completed trace");
+    this->num_data_bytes += trace_node.num_data_bytes;
+    this->history.push_back(trace_node);
+}
+
+void Trace::validate() {
+    for (const auto& cmd : this->queue().worker_queue) {
+        if (cmd.blocking.has_value()) {
+            TT_FATAL(cmd.blocking.value() == false, "Blocking commands are not supported in traces");
+        }
+    }
+}
+
+uint32_t Trace::next_trace_id() {
+    static uint32_t global_trace_id = 0;
+    return global_trace_id++;
+}
+
+uint32_t Trace::instantiate(CommandQueue& cq) {
+    uint32_t trace_id = next_trace_id();
+    cq.trace_ptr = this;
+
+    // Stage the trace commands into device DRAM that the command queue will read from
+    // - flatten commands into tightly packed data structure
+    // - allocate the data into a DRAM interleaved buffer using 2KB page size
+    // - commit the DRAM buffer via an enqueue WB command
+    // - map the trace id to the DRAM buffer for later enqueue Trace
+
+    if (trace_instances.count(trace_id)) {
+        TT_THROW("Trace ID " + std::to_string(trace_id) + " already exists");
+    }
+
+    trace_instances.insert(trace_id);
+    return trace_id;
+}
+
+}

--- a/tt_metal/impl/trace/trace.hpp
+++ b/tt_metal/impl/trace/trace.hpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// #include <algorithm>
+// #include <chrono>
+// #include <fstream>
+// #include <thread>
+#include <memory>
+#include <utility>
+
+#include "tt_metal/common/base.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/dispatch/command_queue.hpp"
+#include "tt_metal/impl/program/program.hpp"
+
+namespace tt::tt_metal {
+
+using std::pair;
+using std::set;
+using std::shared_ptr;
+using std::tuple;
+using std::unique_ptr;
+using std::weak_ptr;
+
+class CommandQueue;
+enum class EnqueueCommandType;
+
+class Trace {
+    // TODO: delete the extra bloat not needed once implementation is complete
+   private:
+    struct TraceNode {
+        DeviceCommand command;
+        const vector<uint32_t> data;
+        EnqueueCommandType command_type;
+        uint32_t num_data_bytes;
+    };
+    bool trace_complete;
+    vector<TraceNode> history;
+    uint32_t num_data_bytes;
+    std::set<uint32_t> trace_instances;
+    std::unique_ptr<CommandQueue> cq;
+    static uint32_t next_trace_id();
+    void record(const TraceNode& trace_node);
+    void validate();
+
+    friend class CommandQueue;
+    friend class EnqueueProgramCommand;
+    friend CommandQueue& BeginTrace(Trace& trace);
+    friend void EndTrace(Trace& trace);
+    friend void EnqueueTrace(CommandQueue& cq, uint32_t trace_id, bool blocking);
+
+   public:
+    Trace();
+    CommandQueue& queue() const { return *cq; };
+    uint32_t instantiate(CommandQueue& cq);  // return a unique trace id
+};
+
+}


### PR DESCRIPTION
It is dispatch agnostic, so moving it out of the dispatch/command_queue.* files to make it easier for later FD2 transition of trace code