### PR TITLE
#0: Change order of device and use_program_cache fixture in remaining pytests

### DIFF
--- a/models/demos/falcon7b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon7b/tests/test_falcon_end_to_end.py
@@ -332,6 +332,7 @@ def run_test_FalconCausalLM_end_to_end(
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
 @skip_for_wormhole_b0(reason_str="Hangs way too often, issue #4425")
 def test_FalconCausalLM_end_to_end_with_program_cache(
+    device,
     use_program_cache,
     model_version,
     llm_mode,
@@ -343,7 +344,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     request,
     model_config_str,
     model_location_generator,
-    device,
 ):
     if is_e75(device) and batch == 32:
         pytest.skip("Falcon batch 32 is unsupported on E75")

--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -38,7 +38,7 @@ from models.utility_functions import (
     is_e75,
     is_wormhole_b0,
     skip_for_grayskull,
-    skip_for_wormhole_b0
+    skip_for_wormhole_b0,
 )
 from models.perf.perf_utils import prep_perf_report
 
@@ -387,6 +387,7 @@ class TestParametrized:
     )
     @skip_for_wormhole_b0()
     def test_perf_gs_bare_metal(
+        device,
         use_program_cache,
         model_version,
         llm_mode,
@@ -399,7 +400,6 @@ class TestParametrized:
         request,
         model_config_str,
         model_location_generator,
-        device,
     ):
         if is_e75(device) and batch == 32:
             pytest.skip("Falcon batch 32 is not supported on E75")
@@ -446,6 +446,7 @@ class TestParametrized:
     )
     @skip_for_grayskull()
     def test_perf_wh_bare_metal(
+        device,
         use_program_cache,
         model_version,
         llm_mode,
@@ -458,7 +459,6 @@ class TestParametrized:
         request,
         model_config_str,
         model_location_generator,
-        device,
     ):
         model_config = get_model_config(model_config_str)
         tt_cache_path = get_tt_cache_path(model_version)
@@ -482,6 +482,7 @@ class TestParametrized:
             model_location_generator,
             expected_inference_time,
         )
+
 
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
@@ -510,6 +511,7 @@ class TestParametrized:
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-L1",))
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     model_version,
     llm_mode,
@@ -522,7 +524,6 @@ def test_perf_virtual_machine(
     request,
     model_config_str,
     model_location_generator,
-    device,
 ):
     if is_e75(device) and batch == 32:
         pytest.skip("Falcon batch 32 is not supported on E75")

--- a/models/demos/metal_BERT_large_11/tests/test_bert.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert.py
@@ -188,6 +188,7 @@ def run_bert_question_and_answering_inference(
     ids=["BERT_LARGE"],
 )
 def test_bert(
+    device,
     use_program_cache,
     model_version,
     batch,
@@ -198,7 +199,6 @@ def test_bert(
     pcc,
     model_config_str,
     model_location_generator,
-    device,
 ):
     if is_e75(device):
         pytest.skip(f"Bert large 11 is not supported on E75")

--- a/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -351,6 +351,7 @@ def test_bert_batch_dram(
     ids=["BERT_LARGE"],
 )
 def test_bert_batch_dram_with_program_cache(
+    device,
     use_program_cache,
     model_version,
     batch,
@@ -362,7 +363,6 @@ def test_bert_batch_dram_with_program_cache(
     model_config_str,
     model_location_generator,
     request,
-    device,
 ):
     if is_e75(device):
         pytest.skip(f"Bert large 11 is not supported on E75")

--- a/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
@@ -155,6 +155,7 @@ def run_perf_bert11(
     ),
 )
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     batch_size,
     model_config_str,
@@ -162,7 +163,6 @@ def test_perf_virtual_machine(
     expected_compile_time,
     inference_iterations,
     model_location_generator,
-    device,
 ):
     if is_e75(device):
         pytest.skip("Bert large 11 is not supported on E75")
@@ -187,6 +187,7 @@ def test_perf_virtual_machine(
     ),
 )
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     batch_size,
     model_config_str,
@@ -194,7 +195,6 @@ def test_perf_bare_metal(
     expected_compile_time,
     inference_iterations,
     model_location_generator,
-    device,
 ):
     if is_e75(device):
         pytest.skip("Bert large 11 is not supported on E75")

--- a/models/demos/resnet/demo/demo.py
+++ b/models/demos/resnet/demo/demo.py
@@ -229,11 +229,11 @@ def test_demo_imagenet(batch_size, iterations, imagenet_label_dict, model_locati
     ((8, "models/demos/resnet/demo/images/"),),
 )
 def test_demo_sample(
+    device,
     use_program_cache,
     batch_size,
     input_loc,
     imagenet_label_dict,
-    device,
 ):
     run_resnet_inference(
         batch_size,

--- a/models/demos/resnet/tests/test_demo.py
+++ b/models/demos/resnet/tests/test_demo.py
@@ -12,11 +12,11 @@ from models.demos.resnet.demo.demo import run_resnet_inference, run_resnet_image
     ((8, "models/demos/resnet/demo/images/"),),
 )
 def test_demo_sample(
+    device,
     use_program_cache,
     batch_size,
     input_loc,
     imagenet_label_dict,
-    device,
 ):
     expected_prediction = [
         "ruffed grouse, partridge, Bonasa umbellus",

--- a/models/demos/resnet/tests/test_metal_resnet50.py
+++ b/models/demos/resnet/tests/test_metal_resnet50.py
@@ -135,7 +135,7 @@ golden_pcc = {
     ids=["HiFi4", "HiFi2", "LoFi"],
 )
 def test_run_resnet50_inference(
-    use_program_cache, device, batch_size, weights_dtype, activations_dtype, math_fidelity, imagenet_sample_input
+    device, use_program_cache, batch_size, weights_dtype, activations_dtype, math_fidelity, imagenet_sample_input
 ):
     if is_e75(device):
         pytest.skip("Resnet50 is not supported on E75")

--- a/models/demos/resnet/tests/test_perf_accuracy_resnet.py
+++ b/models/demos/resnet/tests/test_perf_accuracy_resnet.py
@@ -166,6 +166,7 @@ def run_perf_resnet(
     ((16, 0.015, 33, 160), (20, 0.0185, 33, 160)),
 )
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     model_location_generator,
     batch_size,
@@ -173,7 +174,6 @@ def test_perf_bare_metal(
     expected_compile_time,
     hf_cat_image_sample_input,
     iterations,
-    device,
     function_level_defaults,
 ):
     if is_e75(device):
@@ -196,6 +196,7 @@ def test_perf_bare_metal(
     ((16, 0.015, 36, 50), (20, 0.016, 36, 50)),
 )
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     model_location_generator,
     batch_size,
@@ -203,7 +204,6 @@ def test_perf_virtual_machine(
     expected_compile_time,
     hf_cat_image_sample_input,
     iterations,
-    device,
     function_level_defaults,
 ):
     if is_e75(device):

--- a/models/demos/resnet/tests/test_perf_resnet.py
+++ b/models/demos/resnet/tests/test_perf_resnet.py
@@ -133,12 +133,12 @@ def run_perf_resnet(
     ),
 )
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     batch_size,
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    device,
 ):
     if is_e75(device):
         pytest.skip("Resnet is not supported on E75")
@@ -164,12 +164,12 @@ def test_perf_bare_metal(
     ),
 )
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     batch_size,
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    device,
 ):
     if is_e75(device):
         pytest.skip("Resnet is not supported on E75")

--- a/models/demos/resnet/tests/test_resnet50_conv.py
+++ b/models/demos/resnet/tests/test_resnet50_conv.py
@@ -668,7 +668,7 @@ hardcoded_conv_blocking_and_parallelization_config = {
     ids=["output_BFLOAT16", "output_BFLOAT8_B"],
 )
 def test_resnet50_conv(
-    use_program_cache, device, N, K, C, H, W, R, S, stride_h, stride_w, pad_h, pad_w, weights_dtype, output_dtype
+    device, use_program_cache, N, K, C, H, W, R, S, stride_h, stride_w, pad_h, pad_w, weights_dtype, output_dtype
 ):
     output_mem_config = tt_lib.tensor.MemoryConfig(
         tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1

--- a/models/demos/ttnn_falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/test_falcon_causallm.py
@@ -206,6 +206,7 @@ def run_test_FalconCausalLM_inference(
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
 def test_FalconCausalLM_inference(
+    device,
     use_program_cache,
     model_version,
     llm_mode,
@@ -217,7 +218,6 @@ def test_FalconCausalLM_inference(
     request,
     model_config_str,
     model_location_generator,
-    device,
 ):
     enable_persistent_kernel_cache()
     model_config = get_model_config(model_config_str)

--- a/models/demos/ttnn_falcon7b/tests/test_falcon_model.py
+++ b/models/demos/ttnn_falcon7b/tests/test_falcon_model.py
@@ -216,6 +216,7 @@ def run_test_FalconModel_inference(
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
 def test_FalconModel_inference(
+    device,
     use_program_cache,
     model_version,
     llm_mode,
@@ -225,7 +226,6 @@ def test_FalconModel_inference(
     num_layers,
     pcc,
     model_config_str,
-    device,
 ):
     enable_persistent_kernel_cache()
     model_config = get_model_config(model_config_str)

--- a/models/demos/ttnn_falcon7b/tests/test_metal_falcon.py
+++ b/models/demos/ttnn_falcon7b/tests/test_metal_falcon.py
@@ -233,6 +233,7 @@ def run_test_FalconCausalLM_end_to_end(
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-L1",))
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     model_version,
     llm_mode,
@@ -245,7 +246,6 @@ def test_perf_bare_metal(
     request,
     model_config_str,
     model_location_generator,
-    device,
 ):
     if is_e75(device) and batch == 32:
         pytest.skip("Falcon batch 32 is not supported on E75")

--- a/models/demos/ttnn_falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/ttnn_falcon7b/tests/test_perf_falcon.py
@@ -406,6 +406,7 @@ def run_test_FalconCausalLM_end_to_end(
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-L1",))
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     model_version,
     llm_mode,
@@ -418,7 +419,6 @@ def test_perf_bare_metal(
     request,
     model_config_str,
     model_location_generator,
-    device,
 ):
     if is_e75(device) and batch == 32:
         pytest.skip("Falcon batch 32 is not supported on E75")
@@ -474,6 +474,7 @@ def test_perf_bare_metal(
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-L1",))
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     model_version,
     llm_mode,
@@ -486,7 +487,6 @@ def test_perf_virtual_machine(
     request,
     model_config_str,
     model_location_generator,
-    device,
 ):
     if is_e75(device) and batch == 32:
         pytest.skip("Falcon batch 32 is not supported on E75")

--- a/models/experimental/bloom/tests/test_perf_bloom.py
+++ b/models/experimental/bloom/tests/test_perf_bloom.py
@@ -105,7 +105,7 @@ def run_perf_bloom(expected_inference_time, expected_compile_time, device):
         ),
     ),
 )
-def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_bare_metal(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_bloom(expected_inference_time, expected_compile_time, device)
 
 
@@ -119,5 +119,5 @@ def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_co
         ),
     ),
 )
-def test_perf_virtual_machine(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_virtual_machine(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_bloom(expected_inference_time, expected_compile_time, device)

--- a/models/experimental/convnet_mnist/tests/perf_convnet_mnist.py
+++ b/models/experimental/convnet_mnist/tests/perf_convnet_mnist.py
@@ -27,7 +27,7 @@ from models.experimental.convnet_mnist.convnet_mnist_utils import get_test_data
         ),
     ),
 )
-def test_perf(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf(device, use_program_cache, expected_inference_time, expected_compile_time):
     disable_persistent_kernel_cache()
     first_key = "first_iter"
     second_key = "second_iter"

--- a/models/experimental/deit/tests/test_perf_accuracy_deit.py
+++ b/models/experimental/deit/tests/test_perf_accuracy_deit.py
@@ -159,11 +159,11 @@ def run_perf_deit(
     ),
 )
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    device,
     iterations,
     model_location_generator,
 ):
@@ -189,11 +189,11 @@ def test_perf_bare_metal(
     ),
 )
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    device,
     iterations,
     model_location_generator,
 ):

--- a/models/experimental/deit/tests/test_perf_deit.py
+++ b/models/experimental/deit/tests/test_perf_deit.py
@@ -87,11 +87,11 @@ def run_perf_deit(expected_inference_time, expected_compile_time, hf_cat_image_s
     ),
 )
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    device,
 ):
     run_perf_deit(
         expected_inference_time,
@@ -112,11 +112,11 @@ def test_perf_bare_metal(
     ),
 )
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    device,
 ):
     run_perf_deit(
         expected_inference_time,

--- a/models/experimental/distilbert/tests/test_perf_accuracy_distilbert.py
+++ b/models/experimental/distilbert/tests/test_perf_accuracy_distilbert.py
@@ -153,7 +153,7 @@ def run_perf_distilbert(expected_inference_time, expected_compile_time, device, 
         ),
     ),
 )
-def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_compile_time, device, iterations):
+def test_perf_bare_metal(device, use_program_cache, expected_inference_time, expected_compile_time, iterations):
     run_perf_distilbert(expected_inference_time, expected_compile_time, device, iterations)
 
 
@@ -168,5 +168,5 @@ def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_co
         ),
     ),
 )
-def test_perf_virtual_machine(use_program_cache, expected_inference_time, expected_compile_time, device, iterations):
+def test_perf_virtual_machine(device, use_program_cache, expected_inference_time, expected_compile_time, iterations):
     run_perf_distilbert(expected_inference_time, expected_compile_time, device, iterations)

--- a/models/experimental/efficientnet/tests/perf_efficientnet.py
+++ b/models/experimental/efficientnet/tests/perf_efficientnet.py
@@ -40,11 +40,11 @@ def make_input_tensor(imagenet_sample_input, resize=256, crop=224):
     ),
 )
 def test_perf_efficientnet_b0(
+    device,
     use_program_cache,
     imagenet_sample_input,
     expected_inference_time,
     expected_compile_time,
-    device,
 ):
     disable_persistent_kernel_cache()
     first_key = "first_iter"

--- a/models/experimental/efficientnet/tests/test_perf_accuracy.py
+++ b/models/experimental/efficientnet/tests/test_perf_accuracy.py
@@ -145,13 +145,13 @@ def run_perf_efficientnet_b0(
     ),
 )
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     imagenet_sample_input,
     model_location_generator,
     expected_inference_time,
     expected_compile_time,
     iterations,
-    device,
 ):
     run_perf_efficientnet_b0(
         imagenet_sample_input,
@@ -175,13 +175,13 @@ def test_perf_bare_metal(
     ),
 )
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     imagenet_sample_input,
     model_location_generator,
     expected_inference_time,
     expected_compile_time,
     iterations,
-    device,
 ):
     run_perf_efficientnet_b0(
         imagenet_sample_input,

--- a/models/experimental/lenet/tests/test_perf_accuracy_lenet.py
+++ b/models/experimental/lenet/tests/test_perf_accuracy_lenet.py
@@ -112,7 +112,7 @@ def run_perf_inference(device, pcc, iterations, model_location_generator, reset_
     "pcc, iterations",
     ((0.99, 1000),),
 )
-def test_perf_bare_metal(use_program_cache, device, pcc, iterations, model_location_generator, reset_seeds):
+def test_perf_bare_metal(device, use_program_cache, pcc, iterations, model_location_generator, reset_seeds):
     run_perf_inference(device, pcc, iterations, model_location_generator, reset_seeds)
 
 
@@ -121,5 +121,5 @@ def test_perf_bare_metal(use_program_cache, device, pcc, iterations, model_locat
     "pcc, iterations",
     ((0.99, 1000),),
 )
-def test_perf_virtual_machine(use_program_cache, device, pcc, iterations, model_location_generator, reset_seeds):
+def test_perf_virtual_machine(device, use_program_cache, pcc, iterations, model_location_generator, reset_seeds):
     run_perf_inference(device, pcc, iterations, model_location_generator, reset_seeds)

--- a/models/experimental/llama_old/tests/test_perf_llama.py
+++ b/models/experimental/llama_old/tests/test_perf_llama.py
@@ -120,7 +120,7 @@ def run_perf_llama(expected_inference_time, expected_compile_time, device):
     "expected_inference_time, expected_compile_time",
     ((0.150, 10),),
 )
-def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_bare_metal(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_llama(expected_inference_time, expected_compile_time, device)
 
 
@@ -129,5 +129,5 @@ def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_co
     "expected_inference_time, expected_compile_time",
     ((0.3, 11),),
 )
-def test_perf_virtual_machine(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_virtual_machine(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_llama(expected_inference_time, expected_compile_time, device)

--- a/models/experimental/mistral/tests/test_perf_mistral.py
+++ b/models/experimental/mistral/tests/test_perf_mistral.py
@@ -127,7 +127,7 @@ def run_perf_mistral(expected_inference_time, expected_compile_time, device, mod
     ),
 )
 def test_perf_bare_metal(
-    use_program_cache, expected_inference_time, expected_compile_time, device, model_location_generator
+    device, use_program_cache, expected_inference_time, expected_compile_time, model_location_generator
 ):
     run_perf_mistral(expected_inference_time, expected_compile_time, device, model_location_generator)
 
@@ -143,6 +143,6 @@ def test_perf_bare_metal(
     ),
 )
 def test_perf_virtual_machine(
-    use_program_cache, expected_inference_time, expected_compile_time, device, model_location_generator
+    device, use_program_cache, expected_inference_time, expected_compile_time, model_location_generator
 ):
     run_perf_mistral(expected_inference_time, expected_compile_time, device, model_location_generator)

--- a/models/experimental/roberta/tests/test_perf_accuracy_roberta.py
+++ b/models/experimental/roberta/tests/test_perf_accuracy_roberta.py
@@ -184,7 +184,7 @@ def run_perf_roberta(expected_inference_time, expected_compile_time, device, ite
         ),
     ),
 )
-def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_compile_time, device, iterations):
+def test_perf_bare_metal(device, use_program_cache, expected_inference_time, expected_compile_time, iterations):
     run_perf_roberta(expected_inference_time, expected_compile_time, device, iterations)
 
 
@@ -199,5 +199,5 @@ def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_co
         ),
     ),
 )
-def test_perf_virtual_machine(use_program_cache, expected_inference_time, expected_compile_time, device, iterations):
+def test_perf_virtual_machine(device, use_program_cache, expected_inference_time, expected_compile_time, iterations):
     run_perf_roberta(expected_inference_time, expected_compile_time, device, iterations)

--- a/models/experimental/roberta/tests/test_perf_roberta.py
+++ b/models/experimental/roberta/tests/test_perf_roberta.py
@@ -100,7 +100,7 @@ def run_perf_roberta(expected_inference_time, expected_compile_time, device):
         ),
     ),
 )
-def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_bare_metal(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_roberta(expected_inference_time, expected_compile_time, device)
 
 
@@ -114,5 +114,5 @@ def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_co
         ),
     ),
 )
-def test_perf_virtual_machine(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_virtual_machine(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_roberta(expected_inference_time, expected_compile_time, device)

--- a/models/experimental/ssd/tests/test_perf_accuracy_ssd.py
+++ b/models/experimental/ssd/tests/test_perf_accuracy_ssd.py
@@ -156,8 +156,8 @@ def run_perf_ssd(
     ),
 )
 def test_perf_bare_metal(
-    use_program_cache,
     device,
+    use_program_cache,
     expected_inference_time,
     expected_compile_time,
     imagenet_sample_input,
@@ -186,8 +186,8 @@ def test_perf_bare_metal(
     ),
 )
 def test_perf_virtual_machine(
-    use_program_cache,
     device,
+    use_program_cache,
     expected_inference_time,
     expected_compile_time,
     imagenet_sample_input,

--- a/models/experimental/stable_diffusion/tests/test_perf_unbatched_stable_diffusion.py
+++ b/models/experimental/stable_diffusion/tests/test_perf_unbatched_stable_diffusion.py
@@ -289,7 +289,7 @@ def run_perf_unbatched_stable_diffusion(expected_inference_time, expected_compil
         ),
     ),
 )
-def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_bare_metal(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_unbatched_stable_diffusion(expected_inference_time, expected_compile_time, device)
 
 
@@ -303,5 +303,5 @@ def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_co
         ),
     ),
 )
-def test_perf_virtual_machine(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_virtual_machine(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_unbatched_stable_diffusion(expected_inference_time, expected_compile_time, device)

--- a/models/experimental/swin/tests/test_perf_accuracy_swin.py
+++ b/models/experimental/swin/tests/test_perf_accuracy_swin.py
@@ -121,7 +121,7 @@ def run_swin_perf(device, model_name, iterations, model_location_generator):
     "model_name,iterations",
     (("microsoft/swin-tiny-patch4-window7-224", 20),),
 )
-def test_perf_bare_metal(use_program_cache, device, model_name, iterations, model_location_generator):
+def test_perf_bare_metal(device, use_program_cache, model_name, iterations, model_location_generator):
     run_swin_perf(device, model_name, iterations, model_location_generator)
 
 
@@ -130,5 +130,5 @@ def test_perf_bare_metal(use_program_cache, device, model_name, iterations, mode
     "model_name,iterations",
     (("microsoft/swin-tiny-patch4-window7-224", 20),),
 )
-def test_perf_virtual_machine(use_program_cache, device, model_name, iterations, model_location_generator):
+def test_perf_virtual_machine(device, use_program_cache, model_name, iterations, model_location_generator):
     run_swin_perf(device, model_name, iterations, model_location_generator)

--- a/models/experimental/t5/tests/test_perf_t5.py
+++ b/models/experimental/t5/tests/test_perf_t5.py
@@ -120,7 +120,7 @@ def run_perf_t5(expected_inference_time, expected_compile_time, device):
         ),
     ),
 )
-def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_bare_metal(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_t5(expected_inference_time, expected_compile_time, device)
 
 
@@ -134,5 +134,5 @@ def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_co
         ),
     ),
 )
-def test_perf_virtual_machine(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_virtual_machine(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_t5(expected_inference_time, expected_compile_time, device)

--- a/models/experimental/trocr/tests/test_perf_trocr.py
+++ b/models/experimental/trocr/tests/test_perf_trocr.py
@@ -82,7 +82,7 @@ def test_perf(expected_inference_time, expected_compile_time, device):
         ),
     ),
 )
-def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_bare_metal(device, use_program_cache, expected_inference_time, expected_compile_time):
     test_perf(expected_inference_time, expected_compile_time, device)
 
 
@@ -96,5 +96,5 @@ def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_co
         ),
     ),
 )
-def test_perf_virtual_machine(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_virtual_machine(device, use_program_cache, expected_inference_time, expected_compile_time):
     test_perf(expected_inference_time, expected_compile_time, device)

--- a/models/experimental/vgg/tests/test_perf_vgg.py
+++ b/models/experimental/vgg/tests/test_perf_vgg.py
@@ -90,11 +90,11 @@ def run_perf_vgg(imagenet_sample_input, expected_inference_time, expected_compil
     ),
 )
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     imagenet_sample_input,
     expected_inference_time,
     expected_compile_time,
-    device,
 ):
     run_perf_vgg(imagenet_sample_input, expected_inference_time, expected_compile_time, device)
 
@@ -110,10 +110,10 @@ def test_perf_bare_metal(
     ),
 )
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     imagenet_sample_input,
     expected_inference_time,
     expected_compile_time,
-    device,
 ):
     run_perf_vgg(imagenet_sample_input, expected_inference_time, expected_compile_time, device)

--- a/models/experimental/vit/tests/test_perf_vit.py
+++ b/models/experimental/vit/tests/test_perf_vit.py
@@ -91,11 +91,11 @@ def run_perf_vit(expected_inference_time, expected_compile_time, hf_cat_image_sa
     ),
 )
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    device,
 ):
     run_perf_vit(
         expected_inference_time,
@@ -116,11 +116,11 @@ def test_perf_bare_metal(
     ),
 )
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    device,
 ):
     run_perf_vit(
         expected_inference_time,

--- a/models/experimental/whisper/tests/test_perf_whisper.py
+++ b/models/experimental/whisper/tests/test_perf_whisper.py
@@ -113,7 +113,7 @@ def run_perf_whisper(expected_inference_time, expected_compile_time, device):
         ),
     ),
 )
-def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_bare_metal(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_whisper(expected_inference_time, expected_compile_time, device)
 
 
@@ -127,5 +127,5 @@ def test_perf_bare_metal(use_program_cache, expected_inference_time, expected_co
         ),
     ),
 )
-def test_perf_virtual_machine(use_program_cache, expected_inference_time, expected_compile_time, device):
+def test_perf_virtual_machine(device, use_program_cache, expected_inference_time, expected_compile_time):
     run_perf_whisper(expected_inference_time, expected_compile_time, device)

--- a/models/experimental/yolov3/tests/perf_yolov3.py
+++ b/models/experimental/yolov3/tests/perf_yolov3.py
@@ -24,7 +24,7 @@ from models.perf.perf_utils import prep_perf_report
 BATCH_SIZE = 1
 
 
-def test_perf(use_program_cache, model_location_generator, device):
+def test_perf(device, use_program_cache, model_location_generator):
     disable_persistent_kernel_cache()
     first_key = "first_iter"
     second_key = "second_iter"

--- a/models/experimental/yolov3/tests/test_perf_accuracy_yolov3.py
+++ b/models/experimental/yolov3/tests/test_perf_accuracy_yolov3.py
@@ -227,11 +227,11 @@ def run_perf_yolov3(expected_inference_time, expected_compile_time, model_locati
     ),
 )
 def test_perf_bare_metal(
+    device,
     use_program_cache,
     expected_inference_time,
     expected_compile_time,
     model_location_generator,
-    device,
     iterations,
     reset_seeds,
 ):
@@ -250,11 +250,11 @@ def test_perf_bare_metal(
     ),
 )
 def test_perf_virtual_machine(
+    device,
     use_program_cache,
     expected_inference_time,
     expected_compile_time,
     model_location_generator,
-    device,
     iterations,
     reset_seeds,
 ):

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv.py
@@ -433,8 +433,8 @@ hardcoded_conv_blocking_and_parallelization_config = {
     "math_fidelity", [tt_lib.tensor.MathFidelity.HiFi4, tt_lib.tensor.MathFidelity.LoFi], ids=["HiFi4", "LoFi"]
 )
 def test_resnet50_conv(
-    use_program_cache,
     device,
+    use_program_cache,
     math_fidelity,
     activations_dtype,
     weights_dtype,


### PR DESCRIPTION
Perf tests were failing due to incorrect dependency order.

fyi @yan-zaretskiy 