### PR TITLE
#3766: Various fixes for Ubuntu 22.04 / Python 3.10

### DIFF
--- a/.github/actions/install-metal-deps/dependencies.json
+++ b/.github/actions/install-metal-deps/dependencies.json
@@ -8,5 +8,14 @@
     "libboost-all-dev=1.71.0.0ubuntu2",
     "libsndfile1=1.0.28-7ubuntu0.2",
     "libhwloc-dev"
+  ],
+  "ubuntu-22.04": [
+    "software-properties-common",
+    "build-essential",
+    "python3.10-venv",
+    "libyaml-cpp-dev",
+    "libboost-all-dev",
+    "libsndfile1",
+    "libhwloc-dev"
   ]
 }

--- a/.github/actions/install-metal-dev-deps/dependencies.json
+++ b/.github/actions/install-metal-dev-deps/dependencies.json
@@ -8,5 +8,13 @@
     "libtbb-dev",
     "libcapstone-dev",
     "pkg-config"
+  ],
+  "ubuntu-22.04": [
+    "git",
+    "git-lfs",
+    "pandoc",
+    "libtbb-dev",
+    "libcapstone-dev",
+    "pkg-config"
   ]
 }

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5.0.0
         with:
-          python-version: '3.8'
           cache: 'pip'
           cache-dependency-path: infra/requirements-infra.txt
       - name: Install infra deps

--- a/.github/workflows/eager-package-main.yaml
+++ b/.github/workflows/eager-package-main.yaml
@@ -11,7 +11,7 @@ jobs:
   build-eager-package:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         arch: [grayskull, wormhole_b0]
     uses: ./.github/workflows/eager-package.yaml
     with:
@@ -22,7 +22,7 @@ jobs:
     needs: build-eager-package
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         arch: [grayskull, wormhole_b0]
     runs-on: ${{ matrix.os }}
     environment: production
@@ -45,7 +45,7 @@ jobs:
       - name: Set up dynamic env vars
         run: |
           source tests/end_to_end_tests/env/bin/activate
-          echo "TT_METAL_HOME=$(python -m tt_metal.scripts.get_home_dir --short)" >> $GITHUB_ENV
+          echo "TT_METAL_HOME=$(python3 -m tt_metal.scripts.get_home_dir --short)" >> $GITHUB_ENV
       - name: Activate env and run release tests - host
         shell: bash
         run: |
@@ -79,11 +79,11 @@ jobs:
       - name: Set up dynamic env vars
         run: |
           source tests/end_to_end_tests/env/bin/activate
-          echo "TT_METAL_HOME=$(python -m tt_metal.scripts.get_home_dir --short)" >> $GITHUB_ENV
+          echo "TT_METAL_HOME=$(python3 -m tt_metal.scripts.get_home_dir --short)" >> $GITHUB_ENV
       - name: Set up kernel builds
         run: |
           source tests/end_to_end_tests/env/bin/activate
-          python -m tt_metal.scripts.set_up_kernels --short prepare
+          python3 -m tt_metal.scripts.set_up_kernels --short prepare
       - name: Activate env and run release tests - silicon
         shell: bash
         run: |

--- a/.github/workflows/eager-package.yaml
+++ b/.github/workflows/eager-package.yaml
@@ -35,7 +35,6 @@ jobs:
         run: git clean -f -d
       - uses: actions/setup-python@v5.0.0
         with:
-          python-version: '3.8'
           cache: 'pip'
           cache-dependency-path: |
             tt_metal/python_env/requirements-dev.txt
@@ -47,6 +46,10 @@ jobs:
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - name: Use g++ as umd compiler for ubuntu 22.04
+        if: ${{ inputs.os == 'ubuntu-22.04' }}
+        run: |
+          echo "DEVICE_CXX=g++" >> $GITHUB_ENV
       - name: Build Python package distribution
         run: python -m build
       - name: Upload distribution as artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "pyelftools==0.29",
   "curtsies==0.4.1",
 ]
-requires-python = ">=3.8,<3.9"
+requires-python = ">=3.8"
 description = "General compute framework for Tenstorrent devices"
 dynamic = ["version"]
 

--- a/tt_metal/python_env/module.mk
+++ b/tt_metal/python_env/module.mk
@@ -11,10 +11,10 @@ python_env/clean:
 
 # .PRECIOUS: $(PYTHON_ENV)/.installed $(PYTHON_ENV)/%
 $(PYTHON_ENV)/.installed:
-	python3.8 -m venv $(PYTHON_ENV)
-	bash -c "source $(PYTHON_ENV)/bin/activate && python -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu"
+	python3 -m venv $(PYTHON_ENV)
+	bash -c "source $(PYTHON_ENV)/bin/activate && python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu"
 	echo "Installing python env build backend requirements..."
-	bash -c "source $(PYTHON_ENV)/bin/activate && python -m pip install setuptools wheel"
+	bash -c "source $(PYTHON_ENV)/bin/activate && python3 -m pip install setuptools wheel"
 	touch $@
 
 $(PYTHON_ENV)/%: $(PYTHON_ENV)/.installed
@@ -27,7 +27,7 @@ else
 $(PYTHON_ENV)/.installed-dev: $(PYTHON_ENV)/.installed tt_metal/python_env/requirements-dev.txt
 endif
 	echo "Installing dev environment packages..."
-	bash -c "source $(PYTHON_ENV)/bin/activate && python -m pip install -r tt_metal/python_env/requirements-dev.txt"
+	bash -c "source $(PYTHON_ENV)/bin/activate && python3 -m pip install -r tt_metal/python_env/requirements-dev.txt"
 	echo "Installing editable dev version of tt_eager packages..."
 	bash -c "source $(PYTHON_ENV)/bin/activate && pip install -e ."
 	echo "Installing editable dev version of ttnn package..."


### PR DESCRIPTION
- Added eager package builds and host side runs for Ubuntu 22.04
- Deleted hardcoded 3.8 versions for setup-python action, relying on system instead
- Get rid of hard dependency on 3.8 for our package, and instead do
- Switch python environment commands for python_env module.mk to be version agnostic