### PR TITLE
FD2.0 CQ_DISPATCH_CMD_WRITE_PAGED initial implementation and tests

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -277,7 +277,7 @@ int main(int argc, char **argv) {
             "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp",
             {spoof_prefetch_core},
             tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = spoof_prefetch_compile_args,
                 .defines = defines
@@ -292,7 +292,7 @@ int main(int argc, char **argv) {
             "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
             {dispatch_core},
             tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = dispatch_compile_args,
                 .defines = defines

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -845,7 +845,7 @@ int main(int argc, char **argv) {
             "tt_metal/impl/dispatch/kernels/cq_prefetch_hd.cpp",
             {prefetch_core},
             tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = prefetch_compile_args,
                 .defines = defines
@@ -857,7 +857,7 @@ int main(int argc, char **argv) {
             "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
             {dispatch_core},
             tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = dispatch_compile_args,
                 .defines = defines


### PR DESCRIPTION
Initial merge containing:

1. Dispatcher support for `CQ_DISPATCH_CMD_WRITE_PAGED` cmd (l1 and DRAM variant)
2. Dispatcher test/infra updates (mostly new functions for paged write handling) for L1, DRAM and perf testing.
3. A script for bunch of interesting testcases I've tried so far crossed with DRAM/L1, for easy verif, and comparisons (since these tests are not yet in CI, will work on that later).

I made the kernel changes last Tuesday and then had been spending time to figure out how to test it via test_dispatcher. So far the first attempt is passing everything I've thrown at it!

More testing WIP (test_prefetcher.cpp end-to-end paged-write + read w/ comparison, and Grayskull) will likely include in folowup PR.   Want to get this in to unblock `EnqueueWriteBuffer` bringup. 

**Passing Post-Commit Run (nothing in post-commit that uses this yet):**

https://github.com/tenstorrent-metal/tt-metal/actions/runs/8319432987
