### PR TITLE
Support moreh_getitem forward

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_getitem.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_getitem.py
@@ -44,8 +44,6 @@ def to_output_4d_shape(shape, index_dims, index_size):
     ),
 )
 def test_getitem_RAW_MJOR_one_index(shape_index_dim, dtype, index_size, device):
-    ttl.program_cache.enable()
-
     shape, index_dim = shape_index_dim
     torch.manual_seed(2)
 
@@ -104,8 +102,6 @@ def test_getitem_RAW_MJOR_one_index(shape_index_dim, dtype, index_size, device):
     ),
 )
 def test_getitem_RAW_MAJOR_two_indices(shape_index_dims, dtype, index_size, device):
-    ttl.program_cache.enable()
-
     shape, index_dims = shape_index_dims
     torch.manual_seed(1)
 
@@ -161,8 +157,6 @@ def test_getitem_RAW_MAJOR_two_indices(shape_index_dims, dtype, index_size, devi
     ids=["int32", "bfloat16"],
 )
 def test_getitem_RAW_MAJOR_three_indices(shape_index_dims, dtype, index_size, device):
-    ttl.program_cache.enable()
-
     shape, index_dims = shape_index_dims
     torch.manual_seed(1)
 
@@ -231,8 +225,6 @@ def test_getitem_RAW_MAJOR_three_indices(shape_index_dims, dtype, index_size, de
     ),
 )
 def test_getitem_tilized_one_index(shape_index_dim, dtype, index_size, device):
-    ttl.program_cache.enable()
-
     shape, index_dim = shape_index_dim
     torch.manual_seed(2)
 
@@ -306,8 +298,6 @@ def test_getitem_tilized_one_index(shape_index_dim, dtype, index_size, device):
     ),
 )
 def test_getitem_tilized_two_indices(shape_index_dims, dtype, index_size, device):
-    ttl.program_cache.enable()
-
     shape, index_dims = shape_index_dims
     torch.manual_seed(2)
 
@@ -382,8 +372,6 @@ def test_getitem_tilized_two_indices(shape_index_dims, dtype, index_size, device
     ),
 )
 def test_getitem_tilized_three_indices(shape_index_dims, dtype, index_size, device):
-    ttl.program_cache.enable()
-
     shape, index_dims = shape_index_dims
     torch.manual_seed(2)
 
@@ -453,8 +441,6 @@ def test_getitem_tilized_three_indices(shape_index_dims, dtype, index_size, devi
     ),
 )
 def test_getitem_tilized_four_indices(shape_index_dims, dtype, index_size, device):
-    ttl.program_cache.enable()
-
     shape, index_dims = shape_index_dims
     torch.manual_seed(2)
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_getitem.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_getitem.py
@@ -1,0 +1,501 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import tt_lib as ttl
+import pytest
+from models.utility_functions import comp_allclose_and_pcc
+from loguru import logger
+
+
+def to_output_4d_shape(shape, index_dims, index_size):
+    output_4d_shape = list(shape)
+    for index_dim in index_dims:
+        output_4d_shape[index_dim] = 1
+
+    output_4d_shape[index_dims[-1]] = index_size
+
+    return output_4d_shape
+
+
+@pytest.mark.parametrize(
+    "shape_index_dim",
+    (
+        ((10, 70), 0),
+        ((10, 5, 70), 1),
+        ((10, 5, 7, 70), 2),
+    ),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        torch.int32,
+        torch.bfloat16,
+    ),
+    ids=["int32", "bfloat16"],
+)
+@pytest.mark.parametrize(
+    "index_size",
+    (
+        4,
+        100,
+    ),
+)
+def test_getitem_RAW_MJOR_one_index(shape_index_dim, dtype, index_size, device):
+    ttl.program_cache.enable()
+
+    shape, index_dim = shape_index_dim
+    torch.manual_seed(2)
+
+    if dtype == torch.int32:
+        tt_dtype = ttl.tensor.DataType.UINT32
+    if dtype == torch.bfloat16:
+        tt_dtype = ttl.tensor.DataType.BFLOAT16
+
+    x = torch.randint(low=0, high=10, size=shape).to(dtype)
+    dev_x = ttl.tensor.Tensor(x, tt_dtype).to(device)
+
+    idx_value_max = shape[index_dim] - 1
+    idx = torch.randint(0, idx_value_max, (index_size,))
+    dev_idx = ttl.tensor.Tensor(idx, ttl.tensor.DataType.UINT32).to(device)
+
+    if index_dim == 0:
+        tt_cpu = x[idx]
+    elif index_dim == 1:
+        tt_cpu = x[:, idx]
+    elif index_dim == 2:
+        tt_cpu = x[:, :, idx]
+    elif index_dim == 3:
+        tt_cpu = x[:, :, :, idx]
+
+    tt_npu = ttl.operations.primary.moreh_getitem(dev_x, [dev_idx], [index_dim])
+
+    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    tt_dev = tt_npu.cpu().to_torch()
+
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
+    logger.info(out)
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_index_dims",
+    (
+        ((10, 15, 7, 80), (0, 1)),
+        ((10, 15, 7, 80), (1, 2)),
+    ),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        torch.int32,
+        torch.bfloat16,
+    ),
+    ids=["int32", "bfloat16"],
+)
+@pytest.mark.parametrize(
+    "index_size",
+    (
+        4,
+        100,
+    ),
+)
+def test_getitem_RAW_MAJOR_two_indices(shape_index_dims, dtype, index_size, device):
+    ttl.program_cache.enable()
+
+    shape, index_dims = shape_index_dims
+    torch.manual_seed(1)
+
+    if dtype == torch.int32:
+        tt_dtype = ttl.tensor.DataType.UINT32
+    if dtype == torch.bfloat16:
+        tt_dtype = ttl.tensor.DataType.BFLOAT16
+
+    x = torch.randint(low=0, high=10, size=shape).to(dtype)
+    dev_x = ttl.tensor.Tensor(x, tt_dtype).to(device)
+
+    indices = []
+    dev_indices = []
+    for index_dim in index_dims:
+        idx_value_max = shape[index_dim] - 1
+        idx = torch.randint(0, idx_value_max, (index_size,))
+        dev_idx = ttl.tensor.Tensor(idx, ttl.tensor.DataType.UINT32).to(device)
+        indices.append(idx)
+        dev_indices.append(dev_idx)
+
+    if index_dims == (0, 1):
+        tt_cpu = x[indices[0], indices[1]]
+    if index_dims == (1, 2):
+        tt_cpu = x[:, indices[0], indices[1]]
+    tt_npu = ttl.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
+
+    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    tt_dev = tt_npu.cpu().to_torch()
+
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
+    logger.info(out)
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_index_dims",
+    (((10, 15, 7, 80), (0, 1, 2)),),
+)
+@pytest.mark.parametrize(
+    "index_size",
+    (
+        4,
+        100,
+    ),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        torch.int32,
+        torch.bfloat16,
+    ),
+    ids=["int32", "bfloat16"],
+)
+def test_getitem_RAW_MAJOR_three_indices(shape_index_dims, dtype, index_size, device):
+    ttl.program_cache.enable()
+
+    shape, index_dims = shape_index_dims
+    torch.manual_seed(1)
+
+    if dtype == torch.int32:
+        tt_dtype = ttl.tensor.DataType.UINT32
+    if dtype == torch.bfloat16:
+        tt_dtype = ttl.tensor.DataType.BFLOAT16
+
+    x = torch.randint(low=0, high=10, size=shape).to(dtype)
+    dev_x = ttl.tensor.Tensor(x, tt_dtype).to(device)
+
+    indices = []
+    dev_indices = []
+    for index_dim in index_dims:
+        idx_value_max = shape[index_dim] - 1
+        idx = torch.randint(0, idx_value_max, (index_size,))
+        dev_idx = ttl.tensor.Tensor(idx, ttl.tensor.DataType.UINT32).to(device)
+        indices.append(idx)
+        dev_indices.append(dev_idx)
+
+    if index_dims == (0, 1, 2):
+        tt_cpu = x[indices[0], indices[1], indices[2]]
+    tt_npu = ttl.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
+
+    assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
+    tt_dev = tt_npu.cpu().to_torch()
+
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
+    logger.info(out)
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_index_dim",
+    (
+        ((10, 5, 7, 70), 0),
+        ((1, 10, 5, 64), 1),
+        ((1, 1, 10, 70), 2),
+        ((1, 1, 2, 6), 3),
+        ((1, 1, 1, 30), 3),
+        ((5, 7, 3, 80), 3),
+    ),
+    ids=[
+        "N",
+        "C",
+        "H",
+        "W1",
+        "W2",
+        "W_LARGE",
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        torch.int32,
+        torch.bfloat16,
+    ),
+    ids=["int32", "bfloat16"],
+)
+@pytest.mark.parametrize(
+    "index_size",
+    (
+        4,
+        100,
+    ),
+)
+def test_getitem_tilized_one_index(shape_index_dim, dtype, index_size, device):
+    ttl.program_cache.enable()
+
+    shape, index_dim = shape_index_dim
+    torch.manual_seed(2)
+
+    if dtype == torch.int32:
+        tt_dtype = ttl.tensor.DataType.UINT32
+    if dtype == torch.bfloat16:
+        tt_dtype = ttl.tensor.DataType.BFLOAT16
+
+    x = torch.randint(low=0, high=10, size=shape).to(dtype)
+    x = torch.arange(0, x.numel()).reshape(shape).to(dtype)
+
+    dev_x = (
+        ttl.tensor.Tensor(x, tt_dtype).reshape(shape).pad_to_tile(float("nan")).to(ttl.tensor.Layout.TILE).to(device)
+    )
+
+    idx_value_max = shape[index_dim] - 1
+    idx = torch.randint(0, idx_value_max, (index_size,))
+    dev_idx = (
+        ttl.tensor.Tensor(idx, ttl.tensor.DataType.UINT32)
+        .reshape(1, 1, 1, index_size)
+        .pad_to_tile(float("nan"))
+        .to(ttl.tensor.Layout.TILE)
+        .to(device)
+    )
+
+    if index_dim == 0:
+        tt_cpu = x[idx]
+    elif index_dim == 1:
+        tt_cpu = x[:, idx]
+    elif index_dim == 2:
+        tt_cpu = x[:, :, idx]
+    elif index_dim == 3:
+        tt_cpu = x[:, :, :, idx]
+
+    tt_npu = ttl.operations.primary.moreh_getitem(dev_x, [dev_idx], [index_dim])
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR)
+
+    cpu_4d_shape = to_output_4d_shape(shape, [index_dim], index_size)
+
+    tt_npu = tt_npu.unpad_from_tile(cpu_4d_shape)
+    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
+    logger.info(out)
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_index_dims",
+    (
+        ((10, 15, 7, 70), (0, 1)),
+        ((10, 15, 7, 70), (1, 2)),
+        ((10, 15, 7, 70), (2, 3)),
+    ),
+    ids=["NC", "CH", "HW"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        torch.int32,
+        torch.bfloat16,
+    ),
+    ids=["int32", "bfloat16"],
+)
+@pytest.mark.parametrize(
+    "index_size",
+    (
+        4,
+        100,
+    ),
+)
+def test_getitem_tilized_two_indices(shape_index_dims, dtype, index_size, device):
+    ttl.program_cache.enable()
+
+    shape, index_dims = shape_index_dims
+    torch.manual_seed(2)
+
+    if dtype == torch.int32:
+        tt_dtype = ttl.tensor.DataType.UINT32
+    if dtype == torch.bfloat16:
+        tt_dtype = ttl.tensor.DataType.BFLOAT16
+
+    x = torch.randint(low=0, high=10, size=shape).to(dtype)
+
+    dev_x = (
+        ttl.tensor.Tensor(x, tt_dtype).reshape(shape).pad_to_tile(float("nan")).to(ttl.tensor.Layout.TILE).to(device)
+    )
+
+    indices = []
+    dev_indices = []
+    for index_dim in index_dims:
+        idx_value_max = shape[index_dim] - 1
+        idx = torch.randint(0, idx_value_max, (index_size,))
+        dev_idx = (
+            ttl.tensor.Tensor(idx, ttl.tensor.DataType.UINT32)
+            .reshape(1, 1, 1, index_size)
+            .pad_to_tile(float("nan"))
+            .to(ttl.tensor.Layout.TILE)
+            .to(device)
+        )
+        indices.append(idx)
+        dev_indices.append(dev_idx)
+
+    if index_dims == (0, 1):
+        tt_cpu = x[indices[0], indices[1]]
+    if index_dims == (1, 2):
+        tt_cpu = x[:, indices[0], indices[1]]
+    if index_dims == (2, 3):
+        tt_cpu = x[:, :, indices[0], indices[1]]
+
+    tt_npu = ttl.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR)
+
+    output_4d_shape = to_output_4d_shape(shape, index_dims, index_size)
+
+    tt_npu = tt_npu.unpad_from_tile(output_4d_shape)
+    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
+    logger.info(out)
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_index_dims",
+    (
+        ((10, 15, 7, 70), (0, 1, 2)),
+        ((10, 15, 7, 70), (1, 2, 3)),
+    ),
+    ids=["NC", "CH"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        torch.int32,
+        torch.bfloat16,
+    ),
+    ids=["int32", "bfloat16"],
+)
+@pytest.mark.parametrize(
+    "index_size",
+    (
+        4,
+        100,
+    ),
+)
+def test_getitem_tilized_three_indices(shape_index_dims, dtype, index_size, device):
+    ttl.program_cache.enable()
+
+    shape, index_dims = shape_index_dims
+    torch.manual_seed(2)
+
+    if dtype == torch.int32:
+        tt_dtype = ttl.tensor.DataType.UINT32
+    if dtype == torch.bfloat16:
+        tt_dtype = ttl.tensor.DataType.BFLOAT16
+
+    x = torch.randint(low=0, high=10, size=shape).to(dtype)
+
+    dev_x = (
+        ttl.tensor.Tensor(x, tt_dtype).reshape(shape).pad_to_tile(float("nan")).to(ttl.tensor.Layout.TILE).to(device)
+    )
+
+    indices = []
+    dev_indices = []
+    for index_dim in index_dims:
+        idx_value_max = shape[index_dim] - 1
+        idx = torch.randint(0, idx_value_max, (index_size,))
+        dev_idx = (
+            ttl.tensor.Tensor(idx, ttl.tensor.DataType.UINT32)
+            .reshape(1, 1, 1, index_size)
+            .pad_to_tile(float("nan"))
+            .to(ttl.tensor.Layout.TILE)
+            .to(device)
+        )
+        indices.append(idx)
+        dev_indices.append(dev_idx)
+
+    if index_dims == (0, 1, 2):
+        tt_cpu = x[indices[0], indices[1], indices[2]]
+    if index_dims == (1, 2, 3):
+        tt_cpu = x[:, indices[0], indices[1], indices[2]]
+
+    tt_npu = ttl.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR)
+
+    output_4d_shape = to_output_4d_shape(shape, index_dims, index_size)
+
+    tt_npu = tt_npu.unpad_from_tile(output_4d_shape)
+    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
+    logger.info(out)
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_index_dims",
+    (((10, 15, 7, 80), (0, 1, 2, 3)),),
+    ids=["NCHW"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        torch.int32,
+        torch.bfloat16,
+    ),
+    ids=["int32", "bfloat16"],
+)
+@pytest.mark.parametrize(
+    "index_size",
+    (
+        4,
+        100,
+    ),
+)
+def test_getitem_tilized_four_indices(shape_index_dims, dtype, index_size, device):
+    ttl.program_cache.enable()
+
+    shape, index_dims = shape_index_dims
+    torch.manual_seed(2)
+
+    if dtype == torch.int32:
+        tt_dtype = ttl.tensor.DataType.UINT32
+    if dtype == torch.bfloat16:
+        tt_dtype = ttl.tensor.DataType.BFLOAT16
+
+    x = torch.randint(low=0, high=10, size=shape).to(dtype)
+
+    dev_x = (
+        ttl.tensor.Tensor(x, tt_dtype).reshape(shape).pad_to_tile(float("nan")).to(ttl.tensor.Layout.TILE).to(device)
+    )
+
+    indices = []
+    dev_indices = []
+    for index_dim in index_dims:
+        idx_value_max = shape[index_dim] - 1
+        idx = torch.randint(0, idx_value_max, (index_size,))
+        dev_idx = (
+            ttl.tensor.Tensor(idx, ttl.tensor.DataType.UINT32)
+            .reshape(1, 1, 1, index_size)
+            .pad_to_tile(float("nan"))
+            .to(ttl.tensor.Layout.TILE)
+            .to(device)
+        )
+        indices.append(idx)
+        dev_indices.append(dev_idx)
+
+    tt_cpu = x[indices[0], indices[1], indices[2], indices[3]]
+
+    tt_npu = ttl.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR)
+
+    output_4d_shape = to_output_4d_shape(shape, index_dims, index_size)
+
+    tt_npu = tt_npu.unpad_from_tile(output_4d_shape)
+
+    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
+    logger.info(out)
+
+    assert passing

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -179,6 +179,9 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/fold/fold_op.cpp \
 	tt_eager/tt_dnn/op_library/fold/single_core/fold_op_single_core.cpp \
 	tt_eager/tt_dnn/op_library/fold/multi_core/fold_op_multi_core.cpp \
+	tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.cpp \
+	tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/moreh_getitem_rm.cpp \
+	tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp \
 
 TT_DNN_LIB = $(LIBDIR)/libtt_dnn.a
 TT_DNN_DEFINES =

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.cpp
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.hpp"
+
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_eager/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+
+using namespace tt::constants;
+using namespace std;
+using namespace tt::tt_metal;
+
+namespace tt {
+namespace operations {
+namespace primary {
+
+void MorehGetitem::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    // validate input tensor
+    auto& input_tensor = input_tensors.at(0);
+    auto layout = input_tensor.get_layout();
+
+    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operands to getitem need to be on device!");
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Operands to getitem need to be allocated in buffers on device!");
+    auto dtype = input_tensor.get_dtype();
+    TT_ASSERT(dtype == DataType::UINT32 || dtype == DataType::BFLOAT16);
+
+    // validate index tensors
+    uint32_t index_size = input_tensors.at(1).get_legacy_shape()[-1];
+    for (uint32_t i = 1; i < input_tensors.size(); i++) {
+        auto& index_tensor = input_tensors.at(i);
+        TT_ASSERT(index_tensor.storage_type() == StorageType::DEVICE, "Operands to getitem need to be on device!");
+        TT_ASSERT(index_tensor.buffer() != nullptr, "Operands to getitem need to be allocated in buffers on device!");
+        TT_ASSERT(index_tensor.get_dtype() == DataType::UINT32);
+
+        auto index_shape = index_tensor.get_legacy_shape();
+        if (index_tensor.get_layout() == Layout::ROW_MAJOR) {
+            TT_ASSERT(index_shape.rank() == 1);
+        } else if (index_tensor.get_layout() == Layout::TILE) {
+            TT_ASSERT(index_shape.rank() == 4);
+        }
+        TT_ASSERT(index_size == index_shape[-1], "The shapes of all index tensors must be identical!");
+    }
+
+    if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
+        for (auto dim : this->index_dims) {
+            TT_ASSERT(dim != 3, "getitem for ROW_MAJOR layout not support W index tensor!");
+        }
+    }
+
+    uint32_t dim_start = this->index_dims.front();
+    uint32_t i = 0;
+    for (auto dim : this->index_dims) {
+        TT_ASSERT(dim_start + i == dim, fmt::format("The value of index_dims={} must be consecutive integers.", this->index_dims));
+        i++;
+    }
+
+    if(output_tensors.empty() || !output_tensors.at(0).has_value()){
+        // If the user decided to not use any optional output tensors, then this would be empty or would be a nullptr.
+        return;
+    }
+    TT_ASSERT(output_tensors.size() == 1, "Must have 1 output tensor");
+    TT_ASSERT(dtype == output_tensors.front().value().get_dtype());
+}
+
+std::vector<Shape> MorehGetitem::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    Shape output_shape = input_tensors.at(0).get_legacy_shape();
+    auto layout = input_tensors.at(0).get_layout();
+
+    if (layout == Layout::TILE) {
+        // compute output shape
+        // ex)
+        // input: (10, 20, 30, 40)
+        // index_tensor: [(100), (100)]
+        // index_dims = 1,2
+        // output: (10, 1, 100, 40)
+        auto dimensions_pads = std::vector<Padding::PadDimension>();
+        std::vector<uint32_t> output_size_vec;
+
+        for (int dim = 0; dim < 4; dim++) {
+            dimensions_pads.push_back(output_shape.padding()[dim]);
+            output_size_vec.push_back(output_shape[dim]);
+        }
+
+        auto index = input_tensors.at(1);
+        uint32_t index_size = index.get_legacy_shape()[3];
+        uint32_t index_size_without_padding = index.get_legacy_shape().without_padding()[3];
+        uint32_t padding_back = index_size - index_size_without_padding;
+
+        uint32_t last_dim = this->index_dims.back();
+
+        for (uint32_t i = 0; i < this->index_dims.size(); i++) {
+            uint32_t dim = this->index_dims.at(i);
+            auto index = input_tensors.at(i + 1);
+
+            if (dim == 2 || dim == 3) {
+                dimensions_pads[dim] = Padding::PadDimension{.front=0, .back=31};
+                output_size_vec[dim] = 32;
+            } else {
+                output_size_vec[dim] = 1;
+            }
+        }
+
+        if (last_dim == 2 || last_dim == 3) {
+            output_size_vec[last_dim] = index_size;
+            dimensions_pads[last_dim] = Padding::PadDimension{.front=0, .back=padding_back};
+        } else {
+            output_size_vec[last_dim] = index_size_without_padding;
+        }
+
+        const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
+        output_shape = Shape(output_size_vec, padding);
+
+    } else {
+        // compute output shape
+        // ex)
+        // input: (10, 20, 30, 40)
+        // index_tensor: [(100), (100)]
+        // index_dims = 1,2
+        // output: (10, 100, 40)
+        std::vector<uint32_t> output_size_vec;
+
+        auto input_shape = input_tensors.at(0).get_legacy_shape();
+        uint32_t input_rank = input_shape.rank();
+
+        auto index = input_tensors.at(1);
+        uint32_t index_size = index.get_legacy_shape()[0];
+
+        uint32_t start_dim = this->index_dims.front();
+        uint32_t last_dim = this->index_dims.back();
+        for(uint32_t input_dim = 0 ; input_dim < input_rank; input_dim++) {
+            if (input_dim < start_dim) {
+                output_size_vec.push_back(input_shape[input_dim]);
+            } else if (start_dim == input_dim) {
+                output_size_vec.push_back(index_size);
+            } else if (last_dim < input_dim) {
+                output_size_vec.push_back(input_shape[input_dim]);
+            }
+        }
+
+        output_shape = Shape(output_size_vec);
+    }
+
+    return {output_shape};
+}
+
+std::vector<Tensor> MorehGetitem::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (!output_tensors.empty() && output_tensors.at(0).has_value()) {
+        return {output_tensors.at(0).value()};
+    }
+
+    auto dtype = input_tensors.at(0).get_dtype();
+    auto layout = input_tensors.at(0).get_layout();
+    Tensor output =
+        operation::generic_create_output_tensors(*this, input_tensors, dtype, layout, this->output_mem_config).at(0);
+
+    return {output};
+}
+
+operation::ProgramWithCallbacks MorehGetitem::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    auto& input = input_tensors.at(0);
+    auto& output = output_tensors.at(0);
+
+    std::vector<Tensor> index_tensors;
+    for (uint32_t i = 1; i < input_tensors.size(); i++) {
+        index_tensors.push_back(input_tensors.at(i));
+    }
+
+    if (input.get_layout() == Layout::ROW_MAJOR) {
+        return {moreh_getitem_rm(input, index_tensors, this->index_dims, output, this->core_range)};
+    }
+
+    return {moreh_getitem_tilized(input, index_tensors, this->index_dims, output, this->core_range)};
+}
+
+Tensor moreh_getitem(
+    const Tensor& input_tensor,
+    const std::vector<Tensor>& index_tensors,
+    const std::vector<uint32_t>& index_dims,
+    std::optional<Tensor> output_tensor,
+    const MemoryConfig& output_mem_config) {
+    auto device = input_tensor.device();
+    auto grid_coord = device->compute_with_storage_grid_size();
+    const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
+
+    std::vector<Tensor> new_input_tensors;
+    new_input_tensors.push_back(input_tensor);
+    new_input_tensors.insert(new_input_tensors.end(), index_tensors.begin(), index_tensors.end());
+
+    output_tensor =
+        operation::run(
+            MorehGetitem{.index_dims = index_dims, .core_range = all_cores, .output_mem_config = output_mem_config},
+            new_input_tensors,
+            {},
+            {output_tensor})
+            .at(0);
+
+    return output_tensor.value();
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.hpp
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <optional>
+
+#include "tt_dnn/op_library/operation.hpp"
+#include "tt_eager/tensor/tensor.hpp"
+
+namespace tt {
+namespace operations {
+namespace primary {
+
+using namespace tt_metal;
+
+operation::ProgramWithCallbacks moreh_getitem_rm(
+    const Tensor &input,
+    const std::vector<Tensor> &index_tensors,
+    const std::vector<uint32_t> &index_dims,
+    const Tensor &output,
+    const CoreRange core_range);
+
+operation::ProgramWithCallbacks moreh_getitem_tilized(
+    const Tensor &input,
+    const std::vector<Tensor> &index_tensors,
+    const std::vector<uint32_t> &index_dims,
+    const Tensor &output,
+    const CoreRange core_range);
+
+struct MorehGetitem {
+    const std::vector<uint32_t> index_dims;
+    const CoreRange core_range;  // unused for now
+    const MemoryConfig output_mem_config;
+
+    void validate_with_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
+    static constexpr auto attribute_names = std::make_tuple("index_dims", "output_mem_config");
+    const auto attribute_values() const {
+        return std::make_tuple(std::cref(this->index_dims), std::cref(this->output_mem_config));
+    }
+};
+
+Tensor moreh_getitem(
+    const Tensor &input_tensor,
+    const std::vector<Tensor> &index_tensors,
+    const std::vector<uint32_t> &index_dims,
+    std::optional<Tensor> output_tensor = std::nullopt,
+    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/kernels/reader_moreh_getitem.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/kernels/reader_moreh_getitem.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t i = 0;
+    // buffers
+    uint32_t src_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index0_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index1_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index2_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index3_addr = get_arg_val<uint32_t>(i++);
+
+    // input
+    uint32_t input_stick_idx_stride_n = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_h = get_arg_val<uint32_t>(i++);
+
+    // index
+    uint32_t index0_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index1_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index2_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index3_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index0_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index1_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index2_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index3_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index_size = get_arg_val<uint32_t>(i++);
+    int32_t index_start_dim = static_cast<int32_t>(get_arg_val<uint32_t>(i++));
+    int32_t index_end_dim = static_cast<int32_t>(get_arg_val<uint32_t>(i++));
+
+    // output
+    uint32_t output_size_n = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_h = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_w = get_arg_val<uint32_t>(i++);
+
+    // etc
+    uint32_t start_id = get_arg_val<uint32_t>(i++);
+    uint32_t num_sticks = get_arg_val<uint32_t>(i++);
+    uint32_t stick_size = get_arg_val<uint32_t>(i++);
+
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_in2 = tt::CB::c_in2;
+    constexpr auto cb_in3 = tt::CB::c_in3;
+    constexpr auto cb_in4 = tt::CB::c_in4;
+
+    constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool index0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool index1_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr bool index2_is_dram = get_compile_time_arg_val(3) == 1;
+    constexpr bool index3_is_dram = get_compile_time_arg_val(4) == 1;
+
+    const InterleavedAddrGen<in_is_dram> s0 = {.bank_base_address = src_addr, .page_size = stick_size};
+
+    const InterleavedAddrGen<index0_is_dram> index0 = {
+        .bank_base_address = index0_addr, .page_size = index0_stick_size};
+    const InterleavedAddrGen<index1_is_dram> index1 = {
+        .bank_base_address = index1_addr, .page_size = index1_stick_size};
+    const InterleavedAddrGen<index2_is_dram> index2 = {
+        .bank_base_address = index2_addr, .page_size = index2_stick_size};
+    const InterleavedAddrGen<index3_is_dram> index3 = {
+        .bank_base_address = index3_addr, .page_size = index3_stick_size};
+
+    uint32_t index_is_defined[4] = {
+        index0_is_defined,
+        index1_is_defined,
+        index2_is_defined,
+        index3_is_defined,
+    };
+
+    tt::CB index_cbs[4] = {
+        cb_in1,
+        cb_in2,
+        cb_in3,
+        cb_in4,
+    };
+
+    uint32_t output_size_list[4] = {
+        output_size_n,
+        output_size_c,
+        output_size_h,
+        output_size_w,
+    };
+
+    uint32_t input_stick_idx_strides[3] = {
+        input_stick_idx_stride_n,
+        input_stick_idx_stride_c,
+        input_stick_idx_stride_h,
+    };
+
+    uint32_t index_stick_sizes[4] = {
+        index0_stick_size,
+        index1_stick_size,
+        index2_stick_size,
+        index3_stick_size,
+    };
+
+    uint32_t end_id = start_id + num_sticks;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        // compute src noc id
+        uint32_t noc_id = 0;
+        uint32_t output_stick_idx = i;
+        uint32_t index_index = 0;
+        bool is_first_index = true;
+        int32_t output_dim = 2;
+        for (int32_t dim = 2; dim >= 0; dim--) {
+
+            uint32_t input_stick_idx_stride = input_stick_idx_strides[dim];
+            auto output_size = output_size_list[output_dim];
+
+            if (index_is_defined[dim]) {
+                // read index tensor
+                tt::CB idx_cb = index_cbs[dim];
+
+                cb_reserve_back(idx_cb, 1);
+                uint32_t index_l1_addr = get_write_ptr(idx_cb);
+                uint64_t index_noc_addr;
+
+                if (is_first_index) {
+                    index_index = output_stick_idx % index_size;
+                }
+
+                if (dim == 0) {
+                    index_noc_addr = get_noc_addr(0, index0);
+                }
+                if (dim == 1) {
+                    index_noc_addr = get_noc_addr(0, index1);
+                }
+                if (dim == 2) {
+                    index_noc_addr = get_noc_addr(0, index2);
+                }
+                noc_async_read(index_noc_addr, index_l1_addr, index_stick_sizes[dim]);
+                noc_async_read_barrier();
+
+                volatile tt_l1_ptr uint32_t* index_l1_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_l1_addr);
+                uint32_t noc_idx = index_l1_ptr[index_index];
+
+                noc_id += noc_idx * input_stick_idx_stride;
+                if (is_first_index) {
+                    output_stick_idx /= output_size;
+                }
+                is_first_index = false;
+            } else {
+                uint32_t noc_idx = output_stick_idx % output_size;
+                noc_id += noc_idx * input_stick_idx_stride;
+                output_stick_idx /= output_size;
+            }
+            if (!(index_start_dim < dim && dim <= index_end_dim)) {
+                output_dim --;
+            }
+        }
+
+        cb_reserve_back(cb_in0, 1);
+        uint32_t l1_write_addr = get_write_ptr(cb_in0);
+        uint64_t src_noc_addr = get_noc_addr(noc_id, s0);
+        noc_async_read(src_noc_addr, l1_write_addr, stick_size);
+        noc_async_read_barrier();
+        cb_push_back(cb_in0, 1);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/kernels/writer_moreh_getitem.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/kernels/writer_moreh_getitem.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t i = 0;
+    // buffer
+    uint32_t dst_addr = get_arg_val<uint32_t>(i++);
+
+    // output
+    uint32_t output_stick_size = get_arg_val<uint32_t>(i++);
+
+    // etc
+    uint32_t start_id = get_arg_val<uint32_t>(i++);
+    uint32_t num_sticks = get_arg_val<uint32_t>(i++);
+
+    constexpr uint32_t cb_id_out = tt::CB::c_in0;
+
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+
+    const InterleavedAddrGen<dst_is_dram> s0 = {
+        .bank_base_address = dst_addr,
+        .page_size = output_stick_size
+    };
+
+    uint32_t end_id = start_id + num_sticks;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+        cb_wait_front(cb_id_out, 1);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        uint64_t dst_noc_addr = get_noc_addr(i, s0);
+        noc_async_write(l1_read_addr, dst_noc_addr, output_stick_size);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, 1);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/moreh_getitem_rm.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/moreh_getitem_rm.cpp
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_eager/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_eager/tensor/tensor_impl.hpp"
+
+using namespace tt::constants;
+using namespace std;
+using namespace tt::tt_metal;
+
+namespace tt {
+namespace operations {
+namespace primary {
+
+struct IndexInfo
+{
+    bool is_defined;
+    bool is_dram;
+    uint32_t address;
+    uint32_t unit_size;
+};
+
+operation::ProgramWithCallbacks moreh_getitem_rm(
+    const Tensor &input,
+    const std::vector<Tensor> &index_tensors,
+    const std::vector<uint32_t> &index_dims,
+    const Tensor &output,
+    const CoreRange core_range) {
+
+    log_debug(LogTest, "moreh_getitem_rm");
+
+    auto input_shape = input.get_legacy_shape();
+    Shape output_shape = output.get_legacy_shape();
+
+    Shape input_4d_shape(tensor_impl::detail::to_4D_shape(input_shape));
+    Shape output_4d_shape = tensor_impl::detail::to_4D_shape(output_shape);
+
+    uint32_t index_start_dim = index_dims.front();
+    uint32_t index_end_dim = index_dims.back();
+
+    Tensor input_4d = input;
+    input_4d = input_4d.reshape(input_4d_shape);
+
+    IndexInfo index_info[4] = {0};
+
+
+    uint32_t dim_offset = 4 - input_shape.rank();
+    for (uint32_t i = 0 ; i < index_tensors.size(); i++) {
+        auto dim = index_dims[i] + dim_offset;
+        auto index = index_tensors.at(i);
+
+        index_info[dim].is_defined = true;
+        index_info[dim].address = index_tensors.at(i).buffer()->address();
+        index_info[dim].is_dram = is_dram(index_tensors.at(i));
+        index_info[dim].unit_size = index.get_legacy_shape()[-1] * index.element_size();
+    }
+
+    uint32_t index_size = index_tensors.front().get_legacy_shape()[-1];
+
+    uint32_t input_unit_size = input_4d_shape[-1] * input_4d.element_size();
+    uint32_t output_unit_size = input_unit_size;
+
+    // split work
+    uint32_t num_units = output.volume() / output_shape[-1];
+    log_debug(LogTest, "num_units {}", num_units);
+
+    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
+    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
+        split_work_to_cores(core_range, num_units);
+
+    Program program = Program();
+
+    // create circular buffers
+    auto src_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    auto index_cb_data_format = tt_metal::datatype_to_dataformat_converter(index_tensors.at(0).get_dtype());
+    auto output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+
+    auto src_cb_index = tt::CB::c_in0;
+    auto rounded_input_page_size = round_up_to_mul32(input_unit_size);
+    auto cb_src0_config = tt_metal::CircularBufferConfig(rounded_input_page_size, {{src_cb_index, src_cb_data_format}})
+                              .set_page_size(src_cb_index, rounded_input_page_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    for (uint32_t dim = 0; dim < 4; dim++) {
+        if (!index_info[dim].is_defined)
+            continue;
+
+        auto src1_cb_index = tt::CB::c_in1 + dim;
+        auto index_page_size = round_up_to_mul32(index_info[dim].unit_size);
+        auto cb_index_config = tt_metal::CircularBufferConfig(index_page_size, {{src1_cb_index, index_cb_data_format}})
+                                   .set_page_size(src1_cb_index, index_page_size);
+        auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_index_config);
+    }
+
+    auto out_cb_index = tt::CB::c_out0;
+    auto rounded_output_page_size = round_up_to_mul32(input_unit_size);
+    auto cb_out0_config =
+        tt_metal::CircularBufferConfig(rounded_input_page_size, {{out_cb_index, output_cb_data_format}})
+            .set_page_size(out_cb_index, rounded_input_page_size);
+    auto cb_out0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_out0_config);
+
+
+    // create read/wrtie kernel
+    auto src_is_dram = is_dram(input_4d);
+    auto dst_is_dram = is_dram(output);
+
+    std::map<string, string> reader_defines;
+    std::map<string, string> writer_defines;
+
+    auto reader_kernel_id = CreateReadKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/kernels/reader_moreh_getitem.cpp",
+        all_cores,
+        {
+            src_is_dram,
+            index_info[0].is_dram,
+            index_info[1].is_dram,
+            index_info[2].is_dram,
+            index_info[3].is_dram,
+        },
+        reader_defines);
+    auto writer_kernel_id = CreateWriteKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/kernels/writer_moreh_getitem.cpp",
+        all_cores,
+        {dst_is_dram},
+        writer_defines);
+
+    uint32_t input_stick_idx_stride_h = 1;
+    uint32_t input_stick_idx_stride_c = input_stick_idx_stride_h * input_4d_shape.without_padding()[2];
+    uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_4d_shape.without_padding()[1];
+
+    // Set Runtime Args
+    auto core_x_offset = core_range.start.x;
+    auto core_y_offset = core_range.start.y;
+
+    uint32_t g1_numcores = core_group_1.num_cores();
+    uint32_t g2_numcores = core_group_2.num_cores();
+
+    uint32_t start_id = 0;
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
+        CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
+        uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
+
+        vector<uint32_t> reader_args = {
+            // buffers
+            input_4d.buffer()->address(),
+            index_info[0].address,
+            index_info[1].address,
+            index_info[2].address,
+            index_info[3].address,
+
+            // input
+            input_stick_idx_stride_n,
+            input_stick_idx_stride_c,
+            input_stick_idx_stride_h,
+
+            // index
+            index_info[0].is_defined,
+            index_info[1].is_defined,
+            index_info[2].is_defined,
+            index_info[3].is_defined,
+            index_info[0].unit_size,
+            index_info[1].unit_size,
+            index_info[2].unit_size,
+            index_info[3].unit_size,
+            index_size,
+            index_start_dim,
+            index_end_dim,
+
+            // output
+            output_4d_shape[0],
+            output_4d_shape[1],
+            output_4d_shape[2],
+            output_4d_shape[3],
+
+            // etc
+            start_id,
+            num_units_per_core,
+            input_unit_size,
+        };
+
+        vector<uint32_t> writer_args = {
+            // buffer
+            output.buffer()->address(),
+
+            // output
+            output_unit_size,
+
+            // etc
+            start_id,
+            num_units_per_core,
+        };
+
+        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
+        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+
+        start_id += num_units_per_core;
+    }
+
+    auto override_runtime_args_callback =
+        [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h, index_dims, dim_offset](
+            const Program &program,
+            const std::vector<Buffer *> &input_buffers,
+            const std::vector<Buffer *> &output_buffers) {
+            TT_ASSERT(output_buffers.size() == 1);
+
+            auto src_buffer = input_buffers.at(0);
+            auto dst_buffer = output_buffers.at(0);
+
+            IndexInfo index_info[4] = {0};
+
+            for (uint32_t i = 0; i < index_dims.size(); i++) {
+                auto dim = index_dims[i] + dim_offset;
+                auto index_buffer = input_buffers.at(i + 1);
+
+                index_info[dim].address = index_buffer->address();
+            }
+
+            for (uint32_t icore = 0; icore < num_cores; icore++) {
+                CoreCoord core = {icore / core_h, icore % core_h};
+
+                {
+                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    runtime_args[0] = src_buffer->address();
+                    runtime_args[1] = index_info[0].address;
+                    runtime_args[2] = index_info[1].address;
+                    runtime_args[3] = index_info[2].address;
+                    runtime_args[4] = index_info[3].address;
+                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
+                }
+
+                {
+                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    runtime_args[0] = dst_buffer->address();
+                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
+                }
+            }
+        };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/common.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/common.hpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#define TILE_HEIGHT 32
+#define TILE_WIDTH 32
+#define FACE_WIDTH 16
+
+#define INDEX_TILE_SIZE (4096)
+
+uint32_t get_noc_offset_in_tile(uint32_t stick_h, uint32_t stick_w, uint32_t tile_h, uint32_t element_size) {
+    uint32_t noc_offset = 0;
+    stick_h = stick_h - tile_h * TILE_HEIGHT;
+
+    const bool is_even = (stick_w % 2 == 0);
+    const bool is_odd = !is_even;
+
+    const uint32_t stick_bytes = FACE_WIDTH * element_size;
+
+    if (stick_h < FACE_WIDTH && is_even) noc_offset += stick_h * stick_bytes;
+    else if (stick_h < FACE_WIDTH && is_odd) noc_offset += (16 + stick_h) * stick_bytes;
+    else if (stick_h >= FACE_WIDTH && is_even) noc_offset += (16 + stick_h) * stick_bytes;
+    else if (stick_h >= FACE_WIDTH && is_odd) noc_offset += (32 + stick_h) * stick_bytes;
+
+    return noc_offset;
+}
+
+struct Idx4d
+{
+    uint32_t n;
+    uint32_t c;
+    uint32_t h;
+    uint32_t w;
+};
+
+Idx4d get_stick_indices(uint32_t stick_idx, uint32_t size_c, uint32_t size_h, uint32_t num_stick_width) {
+    Idx4d stick_index_4d;
+
+    stick_index_4d.w = stick_idx % num_stick_width;
+    uint32_t stick_nch = stick_idx / num_stick_width;
+
+    stick_index_4d.h = stick_nch % size_h;
+    uint32_t stick_nc = stick_nch / size_h;
+
+    stick_index_4d.c = stick_nc % size_c;
+    stick_index_4d.n = stick_nc / size_c;
+
+    return stick_index_4d;
+}
+
+Idx4d get_tile_indices(Idx4d stick_index_4d) {
+    Idx4d tile_index_4d;
+
+    tile_index_4d.n = stick_index_4d.n;
+    tile_index_4d.c = stick_index_4d.c;
+    tile_index_4d.h = stick_index_4d.h / TILE_HEIGHT;
+    tile_index_4d.w = stick_index_4d.w / 2;
+
+    return tile_index_4d;
+}

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize.cpp
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/common.hpp"
+
+void kernel_main() {
+    uint32_t i = 0;
+
+    // buffers
+    uint32_t src_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index0_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index1_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index2_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index3_addr = get_arg_val<uint32_t>(i++);
+
+    // input
+    uint32_t input_stick_idx_stride_n = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_h = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_w = get_arg_val<uint32_t>(i++);
+    uint32_t input_size_c_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t input_size_h_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t input_noc_id_stride_n = get_arg_val<uint32_t>(i++);
+    uint32_t input_noc_id_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_noc_id_stride_h = get_arg_val<uint32_t>(i++);
+    uint32_t input_num_stick_width = get_arg_val<uint32_t>(i++);
+
+    // index
+    uint32_t index0_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index1_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index2_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index3_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index0_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index1_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index2_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index3_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index_size = get_arg_val<uint32_t>(i++);
+
+    // output
+    uint32_t output_size_n = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_h = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_w = get_arg_val<uint32_t>(i++);
+    uint32_t output_num_stick_width = get_arg_val<uint32_t>(i++);
+
+    // etc
+    uint32_t start_id = get_arg_val<uint32_t>(i++);
+    uint32_t num_sticks = get_arg_val<uint32_t>(i++);
+    uint32_t stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t element_size = get_arg_val<uint32_t>(i++);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_in2 = tt::CB::c_in2;
+    constexpr auto cb_in3 = tt::CB::c_in3;
+    constexpr auto cb_in4 = tt::CB::c_in4;
+
+    constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool index0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool index1_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr bool index2_is_dram = get_compile_time_arg_val(3) == 1;
+    constexpr bool index3_is_dram = get_compile_time_arg_val(4) == 1;
+
+    const InterleavedAddrGen<in_is_dram> s0 = {
+        .bank_base_address = src_addr,
+        .page_size = 1024 * element_size,
+    };
+
+    const InterleavedAddrGen<index0_is_dram> index0 = {
+        .bank_base_address = index0_addr, .page_size = INDEX_TILE_SIZE};
+    const InterleavedAddrGen<index1_is_dram> index1 = {
+        .bank_base_address = index1_addr, .page_size = INDEX_TILE_SIZE};
+    const InterleavedAddrGen<index2_is_dram> index2 = {
+        .bank_base_address = index2_addr, .page_size = INDEX_TILE_SIZE};
+    const InterleavedAddrGen<index3_is_dram> index3 = {
+        .bank_base_address = index3_addr, .page_size = INDEX_TILE_SIZE};
+
+    uint32_t index_is_defined[4] = {
+        index0_is_defined,
+        index1_is_defined,
+        index2_is_defined,
+        index3_is_defined,
+    };
+
+    tt::CB index_cbs[4] = {
+        cb_in1,
+        cb_in2,
+        cb_in3,
+        cb_in4,
+    };
+
+    uint32_t output_size_list[4] = {
+        output_size_n,
+        output_size_c,
+        output_size_h,
+        output_size_w,
+    };
+
+    uint32_t input_stick_idx_strides[4] = {
+        input_stick_idx_stride_n,
+        input_stick_idx_stride_c,
+        input_stick_idx_stride_h,
+        input_stick_idx_stride_w,
+    };
+
+    #define NOC_MINIMUM_READ_SIZE 32
+
+    uint32_t end_id = start_id + num_sticks;
+
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        // compute src noc id
+        uint32_t output_stick_idx = i;
+        uint32_t input_stick_idx = 0;
+        uint32_t index_index = 0;
+        bool is_first_index = true;
+
+        for (int32_t dim = 3; dim >= 0; dim--) {
+            uint32_t input_stick_idx_stride = input_stick_idx_strides[dim];
+
+            if (index_is_defined[dim]) {
+                tt::CB idx_cb = index_cbs[dim];
+
+                cb_reserve_back(idx_cb, 1);
+                uint32_t index_l1_addr = get_write_ptr(idx_cb);
+                uint64_t index_noc_addr;
+
+                if (is_first_index) {
+                    index_index = output_stick_idx % index_size;
+                    is_first_index = false;
+                }
+                uint32_t index_noc_id = index_index / TILE_HEIGHT;
+                if (dim == 0) {
+                    index_noc_addr = get_noc_addr(index_noc_id, index0);
+                }
+                if (dim == 1) {
+                    index_noc_addr = get_noc_addr(index_noc_id, index1);
+                }
+                if (dim == 2) {
+                    index_noc_addr = get_noc_addr(index_noc_id, index2);
+                }
+                noc_async_read(index_noc_addr, index_l1_addr, INDEX_TILE_SIZE);
+                noc_async_read_barrier();
+
+                volatile tt_l1_ptr uint32_t* index_l1_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_l1_addr);
+                uint32_t index_dim_offset;
+                uint32_t index_tile_idx = index_index % TILE_WIDTH;
+                if (index_tile_idx < FACE_WIDTH) index_dim_offset = index_tile_idx;
+                else index_dim_offset = index_tile_idx + 256 - 16;
+
+                uint32_t index_val = index_l1_ptr[index_dim_offset];
+
+                input_stick_idx += index_val * input_stick_idx_stride;
+            } else {
+                uint32_t index_val;
+
+                if (dim == 3) {
+                    index_val = output_stick_idx % input_num_stick_width;
+                    input_stick_idx += index_val * input_stick_idx_stride;
+                } else {
+                    auto output_size = output_size_list[dim];
+                    index_val = output_stick_idx % output_size;
+                    input_stick_idx += index_val * input_stick_idx_stride;
+                }
+            }
+            if (dim == 3) {
+                output_stick_idx /= output_num_stick_width;
+            } else {
+                auto output_size = output_size_list[dim];
+                output_stick_idx /= output_size;
+            }
+        }
+
+        // input_stick_idx = 5;
+        cb_reserve_back(cb_in0, 1);
+        uint32_t l1_write_addr = get_write_ptr(cb_in0);
+
+        Idx4d stick_index_4d = get_stick_indices(input_stick_idx, input_size_c_without_padding, input_size_h_without_padding, input_num_stick_width);
+        Idx4d tile_index_4d = get_tile_indices(stick_index_4d);
+
+        uint32_t noc_id =   tile_index_4d.n * input_noc_id_stride_n +
+                            tile_index_4d.c * input_noc_id_stride_c +
+                            tile_index_4d.h * input_noc_id_stride_h +
+                            tile_index_4d.w;
+        uint32_t noc_offset = get_noc_offset_in_tile(stick_index_4d.h , stick_index_4d.w, tile_index_4d.h, element_size);
+
+        uint64_t src_noc_addr = get_noc_addr(noc_id, s0, noc_offset);
+
+        noc_async_read(src_noc_addr, l1_write_addr, stick_size);
+        noc_async_read_barrier();
+        cb_push_back(cb_in0, 1);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize_w.cpp
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/common.hpp"
+
+void kernel_main() {
+    uint32_t i = 0;
+    // buffers
+    uint32_t src_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index0_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index1_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index2_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index3_addr = get_arg_val<uint32_t>(i++);
+
+    // input
+    uint32_t input_stick_idx_stride_n = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_h = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_w = get_arg_val<uint32_t>(i++);
+    uint32_t input_size_c_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t input_size_h_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t input_num_stick_width = get_arg_val<uint32_t>(i++);
+    uint32_t input_noc_id_stride_n = get_arg_val<uint32_t>(i++);
+    uint32_t input_noc_id_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_noc_id_stride_h = get_arg_val<uint32_t>(i++);
+
+
+    // index
+    uint32_t index0_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index1_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index2_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index3_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index0_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index1_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index2_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index3_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index_size = get_arg_val<uint32_t>(i++);
+
+    // output
+    uint32_t output_size_n = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_h = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_w = get_arg_val<uint32_t>(i++);
+    uint32_t output_num_stick_width = get_arg_val<uint32_t>(i++);
+
+    // etc
+    uint32_t start_id = get_arg_val<uint32_t>(i++);
+    uint32_t num_sticks = get_arg_val<uint32_t>(i++);
+    uint32_t element_size = get_arg_val<uint32_t>(i++);
+    uint32_t num_elements_per_alignment = get_arg_val<uint32_t>(i++);
+    uint32_t num_alignment_width = get_arg_val<uint32_t>(i++);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_in2 = tt::CB::c_in2;
+    constexpr auto cb_in3 = tt::CB::c_in3;
+    constexpr auto cb_in4 = tt::CB::c_in4;
+
+    constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool index0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr bool index1_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr bool index2_is_dram = get_compile_time_arg_val(3) == 1;
+    constexpr bool index3_is_dram = get_compile_time_arg_val(4) == 1;
+
+    const InterleavedAddrGen<in_is_dram> s0 = {
+        .bank_base_address = src_addr,
+        .page_size = 1024 * element_size,
+    };
+
+    const InterleavedAddrGen<index0_is_dram> index0 = {
+        .bank_base_address = index0_addr, .page_size = INDEX_TILE_SIZE};
+    const InterleavedAddrGen<index1_is_dram> index1 = {
+        .bank_base_address = index1_addr, .page_size = INDEX_TILE_SIZE};
+    const InterleavedAddrGen<index2_is_dram> index2 = {
+        .bank_base_address = index2_addr, .page_size = INDEX_TILE_SIZE};
+    const InterleavedAddrGen<index3_is_dram> index3 = {
+        .bank_base_address = index3_addr, .page_size = INDEX_TILE_SIZE};
+
+    uint32_t index_is_defined[4] = {
+        index0_is_defined,
+        index1_is_defined,
+        index2_is_defined,
+        index3_is_defined,
+    };
+
+    tt::CB index_cbs[4] = {
+        cb_in1,
+        cb_in2,
+        cb_in3,
+        cb_in4,
+    };
+
+    uint32_t output_size_list[4] = {
+        output_size_n,
+        output_size_c,
+        output_size_h,
+        output_size_w,
+    };
+
+    uint32_t input_stick_idx_strides[4] = {
+        input_stick_idx_stride_n,
+        input_stick_idx_stride_c,
+        input_stick_idx_stride_h,
+        input_stick_idx_stride_w,
+    };
+
+    uint32_t w_index;
+
+    #define NOC_MINIMUM_READ_SIZE 32
+
+    uint32_t end_id = start_id + num_sticks;
+    uint32_t index_size_w = output_size_w;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+
+        uint32_t index_w_index = i % num_alignment_width;
+        uint32_t index_off = index_w_index * num_elements_per_alignment;
+        uint32_t index_start = index_off;
+        uint32_t index_end = min(index_off + num_elements_per_alignment, index_size_w);
+
+        uint32_t j = 0;
+        for (uint32_t index_index = index_start; index_index < index_end; index_index++, j++) {
+
+            // compute src noc id
+            uint32_t output_stick_h = (i / num_alignment_width);
+            uint32_t output_stick_w = index_index / FACE_WIDTH;
+            uint32_t output_stick_idx = output_stick_h * output_num_stick_width + output_stick_w;
+            uint32_t input_stick_idx = 0;
+            for (int32_t dim = 3; dim >= 0; dim--) {
+                uint32_t input_stick_idx_stride = input_stick_idx_strides[dim];
+
+                if (index_is_defined[dim]) {
+                    // read index tensor
+                    tt::CB idx_cb = index_cbs[dim];
+
+                    cb_reserve_back(idx_cb, 1);
+                    uint32_t index_l1_addr = get_write_ptr(idx_cb);
+                    uint64_t index_noc_addr;
+
+                    uint32_t index_noc_id;
+                    if (dim == 3) {
+                        index_noc_id = index_index / TILE_WIDTH;
+                    } else {
+                        index_noc_id = index_index / TILE_HEIGHT;
+                    }
+                    if (dim == 0) {
+                        index_noc_addr = get_noc_addr(index_noc_id, index0);
+                    }
+                    if (dim == 1) {
+                        index_noc_addr = get_noc_addr(index_noc_id, index1);
+                    }
+                    if (dim == 2) {
+                        index_noc_addr = get_noc_addr(index_noc_id, index2);
+                    }
+                    if (dim == 3) {
+                        index_noc_addr = get_noc_addr(index_noc_id, index3);
+                    }
+                    noc_async_read(index_noc_addr, index_l1_addr, INDEX_TILE_SIZE);
+                    noc_async_read_barrier();
+
+                    if (dim == 3) {
+                        volatile tt_l1_ptr uint32_t* index_l1_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_l1_addr);
+                        uint32_t index_dim_offset = index_index % FACE_WIDTH;
+                        if ((index_index % TILE_WIDTH) >= 16) index_dim_offset += 256;
+
+                        uint32_t index_val = index_l1_ptr[index_dim_offset];
+
+                        w_index = index_val;
+                        input_stick_idx += index_val / FACE_WIDTH;
+                    } else {
+                        volatile tt_l1_ptr uint32_t* index_l1_ptr =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_l1_addr);
+                        uint32_t index_dim_offset;
+                        uint32_t index_tile_idx = index_index % TILE_WIDTH;
+                        if (index_tile_idx < FACE_WIDTH) index_dim_offset = index_tile_idx;
+                        else index_dim_offset = index_tile_idx + 256 - 16;
+
+                        uint32_t index_val = index_l1_ptr[index_dim_offset];
+
+                        input_stick_idx += index_val * input_stick_idx_stride;
+                    }
+                } else {
+                    uint32_t index_val;
+
+                    auto output_size = output_size_list[dim];
+                    index_val = output_stick_idx % output_size;
+                    input_stick_idx += index_val * input_stick_idx_stride;
+                }
+                if (dim == 3) {
+                    output_stick_idx /= output_num_stick_width;
+                } else {
+                    auto output_size = output_size_list[dim];
+                    output_stick_idx /= output_size;
+                }
+            }
+
+            cb_reserve_back(cb_in0, 1);
+            uint32_t l1_write_addr = get_write_ptr(cb_in0);
+
+            Idx4d stick_index_4d = get_stick_indices(input_stick_idx, input_size_c_without_padding, input_size_h_without_padding, input_num_stick_width);
+            Idx4d tile_index_4d = get_tile_indices(stick_index_4d);
+
+            uint32_t noc_id =   tile_index_4d.n * input_noc_id_stride_n +
+                                tile_index_4d.c * input_noc_id_stride_c +
+                                tile_index_4d.h * input_noc_id_stride_h +
+                                tile_index_4d.w;
+
+            uint32_t noc_offset = get_noc_offset_in_tile(stick_index_4d.h , stick_index_4d.w, tile_index_4d.h, element_size);
+
+            if (num_elements_per_alignment == 8) {
+                noc_offset += ((w_index / 8) % 2) * NOC_MINIMUM_READ_SIZE;
+            }
+
+            uint64_t src_noc_addr = get_noc_addr(noc_id, s0, noc_offset);
+
+            noc_async_read(src_noc_addr, l1_write_addr, NOC_MINIMUM_READ_SIZE);
+            noc_async_read_barrier();
+
+            if (element_size == 4) {
+                volatile tt_l1_ptr uint32_t* index_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr);
+                index_l1_ptr[0] = index_l1_ptr[w_index % num_elements_per_alignment];
+            } else if (element_size == 2) {
+                volatile tt_l1_ptr uint16_t* index_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
+                index_l1_ptr[0] = index_l1_ptr[w_index % num_elements_per_alignment];
+            }
+
+            cb_push_back(cb_in0, 1);
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/common.hpp"
+
+void kernel_main() {
+    uint32_t i = 0;
+    // buffers
+    uint32_t dst_addr = get_arg_val<uint32_t>(i++);
+
+    // output
+    uint32_t output_size_c_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_h_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_w_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t output_noc_id_stride_n = get_arg_val<uint32_t>(i++);
+    uint32_t output_noc_id_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_noc_id_stride_h = get_arg_val<uint32_t>(i++);
+    uint32_t output_num_stick_width = get_arg_val<uint32_t>(i++);
+
+    // etc
+    uint32_t start_id = get_arg_val<uint32_t>(i++);
+    uint32_t num_sticks = get_arg_val<uint32_t>(i++);
+    uint32_t stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t element_size = get_arg_val<uint32_t>(i++);
+
+    constexpr uint32_t cb_id_out = tt::CB::c_in0;
+
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+
+    const InterleavedAddrGen<dst_is_dram> s0 = {
+        .bank_base_address = dst_addr,
+        .page_size = 1024 * element_size,
+    };
+
+    uint32_t end_id = start_id + num_sticks;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+        cb_wait_front(cb_id_out, 1);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+
+        uint32_t stick_idx = i;
+
+        Idx4d stick_index_4d = get_stick_indices(stick_idx, output_size_c_without_padding, output_size_h_without_padding, output_num_stick_width);
+        Idx4d tile_index_4d = get_tile_indices(stick_index_4d);
+
+        uint32_t noc_id =   tile_index_4d.n * output_noc_id_stride_n +
+                            tile_index_4d.c * output_noc_id_stride_c +
+                            tile_index_4d.h * output_noc_id_stride_h +
+                            tile_index_4d.w;
+
+        uint32_t noc_offset = get_noc_offset_in_tile(stick_index_4d.h, stick_index_4d.w, tile_index_4d.h, element_size);
+
+        uint64_t dst_noc_addr = get_noc_addr(noc_id, s0, noc_offset);
+
+        noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, 1);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize_w.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/common.hpp"
+
+void kernel_main() {
+    uint32_t i = 0;
+    // buffers
+    uint32_t dst_addr = get_arg_val<uint32_t>(i++);
+
+    // output
+    uint32_t output_size_c_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_h_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_w_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t output_noc_id_stride_n = get_arg_val<uint32_t>(i++);
+    uint32_t output_noc_id_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_noc_id_stride_h = get_arg_val<uint32_t>(i++);
+    uint32_t output_num_stick_width = get_arg_val<uint32_t>(i++);
+
+    // etc
+    uint32_t start_id = get_arg_val<uint32_t>(i++);
+    uint32_t num_sticks = get_arg_val<uint32_t>(i++);
+    uint32_t stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t element_size = get_arg_val<uint32_t>(i++);
+    uint32_t num_elements_per_alignment = get_arg_val<uint32_t>(i++);
+    uint32_t num_alignment_width = get_arg_val<uint32_t>(i++);
+
+    constexpr uint32_t cb_id_out0 = tt::CB::c_in0;
+    constexpr uint32_t cb_id_out1 = tt::CB::c_out1;
+
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+
+    const InterleavedAddrGen<dst_is_dram> s0 = {
+        .bank_base_address = dst_addr,
+        .page_size = 1024 * element_size,
+    };
+
+    #define NOC_MINIMUM_READ_SIZE 32
+
+    uint32_t l1_read_addr0 = get_read_ptr(cb_id_out0);
+    uint32_t l1_read_addr1 = get_read_ptr(cb_id_out1);
+
+    uint32_t end_id = start_id + num_sticks;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+
+        uint32_t output_stick_w = i % num_alignment_width;
+        uint32_t w_off = output_stick_w * num_elements_per_alignment;
+        uint32_t w_start = w_off;
+        uint32_t w_end = min(w_off + num_elements_per_alignment, output_size_w_without_padding);
+
+        uint32_t stick_y = (i / num_alignment_width);
+        uint32_t stick_x = w_start / FACE_WIDTH;
+        uint32_t stick_idx = stick_y * output_num_stick_width + stick_x;
+
+        Idx4d stick_index_4d = get_stick_indices(stick_idx, output_size_c_without_padding, output_size_h_without_padding, output_num_stick_width);
+        Idx4d tile_index_4d = get_tile_indices(stick_index_4d);
+
+        uint32_t noc_id =   tile_index_4d.n * output_noc_id_stride_n +
+                            tile_index_4d.c * output_noc_id_stride_c +
+                            tile_index_4d.h * output_noc_id_stride_h +
+                            tile_index_4d.w;
+
+        uint32_t noc_offset = get_noc_offset_in_tile(stick_index_4d.h, stick_index_4d.w, tile_index_4d.h, element_size);
+
+        if (num_elements_per_alignment == 8) {
+            noc_offset += ((w_start / 8) % 2) * NOC_MINIMUM_READ_SIZE;
+        }
+
+        uint32_t j = 0;
+        for (uint32_t w = w_start ; w < w_end; w++, j++) {
+            cb_wait_front(cb_id_out0, 1);
+
+            if (element_size == 4) {
+                volatile tt_l1_ptr uint32_t* index_l1_ptr0 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_read_addr0);
+                volatile tt_l1_ptr uint32_t* index_l1_ptr1 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_read_addr1);
+
+                index_l1_ptr1[j] = index_l1_ptr0[0];
+            } else if (element_size == 2) {
+                volatile tt_l1_ptr uint16_t* index_l1_ptr0 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_read_addr0);
+                volatile tt_l1_ptr uint16_t* index_l1_ptr1 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_read_addr1);
+
+                index_l1_ptr1[j] = index_l1_ptr0[0];
+            }
+
+            cb_pop_front(cb_id_out0, 1);
+
+        }
+
+        uint64_t dst_noc_addr = get_noc_addr(noc_id, s0, noc_offset);
+        noc_async_write(l1_read_addr1, dst_noc_addr, NOC_MINIMUM_READ_SIZE);
+        noc_async_write_barrier();
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp
@@ -1,0 +1,556 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_eager/tensor/tensor_impl.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_eager/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+using namespace tt::constants;
+using namespace std;
+using namespace tt::tt_metal;
+
+namespace tt {
+namespace operations {
+namespace primary {
+
+struct IndexInfo {
+    bool is_defined;
+    bool is_dram;
+    uint32_t address;
+    uint32_t unit_size;
+};
+
+operation::ProgramWithCallbacks moreh_getitem_tilized(
+    const Tensor &input,
+    const std::vector<Tensor> &index_tensors,
+    const std::vector<uint32_t> &index_dims,
+    const Tensor &output,
+    const CoreRange core_range) {
+    log_debug(LogTest, "moreh_getitem_tilized");
+
+    auto input_shape = input.get_legacy_shape();
+    Shape output_shape = output.get_legacy_shape();
+
+    bool is_w_index_exist = false;
+    for (auto dim : index_dims) {
+        if (dim == 3) {
+            is_w_index_exist = true;
+        }
+    }
+
+    if (is_w_index_exist) {
+        // compute index info
+        IndexInfo index_info[4] = {0};
+
+        uint32_t dim_offset = 4 - input_shape.rank();
+        for (uint32_t i = 0; i < index_tensors.size(); i++) {
+            auto dim = index_dims[i] + dim_offset;
+            auto index = index_tensors.at(i);
+
+            index_info[dim].is_defined = true;
+            index_info[dim].address = index.buffer()->address();
+            index_info[dim].is_dram = is_dram(index);
+            index_info[dim].unit_size = index.element_size();
+        }
+
+        uint32_t index_size = index_tensors.at(0).get_legacy_shape().without_padding()[-1];
+
+        uint32_t input_unit_size = input.element_size();
+        uint32_t output_unit_size = output.element_size();
+
+        // split work
+        auto input_shape_without_padding = input_shape.without_padding();
+        auto output_shape_without_padding = output_shape.without_padding();
+        uint32_t alignment_size = 32;
+        uint32_t num_elements_per_alignment = alignment_size / output_unit_size;
+        uint32_t num_units =
+            output_shape_without_padding[0] * output_shape_without_padding[1] * output_shape_without_padding[2] *
+            ((output_shape_without_padding[3] + num_elements_per_alignment - 1) / num_elements_per_alignment);
+        log_debug(LogTest, "num_units {}", num_units);
+
+        uint32_t core_w = core_range.end.x - core_range.start.x + 1;
+        uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+
+        auto
+            [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
+                split_work_to_cores(core_range, num_units);
+
+        Program program = Program();
+
+        // create circular buffers
+        auto src_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+        auto index_cb_data_format = tt_metal::datatype_to_dataformat_converter(index_tensors.at(0).get_dtype());
+        auto output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+
+        auto src_cb_index = tt::CB::c_in0;
+        auto rounded_input_page_size = round_up_to_mul32(input_unit_size);
+        auto cb_src0_config =
+            tt_metal::CircularBufferConfig(rounded_input_page_size, {{src_cb_index, src_cb_data_format}})
+                .set_page_size(src_cb_index, rounded_input_page_size);
+        auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+        for (uint32_t dim = 0; dim < 4; dim++) {
+            if (!index_info[dim].is_defined)
+                continue;
+
+            auto src1_cb_index = tt::CB::c_in1 + dim;
+            auto index_page_size = 1024 * 4;
+            auto cb_index_config =
+                tt_metal::CircularBufferConfig(index_page_size, {{src1_cb_index, index_cb_data_format}})
+                    .set_page_size(src1_cb_index, index_page_size);
+            auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_index_config);
+        }
+
+        auto out_cb0_index = tt::CB::c_out0;
+        auto rounded_output_page_size = round_up_to_mul32(output_unit_size);
+        auto cb_out0_config =
+            tt_metal::CircularBufferConfig(rounded_output_page_size, {{out_cb0_index, output_cb_data_format}})
+                .set_page_size(out_cb0_index, rounded_output_page_size);
+        auto cb_out0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_out0_config);
+
+        auto out_cb1_index = tt::CB::c_out1;
+        auto cb_out1_config =
+            tt_metal::CircularBufferConfig(rounded_output_page_size, {{out_cb1_index, output_cb_data_format}})
+                .set_page_size(out_cb1_index, rounded_output_page_size);
+        auto cb_out1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_out1_config);
+
+        // create read/wrtie kernel
+        auto src_is_dram = is_dram(input);
+        auto dst_is_dram = is_dram(output);
+
+        std::map<string, string> reader_defines;
+        std::map<string, string> writer_defines;
+
+        auto reader_kernel_id = CreateReadKernel(
+            program,
+            "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize_w.cpp",
+            all_cores,
+            {
+                src_is_dram,
+                index_info[0].is_dram,
+                index_info[1].is_dram,
+                index_info[2].is_dram,
+                index_info[3].is_dram,
+            },
+            reader_defines);
+        auto writer_kernel_id = CreateWriteKernel(
+            program,
+            "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize_w.cpp",
+            all_cores,
+            {dst_is_dram},
+            writer_defines);
+
+        uint32_t face_width = 16;
+        uint32_t input_num_stick_width = div_up(input_shape_without_padding[3], face_width);
+        uint32_t num_alignment_width = div_up(output_shape_without_padding[3], num_elements_per_alignment);
+        uint32_t output_num_stick_width = div_up(output_shape_without_padding[3], face_width);
+
+        uint32_t input_num_tile_c = input_shape[1];
+        uint32_t input_num_tile_height = input_shape[2] / TILE_HEIGHT;
+        uint32_t input_num_tile_width = input_shape[3] / TILE_WIDTH;
+
+        uint32_t input_noc_id_stride_h = input_num_tile_width;
+        uint32_t input_noc_id_stride_c = input_noc_id_stride_h * input_num_tile_height;
+        uint32_t input_noc_id_stride_n = input_noc_id_stride_c * input_num_tile_c;
+
+        uint32_t output_num_tile_c = output_shape[1];
+        uint32_t output_num_tile_height = output_shape[2] / TILE_HEIGHT;
+        uint32_t output_num_tile_width = output_shape[3] / TILE_WIDTH;
+
+        uint32_t output_noc_id_stride_h = output_num_tile_width;
+        uint32_t output_noc_id_stride_c = output_noc_id_stride_h * output_num_tile_height;
+        uint32_t output_noc_id_stride_n = output_noc_id_stride_c * output_num_tile_c;
+
+        uint32_t input_stick_idx_stride_w = 1;
+        uint32_t input_stick_idx_stride_h = input_num_stick_width;
+        uint32_t input_stick_idx_stride_c = input_stick_idx_stride_h * input_shape.without_padding()[2];
+        uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_shape.without_padding()[1];
+
+        // Set Runtime Args
+        auto core_x_offset = core_range.start.x;
+        auto core_y_offset = core_range.start.y;
+
+        uint32_t g1_numcores = core_group_1.num_cores();
+        uint32_t g2_numcores = core_group_2.num_cores();
+
+        uint32_t start_id = 0;
+        for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
+            CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
+            uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
+
+            vector<uint32_t> reader_args = {
+                // buffers
+                input.buffer()->address(),
+                index_info[0].address,
+                index_info[1].address,
+                index_info[2].address,
+                index_info[3].address,
+
+                // input
+                input_stick_idx_stride_n,
+                input_stick_idx_stride_c,
+                input_stick_idx_stride_h,
+                input_stick_idx_stride_w,
+                input_shape_without_padding[1],
+                input_shape_without_padding[2],
+                input_num_stick_width,
+                input_noc_id_stride_n,
+                input_noc_id_stride_c,
+                input_noc_id_stride_h,
+
+                // index
+                index_info[0].is_defined,
+                index_info[1].is_defined,
+                index_info[2].is_defined,
+                index_info[3].is_defined,
+                index_info[0].unit_size,
+                index_info[1].unit_size,
+                index_info[2].unit_size,
+                index_info[3].unit_size,
+                index_size,
+
+                // output
+                output_shape_without_padding[0],
+                output_shape_without_padding[1],
+                output_shape_without_padding[2],
+                output_shape_without_padding[3],
+                output_num_stick_width,
+
+                // etc
+                start_id,
+                num_units_per_core,
+                input.element_size(),
+                num_elements_per_alignment,
+                num_alignment_width,
+            };
+
+            vector<uint32_t> writer_args = {
+                // buffers
+                output.buffer()->address(),
+
+                // output
+                output_shape_without_padding[1],
+                output_shape_without_padding[2],
+                output_shape_without_padding[3],
+                output_noc_id_stride_n,
+                output_noc_id_stride_c,
+                output_noc_id_stride_h,
+                output_num_stick_width,
+
+                // etc
+                start_id,
+                num_units_per_core,
+                output_unit_size,
+                output.element_size(),
+                num_elements_per_alignment,
+                num_alignment_width,
+            };
+
+            SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
+            SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+
+            start_id += num_units_per_core;
+        }
+        auto override_runtime_args_callback = [reader_kernel_id = reader_kernel_id,
+                                               writer_kernel_id = writer_kernel_id,
+                                               num_cores,
+                                               core_h,
+                                               index_dims,
+                                               dim_offset](
+                                                  const Program &program,
+                                                  const std::vector<Buffer *> &input_buffers,
+                                                  const std::vector<Buffer *> &output_buffers) {
+            TT_ASSERT(output_buffers.size() == 1);
+
+            auto src_buffer = input_buffers.at(0);
+            auto dst_buffer = output_buffers.at(0);
+
+            IndexInfo index_info[4] = {0};
+
+            for (uint32_t i = 0; i < index_dims.size(); i++) {
+                auto dim = index_dims[i] + dim_offset;
+                auto index_buffer = input_buffers.at(i + 1);
+
+                index_info[dim].address = index_buffer->address();
+            }
+
+            for (uint32_t icore = 0; icore < num_cores; icore++) {
+                CoreCoord core = {icore / core_h, icore % core_h};
+
+                {
+                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    runtime_args[0] = src_buffer->address();
+                    runtime_args[1] = index_info[0].address;
+                    runtime_args[2] = index_info[1].address;
+                    runtime_args[3] = index_info[2].address;
+                    runtime_args[4] = index_info[3].address;
+                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
+                }
+
+                {
+                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    runtime_args[0] = dst_buffer->address();
+                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
+                }
+            }
+        };
+
+        return {std::move(program), override_runtime_args_callback};
+    } else {
+        // compute index info
+        IndexInfo index_info[4] = {0};
+
+        uint32_t dim_offset = 4 - input_shape.rank();
+        for (uint32_t i = 0; i < index_tensors.size(); i++) {
+            auto dim = index_dims[i] + dim_offset;
+            auto index = index_tensors.at(i);
+
+            index_info[dim].is_defined = true;
+            index_info[dim].address = index_tensors.at(i).buffer()->address();
+            index_info[dim].is_dram = is_dram(index_tensors.at(i));
+            index_info[dim].unit_size = index.get_legacy_shape()[-1] * index.element_size();
+        }
+        uint32_t index_size = index_tensors.at(0).get_legacy_shape().without_padding()[-1];
+
+        uint32_t input_unit_size = 16 * input.element_size();
+        uint32_t output_unit_size = 16 * output.element_size();
+
+        // split work
+        auto input_shape_without_padding = input_shape.without_padding();
+        auto output_shape_without_padding = output_shape.without_padding();
+        uint32_t num_units = output_shape_without_padding[0] * output_shape_without_padding[1] *
+                             output_shape_without_padding[2] * ((output_shape_without_padding[3] + 15) / 16);
+        log_debug(LogTest, "num_units {}", num_units);
+
+        uint32_t core_w = core_range.end.x - core_range.start.x + 1;
+        uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+
+        auto
+            [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
+                split_work_to_cores(core_range, num_units);
+
+        Program program = Program();
+
+        // create circular buffers
+        auto src_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+        auto index_cb_data_format = tt_metal::datatype_to_dataformat_converter(index_tensors.at(0).get_dtype());
+        auto output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+
+        auto src_cb_index = tt::CB::c_in0;
+        auto rounded_input_page_size = round_up_to_mul32(input_unit_size);
+        auto cb_src0_config =
+            tt_metal::CircularBufferConfig(rounded_input_page_size, {{src_cb_index, src_cb_data_format}})
+                .set_page_size(src_cb_index, rounded_input_page_size);
+        auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+        for (uint32_t dim = 0; dim < 4; dim++) {
+            if (!index_info[dim].is_defined)
+                continue;
+
+            auto src1_cb_index = tt::CB::c_in1 + dim;
+            // auto index_page_size = round_up_to_mul32(index_info[dim].unit_size);
+            auto index_page_size = 1024 * 4;
+            auto cb_index_config =
+                tt_metal::CircularBufferConfig(index_page_size, {{src1_cb_index, index_cb_data_format}})
+                    .set_page_size(src1_cb_index, index_page_size);
+            auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_index_config);
+        }
+
+        auto out_cb_index = tt::CB::c_out0;
+        auto rounded_output_page_size = round_up_to_mul32(input_unit_size);
+        auto cb_out0_config =
+            tt_metal::CircularBufferConfig(rounded_input_page_size, {{out_cb_index, output_cb_data_format}})
+                .set_page_size(out_cb_index, rounded_input_page_size);
+        auto cb_out0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_out0_config);
+
+        // create read/wrtie kernel
+        auto src_is_dram = is_dram(input);
+        auto dst_is_dram = is_dram(output);
+
+        std::map<string, string> reader_defines;
+        std::map<string, string> writer_defines;
+
+        auto reader_kernel_id = CreateReadKernel(
+            program,
+            "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize.cpp",
+            all_cores,
+            {
+                src_is_dram,
+                index_info[0].is_dram,
+                index_info[1].is_dram,
+                index_info[2].is_dram,
+                index_info[3].is_dram,
+            },
+            reader_defines);
+        auto writer_kernel_id = CreateWriteKernel(
+            program,
+            "tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize.cpp",
+            all_cores,
+            {dst_is_dram},
+            writer_defines);
+
+        uint32_t face_width = 16;
+        uint32_t input_num_stick_width = div_up(input_shape_without_padding[3], face_width);
+        uint32_t output_num_stick_width = div_up(output_shape_without_padding[3], face_width);
+
+        uint32_t input_num_tile_c = input_shape[1];
+        uint32_t input_num_tile_height = input_shape[2] / TILE_HEIGHT;
+        uint32_t input_num_tile_width = input_shape[3] / TILE_WIDTH;
+
+        uint32_t input_noc_id_stride_h = input_num_tile_width;
+        uint32_t input_noc_id_stride_c = input_noc_id_stride_h * input_num_tile_height;
+        uint32_t input_noc_id_stride_n = input_noc_id_stride_c * input_num_tile_c;
+
+        uint32_t output_num_tile_c = output_shape[1];
+        uint32_t output_num_tile_height = output_shape[2] / TILE_HEIGHT;
+        uint32_t output_num_tile_width = output_shape[3] / TILE_WIDTH;
+
+        uint32_t output_noc_id_stride_h = output_num_tile_width;
+        uint32_t output_noc_id_stride_c = output_noc_id_stride_h * output_num_tile_height;
+        uint32_t output_noc_id_stride_n = output_noc_id_stride_c * output_num_tile_c;
+
+        uint32_t input_stick_idx_stride_w = 1;
+        uint32_t input_stick_idx_stride_h = input_num_stick_width;
+        uint32_t input_stick_idx_stride_c = input_stick_idx_stride_h * input_shape.without_padding()[2];
+        uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_shape.without_padding()[1];
+
+
+        // Set Runtime Args
+        auto core_x_offset = core_range.start.x;
+        auto core_y_offset = core_range.start.y;
+
+        uint32_t g1_numcores = core_group_1.num_cores();
+        uint32_t g2_numcores = core_group_2.num_cores();
+
+        uint32_t start_id = 0;
+        for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
+            CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
+            uint32_t num_units_per_core = i < g1_numcores ? num_units_per_core_group_1 : num_units_per_core_group_2;
+
+            vector<uint32_t> reader_args = {
+                // buffers
+                input.buffer()->address(),
+                index_info[0].address,
+                index_info[1].address,
+                index_info[2].address,
+                index_info[3].address,
+
+                // input
+                input_stick_idx_stride_n,
+                input_stick_idx_stride_c,
+                input_stick_idx_stride_h,
+                input_stick_idx_stride_w,
+                input_shape_without_padding[1],
+                input_shape_without_padding[2],
+                input_noc_id_stride_n,
+                input_noc_id_stride_c,
+                input_noc_id_stride_h,
+                input_num_stick_width,
+
+                // index
+                index_info[0].is_defined,
+                index_info[1].is_defined,
+                index_info[2].is_defined,
+                index_info[3].is_defined,
+                index_info[0].unit_size,
+                index_info[1].unit_size,
+                index_info[2].unit_size,
+                index_info[3].unit_size,
+                index_size,
+
+                // output
+                output_shape[0],
+                output_shape[1],
+                output_shape_without_padding[2],
+                output_shape_without_padding[3],
+                output_num_stick_width,
+
+                //etc
+                start_id,
+                num_units_per_core,
+                input_unit_size,
+                input.element_size(),
+            };
+
+            vector<uint32_t> writer_args = {
+                // buffers
+                output.buffer()->address(),
+
+                // output
+                output_shape_without_padding[1],
+                output_shape_without_padding[2],
+                output_shape_without_padding[3],
+                output_noc_id_stride_n,
+                output_noc_id_stride_c,
+                output_noc_id_stride_h,
+                output_num_stick_width,
+
+                // etc
+                start_id,
+                num_units_per_core,
+                output_unit_size,
+                output.element_size(),
+            };
+
+            SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
+            SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+
+            start_id += num_units_per_core;
+        }
+        auto override_runtime_args_callback = [reader_kernel_id = reader_kernel_id,
+                                               writer_kernel_id = writer_kernel_id,
+                                               num_cores,
+                                               core_h,
+                                               index_dims,
+                                               dim_offset](
+                                                  const Program &program,
+                                                  const std::vector<Buffer *> &input_buffers,
+                                                  const std::vector<Buffer *> &output_buffers) {
+            TT_ASSERT(output_buffers.size() == 1);
+
+            auto src_buffer = input_buffers.at(0);
+            auto dst_buffer = output_buffers.at(0);
+
+            IndexInfo index_info[4] = {0};
+
+            for (uint32_t i = 0; i < index_dims.size(); i++) {
+                auto dim = index_dims[i] + dim_offset;
+                auto index_buffer = input_buffers.at(i + 1);
+
+                index_info[dim].address = index_buffer->address();
+            }
+
+            for (uint32_t icore = 0; icore < num_cores; icore++) {
+                CoreCoord core = {icore / core_h, icore % core_h};
+
+                {
+                    auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    runtime_args[0] = src_buffer->address();
+                    runtime_args[1] = index_info[0].address;
+                    runtime_args[2] = index_info[1].address;
+                    runtime_args[3] = index_info[2].address;
+                    runtime_args[4] = index_info[3].address;
+                    SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
+                }
+
+                {
+                    auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    runtime_args[0] = dst_buffer->address();
+                    SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
+                }
+            }
+        };
+
+        return {std::move(program), override_runtime_args_callback};
+    }
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -37,6 +37,7 @@
 #include "tt_dnn/op_library/moreh_groupnorm_backward/moreh_groupnorm_backward_op.hpp"
 #include "tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
 #include "tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp"
+#include "tt_dnn/op_library/moreh_getitem/moreh_getitem_op.hpp"
 
 namespace py = pybind11;
 
@@ -905,6 +906,16 @@ void py_module(py::module& m_primary) {
         py::arg("output_grad").noconvert(),
         py::arg("input_grad").noconvert(),
         "Performs mean backward operation. Returns an input_grad tensor.");
+
+    m_primary.def(
+        "moreh_getitem",
+        &moreh_getitem,
+        py::arg("input_tensor").noconvert(),
+        py::arg("index_tensors").noconvert(),
+        py::arg("index_dims").noconvert(),
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        "Performs a getitem operation. Returns an output tensor.");
 }
 
 }  // namespace


### PR DESCRIPTION
Support `moreh_getitem` forward.

```Python
import torch

a = torch.rand([20,30,40,50], dtype=torch.float)

idx = torch.tensor([1,2,3])

ret = a[:,idx,idx,:]
print(ret.shape) # (20, 3, 50)
```
moreh_getitem is an operation that copies input to output based on the indicies, as shown in the example above.


