### PR TITLE
#6204: added support for num_users < 32 for update cache op.

### DIFF
--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/compute/update_cache.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/compute/update_cache.cpp
@@ -20,6 +20,7 @@ void MAIN {
     constexpr uint32_t out_cb = get_compile_time_arg_val(5);
     constexpr uint32_t num_batched_heads = get_compile_time_arg_val(6);
     constexpr uint32_t Wt = get_compile_time_arg_val(7);
+    constexpr uint32_t u_range = get_compile_time_arg_val(8);
 
     untilize_init(in_cb, untilized_in_cb);
 
@@ -34,7 +35,7 @@ void MAIN {
 
         unpack_reconfig_data_format_srca(in_cb, cache_cb);
 
-        for(uint32_t u = 0; u < 32; ++u) {
+        for(uint32_t u = 0; u <u_range; ++u) {
             untilize_init_short(cache_cb);
             cb_wait_front(cache_cb, Wt);
             cb_reserve_back(untilized_cache_cb, Wt);

--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -49,6 +49,7 @@ void kernel_main() {
 
     uint32_t cache_id = cache_start_id;
     uint32_t b = batch_start_id;
+    uint32_t u_range = min(static_cast<uint32_t>(32), B);
 
     for (uint32_t h = 0; h < num_batched_heads; ++h) {
         #ifndef INPUT_SHARDED
@@ -62,7 +63,7 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(input_cb_id, Wt);
         #endif
-        for (uint32_t u = 0; u < 32; ++u) {
+        for (uint32_t u = 0; u < u_range; ++u) {
             cb_reserve_back(cache_cb_id, Wt);
             uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
             for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {

--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -37,12 +37,13 @@ void kernel_main() {
 
     uint32_t cache_id = cache_start_id;
     uint32_t b = batch_start_id;
+    uint32_t u_range = min(static_cast<uint32_t>(32), B);
 
     for (uint32_t h = 0; h < num_batched_heads; ++h) {
         cb_wait_front(untilized_input_cb_id, Wt);
         uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(untilized_input_cb_id));
 
-        for (uint32_t u = 0; u < 32; ++u) {
+        for (uint32_t u = 0; u < u_range; ++u) {
             cb_wait_front(untilized_cache_cb_id, Wt);
             cb_reserve_back(untilized_cache2_cb_id, Wt);
             uint32_t cache_l1_write_addr = get_read_ptr(untilized_cache_cb_id) + offset;

--- a/tt_eager/tt_dnn/op_library/update_cache/update_cache_op.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/update_cache_op.cpp
@@ -62,7 +62,7 @@ void UpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
         } else {
             TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
         }
-        TT_FATAL(cache_tensor.get_legacy_shape()[0] == input_tensor.get_legacy_shape()[-2]);
+        TT_FATAL(cache_tensor.get_legacy_shape()[0] <= input_tensor.get_legacy_shape()[-2]);
     }
 }
 


### PR DESCRIPTION
- This new feature now supports `update_cache` with num_users less than 32. See details in #6204 
- Added test on new feature and made sure existing tests do not regress