### PR TITLE
#6125: Update in0_block_w to be full shard width for sharded 2D systolic matmul

### DIFF
--- a/tt_eager/tt_dnn/op_library/bmm/multi_core/bmm_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core/bmm_op_multi_core.cpp
@@ -43,7 +43,7 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_output_tiles_per_core_group_1, num_output_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_output_tiles_total);
 
     tt_metal::Buffer *dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     // C = A*B
     // MN = MK*KN
@@ -138,7 +138,7 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
 		} else if (core_group_2.core_coord_in_core_ranges(core)) {
 			num_output_tiles_per_core = num_output_tiles_per_core_group_2;
 		} else {
-			TT_ASSERT(false, "Core not in specified core ranges");
+			TT_FATAL(false, "Core not in specified core ranges");
 		}
         tt_metal::SetRuntimeArgs(
             program, reader_id, core,

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse/bmm_op_multi_core_reuse.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse/bmm_op_multi_core_reuse.cpp
@@ -262,9 +262,9 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(const Tensor &a, const T
     uint32_t per_core_M = 16;
     uint32_t per_core_N = 16;
 
-    TT_ASSERT(Mt % per_core_M == 0);
-    TT_ASSERT(Nt % per_core_N == 0);
-    TT_ASSERT(Kt % in0_block_w == 0);
+    TT_FATAL(Mt % per_core_M == 0);
+    TT_FATAL(Nt % per_core_N == 0);
+    TT_FATAL(Kt % in0_block_w == 0);
 
     // This should allocate a DRAM buffer on the device
     tt_metal::Device *device = a.device();
@@ -273,14 +273,14 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(const Tensor &a, const T
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
     uint32_t num_blocks_total = (Mt / per_core_M) * (Nt / per_core_N);
-    TT_ASSERT(num_blocks_total <= num_cores_x * num_cores_y);
+    TT_FATAL(num_blocks_total <= num_cores_x * num_cores_y);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
     Shape cshape = output.get_legacy_shape(); // C=A*B, N1MK*11KN->N1MN
     tt_metal::Buffer *out_buffer = output.buffer();
-    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -545,8 +545,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         const std::vector<Tensor>& output_tensors
     ) {
-        TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 3);
-        TT_ASSERT(output_tensors.size() == 1);
+        TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
+        TT_FATAL(output_tensors.size() == 1);
 
         auto src_buffer_a = input_tensors.at(0).buffer();
         auto src_buffer_b = input_tensors.at(1).buffer();
@@ -1097,8 +1097,8 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         const std::vector<Tensor>& output_tensors
     ) {
-        TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 3);
-        TT_ASSERT(output_tensors.size() == 1);
+        TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
+        TT_FATAL(output_tensors.size() == 1);
 
         auto src_buffer_a = input_tensors.at(0).buffer();
         auto src_buffer_b = input_tensors.at(1).buffer();
@@ -1167,9 +1167,9 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b; // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
-        TT_ASSERT(c.storage_type() == StorageType::DEVICE);
-        TT_ASSERT(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_ASSERT(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+        TT_FATAL(c.storage_type() == StorageType::DEVICE);
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
         bias_buffer = c.buffer();
 
@@ -1183,20 +1183,20 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     tt_metal::Buffer *in0_buffer = a.buffer();
     tt_metal::Buffer *in1_buffer = b.buffer();
     if (bcast_batch)
-        TT_ASSERT(bshape[0]*bshape[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
+        TT_FATAL(bshape[0]*bshape[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
     else {
         // same condition as above, different message
-        TT_ASSERT(ashape[1] == bshape[1] && ashape[0] == bshape[0]
+        TT_FATAL(ashape[1] == bshape[1] && ashape[0] == bshape[0]
             && "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
     }
-    TT_ASSERT(in0_buffer->size() % in0_single_tile_size == 0);
-    TT_ASSERT(in1_buffer->size() % in1_single_tile_size == 0);
+    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
+    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
 
-    TT_ASSERT(ashape[3] == bshape[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
-    TT_ASSERT(ashape[2] % TILE_HEIGHT == 0);
-    TT_ASSERT(ashape[3] % TILE_WIDTH == 0);
-    TT_ASSERT(bshape[2] % TILE_HEIGHT == 0);
-    TT_ASSERT(bshape[3] % TILE_WIDTH == 0);
+    TT_FATAL(ashape[3] == bshape[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
+    TT_FATAL(ashape[2] % TILE_HEIGHT == 0);
+    TT_FATAL(ashape[3] % TILE_WIDTH == 0);
+    TT_FATAL(bshape[2] % TILE_HEIGHT == 0);
+    TT_FATAL(bshape[3] % TILE_WIDTH == 0);
 
     MathFidelity math_fidelity;
     bool math_approx_mode;
@@ -1206,13 +1206,13 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_FATAL(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = false;
             packer_l1_acc = false;
         } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
+            TT_FATAL(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
@@ -1224,7 +1224,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     }, compute_kernel_config);
 
     if (fp32_dest_acc_en) {
-        TT_ASSERT(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
+        TT_FATAL(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -1242,7 +1242,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
         Mt = B * Mt;
         B = 1;
     }
-    TT_ASSERT(Kt % in0_block_w == 0);
+    TT_FATAL(Kt % in0_block_w == 0);
 
     // This should allocate a DRAM buffer on the device
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -1252,7 +1252,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     uint32_t num_blocks_y = (Mt - 1) / per_core_M + 1;
     uint32_t num_blocks_x = (Nt - 1) / per_core_N + 1;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
-    TT_ASSERT(
+    TT_FATAL(
         num_blocks_total <= num_cores_x * num_cores_y,
         "Number of blocks exceeds number of cores: {} blocks > {} cores",
         num_blocks_total,
@@ -1262,43 +1262,47 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
     tt_metal::Buffer *out_buffer = output.buffer();
-    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
-    if (mcast_in0) {
-        return reuse_mcast_1d_optimized_helpers::create_program_mcast_in0(
-            device,
-            math_fidelity, fp32_dest_acc_en, math_approx_mode, packer_l1_acc,
-            compute_with_storage_grid_size,
-            B, Mt, Nt, Kt,
-            bcast_batch,
-            in0_block_w,
-            out_subblock_h, out_subblock_w,
-            per_core_M, per_core_N,
-            fused_activation,
-            in0_buffer, in1_buffer, bias_buffer, out_buffer,
-            in0_data_format, in1_data_format, bias_data_format, output_data_format,
-            a.memory_config().is_sharded(), output.memory_config().is_sharded(),
-            untilize_out
-        );
+    if (compute_with_storage_grid_size.x > 1 or compute_with_storage_grid_size.y > 1) {
+      if (mcast_in0) {
+          return reuse_mcast_1d_optimized_helpers::create_program_mcast_in0(
+              device,
+              math_fidelity, fp32_dest_acc_en, math_approx_mode, packer_l1_acc,
+              compute_with_storage_grid_size,
+              B, Mt, Nt, Kt,
+              bcast_batch,
+              in0_block_w,
+              out_subblock_h, out_subblock_w,
+              per_core_M, per_core_N,
+              fused_activation,
+              in0_buffer, in1_buffer, bias_buffer, out_buffer,
+              in0_data_format, in1_data_format, bias_data_format, output_data_format,
+              a.memory_config().is_sharded(), output.memory_config().is_sharded(),
+              untilize_out
+          );
+      } else {
+          return reuse_mcast_1d_optimized_helpers::create_program_mcast_in1(
+              device,
+              math_fidelity, fp32_dest_acc_en, math_approx_mode, packer_l1_acc,
+              compute_with_storage_grid_size,
+              B, Mt, Nt, Kt,
+              bcast_batch,
+              in0_block_w,
+              out_subblock_h, out_subblock_w,
+              per_core_M, per_core_N,
+              fused_activation,
+              in0_buffer, in1_buffer, bias_buffer, out_buffer,
+              in0_data_format, in1_data_format, bias_data_format, output_data_format,
+              a.memory_config().is_sharded(), output.memory_config().is_sharded(),
+              untilize_out
+          );
+      }
     } else {
-        return reuse_mcast_1d_optimized_helpers::create_program_mcast_in1(
-            device,
-            math_fidelity, fp32_dest_acc_en, math_approx_mode, packer_l1_acc,
-            compute_with_storage_grid_size,
-            B, Mt, Nt, Kt,
-            bcast_batch,
-            in0_block_w,
-            out_subblock_h, out_subblock_w,
-            per_core_M, per_core_N,
-            fused_activation,
-            in0_buffer, in1_buffer, bias_buffer, out_buffer,
-            in0_data_format, in1_data_format, bias_data_format, output_data_format,
-            a.memory_config().is_sharded(), output.memory_config().is_sharded(),
-            untilize_out
-        );
+        TT_FATAL(false, "Grid is invalid for mcast matmul!");
     }
 }
 

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -776,8 +776,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         const std::vector<Tensor>& output_tensors
     ) {
-        TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 3);
-        TT_ASSERT(output_tensors.size() == 1);
+        TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
+        TT_FATAL(output_tensors.size() == 1);
 
         auto src_buffer_a = input_tensors.at(0).buffer();
         auto src_buffer_b = input_tensors.at(1).buffer();
@@ -860,9 +860,9 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b; // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
-        TT_ASSERT(c.storage_type() == StorageType::DEVICE);
-        TT_ASSERT(a.device() == c.device(), "Operands to matmul need to be on the same device!");
-        TT_ASSERT(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+        TT_FATAL(c.storage_type() == StorageType::DEVICE);
+        TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
+        TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
         bias_buffer = c.buffer();
 
@@ -876,20 +876,20 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     tt_metal::Buffer *in0_buffer = a.buffer();
     tt_metal::Buffer *in1_buffer = b.buffer();
     if (bcast_batch)
-        TT_ASSERT(bshape[0]*bshape[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
+        TT_FATAL(bshape[0]*bshape[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
     else {
         // same condition as above, different message
-        TT_ASSERT(ashape[1] == bshape[1] && ashape[0] == bshape[0]
+        TT_FATAL(ashape[1] == bshape[1] && ashape[0] == bshape[0]
             && "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
     }
-    TT_ASSERT(in0_buffer->size() % in0_single_tile_size == 0);
-    TT_ASSERT(in1_buffer->size() % in1_single_tile_size == 0);
+    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
+    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
 
-    TT_ASSERT(ashape[3] == bshape[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
-    TT_ASSERT(ashape[2] % TILE_HEIGHT == 0);
-    TT_ASSERT(ashape[3] % TILE_WIDTH == 0);
-    TT_ASSERT(bshape[2] % TILE_HEIGHT == 0);
-    TT_ASSERT(bshape[3] % TILE_WIDTH == 0);
+    TT_FATAL(ashape[3] == bshape[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
+    TT_FATAL(ashape[2] % TILE_HEIGHT == 0);
+    TT_FATAL(ashape[3] % TILE_WIDTH == 0);
+    TT_FATAL(bshape[2] % TILE_HEIGHT == 0);
+    TT_FATAL(bshape[3] % TILE_WIDTH == 0);
 
     MathFidelity math_fidelity;
     bool math_approx_mode;
@@ -899,13 +899,13 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_FATAL(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = false;
             packer_l1_acc = false;
         } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
+            TT_FATAL(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
@@ -917,7 +917,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     }, compute_kernel_config);
 
     if (fp32_dest_acc_en) {
-        TT_ASSERT(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
+        TT_FATAL(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -934,7 +934,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
         Mt = B * Mt;
         B = 1;
     }
-    TT_ASSERT(Kt % in0_block_w == 0);
+    TT_FATAL(Kt % in0_block_w == 0);
 
     // This should allocate a DRAM buffer on the device
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -944,7 +944,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     uint32_t num_blocks_y = (Mt - 1) / per_core_M + 1;
     uint32_t num_blocks_x = (Nt - 1) / per_core_N + 1;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
-    TT_ASSERT(
+    TT_FATAL(
         num_blocks_total <= num_cores_x * num_cores_y,
         fmt::format(
             "Num total blocks must be smaller than num blocks y and num blocks x: {} <= {} * {}",
@@ -960,7 +960,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
     tt_metal::Buffer *out_buffer = output.buffer();
-    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
@@ -985,9 +985,9 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(cons
         );
     } else if (core_range.x > 1 or core_range.y > 1) {
         // Refer to bmm_op_multi_core_reuse_mcast_padding_generalized.cpp
-        TT_ASSERT(false, "1D mcast for in0 or in1 is not implemented yet.");
+        TT_FATAL(false, "1D mcast for in0 or in1 is not implemented yet.");
     } else {
-        TT_ASSERT(false, "Grid is invalid for mcast matmul!");
+        TT_FATAL(false, "Grid is invalid for mcast matmul!");
     }
 
     return {};

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
@@ -120,7 +120,7 @@ operation::ProgramWithCallbacks create_program(
     uint32_t num_evenly_divided_output_blocks = num_output_blocks_total / num_cores;
 
     // Assume all of core_range is used (ie. num_evenly_divided_output_blocks > 0)
-    TT_ASSERT(num_evenly_divided_output_blocks > 0, "Not all cores from core_range was used!");
+    TT_FATAL(num_evenly_divided_output_blocks > 0, "Not all cores from core_range was used!");
     uint32_t start_core_x = 0;
     uint32_t start_core_y = 0;
     uint32_t num_cores_c = core_range.x;
@@ -481,7 +481,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
 
     // Pass in a and b shapes instead
 
-    TT_ASSERT(bcast_batch == false, "Bcast batch not supported for this parallelization");
+    TT_FATAL(bcast_batch == false, "Bcast batch not supported for this parallelization");
 
     const auto& ashape = a.get_legacy_shape();
     const auto& bshape = b.get_legacy_shape();
@@ -498,10 +498,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     tt_metal::Buffer *in0_buffer = a.buffer();
     tt_metal::Buffer *in1_buffer = b.buffer();
     if (bcast_batch)
-        TT_ASSERT(bshape[0]*bshape[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
+        TT_FATAL(bshape[0]*bshape[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
     else {
         // same condition as above, different message
-        TT_ASSERT(ashape[1] == bshape[1] && ashape[0] == bshape[0]
+        TT_FATAL(ashape[1] == bshape[1] && ashape[0] == bshape[0]
             && "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
     }
 
@@ -513,13 +513,13 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     std::visit([&](auto&& compute_kernel_config) {
         using T = std::decay_t<decltype(compute_kernel_config)>;
         if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+            TT_FATAL(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = false;
             packer_l1_acc = false;
         } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
+            TT_FATAL(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
             math_fidelity = compute_kernel_config.math_fidelity;
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
@@ -531,7 +531,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     }, compute_kernel_config);
 
     if (fp32_dest_acc_en) {
-        TT_ASSERT(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
+        TT_FATAL(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -545,7 +545,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     uint32_t Nt = bshape[3]/TILE_WIDTH;
 
     // TODO: Generalize
-    TT_ASSERT(fuse_batch, "Only fuse_batch=true is supported for bert large optimized bmm!");
+    TT_FATAL(fuse_batch, "Only fuse_batch=true is supported for bert large optimized bmm!");
 
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
@@ -560,7 +560,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     ////////////////////////////////////////////////////////////////////////////
     // Pass in cshape instead
     tt_metal::Buffer *out_buffer = output.buffer();
-    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_padding/bmm_op_multi_core_reuse_padding.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_padding/bmm_op_multi_core_reuse_padding.cpp
@@ -288,7 +288,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_padding(const Tensor &a,
     uint32_t per_core_M = 16;
     uint32_t per_core_N = 16;
 
-    TT_ASSERT(Kt % in0_block_w == 0);
+    TT_FATAL(Kt % in0_block_w == 0);
 
     // This should allocate a DRAM buffer on the device
     tt_metal::Device *device = a.device();
@@ -300,14 +300,14 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_padding(const Tensor &a,
     uint32_t num_blocks_y = (Mt - 1) / per_core_M + 1; // Should always be 1
     uint32_t num_blocks_x = (Nt - 1) / per_core_N + 1; // Should always be 1
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
-    TT_ASSERT(num_blocks_total <= num_cores_x * num_cores_y);
+    TT_FATAL(num_blocks_total <= num_cores_x * num_cores_y);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
     Shape cshape = output.get_legacy_shape(); // C=A*B, N1MK*11KN->N1MN
     tt_metal::Buffer *out_buffer = output.buffer();
-    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup

--- a/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core.cpp
@@ -31,7 +31,7 @@ operation::ProgramWithCallbacks matmul_single_core(const Tensor &a, const Tensor
     Shape cshape = output.get_legacy_shape(); // C=A*B, N1MK*11KN->N1MN
 
     tt_metal::Buffer *dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     // C = A*B
     // MN = MK*KN

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -262,7 +262,7 @@ def create_matmul_program_config(
             shard_shape = input_tensor_a_memory_config.shard_spec.shape
             m_tiles_per_core = shard_shape[0] // ttnn.TILE_SIZE
             n_tiles_per_core = (N * shard_shape[1]) // (K * ttnn.TILE_SIZE)
-            k_tiles_per_core = 1
+            k_tiles_per_core = shard_shape[1] // ttnn.TILE_SIZE
 
         m_subblock_size, n_subblock_size = _get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, fp32_dst)
 


### PR DESCRIPTION
- The underlying in0 reader kernel expects to only mcast its shard once, so in0_block_w should be full shard width