### PR TITLE
#5424: sfpu kernel cleanup - removing duplicate ckernels

### DIFF
--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -8,6 +8,7 @@
 #include "ckernel.h"
 #include "noc_nonblocking_api.h"
 #include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_exp.h"
 #include <limits>
 
 #include "sfpi.h"
@@ -18,108 +19,17 @@ namespace ckernel
 {
 namespace sfpu
 {
-sfpi_inline vFloat sfpu_exp(vFloat val)
-{
-    // If exponent is > -1 extract it and replace with -1
-    vInt exp = exexp(val);
-    v_if (exp >= 0) {
-        val = setexp(val, 126);
-    }
-    v_endif;
-
-    // Run series in Horner form
-    vFloat tmp = val * vConst0p8369 + 0.8634F;
-    val = val * tmp + vConst1;
-
-    v_if (exp >= 0) {
-        val = val * val;
-        #pragma GCC unroll 0
-        for (int s_iter = 0; s_iter < 7; s_iter++) {
-            exp = exp - 1;
-            // Narrow predication on each loop
-            v_and(exp >= 0);
-            val = val * val;
-        }
-    }
-    v_endif;
-
-    return val;
-}
 
 template <bool APPROXIMATION_MODE, bool ZERO_NEGATIVE, bool SCALE_EN=false, int ITERATIONS=4>
 inline void calculate_exponential(int16_t exp_base_scale_factor = 0)
 {
-    vFloat c23_73;
-    vInt adj_exp;
-
-    if constexpr (APPROXIMATION_MODE)
-    {
-        c23_73 = l_reg[LRegs::LReg0];
-        adj_exp = l_reg[LRegs::LReg2];
-    }
-
-    #pragma GCC unroll 2
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        vFloat val = dst_reg[0];
-
-        if constexpr(SCALE_EN) {
-            val = val * s2vFloat16a(exp_base_scale_factor);
-            dst_reg[0] = val;
-        }
-        if constexpr (APPROXIMATION_MODE)
-        {
-            v_if (val >= 89) {
-                vFloat val_inf = std::numeric_limits<float>::infinity();
-                dst_reg[0] = val_inf;
-            } v_elseif(val < -42) {
-                dst_reg[0] = 0.0f;
-            } v_else {
-                // * by 1/ln2 and add convert to 7.3 FxP format
-                val = val * vConst1p4424 + c23_73;
-
-                // Remove Exponent of 7 and bias the Mantissa to 127.
-                // LREG2 already holds 2's complement value so we simply do REG2 + REG3
-                vInt val_short = adj_exp + reinterpret<vInt>(val);
-
-                // SHL to move integer bits to exponent
-                val_short <<= 10 - p_exp::FRAC_BITS;
-                dst_reg[0] = reinterpret<vFloat>(val_short);
-            }
-            v_endif;
-        }
-        else
-        {
-            // Force sign to 0 (make number positive)
-            val = sfpu_exp(setsgn(val, 0));
-
-            vFloat orig = dst_reg[0];
-
-            // Loaded by reciprocal
-            dst_reg[0] = val;
-            v_if (orig < 0) {
-                dst_reg[0] = sfpu_reciprocal<false>(val);
-            }
-            v_endif;
-        }
-
-        dst_reg++;
-    }
-
-    if constexpr (APPROXIMATION_MODE)
-    {
-        l_reg[LRegs::LReg0] = c23_73;
-        l_reg[LRegs::LReg2] = adj_exp;
-    }
+    _calculate_exponential_<APPROXIMATION_MODE, ZERO_NEGATIVE, SCALE_EN, ITERATIONS>(exp_base_scale_factor);
 }
 
 
 template <bool APPROXIMATION_MODE>
 void exp_init() {
-    if constexpr(APPROXIMATION_MODE) {
-        TTI_SFPLOADI(p_sfpu::LREG0, 0, p_exp::C23_73);
-        TTI_SFPLOADI(p_sfpu::LREG2, 0, p_exp::ADJ_EXP);
-    }
+    _init_exponential_<APPROXIMATION_MODE>();
 }
 
 template <bool APPROXIMATION_MODE, bool ZERO_NEGATIVE>
@@ -151,7 +61,7 @@ sfpi_inline vFloat calculate_exponential_body(vFloat in)
     else
     {
         // Force sign to 0 (make number positive)
-        vFloat exp = sfpu_exp(setsgn(in, 0));
+        vFloat exp = _sfpu_exp_(setsgn(in, 0));
 
         // Load input value, to determine whether reciprocal needs to be run
         vFloat val = dst_reg[0];
@@ -161,7 +71,7 @@ sfpi_inline vFloat calculate_exponential_body(vFloat in)
         dst_reg[0] = exp;
 
         v_if (val < 0) {
-            dst_reg[0] = sfpu_reciprocal<true>(exp);
+            dst_reg[0] = _sfpu_reciprocal_<true>(exp);
         }
         v_endif;
     }
@@ -201,7 +111,7 @@ sfpi_inline vFloat calculate_exponential_body_improved(vFloat in)
     else
     {
         // Force sign to 0 (make number positive)
-        vFloat exp = sfpu_exp(setsgn(in, 0));
+        vFloat exp = _sfpu_exp_(setsgn(in, 0));
 
         // Load input value, to determine whether reciprocal needs to be run
         vFloat val = dst_reg[0];
@@ -211,8 +121,8 @@ sfpi_inline vFloat calculate_exponential_body_improved(vFloat in)
         out = exp;
 
         v_if (val < 0) {
-            //dst_reg[0] = sfpu_reciprocal<true>(exp);
-            out = sfpu_reciprocal<true>(exp);
+            //dst_reg[0] = _sfpu_reciprocal_<true>(exp);
+            out = _sfpu_reciprocal_<true>(exp);
         }
         v_endif;
     }

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -7,6 +7,7 @@
 #include "ckernel_defs.h"
 #include "ckernel.h"
 #include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_recip.h"
 
 #include "sfpi.h"
 
@@ -17,74 +18,10 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool save_reg, int max_iter = 3>
-sfpi_inline vFloat sfpu_reciprocal(const vFloat in)
-{
-    vInt orig_exp;
-
-    if constexpr (max_iter == 1) {
-        // If we are only doing one iteration of the MAD loop, then we only need to use one LREG for the MAD instructions because we have our "first guess" in a hard-coded register
-        // This allows us to avoid having to load back in the original value later on
-        orig_exp = exexp(in);
-    }
-
-    // Force sign to 1 (make number negative)
-    vFloat val = setsgn(in, 1);
-
-    val = setexp(val, 126); // Set exponent to 126 to make the number in 0.5-1
-    // Use 1.44 as first guess at x, ideal value would be 1.33, but we happen to have 1.44 available, so use that to avoid a load
-    vFloat two;
-    if (!save_reg) {
-        two = 2.0f;
-    }
-    vFloat result = vConst1p4424 * (val * vConst1p4424 + (save_reg ? 2.0f : two));
-
-    for (int s_iter = 0; s_iter < (max_iter-1); s_iter++) {
-        result = result * (val * result + (save_reg ? 2.0f : two));
-    }
-
-    vInt new_exp = exexp(result);
-    if constexpr (max_iter != 1) {
-        orig_exp = exexp(dst_reg[0]);
-    }
-
-    // "Subtract" exponents, and re-bias.
-    // Execute: -1 - exp, then exp += 127
-    new_exp -= orig_exp;
-    new_exp += 126;
-
-    v_if (new_exp < 0) {
-        // If rebiased exponent is negative, we need to saturate at 0.
-        // This means the initial number was too big so reciprocal result should be 0
-        result = 0.0F;
-        new_exp = 0;
-    }
-    v_endif;
-
-    // Set newly denormalized exponent to result exponent field
-    return setexp(result, new_exp);
-}
-
 template <bool APPROXIMATION_MODE, int ITERATIONS=4>
 inline void calculate_reciprocal()
 {
-    #pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        vFloat in = dst_reg[0];
-        vFloat out = sfpu_reciprocal<true, APPROXIMATION_MODE ? 2 : 3>(in);
-
-        // Reload to reduce register pressure
-        v_if (dst_reg[0] < 0.0F) {
-            // Invert sign on calculated value if CC=1 (number is negative)
-            out = -out;
-        }
-        v_endif;
-
-        dst_reg[0] = out;
-
-        dst_reg++;
-    }
+    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS>();
 }
 
 } // namespace sfpu

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -37,7 +37,6 @@ inline void relu_max(uint uint_threshold)
     }
 }
 
-
 // RELU MIN
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -21,7 +21,7 @@ inline void calculate_rsqrt()
     for (int d = 0; d < ITERATIONS; d++)
     {
         vFloat in = dst_reg[0];
-        vFloat result = sfpu_reciprocal<false>(in);
+        vFloat result = _sfpu_reciprocal_<false>(in);
         v_if(dst_reg[0] < 1.0f){
             result = 1.0f;
         }v_endif;

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -7,6 +7,7 @@
 #include "ckernel_defs.h"
 #include "ckernel.h"
 #include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_sqrt.h"
 
 #include "sfpi.h"
 
@@ -20,54 +21,13 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int ITERATIONS=4, int RECIPROCAL_ITERATIONS=2>
 inline void calculate_sqrt()
 {
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        vFloat val = dst_reg[0];
-
-        if constexpr (APPROXIMATION_MODE)
-        {
-            vUInt magic = l_reg[LRegs::LReg2];
-
-            //sqrt initial approximation
-            // adjust bias
-            vUInt val_s = magic + reinterpret<vUInt>(val);
-
-            // approximation of square root
-            val_s >>= 1;
-            dst_reg[0] = reinterpret<vFloat>(val_s);
-
-            l_reg[LRegs::LReg2] = magic;
-        }
-        else
-        {
-            // Recip root method
-            //// Init approx
-            //u.i = SQRT_MAGIC_F - (u.i >> 1);
-            vUInt magic = reinterpret<vUInt>(vFloat(s2vFloat16b(0x5f37)));
-            vFloat approx = reinterpret<vFloat>(magic - (reinterpret<vUInt>(val) >> 1));
-
-            // Re-load to save a MOV
-            val = dst_reg[0];
-
-            //Reciproot iterations
-            for (int r = 0; r < RECIPROCAL_ITERATIONS; r++)
-            {
-                //x*r*(1.5f - xhalf*r*r);
-                approx = (approx * approx * val * vConstNeg0p5 + vConst1 + 0.5F) * approx;
-            }
-
-            dst_reg[0] = approx * val;
-        }
-
-        dst_reg++;
-    }
+    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, RECIPROCAL_ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE>
 void sqrt_init() {
-    if (APPROXIMATION_MODE) {
-        TTI_SFPLOADI(2, 0, 127 << 7);
-    }
+    _init_sqrt_<APPROXIMATION_MODE>();
 }
+
 } // namespace sfpu
 } // namespace ckernel

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -177,6 +177,7 @@ inline void calculate_sine()
         dst_reg++;
     }
 }
+
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_cosine()
 {
@@ -221,7 +222,7 @@ sfpi_inline vFloat sfpu_atan_maclaurin_series(vFloat val)
         dst_reg[0] = sfpi::abs(val)  ;
     }
     v_else{
-        dst_reg[0] =  sfpu_reciprocal<true>(sfpi::abs(val));
+        dst_reg[0] =  _sfpu_reciprocal_<true>(sfpi::abs(val));
     }
     v_endif;
 

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_identity.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_identity.h
@@ -20,7 +20,6 @@ inline void llk_math_eltwise_unary_sfpu_identity(uint dst_index, int vector_mode
                                 (ckernel::sfpu::calculate_identity<APPROXIMATE, first_iterations>,
                                 ckernel::sfpu::calculate_identity<APPROXIMATE,4>,
                                 dst_index, vector_mode);
-
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_isinf_isnan.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_isinf_isnan.h
@@ -26,7 +26,6 @@ inline void llk_math_eltwise_unary_sfpu_isinf(uint dst_index, int vector_mode = 
                                 (ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isinf, APPROXIMATE, 1>,
                                 ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isinf, APPROXIMATE>,
                                 dst_index, vector_mode);
-
 }
 
 //isposinf
@@ -41,7 +40,6 @@ inline void llk_math_eltwise_unary_sfpu_isposinf(uint dst_index, int vector_mode
                                 (ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isposinf, APPROXIMATE, 1>,
                                 ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isposinf, APPROXIMATE>,
                                 dst_index, vector_mode);
-
 }
 
 
@@ -50,13 +48,13 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_isneginf_init() {
     llk_math_eltwise_unary_sfpu_init<APPROXIMATE>();
 }
+
 template <bool APPROXIMATE, DstSync Dst = DstSync::SyncFull>
 inline void llk_math_eltwise_unary_sfpu_isneginf(uint dst_index, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE, Dst>
                                 (ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isneginf, APPROXIMATE, 1>,
                                 ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isneginf, APPROXIMATE>,
                                 dst_index, vector_mode);
-
 }
 
 //isnan
@@ -64,13 +62,13 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_isnan_init() {
     llk_math_eltwise_unary_sfpu_init<APPROXIMATE>();
 }
+
 template <bool APPROXIMATE, DstSync Dst = DstSync::SyncFull>
 inline void llk_math_eltwise_unary_sfpu_isnan(uint dst_index, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE, Dst>
                                 (ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isnan, APPROXIMATE, 1>,
                                 ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isnan, APPROXIMATE>,
                                 dst_index, vector_mode);
-
 }
 
 //isfinite
@@ -78,13 +76,13 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_isfinite_init() {
     llk_math_eltwise_unary_sfpu_init<APPROXIMATE>();
 }
+
 template <bool APPROXIMATE, DstSync Dst = DstSync::SyncFull>
 inline void llk_math_eltwise_unary_sfpu_isfinite(uint dst_index, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE, Dst>
                                 (ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isfinite, APPROXIMATE, 1>,
                                 ckernel::sfpu::calculate_sfpu_isinf_isnan<SfpuType::isfinite, APPROXIMATE>,
                                 dst_index, vector_mode);
-
 }
 
 }

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_logical_not_noti.h
@@ -18,6 +18,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_init() {
     llk_math_eltwise_unary_sfpu_init<APPROXIMATE>();
 }
+
 template <bool APPROXIMATE, DstSync Dst = DstSync::SyncFull>
 inline void llk_math_eltwise_unary_sfpu_logical_not_unary_op(uint dst_index) {
     llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE, Dst>

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_relu.h
@@ -69,8 +69,8 @@ template <bool APPROXIMATE, DstSync Dst = DstSync::SyncFull>
 inline void llk_math_eltwise_unary_sfpu_lrelu(uint dst_index, int param0 = 0) {
     llk_math_eltwise_unary_sfpu_1_param<APPROXIMATE, Dst>
                                 (ckernel::sfpu::calculate_lrelu<APPROXIMATE,4>,
-				 ckernel::sfpu::calculate_lrelu<APPROXIMATE,4>,
-				 dst_index, VectorMode::RC, param0);
+                                ckernel::sfpu::calculate_lrelu<APPROXIMATE,4>,
+                                dst_index, VectorMode::RC, param0);
 }
 
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_abs.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_abs.h"
 
 using namespace sfpi;
 
@@ -16,13 +17,7 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_abs()
 {
-    // SFPU microcode
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        vFloat v = dst_reg[0];
-        dst_reg[0] = sfpi::abs(v);
-        dst_reg++;
-    }
+    _calculate_abs_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_cast_fp32_to_fp16a.h"
 
 using namespace sfpi;
 
@@ -16,16 +17,7 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void cast_fp32_to_fp16a()
 {
-    #pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        //vFloat val = dst_reg[0];
-        //dst_reg[0] = float_to_fp16a(val, 0);
-        TTI_SFPLOAD(0, 0, 3, 0);
-        TTI_SFP_STOCH_RND(0,0,0,0,0,8);
-        TTI_SFPSTORE(0,1,3,0);
-        dst_reg++;
-    }
+    _cast_fp32_to_fp16a_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_clamp.h"
 
 using namespace sfpi;
 
@@ -16,32 +17,7 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_clamp(uint param0, uint param1, uint param2)
 {
-    // All params are in FP16 format
-    // param0 = min
-    // param1 = max
-
-    //uint format = (param0 >> 16)&0x1;
-    s2vFloat16::Format format = s2vFloat16::fp16a;
-
-    // SFPU microcode
-    vFloat min = s2vFloat16(param0, format);
-    vFloat max = s2vFloat16(param1, format);
-    #pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        vFloat val = dst_reg[0];
-
-        v_if (val < min) {
-            val = s2vFloat16(param0, format);
-        } v_elseif (val >= max) {
-            val = s2vFloat16(param1, format);
-        }
-        v_endif;
-
-        dst_reg[0] = val + s2vFloat16b(param2); // 12 bits
-
-        dst_reg++;
-    }
+    _calculate_clamp_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, param0, param1, param2);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_dropout.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_dropout.h"
 
 using namespace sfpi;
 
@@ -16,50 +17,13 @@ namespace sfpu {
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_dropout(uint prob, uint scale)
 {
-    // SFPU microcode
-
-    vUInt rand = l_reg[LRegs::LReg3];
-
-    #pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        ////////////////////////
-        // Scale samples
-        ///////////////////////
-        dst_reg[0] = dst_reg[0] * s2vFloat16b(scale);
-
-        ////////////////////////
-        // Drop samples
-        ///////////////////////
-        v_if (rand < prob) {
-            dst_reg[0] = vConst0;
-        }
-        v_endif;
-
-        ////////////////////////
-        // 16-bit PRNG update
-        ///////////////////////
-        vUInt lfsr = vConstIntPrgm1;
-        vUInt tmp = lfsr & rand;
-        rand = rand >> 1;
-        v_if (tmp != 0) {
-            vUInt mask = vConstIntPrgm0;
-            rand ^= mask;
-        }
-        v_endif;
-
-        dst_reg++;
-    }
-
-    l_reg[LRegs::LReg3] = rand;
+    _calculate_dropout_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS, prob, scale);
 }
 
 template <bool APPROXIMATION_MODE>
 inline void dropout_init(const uint seed)
 {
-    vConstIntPrgm0 = 0xb400;
-    vConstIntPrgm1 = 0x1; // binary 0b1 - used to extract LSB
-
-    _init_dropout_seed_(seed);
+    _init_dropout_(seed);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -32,17 +32,7 @@ inline void calculate_exp2()
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    }
-    else{
-        vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    _init_exponential_<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -29,17 +29,7 @@ inline void calculate_expm1()
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    }
-    else{
-        vConstFloatPrgm0 = 1.442695f; // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    _init_exponential_<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -120,6 +120,7 @@ void JitBuildEnv::init(uint32_t device_id, tt::ARCH arch)
         "-I" + this->root_ + "tt_metal/hw/ckernels/" + this->arch_name_ + "/metal/common " +
         "-I" + this->root_ + "tt_metal/hw/ckernels/" + this->arch_name_ + "/metal/llk_io " +
         "-I" + this->root_ + "tt_metal/third_party/tt_llk_" + this->arch_name_ + "/common/inc " + // TODO(fixme) datamovement fw shouldn't read this
+        "-I" + this->root_ + "tt_metal/third_party/tt_llk_" + this->arch_name_ + "/common/inc/sfpu " + // TODO(fixme) datamovement fw shouldn't read this
         "-I" + this->root_ + "tt_metal/third_party/tt_llk_" + this->arch_name_ + "/llk_lib ";
 
     this->lflags_ = common_flags;


### PR DESCRIPTION
Removing duplicate kernels for easier debugging.
Done by comparing metal ckernels to gs/whb0 llk submodule kernels to determine which to keep.