### PR TITLE
#0: env var to toggle memory reports TT_METAL_ENABLE_MEMORY_REPORTS

### DIFF
--- a/tt_metal/detail/reports/memory_reporter.hpp
+++ b/tt_metal/detail/reports/memory_reporter.hpp
@@ -64,7 +64,7 @@ class MemoryReporter {
     static MemoryReporter& inst();
     static bool enabled();
    private:
-    MemoryReporter(){};
+    MemoryReporter();
     ~MemoryReporter();
     void init_reports();
     static std::atomic<bool> is_enabled_;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -485,9 +485,11 @@ void Program::validate_circular_buffer_region(const Device *device) const {
     for (const CircularBufferAllocator &cb_allocator : this->cb_allocators_) {
         uint64_t cb_region_end = cb_allocator.get_cb_region_end();
         if (cb_region_end > max_l1_size) {
+            detail::DumpDeviceMemoryState(device);
             TT_THROW("Statically allocated circular buffers on core range {} grow to {} B which is beyond max L1 size of {} B", cb_allocator.core_range.str(), cb_region_end, max_l1_size);
         }
         if (lowest_address.has_value() and lowest_address.value() < cb_region_end) {
+            detail::DumpDeviceMemoryState(device);
             TT_THROW("Statically allocated circular buffers in program {} clash with L1 buffers on core range {}. L1 buffer allocated at {} and static circular buffer region ends at {}", this->id, cb_allocator.core_range.str(), lowest_address.value(), cb_region_end);
         }
     }


### PR DESCRIPTION
Automatically dump memory reports on CB alloc errors.