### PR TITLE
#6164: Update test_noc_unicast_vs_multicast_to_single_core_latency to not use same cores for producer and consumer on WH

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -18,7 +18,9 @@ void measure_latency(string kernel_name) {
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
     uint8_t num_hw_cqs = device->num_hw_cqs();
     CoreCoord producer_logical_core = tt_metal::dispatch_core_manager::get(num_hw_cqs).issue_queue_reader_core(device->id(), channel, 0);
-    CoreCoord consumer_logical_core = tt_metal::dispatch_core_manager::get(num_hw_cqs).completion_queue_writer_core(device->id(), channel, 0);
+    CoreCoord consumer_logical_core = tt_metal::dispatch_core_manager::get(num_hw_cqs).command_dispatcher_core(device->id(), channel, 0);
+
+    TT_ASSERT(producer_logical_core != consumer_logical_core, "Producer and consumer core are {}. They should not be the same!", producer_logical_core.str());
 
     auto first_worker_physical_core = device->worker_core_from_logical_core({0, 0});
 


### PR DESCRIPTION
Passing benchmark suite: 

https://github.com/tenstorrent-metal/tt-metal/actions/runs/8211366678/job/22460188360