### PR TITLE
#6315: Fix dprint tests for T3000

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
@@ -59,6 +59,7 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
 
 TEST_F(DPrintFixture, TestPrintFinish) {
     auto devices = this->devices_;
-    // Run only on the first device
+    // Run only on the first device, as this tests disconnects devices and this can cause
+    // issues on multi-device setups.
     this->RunTestOnDevice(RunTest, devices[0]);
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
@@ -58,11 +58,7 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
 }
 
 TEST_F(DPrintFixture, TestPrintFinish) {
-    // Iterate devices in reverse for this test. Since the test closes the devices early, avoid
-    // closing L chip before R chip.
     auto devices = this->devices_;
-    std::reverse(devices.begin(), devices.end());
-    for (Device* device : devices) {
-        this->RunTestOnDevice(RunTest, device);
-    }
+    // Run only on the first device
+    this->RunTestOnDevice(RunTest, devices[0]);
 }


### PR DESCRIPTION
- Update WaitForPrintsFinished to allow dprint server thread to make progress
- Update test_print_before_finish to run on one device only as closing some devices causes the test to fail on other devices.