### PR TITLE
#0: Modify Bert Large Perf test to delete intermediates at the end of each iteration

### DIFF
--- a/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
@@ -117,14 +117,12 @@ def run_perf_bert11(
             tt_output = tt_model(tt_embedding, tt_attention_mask)
             tt_output = tt_output.cpu(blocking=False)
             outputs.append(tt_output)
-
+            del tt_attention_mask
+            del tt_embedding_inputs
+            del tt_embedding
         # Run last inference iteration
         tt_lib.device.Synchronize(device)
         profiler.end(second_run_accum_key, force_enable=True)
-
-        del tt_attention_mask
-        del tt_embedding_inputs
-        del tt_embedding
         del tt_output
 
     first_iter_time = profiler.get(first_run_key)


### PR DESCRIPTION
 - Using shared_ptr for tensor attributes will no longer override device storage if any variable holds a reference to the storage
 - In this case, tt_embeddings var held ref count and was not explictly deleted, leading to a different memory allocation order for each iteration, eventually causing an OOM issue
 
fyi @tt-rkim this should resolve the bert large perf test failures you saw