### PR TITLE
#6284: Add backward support for imag and real

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -1054,6 +1054,10 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.unary_remainder_bw
 
+.. autofunction:: tt_lib.tensor.imag_bw
+
+.. autofunction:: tt_lib.tensor.real_bw
+
 Loss Functions
 ==============
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_imag.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_imag.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_imag(input_shapes, device):
+    torch.manual_seed(0)
+    in_data = torch.randn(input_shapes, dtype=torch.complex64)
+    in_data.requires_grad = True
+
+    torch.manual_seed(42)
+    grad_data = torch.randn(input_shapes, dtype=torch.complex64)
+    grad_data = grad_data.imag
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=3)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.imag_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.imag(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=3)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_real.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_real.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_real(input_shapes, device):
+    torch.manual_seed(0)
+    in_data = torch.randn(input_shapes, dtype=torch.complex64)
+    in_data.requires_grad = True
+
+    torch.manual_seed(42)
+    grad_data = torch.randn(input_shapes, dtype=torch.complex64)
+    grad_data = grad_data.real
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=3)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.real_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.real(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=3)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1658,6 +1658,34 @@ std::vector<Tensor> conj_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _conj_bw)(grad, input, output_mem_config);
 }
 
+// complex imag
+// imag: at::imag(grad)
+std::vector<Tensor> _imag_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    CHECK_FOR_COMPLEX(input);
+    std::vector<Tensor> grad_tensor;
+    Tensor grad_result = mk_complex(zeros_like(real(input, output_mem_config), output_mem_config), grad, output_mem_config) ;
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+std::vector<Tensor> imag_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _imag_bw)(grad, input, output_mem_config);
+}
+
+// complex real
+// real: at::real(grad)
+std::vector<Tensor> _real_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    CHECK_FOR_COMPLEX(input);
+    std::vector<Tensor> grad_tensor;
+    Tensor grad_result = mk_complex(grad, zeros_like(imag(input, output_mem_config), output_mem_config), output_mem_config);
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+std::vector<Tensor> real_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _real_bw)(grad, input, output_mem_config);
+}
+
 #undef CHECK_FOR_COMPLEX
 
 }//namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -252,6 +252,10 @@ std::vector<Tensor> unary_remainder_bw(const Tensor& grad, const Tensor& input, 
 
 std::vector<Tensor> conj_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> imag_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> real_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 } //namespace tt_metal
 
 } //namespace tt

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -1926,5 +1926,37 @@ namespace tt::tt_metal::detail{
                 "scalar", "scalar value", "float", "float", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
+
+    m_tensor.def("imag_bw", &tt::tt_metal::imag_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for imaginary part of complex tensor ``input`` with given ``grad``
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("real_bw", &tt::tt_metal::real_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for real part of complex tensor ``input`` with given ``grad``
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
     }
 }


### PR DESCRIPTION
Add backward support for imag and real for Type 1 complex tensor
CI test: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8292204238