### PR TITLE
#6361: Update ttnn repeat to use correct shapes when formatting output

### DIFF
--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -502,7 +502,7 @@ def _repeat_validate_input_tensors(operation_name, input_tensor, *args, **kwargs
         input_tensor,
         ranks=(2, 3, 4),
         dtypes=(ttnn.bfloat16, ttnn.bfloat8_b, ttnn.uint16, ttnn.uint32),
-        layouts=(ttnn.TILE_LAYOUT,),
+        layouts=(ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
         can_be_on_device=True,
         can_be_on_cpu=True,
     )
@@ -546,11 +546,11 @@ def repeat(
     device = input_tensor.device()
     layout = input_tensor.layout
     rank = len(input_tensor.shape)
-    if dtype == ttnn.bfloat16 and rank == 4:
+    if rank == 4:
         output_tensor = ttl.tensor.repeat(input_tensor, shape)
         *batch, _, _ = output_tensor.shape
-        *_, h, w = input_tensor.shape
-        *_, padded_h, padded_w = input_tensor.shape.with_tile_padding()
+        *_, h, w = output_tensor.shape
+        *_, padded_h, padded_w = output_tensor.shape.with_tile_padding()
 
         output_tensor = ttnn.reshape(output_tensor, shape=ttnn.Shape(batch + [h, w], batch + [padded_h, padded_w]))
         return output_tensor


### PR DESCRIPTION
@arakhmati I'm not too familiar with everything that is expected/set up with ttnn, but for the tt_lib version of the op the only restriction is that the byte size of the last dim is aligned if we are trying to repeat on the last dim.

Is it correct for me to remove the dtype restriction if tt_lib version supports any dtype? Not sure how/if we can make ttnn only fallback for the specific alignment case. Other potential issue with removing the restrictions is that ttnn is doing the pad/reshape to tile afterwards so not sure if that's affected.