### PR TITLE
#5661: Enable gtests for fast dispatch + R chip

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -82,16 +82,6 @@ protected:
     }
 
     bool SkipTest(unsigned int device_id) {
-        // Skip condition is fast dispatch for remote devices
-        if (this->has_remote_devices_ && !this->slow_dispatch_ && device_id != 0) {
-            log_info(
-                tt::LogTest,
-                "Skipping test on device {} due to fast dispatch unsupported on remote devices.",
-                device_id
-            );
-            return true;
-        }
-
         // Also skip all devices after device 0 for grayskull. This to match all other tests
         // targetting device 0 by default (and to not cause issues with BMs that have E300s).
         // TODO: when we can detect only supported devices, this check can be removed.

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
@@ -130,11 +130,11 @@ bool matmul_large_block(CommonFixture *fixture, tt_metal::Device *device, bool a
     tt_metal::Program program = tt_metal::CreateProgram();
 
     CoreCoord core = {0, 0};
-    uint32_t M = 8;
-    uint32_t K = 4;
+    uint32_t M = 4;
+    uint32_t K = 2;
     uint32_t N = K;
-    int out_subblock_h = 4;
-    int out_subblock_w = 2;
+    int out_subblock_h = 2;
+    int out_subblock_w = 1;
     int in0_block_w = K;
 
     uint32_t single_tile_size = 2 * 1024;
@@ -341,9 +341,6 @@ bool matmul_large_block(CommonFixture *fixture, tt_metal::Device *device, bool a
 
 TEST_F(CommonFixture, MatmulLargeBlock) {
     for (unsigned int id=0; id < devices_.size(); id++){
-        // TODO: #6097, fix this for fast dispatch remote device.
-        if (!this->slow_dispatch_ && id > 0)
-            continue;
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(this, devices_.at(id), false, false));
         log_info (LogTest, "Tilized input, Tilized output Passed");
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(this, devices_.at(id), true, false));

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
@@ -341,6 +341,9 @@ bool matmul_large_block(CommonFixture *fixture, tt_metal::Device *device, bool a
 
 TEST_F(CommonFixture, MatmulLargeBlock) {
     for (unsigned int id=0; id < devices_.size(); id++){
+        // TODO: #6097, fix this for fast dispatch remote device.
+        if (!this->slow_dispatch_ && id > 0)
+            continue;
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(this, devices_.at(id), false, false));
         log_info (LogTest, "Tilized input, Tilized output Passed");
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(this, devices_.at(id), true, false));

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/test_flatten.cpp
@@ -199,6 +199,9 @@ TEST_F(CommonFixture, Flatten){
         num_tiles_c = 1;
     }
     for (unsigned int id=0; id < devices_.size(); id++){
+        // TODO: #6097, fix this for fast dispatch remote device.
+        if (!this->slow_dispatch_ && id > 0)
+            continue;
         ASSERT_TRUE(gtest_smoke::test_flatten::flatten(this, devices_.at(id), num_tiles_r, num_tiles_c));
     }
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
@@ -80,13 +80,6 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
 }
 
 TEST_F(DPrintFixture, TestPrintEthCores) {
-    if (!this->slow_dispatch_) {
-        log_info(
-            tt::LogTest,
-            "Skipping test due to fast dispatch dprint unsupported on eth cores."
-        );
-        GTEST_SKIP();
-    }
     for (Device* device : this->devices_) {
         // Skip if no ethernet cores on this device
         if (device->get_active_ethernet_cores(true).size() == 0) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
@@ -58,10 +58,11 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
 }
 
 TEST_F(DPrintFixture, TestPrintFinish) {
-    for (Device* device : this->devices_) {
-        // TODO: #6095, fix this for fast dispatch remote device.
-        if (!this->slow_dispatch_ && device->id() > 0)
-            continue;
+    // Iterate devices in reverse for this test. Since the test closes the devices early, avoid
+    // closing L chip before R chip.
+    auto devices = this->devices_;
+    std::reverse(devices.begin(), devices.end());
+    for (Device* device : devices) {
         this->RunTestOnDevice(RunTest, device);
     }
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
@@ -59,6 +59,9 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
 
 TEST_F(DPrintFixture, TestPrintFinish) {
     for (Device* device : this->devices_) {
+        // TODO: #6095, fix this for fast dispatch remote device.
+        if (!this->slow_dispatch_ && device->id() > 0)
+            continue;
         this->RunTestOnDevice(RunTest, device);
     }
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
@@ -276,7 +276,6 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
 }
 
 TEST_F(DPrintFixture, TestPrintRaiseWait) {
-   GTEST_SKIP();
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
@@ -151,6 +151,9 @@ TEST_F(CommonFixture, DRAMLoopbackSingleCore){
         .data_movement_cfg = {.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
     };
     for (unsigned int id=0; id < devices_.size(); id++){
+        // TODO: #6097, fix this for fast dispatch remote device.
+        if (!this->slow_dispatch_ && id > 0)
+            continue;
         ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config, src_vec));
     }
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
@@ -140,7 +140,7 @@ bool dram_single_core (CommonFixture* fixture, tt_metal::Device *device, const D
 }
 
 TEST_F(CommonFixture, DRAMLoopbackSingleCore){
-    uint32_t buffer_size = 2 * 1024 * 50;
+    uint32_t buffer_size = 2 * 1024 * 25;
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
     unit_tests_common::dram::test_dram::DRAMConfig dram_test_config = {
@@ -151,9 +151,6 @@ TEST_F(CommonFixture, DRAMLoopbackSingleCore){
         .data_movement_cfg = {.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
     };
     for (unsigned int id=0; id < devices_.size(); id++){
-        // TODO: #6097, fix this for fast dispatch remote device.
-        if (!this->slow_dispatch_ && id > 0)
-            continue;
         ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config, src_vec));
     }
 }


### PR DESCRIPTION
Enable a bunch of gtests to run on fast dispatch + R chip. Some failures skipped, to be addressed as separate issues:

#6095 
#6096 
#6097 

CI passing: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8179911390