### PR TITLE
#6129: Expose kernel config attrs and use 4 dst tiles for fp32 configs

### DIFF
--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -330,7 +330,9 @@ void TensorModule(py::module &m_tensor) {
             py::kw_only(),
             py::arg("math_fidelity") = MathFidelity::Invalid,
             py::arg("math_approx_mode") = true
-        );
+        )
+        .def_readwrite("math_fidelity", &GrayskullComputeKernelConfig::math_fidelity)
+        .def_readwrite("math_approx_mode", &GrayskullComputeKernelConfig::math_approx_mode);
 
     py::class_<WormholeComputeKernelConfig>(m_tensor, "WormholeComputeKernelConfig")
         .def(
@@ -340,7 +342,11 @@ void TensorModule(py::module &m_tensor) {
             py::arg("math_approx_mode") = true,
             py::arg("fp32_dest_acc_en") = false,
             py::arg("packer_l1_acc") = false
-        );
+        )
+        .def_readwrite("math_fidelity", &WormholeComputeKernelConfig::math_fidelity)
+        .def_readwrite("math_approx_mode", &WormholeComputeKernelConfig::math_approx_mode)
+        .def_readwrite("fp32_dest_acc_en", &WormholeComputeKernelConfig::fp32_dest_acc_en)
+        .def_readwrite("packer_l1_acc", &WormholeComputeKernelConfig::packer_l1_acc);
 
     detail::bind_unary_op(m_tensor, "mean_hw", tt::tt_metal::mean_hw, R"doc(  Returns a new tensor with the variance of the input tensor ``{0}`` on H,W axes.)doc");
     detail::bind_unary_op(m_tensor, "global_mean", tt::tt_metal::global_mean, R"doc(  Returns a new tensor with the mean of the input tensor ``{0}`` on all axes.)doc");


### PR DESCRIPTION
Fix https://github.com/tenstorrent-metal/tt-metal/issues/6129

This only fixes the problem in ttnn. It will work whenever a `program_config` or `core_grid` is passed to `ttnn.linear` or `ttnn.matmul`. 

That same issue is also present in tt_lib's C++ implementation of linear (and probably matmul) - this is observed if you pass a fp32 `compute_kernel_config` but do not set `program_config` or `core_grid` - in this case tt_lib generates an invalid `program_config`.

Honestly that's out of scope for me as a model developer today and is not a use case we will hit as we always specify one of these. A bit disturbing that the subblock-selection logic appears to be replicated between ttnn and tt_lib though. @arakhmati do you want to raise a follow-up ticket to get that fixed?