### PR TITLE
Update cache op optimizations

### DIFF
--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/compute/update_cache.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/compute/update_cache.cpp
@@ -18,9 +18,8 @@ void MAIN {
     constexpr uint32_t out_cb = get_compile_time_arg_val(5);
     constexpr uint32_t num_batched_heads = get_compile_time_arg_val(6);
     constexpr uint32_t Wt = get_compile_time_arg_val(7);
-    constexpr uint32_t u_range = get_compile_time_arg_val(8);
-    constexpr uint32_t granularity = get_compile_time_arg_val(9);
-
+    constexpr uint32_t granularity = get_compile_time_arg_val(8);
+    constexpr uint32_t u_count = get_compile_time_arg_val(9);
 
     pack_untilize_init<Wt>(in_cb, untilized_in_cb);
 
@@ -33,7 +32,7 @@ void MAIN {
         cb_pop_front(in_cb, Wt);
 
         unpack_reconfig_data_format_srca(in_cb, cache_cb);
-        for(uint32_t u = 0; u < u_range / granularity; ++u) {
+        for(uint32_t u = 0; u < u_count; ++u) {
             pack_untilize_init_short<Wt>(cache_cb, untilized_cache_cb);
 
             for (uint32_t g = 0; g < granularity; ++g) {

--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/compute/update_cache.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/compute/update_cache.cpp
@@ -19,8 +19,8 @@ void MAIN {
     constexpr uint32_t num_batched_heads = get_compile_time_arg_val(6);
     constexpr uint32_t Wt = get_compile_time_arg_val(7);
     constexpr uint32_t u_range = get_compile_time_arg_val(8);
+    constexpr uint32_t granularity = get_compile_time_arg_val(9);
 
-    constexpr uint32_t granularity = 2;
 
     pack_untilize_init<Wt>(in_cb, untilized_in_cb);
 
@@ -37,6 +37,7 @@ void MAIN {
             pack_untilize_init_short<Wt>(cache_cb, untilized_cache_cb);
 
             for (uint32_t g = 0; g < granularity; ++g) {
+                // Untilize a block from the cache
                 cb_wait_front(cache_cb, Wt);
                 cb_reserve_back(untilized_cache_cb, Wt);
                 pack_untilize_block<Wt>(cache_cb, 1, untilized_cache_cb);
@@ -51,6 +52,7 @@ void MAIN {
             tilize_init_short(untilized_cache2_cb, Wt);
 
             for (uint32_t g = 0; g < granularity; ++g) {
+                // Wait on writer to update block. Tilize.
                 cb_wait_front(untilized_cache2_cb, Wt);
                 cb_reserve_back(out_cb, Wt);
                 tilize_block(untilized_cache2_cb, Wt, out_cb);

--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -22,15 +22,13 @@ void kernel_main() {
     constexpr bool input_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr uint32_t cache_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t granularity = get_compile_time_arg_val(4);
 
-    // ublocks size defined in tiles
-    constexpr uint32_t onetile = 1;
+
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
     const DataFormat cache_data_format = get_dataformat(cache_cb_id);
     const uint32_t input_tile_bytes = get_tile_size(input_cb_id);
     const DataFormat input_data_format = get_dataformat(input_cb_id);
-
-    constexpr uint32_t granularity = 2;
 
     const InterleavedAddrGenFast<cache_is_dram> s0 = {
         .bank_base_address = cache_addr,

--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
     constexpr uint32_t cache_cb_id = get_compile_time_arg_val(2);
     constexpr uint32_t input_cb_id = get_compile_time_arg_val(3);
     constexpr uint32_t granularity = get_compile_time_arg_val(4);
-
+    constexpr uint32_t u_count = get_compile_time_arg_val(5);
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
     const DataFormat cache_data_format = get_dataformat(cache_cb_id);
@@ -49,7 +49,6 @@ void kernel_main() {
 
     uint32_t cache_id = cache_start_id;
     uint32_t b = batch_start_id;
-    uint32_t u_range = min(static_cast<uint32_t>(32), B);
 
     for (uint32_t h = 0; h < num_batched_heads; ++h) {
         #ifndef INPUT_SHARDED
@@ -63,7 +62,7 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(input_cb_id, Wt);
         #endif
-        for (uint32_t u = 0; u < u_range / granularity; ++u) {
+        for (uint32_t u = 0; u < u_count; ++u) {
             cb_reserve_back(cache_cb_id, Wt * granularity);
             uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
             for (uint32_t g = 0; g < granularity; ++g) {

--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -60,7 +60,6 @@ void kernel_main() {
                 cb_pop_front(untilized_cache_cb_id, Wt); // NEW
             }
 
-
             for (uint32_t g = 0; g < granularity; ++g) {
                 // Wait on compute to tilize an updated block. Write that block to DRAM
                 cb_wait_front(cache_cb_id, Wt);
@@ -75,12 +74,12 @@ void kernel_main() {
                     b = 0;
                     cache_id = cache_id - cache_total_num_tiles + cache_head_num_tiles; // Start of next head
                 }
+                noc_async_writes_flushed();
                 cb_pop_front(cache_cb_id, Wt);
             }
         }
-        // Delay syncing the writes to maximize perf.
-        noc_async_write_barrier();
-
         cb_pop_front(untilized_input_cb_id, Wt);
     }
+    // Delay syncing the writes to maximize perf.
+    noc_async_write_barrier();
 }

--- a/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -26,6 +26,7 @@ void kernel_main() {
     constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(3);
     constexpr uint32_t untilized_input_cb_id = get_compile_time_arg_val(4);
     constexpr uint32_t granularity = get_compile_time_arg_val(5);
+    constexpr uint32_t u_count = get_compile_time_arg_val(6);
 
 
     const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
@@ -39,13 +40,12 @@ void kernel_main() {
 
     uint32_t cache_id = cache_start_id;
     uint32_t b = batch_start_id;
-    uint32_t u_range = min(static_cast<uint32_t>(32), B);
 
     for (uint32_t h = 0; h < num_batched_heads; ++h) {
         cb_wait_front(untilized_input_cb_id, Wt);
         uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(untilized_input_cb_id)) + batch_read_offset;
 
-        for (uint32_t u = 0; u < u_range / granularity; ++u) {
+        for (uint32_t u = 0; u < u_count; ++u) {
             // Operating on a granularity > 1 led to performance improvements.
             // It introduces a double-buffered pipeline between compute and writer.
             for (uint32_t g = 0; g < granularity; ++g) {

--- a/tt_eager/tt_dnn/op_library/update_cache/multi_core/update_cache_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/multi_core/update_cache_op_multi_core.cpp
@@ -75,7 +75,7 @@ operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tens
         num_input_tiles = 2 * Wt; // double buffered
     }
     uint32_t src0_cb_index = CB::c_in0;
-    uint32_t num_cache_tiles = 2 * Wt; // double buffered
+    uint32_t num_cache_tiles = 4 * Wt; // double buffered
     tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(num_cache_tiles * cache_single_tile_size, {{src0_cb_index, cache_cb_data_format}})
 		.set_page_size(src0_cb_index, cache_single_tile_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
@@ -89,7 +89,8 @@ operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tens
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
     uint32_t interm0_cb_index = CB::c_intermed0;
     uint32_t interm1_cb_index = CB::c_intermed1;
-    uint32_t num_interm_tiles = Wt;
+    // uint32_t num_interm_tiles = 2 * Wt;
+    uint32_t num_interm_tiles = 4 * Wt;
     std::map<uint8_t, tt::DataFormat> interim_data_format_spec = {
         {interm0_cb_index, interm_cb_data_format},
         {interm1_cb_index, interm_cb_data_format}
@@ -106,7 +107,10 @@ operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tens
 
     // Output is same tensor as cache input, so cb/tile size is same
     uint32_t output_cb_index = CB::c_out0;
-    uint32_t num_output_tiles = 2 * Wt;
+    // uint32_t num_output_tiles = 2 * Wt;
+
+    // Save full output for single head
+    uint32_t num_output_tiles = B * Wt;
     tt_metal::CircularBufferConfig cb_output_config = tt_metal::CircularBufferConfig(num_output_tiles * cache_single_tile_size, {{output_cb_index, cache_cb_data_format}})
 		.set_page_size(output_cb_index, cache_single_tile_size);
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);

--- a/tt_eager/tt_dnn/op_library/update_cache/single_core/update_cache_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/single_core/update_cache_op_single_core.cpp
@@ -62,7 +62,8 @@ operation::ProgramWithCallbacks update_cache_single_core(const Tensor& cache_ten
 
     uint32_t interm0_cb_index = CB::c_intermed0;
     uint32_t interm1_cb_index = CB::c_intermed1;
-    uint32_t num_interm_tiles = Wt;
+    // uint32_t num_interm_tiles = 2 * Wt;
+    uint32_t num_interm_tiles = 4 * Wt;
     std::map<uint8_t, tt::DataFormat> interim_data_format_spec = {
         {interm0_cb_index, interm_cb_data_format},
         {interm1_cb_index, interm_cb_data_format}
@@ -79,7 +80,7 @@ operation::ProgramWithCallbacks update_cache_single_core(const Tensor& cache_ten
 
     // Output is same tensor as cache input, so cb/tile size is same
     uint32_t output_cb_index = CB::c_out0;
-    uint32_t num_output_tiles = 2 * Wt;
+    uint32_t num_output_tiles = B * Wt;
     tt_metal::CircularBufferConfig cb_output_config = tt_metal::CircularBufferConfig(num_output_tiles * cache_single_tile_size, {{output_cb_index, cache_cb_data_format}})
 		.set_page_size(output_cb_index, cache_single_tile_size);
     auto cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);

--- a/tt_eager/tt_dnn/op_library/update_cache/single_core/update_cache_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/update_cache/single_core/update_cache_op_single_core.cpp
@@ -92,12 +92,15 @@ operation::ProgramWithCallbacks update_cache_single_core(const Tensor& cache_ten
 
     bool src_is_dram = src_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    const uint32_t u_range = min(static_cast<uint32_t>(32), Bcache);
+    const uint32_t u_count = u_range/granularity;
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t) dst_is_dram,
         (std::uint32_t) src_is_dram,
         (std::uint32_t) src0_cb_index,
         (std::uint32_t) src1_cb_index,
-        (std::uint32_t) granularity
+        (std::uint32_t) granularity,
+        (std::uint32_t) u_count
     };
 
 
@@ -107,7 +110,8 @@ operation::ProgramWithCallbacks update_cache_single_core(const Tensor& cache_ten
         (std::uint32_t) interm0_cb_index,
         (std::uint32_t) interm1_cb_index,
         (std::uint32_t) interm2_cb_index,
-        (std::uint32_t) granularity
+        (std::uint32_t) granularity,
+        (std::uint32_t) u_count
     };
 
     tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
@@ -122,7 +126,6 @@ operation::ProgramWithCallbacks update_cache_single_core(const Tensor& cache_ten
         core,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
-    uint32_t u_range = min(static_cast<uint32_t>(32), Bcache);
     vector<uint32_t> compute_kernel_args = {
         src0_cb_index,
         src1_cb_index,
@@ -132,8 +135,8 @@ operation::ProgramWithCallbacks update_cache_single_core(const Tensor& cache_ten
         output_cb_index,
         num_batched_heads,
         Wt,
-        u_range,
-        granularity
+        granularity,
+        u_count
     };
 
     auto eltwise_unary_kernel_id = tt_metal::CreateKernel(

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -40,16 +40,16 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb)
 template <uint32_t block_ct_dim = 8>
 ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb) {
     for (uint32_t r = 0; r < block_rt_dim; ++r) {
-        MATH(( llk_math_wait_for_dest_available<SYNC>() ));
+        MATH(( llk_math_wait_for_dest_available<SyncHalf>() ));
         for (uint32_t c = 0; c < block_ct_dim; ++c) {
             UNPACK(( llk_unpack_A(icb, c) ));
             MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, SyncHalf>(c) ));
         }
-        MATH(( llk_math_dest_section_done<SYNC>() ));
+        MATH(( llk_math_dest_section_done<SyncHalf>() ));
 
         PACK(( llk_packer_wait_for_math_done() ));
         PACK(( llk_pack_untilize<block_ct_dim>(1 /*num_blocks*/, ocb) ));
-        PACK(( llk_pack_dest_section_done<SYNC>() ));
+        PACK(( llk_pack_dest_section_done<SyncHalf>() ));
     }
 }
 
@@ -71,6 +71,14 @@ ALWI void pack_untilize_dst_init_short(uint32_t ocb, uint32_t face_r_dim = 16, u
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
 ALWI void pack_untilize_dst(uint32_t ocb, uint32_t block_rt_dim = 1, uint32_t block_c_index = 0 /* used when full_ct_dim > block_ct_dim*/, uint32_t face_r_dim = 16, uint32_t num_faces = 4) {
     PACK(( llk_pack_untilize<block_ct_dim, full_ct_dim>(block_rt_dim, ocb, face_r_dim, num_faces, block_c_index) ));
+}
+
+template <uint32_t block_ct_dim = 8>
+ALWI void pack_untilize_init_short(uint32_t icb, uint32_t ocb)
+{
+    UNPACK(( llk_unpack_A_init(false, false, icb) )); // init must be after configure
+    MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb) ));
+    pack_untilize_dst_init_short<block_ct_dim>(ocb);
 }
 
 }


### PR DESCRIPTION
Issue: #6193 
This PR improves perf by around 3x. I tested dhead=64 and 128, and both saw the same improvement.

Please review: Should `granularity` be a compile time arg like I did it?

This PR passes sweep tests locally `tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py`

pipeline: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8270299357
