### PR TITLE
Build tests during artifact creation

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -33,11 +33,11 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
       - name: Build python env
         run: |
           make python_env/dev PYTHON_ENV=$HOME/python_env -B
-      - name: Build tt-metal CPP tests
-        run: make tests
       - name: Run pre/post regression tests
         timeout-minutes: 15
         run: |

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -24,11 +24,11 @@ jobs:
       - name: Build tt-metal and libs
         run: |
           make build PYTHON_ENV=$HOME/python_env
-      - uses: actions/upload-artifact@v4
+          make tests
+      - name: 'Tar files'
+        run: tar -cvf ttm_${{ matrix.arch }}.tar build/hw build/lib tt_eager/tt_lib/*.so ttnn/ttnn/*.so build/programming_examples build/test
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v4
         with:
           name: TTMetal_build_${{ matrix.arch }}
-          path: |
-            build/hw
-            build/lib
-            tt_eager/tt_lib/*.so
-            ttnn/ttnn/*.so
+          path: ttm_${{ matrix.arch }}.tar

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -33,6 +33,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
       - name: Build python env
         run: |
           make python_env/dev PYTHON_ENV=$HOME/python_env -B
@@ -93,6 +95,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
       - name: Build python env
         run: |
           make python_env/dev PYTHON_ENV=$HOME/python_env -B
@@ -131,6 +135,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
       - name: Build python env
         run: |
           make python_env/dev PYTHON_ENV=$HOME/python_env -B
@@ -169,11 +175,11 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
       - name: Build python env
         run: |
           make python_env/dev PYTHON_ENV=$HOME/python_env -B
-      - name: Build tt-metal CPP tests
-        run: make tests
       - name: Run API Sweep tests
         timeout-minutes: 60
         run: |


### PR DESCRIPTION
Currently we are building C++ tests on-the-fly in silicon pipelines that need to run C++ tests. This change builds the C++ tests along with libraries.

Con: 

1. Build stage takes 1 minute longer

Pros: 

1. 6 silicon pipelines (so far) don't need to build C++ tests separately, which takes up to 10 minutes in a silicon runner VM
2. Separate building from running completely

Tar file is needed to preserve permissions between upload and download artifact steps ( known issue ). Without this, files in a downloaded artifact don't have execute permissions for example.

