### PR TITLE
#5966: Revert change to use 1d_systolic_array for ttnn conv2d in resnet tests for in_channels <= 256 because it's running into the optimized_conv problem again

### DIFF
--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet.py
@@ -26,7 +26,7 @@ from models.experimental.functional_resnet.tt.ttnn_functional_resnet import resn
 
 
 def update_ttnn_module_args(ttnn_module_args):
-    ttnn_module_args["use_1d_systolic_array"] = ttnn_module_args.in_channels <= 256
+    ttnn_module_args["use_1d_systolic_array"] = ttnn_module_args.in_channels < 256
     ttnn_module_args["enable_auto_formatting"] = ttnn_module_args.kernel_size < (7, 7)
     ttnn_module_args["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
 

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet.py
@@ -407,6 +407,7 @@ def test_bottleneck_block_with_downsample(device):
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.skip(reason="Tries to allocate >1MB L1 space for CBs - Issue #5966 for optimized_conv")
 def test_resnet_50(device):
     torch.manual_seed(0)
 


### PR DESCRIPTION
…