### PR TITLE
Agrebenisan/swq hwq cardinality cleanup

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -771,7 +771,7 @@ TEST_F(CommandQueueFixture, TestRandomizedProgram) {
 
     // This loop caches program and runs
     for (Program& program: programs) {
-        EnqueueProgram(*this->cmd_queue, program, false);
+        EnqueueProgram(this->device_->command_queue(), program, false);
     }
 
     // This loops assumes already cached
@@ -780,11 +780,11 @@ TEST_F(CommandQueueFixture, TestRandomizedProgram) {
         auto rng = std::default_random_engine {};
         std::shuffle(std::begin(programs), std::end(programs), rng);
         for (Program& program: programs) {
-            EnqueueProgram(*this->cmd_queue, program, false);
+            EnqueueProgram(this->device_->command_queue(), program, false);
         }
     }
 
-    Finish(*this->cmd_queue);
+    Finish(this->device_->command_queue());
 }
 
 }  // namespace stress_tests

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -353,7 +353,7 @@ TEST_F(CommandQueueFixture, TestPageSizeTooLarge) {
     // Should throw a host error due to the page size not fitting in the consumer CB
     TestBufferConfig config = {.num_pages = 1024, .page_size = 250880 * 2, .buftype = BufferType::DRAM};
 
-    EXPECT_ANY_THROW(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, *this->cmd_queue, config));
+    EXPECT_ANY_THROW(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(this->device_, this->device_->command_queue(), config));
 }
 
 TEST_F(CommandQueueSingleCardFixture, TestWrapHostHugepageOnEnqueueReadBuffer) {
@@ -620,7 +620,7 @@ TEST_F(CommandQueueFixture, StressWrapTest) {
     BufferStressTestConfig config = {
         .page_size = 4096, .max_num_pages_per_buffer = 2000, .num_iterations = 10000, .num_unique_vectors = 20};
     EXPECT_TRUE(
-        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_wrap(this->device_, *this->cmd_queue, config));
+        local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_wrap(this->device_, this->device_->command_queue(), config));
 }
 
 }  // end namespace stress_tests

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -370,8 +370,7 @@ TEST_F(CommandQueueSingleCardFixture, TestWrapHostHugepageOnEnqueueReadBuffer) {
         uint32_t num_pages = buffer_size / page_size;
 
         TestBufferConfig buf_config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
-        CommandQueue a(device, 0);
-        local_test_functions::test_EnqueueWrap_on_EnqueueReadBuffer(device, a, buf_config);
+        local_test_functions::test_EnqueueWrap_on_EnqueueReadBuffer(device, device->command_queue(), buf_config);
     }
 }
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
@@ -257,7 +257,7 @@ TEST_F(CommandQueueFixture, TestEventsMixedWriteBufferRecordWaitSynchronize) {
 
             // Cannot count on event being populated with async cq, so only check with passthrough.
             if (mode == CommandQueue::CommandQueueMode::PASSTHROUGH) {
-                EXPECT_EQ(event->cq_id, this->cmd_queue->id());
+                EXPECT_EQ(event->cq_id, this->device_->command_queue().id());
                 EXPECT_EQ(event->event_id, cmds_issued_per_cq);
             }
 
@@ -269,7 +269,7 @@ TEST_F(CommandQueueFixture, TestEventsMixedWriteBufferRecordWaitSynchronize) {
                 EventSynchronize(event);
                 // For async, can verify event fields here since previous function already called wait-until-ready.
                 if (mode == CommandQueue::CommandQueueMode::ASYNC) {
-                    EXPECT_EQ(event->cq_id, this->cmd_queue->id());
+                    EXPECT_EQ(event->cq_id, this->device_->command_queue().id());
                     EXPECT_EQ(event->event_id, cmds_issued_per_cq);
                 }
             }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -14,7 +14,6 @@ class CommandQueueFixture : public ::testing::Test {
    protected:
     tt::ARCH arch_;
     Device* device_;
-    std::unique_ptr<CommandQueue> cmd_queue;
     void SetUp() override {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
@@ -26,7 +25,6 @@ class CommandQueueFixture : public ::testing::Test {
         const int device_id = 0;
 
         this->device_ = tt::tt_metal::CreateDevice(device_id);
-        this->cmd_queue = std::make_unique<CommandQueue> ( device_, 0);
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/compute/sfpu/sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/compute/sfpu/sfpu_compute.cpp
@@ -256,7 +256,7 @@ TEST_P(SingleCoreSingleDeviceSfpuParameterizedFixture, SfpuCompute) {
             .sfpu_op = sfpu_op,
             .approx_mode = false};
         log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-        EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     }
 }
 
@@ -304,7 +304,7 @@ TEST_P(SingleCoreSingleDeviceSfpuParameterizedApproxFixture, SfpuCompute) {
             .sfpu_op = sfpu_op,
             .approx_mode = true};
         log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-        EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     }
 }
 INSTANTIATE_TEST_SUITE_P(
@@ -349,21 +349,21 @@ TEST_F(CommandQueueFixture, DISABLED_MultiContinguousCoreSingleTileSfpuApproxCom
 
     test_config.num_tiles = 1;
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
 }
 
 TEST_F(CommandQueueFixture, DISABLED_MultiContinguousCoreMultiTileSfpuApproxCompute) {
@@ -388,21 +388,21 @@ TEST_F(CommandQueueFixture, DISABLED_MultiContinguousCoreMultiTileSfpuApproxComp
     test_config.num_tiles = 4;
 
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
 }
 TEST_F(CommandQueueFixture, DISABLED_AllCoreSingleTileSfpuApproxCompute) {
     unit_tests::compute::sfpu::SfpuConfig test_config = {
@@ -427,21 +427,21 @@ TEST_F(CommandQueueFixture, DISABLED_AllCoreSingleTileSfpuApproxCompute) {
 
     test_config.num_tiles = 1;
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
 }
 TEST_F(CommandQueueFixture, DISABLED_AllCoreMultiTileSfpuApproxCompute) {
     unit_tests::compute::sfpu::SfpuConfig test_config = {
@@ -465,19 +465,19 @@ TEST_F(CommandQueueFixture, DISABLED_AllCoreMultiTileSfpuApproxCompute) {
     test_config.cores = core_set;
     test_config.num_tiles = 4;
     test_config.sfpu_op = "relu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "exponential";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "reciprocal";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "gelu";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "sqrt";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "sigmoid";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "log";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     test_config.sfpu_op = "tanh";
-    EXPECT_TRUE(run_sfpu_all_same_buffer(*this->cmd_queue, test_config));
+    EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
 }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueTrace.cpp
@@ -80,8 +80,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTrace) {
     Buffer input(this->device_, 2048, 2048, BufferType::DRAM);
     Buffer output(this->device_, 2048, 2048, BufferType::DRAM);
 
-    CommandQueue command_queue(this->device_, 0);
-    CommandQueue data_movement_queue(this->device_, 1);
+    CommandQueue& command_queue = this->device_->command_queue(0);
+    CommandQueue& data_movement_queue = this->device_->command_queue(1);
 
     Program simple_program = create_simple_unary_program(input, output);
     vector<uint32_t> input_data(input.size() / sizeof(uint32_t), 0);
@@ -123,8 +123,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTraceLoops) {
     Buffer input(this->device_, 2048, 2048, BufferType::DRAM);
     Buffer output(this->device_, 2048, 2048, BufferType::DRAM);
 
-    CommandQueue command_queue(this->device_, 0);
-    CommandQueue data_movement_queue(this->device_, 1);
+    CommandQueue& command_queue = this->device_->command_queue(0);
+    CommandQueue& data_movement_queue = this->device_->command_queue(1);
 
     Program simple_program = create_simple_unary_program(input, output);
     vector<uint32_t> input_data(input.size() / sizeof(uint32_t), 0);
@@ -178,7 +178,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTraceBenchmark) {
 
     // Single Q for data and commands
     // Keep this queue in passthrough mode for now
-    CommandQueue command_queue(this->device_, 0);
+    CommandQueue& command_queue = this->device_->command_queue(0);
 
     Program simple_program = create_simple_unary_program(input, output);
     vector<uint32_t> input_data(input.size() / sizeof(uint32_t), 0);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -56,8 +56,8 @@ namespace dram_tests {
 
 TEST_F(MultiCommandQueueSingleDeviceFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -68,8 +68,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, WriteOneTileToAllDramBanks) {
         .page_size = 2048,
         .buftype = BufferType::DRAM};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -81,8 +81,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, WriteOneTileAcrossAllDramBanksTwice
         .page_size = 2048,
         .buftype = BufferType::DRAM};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -95,8 +95,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, Sending131072Pages) {
         .page_size = 128,
         .buftype = BufferType::DRAM};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -104,8 +104,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, Sending131072Pages) {
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestNon32BAlignedPageSizeForDram) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -114,8 +114,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestNon32BAlignedPageSizeForDram2) 
     // From stable diffusion read buffer
     TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -127,8 +127,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestPageSizeTooLarge) {
     // Should throw a host error due to the page size not fitting in the consumer CB
     TestBufferConfig config = {.num_pages = 1024, .page_size = 250880 * 2, .buftype = BufferType::DRAM};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_ANY_THROW(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -141,8 +141,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestIssueMultipleReadWriteCommandsF
 
     TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -154,8 +154,8 @@ namespace l1_tests {
 
 TEST_F(MultiCommandQueueSingleDeviceFixture, WriteOneTileToL1Bank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -167,8 +167,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, WriteOneTileToAllL1Banks) {
         .page_size = 2048,
         .buftype = BufferType::L1};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -180,8 +180,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, WriteOneTileToAllL1BanksTwiceRoundR
         .page_size = 2048,
         .buftype = BufferType::L1};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }
@@ -189,8 +189,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, WriteOneTileToAllL1BanksTwiceRoundR
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestNon32BAlignedPageSizeForL1) {
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
-    CommandQueue a(this->device_, 0);
-    CommandQueue b(this->device_, 1);
+    CommandQueue& a = this->device_->command_queue(0);
+    CommandQueue& b = this->device_->command_queue(1);
     vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
     EXPECT_TRUE(local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(this->device_, cqs, config));
 }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -842,7 +842,11 @@ bool Device::close() {
 
     this->active_devices_.deactivate_device(this->id_);
     this->disable_and_clear_program_cache();
+    this->sw_command_queues_.clear();
+    this->hw_command_queues_.clear();
+
     this->initialized_ = false;
+
     return true;
 }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -741,10 +741,10 @@ void Device::initialize_command_queue() {
     using_fast_dispatch = true;
     this->sysmem_manager_ = std::make_unique<SystemMemoryManager>(this->id_, this->num_hw_cqs());
     hw_command_queues_.resize(num_hw_cqs());
-    sw_command_queues_.resize(num_hw_cqs());
     for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
         hw_command_queues_[cq_id] = std::make_unique<HWCommandQueue>(this, cq_id);
-        sw_command_queues_[cq_id] = std::make_unique<CommandQueue>(this, cq_id);
+        // Need to do this since CommandQueue constructor is private
+        sw_command_queues_.push_back(std::unique_ptr<CommandQueue>(new CommandQueue(this, cq_id)));
     }
     if (tt::Cluster::instance().arch() == tt::ARCH::GRAYSKULL) {
         this->compile_command_queue_programs_for_grayskull();
@@ -769,9 +769,9 @@ void Device::initialize_command_queue() {
 void Device::initialize_synchronous_sw_cmd_queue() {
     // Initialize a single Software Command Queue for SD, using passthrough mode.
     // This queue is used for all host bound functions using the Software CQ in SD mode.
-    sw_command_queues_.resize(num_hw_cqs());
     for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
-        sw_command_queues_[cq_id] = std::make_unique<CommandQueue>(this, cq_id);
+        // Need to do this since CommandQueue constructor is private
+        sw_command_queues_.push_back(std::unique_ptr<CommandQueue>(new CommandQueue(this, cq_id)));
         sw_command_queues_[cq_id]->set_mode(CommandQueue::CommandQueueMode::PASSTHROUGH);
     }
 }

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -521,6 +521,7 @@ struct CommandInterface {
 };
 
 class CommandQueue {
+   friend class Device;
    public:
     enum class CommandQueueMode {
         PASSTHROUGH = 0,
@@ -531,9 +532,11 @@ class CommandQueue {
     ~CommandQueue();
 
     // Command queue constructor
+    private:
     CommandQueue(Device* device, uint32_t id, CommandQueueMode mode = CommandQueue::default_mode());
 
     // Trace queue constructor
+    public:
     CommandQueue(Trace* trace);
 
     // Getters for private members


### PR DESCRIPTION
This PR ensures that software queues are owned by device and can only be referenced, not created, by user. This ensures that software queues are always cleaned up at the exact same time as device is.