### PR TITLE
#0: Fix end_to_end_tests to use get_legacy_shape() instead of shape() because of @arakhmati's recent Tensor class uplift

### DIFF
--- a/tests/end_to_end_tests/test_unit_ops.py
+++ b/tests/end_to_end_tests/test_unit_ops.py
@@ -20,7 +20,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
 
     xtt = tt_lib.tensor.Tensor(x, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     xtt = tt_lib.tensor.reshape(xtt, 5, 3, 96, 64)
-    assert xtt.shape() == [5, 3, 96, 64]
+    assert xtt.get_legacy_shape() == [5, 3, 96, 64]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
     x = x.reshape([5, 3, 96, 64])
@@ -28,7 +28,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = tt_lib.tensor.reshape(xtt, 3, 5, 64, 96)
-    assert xtt.shape() == [3, 5, 64, 96]
+    assert xtt.get_legacy_shape() == [3, 5, 64, 96]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
     x = x.reshape([3, 5, 64, 96])
@@ -36,7 +36,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = tt_lib.tensor.reshape(xtt, -1, 5, 96, 64)
-    assert xtt.shape() == [3, 5, 96, 64]
+    assert xtt.get_legacy_shape() == [3, 5, 96, 64]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
     x = x.reshape([3, 5, 96, 64])
@@ -44,7 +44,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = tt_lib.tensor.reshape(xtt, 3, -1, 64, 96)
-    assert xtt.shape() == [3, 5, 64, 96]
+    assert xtt.get_legacy_shape() == [3, 5, 64, 96]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
     x = x.reshape([3, 5, 64, 96])
@@ -52,7 +52,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = tt_lib.tensor.reshape(xtt, 3, 5, -1, 64)
-    assert xtt.shape() == [3, 5, 96, 64]
+    assert xtt.get_legacy_shape() == [3, 5, 96, 64]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
     x = x.reshape([3, 5, 96, 64])
@@ -60,7 +60,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = tt_lib.tensor.reshape(xtt, 3, 5, 64, -1)
-    assert xtt.shape() == [3, 5, 64, 96]
+    assert xtt.get_legacy_shape() == [3, 5, 64, 96]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
     x = x.reshape([3, 5, 64, 96])
@@ -68,7 +68,7 @@ def test_tile_major_reshape_sweep(reset_seeds, first_grayskull_device):
     assert eq
 
     xtt = tt_lib.tensor.reshape(xtt, 3, 5, 32, -1)
-    assert xtt.shape() == [3, 5, 32, 96 * 2]
+    assert xtt.get_legacy_shape() == [3, 5, 32, 96 * 2]
     xtt_host = xtt.cpu()
     tt_got_back = xtt_host.to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
     x = x.reshape([3, 5, 32, 96 * 2])


### PR DESCRIPTION
… 