### PR TITLE
#5733: ttnn/cpp: run_operation for multi-device

### DIFF
--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -5,9 +5,10 @@
 import torch
 import typing
 import pytest
-import tt_lib as ttl
 import ttnn
 from loguru import logger
+from tests.ttnn.utils_for_testing import assert_with_pcc
+import transformers
 
 
 #######
@@ -116,3 +117,131 @@ def test_ttnn_multi_device_all_gather(pcie_device_mesh):
     for device_tensor in device_tensors:
         device_tensor_torch = ttnn.to_torch(device_tensor)
         assert torch.all(device_tensor_torch == full_tensor)
+
+
+def test_multi_device_single_op_unary(pcie_device_mesh):
+    """Multidevice API test: Running tensor-parallel multi-device single-op unary"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor
+
+    torch_input_tensor = torch.rand((1, 1, 32, 128), dtype=torch.bfloat16)
+    torch_output_golden = torch.nn.functional.gelu(torch_input_tensor)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3),
+        device=pcie_device_mesh,
+    )
+    ttnn_output_tensor = ttnn.gelu(ttnn_input_tensor)
+
+    ttnn_torch_output_tensor = ttnn.to_torch(
+        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=3)
+    )
+    assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.999)
+
+
+def test_multi_device_single_op_binary(pcie_device_mesh):
+    """Multidevice API test: Running tensor-parallel multi-device single-op binary"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor
+
+    torch_input_a_tensor = torch.rand((1, 1, 32, 128), dtype=torch.bfloat16)
+    torch_input_b_tensor = torch.rand((1, 1, 32, 128), dtype=torch.bfloat16)
+    torch_output_golden = torch_input_a_tensor + torch_input_b_tensor
+
+    ttnn_input_a_tensor = ttnn.from_torch(
+        torch_input_a_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=pcie_device_mesh,
+        mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3),
+    )
+    ttnn_input_b_tensor = ttnn.from_torch(
+        torch_input_b_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=pcie_device_mesh,
+        mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3),
+    )
+    ttnn_output_tensor = ttnn.add(ttnn_input_a_tensor, ttnn_input_b_tensor)
+
+    ttnn_torch_output_tensor = ttnn.to_torch(
+        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=3)
+    )
+    assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.999)
+
+
+def test_multi_device_multi_op(pcie_device_mesh):
+    """Multidevice API test: Running tensor-parallel multi-device multi-op"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor
+
+    torch_input_tensor = torch.rand((1, 1, 32, 128), dtype=torch.bfloat16)
+    torch_output_golden = torch.nn.functional.gelu(torch_input_tensor)
+    torch_output_golden = torch.exp(torch_output_golden)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3),
+        device=pcie_device_mesh,
+    )
+    ttnn_gelu_output = ttnn.gelu(ttnn_input_tensor)
+    ttnn_output_tensor = ttnn.exp(ttnn_gelu_output)
+
+    ttnn_torch_output_tensor = ttnn.to_torch(
+        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=3)
+    )
+    assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.999)
+
+
+def test_multi_device_data_parallel_matmul_op(pcie_device_mesh):
+    """Multidevice API: Data Parallel on matmul"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
+
+    torch_input_a_tensor = torch.rand((4, 1, 32, 128), dtype=torch.bfloat16)
+    torch_input_b_tensor = torch.rand((1, 1, 128, 32), dtype=torch.bfloat16)
+    torch_output_golden = torch_input_a_tensor @ torch_input_b_tensor
+
+    ttnn_input_a_tensor = ttnn.from_torch(
+        torch_input_a_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=pcie_device_mesh,
+        mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0),
+    )
+    ttnn_input_b_tensor = ttnn.from_torch(
+        torch_input_b_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=pcie_device_mesh,
+        mesh_mapper=ReplicateTensorToMesh(pcie_device_mesh),
+    )
+    ttnn_output_tensor = ttnn_input_a_tensor @ ttnn_input_b_tensor
+
+    ttnn_torch_output_tensor = ttnn.to_torch(
+        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+    )
+    assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.997)
+
+
+def test_multi_device_data_parallel_matmul_op(pcie_device_mesh):
+    """Multidevice API: Data Parallel on matmul"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
+
+    torch_input_a_tensor = torch.rand((4, 1, 32, 128), dtype=torch.bfloat16)
+    torch_input_b_tensor = torch.rand((1, 1, 128, 32), dtype=torch.bfloat16)
+    torch_output_golden = torch_input_a_tensor @ torch_input_b_tensor
+
+    ttnn_input_a_tensor = ttnn.from_torch(
+        torch_input_a_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=pcie_device_mesh,
+        mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0),
+    )
+    ttnn_input_b_tensor = ttnn.from_torch(
+        torch_input_b_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=pcie_device_mesh,
+        mesh_mapper=ReplicateTensorToMesh(pcie_device_mesh),
+    )
+    ttnn_output_tensor = ttnn_input_a_tensor @ ttnn_input_b_tensor
+
+    ttnn_torch_output_tensor = ttnn.to_torch(
+        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+    )
+    assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.997)

--- a/tt_eager/tensor/tensor_utils.cpp
+++ b/tt_eager/tensor/tensor_utils.cpp
@@ -189,6 +189,35 @@ const Shape infer_dims_for_reshape(int N, int C, int H, int W, uint32_t old_volu
   }
 
   bool is_device_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::DEVICE; }
+
+Tensor get_device_tensor(const Device* device, const Tensor& multi_device_tensor) {
+    const auto& tensor_storage = std::get<MultiDeviceStorage>(multi_device_tensor.get_storage());
+    for (const auto& device_buffer : tensor_storage.buffers) {
+        if (device_buffer->device() == device) {
+            return Tensor{
+                DeviceStorage{device_buffer},
+                multi_device_tensor.get_legacy_shape(),
+                multi_device_tensor.get_dtype(),
+                multi_device_tensor.get_layout()
+            };
+        }
+    }
+    TT_THROW("Device not found in multi-device tensor");
+}
+
+std::vector<Device*> get_devices(const Tensor& tensor) {
+    std::vector<Device*> devices;
+    if (tensor.storage_type() == tt::tt_metal::StorageType::MULTI_DEVICE) {
+        const auto& tensor_storage = std::get<tt::tt_metal::MultiDeviceStorage>(tensor.get_storage());
+        for (int i = 0; i < tensor_storage.buffers.size(); ++i) {
+            devices.push_back(tensor_storage.buffers[i]->device());
+        }
+        return devices;
+    } else {
+        TT_THROW("Tensor is not a multi-device tensor");
+    }
+}
+
 }
 
 }

--- a/tt_eager/tensor/tensor_utils.hpp
+++ b/tt_eager/tensor/tensor_utils.hpp
@@ -47,6 +47,42 @@ namespace tt_metal {
 
    bool is_cpu_tensor(const Tensor& tensor);
    bool is_device_tensor(const Tensor& tensor);
-}
 
+// Given a multi-device tensor and a device, returns the tensor on the given device.
+Tensor get_device_tensor(const Device* device, const Tensor& multi_device_tensor);
+
+// Given a multi-device tensor, return all the devices it is mapped to.
+std::vector<Device*> get_devices(const Tensor& multi_device_tensor);
+
+template<typename TensorContainer>
+auto get_device_tensors(Device* device, const TensorContainer& input_tensors) {
+    // Could be Tensor, const Tensor, std::optional<Tensor>, or std::optional<const Tensor>
+    using ValueType = typename TensorContainer::value_type;
+
+    // We need a way to extract the underlying Tensor type (const or non-const) from ValueType
+    // and to decide whether we are dealing with an optional type.
+    using IsOptional = std::conditional_t<std::is_same_v<ValueType, std::optional<Tensor>> || std::is_same_v<ValueType, std::optional<const Tensor>>,
+                                        std::true_type, std::false_type>;
+    using TensorType = std::conditional_t<std::is_same_v<ValueType, std::optional<Tensor>> || std::is_same_v<ValueType, Tensor>,
+                                        Tensor, const Tensor>;
+
+    // Result container type adjustment based on input type
+    using ResultType = std::conditional_t<IsOptional::value, std::optional<TensorType>, TensorType>;
+    std::vector<ResultType> transformed_tensors;
+
+    for (const auto& tensor : input_tensors) {
+        if constexpr (IsOptional::value) {
+            if (tensor.has_value()) {
+                transformed_tensors.push_back(get_device_tensor(device, *tensor));
+            } else {
+                transformed_tensors.push_back(std::nullopt);
+            }
+        } else {
+            transformed_tensors.push_back(get_device_tensor(device, tensor));
+        }
+    }
+    return transformed_tensors;
 }
+} // namespace tt_metal
+
+} // namespace tt

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -19,6 +19,27 @@ inline bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageT
     return tensor.storage_type() == storage_type;
 }
 
+inline bool is_tensor_on_device(const ttnn::Tensor& tensor) {
+    return tensor.storage_type() == StorageType::DEVICE;
+}
+
+inline bool is_tensor_on_multi_device(const ttnn::Tensor& tensor) {
+    return tensor.storage_type() == StorageType::MULTI_DEVICE;
+}
+
+inline bool is_tensor_on_device_or_multidevice(const ttnn::Tensor& tensor) {
+    return is_tensor_on_device(tensor) or is_tensor_on_multi_device(tensor);
+}
+
+inline bool any_tensor_on_multi_device(const std::vector<ttnn::Tensor>& tensors) {
+    for (const auto& tensor : tensors) {
+        if (is_tensor_on_multi_device(tensor)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 inline void set_printoptions(const std::string& profile) {
     tt::tt_metal::tensor_impl::TTNN_TENSOR_PRINT_PROFILE =
         magic_enum::enum_cast<tt::tt_metal::tensor_impl::TensorPrintProfile>(profile, [](char lhs, char rhs) {
@@ -29,5 +50,9 @@ inline void set_printoptions(const std::string& profile) {
 }  // namespace core
 
 using core::has_storage_type_of;
+using core::is_tensor_on_device;
+using core::is_tensor_on_multi_device;
+using core::is_tensor_on_device_or_multidevice;
+using core::any_tensor_on_multi_device;
 using core::set_printoptions;
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/validation.hpp
+++ b/ttnn/cpp/ttnn/validation.hpp
@@ -57,7 +57,7 @@ void validate_input_tensor(
     if (input_schema.can_be_on_device and input_schema.can_be_on_cpu) {
         // pass
     } else if (input_schema.can_be_on_device) {
-        if (not ttnn::has_storage_type_of(tensor, ttnn::DEVICE_STORAGE_TYPE)) {
+        if (not ttnn::is_tensor_on_device_or_multidevice(tensor)) {
             TT_THROW("{}: Tensor must be on device!", operation_name);
         }
     } else if (input_schema.can_be_on_cpu) {


### PR DESCRIPTION
This implements and adds basic unit tests for:
- Multi-Device Single-Op Tests #5735
- Multi-Device Subgraph-Level Tests #5736
- Multi-Device Sharding Tests #5737
- Multi-Device Data Parallel Tests #5738