### PR TITLE
Add missing ttnn tests and disable broken tests until issues are fixed

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -20,6 +20,7 @@ fi
 
 if [ "$ARCH_NAME" != "wormhole_b0" ]; then
     env pytest $TT_METAL_HOME/tests/ttnn/unit_tests
+
     # Tests for tensors in L1
     pytest $TT_METAL_HOME/models/experimental/bert_large_performant/unit_tests/test_bert_large*matmul* -k in0_L1-in1_L1-bias_L1-out_L1
     pytest $TT_METAL_HOME/models/experimental/bert_large_performant/unit_tests/test_bert_large*bmm* -k in0_L1-in1_L1-out_L1

--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -19,6 +19,7 @@ fi
 # you can move to where you'd like.
 
 if [ "$ARCH_NAME" != "wormhole_b0" ]; then
+    env pytest $TT_METAL_HOME/tests/ttnn/unit_tests
     # Tests for tensors in L1
     pytest $TT_METAL_HOME/models/experimental/bert_large_performant/unit_tests/test_bert_large*matmul* -k in0_L1-in1_L1-bias_L1-out_L1
     pytest $TT_METAL_HOME/models/experimental/bert_large_performant/unit_tests/test_bert_large*bmm* -k in0_L1-in1_L1-out_L1

--- a/tests/ttnn/unit_tests/operations/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_conv2d.py
@@ -600,6 +600,7 @@ def test_resnet50_conv_wh_fp32(
     )
 
 
+@pytest.mark.skip("ttnn test coverage hole - fails in pipeline")
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
     (

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -33,7 +33,8 @@ def test_multi_device_open_close_full_device_mesh_fixture(pcie_device_mesh):
     """Using `pcie_device_mesh` pytest fixture defined in conftest.py"""
     pass
 
-@pytest.mark.skip("ttnn fails in pipeline")
+
+@pytest.mark.skip("ttnn test coverage hole - fails in pipeline")
 def test_multi_device_open_close_using_context_manager():
     """Using context manager to open and close multi-device"""
     device_grid, device_ids = ttnn.DeviceGrid(2, 2), ttnn.get_device_ids()
@@ -47,6 +48,7 @@ def test_multi_device_open_close_using_context_manager():
 #######
 
 
+@pytest.mark.skip("ttnn test coverage hole - fails in pipeline")
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 def test_ttnn_to_and_from_multi_device_shard(layout, memory_config):

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -33,7 +33,7 @@ def test_multi_device_open_close_full_device_mesh_fixture(pcie_device_mesh):
     """Using `pcie_device_mesh` pytest fixture defined in conftest.py"""
     pass
 
-
+@pytest.mark.skip("ttnn fails in pipeline")
 def test_multi_device_open_close_using_context_manager():
     """Using context manager to open and close multi-device"""
     device_grid, device_ids = ttnn.DeviceGrid(2, 2), ttnn.get_device_ids()

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -69,6 +69,7 @@ def test_ttnn_to_and_from_multi_device_shard(layout, memory_config):
         assert torch.all(torch_tensor == torch_loop_back_tensor)
 
 
+@pytest.mark.skip("ttnn test coverage hole - fails in pipeline")
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 def test_multi_device_check_per_device_shard(layout, memory_config):


### PR DESCRIPTION
Had to disable the following ttnn tests but adds ttnn test coverage back into CI workflows.

git bisecting shows that the following tests failed and that errors come from this PR
https://github.com/tenstorrent-metal/tt-metal/issues/5730

ttnn/unit_tests/test_multi_device.py
test_multi_device_open_close_using_context_manager
Test Fails and exits gracefully

ttnn/unit_tests/test_multi_device.py
test_ttnn_to_and_from_multi_device_shard(...)
Test Fails and exits gracefully

ttnn/unit_tests/test_multi_device.py
test_multi_device_open_close_using_context_manager()
Test Fails and exits gracefully

ttnn/unit_tests/operations/test_conv2d.py
test_sd_conv() 
Test hangs the machine

ttnn/unit_tests/tests_multi_device.py
test_multi_device_check_per_device_shard()
Test Fails and exits gracefully

Working workflow with ttnn tests running under fd-unit-tests/model-tests
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8197776520
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8198317648 (rebased)