### PR TITLE
#6405: Add backward support for complex recip

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -1058,6 +1058,8 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.unary_remainder_bw
 
+.. autofunction:: tt_lib.tensor.complex_recip_bw
+
 .. autofunction:: tt_lib.tensor.imag_bw
 
 .. autofunction:: tt_lib.tensor.real_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_recip.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_recip.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results
+from models.utility_functions import (
+    skip_for_wormhole_b0,
+)
+
+
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_complex_recip(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (-110, 90), (-100, 70))
+    in_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-50, 50), (-60, 60))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=-1)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.complex_recip_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.reciprocal(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+# zero input complex tensor
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@skip_for_wormhole_b0()
+def test_bw_complex_recip_zero_inp(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (0, 0), (0, 0))
+    in_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-50, 50), (-60, 60))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=-1)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.complex_recip_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.reciprocal(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+# zero grad complex tensor
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_complex_recip_zero_grad(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (-50, 50), (-60, 60))
+    in_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (0, 0), (0, 0))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=-1)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.complex_recip_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.reciprocal(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_complex_recip_zero_inp_real(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (0, 0), (-100, 70))
+    in_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-110, 90), (-100, 70))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=-1)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.complex_recip_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.reciprocal(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_complex_recip_zero_inp_imag(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (-100, 70), (0, 0))
+    in_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-110, 90), (-100, 70))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=-1)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.complex_recip_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.reciprocal(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_complex_recip_zero_grad_real(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (-110, 90), (-100, 70))
+    in_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (0, 0), (-100, 70))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=-1)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.complex_recip_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.reciprocal(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_complex_recip_zero_grad_imag(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (-110, 90), (-100, 70))
+    in_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-100, 70), (0, 0))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=-1)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.complex_recip_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.reciprocal(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -252,6 +252,8 @@ std::vector<Tensor> unary_remainder_bw(const Tensor& grad, const Tensor& input, 
 
 std::vector<Tensor> conj_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> complex_recip_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 std::vector<Tensor> imag_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> real_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -43,6 +43,22 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+    m_tensor.def("complex_recip_bw", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&complex_recip_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for reciprocal of complex tensor ``input`` with given ``grad``
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
     m_tensor.def("unary_mul_bw", &tt::tt_metal::unary_mul_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for multiplication with given ``grad`` and ``scalar``


### PR DESCRIPTION
Add backward support for complex reciprocal for Type 1 complex tensor
Part of primary issue #6443 
CI test: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8609432858
https://github.com/tenstorrent/tt-metal/actions/runs/8783233324