### PR TITLE
#0: Fix Falcon40B tests for CI

### DIFF
--- a/models/demos/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/falcon40b/tests/test_falcon_attention.py
@@ -354,7 +354,7 @@ def test_FalconAttention_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: enable program cache as soon as multi chip correctness is verified
+    use_program_cache,
 ):
     if llm_mode == "prefill" and model_config_str == "BFLOAT16-SHARDED":
         pytest.skip("Prefill is only tested for BFLOAT8_B!")

--- a/models/demos/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon40b/tests/test_falcon_causallm.py
@@ -346,7 +346,7 @@ def test_FalconCausalLM_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: enable program cache as soon as multi chip correctness is verified
+    use_program_cache,
 ):
     if llm_mode == "prefill":
         if model_config_str == "BFLOAT16-SHARDED":

--- a/models/demos/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon40b/tests/test_falcon_decoder.py
@@ -373,7 +373,7 @@ def test_FalconDecoder_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: enable program cache as soon as multi chip correctness is verified
+    use_program_cache,
 ):
     if llm_mode == "prefill" and model_config_str == "BFLOAT16-SHARDED":
         pytest.skip("Prefill is only tested for BFLOAT8_B!")

--- a/models/demos/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon40b/tests/test_falcon_end_to_end.py
@@ -430,7 +430,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: enable program cache as soon as multi chip correctness is verified
+    use_program_cache,
 ):
     if llm_mode == "prefill":
         if model_config_str == "BFLOAT16-SHARDED":

--- a/models/demos/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/falcon40b/tests/test_falcon_mlp.py
@@ -123,7 +123,7 @@ def test_FalconMLP_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: enable program cache as soon as multi chip correctness is verified
+    use_program_cache,
 ):
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)

--- a/models/demos/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/falcon40b/tests/test_falcon_model.py
@@ -341,7 +341,7 @@ def test_FalconModel_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: enable program cache as soon as multi chip correctness is verified
+    use_program_cache,
 ):
     if llm_mode == "prefill":
         if model_config_str == "BFLOAT16-SHARDED":

--- a/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
@@ -23,11 +23,15 @@ TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="D
 TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueMultiDeviceFixture.*"
 pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k post_commit
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-0.99-0.99-0.99-tiiuae/falcon-40b-instruct-0-prefill_seq32-4]
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-0.99-0.99-0.99-tiiuae/falcon-40b-instruct-0-decode_batch32-4]
+
+# Falcon40B 4 chip tests
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-prefill_seq32-4]
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-4]
 pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-4]
 
-#pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-0.99-0.99-0.99-tiiuae/falcon-40b-instruct-0-prefill_seq32-8]
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-0.99-0.99-0.99-tiiuae/falcon-40b-instruct-0-decode_batch32-8]
+# Falcon40B 8 chip tests
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-prefill_seq32-8]
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8]
 pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8]
+
 pytest tests/ttnn/unit_tests/test_multi_device.py


### PR DESCRIPTION
- Re-enable program_cache for all unit tests
- Update pytest args for multi-chip CI