### PR TITLE
Events API w/ Async CQ fix for out-of-order event id (and Event/AsyncCQ tests)

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
@@ -15,141 +15,214 @@ TEST_F(CommandQueueFixture, TestEventsWrittenToCompletionQueueInOrder) {
     size_t num_buffers = 100;
     uint32_t page_size = 2048;
     vector<uint32_t> page(page_size / sizeof(uint32_t));
-    uint32_t completion_queue_base = this->device_->sysmem_manager().get_completion_queue_read_ptr(0);
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
-    constexpr uint32_t completion_queue_event_alignment = 32;
-    for (size_t i = 0; i < num_buffers; i++) {
-        Buffer buf(this->device_, page_size, page_size, BufferType::DRAM);
-        EnqueueWriteBuffer(*this->cmd_queue, buf, page, false);
-    }
-    Finish(*this->cmd_queue);
+    uint32_t expected_event_id = 0;
 
-    // Read completion queue and ensure we see events 0-99 inclusive in order
-    uint32_t event;
-    for (size_t i = 0; i < num_buffers; i++) {
-        uint32_t host_addr = completion_queue_base + i * completion_queue_event_alignment;
-        tt::Cluster::instance().read_sysmem(&event, 4, host_addr, mmio_device_id, channel);
-        EXPECT_EQ(event, i);
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH, CommandQueue::CommandQueueMode::ASYNC}) {
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        this->device_->command_queue().set_mode(mode);
+        auto start = std::chrono::system_clock::now();
+
+        uint32_t completion_queue_base = this->device_->sysmem_manager().get_completion_queue_read_ptr(0);
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
+        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
+        constexpr uint32_t completion_queue_event_alignment = 32;
+        for (size_t i = 0; i < num_buffers; i++) {
+            std::shared_ptr<Buffer> buf = std::make_shared<Buffer>(this->device_, page_size, page_size, BufferType::DRAM);
+            EnqueueWriteBuffer(this->device_->command_queue(), buf, page, false);
+        }
+        Finish(this->device_->command_queue());
+
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {:.2f} us", mode, elapsed_seconds.count() * 1000 * 1000);
+
+        // Read completion queue and ensure we see events 0-99 inclusive in order
+        uint32_t event;
+        for (size_t i = 0; i < num_buffers; i++) {
+            uint32_t host_addr = completion_queue_base + i * completion_queue_event_alignment;
+            tt::Cluster::instance().read_sysmem(&event, 4, host_addr, mmio_device_id, channel);
+            EXPECT_EQ(event, expected_event_id++);
+        }
+
     }
+    this->device_->command_queue().set_mode(current_mode);
+
+
 }
 
 // Basic test, record events, check that Event struct was updated. Enough commands to trigger issue queue wrap.
 TEST_F(CommandQueueFixture, TestEventsEnqueueRecordEventIssueQueueWrap) {
-    size_t num_events = 100000; // Enough to wrap issue queue. 768MB and cmds are 22KB each, so 35k cmds.
-    for (size_t i = 0; i < num_events; i++) {
-        auto event = std::make_shared<Event>(); // type is std::shared_ptr<Event>
-        EnqueueRecordEvent(*this->cmd_queue, event);
-        EXPECT_EQ(event->event_id, i);
-        EXPECT_EQ(event->cq_id, this->cmd_queue->id());
+
+    const size_t num_events = 100000; // Enough to wrap issue queue. 768MB and cmds are 22KB each, so 35k cmds.
+    uint32_t cmds_issued_per_cq = 0;
+
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH, CommandQueue::CommandQueueMode::ASYNC}) {
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        this->device_->command_queue().set_mode(mode);
+        auto start = std::chrono::system_clock::now();
+
+        for (size_t i = 0; i < num_events; i++) {
+            auto event = std::make_shared<Event>(); // type is std::shared_ptr<Event>
+            EnqueueRecordEvent(this->device_->command_queue(), event);
+
+            if (mode == CommandQueue::CommandQueueMode::ASYNC) {
+                event->wait_until_ready(); // To check Event fields from host, must block until async cq populated event.
+            }
+            EXPECT_EQ(event->event_id, cmds_issued_per_cq);
+            EXPECT_EQ(event->cq_id, this->device_->command_queue().id());
+            cmds_issued_per_cq++;
+        }
+        Finish(this->device_->command_queue());
+
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {:.2f} us", mode, elapsed_seconds.count() * 1000 * 1000);
     }
-    Finish(*this->cmd_queue);
+    this->device_->command_queue().set_mode(current_mode);
 }
 
 // Test where Host synchronously waits for event to be completed.
 TEST_F(CommandQueueFixture, TestEventsEnqueueRecordEventAndSynchronize) {
-    size_t num_events = 100;
-    size_t num_events_between_sync = 10;
-    std::vector<std::shared_ptr<Event>> sync_events;
+    const size_t num_events = 100;
+    const size_t num_events_between_sync = 10;
 
-    // A bunch of events recorded, occasionally will sync from host.
-    for (size_t i = 0; i < num_events; i++) {
-        auto event = sync_events.emplace_back(std::make_shared<Event>());
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH, CommandQueue::CommandQueueMode::ASYNC}) {
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        auto start = std::chrono::system_clock::now();
+        this->device_->command_queue().set_mode(mode);
 
-        // Uncomment this to ensure syncing on uninitialized event would assert.
-        // EventSynchronize(event);
+        std::vector<std::shared_ptr<Event>> sync_events;
 
-        EnqueueRecordEvent(*this->cmd_queue, event);
-        log_debug(tt::LogTest, "Done recording event. Got Event(event_id: {} cq_id: {})", event->event_id, event->cq_id);
-        EXPECT_EQ(event->event_id, i);
-        EXPECT_EQ(event->cq_id, this->cmd_queue->id());
+        // A bunch of events recorded, occasionally will sync from host.
+        for (size_t i = 0; i < num_events; i++) {
+            auto event = sync_events.emplace_back(std::make_shared<Event>());
+            EnqueueRecordEvent(this->device_->command_queue(), event);
 
-        // Host synchronize every N number of events.
-        if (i > 0 && ((i % num_events_between_sync) == 0)) {
-            EventSynchronize(event);
+            // Host synchronize every N number of events.
+            if (i > 0 && ((i % num_events_between_sync) == 0)) {
+                EventSynchronize(event);
+            }
         }
+
+        // A bunch of bonus syncs where event_id is mod on earlier ID's.
+        EventSynchronize(sync_events.at(2));
+        EventSynchronize(sync_events.at(sync_events.size() - 2));
+        EventSynchronize(sync_events.at(5));
+
+        // Uncomment this to confirm future events not yet seen would hang.
+        // log_debug(tt::LogTest, "The next event is not yet seen, would hang");
+        // auto future_event = sync_events.at(0);
+        // future_event->event_id = num_events + 2;
+        // EventSynchronize(future_event);
+
+        Finish(this->device_->command_queue());
+
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {:.2f} us", mode, elapsed_seconds.count() * 1000 * 1000);
     }
-
-    // A bunch of bonus syncs where event_id is mod on earlier ID's.
-    EventSynchronize(sync_events.at(2));
-    EventSynchronize(sync_events.at(sync_events.size() - 2));
-    EventSynchronize(sync_events.at(5));
-
-    // Uncomment this to confirm future events not yet seen would hang.
-    // log_debug(tt::LogTest, "The next event is not yet seen, would hang");
-    // auto future_event = sync_events.at(0);
-    // future_event->event_id = num_events + 2;
-    // EventSynchronize(future_event);
-
-    Finish(*this->cmd_queue);
+    this->device_->command_queue().set_mode(current_mode);
 }
 
 // Device sync. Single CQ here, less interesting than 2CQ but still useful. Ensure no hangs.
 TEST_F(CommandQueueFixture, TestEventsQueueWaitForEventBasic) {
 
-    size_t num_events = 50;
-    size_t num_events_between_sync = 5;
-    std::vector<std::shared_ptr<Event>> sync_events;
+    const size_t num_events = 50;
+    const size_t num_events_between_sync = 5;
 
-    // A bunch of events recorded, occasionally will sync from device.
-    for (size_t i = 0; i < num_events; i++) {
-        auto event = sync_events.emplace_back(std::make_shared<Event>());
-        EnqueueRecordEvent(*this->cmd_queue, event);
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH, CommandQueue::CommandQueueMode::ASYNC}) {
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        auto start = std::chrono::system_clock::now();
+        this->device_->command_queue().set_mode(mode);
+        std::vector<std::shared_ptr<Event>> sync_events;
 
-        // Device synchronize every N number of events.
-        if (i > 0 && ((i % num_events_between_sync) == 0)) {
-            log_debug(tt::LogTest, "Going to WaitForEvent(event_id: {} cq_id: {}) - should pass.", event->event_id, event->cq_id);
-            EnqueueWaitForEvent(*this->cmd_queue, event);
+        // A bunch of events recorded, occasionally will sync from device.
+        for (size_t i = 0; i < num_events; i++) {
+            auto event = sync_events.emplace_back(std::make_shared<Event>());
+            EnqueueRecordEvent(this->device_->command_queue(), event);
+
+            // Device synchronize every N number of events.
+            if (i > 0 && ((i % num_events_between_sync) == 0)) {
+                log_debug(tt::LogTest, "Going to WaitForEvent for i: {}", i);
+                EnqueueWaitForEvent(this->device_->command_queue(), event);
+            }
         }
+
+        // A bunch of bonus syncs where event_id is mod on earlier ID's.
+        EnqueueWaitForEvent(this->device_->command_queue(), sync_events.at(0));
+        EnqueueWaitForEvent(this->device_->command_queue(), sync_events.at(sync_events.size() - 5));
+        EnqueueWaitForEvent(this->device_->command_queue(), sync_events.at(4));
+
+        // Uncomment this to confirm future events not yet seen would hang.
+        // auto future_event = sync_events.at(0);
+        // future_event->event_id = (num_events * 2) + 2;
+        // log_debug(tt::LogTest, "The next event (event_id: {}) is not yet seen, would hang", future_event->event_id);
+        // EnqueueWaitForEvent(this->device_->command_queue(), future_event);
+
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {:.2f} us", mode, elapsed_seconds.count() * 1000 * 1000);
     }
-
-    // A bunch of bonus syncs where event_id is mod on earlier ID's.
-    EnqueueWaitForEvent(*this->cmd_queue, sync_events.at(0));
-    EnqueueWaitForEvent(*this->cmd_queue, sync_events.at(sync_events.size() - 5));
-    EnqueueWaitForEvent(*this->cmd_queue, sync_events.at(4));
-
-    // Uncomment this to confirm future events not yet seen would hang.
-    // auto future_event = sync_events.at(0);
-    // future_event->event_id = (num_events * 2) + 2;
-    // log_debug(tt::LogTest, "The next event (event_id: {}) is not yet seen, would hang", future_event->event_id);
-    // EnqueueWaitForEvent(*this->cmd_queue, future_event);
-
+    this->device_->command_queue().set_mode(current_mode);
 }
 
 // Mix of WritesBuffers, RecordEvent, WaitForEvent, EventSynchronize with some checking.
 TEST_F(CommandQueueFixture, TestEventsMixedWriteBufferRecordWaitSynchronize) {
-    size_t num_buffers = 100;
-    uint32_t page_size = 2048;
+    const size_t num_buffers = 100;
+    const uint32_t page_size = 2048;
     vector<uint32_t> page(page_size / sizeof(uint32_t));
-    uint32_t completion_queue_base = this->device_->sysmem_manager().get_completion_queue_read_ptr(0);
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
-    constexpr uint32_t completion_queue_event_alignment = 32;
-    for (size_t i = 0; i < num_buffers; i++) {
+    uint32_t cmds_issued_per_cq = 0;
+    const uint32_t num_cmds_per_cq = 3; // Record, Write, Wait
+    uint32_t expected_event_id = 0;
 
-        // Record Event
-        auto event = std::make_shared<Event>(); // type is std::shared_ptr<Event>
-        EnqueueRecordEvent(*this->cmd_queue, event);
-        EXPECT_EQ(event->cq_id, this->cmd_queue->id());
-        EXPECT_EQ(event->event_id, i * 3);
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH, CommandQueue::CommandQueueMode::ASYNC}) {
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        auto start = std::chrono::system_clock::now();
+        this->device_->command_queue().set_mode(mode);
 
-        Buffer buf(this->device_, page_size, page_size, BufferType::DRAM);
-        EnqueueWriteBuffer(*this->cmd_queue, buf, page, false);
+        uint32_t completion_queue_base = this->device_->sysmem_manager().get_completion_queue_read_ptr(0);
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
+        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
+        constexpr uint32_t completion_queue_event_alignment = 32;
+        for (size_t i = 0; i < num_buffers; i++) {
 
-        EnqueueWaitForEvent(*this->cmd_queue, event);
+            log_debug(tt::LogTest, "Mode: {} i: {} - Going to record event, write, wait, synchronize.", mode, i);
+            auto event = std::make_shared<Event>(); // type is std::shared_ptr<Event>
+            EnqueueRecordEvent(this->device_->command_queue(), event);
 
-        if (i % 10 == 0) {
-            EventSynchronize(event);
+            // Cannot count on event being populated with async cq, so only check with passthrough.
+            if (mode == CommandQueue::CommandQueueMode::PASSTHROUGH) {
+                EXPECT_EQ(event->cq_id, this->cmd_queue->id());
+                EXPECT_EQ(event->event_id, cmds_issued_per_cq);
+            }
+
+            std::shared_ptr<Buffer> buf = std::make_shared<Buffer>(this->device_, page_size, page_size, BufferType::DRAM);
+            EnqueueWriteBuffer(this->device_->command_queue(), buf, page, false);
+            EnqueueWaitForEvent(this->device_->command_queue(), event);
+
+            if (i % 10 == 0) {
+                EventSynchronize(event);
+                // For async, can verify event fields here since previous function already called wait-until-ready.
+                if (mode == CommandQueue::CommandQueueMode::ASYNC) {
+                    EXPECT_EQ(event->cq_id, this->cmd_queue->id());
+                    EXPECT_EQ(event->event_id, cmds_issued_per_cq);
+                }
+            }
+            cmds_issued_per_cq += num_cmds_per_cq;
         }
-    }
-    Finish(*this->cmd_queue);
+        Finish(this->device_->command_queue());
 
-    // Read completion queue and ensure we see events 0-297 inclusive in order
-    uint32_t event;
-    const uint32_t num_cmds_per_buf = 3; // Record, Write, Wait
-    for (size_t i = 0; i < num_buffers * num_cmds_per_buf; i++) {
-        uint32_t host_addr = completion_queue_base + i * completion_queue_event_alignment;
-        tt::Cluster::instance().read_sysmem(&event, 4, host_addr, mmio_device_id, channel);
-        EXPECT_EQ(event, i);
+        // Read completion queue and ensure we see expected event IDs
+        uint32_t event_id;
+        for (size_t i = 0; i < num_buffers * num_cmds_per_cq; i++) {
+            uint32_t host_addr = completion_queue_base + i * completion_queue_event_alignment;
+            tt::Cluster::instance().read_sysmem(&event_id, 4, host_addr, mmio_device_id, channel);
+            EXPECT_EQ(event_id, expected_event_id++);
+        }
+
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {:.2f} us", mode, elapsed_seconds.count() * 1000 * 1000);
     }
+    this->device_->command_queue().set_mode(current_mode);
 }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWaitForEvent.cpp
@@ -22,152 +22,224 @@ void FinishAllCqs(vector<std::reference_wrapper<CommandQueue>>& cqs) {
     }
 }
 
+void SetAllCqsMode(vector<std::reference_wrapper<CommandQueue>>& cqs, CommandQueue::CommandQueueMode mode) {
+    for (uint i = 0; i < cqs.size(); i++) {
+        cqs[i].get().set_mode(mode);
+    }
+}
+
 }
 
 namespace basic_tests {
 
-// Simplest test to record Event per CQ and wait from host.
+// Simplest test to record Event per CQ and wait from host, and verify populated Event struct is correct (many events, wrap issue queue)
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEventSynchronizeSanity) {
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
-    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
-    std::unordered_map<uint, std::vector<std::shared_ptr<Event>>> sync_events;
-    size_t num_events = 10;
+    vector<std::reference_wrapper<CommandQueue>> cqs = {this->device_->command_queue(0), this->device_->command_queue(1)};
+    vector<uint32_t> cmds_issued_per_cq = {0, 0};
 
-    for (size_t j = 0; j < num_events; j++) {
-        for (uint i = 0; i < cqs.size(); i++) {
-            log_debug(tt::LogTest, "Recording and Host Syncing on event for CQ ID: {}", cqs[i].get().id());
-            auto event = sync_events[i].emplace_back(std::make_shared<Event>());
-            EnqueueRecordEvent(cqs[i], event);
-            EXPECT_EQ(event->cq_id, cqs[i].get().id());
-            EXPECT_EQ(event->event_id, j); // 1 cmd per CQ
-            EventSynchronize(event);
-        }
-    }
+    TT_ASSERT(cqs.size() == 2);
+    const int num_cmds_per_cq = 1;
 
-    // Sync on earlier events again per CQ just to show it works.
-    for (uint i = 0; i < cqs.size(); i++) {
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH, CommandQueue::CommandQueueMode::ASYNC}) {
+        local_test_functions::SetAllCqsMode(cqs, mode);
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        auto start = std::chrono::system_clock::now();
+
+        std::unordered_map<uint, std::vector<std::shared_ptr<Event>>> sync_events;
+        const size_t num_events = 10;
+
         for (size_t j = 0; j < num_events; j++) {
-            EventSynchronize(sync_events.at(i)[j]);
+            for (uint i = 0; i < cqs.size(); i++) {
+                log_debug(tt::LogTest, "Mode: {} j : {} Recording and Host Syncing on event for CQ ID: {}", mode, j, cqs[i].get().id());
+                auto event = sync_events[i].emplace_back(std::make_shared<Event>());
+                EnqueueRecordEvent(cqs[i], event);
+                EventSynchronize(event);
+                // Can check events fields after prev sync w/ async CQ.
+                EXPECT_EQ(event->cq_id, cqs[i].get().id());
+                EXPECT_EQ(event->event_id, cmds_issued_per_cq[i]);
+                cmds_issued_per_cq[i] += num_cmds_per_cq;
+            }
         }
-    }
 
-    local_test_functions::FinishAllCqs(cqs);
+        // Sync on earlier events again per CQ just to show it works.
+        for (uint i = 0; i < cqs.size(); i++) {
+            for (size_t j = 0; j < num_events; j++) {
+                EventSynchronize(sync_events.at(i)[j]);
+            }
+        }
+
+        local_test_functions::FinishAllCqs(cqs);
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {:.2f} us", mode, elapsed_seconds.count() * 1000 * 1000);
+
+    }
+    local_test_functions::SetAllCqsMode(cqs, current_mode);
 }
 
-// Simplest test to record and wait-for-events on same CQ.
+// Simplest test to record and wait-for-events on same CQ. Only check event struct members in passthrough mode to not add any extra
+// sync/delay via wait_until_ready().
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueWaitForEventSanity) {
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
-    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+    vector<std::reference_wrapper<CommandQueue>> cqs = {this->device_->command_queue(0), this->device_->command_queue(1)};
+    vector<uint32_t> cmds_issued_per_cq = {0, 0};
     size_t num_events = 10;
 
-    for (size_t j = 0; j < num_events; j++) {
-        for (uint i = 0; i < cqs.size(); i++) {
-            log_debug(tt::LogTest, "Recording and Device Syncing on event for CQ ID: {}", cqs[i].get().id());
-            auto event = std::make_shared<Event>();
-            EnqueueRecordEvent(cqs[i], event);
-            EXPECT_EQ(event->cq_id, cqs[i].get().id());
-            EXPECT_EQ(event->event_id, j * 2);
-            EnqueueWaitForEvent(cqs[i], event);
+    TT_ASSERT(cqs.size() == 2);
+    const int num_cmds_per_cq = 2;
+
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH, CommandQueue::CommandQueueMode::ASYNC}) {
+        local_test_functions::SetAllCqsMode(cqs, mode);
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        auto start = std::chrono::system_clock::now();
+
+        for (size_t j = 0; j < num_events; j++) {
+            for (uint i = 0; i < cqs.size(); i++) {
+                log_debug(tt::LogTest, "Mode: {} j : {} Recording and Device Syncing on event for CQ ID: {}", mode, j, cqs[i].get().id());
+                auto event = std::make_shared<Event>();
+                EnqueueRecordEvent(cqs[i], event);
+
+                // Only in passthrough mode is Event populated right away.
+                if (mode == CommandQueue::CommandQueueMode::PASSTHROUGH) {
+                    EXPECT_EQ(event->cq_id, cqs[i].get().id());
+                    EXPECT_EQ(event->event_id, cmds_issued_per_cq[i]);
+                }
+
+                EnqueueWaitForEvent(cqs[i], event);
+                cmds_issued_per_cq[i] += num_cmds_per_cq;
+            }
         }
+        local_test_functions::FinishAllCqs(cqs);
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {:.2f} us", mode, elapsed_seconds.count() * 1000 * 1000);
+
     }
-    local_test_functions::FinishAllCqs(cqs);
+    local_test_functions::SetAllCqsMode(cqs, current_mode);
 }
 
 // Record event on one CQ, wait-for-that-event on another CQ. Then do the flip. Occasionally insert
 // syncs from Host per CQ, and verify completion queues per CQ are correct.
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueWaitForEventCrossCQs) {
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
-    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
-    size_t num_events_per_cq = 10;
+    vector<std::reference_wrapper<CommandQueue>> cqs = {this->device_->command_queue(0), this->device_->command_queue(1)};
+    vector<uint32_t> cmds_issued_per_cq = {0, 0};
+    const size_t num_events_per_cq = 10;
 
     // Currently hardcoded for 2 CQ. For 3+ CQ, can extend to record for CQ0, Wait for CQ1,CQ2,etc.
     TT_ASSERT(cqs.size() == 2);
-    const int num_cmds_per_cq = 2;
+    const int num_cmds_per_cq = 1;
+    vector<uint32_t> expected_event_id = {0, 0};
 
-    // Store completion queue base address from initial rdptr, for later readback.
-    vector<uint32_t> completion_queue_base;
-    for (uint i = 0; i < cqs.size(); i++) {
-        completion_queue_base.push_back(this->device_->sysmem_manager().get_completion_queue_read_ptr(i));
-    }
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH, CommandQueue::CommandQueueMode::ASYNC}) {
+        local_test_functions::SetAllCqsMode(cqs, mode);
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        auto start = std::chrono::system_clock::now();
 
-    // Issue a number of Event Record/Waits per CQ, with Record/Wait on alternate CQs
-    for (size_t j = 0; j < num_events_per_cq; j++) {
+        // Store completion queue base address from initial rdptr, for later readback.
+        vector<uint32_t> completion_queue_base;
         for (uint i = 0; i < cqs.size(); i++) {
-            auto &cq_record_event = cqs[i];
-            auto &cq_wait_event = cqs[(i + 1) % cqs.size()];
-            auto event = std::make_shared<Event>();
-            log_debug(tt::LogTest, "Recording event on CQ ID: {} and Device Syncing on CQ ID: {}", cq_record_event.get().id(), cq_wait_event.get().id());
+            completion_queue_base.push_back(this->device_->sysmem_manager().get_completion_queue_read_ptr(i));
+        }
 
-            EnqueueRecordEvent(cq_record_event, event);
-            EXPECT_EQ(event->cq_id, cq_record_event.get().id());
-            EXPECT_EQ(event->event_id, i + (j * num_cmds_per_cq));
-            EnqueueWaitForEvent(cq_wait_event, event);
+        // Issue a number of Event Record/Waits per CQ, with Record/Wait on alternate CQs
+        for (size_t j = 0; j < num_events_per_cq; j++) {
+            for (uint i = 0; i < cqs.size(); i++) {
 
-            // Occasionally do host wait for extra coverage from both CQs.
-            if (j > 0 && ((j % 3) == 0)) {
-                EventSynchronize(event);
+                auto cq_idx_record = i;
+                auto cq_idx_wait = (i + 1) % cqs.size();
+                auto event = std::make_shared<Event>();
+                log_debug(tt::LogTest, "Mode: {} j : {} Recording event on CQ ID: {} and Device Syncing on CQ ID: {}", mode, j, cqs[cq_idx_record].get().id(), cqs[cq_idx_wait].get().id());
+                EnqueueRecordEvent(cqs[cq_idx_record], event);
+
+                if (mode == CommandQueue::CommandQueueMode::ASYNC) {
+                    event->wait_until_ready();
+                }
+
+                EXPECT_EQ(event->cq_id, cqs[cq_idx_record].get().id());
+                EXPECT_EQ(event->event_id, cmds_issued_per_cq[i]);
+                EnqueueWaitForEvent(cqs[cq_idx_wait], event);
+
+                // Occasionally do host wait for extra coverage from both CQs.
+                if (j > 0 && ((j % 3) == 0)) {
+                    EventSynchronize(event);
+                }
+                cmds_issued_per_cq[cq_idx_record] += num_cmds_per_cq;
+                cmds_issued_per_cq[cq_idx_wait] += num_cmds_per_cq;
             }
         }
-    }
 
-    local_test_functions::FinishAllCqs(cqs);
+        local_test_functions::FinishAllCqs(cqs);
 
-    // Check that completion queue per device is correct. Ensure expected event_ids seen in order.
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
-    constexpr uint32_t completion_queue_event_alignment = 32;
-    uint32_t event;
+        // Check that completion queue per device is correct. Ensure expected event_ids seen in order.
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_->id());
+        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
+        constexpr uint32_t completion_queue_event_alignment = 32;
+        uint32_t event;
 
-    for (uint cq_id = 0; cq_id < cqs.size(); cq_id++) {
-        for (size_t i = 0; i < num_cmds_per_cq * num_events_per_cq; i++) {
-            uint32_t host_addr = completion_queue_base[cq_id] + i * completion_queue_event_alignment;
-            tt::Cluster::instance().read_sysmem(&event, 4, host_addr, mmio_device_id, channel);
-            EXPECT_EQ(event, i);
+        for (uint cq_id = 0; cq_id < cqs.size(); cq_id++) {
+            for (size_t i = 0; i < num_cmds_per_cq * cqs.size() * num_events_per_cq; i++) {
+                uint32_t host_addr = completion_queue_base[cq_id] + i * completion_queue_event_alignment;
+                tt::Cluster::instance().read_sysmem(&event, 4, host_addr, mmio_device_id, channel);
+                log_debug(tt::LogTest, "Checking completion queue. mode: {} cq_id: {} i: {} host_addr: {}. Got event_id: {}", mode, cq_id, i, host_addr, event);
+                EXPECT_EQ(event, expected_event_id[cq_id]++);
+            }
         }
+
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {:.2f} us", mode, elapsed_seconds.count() * 1000 * 1000);
     }
+    local_test_functions::SetAllCqsMode(cqs, current_mode);
 }
 
 // Simple 2CQ test to mix reads, writes, record-event, wait-for-event in a basic way. It's simple because
 // the write, record-event, wait-event, read-event are all on the same CQ, but cover both CQ's.
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsReadWriteWithWaitForEventSameCQ) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 256, .buftype = BufferType::DRAM};
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
-    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+    vector<std::reference_wrapper<CommandQueue>> cqs = {this->device_->command_queue(0), this->device_->command_queue(1)};
+    vector<uint32_t> cmds_issued_per_cq = {0, 0};
+
     size_t buf_size = config.num_pages * config.page_size;
 
     size_t num_buffers_per_cq = 10;
     bool pass = true;
-    std::unordered_map<uint, std::vector<std::shared_ptr<Event>>> sync_events;
 
-    for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
-        vector<std::unique_ptr<Buffer>> buffers;
-        vector<vector<uint32_t>> srcs;
-        for (uint i = 0; i < cqs.size(); i++) {
-            uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
-            buffers.push_back(std::make_unique<Buffer>(this->device_, buf_size, config.page_size, config.buftype));
-            srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
-            log_debug(tt::LogTest, "Doing Write to cq_id: {} of data: {}", i, srcs[i]);
-            EnqueueWriteBuffer(cqs[i], *buffers[i], srcs[i], false);
-            auto event = sync_events[i].emplace_back(std::make_shared<Event>());
-            EnqueueRecordEvent(cqs[i], event);
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH}) {
+        local_test_functions::SetAllCqsMode(cqs, mode);
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        auto start = std::chrono::system_clock::now();
+
+        std::unordered_map<uint, std::vector<std::shared_ptr<Event>>> sync_events;
+
+        for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
+            vector<std::shared_ptr<Buffer>> buffers;
+            vector<vector<uint32_t>> srcs;
+            for (uint i = 0; i < cqs.size(); i++) {
+                uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
+                buffers.push_back(std::make_shared<Buffer>(this->device_, buf_size, config.page_size, config.buftype));
+                srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
+                log_debug(tt::LogTest, "Mode: {} buf_idx: {} Doing Write to cq_id: {} of data: {}", mode, buf_idx, i, srcs[i]);
+                EnqueueWriteBuffer(cqs[i], *buffers[i], srcs[i], false);
+                auto event = sync_events[i].emplace_back(std::make_shared<Event>());
+                EnqueueRecordEvent(cqs[i], event);
+            }
+
+            for (uint i = 0; i < cqs.size(); i++) {
+                auto event = sync_events[i][buf_idx];
+                EnqueueWaitForEvent(cqs[i], event);
+                vector<uint32_t> result;
+                EnqueueReadBuffer(cqs[i], *buffers[i], result, true); // Blocking.
+                bool local_pass = (srcs[i] == result);
+                log_debug(tt::LogTest, "Mode: {} Checking buf_idx: {} cq_idx: {} local_pass: {} write_data: {} read_results: {}", mode, buf_idx, i, local_pass, srcs[i], result);
+                pass &= local_pass;
+            }
         }
 
-        for (uint i = 0; i < cqs.size(); i++) {
-            auto event = sync_events[i][buf_idx];
-            EnqueueWaitForEvent(cqs[i], event);
-            vector<uint32_t> result;
-            EnqueueReadBuffer(cqs[i], *buffers[i], result, true);
-            log_debug(tt::LogTest, "Doing Read to cq_id: {} got data: {}", i, result);
-            bool local_pass = (srcs[i] == result);
-            pass &= local_pass;
-        }
+        local_test_functions::FinishAllCqs(cqs);
+        std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {:.2f} us", mode, elapsed_seconds.count() * 1000 * 1000);
     }
-
-    local_test_functions::FinishAllCqs(cqs);
+    local_test_functions::SetAllCqsMode(cqs, current_mode);
     EXPECT_TRUE(pass);
 }
 
@@ -176,47 +248,60 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsReadWriteWithWaitForEvent
 // Ensure read back data is correct, data is different for each write.
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsReadWriteWithWaitForEventCrossCQs) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
-    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+    vector<std::reference_wrapper<CommandQueue>> cqs = {this->device_->command_queue(0), this->device_->command_queue(1)};
+    vector<uint32_t> cmds_issued_per_cq = {0, 0};
 
     size_t num_buffers_per_cq = 50;
     bool pass = true;
 
-    for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH}) {
+        local_test_functions::SetAllCqsMode(cqs, mode);
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        auto start = std::chrono::system_clock::now();
 
-        // Increase number of pages and page size every 10 buffers, to change async timing betwen CQs.
-        if (buf_idx > 0 && ((buf_idx % 10) == 0)) {
-            config.page_size *= 2;
-            config.num_pages *= 2;
+        for (uint buf_idx = 0; buf_idx < num_buffers_per_cq; buf_idx++) {
+
+            // Increase number of pages and page size every 10 buffers, to change async timing betwen CQs.
+            if (buf_idx > 0 && ((buf_idx % 10) == 0)) {
+                config.page_size *= 2;
+                config.num_pages *= 2;
+            }
+
+            vector<std::shared_ptr<Buffer>> buffers;
+            vector<vector<uint32_t>> srcs;
+            size_t buf_size = config.num_pages * config.page_size;
+
+            for (uint i = 0; i < cqs.size(); i++) {
+
+                uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
+                auto &cq_write = cqs[i];
+                auto &cq_read = cqs[(i + 1) % cqs.size()];
+                auto event = std::make_shared<Event>();
+                vector<uint32_t> result;
+
+                buffers.push_back(std::make_shared<Buffer>(this->device_, buf_size, config.page_size, config.buftype));
+                srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
+
+                // Blocking Read after Non-Blocking Write on alternate CQs, events ensure ordering.
+                log_debug(tt::LogTest, "Mode: {} buf_idx: {} Doing Write (page_size: {} num_pages: {}) to cq_id: {}", mode, buf_idx, config.page_size, config.num_pages, cq_write.get().id());
+                EnqueueWriteBuffer(cq_write, *buffers[i], srcs[i], false);
+                EnqueueRecordEvent(cq_write, event);
+                EnqueueWaitForEvent(cq_read, event);
+                EnqueueReadBuffer(cq_read, *buffers[i], result, true);
+                bool local_pass = (srcs[i] == result);
+                log_debug(tt::LogTest, "Mode: {} Checking buf_idx: {} cq_idx: {} local_pass: {} write_data: {} read_results: {}", mode, buf_idx, i, local_pass, srcs[i], result);
+                pass &= local_pass;
+            }
         }
 
-        vector<std::unique_ptr<Buffer>> buffers;
-        vector<vector<uint32_t>> srcs;
-        size_t buf_size = config.num_pages * config.page_size;
+        local_test_functions::FinishAllCqs(cqs);
 
-        for (uint i = 0; i < cqs.size(); i++) {
-
-            uint32_t wr_data_base = (buf_idx * 1000) + (i * 100);
-            auto &cq_write = cqs[i];
-            auto &cq_read = cqs[(i + 1) % cqs.size()];
-            auto event = std::make_shared<Event>();
-            vector<uint32_t> result;
-
-            buffers.push_back(std::make_unique<Buffer>(this->device_, buf_size, config.page_size, config.buftype));
-            srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
-
-            // Blocking Read after Non-Blocking Write on alternate CQs, events ensure ordering.
-            log_debug(tt::LogTest, "Doing Write (page_size: {} num_pages: {}) to cq_id: {}", config.page_size, config.num_pages, cq_write.get().id());
-            EnqueueWriteBuffer(cq_write, *buffers[i], srcs[i], false);
-            EnqueueRecordEvent(cq_write, event);
-            EnqueueWaitForEvent(cq_read, event);
-            EnqueueReadBuffer(cq_read, *buffers[i], result, true);
-            pass &= (srcs[i] == result);
-        }
+        auto end = std::chrono::system_clock::now();
+        std::chrono::duration<double> elapsed_seconds = (end-start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {}us", mode, elapsed_seconds.count() * 1000 * 1000);
     }
-
-    local_test_functions::FinishAllCqs(cqs);
+    local_test_functions::SetAllCqsMode(cqs, current_mode);
     EXPECT_TRUE(pass);
 }
 
@@ -225,9 +310,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsReadWriteWithWaitForEvent
 // write after read before checking correct data read at the end after all cmds finished on device.
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsReadWriteWithWaitForEventCrossCQsPingPong) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 16, .buftype = BufferType::DRAM};
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
-    vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
+    vector<std::reference_wrapper<CommandQueue>> cqs = {this->device_->command_queue(0), this->device_->command_queue(1)};
     size_t buf_size = config.num_pages * config.page_size;
 
     bool pass = true;
@@ -238,73 +321,92 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsReadWriteWithWaitForEvent
     bool use_events = true; // Set to false to see failures.
 
     TT_ASSERT(cqs.size() == 2);
-    auto &cq_write = cqs[0];
-    auto &cq_read = cqs[1];
 
-    // Another loop for increased testing. Repeat test multiple times for different buffers.
-    for (int i = 0; i < num_buffers; i++) {
+    auto current_mode = CommandQueue::default_mode();
+    for (const CommandQueue::CommandQueueMode mode : {CommandQueue::CommandQueueMode::PASSTHROUGH}) {
+        local_test_functions::SetAllCqsMode(cqs, mode);
+        tt::log_info(tt::LogTest, "Using CQ Mode: {}", mode);
+        auto start = std::chrono::system_clock::now();
 
-        vector<vector<uint32_t>> write_data;
-        vector<vector<uint32_t>> read_results;
-        vector<std::unique_ptr<Buffer>> buffers;
+        // Repeat test starting with different CQ ID. Could have placed this loop lower down.
+        for (uint cq_idx = 0; cq_idx < cqs.size(); cq_idx++) {
 
-        buffers.push_back(std::make_unique<Buffer>(this->device_, buf_size, config.page_size, config.buftype));
+            auto &cq_write = cqs[cq_idx];
+            auto &cq_read = cqs[(cq_idx + 1) % cqs.size()];
 
-        // Number of write-read combos per buffer. Fewer make RAW race without events easier to hit.
-        for (uint j = 0; j < num_wr_rd_per_buf; j++) {
+            // Another loop for increased testing. Repeat test multiple times for different buffers.
+            for (int i = 0; i < num_buffers; i++) {
 
-            // 2 Events to synchronize delaying the read after write, and delaying the next write after read.
-            auto event_sync_read_after_write = std::make_shared<Event>();
-            auto event_sync_write_after_read = std::make_shared<Event>();
+                vector<vector<uint32_t>> write_data;
+                vector<vector<uint32_t>> read_results;
+                vector<std::shared_ptr<Buffer>> buffers;
 
-            // Add entry in resutls vector, and construct write data, unique per loop
-            read_results.emplace_back();
-            write_data.push_back(generate_arange_vector(buffers.back()->size(), j * 100));
+                buffers.push_back(std::make_shared<Buffer>(this->device_, buf_size, config.page_size, config.buftype));
 
-            // Issue non-blocking write via first CQ and record event to synchronize with read on other CQ.
-            log_debug(tt::LogTest, "Doing Write j: {} (page_size: {} num_pages: {}) to cq_id: {} write_data: {}", j, config.page_size, config.num_pages, cq_write.get().id(), write_data.back());
-            EnqueueWriteBuffer(cq_write, *buffers.back(), write_data.back(), false);
-            if (use_events) EnqueueRecordEvent(cq_write, event_sync_read_after_write);
+                // Number of write-read combos per buffer. Fewer make RAW race without events easier to hit.
+                for (uint j = 0; j < num_wr_rd_per_buf; j++) {
 
-            // Issue wait for write to complete, and non-blocking read from the second CQ.
-            if (use_events) EnqueueWaitForEvent(cq_read, event_sync_read_after_write);
-            EnqueueReadBuffer(cq_read, *buffers.back(), read_results.back(), false);
-            log_debug(tt::LogTest, "Issued Read for j: {} got data: {}", j, read_results.back()); // Data not ready since non-blocking.
+                    // 2 Events to synchronize delaying the read after write, and delaying the next write after read.
+                    auto event_sync_read_after_write = std::make_shared<Event>();
+                    auto event_sync_write_after_read = std::make_shared<Event>();
 
-            // If more loops, Record Event on second CQ and wait for it to complete on first CQ before next loop's write.
-            if (use_events && j < num_wr_rd_per_buf-1) {
-                EnqueueRecordEvent(cq_read, event_sync_write_after_read);
-                EnqueueWaitForEvent(cq_write, event_sync_write_after_read);
-            }
-        }
+                    // Add entry in resutls vector, and construct write data, unique per loop
+                    read_results.emplace_back();
+                    write_data.push_back(generate_arange_vector(buffers.back()->size(), j * 100));
 
-        // Basically like Finish, but use host sync on event to ensure all read cmds are finished.
-        if (use_events) {
-            auto event_done_reads = std::make_shared<Event>();
-            EnqueueRecordEvent(cq_read, event_done_reads);
-            EventSynchronize(event_done_reads);
-        }
+                    // Issue non-blocking write via first CQ and record event to synchronize with read on other CQ.
+                    log_debug(tt::LogTest, "Mode: {} cq_idx: {} Doing Write j: {} (page_size: {} num_pages: {}) to cq_id: {} write_data: {}", mode, cq_idx, j, config.page_size, config.num_pages, cq_write.get().id(), write_data.back());
+                    EnqueueWriteBuffer(cq_write, *buffers.back(), write_data.back(), false);
+                    if (use_events) EnqueueRecordEvent(cq_write, event_sync_read_after_write);
 
-        TT_ASSERT(write_data.size() == read_results.size());
-        TT_ASSERT(write_data.size() == num_wr_rd_per_buf);
+                    // Issue wait for write to complete, and non-blocking read from the second CQ.
+                    if (use_events) EnqueueWaitForEvent(cq_read, event_sync_read_after_write);
+                    EnqueueReadBuffer(cq_read, *buffers.back(), read_results.back(), false);
+                    log_debug(tt::LogTest, "Mode: {} cq_idx: {} Issued Read for j: {} to cq_id: {} got data: {}", mode, cq_idx, j, cq_read.get().id(), read_results.back()); // Data not ready since non-blocking.
 
-        for (uint j = 0; j < num_wr_rd_per_buf; j++) {
-            // Make copy of read results, helpful for comparison without events, since vector may be updated between comparison and debug log.
-            auto read_results_snapshot = read_results[j];
-            bool local_pass = write_data[j] == read_results_snapshot;
-            log_debug(tt::LogTest, "Checking j: {} local_pass: {} write_data: {} read_results: {}", j, local_pass, write_data[j], read_results_snapshot);
-            pass &= local_pass;
-        }
+                    // If more loops, Record Event on second CQ and wait for it to complete on first CQ before next loop's write.
+                    if (use_events && j < num_wr_rd_per_buf-1) {
+                        EnqueueRecordEvent(cq_read, event_sync_write_after_read);
+                        EnqueueWaitForEvent(cq_write, event_sync_write_after_read);
+                    }
+                }
 
-        // Before starting test with another buffer, drain CQs. Without this, see segfaults after
-        // adding num_buffers loop.
+                // Basically like Finish, but use host sync on event to ensure all read cmds are finished.
+                if (use_events) {
+                    auto event_done_reads = std::make_shared<Event>();
+                    EnqueueRecordEvent(cq_read, event_done_reads);
+                    EventSynchronize(event_done_reads);
+                }
+
+                TT_ASSERT(write_data.size() == read_results.size());
+                TT_ASSERT(write_data.size() == num_wr_rd_per_buf);
+
+                for (uint j = 0; j < num_wr_rd_per_buf; j++) {
+                    // Make copy of read results, helpful for comparison without events, since vector may be updated between comparison and debug log.
+                    auto read_results_snapshot = read_results[j];
+                    bool local_pass = write_data[j] == read_results_snapshot;
+                    if (!local_pass) {
+                        log_warning(tt::LogTest, "Mode: {} cq_idx: {} Checking j: {} local_pass: {} write_data: {} read_results: {}", mode, cq_idx, j, local_pass, write_data[j], read_results_snapshot);
+                    }
+                    pass &= local_pass;
+                }
+
+                // Before starting test with another buffer, drain CQs. Without this, see segfaults after
+                // adding num_buffers loop.
+                local_test_functions::FinishAllCqs(cqs);
+
+            } // num_buffers
+
+        } // cqs
+
         local_test_functions::FinishAllCqs(cqs);
 
-    } // num_buffers
-
-    local_test_functions::FinishAllCqs(cqs);
+        auto end = std::chrono::system_clock::now();
+        std::chrono::duration<double> elapsed_seconds = (end-start);
+        tt::log_info(tt::LogTest, "Test with CQ Mode: {} Finished in {}us", mode, elapsed_seconds.count() * 1000 * 1000);
+    }
+    local_test_functions::SetAllCqsMode(cqs, current_mode);
     EXPECT_TRUE(pass);
-
 }
 
 

--- a/tt_metal/impl/event/event.hpp
+++ b/tt_metal/impl/event/event.hpp
@@ -5,6 +5,9 @@
 #pragma once
 
 #include <cstdint>
+#include <thread>
+#include "common/assert.hpp"
+#include "tt_metal/common/logger.hpp"
 namespace tt::tt_metal
 {
     class Device;
@@ -13,5 +16,19 @@ namespace tt::tt_metal
         Device * device = nullptr;
         uint32_t cq_id = -1;
         uint32_t event_id = -1;
+        std::atomic<bool> ready = false; // Event is ready for use.
+
+        // With async CQ, must wait until event is populated by child thread before using.
+        // Opened #5988 to track removing this, and finding different solution.
+        void wait_until_ready() {
+            while (!ready) {
+                std::this_thread::sleep_for(std::chrono::microseconds(10));
+                log_trace(tt::LogMetal, "Waiting for Event to be ready. (ready: {} cq_id: {} event_id: {})", ready, cq_id, event_id);
+            }
+
+            TT_ASSERT(device != nullptr, "Event must have initialized device ptr");
+            TT_ASSERT(event_id != -1, "Event must have initialized event_id");
+            TT_ASSERT(cq_id != -1, "Event must have initialized cq_id");
+        }
     };
 }


### PR DESCRIPTION
This is dependent on async cq changes in #5808 being merged.

Recap on some offline discussions yesterday between @tooniz / @tt-asaigal and myself.

- During initial Events commita week ago at 380bb3c5b,  I had previously put the `get_next_event()` call (that increments, returns next event id) outside of async worker thread for `EnqueueRecordEvent(cq, Event)` because I wanted the returned `Event` struct to caller to be populated and available for use right away in `EnqueueWaitForEvent(cq, Event)` or `EventSynchronize(Event)` (host-side sync on event) and not at some unknown time later.  Turns out this was a bad idea to have this event increment event id in main thread, but all other cmds increment it in child thread, when async CQ are enabled... I was getting race conditions (asserts about not-incrementing event id) and seeing the event id returned from `EnqueueRecordEvent()` higher than anticipated (out of order) because earlier commands still in async CQ didn't get serviced yet.  Example:

```
EnqueueRecordEvent() // event_id=0 good picked by main thread 
EnqueueRecordEvent() // event_id=1 good picked by main thread 
EnqueueWaitForEvent() // delayed, pushed to child thread, event_id incremented ~whenever it gets to it. Can happen late, event_id=3, not good. 
EnqueueRecordEvent() // event_id=2 whoops, not good - picked by main thread.
```

Then realized that event id selection must all be on the same thread for a CQ for this to work.

**The Fix**

Solutions considered:

1. Lift all `Enqueue_*` cmds calling of `this->manager.get_next_event(this->id);` out of child thread and into parent thread.  Seems not possible/easy for `EnqueueWriteBuffer()` and `EnqueueReadBuffer` because they generate different number of device cmds and event ids based on state of issue queue and completion queue respectively, and keep issuing smaller cmds based on that state
2. Move `EnqueueRecordEvent()` calling of `this->manager.get_next_event(this->id);` back into child thread like other cmds so that all event id generation is ordered.   This means that Event struct would not be populated in any guaranteed time to caller/main thread. That's kind of okay.  Just need to "wait" until the Event is populated by child thread before using it (either by other CQ child thread, or by host), so introduced an event.wait_until_ready() which simply waits until the thread populated the event and set `ready=true`
3. Something else like pre-allocating pools of event ids with enough `room` on host side, and the child threads using them from the pool.  Don't love this idea, needs some more thougt,opened #5988 to pursue further.


Going with option 2 for now, since the implementation is easy, simple, and reasonable.  

```
 void EnqueueWaitForEventImpl(CommandQueue& cq, std::shared_ptr<Event> event) {
+    event->wait_until_ready(); // Block until event populated. Worker thread.
```

The downside is that it adds a dependency between async CQ worker threads that technically wasn't there before (the same dependency was there on device execution side though, as in the WaitForEvent cmd waited for the RecordEvent cmd to finish executing on device), but we think it's a reasonable fix for broken functionality today (especially given Events not planned to be used cross-chip in short term) and to get Events w/ async CQ working.  Other ideas being pursued in ticket linked above.

**Tests**

Also updated current set of Events tt_metal unit tests to loop over CQ modes `PASSTHROUGH` and `ASYNC` for extra coverage, all but 2 tests passing today (pending on an upcoming fix from @tt-asaigal for multi-cq + async).

```
TT_METAL_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue  --gtest_filter='MultiCommandQueueSingleDeviceFixture.TestEvents*' |& tee multi_cq_async_tests.log
```