### PR TITLE
#6382: Add backward support for complex add and sub

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_add.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results
+
+
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "alpha",
+    [-2, 0.9, 5, 10],
+)
+def test_bw_cplx_add(input_shapes, alpha, device):
+    in_data = random_complex_tensor(input_shapes, (-110, 100), (-80, 80))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shapes, (-90, 90), (-70, 70))
+    other_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-50, 50), (-20, 60))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=3)
+    other_data_cplx = torch.cat((other_data.real, other_data.imag), dim=3)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    other_tensor = (
+        tt_lib.tensor.Tensor(other_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=3)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    tt_output_tensor_on_device = tt_lib.tensor.complex_add_bw(grad_tensor, input_tensor, other_tensor, alpha=alpha)
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    pyt_y = torch.add(in_data, other_data, alpha=alpha)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_self_real = torch.real(in_data.grad)
+    grad_self_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+    golden_tensor = [
+        torch.cat((grad_self_real, grad_self_imag), dim=3),
+        torch.cat((grad_other_real, grad_other_imag), dim=3),
+    ]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_sub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_sub.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results
+
+
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "alpha",
+    [-2, 0.5, 5, 10],
+)
+def test_bw_cplx_sub(input_shapes, alpha, device):
+    in_data = random_complex_tensor(input_shapes, (-110, 100), (-80, 80))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shapes, (-90, 90), (-70, 70))
+    other_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-50, 50), (-20, 60))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=3)
+    other_data_cplx = torch.cat((other_data.real, other_data.imag), dim=3)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    other_tensor = (
+        tt_lib.tensor.Tensor(other_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=3)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    tt_output_tensor_on_device = tt_lib.tensor.complex_sub_bw(grad_tensor, input_tensor, other_tensor, alpha=alpha)
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    pyt_y = torch.sub(in_data, other_data, alpha=alpha)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_self_real = torch.real(in_data.grad)
+    grad_self_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+    golden_tensor = [
+        torch.cat((grad_self_real, grad_self_imag), dim=3),
+        torch.cat((grad_other_real, grad_other_imag), dim=3),
+    ]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1964,6 +1964,41 @@ std::vector<Tensor> complex_mul_bw(const Tensor& grad, const Tensor& input, cons
     return operation::decorate_as_composite(__func__, _complex_mul_bw)(grad, input, other, output_mem_config);
 }
 
+// complex add
+// self: grad, other: grad * alpha
+std::vector<Tensor> _complex_add_bw(const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config) {
+    CHECK_FOR_COMPLEX(input);
+    CHECK_FOR_COMPLEX(other);
+    CHECK_FOR_COMPLEX(grad);
+    std::vector<Tensor> grad_tensor;
+    grad_tensor.emplace_back(grad);
+    Tensor grad_b = mul_unary(grad, alpha, output_mem_config );
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+std::vector<Tensor> complex_add_bw(const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _complex_add_bw)(grad, input, other, alpha, output_mem_config);
+}
+
+// complex sub
+// self: grad, other: -grad * alpha
+std::vector<Tensor> _complex_sub_bw(const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config) {
+    CHECK_FOR_COMPLEX(input);
+    CHECK_FOR_COMPLEX(other);
+    CHECK_FOR_COMPLEX(grad);
+    std::vector<Tensor> grad_tensor;
+    grad_tensor.emplace_back(grad);
+    UnaryWithParam op1 {UnaryOpType::NEG};
+    UnaryWithParam op2 {UnaryOpType::MUL_UNARY_SFPU, alpha};
+    Tensor grad_b = unary_chain( grad, {op1, op2}, output_mem_config);
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+std::vector<Tensor> complex_sub_bw(const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _complex_sub_bw)(grad, input, other, alpha, output_mem_config);
+}
 #undef CHECK_FOR_COMPLEX
 
 std::vector<Tensor> _multigammaln_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -263,6 +263,10 @@ std::vector<Tensor> complex_div_bw(const Tensor& grad, const Tensor& input, cons
 
 std::vector<Tensor> polar_bw(const Tensor& grad, const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> complex_add_bw(const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> complex_sub_bw(const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 std::vector<Tensor> multigammaln_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> repeat_bw(const Tensor& grad, const Tensor& input, const Shape& shape, const MemoryConfig& output_mem_config);

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -1972,7 +1972,7 @@ namespace tt::tt_metal::detail{
             .. csv-table::
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
-                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
@@ -1988,7 +1988,7 @@ namespace tt::tt_metal::detail{
             .. csv-table::
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
-                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
@@ -2110,6 +2110,42 @@ namespace tt::tt_metal::detail{
                 "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
                 "input", "First input tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
                 "other", "Second input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("complex_add_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&>(&complex_add_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for addition of  complex tensors``input`` and ``other`` with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "First input tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "other", "Second input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "alpha", "Alpha value", "float", "default to 1.0f", "No"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("complex_sub_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&>(&complex_sub_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for subtraction of  complex tensors``input`` and ``other`` with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "First input tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "other", "Second input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "alpha", "Alpha value", "float", "default to 1.0f", "No"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 


### PR DESCRIPTION
Add backward support for complex add and sub for Type 1 complex tensor
Part of primary issue #6443 
CI test : https://github.com/tenstorrent-metal/tt-metal/actions/runs/8330542591
https://github.com/tenstorrent/tt-metal/actions/runs/8793605470
slow dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/8800457656
fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/8800454251