### PR TITLE
#6424: Split TestPrintEthCores into two kernels as workaround.

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp
@@ -22,7 +22,8 @@ void kernel_main() {
 
     DPRINT_DATA0(
         DPRINT << "Test Debug Print: Data0" << ENDL();
-        print_test_data();
+        print_test_data_basic_types();
+        print_test_data_modifiers();
         // Let the next core (PACK) know to start printing.
         DPRINT << RAISE{1};
     );

--- a/tests/tt_metal/tt_metal/test_kernels/misc/erisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/erisc_print.cpp
@@ -11,5 +11,5 @@
 
 void kernel_main() {
     DPRINT << "Test Debug Print: ERISC" << ENDL();
-    print_test_data();
+    print_test_data_basic_types();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/erisc_print_modifiers.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/erisc_print_modifiers.cpp
@@ -2,14 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "debug/dprint.h"
+#include "dataflow_api.h"
 #include "debug/dprint_test_common.h"
 
 /*
- * Test kernel that wait for a signal that never raises.
+ * Test printing from a kernel running on BRISC.
 */
 
 void kernel_main() {
-    DPRINT << WAIT{1};
     print_test_data_modifiers();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/ncrisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/ncrisc_print.cpp
@@ -14,6 +14,7 @@ void kernel_main() {
         // Wait for previous core (UNPACK) to finish printing.
         DPRINT << WAIT{4};
         DPRINT << "Test Debug Print: Data1" << ENDL();
-        print_test_data();
+        print_test_data_basic_types();
+        print_test_data_modifiers();
     );
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/trisc_print.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/trisc_print.cpp
@@ -14,7 +14,8 @@ void MAIN {
         // Wait for previous core (DATA0) to finish printing.
         DPRINT << WAIT{1};
         DPRINT << "Test Debug Print: Unpack" << ENDL();
-        print_test_data();
+        print_test_data_basic_types();
+        print_test_data_modifiers();
         // Let the next core (MATH) know to start printing.
         DPRINT << RAISE{2};
     );
@@ -22,7 +23,8 @@ void MAIN {
         // Wait for previous core (DATA0) to finish printing.
         DPRINT << WAIT{2};
         DPRINT << "Test Debug Print: Math" << ENDL();
-        print_test_data();
+        print_test_data_basic_types();
+        print_test_data_modifiers();
         // Let the next core (PACK) know to start printing.
         DPRINT << RAISE{3};
     );
@@ -30,7 +32,8 @@ void MAIN {
         // Wait for previous core (DATA0) to finish printing.
         DPRINT << WAIT{3};
         DPRINT << "Test Debug Print: Pack" << ENDL();
-        print_test_data();
+        print_test_data_basic_types();
+        print_test_data_modifiers();
         // Let the next core (DATA0) know to start printing.
         DPRINT << RAISE{4};
     );

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
@@ -38,7 +38,7 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
         Program program = Program();
 
         // Create the kernel
-        // TODO: When #5566 is implemented combine these kernels again.
+        // TODO: When #6424 is fixed combine these kernels again.
         KernelHandle erisc_kernel_id = CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/misc/erisc_print.cpp",
@@ -48,10 +48,21 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
         // Run the program
         log_info(
             tt::LogTest,
-            "Running print test on device {}, eth core logical={}/physical={}",
+            "Running print test on eth core {}:({},{})",
             device->id(),
-            core.str(),
-            device->ethernet_core_from_logical_core(core).str()
+            core.x,
+            core.y
+        );
+        fixture->RunProgram(device, program);
+
+        program = Program();
+        erisc_kernel_id = CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/erisc_print_modifiers.cpp",
+            core,
+            tt_metal::EthernetConfig{
+                .noc = tt_metal::NOC::NOC_0
+            }
         );
         fixture->RunProgram(device, program);
 
@@ -69,8 +80,6 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
 }
 
 TEST_F(DPrintFixture, TestPrintEthCores) {
-    // Skip test until #6378 is fixed
-    GTEST_SKIP();
     for (Device* device : this->devices_) {
         // Skip if no ethernet cores on this device
         if (device->get_active_ethernet_cores(true).size() == 0) {

--- a/tt_metal/hw/inc/debug/dprint_test_common.h
+++ b/tt_metal/hw/inc/debug/dprint_test_common.h
@@ -5,7 +5,8 @@
 #include "debug/dprint.h"
 
 // A helper function to exercise print features.
-inline void print_test_data() {
+// TODO: When #5566 is implemented combine these functions again.
+inline void print_test_data_basic_types() {
     uint8_t  my_uint8  = 101;
     uint16_t my_uint16 = 555;
     uint32_t my_uint32 = 123456;
@@ -18,6 +19,11 @@ inline void print_test_data() {
     DPRINT << "Basic Types:\n" << 101 << -1.6180034f << '@' << BF16(0x3dfb) << ENDL();
     DPRINT << my_uint8 << my_uint16 << my_uint32 << my_uint64 << ENDL();
     DPRINT << my_int8 << my_int16 << my_int32 << my_int64 << ENDL();
+}
+
+inline void print_test_data_modifiers() {
+    uint32_t my_uint32 = 123456;
+    float my_float = 3.14159f;
     DPRINT << "SETPRECISION/FIXED/DEFAULTFLOAT:\n";
     DPRINT << SETPRECISION(5) << my_float << ENDL();
     DPRINT << SETPRECISION(9) << my_float << ENDL();


### PR DESCRIPTION
Story here is that we fixed the issue in one commit from my last PR. I then proceeded to do some test cleanup, which perturbed the kernel enough to expose the issue again (seems like our fix only partially covers the original issue). New issue with a better description here: #6424 

I'll need to consult Paul for help on the full fix (seems build related), but for now undo the test cleanup I added here so the test can run on CI.

CI currently running: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8289019164
I did check on VM50 that the test passes on exactly the same commit that CI is running on here.