### PR TITLE
#6146: Add backward support for conj

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -834,6 +834,8 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.addcdiv_bw
 
+.. autofunction:: tt_lib.tensor.conj_bw
+
 .. autofunction:: tt_lib.tensor.unary_mul_bw
 
 .. autofunction:: tt_lib.tensor.unary_add_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_conj.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_conj.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_conj(input_shapes, device):
+    torch.manual_seed(0)
+    in_data = torch.randn(input_shapes, dtype=torch.complex64)
+    in_data.requires_grad = True
+
+    torch.manual_seed(42)
+    grad_data = torch.randn(input_shapes, dtype=torch.complex64)
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=3)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=3)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.conj_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.conj(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=3)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -10,10 +10,12 @@
 #include "tt_eager/tensor/tensor_utils.hpp"
 #include "tt_dnn/op_library/math.hpp"
 #include "tt_dnn/op_library/unpad/unpad_op.hpp"
+#include "tt_dnn/op_library/complex/complex_ops.hpp"
 
 namespace tt {
 
 namespace tt_metal {
+
 
 std::vector<Tensor> _addalpha_bw(const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
@@ -1636,6 +1638,27 @@ std::vector<Tensor> unary_remainder_bw(const Tensor& grad, const Tensor& input, 
 {
     return operation::decorate_as_composite(__func__, _unary_remainder_bw)(grad, input, scalar, output_mem_config);
 }
+
+#define CHECK_FOR_COMPLEX(input) do {\
+  TT_ASSERT( utility::is_complex_shape(input), "works for complex shape only"); \
+  /* TT_ASSERT( input.shape()[0] == 1, "tensor should have batch size 1"); */ \
+  } while(0);
+
+//complex conj
+std::vector<Tensor> _conj_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    CHECK_FOR_COMPLEX(input);
+    CHECK_FOR_COMPLEX(grad);
+    std::vector<Tensor> grad_tensor;
+    Tensor grad_result = conj(grad, output_mem_config);
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+std::vector<Tensor> conj_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _conj_bw)(grad, input, output_mem_config);
+}
+
+#undef CHECK_FOR_COMPLEX
 
 }//namespace tt_metal
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -10,6 +10,7 @@
 #include "tensor/tensor.hpp"
 #include "tensor/tensor_utils.hpp"
 #include "tensor/owned_buffer_functions.hpp"
+#include "tt_dnn/op_library/complex/complex_ops.hpp"
 
 
 
@@ -248,6 +249,8 @@ std::vector<Tensor> le_bw(const Tensor& grad, const MemoryConfig& output_mem_con
 std::vector<Tensor> unary_fmod_bw(const Tensor& grad, const Tensor& input, float eps=0.0f, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> unary_remainder_bw(const Tensor& grad, const Tensor& input, float eps=0.0f, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> conj_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 } //namespace tt_metal
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -27,6 +27,22 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+    m_tensor.def("conj_bw", &tt::tt_metal::conj_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for conjugate for complex tensor ``input`` with given ``grad``
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
     m_tensor.def("unary_mul_bw", &tt::tt_metal::unary_mul_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for multiplication with given ``grad`` and ``scalar``
@@ -1876,7 +1892,6 @@ namespace tt::tt_metal::detail{
                 "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
-
 
    m_tensor.def("unary_fmod_bw", &tt::tt_metal::unary_fmod_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(


### PR DESCRIPTION
Add backward support for conj for Type 1 complex tensor
CI tests: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8240262215