### PR TITLE
#6120: Add backward support for divtrunc

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -1016,6 +1016,10 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.frac_bw
 
+.. autofunction:: tt_lib.tensor.unary_divtrunc_bw
+
+.. autofunction:: tt_lib.tensor.binary_divtrunc_bw
+
 Loss Functions
 ==============
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_divtrunc.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_divtrunc.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_binary_divtrunc(input_shapes, device):
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data = torch.Tensor(size=input_shapes).uniform_()
+    in_data.requires_grad = True
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+
+    pyt_y = torch.div(in_data, other_data, rounding_mode="trunc")
+
+    tt_output_tensor_on_device = tt_lib.tensor.binary_divtrunc_bw(grad_tensor, input_tensor, other_tensor)
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad, other_data.grad]
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_divtrunc.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_divtrunc.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "scalar",
+    (
+        1.5,
+        15.8,
+        3.9,
+    ),
+)
+def test_bw_unary_divtrunc(input_shapes, scalar, device):
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data = torch.Tensor(size=input_shapes).uniform_()
+    in_data.requires_grad = True
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    pyt_y = torch.div(in_data, scalar, rounding_mode="trunc")
+
+    tt_output_tensor_on_device = tt_lib.tensor.unary_divtrunc_bw(grad_tensor, input_tensor, scalar)
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1362,6 +1362,30 @@ std::vector<Tensor> trunc_bw(const Tensor& grad, const Tensor& input, const Memo
 {
     return operation::decorate_as_composite(__func__, _trunc_bw)(grad, input, output_mem_config);
 }
+
+std::vector<Tensor> _unary_divtrunc_bw(const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor grad_result = zeros_like(grad, output_mem_config);
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+std::vector<Tensor> unary_divtrunc_bw(const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _unary_divtrunc_bw)(grad, input, scalar, output_mem_config);
+}
+
+std::vector<Tensor> _binary_divtrunc_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor grad_a = zeros_like(grad, output_mem_config);
+    grad_tensor.emplace_back(grad_a);
+    Tensor grad_b = zeros_like(grad, output_mem_config);
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+std::vector<Tensor> binary_divtrunc_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _binary_divtrunc_bw)(grad, input, other, output_mem_config);
+}
 }//namespace tt_metal
 
 }//namespace tt

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -213,6 +213,10 @@ std::vector<Tensor> frac_bw(const Tensor& grad, const Tensor& input, const Memor
 
 std::vector<Tensor> trunc_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> unary_divtrunc_bw(const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> binary_divtrunc_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 } //namespace tt_metal
 
 } //namespace tt

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -1613,5 +1613,39 @@ namespace tt::tt_metal::detail{
                 "input", "Tensor trunc is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
+
+    m_tensor.def("unary_divtrunc_bw", &tt::tt_metal::unary_divtrunc_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for trunc of ``input`` tensors with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor divtrunc is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "scalar", "Scalar value", "float", "float", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("binary_divtrunc_bw", &tt::tt_metal::binary_divtrunc_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for divtrunc of ``input`` and ``other`` tensors with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor divtrunc is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "other", "Tensor divtrunc is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
     }
 }


### PR DESCRIPTION
Add backward support for unary and binary divtrunc
Fast Dispatch Test : https://github.com/tenstorrent-metal/tt-metal/actions/runs/8186055737
Slow Dispatch Test: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8186057224