### PR TITLE
#6383: Add backward support for complex mul

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -1061,6 +1061,8 @@ Backward Operations
 .. autofunction:: tt_lib.tensor.imag_bw
 
 .. autofunction:: tt_lib.tensor.real_bw
+    
+.. autofunction:: tt_lib.tensor.complex_mul_bw
 
 .. autofunction:: tt_lib.tensor.complex_div_bw
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_mul.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, compare_results
+
+
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_cplx_mul(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (-90, 100), (-70, 70))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shapes, (-110, 90), (-20, 80))
+    other_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-30, 30), (-40, 40))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=3)
+    other_data_cplx = torch.cat((other_data.real, other_data.imag), dim=3)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    other_tensor = (
+        tt_lib.tensor.Tensor(other_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=3)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    tt_output_tensor_on_device = tt_lib.tensor.complex_mul_bw(grad_tensor, input_tensor, other_tensor)
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    pyt_y = torch.mul(in_data, other_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_self_real = torch.real(in_data.grad)
+    grad_self_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+    golden_tensor = [
+        torch.cat((grad_self_real, grad_self_imag), dim=3),
+        torch.cat((grad_other_real, grad_other_imag), dim=3),
+    ]
+
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1921,6 +1921,25 @@ std::vector<Tensor> complex_div_bw(const Tensor& grad, const Tensor& input, cons
     return operation::decorate_as_composite(__func__, _complex_div_bw)(grad, input, other, output_mem_config);
 }
 
+// complex mul
+// grad_input = grad * other.conj()
+// grad_other = grad * input.conj()
+std::vector<Tensor> _complex_mul_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    CHECK_FOR_COMPLEX(input);
+    CHECK_FOR_COMPLEX(other);
+    CHECK_FOR_COMPLEX(grad);
+    std::vector<Tensor> grad_tensor;
+    Tensor grad_a = complex_mul(grad, conj(other,output_mem_config), output_mem_config);
+    grad_tensor.emplace_back(grad_a);
+    Tensor grad_b = complex_mul(grad, conj(input,output_mem_config), output_mem_config);
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+std::vector<Tensor> complex_mul_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _complex_mul_bw)(grad, input, other, output_mem_config);
+}
+
 #undef CHECK_FOR_COMPLEX
 
 std::vector<Tensor> _multigammaln_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -256,6 +256,8 @@ std::vector<Tensor> imag_bw(const Tensor& grad, const Tensor& input, const Memor
 
 std::vector<Tensor> real_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> complex_mul_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 std::vector<Tensor> complex_div_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> polar_bw(const Tensor& grad, const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -2079,5 +2079,23 @@ namespace tt::tt_metal::detail{
                 "scalar", "Scalar value", "float", "default to 1.0f", "No"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
+
+    m_tensor.def("complex_mul_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&complex_mul_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for multiplication of complex tensors``input`` and ``other`` with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "First input tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "other", "Second input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
     }
 }


### PR DESCRIPTION
Add backward support for complex mul for Type 1 complex tensor
Primary issue #6443 
CI tests: https://github.com/tenstorrent/tt-metal/actions/runs/8771988907