### PR TITLE
Fix Events feature for FD1.3 (out-of-order event ids, events feature missing) #6093

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
@@ -59,7 +59,7 @@ protected:
         tt::llrt::OptionsG.set_watcher_dump_all(watcher_previous_dump_all);
         tt::llrt::OptionsG.set_watcher_append(watcher_previous_append);
         tt::llrt::OptionsG.set_test_mode_enabled(test_mode_previous);
-        tt::watcher_server_clear_error_flag();
+        tt::watcher_server_set_error_flag(false);
     }
 
     void RunTestOnDevice(

--- a/tt_metal/hostdevcommon/common_runtime_address_map.h
+++ b/tt_metal/hostdevcommon/common_runtime_address_map.h
@@ -91,8 +91,8 @@ constexpr static uint32_t CQ_ISSUE_WRITE_PTR = CQ_ISSUE_READ_PTR + L1_ALIGNMENT;
 constexpr static uint32_t CQ_COMPLETION_WRITE_PTR = CQ_ISSUE_WRITE_PTR + L1_ALIGNMENT;
 constexpr static uint32_t CQ_COMPLETION_READ_PTR = CQ_COMPLETION_WRITE_PTR + L1_ALIGNMENT;
 constexpr static uint32_t CQ_COMPLETION_LAST_EVENT = CQ_COMPLETION_READ_PTR + L1_ALIGNMENT;
-constexpr static uint32_t CQ_COMPLETION_16B_SCRATCH = CQ_ISSUE_READ_PTR; // 16B unused in consumer core.
-constexpr static uint32_t EVENT_PTR = CQ_COMPLETION_LAST_EVENT + L1_ALIGNMENT;
+constexpr static uint32_t CQ_COMPLETION_16B_SCRATCH = CQ_COMPLETION_LAST_EVENT + L1_ALIGNMENT;
+constexpr static uint32_t EVENT_PTR = CQ_COMPLETION_16B_SCRATCH + L1_ALIGNMENT;
 
 // Host addresses for dispatch
 static constexpr uint32_t HOST_CQ_ISSUE_READ_PTR = 0;

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -648,8 +648,8 @@ bool watcher_server_killed_due_to_error() {
     return watcher::watcher_killed_due_to_error;
 }
 
-void watcher_server_clear_error_flag() {
-    watcher::watcher_killed_due_to_error = false;
+void watcher_server_set_error_flag(bool val) {
+    watcher::watcher_killed_due_to_error = val;
 }
 
 void watcher_clear_log() {

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -19,10 +19,10 @@ int watcher_register_kernel(const string& name);
 
 // Check whether the watcher server has been killed due to an error detected.
 bool watcher_server_killed_due_to_error();
-// Function to clear this flag, so that non-watcher runs can continue as normal.
+// Function to set this flag to true/false, so that non-watcher runs can continue as normal when set to false.
 // TODO(dma): this doesn't currently clear the actual error codes on the device. Once watcher is
 // moved out of llrt we can change this to watcher_clear_errors().
-void watcher_server_clear_error_flag();
+void watcher_server_set_error_flag(bool val);
 
 // Helper function to clear the watcher log file
 void watcher_clear_log();

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -726,6 +726,9 @@ const DeviceCommand EnqueueRecordEventCommand::assemble_device_command(uint32_t)
     command.set_issue_data_size(0); // No extra data just CMD.
     command.set_completion_data_size(align(EVENT_PADDED_SIZE, 32));
     command.set_event(this->event);
+    if (tt::Cluster::instance().arch() == tt::ARCH::WORMHOLE_B0) {
+        command.set_stall(); // Ensure ordering w/ programs in FD1.3+ prefetcher.
+    }
     return command;
 }
 
@@ -752,7 +755,9 @@ const DeviceCommand EnqueueWaitForEventCommand::assemble_device_command(uint32_t
     command.set_issue_data_size(0); // No extra data just CMD.
     command.set_completion_data_size(align(EVENT_PADDED_SIZE, 32));
     command.set_event(this->event);
-
+    if (tt::Cluster::instance().arch() == tt::ARCH::WORMHOLE_B0) {
+        command.set_stall(); // Ensure ordering w/ programs in FD1.3+ prefetcher.
+    }
     // #5529 - Cross chip sync needs to be implemented. Currently, we only support sync on the same chip.
     TT_ASSERT(this->sync_event.device == this->device,
             "EnqueueWaitForEvent() cross-chip sync not yet supported. Sync event device: {} this device: {}",

--- a/tt_metal/impl/dispatch/kernels/cq_prefetcher.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetcher.hpp
@@ -338,6 +338,7 @@ class ProgramEventBuffer {
                 completion_queue_reserve_back(32); // Need to clean up
                 *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(event_addr) = event;
                 write_event(event_addr);
+                record_last_completed_event(event);
                 completion_queue_push_back(32, this->completion_queue_start_addr, this->host_completion_queue_write_addr);
             } else {
                 uint64_t my_noc_encoding = uint64_t(NOC_XY_ENCODING(my_x[0], my_y[0])) << 32;


### PR DESCRIPTION
Closes #6093 - see 2 commit descriptions, mainly:

1. events feature got dropped in FD1.3 , add it back
2. EnqueueRecordEvent, EnqueueWaitForEvent cmds were not ordered with programs in FD1.3 and those cmds if issued after programs could return to completion queue before the program


Will be beefing up Events tests in follow up PR or in this one if I can finish it before tomorrow, but wanted @DrJessop and @abhullar-tt approval, eyes on this in the meantime.

I think I updated cq_prefetcher correctly for all cases.  Didn't bother optimizing/refactoring code here, just wanted to keep the initial fix "simple"