### PR TITLE
#5589: TTNN - l1 loss sweep and unit tests

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -1584,4 +1584,20 @@ op_map = {
         "tt_lib_op": ttnn_ops.upsample,
         "pytorch_op": pytorch_ops.upsample,
     },
+    "ttnn-l1_loss_sum": {
+        "tt_lib_op": ttnn_ops.l1_loss_sum,
+        "pytorch_op": pytorch_ops.l1_loss_sum,
+    },
+    "ttnn-l1_loss": {
+        "tt_lib_op": ttnn_ops.l1_loss,
+        "pytorch_op": pytorch_ops.l1_loss,
+    },
+    "ttnn-l1_loss_sum": {
+        "tt_lib_op": ttnn_ops.l1_loss_sum,
+        "pytorch_op": pytorch_ops.l1_loss_sum,
+    },
+    "ttnn-l1_loss_mean": {
+        "tt_lib_op": ttnn_ops.l1_loss_mean,
+        "pytorch_op": pytorch_ops.l1_loss_mean,
+    },
 }

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1804,3 +1804,22 @@ def upsample(x, *args, scale_factor, **kwargs):
     torch_result = torch_result.permute(0, 2, 3, 1)
 
     return torch_result
+
+
+def l1_loss(x, y, *args, **kwargs):
+    # return torch.nn.functional.upsample(x, scale_factor=2)
+    torch_output_tensor = torch.nn.L1Loss(reduction="none")(x, y)
+    return torch_output_tensor
+
+
+def l1_loss_sum(x, y, *args, **kwargs):
+    # return torch.nn.functional.upsample(x, scale_factor=2)
+    torch_output_tensor = torch.nn.L1Loss(reduction="sum")(x, y)
+
+    return torch_output_tensor
+
+
+def l1_loss_mean(x, y, *args, **kwargs):
+    # return torch.nn.functional.upsample(x, scale_factor=2)
+    torch_output_tensor = torch.nn.L1Loss(reduction="mean")(x, y)
+    return torch_output_tensor

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
+
+
+def run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device):
+    torch.manual_seed(data_seed)
+
+    x = torch.Tensor(size=input_shape[0]).uniform_(-100, 100).to(torch.bfloat16)
+    y = torch.Tensor(size=input_shape[1]).uniform_(-100, 100).to(torch.bfloat16)
+
+    try:
+        # get ref result
+        ref_value = torch.nn.L1Loss(reduction="none")(x, y)
+
+        x = ttnn_ops.setup_ttnn_tensor(x, device, dlayout[0], in_mem_config[0], dtype[0])
+        y = ttnn_ops.setup_ttnn_tensor(y, device, dlayout[1], in_mem_config[1], dtype[1])
+
+        tt_result = ttnn.l1_loss(x, y, loss_mode="none")
+
+        tt_result = ttnn_ops.ttnn_tensor_to_torch(tt_result, output_mem_config)
+
+    except Exception as e:
+        logger.warning(f"Operation execution crashed")
+        raise e
+
+    assert len(tt_result.shape) == len(ref_value.shape)
+    assert tt_result.shape == ref_value.shape
+    assert_with_pcc(ref_value, tt_result, 0.99)
+
+
+test_sweep_args = [
+    (
+        [(224, 128), (224, 128)],
+        [ttnn.bfloat16, ttnn.bfloat16],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
+        [ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG],
+        ttnn.DRAM_MEMORY_CONFIG,
+        15991940,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
+    (test_sweep_args),
+)
+def test_l1_loss(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+    run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss.py
@@ -10,6 +10,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 
 
 def run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device):
@@ -21,7 +22,8 @@ def run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_con
     try:
         # get ref result
         ref_value = torch.nn.L1Loss(reduction="none")(x, y)
-
+        # x = x.unsqueeze(0)
+        # y = y.unsqueeze(0)
         x = ttnn_ops.setup_ttnn_tensor(x, device, dlayout[0], in_mem_config[0], dtype[0])
         y = ttnn_ops.setup_ttnn_tensor(y, device, dlayout[1], in_mem_config[1], dtype[1])
 
@@ -33,9 +35,14 @@ def run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_con
         logger.warning(f"Operation execution crashed")
         raise e
 
-    assert len(tt_result.shape) == len(ref_value.shape)
-    assert tt_result.shape == ref_value.shape
-    assert_with_pcc(ref_value, tt_result, 0.99)
+    tt_result = tt_result.squeeze(0)
+    tt_result = tt_result.squeeze(0)
+
+    success, pcc_value = comp_pcc(ref_value, tt_result)
+    logger.debug(pcc_value)
+    logger.debug(success)
+
+    assert success
 
 
 test_sweep_args = [

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss_mean.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss_mean.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
+
+
+def run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device):
+    torch.manual_seed(data_seed)
+
+    x = torch.Tensor(size=input_shape[0]).uniform_(-100, 100).to(torch.bfloat16)
+    y = torch.Tensor(size=input_shape[1]).uniform_(-100, 100).to(torch.bfloat16)
+
+    try:
+        # get ref result
+        ref_value = torch.nn.L1Loss(reduction="mean")(x, y)
+
+        x = ttnn_ops.setup_ttnn_tensor(x, device, dlayout[0], in_mem_config[0], dtype[0])
+        y = ttnn_ops.setup_ttnn_tensor(y, device, dlayout[1], in_mem_config[1], dtype[1])
+
+        tt_result = ttnn.l1_loss(x, y, loss_mode="mean")
+
+        tt_result = ttnn_ops.ttnn_tensor_to_torch(tt_result, output_mem_config)
+
+    except Exception as e:
+        logger.warning(f"Operation execution crashed")
+        raise e
+
+    assert len(tt_result.shape) == len(ref_value.shape)
+    assert tt_result.shape == ref_value.shape
+    assert_with_pcc(ref_value, tt_result, 0.99)
+
+
+test_sweep_args = [
+    (
+        [(224, 128), (224, 128)],
+        [ttnn.bfloat16, ttnn.bfloat16],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
+        [ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG],
+        ttnn.DRAM_MEMORY_CONFIG,
+        15991940,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
+    (test_sweep_args),
+)
+def test_l1_loss(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+    run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss_mean.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss_mean.py
@@ -10,6 +10,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 
 
 def run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device):
@@ -21,7 +22,8 @@ def run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_con
     try:
         # get ref result
         ref_value = torch.nn.L1Loss(reduction="mean")(x, y)
-
+        # x = x.unsqueeze(0)
+        # y = y.unsqueeze(0)
         x = ttnn_ops.setup_ttnn_tensor(x, device, dlayout[0], in_mem_config[0], dtype[0])
         y = ttnn_ops.setup_ttnn_tensor(y, device, dlayout[1], in_mem_config[1], dtype[1])
 
@@ -33,9 +35,14 @@ def run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_con
         logger.warning(f"Operation execution crashed")
         raise e
 
-    assert len(tt_result.shape) == len(ref_value.shape)
-    assert tt_result.shape == ref_value.shape
-    assert_with_pcc(ref_value, tt_result, 0.99)
+    tt_result = tt_result.squeeze(0)
+    tt_result = tt_result.squeeze(0)
+
+    success, pcc_value = comp_pcc(ref_value, tt_result)
+    logger.debug(pcc_value)
+    logger.debug(success)
+
+    assert success
 
 
 test_sweep_args = [

--- a/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss_sum.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/wormhole/test_l1_loss_sum.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import random
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
+
+
+def run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, output_mem_config, data_seed, device):
+    torch.manual_seed(data_seed)
+
+    x = torch.Tensor(size=input_shape[0]).uniform_(-100, 100).to(torch.bfloat16)
+    y = torch.Tensor(size=input_shape[1]).uniform_(-100, 100).to(torch.bfloat16)
+
+    try:
+        # get ref result
+        ref_value = torch.nn.L1Loss(reduction="sum")(x, y)
+
+        x = ttnn_ops.setup_ttnn_tensor(x, device, dlayout[0], in_mem_config[0], dtype[0])
+        y = ttnn_ops.setup_ttnn_tensor(y, device, dlayout[1], in_mem_config[1], dtype[1])
+
+        tt_result = ttnn.l1_loss(x, y, loss_mode="sum")
+
+        tt_result = ttnn_ops.ttnn_tensor_to_torch(tt_result, output_mem_config)
+
+    except Exception as e:
+        logger.warning(f"Operation execution crashed")
+        raise e
+
+    assert len(tt_result.shape) == len(ref_value.shape)
+    assert tt_result.shape == ref_value.shape
+    assert_with_pcc(ref_value, tt_result, 0.99)
+
+
+test_sweep_args = [
+    (
+        [(224, 128), (224, 128)],
+        [ttnn.bfloat16, ttnn.bfloat16],
+        [ttnn.TILE_LAYOUT, ttnn.TILE_LAYOUT],
+        [ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG],
+        ttnn.DRAM_MEMORY_CONFIG,
+        15991940,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
+    (test_sweep_args),
+)
+def test_l1_loss(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
+    run_l1_loss_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_l1_loss_mean_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_l1_loss_mean_test.yaml
@@ -1,0 +1,27 @@
+---
+test-list:
+  - ttnn-l1_loss_mean:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: l1_loss_mean_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_l1_loss_sum_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_l1_loss_sum_test.yaml
@@ -1,0 +1,27 @@
+---
+test-list:
+  - ttnn-l1_loss_sum:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: l1_loss_sum_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_l1_loss_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_l1_loss_test.yaml
@@ -1,0 +1,27 @@
+---
+test-list:
+  - ttnn-l1_loss:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: l1_loss_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_l1_loss_mean_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_l1_loss_mean_test.yaml
@@ -1,0 +1,27 @@
+---
+test-list:
+  - ttnn-l1_loss_mean:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: l1_loss_mean_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_l1_loss_sum_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_l1_loss_sum_test.yaml
@@ -1,0 +1,27 @@
+---
+test-list:
+  - ttnn-l1_loss_sum:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: l1_loss_sum_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_l1_loss_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_l1_loss_test.yaml
@@ -1,0 +1,27 @@
+---
+test-list:
+  - ttnn-l1_loss:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: l1_loss_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -2160,3 +2160,69 @@ def upsample(
     t1 = ttnn.upsample(t0, scale_factor=scale_factor)
 
     return ttnn_tensor_to_torch(t1)
+
+
+def l1_loss_sum(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    x = x.unsqueeze(0)
+    y = y.unsqueeze(0)
+
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttnn.l1_loss(t0, t1, loss_mode="sum", memory_config=memory_config_to_ttnn(output_mem_config))
+
+    return ttnn_tensor_to_torch(t1)
+
+
+def l1_loss_mean(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    x = x.unsqueeze(0)
+    y = y.unsqueeze(0)
+
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttnn.l1_loss(t0, t1, loss_mode="mean", memory_config=memory_config_to_ttnn(output_mem_config))
+
+    return ttnn_tensor_to_torch(t1)
+
+
+def l1_loss(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    x = x.unsqueeze(0)
+    y = y.unsqueeze(0)
+
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttnn.l1_loss(t0, t1, loss_mode="none", memory_config=memory_config_to_ttnn(output_mem_config))
+
+    return ttnn_tensor_to_torch(t1)


### PR DESCRIPTION
YAML files and unit tests for l1 loss in case of three reduction variants
- none
- sum
- mean