### PR TITLE
Add Support to Allow Input Batch Offset for Update Cache when Users < 32

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -124,7 +124,7 @@ class TestUpdateCache:
         else:
             xt = xt.to(device)
 
-        cachett = ttl.tensor.update_cache(cachett, xt, cache_idx)
+        cachett = ttl.tensor.update_cache(cachett, xt, cache_idx, batch_offset=batch_offset)
         cache[0:num_users, 0:num_heads, cache_idx : cache_idx + x.shape[-2], 0 : x.shape[-1]] = x
 
         tt_got_back = cachett.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -71,12 +71,16 @@ class TestUpdateCache:
 
     @pytest.mark.parametrize("cache_idx", [0, 1, 127, 1057])
     @pytest.mark.parametrize("cache_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+    @pytest.mark.parametrize(
+        "batch_offset", [0, 16]
+    )  # Only used when num_users < 32 and batch_offset + num_users <= 32
     def test_update_cache_decode(
         self,
         cache_idx,
         head_dim,
         max_seq_len,
         num_users,
+        batch_offset,
         num_heads,
         in_sharded,
         input_dtype,
@@ -84,16 +88,20 @@ class TestUpdateCache:
         device,
         use_program_cache,
     ):
+        if num_users > 32 or (num_users + batch_offset) > 32:
+            pytest.skip("Batch offset is only used when num_users < 32 and batch_offset + num_users <= 32")
         input_shape = [num_users, num_heads, 1, head_dim]
         cache_shape = [num_users, num_heads, max_seq_len, head_dim]
         cache = torch.randn(cache_shape).bfloat16().float()
         cachett = ttl.tensor.Tensor(cache, cache_dtype).to(ttl.tensor.Layout.TILE).to(device)
         x = torch.randn(input_shape).bfloat16().float()
-        # pad dim0 of x to 32 if batch size is less than 32
+        # pad dim0 of x to 32 if batch size is less than 32, make 0-batch_offset elements 0, batch_offset-batch_offset+num_users elements non-zero, and rest 0
+        x_new = x.clone()
         if num_users < 32:
-            xt = pad_by_zero(x.permute(2, 1, 0, 3), tt_dtype=input_dtype)[0]
-        else:
-            xt = ttl.tensor.Tensor(x.permute(2, 1, 0, 3), input_dtype).to(ttl.tensor.Layout.TILE)
+            x_new = torch.cat((torch.zeros(batch_offset, num_heads, 1, head_dim), x_new), dim=0)
+            x_new = torch.cat((x_new, torch.zeros(32 - num_users - batch_offset, num_heads, 1, head_dim)), dim=0)
+            assert x_new.shape[0] == 32, f"Expected x.shape[0] to be 32, got {x_new.shape[0]}"
+        xt = ttl.tensor.Tensor(x_new.permute(2, 1, 0, 3), input_dtype).to(ttl.tensor.Layout.TILE)
         if in_sharded:
             compute_grid_size = device.compute_with_storage_grid_size()
             num_cores = min(max(num_users, 32) // 32 * num_heads, compute_grid_size.x * compute_grid_size.y)
@@ -121,8 +129,15 @@ class TestUpdateCache:
 
         tt_got_back = cachett.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         if input_dtype == ttl.tensor.DataType.BFLOAT16 and cache_dtype == input_dtype:
-            eq, output = comp_equal(cache, tt_got_back)
+            eq_cache, output_cache = comp_equal(cache, tt_got_back)  # checks the entire kv cache
+            eq_update, output_update = comp_equal(
+                x, tt_got_back[0:num_users, 0:num_heads, cache_idx : cache_idx + x.shape[-2], 0 : x.shape[-1]]
+            )  # checks the updated parts
         else:
-            eq, output = comp_pcc(cache, tt_got_back)
-        logger.info(output)
-        assert eq
+            eq_cache, output_cache = comp_pcc(cache, tt_got_back)  # checks the entire kv cache
+            eq_update, output_update = comp_pcc(
+                x, tt_got_back[0:num_users, 0:num_heads, cache_idx : cache_idx + x.shape[-2], 0 : x.shape[-1]]
+            )  # checks the updated parts
+        logger.info(output_cache)
+        logger.info(output_update)
+        assert eq_cache and eq_update

--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -17,6 +17,7 @@ void kernel_main() {
     const uint32_t batch_start_id = get_arg_val<uint32_t>(8);
     const uint32_t Wbytes      = get_arg_val<uint32_t>(9);
     const uint32_t offset      = get_arg_val<uint32_t>(10);
+    const uint32_t batch_read_offset = get_arg_val<uint32_t>(11);
 
     constexpr bool cache_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t cache_cb_id = get_compile_time_arg_val(1);
@@ -41,7 +42,7 @@ void kernel_main() {
 
     for (uint32_t h = 0; h < num_batched_heads; ++h) {
         cb_wait_front(untilized_input_cb_id, Wt);
-        uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(untilized_input_cb_id));
+        uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(untilized_input_cb_id)) + batch_read_offset;
 
         for (uint32_t u = 0; u < u_range; ++u) {
             cb_wait_front(untilized_cache_cb_id, Wt);

--- a/tt_eager/tt_dnn/op_library/update_cache/update_cache_op.hpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/update_cache_op.hpp
@@ -23,14 +23,15 @@ enum class UpdateCacheOpType {
     FILL = 0, UPDATE = 1
 };
 
-operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tensor, const Tensor &input_tensor, const uint32_t update_idx);
-operation::ProgramWithCallbacks update_cache_single_core(const Tensor& cache_tensor, const Tensor &input_tensor, const uint32_t update_idx);
+operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tensor, const Tensor &input_tensor, const uint32_t update_idx, const uint32_t batch_offset);
+operation::ProgramWithCallbacks update_cache_single_core(const Tensor& cache_tensor, const Tensor &input_tensor, const uint32_t update_idx, const uint32_t batch_offset);
 operation::ProgramWithCallbacks fill_cache_multi_core(const Tensor& cache_tensor, const Tensor &input_tensor, const uint32_t batch_idx, const uint32_t update_idx);
 operation::ProgramWithCallbacks fill_cache_single_core(const Tensor& cache_tensor, const Tensor &input_tensor, const uint32_t batch_idx, const uint32_t update_idx);
 
 struct UpdateCache {
     const uint32_t batch_idx;
     const uint32_t update_idx;
+    const uint32_t batch_offset;
     const UpdateCacheOpType op_type;
 
     UpdateCacheOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
@@ -52,12 +53,12 @@ struct UpdateCache {
 };
 
 inline Tensor fill_cache(const Tensor& cache_tensor, const Tensor& input_tensor, const uint32_t batch_idx) {
-    operation::run(UpdateCache{batch_idx, 0, UpdateCacheOpType::FILL}, {cache_tensor, input_tensor});
+    operation::run(UpdateCache{batch_idx, 0, 0, UpdateCacheOpType::FILL}, {cache_tensor, input_tensor});
     return cache_tensor;
 }
 
-inline Tensor update_cache(const Tensor& cache_tensor, const Tensor& input_tensor, const uint32_t update_idx) {
-    operation::run(UpdateCache{0, update_idx, UpdateCacheOpType::UPDATE}, {cache_tensor, input_tensor});
+inline Tensor update_cache(const Tensor& cache_tensor, const Tensor& input_tensor, const uint32_t update_idx, const uint32_t batch_offset) {
+    operation::run(UpdateCache{0, update_idx, batch_offset, UpdateCacheOpType::UPDATE}, {cache_tensor, input_tensor});
     return cache_tensor;
 }
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -531,8 +531,8 @@ void TensorModule(py::module &m_tensor) {
         "Fills the cache tensor in place with the values from input at the specified batch_idx.
     )doc");
     m_tensor.def("update_cache", &update_cache,
-         py::arg("cache").noconvert(), py::arg("input").noconvert(), py::arg("update_idx"), R"doc(
-        "Updates the cache tensor in place with the values from input at the specified update_idx.
+         py::arg("cache").noconvert(), py::arg("input").noconvert(), py::arg("update_idx"), py::arg("batch_offset") = 0, R"doc(
+        "Updates the cache tensor in place with the values from input at the specified update_idx. When cache has batch less than 32, input is assumed to have batch padded to 32 and [batch_offset:batch_offset+batch] from dim[-2] of input is used to update the cache.
     )doc");
 
 


### PR DESCRIPTION
See details in #6317

In addition to implement the feature, I added additional test cases for batch offset as well as making sure `test_update_cache.py` checking both the entire cache and the updated portion.