### PR TITLE
#6223: remove redundant call to context switch

### DIFF
--- a/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
@@ -30,3 +30,4 @@ pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausal
 #pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-0.99-0.99-0.99-tiiuae/falcon-40b-instruct-0-prefill_seq32-8]
 pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-0.99-0.99-0.99-tiiuae/falcon-40b-instruct-0-decode_batch32-8]
 pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8]
+pytest tests/ttnn/unit_tests/test_multi_device.py

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -34,10 +34,11 @@ def test_multi_device_open_close_full_device_mesh_fixture(pcie_device_mesh):
     pass
 
 
-@pytest.mark.skip("ttnn test coverage hole - fails in pipeline")
 def test_multi_device_open_close_using_context_manager():
     """Using context manager to open and close multi-device"""
     device_grid, device_ids = ttnn.DeviceGrid(2, 2), ttnn.get_device_ids()
+    if len(device_ids) <= 1:
+        pytest.skip()
     with ttnn.create_device_mesh(device_grid, device_ids) as device_mesh:
         # Do something with multi_device
         pass
@@ -48,47 +49,43 @@ def test_multi_device_open_close_using_context_manager():
 #######
 
 
-@pytest.mark.skip("ttnn test coverage hole - fails in pipeline")
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_ttnn_to_and_from_multi_device_shard(layout, memory_config):
+def test_ttnn_to_and_from_multi_device_shard(pcie_device_mesh, layout, memory_config):
     """Shard a tensor across devices, compose it back and verify loopback tensor is same as the original tensor"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
     torch_tensor = torch.rand((1, 1, 32, 256), dtype=torch.bfloat16)
 
-    with ttnn.create_device_mesh(ttnn.DeviceGrid(1, 4), ttnn.get_pcie_device_ids()) as device_mesh:
-        ttnn_tensor = ttnn.from_torch(torch_tensor, mesh_mapper=ShardTensorToMesh(device_mesh, dim=3))
-        ttnn_tensor = ttnn.to_layout(ttnn_tensor, layout=layout)
-        ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh, memory_config=memory_config)
-        ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
-        torch_loop_back_tensor = ttnn.to_torch(
-            ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=3)
-        )
+    ttnn_tensor = ttnn.from_torch(torch_tensor, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3))
+    ttnn_tensor = ttnn.to_layout(ttnn_tensor, layout=layout)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_device_mesh, memory_config=memory_config)
+    ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
+    torch_loop_back_tensor = ttnn.to_torch(
+        ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=3)
+    )
 
-        assert torch.all(torch_tensor == torch_loop_back_tensor)
+    assert torch.all(torch_tensor == torch_loop_back_tensor)
 
 
-@pytest.mark.skip("ttnn test coverage hole - fails in pipeline")
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_multi_device_check_per_device_shard(layout, memory_config):
+def test_multi_device_check_per_device_shard(pcie_device_mesh, layout, memory_config):
     """This test checks if the tensor is correctly sharded across devices"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
     torch_tensor = torch.rand((1, 1, 32, 256), dtype=torch.bfloat16)
 
-    with ttnn.create_device_mesh(ttnn.DeviceGrid(1, 4), ttnn.get_pcie_device_ids()) as device_mesh:
-        ttnn_tensor = ttnn.from_torch(torch_tensor, mesh_mapper=ShardTensorToMesh(device_mesh, dim=3))
-        ttnn_tensor = ttnn.to_layout(ttnn_tensor, layout=layout)
-        ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh, memory_config=memory_config)
-        ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
+    ttnn_tensor = ttnn.from_torch(torch_tensor, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3))
+    ttnn_tensor = ttnn.to_layout(ttnn_tensor, layout=layout)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_device_mesh, memory_config=memory_config)
+    ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
 
-        shard_offset, shard_size = 0, 64
-        for device_tensor in ttnn.get_device_tensors(ttnn_loop_back_tensor):
-            device_tensor_torch = ttnn.to_torch(device_tensor)
-            assert torch.all(device_tensor_torch == torch_tensor[..., shard_offset : shard_offset + shard_size])
-            shard_offset += shard_size
+    shard_offset, shard_size = 0, 64
+    for device_tensor in ttnn.get_device_tensors(ttnn_loop_back_tensor):
+        device_tensor_torch = ttnn.to_torch(device_tensor)
+        assert torch.all(device_tensor_torch == torch_tensor[..., shard_offset : shard_offset + shard_size])
+        shard_offset += shard_size
 
 
 def test_multi_device_replicate(pcie_device_mesh):

--- a/tt_metal/hw/inc/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/ethernet/dataflow_api.h
@@ -266,7 +266,6 @@ void eth_wait_for_remote_receiver_done_and_get_local_receiver_data(
     noc_semaphore_inc(receiver_semaphore_noc_addr, 1);
     while (erisc_info->channels[0].bytes_sent != 0) {
         run_routing();
-        internal_::risc_context_switch();
     }
 }
 /**


### PR DESCRIPTION
Somehow also avoids a hang.

@aliuTT or @ubcheema, do either of you have any insight why this redundant context switch would cause a hang?