### PR TITLE
#0: Fix semaphore address gen bug

### DIFF
--- a/tt_metal/impl/buffers/semaphore.hpp
+++ b/tt_metal/impl/buffers/semaphore.hpp
@@ -38,6 +38,7 @@ class Semaphore {
 
     constexpr uint32_t size() const { return SEMAPHORE_SIZE / NUM_SEMAPHORES; }
 
+    uint32_t id() const { return (address_ - SEMAPHORE_BASE) / L1_ALIGNMENT; }
 
     uint32_t address() const { return address_; }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -87,15 +87,7 @@ namespace detail{
         enable_persistent_kernel_cache = false;
     }
 }
-auto Program::semaphores_on_core(const CoreCoord &core) const {
-    std::vector<std::reference_wrapper<const Semaphore>> semaphores;
-    for ( const Semaphore & s : this->semaphores_) {
-        if (s.initialized_on_logical_core(core)) {
-            semaphores.emplace_back(std::cref(s));
-        }
-    }
-    return semaphores;
-}
+
 
 std::atomic<uint64_t> Program::program_counter = 0;
 
@@ -499,10 +491,6 @@ size_t Program::num_semaphores(const CoreCoord &core) const {
 
 size_t Program::num_semaphores() const {
     return semaphores_.size();
-}
-
-uint32_t Program::semaphore_address ( uint32_t sem_idx ) const {
-    return semaphores_.at(sem_idx).address();
 }
 
 void Program::init_semaphores( const Device & device, const CoreCoord &logical_core, const CoreType core_type) const{

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -90,11 +90,18 @@ class Program {
 
     const std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_on_corerange(const CoreRange &cr) const;
 
-    auto semaphores_on_core(const CoreCoord &core) const;
+    auto semaphores_on_core(const CoreCoord &core) const {
+        std::vector<std::reference_wrapper<const Semaphore>> semaphores;
+        for ( const Semaphore & s : this->semaphores_) {
+            if (s.initialized_on_logical_core(core)) {
+                semaphores.emplace_back(std::cref(s));
+            }
+        }
+        return semaphores;
+    }
 
     size_t num_semaphores ( const CoreCoord & core ) const;
     size_t num_semaphores () const;
-    uint32_t semaphore_address ( uint32_t sem_index ) const;
     void init_semaphores ( const Device & device, const CoreCoord &logical_core, const CoreType core_type) const;
     std::unordered_map<CoreType, std::vector<CoreCoord>> logical_cores() const;
 


### PR DESCRIPTION
Before this fix we had a bug where address assignment for multiple semaphores on a core via a core range would overlap 