### PR TITLE
#6364: Autocomplete for pybinded types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ src/firmware/riscv/targets/erisc/src/eth_routing_v2.cpp
 .ipynb_checkpoints/
 
 .envrc
+
+# tt_lib and _ttnn stubs
+*.pyi

--- a/tt_metal/python_env/module.mk
+++ b/tt_metal/python_env/module.mk
@@ -33,3 +33,7 @@ endif
 	echo "Installing editable dev version of ttnn package..."
 	bash -c "source $(PYTHON_ENV)/bin/activate && pip install -e ttnn"
 	touch $@
+	echo "Generating stubs..."
+	bash -c "source $(PYTHON_ENV)/bin/activate && stubgen -m tt_lib -m tt_lib.device -m tt_lib.profiler -m tt_lib.tensor -m tt_lib.dtx -m tt_lib.operations -m tt_lib.operations.primary -m tt_lib.operations.primary.transformers -o tt_eager"
+	bash -c "source $(PYTHON_ENV)/bin/activate && stubgen -p ttnn._ttnn -o ttnn"
+	bash -c "sed -i 's/\._C/tt_lib/g' tt_eager/tt_lib/__init__.pyi"

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -11,6 +11,7 @@ black==23.10.1
 build==0.10.0
 twine==4.0.2
 yamllint==1.32.0
+mypy==1.9.0
 
 # For docs
 -r ../../docs/requirements-docs.txt


### PR DESCRIPTION
Add python stubs for pybinded types to enable
autocomplete support in vscodew with pylance.

New make target 'make stubs' is add which
generates the stubs.

Two packages are covered tt_lib and ttnn._ttnn.
ttnn._ttnn works out of the box after stubs
generation.

For tt_lib I had to do one manual hack in
tt_eager/tt_lib/__init__.py to make it work.
'from _C import' was manually replaced with
'from tt_lib import ...'