### PR TITLE
#6363: Fix so remote does not try direct write to completion queue

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_prefetcher.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetcher.cpp
@@ -235,7 +235,7 @@ void kernel_main() {
             uint32_t num_pages_to_read = pull_and_push_cb_num_pages / 2;
 
             if (is_program) {
-                program_event_buffer.push_event(event);
+                program_event_buffer.push_event<write_to_completion_queue>(event);
                 update_producer_consumer_sync_semaphores(my_noc_encoding, dispatch_noc_encoding, dispatch_semaphore_addr, get_semaphore(0));
                 for (uint32_t i = 0; i < num_buffer_transfers; i++) {
                     uint32_t num_pages_in_transfer = program_pull_and_push_config<PullAndRelayType::BUFFER, PullAndRelayType::CIRCULAR_BUFFER>(
@@ -418,7 +418,7 @@ void kernel_main() {
                 // if there is any program data then we need to read it in from DST CB and send it to dispatcher core CB
                 relay_command<command_start_addr, L1_UNRESERVED_BASE, 0>(db_dispatch_cmd_slot_switch, dispatch_noc_encoding);
                 db_dispatch_cmd_slot_switch = not db_dispatch_cmd_slot_switch;
-                program_event_buffer.push_event(event);
+                program_event_buffer.push_event<write_to_completion_queue>(event);
                 update_producer_consumer_sync_semaphores(my_noc_encoding, dispatch_noc_encoding, dispatch_semaphore_addr, get_semaphore(0));
 
                 volatile tt_l1_ptr uint32_t* buffer_transfer_ptr = command_ptr + DeviceCommand::NUM_ENTRIES_IN_COMMAND_HEADER;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetcher.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetcher.hpp
@@ -312,12 +312,13 @@ class ProgramEventBuffer {
         this->push_noc_encoding = push_noc_encoding;
     }
 
+    template <bool write_to_completion_queue>
     void push_event(uint32_t event) {
         if (this->num_events == 2) {
             volatile tt_l1_ptr uint32_t *dispatch_semaphore_addr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(2));   // Should be initialized to num commands slots on dispatch core by host
             wait_consumer_idle<2>(dispatch_semaphore_addr);
-            this->write_events<true>();
+            this->write_events<write_to_completion_queue>();
             this->num_events = 0;
         }
 


### PR DESCRIPTION
Small but important fix. We had hardcoded 'write to completion queue' even in remote path.