### PR TITLE
#6568: Add lm-evaluation-harness support for Mamba reference model

### DIFF
--- a/models/experimental/mamba/benchmarks/README.md
+++ b/models/experimental/mamba/benchmarks/README.md
@@ -1,0 +1,24 @@
+# lm-eval-harness.py
+
+To run zero-shot evaluations of this model (for comparison against Table
+3 of [Mamba: Linear-Time Sequence Modeling with Selective State Spaces
+](https://arxiv.org/abs/2312.00752)) we use the `lm-evaluation-harness` library.
+
+To install the `lm-evaluation-harness` library, run the following commands:
+
+```sh
+# Clone and then install as an editable package
+git clone https://github.com/EleutherAI/lm-evaluation-harness
+cd lm-evaluation-harness
+pip install -e .
+```
+
+## CPU
+
+Running against the CPU reference model (`MambaDecode`)
+
+```sh
+python benchmarks/lm_harness_eval.py --tasks hellaswag \
+    --device cpu --batch_size 1 --limit 0.1 \
+    --model mamba-cpu-reference
+```

--- a/models/experimental/mamba/benchmarks/lm_harness_eval.py
+++ b/models/experimental/mamba/benchmarks/lm_harness_eval.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Tuple
+from tqdm import tqdm
+
+import torch
+
+from transformers import AutoTokenizer
+
+from models.experimental.mamba.reference.decode_model import MambaDecode, MambaPretrainedModelName
+from models.experimental.mamba.benchmarks.loglikelihood import compute_loglikelihood_given_prompt_and_target
+
+from lm_eval.api.model import LM
+from lm_eval.api.instance import Instance
+from lm_eval.api.registry import register_model
+from lm_eval.__main__ import cli_evaluate
+
+
+@register_model("mamba-cpu-reference")
+class MambaEvalWrapper(LM):
+    def __init__(
+        self,
+        pretrained: MambaPretrainedModelName = "state-spaces/mamba-370m",
+        max_length=2048,
+        batch_size=1,
+        device="cpu",
+    ):
+        LM.__init__(self)
+
+        self.tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
+        self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+        self.vocab_size = self.tokenizer.vocab_size
+
+        self.model = MambaDecode.from_pretrained(pretrained, batch_size=int(batch_size))
+        self.model.eval()
+
+        self.device = torch.device(device)
+
+    def loglikelihood(self, requests: List[Instance]):
+        results = []
+        with torch.no_grad():
+            for instance in tqdm(requests):
+                context, target = instance.arguments
+
+                context_ids = self.tokenizer(context, return_tensors="pt").input_ids.to(
+                    device=self.device
+                )  # (1 x CONTEXT_LEN)
+                if context == "":
+                    context_ids = torch.Tensor([self.tokenizer.eos_token_id])
+                assert len(context_ids.shape) == 2 and context_ids.shape[1] > 0, "Expected at least one context token"
+
+                target_ids = self.tokenizer(target, return_tensors="pt").input_ids.to(
+                    device=self.device
+                )  # (1 x TARGET_LEN)
+                assert len(target_ids.shape) == 2 and target_ids.shape[1] > 0, "Expected at least one target token"
+
+                loglikelihood, is_greedy = compute_loglikelihood_given_prompt_and_target(
+                    context_ids,
+                    target_ids,
+                    self.model,
+                    self.vocab_size,
+                )
+                results.append((loglikelihood, is_greedy))
+        return results
+
+    def generate_until(self, requests):
+        raise NotImplementedError()
+
+    def loglikelihood_rolling(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        raise NotImplementedError()
+
+
+if __name__ == "__main__":
+    cli_evaluate()

--- a/models/experimental/mamba/benchmarks/loglikelihood.py
+++ b/models/experimental/mamba/benchmarks/loglikelihood.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from models.experimental.mamba.reference.decode_model import MambaDecode
+
+
+def compute_loglikelihood(logits, labels) -> float:
+    assert len(logits.shape) == 3, "Expected rank 3"
+    assert labels.shape[-1] == 1, "Label should be 1 in final dim"
+    assert len(labels.shape) == 3, "Expected rank 3"
+    assert logits.shape[-1] > 1, "Logits should be >1 in final dim"
+    assert labels.shape[1] == logits.shape[1], "Length dimension should match"
+    logits = torch.nn.functional.log_softmax(logits, dim=-1)  # (B x L x VOCAB)
+    return torch.gather(logits, -1, labels).sum().detach().cpu().item()
+
+
+def compute_loglikelihood_given_prompt_and_target(context_ids, target_ids, model: MambaDecode, vocab_size: int):
+    # Reset the model hidden/conv states before decoding
+    model.initialize_states()
+
+    # We want logits for each target token so slice the last one off
+    input_ids = torch.cat([context_ids, target_ids], dim=-1)[:, :-1]  # B x L
+
+    num_target_tokens = target_ids.shape[1]
+    last_token = context_ids[:, -1].unsqueeze(1)  # Model expects (Bx1)
+
+    logits = []
+    is_greedy = True
+    for idx in range((input_ids.shape[-1])):
+        out = model(input_ids[:, idx].unsqueeze(1))  # (B x 1) => (B x 1 x VOCAB)
+        probs = torch.nn.functional.log_softmax(out, dim=-1)
+        logits.append(probs)
+
+        last_token = torch.argmax(out, dim=-1)
+        target_token = input_ids[:, idx].unsqueeze(0)
+        assert (
+            last_token.shape == target_token.shape
+        ), f"Expected actual and target token to be same shape ({last_token.shape} vs. {target_token.shape})"
+
+        if last_token.item() != target_token.item():
+            is_greedy = False
+
+    # Compute loglikelihood using the recorded logits
+    logits = torch.cat(logits, dim=1)[:, -num_target_tokens:, :vocab_size]  # (B x L x VOCAB )
+    labels = target_ids.unsqueeze(-1)  # (B x L x 1)
+    loglikelihood = compute_loglikelihood(logits, labels)
+
+    return loglikelihood, is_greedy

--- a/models/experimental/mamba/reference/decode_model.py
+++ b/models/experimental/mamba/reference/decode_model.py
@@ -48,7 +48,7 @@ from einops import rearrange, repeat, einsum
 
 from models.experimental.mamba.reference.args import ModelArgs
 
-from typing import Literal
+from typing import Literal, cast
 
 MambaPretrainedModelName = Literal[
     "state-spaces/mamba-2.8b-slimpj",
@@ -97,7 +97,6 @@ class MambaDecode(nn.Module):
         return logits
 
     def generate(self, inputs: torch.Tensor, num_tokens_to_generate: int) -> torch.Tensor:
-        print(inputs.shape, num_tokens_to_generate)
         num_tokens_in_full_sequence = num_tokens_to_generate + inputs.shape[1]
         for idx in range(num_tokens_in_full_sequence - 1):
             logits = self.forward(inputs[:, idx].unsqueeze(1))
@@ -109,6 +108,12 @@ class MambaDecode(nn.Module):
             inputs.shape[1] == num_tokens_in_full_sequence
         ), f"Expected {num_tokens_in_full_sequence} tokens in the returned result"
         return inputs
+
+    def initialize_states(self):
+        for layer in self.layers:
+            mixer = cast(MambaBlock, layer.mixer)
+            mixer.prev_hidden_states.zero_()
+            mixer.conv_states.zero_()
 
     @staticmethod
     def from_pretrained(pretrained_model_name: MambaPretrainedModelName, batch_size: int = 1):
@@ -248,7 +253,6 @@ class MambaBlock(nn.Module):
             mamba_inner_ref(), https://github.com/state-spaces/mamba/blob/main/mamba_ssm/ops/selective_scan_interface.py#L311
 
         """
-
         (b, l, d) = x.shape
 
         x_and_res = self.in_proj(x)  # shape (b, l, 2 * d_in)

--- a/models/experimental/mamba/tests/test_benchmarks.py
+++ b/models/experimental/mamba/tests/test_benchmarks.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from models.experimental.mamba.reference.decode_model import MambaDecode, MambaPretrainedModelName
+from models.experimental.mamba.benchmarks.loglikelihood import (
+    compute_loglikelihood,
+    compute_loglikelihood_given_prompt_and_target,
+)
+
+from transformers import AutoTokenizer
+
+
+def test_loglikelihood():
+    logits = torch.tensor([[0.5, 1.0], [1.5, 2.5]]).reshape(1, 2, 2)
+    labels = torch.tensor([[0, 1]]).reshape(1, 2, 1)
+    probs = torch.nn.functional.log_softmax(logits, dim=-1)  # (B x L x VOCAB)
+    assert compute_loglikelihood(logits, labels) == probs[0, 0, 0] + probs[0, 1, 1]
+
+
+def get_compute(model_version: MambaPretrainedModelName):
+    tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
+    tokenizer.pad_token_id = tokenizer.eos_token_id
+
+    model = MambaDecode.from_pretrained(model_version)
+    model.eval()
+
+    def compute(context, target):
+        with torch.no_grad():
+            context_ids = tokenizer(context, return_tensors="pt").input_ids  # (1 x CONTEXT_LEN)
+            assert len(context_ids.shape) == 2 and context_ids.shape[1] > 0, "Expected at least one context token"
+
+            target_ids = tokenizer(target, return_tensors="pt").input_ids  # (1 x TARGET_LEN)
+            assert len(target_ids.shape) == 2 and target_ids.shape[1] > 0, "Expected at least one target token"
+
+            return compute_loglikelihood_given_prompt_and_target(context_ids, target_ids, model, tokenizer.vocab_size)
+
+    return compute
+
+
+@pytest.mark.parametrize(
+    "model_version",
+    (("state-spaces/mamba-370m"), ("state-spaces/mamba-2.8b")),
+)
+def test_loglikelihood_from_prompt(model_version: MambaPretrainedModelName):
+    compute = get_compute(model_version)
+
+    llh1, greedy1 = compute("Mamba is the ", "x x x x x")
+    llh2, greedy2 = compute("Mamba is the ", "something something something something something")
+    llh3, greedy3 = compute("Mamba is the ", "this is really really wrong")
+    llh4, greedy4 = compute("Mamba is the ", "first game to be released")
+    llh5, greedy5 = compute("Mamba is the ", "first game to be released")
+
+    assert llh1 < llh4, f"Expected {llh1} < {llh4}"
+    assert llh2 < llh4, f"Expected {llh2} < {llh4}"
+    assert llh3 < llh4, f"Expected {llh3} < {llh4}"
+    assert llh4 == llh5, "Identical queries should match"
+    assert greedy1 == greedy2 == greedy3
+    assert greedy4 == greedy5


### PR DESCRIPTION
Implement a [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) for the Mamba decode reference model (running CPU only). This same harness will eventually be used to benchmark the `tt-metal` implementation of Mamba once it is performant enough to run the benchmark.

One question for the reviewer: how can I enable our unit tests in CI? Is adding them to `tests/scripts/run_models.sh` correct? Will they get run on every pipeline?