### PR TITLE
#5830: [WIP] Capture and instantiation of traces

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1553,14 +1553,14 @@ void FinishImpl(CommandQueue& cq) {
 }
 
 CommandQueue& BeginTrace(Trace& trace) {
-    TT_ASSERT(not trace.trace_complete, "Already completed this trace");
+    TT_ASSERT(not trace.captured(), "Already completed this trace");
     TT_ASSERT(trace.queue().empty(), "Cannot begin trace on one that already captured commands");
     return trace.queue();
 }
 
 void EndTrace(Trace& trace) {
-    TT_ASSERT(not trace.trace_complete, "Already completed this trace");
-    trace.trace_complete = true;
+    TT_ASSERT(not trace.captured(), "Already completed this trace");
+    trace.captured(true);
     trace.validate();
 }
 
@@ -1618,11 +1618,7 @@ CommandQueue::~CommandQueue() {
     if (this->async_mode()) {
         this->stop_worker();
     }
-    if (this->trace_mode()) {
-        TT_ASSERT(this->trace()->trace_complete, "Trace capture must be complete before desctruction");
-    } else {
-        TT_ASSERT(this->worker_queue.empty(), "CQ{} worker queue must be empty on destruction", this->cq_id);
-    }
+    TT_ASSERT(this->worker_queue.empty(), "CQ{} worker queue must be empty on destruction", this->cq_id);
 }
 
 HWCommandQueue& CommandQueue::hw_command_queue() {

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -493,7 +493,7 @@ class HWCommandQueue {
     void completion_wrap(uint32_t event);
     void launch(launch_msg_t& msg);
     friend void EnqueueTraceImpl(CommandQueue& cq);
-    friend void EnqueueProgramImpl(CommandQueue& cq, std::variant < std::reference_wrapper<Program>, std::shared_ptr<Program> > program, bool blocking);
+    friend void EnqueueProgramImpl(CommandQueue& cq, std::variant < std::reference_wrapper<Program>, std::shared_ptr<Program> > program, std::optional<std::reference_wrapper<Trace>> trace, bool blocking);
     friend void EnqueueReadBufferImpl(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, bool blocking);
     friend void EnqueueWriteBufferImpl(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking);
     friend void EnqueueAllocateBufferImpl(AllocBufferMetadata alloc_md);
@@ -518,6 +518,7 @@ struct CommandInterface {
     std::optional<HostDataType> src;
     std::optional<void*> dst;
     std::optional<std::shared_ptr<Event>> event;
+    std::optional<std::reference_wrapper<Trace>> trace;
 };
 
 class CommandQueue {

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -576,7 +576,6 @@ class CommandQueue {
 
     friend class Trace;
     friend void EnqueueTraceImpl(CommandQueue& cq);
-    friend uint32_t InstantiateTrace(Trace& trace, CommandQueue& cq);
 
     // Initialize Command Queue Mode based on the env-var. This will be default, unless the user excplictly sets the mode using set_mode.
     CommandQueueMode mode;

--- a/tt_metal/impl/trace/trace.hpp
+++ b/tt_metal/impl/trace/trace.hpp
@@ -8,10 +8,11 @@
 // #include <chrono>
 // #include <fstream>
 // #include <thread>
+#include <functional>
 #include <memory>
 #include <utility>
 
-#include "tt_metal/common/base.hpp"
+#include "impl/buffers/buffer.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 #include "tt_metal/impl/program/program.hpp"
@@ -19,17 +20,25 @@
 namespace tt::tt_metal {
 
 using std::pair;
+using std::reference_wrapper;
 using std::set;
 using std::shared_ptr;
 using std::tuple;
 using std::unique_ptr;
+using std::unordered_map;
+using std::unordered_set;
+using std::vector;
 using std::weak_ptr;
 
 class CommandQueue;
 enum class EnqueueCommandType;
 
+// Trace instance id to buffer mapping mananged via instantiate and release calls
+// a static map keeps trace buffers alive until explicitly released by the user
+static unordered_map<uint32_t, shared_ptr<Buffer>> trace_buffer_pool;
+
 class Trace {
-    // TODO: delete the extra bloat not needed once implementation is complete
+   // TODO: delete the extra bloat not needed once implementation is complete
    private:
     struct TraceNode {
         DeviceCommand command;
@@ -37,11 +46,14 @@ class Trace {
         EnqueueCommandType command_type;
         uint32_t num_data_bytes;
     };
+
     bool trace_complete;
     vector<TraceNode> history;
     uint32_t num_data_bytes;
-    std::set<uint32_t> trace_instances;
-    std::unique_ptr<CommandQueue> cq;
+
+    // Trace queue used to capture commands
+    unique_ptr<CommandQueue> tq;
+
     static uint32_t next_trace_id();
     void record(const TraceNode& trace_node);
     void validate();
@@ -51,11 +63,13 @@ class Trace {
     friend CommandQueue& BeginTrace(Trace& trace);
     friend void EndTrace(Trace& trace);
     friend void EnqueueTrace(CommandQueue& cq, uint32_t trace_id, bool blocking);
+    friend void EnqueueWriteBuffer(CommandQueue& cq, std::variant<reference_wrapper<Buffer>, shared_ptr<Buffer> > buffer, vector<uint32_t>& src, bool blocking);
 
-   public:
+   public :
     Trace();
-    CommandQueue& queue() const { return *cq; };
-    uint32_t instantiate(CommandQueue& cq);  // return a unique trace id
+    CommandQueue& queue() const { return *tq; };
+    uint32_t instantiate(CommandQueue& tq);  // return a unique trace id
+    static bool has_instance(uint32_t trace_id) { return trace_buffer_pool.find(trace_id) != trace_buffer_pool.end(); }
 };
 
 }


### PR DESCRIPTION
Checkpoint for trace instantiation logic

    // Stage the trace commands into device DRAM that the command queue will read from
    // - flatten commands into tightly packed data structure
    // - allocate the data into a DRAM interleaved buffer using 2KB page size
    // - commit the DRAM buffer via an enqueue WB command
    // - map the trace id to the DRAM buffer for later enqueue Trace

