### PR TITLE
#6183: add unit test for sd matmul ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -497,3 +497,99 @@ def test_falcon_query_key_value_matmul(device, batch_size, m_size, k_size, n_siz
 
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.996)
+
+
+@pytest.mark.parametrize(
+    "batch_size, channel_a, channel_b, m_size, k_size, n_size, has_bias",
+    [
+        (1, 2, 1, 1024, 640, 2560, False),
+        (2, 8, 8, 64, 96, 160, False),
+        (1, 2, 1, 4096, 320, 1280, False),
+        (1, 2, 1, 64, 1280, 5120, False),
+        (2, 8, 8, 64, 64, 160, False),
+        (1, 2, 1, 1024, 640, 768, False),
+        (2, 8, 8, 96, 160, 96, False),
+        (2, 8, 8, 1024, 1024, 96, False),
+        (1, 2, 1, 96, 768, 1024, False),
+        (1, 1, 1, 32, 1280, 1280, True),
+        (2, 8, 8, 4096, 96, 64, False),
+        (1, 2, 1, 64, 5120, 1280, True),
+        (2, 8, 8, 4096, 64, 96, False),
+        (1, 2, 1, 1024, 768, 640, True),
+        (1, 2, 1, 256, 1280, 1280, True),
+        (2, 8, 8, 1024, 96, 96, False),
+        (1, 2, 1, 1024, 640, 2304, False),
+        (1, 1, 1, 32, 1280, 320, True),
+        (1, 2, 1, 96, 768, 2560, False),
+        (1, 2, 1, 4096, 1280, 320, True),
+        (1, 2, 1, 1024, 2560, 640, True),
+        (1, 2, 1, 256, 1280, 3840, False),
+        (1, 1, 1, 32, 320, 1280, True),
+        (1, 2, 1, 4096, 512, 320, True),
+        (1, 2, 1, 64, 1280, 1280, True),
+        (1, 2, 1, 256, 5120, 1280, True),
+        (1, 2, 1, 256, 1280, 1280, False),
+        (2, 8, 8, 256, 160, 96, False),
+        (2, 8, 8, 256, 256, 160, False),
+        (1, 2, 1, 96, 768, 1536, False),
+        (1, 2, 1, 64, 1280, 3840, False),
+        (2, 8, 8, 1024, 96, 1024, False),
+        (2, 8, 8, 256, 96, 160, False),
+        (1, 2, 1, 64, 1280, 1280, False),
+        (2, 8, 8, 4096, 64, 4096, False),
+        (1, 1, 1, 32, 1280, 640, True),
+        (2, 8, 8, 64, 160, 64, False),
+        (1, 2, 1, 4096, 320, 1536, False),
+        (1, 2, 1, 256, 1280, 5120, False),
+        (2, 8, 8, 4096, 4096, 64, False),
+        (2, 8, 8, 256, 160, 256, False),
+        (1, 2, 1, 4096, 320, 512, False),
+    ],
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_sd_matmul(device, batch_size, channel_a, channel_b, m_size, k_size, n_size, has_bias, dtype):
+    torch.manual_seed(0)
+    core_grid = ttnn.CoreGrid(y=8, x=8)
+    TILE_HEIGHT = 32
+
+    if batch_size == 2:
+        if m_size == 1024 and k_size == 96 and n_size == 1024 and dtype == ttnn.bfloat16:
+            pytest.skip("skip: Raises OOM")
+        if m_size == 4096 and k_size == 64 and n_size == 4096:
+            pytest.skip("skip: Raises OOM without decomposition")
+
+    torch_input_tensor_a = torch.randn((batch_size, channel_a, m_size, k_size), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn((batch_size, channel_b, k_size, n_size), dtype=torch.bfloat16)
+    torch_output_tensor = torch_input_tensor_a @ torch_input_tensor_b
+    if has_bias:
+        torch_input_tensor_c = torch.randn((1, 1, TILE_HEIGHT, n_size), dtype=torch.bfloat16)
+        _torch_input_tensor_c = torch.repeat_interleave(
+            torch_input_tensor_c, torch_output_tensor.shape[2] // TILE_HEIGHT, dim=2
+        )
+        torch_output_tensor = torch_output_tensor + _torch_input_tensor_c
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
+    input_tensor_c = (
+        ttnn.from_torch(torch_input_tensor_c, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype) if has_bias else None
+    )
+    pcc = 0.96 if dtype == ttnn.bfloat8_b else 0.98
+
+    if has_bias:
+        output_tensor = ttnn.linear(
+            input_tensor_a,
+            input_tensor_b,
+            bias=input_tensor_c,
+            # use_1d_systolic_array=True,
+            core_grid=core_grid,
+        )
+    else:
+        output_tensor = ttnn.matmul(
+            input_tensor_a,
+            input_tensor_b,
+            # use_1d_systolic_array=True,
+            core_grid=core_grid,
+        )
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)


### PR DESCRIPTION
- Add unit test that covers all input shapes of matmul ops appearing in SD model. Note that input/output sharding is not configured yet. 