### PR TITLE
#6075: add reshard support to the halo op

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_v2.py
@@ -12,7 +12,6 @@ from tt_eager.tt_dnn.op_library.sliding_window_op_infra.untilize_with_halo_confi
     construct_utwh_output_shards,
     validate_utwh_output_shards_and_req_conv_input_shard_start_end,
     validate_tensor_metadata,
-    generate_untilize_with_halo_kernel_configs,
     validate_untilize_with_halo_kernel_configs,
 )
 from tt_eager.tt_dnn.op_library.sliding_window_op_infra.sliding_window_op_config_generation_and_validation import (

--- a/tt_eager/tt_dnn/op_library/sliding_window_op_infra/sliding_window_op_utils.py
+++ b/tt_eager/tt_dnn/op_library/sliding_window_op_infra/sliding_window_op_utils.py
@@ -13,12 +13,13 @@ SlidingWindowOpParams = namedtuple(
 )
 SlidingWindowOpParamsWithParallelConfig = namedtuple(
     "SlidingWindowOpParamsWithParallelConfig",
-    "stride_h stride_w pad_h pad_w window_h window_w batch_size input_h input_w num_cores_w num_cores_h num_cores_nhw",
+    "stride_h stride_w pad_h pad_w window_h window_w batch_size input_h input_w num_cores_w num_cores_h num_cores_nhw act_reshard_num_cores_nhw",
+    defaults=[0],
 )
 
 
 def get_hash_from_sliding_window_op_params(sliding_window_op_params: SlidingWindowOpParamsWithParallelConfig):
-    return f"{sliding_window_op_params.stride_h}_{sliding_window_op_params.stride_w}_{sliding_window_op_params.pad_h}_{sliding_window_op_params.pad_w}_{sliding_window_op_params.window_h}_{sliding_window_op_params.window_w}_{sliding_window_op_params.batch_size}_{sliding_window_op_params.input_h}_{sliding_window_op_params.input_w}_{sliding_window_op_params.num_cores_w}_{sliding_window_op_params.num_cores_h}_{sliding_window_op_params.num_cores_nhw}"
+    return f"{sliding_window_op_params.stride_h}_{sliding_window_op_params.stride_w}_{sliding_window_op_params.pad_h}_{sliding_window_op_params.pad_w}_{sliding_window_op_params.window_h}_{sliding_window_op_params.window_w}_{sliding_window_op_params.batch_size}_{sliding_window_op_params.input_h}_{sliding_window_op_params.input_w}_{sliding_window_op_params.num_cores_w}_{sliding_window_op_params.num_cores_h}_{sliding_window_op_params.num_cores_nhw}_{sliding_window_op_params.act_reshard_num_cores_nhw}"
 
 
 def get_sliding_window_op_output_nhw_shape(
@@ -47,7 +48,7 @@ def calculate_shard_grid(grid_size, num_cores_nhw):
     num_cores_w, num_cores_h = grid_size
     shard_layout = (
         ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED
-        if num_cores_nhw == num_cores_w
+        if (num_cores_nhw == num_cores_w and num_cores_h > 1)
         else ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED
     )
 

--- a/tt_eager/tt_dnn/op_library/untilize/untilize_op.hpp
+++ b/tt_eager/tt_dnn/op_library/untilize/untilize_op.hpp
@@ -105,6 +105,7 @@ struct UntilizeWithHaloV2 {
     const uint32_t ncores_nhw_;
     const uint32_t max_out_nsticks_per_core_;
     const MemoryConfig out_mem_config_;
+    const bool remote_read_;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -112,13 +113,14 @@ struct UntilizeWithHaloV2 {
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
 
     static constexpr auto attribute_names =
-        std::make_tuple("pad_val_", "ncores_nhw_", "max_out_nsticks_per_core_", "out_mem_config_");
+        std::make_tuple("pad_val_", "ncores_nhw_", "max_out_nsticks_per_core_", "out_mem_config_", "remote_read_");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(pad_val_),
             std::cref(ncores_nhw_),
             std::cref(max_out_nsticks_per_core_),
-            std::cref(out_mem_config_));
+            std::cref(out_mem_config_),
+            std::cref(remote_read_));
     }
 };
 Tensor untilize_with_halo_v2(
@@ -129,7 +131,8 @@ Tensor untilize_with_halo_v2(
     const uint32_t pad_val,
     const uint32_t ncores_nhw,
     const uint32_t max_out_nsticks_per_core,
-    const MemoryConfig &mem_config);
+    const MemoryConfig &mem_config,
+    const bool remote_read);
 
 namespace untilize_helpers {
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
@@ -207,6 +207,7 @@ namespace tt::tt_metal::detail{
             py::arg("ncores_height").noconvert(),
             py::arg("max_out_nsticks_per_core").noconvert(),
             py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("remote_read").noconvert() = false,
             R"doc(
                 Untilizes input tiled data to row major format and constructs halo'd output shards.
             )doc");


### PR DESCRIPTION
Conv/Halo op now accepts config override act_reshard_num_cores_nhw which denotes what the num_cores_nhw of the input activations are, which can mismatch with this conv's num_cores_nhw provided the activations are already in row major layout.