### PR TITLE
#6266: Refactored Llama 2 MLP & attention

### DIFF
--- a/models/demos/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/llama2_70b/tt/llama_attention_optimized.py
@@ -435,52 +435,24 @@ class TtLlamaAttention_optimized(torch.nn.Module):
             value_layer.append(v_heads)
             fused_query_key_value[i].deallocate(True)
 
-        for i in range(len(query_layer)):
-            query_layer[i] = tt_lib.tensor.sharded_to_interleaved(
-                query_layer[i], output_mem_config=self.model_config["L1_MEMCFG"]
-            )
-            key_layer[i] = tt_lib.tensor.sharded_to_interleaved(
-                key_layer[i], output_mem_config=self.model_config["L1_MEMCFG"]
-            )
-
         # ROTARY EMBEDDINGS
+        # Q Rotary Embeddings
         for i in range(len(query_layer)):
-            # query_layer[i] = tt_lib.operations.primary.matmul_1d(
-            #     query_layer[i],
-            #     rot_mats[i],
-            #     program_config=self.model_config["ROT_MAT_Q_MM_PROGCFG"],
-            #     output_mem_config=self.model_config["ROT_MAT_Q_MM_OUTPUT_MEMCFG"],
-            #     compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"]
-            #     # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
-            # )
-            # k_heads = tt_lib.matmul(
-            #     k_heads,
-            #     rot_mat,
-            #     # program_config=self.model_config["ROT_MAT_K_MM_PROGCFG"],
-            #     output_mem_config=self.model_config["ROT_MAT_K_MM_OUTPUT_MEMCFG"],
-            #     # [seqlen, n_kv_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_kv_heads, bsz, head_dim]
-            # )
             query_layer[i] = tt_lib.operations.primary.matmul(
                 query_layer[i],
                 rot_mats[i],
-                compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"],
-                output_mem_config=self.model_config["L1_MEMCFG"]
+                program_config=self.model_config["ROT_MAT_Q_MM_PROGCFG"],
+                output_mem_config=self.model_config["ROT_MAT_Q_MM_OUTPUT_MEMCFG"],
+                compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"]
                 # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
             )
-            key_layer[i] = tt_lib.operations.primary.matmul(
-                key_layer[i],
-                rot_mats[i],
-                compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"],
-                output_mem_config=self.model_config["L1_MEMCFG"]
-                # [seqlen, n_kv_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_kv_heads, bsz, head_dim]
-            )
-
-            # Shard key_layer
-            # key_layer[i] = tt_lib.tensor.interleaved_to_sharded(
-            #     key_layer[i],
-            #     sharded_mem_config=self.model_config["ROT_MAT_K_MM_OUTPUT_MEMCFG"],)
-            # Pad and transpose Q for batched matmul
-            if self.batched_attn:
+        # Pad and transpose Q for batched matmul
+        if self.batched_attn:
+            for i in range(len(query_layer)):
+                # Pad and transpose Q for batched matmul
+                query_layer[i] = tt_lib.tensor.sharded_to_interleaved(
+                    query_layer[i], output_mem_config=self.model_config["L1_MEMCFG"]
+                )
                 query_layer[i] = tt_lib.tensor.pad(
                     query_layer[i], [1, self.padded_local_heads, 32, self.head_dim], [0, 0, 0, 0], 0.0
                 )
@@ -509,6 +481,27 @@ class TtLlamaAttention_optimized(torch.nn.Module):
                         ],
                         output_mem_config=self.model_config["DEFAULT_MEMCFG"],
                     )
+                query_layer[i] = tt_lib.tensor.interleaved_to_sharded(
+                    query_layer[i], sharded_mem_config=self.model_config["Q_TRANSPOSE_MEMCFG"]
+                )
+
+        # K Rotary Embeddings
+        for i in range(len(key_layer)):
+            key_layer[i] = tt_lib.tensor.sharded_to_interleaved(
+                key_layer[i], output_mem_config=self.model_config["L1_MEMCFG"]
+            )
+        for i in range(len(key_layer)):
+            key_layer[i] = tt_lib.operations.primary.matmul(
+                key_layer[i],
+                rot_mats[i],
+                output_mem_config=self.model_config["L1_MEMCFG"],
+                compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"],
+                # [seqlen, n_kv_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_kv_heads, bsz, head_dim]
+            )
+            # Shard key_layer for K cache update
+            # key_layer[i] = tt_lib.tensor.interleaved_to_sharded(
+            #     key_layer[i],
+            #     sharded_mem_config=self.model_config["ROT_MAT_K_MM_OUTPUT_MEMCFG"],)
 
         return query_layer, key_layer, value_layer
 
@@ -521,16 +514,6 @@ class TtLlamaAttention_optimized(torch.nn.Module):
         attn_masks: tt_lib.tensor.Tensor,
     ) -> tt_lib.tensor.Tensor:
         padded_layer_past_len = nearest_32(start_pos + 1)
-
-        for i in range(len(query_layer)):
-            if self.batched_attn:
-                query_layer[i] = tt_lib.tensor.interleaved_to_sharded(
-                    query_layer[i], sharded_mem_config=self.model_config["Q_TRANSPOSE_MEMCFG"]
-                )
-            else:
-                query_layer[i] = tt_lib.tensor.interleaved_to_sharded(
-                    query_layer[i], sharded_mem_config=self.model_config["ROT_MAT_Q_MM_OUTPUT_MEMCFG"]
-                )
 
         # K Cache Update
         kv_cache_memcfg = self.model_config["KV_CACHE_SLICE_OUTPUT_MEMCFG"]
@@ -679,8 +662,15 @@ class TtLlamaAttention_optimized(torch.nn.Module):
             attn_weights[i].deallocate(True)
             value_layer[i].deallocate(True)
 
-            if self.batched_attn:
-                # TRANSPOSE
+        return attn_output
+
+    def attn_selfout(
+        self,
+        attn_output: tt_lib.tensor.Tensor,
+    ) -> tt_lib.tensor.Tensor:
+        # ATTENTION SELFOUT
+        if self.batched_attn:
+            for i in range(len(attn_output)):
                 if self.emulated:
                     attn_output[i] = tt_lib.tensor.sharded_to_interleaved(
                         attn_output[i],
@@ -691,27 +681,15 @@ class TtLlamaAttention_optimized(torch.nn.Module):
                         attn_output[i],
                         output_mem_config=self.model_config["L1_MEMCFG"],
                     )
-
-        return attn_output
-
-    def attn_selfout(
-        self,
-        attn_output: tt_lib.tensor.Tensor,
-    ) -> tt_lib.tensor.Tensor:
-        # ATTENTION SELFOUT
-        for i in range(len(attn_output)):
-            if self.batched_attn:
                 # TRANSPOSE
                 # Get batch in dim 1
                 attn_output[i] = tt_lib.tensor.reshape(attn_output[i], 1, 32, 32, 128)
-
                 # Get batch in dim 2
                 attn_output[i] = tt_lib.tensor.transpose(
                     attn_output[i],
                     -2,
                     -3,
                 )
-
                 # UNPAD
                 attn_output_shape = attn_output[i].shape
                 attn_output[i] = tt_lib.tensor.unpad(
@@ -725,7 +703,6 @@ class TtLlamaAttention_optimized(torch.nn.Module):
                     ],
                     output_mem_config=self.model_config["L1_MEMCFG"],
                 )
-
                 # SHARD TO SCORES_TRANSPOSED_OUTPUT_MEMCFG
                 attn_output[i] = tt_lib.tensor.interleaved_to_sharded(
                     attn_output[i], sharded_mem_config=self.model_config["SCORES_TRANSPOSED_OUTPUT_MEMCFG"]
@@ -764,7 +741,7 @@ class TtLlamaAttention_optimized(torch.nn.Module):
                 output_dtype=self.model_config["SELFOUT_MM_OUTPUT_DTYPE"],
                 compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
             )  # seqlen, 1, batch, hidden_size
-        # breakpoint()
+
         # FOR BRINGUP! Outputs are sharded. Interleave them
         # for i in range(len(attn_output)):
         #     attn_output[i] = tt_lib.tensor.sharded_to_interleaved(

--- a/models/demos/llama2_70b/tt/llama_mlp_optimized.py
+++ b/models/demos/llama2_70b/tt/llama_mlp_optimized.py
@@ -141,31 +141,38 @@ class TtLlamaMLP_optimized(nn.Module):
 
     def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
         hidden_states = []
-
+        w1_outs = []
+        w3_outs = []
         for i in range(len(x)):
-            w1_out = tt_lib.operations.primary.matmul_1d(
-                x[i],
-                self.w1_list[i],
-                program_config=self.model_config["PADDED_FF1_MM_PROGCFG"],
-                output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-                output_dtype=self.model_config["PADDED_FF1_MM_OUTPUT_DTYPE"],
-                compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
+            w1_outs.append(
+                tt_lib.operations.primary.matmul_1d(
+                    x[i],
+                    self.w1_list[i],
+                    program_config=self.model_config["PADDED_FF1_MM_PROGCFG"],
+                    output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+                    output_dtype=self.model_config["PADDED_FF1_MM_OUTPUT_DTYPE"],
+                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
+                )
             )
-
-            w3_out = tt_lib.operations.primary.matmul_1d(
-                x[i],
-                self.w3_list[i],
-                program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],
-                output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-                output_dtype=self.model_config["PADDED_FF3_MM_OUTPUT_DTYPE"],
-                compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
+        for i in range(len(x)):
+            w3_outs.append(
+                tt_lib.operations.primary.matmul_1d(
+                    x[i],
+                    self.w3_list[i],
+                    program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],
+                    output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+                    output_dtype=self.model_config["PADDED_FF3_MM_OUTPUT_DTYPE"],
+                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
+                )
             )
             x[i].deallocate(True)
+
+        for i in range(len(w1_outs)):
             hidden_states.append(
-                tt_lib.tensor.mul(w1_out, w3_out, output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"])
+                tt_lib.tensor.mul(w1_outs[i], w3_outs[i], output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"])
             )
-            w1_out.deallocate(True)
-            w3_out.deallocate(True)
+            w1_outs[i].deallocate(True)
+            w3_outs[i].deallocate(True)
 
         for i in range(len(hidden_states)):
             # Put w2_inputs in DRAM


### PR DESCRIPTION
1. Refactored llama_mlp_optimized to put FF1 & FF3 matmuls in separate for-loops to allow more parallelization.
2. Modified llama_attention_optimized to use mcast_1d for Q rotary_embeddings to keep results height-sharded on L1. Making the TMs required for BMM Q x K attention consistent with BMM attn score x V. Also, put Q & K rotary_embeddings matmuls in separate for-loops