### PR TITLE
#5589: add groupnorm for ttnn sweeps

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/common.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/common.py
@@ -705,6 +705,21 @@ def shapes_and_datagen(shape_dict, datagen_dict, test_args_gen, test_tt_dtypes, 
                 start_shape, end_shape, interval, _gen_ttnn_rmsnorm_shapes
             ):
                 yield shapes, datagen_funcs, test_args
+        elif method == "ttnn-groupnorm":
+            assert len(start_shape) == 2
+            assert len(end_shape) == 2
+
+            def _gen_ttnn_rmsnorm_shapes(shape):
+                input_shape = [shape[0], shape[1]]
+                weights_shape = [shape[1]]
+                bias_shape = [shape[1]]
+
+                return [input_shape, weights_shape, bias_shape]
+
+            for shapes, datagen_funcs, test_args in _gen_shapes_and_args(
+                start_shape, end_shape, interval, _gen_ttnn_rmsnorm_shapes
+            ):
+                yield shapes, datagen_funcs, test_args
         else:
             raise NotImplementedError("Method {method} is not a valid choice")
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
@@ -1848,3 +1848,12 @@ def gen_ttnn_repeat_interleave_args(
         dims = np.random.choice([0, shapes_size - 1])
         input_info.update({"repeat": repeats, "dim": dims})
         yield input_info
+
+
+def gen_ttnn_groupnorm_args(
+    input_shapes,
+    dtypes=[supported_tt_dtypes],
+    layouts=[supported_tt_layouts],
+    mem_configs=[supported_mem_configs],
+):
+    return gen_dtype_layout_device(input_shapes, dtypes, layouts, mem_configs, do_sanitize_args=False)

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -1556,4 +1556,12 @@ op_map = {
         "tt_lib_op": ttnn_ops.addcmul,
         "pytorch_op": pytorch_ops.addcmul,
     },
+    "ttnn-groupnorm_noweights": {
+        "tt_lib_op": ttnn_ops.groupnorm_noweights,
+        "pytorch_op": pytorch_ops.groupnorm_noweights,
+    },
+    "ttnn-groupnorm": {
+        "tt_lib_op": ttnn_ops.groupnorm,
+        "pytorch_op": pytorch_ops.ttnn_groupnorm,
+    },
 }

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1778,3 +1778,8 @@ def transformer_concatenate_heads(x, *args, **kwargs):
     torch_output_tensor = ttnn.transformer._torch_concatenate_heads(x)
 
     return torch_output_tensor
+
+
+def ttnn_groupnorm(x, y, z, *args, **kwargs):
+    torch_output_tensor = torch.nn.functional.group_norm(x, num_groups=1, weight=y, bias=z)
+    return torch_output_tensor

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_groupnorm_noweights_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_groupnorm_noweights_test.yaml
@@ -1,0 +1,28 @@
+---
+test-list:
+  - ttnn-groupnorm_noweights:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: gorupnorm_noweights_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_groupnorm_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_groupnorm_test.yaml
@@ -1,0 +1,29 @@
+---
+test-list:
+  - ttnn-groupnorm:
+      shape:
+        start-shape: [32, 64]
+        end-shape: [256, 512]
+        interval: [32, 32]
+        #num-dims: [2]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+        method: ttnn-groupnorm
+      env:
+        # TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_ttnn_groupnorm_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: ttnn_groupnorm_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_groupnorm_noweights_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_groupnorm_noweights_test.yaml
@@ -1,0 +1,28 @@
+---
+test-list:
+  - ttnn-groupnorm_noweights:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        dtype: bfloat16
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: gorupnorm_noweights_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_groupnorm_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_groupnorm_test.yaml
@@ -1,0 +1,29 @@
+---
+test-list:
+  - ttnn-groupnorm:
+      shape:
+        start-shape: [32, 64]
+        end-shape: [256, 512]
+        interval: [32, 32]
+        #num-dims: [2]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+        method: ttnn-groupnorm
+      env:
+        # TT_METAL_SLOW_DISPATCH_MODE: ["", "1"]
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_ttnn_groupnorm_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: ttnn_groupnorm_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -2026,3 +2026,41 @@ def addcmul(
     t3 = ttnn.addcmul(t0, t1, t2, scalar, memory_config=memory_config_to_ttnn(output_mem_config))
 
     return ttnn_tensor_to_torch(t3)
+
+
+def groupnorm_noweights(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+
+    t1 = ttnn.group_norm(t0, num_groups=1, weight=None, bias=None)
+
+    return ttnn_tensor_to_torch(t1)
+
+
+def groupnorm(
+    x,
+    y,
+    z,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+
+    t3 = ttnn.group_norm(t0, num_groups=1, weight=t1, bias=t2)
+
+    return ttnn_tensor_to_torch(t3)


### PR DESCRIPTION
Added sweep tests for ttnn.group_norm with input only and also including both bias and weights