### PR TITLE
#5917: Add test coverage for watcher kernei_id reporting

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -37,6 +37,8 @@ public:
             EnqueueReadBuffer(cq, out_buffer, dst_vec, true);
         }
     }
+    int NumDevices() { return this->devices_.size(); }
+    bool IsSlowDispatch() { return this->slow_dispatch_; }
 
 
 protected:


### PR DESCRIPTION
@aliuTT added the fix for this issue, in the PR just update one of the watcher tests to have coverage for this feature.

Passing CI: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8352185720