### PR TITLE
Alex/metal/remove cb wait markers

### DIFF
--- a/models/demos/resnet/tests/test_perf_device_resnet.py
+++ b/models/demos/resnet/tests/test_perf_device_resnet.py
@@ -13,9 +13,9 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
         [8, "HiFi4-activations_BFLOAT16-weights_BFLOAT16-batch_8", 2750],
         [16, "HiFi2-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16", 5420],
         [20, "HiFi2-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20", 5780],
-        [8, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_8", 4300],
-        [16, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16", 6350],
-        [20, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20", 6800],
+        [8, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_8", 4260],
+        [16, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16", 6260],
+        [20, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20", 7145],
     ],
 )
 def test_perf_device_bare_metal(batch_size, test, expected_perf):

--- a/models/demos/resnet/tests/test_perf_device_resnet.py
+++ b/models/demos/resnet/tests/test_perf_device_resnet.py
@@ -13,9 +13,9 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
         [8, "HiFi4-activations_BFLOAT16-weights_BFLOAT16-batch_8", 2750],
         [16, "HiFi2-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16", 5420],
         [20, "HiFi2-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20", 5780],
-        [8, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_8", 4260],
-        [16, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16", 6260],
-        [20, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20", 7145],
+        [8, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_8", 4500],
+        [16, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16", 6620],
+        [20, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20", 7170],
     ],
 )
 def test_perf_device_bare_metal(batch_size, test, expected_perf):

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_pack.h
@@ -23,7 +23,7 @@ inline void llk_setup_outputs() {
 // Blocking call to wait for free space needed to pack N tiles
 template <bool skip_sync = false, bool wait_for_blocks = false, bool brisc_pack = false>
 inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
-    kernel_profiler::mark_function_sum_start(CB_RESERVE_BACK_MARKER);
+    //kernel_profiler::mark_function_sum_start(CB_RESERVE_BACK_MARKER);
     std::uint32_t output = operand;
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
@@ -43,7 +43,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         std::uint16_t free_tiles_wrap = cb_interface[output].fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t) free_tiles_wrap;
     } while (free_tiles < num_tiles);
-    kernel_profiler::mark_function_sum_end(CB_RESERVE_BACK_MARKER);
+    //kernel_profiler::mark_function_sum_end(CB_RESERVE_BACK_MARKER);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_unpack.h
@@ -37,7 +37,7 @@ inline void llk_setup_operands() {
 
 // Wait for N tiles available in the incoming stream
 inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
-    kernel_profiler::mark_function_sum_start(CB_WAIT_FRONT_MARKER);
+    //kernel_profiler::mark_function_sum_start(CB_WAIT_FRONT_MARKER);
     std::uint32_t input = operand;
     volatile tt_l1_ptr std::uint32_t* tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
@@ -49,7 +49,7 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
         tiles_received = (std::uint16_t) reg_read((std::uint32_t)tiles_received_ptr);
         num_tiles_recv = tiles_received - cb_interface[input].tiles_acked;
     } while (num_tiles_recv < num_tiles_u);
-    kernel_profiler::mark_function_sum_end(CB_WAIT_FRONT_MARKER);
+    //kernel_profiler::mark_function_sum_end(CB_WAIT_FRONT_MARKER);
 }
 
 // Pop N tiles from the incoming stream

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -43,7 +43,7 @@ inline void llk_setup_outputs() {
 // Blocking call to wait for free space needed to pack N tiles
 template <bool skip_sync = false, bool wait_for_blocks = false, bool brisc_pack = false>
 inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32_t num_tiles) {
-    kernel_profiler::mark_function_sum_start(CB_RESERVE_BACK_MARKER);
+    //kernel_profiler::mark_function_sum_start(CB_RESERVE_BACK_MARKER);
     std::uint32_t output = operand;
 
     volatile tt_reg_ptr std::uint32_t* tiles_acked_ptr = get_cb_tiles_acked_ptr(operand);
@@ -63,7 +63,7 @@ inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32
         std::uint32_t free_tiles_wrap = cb_interface[output].fifo_num_pages - (tiles_received - tiles_acked);
         free_tiles = (std::int32_t) free_tiles_wrap;
     } while (free_tiles < num_tiles);
-    kernel_profiler::mark_function_sum_end(CB_RESERVE_BACK_MARKER);
+    //kernel_profiler::mark_function_sum_end(CB_RESERVE_BACK_MARKER);
 }
 
 inline void llk_push_to_brisc(const std::int32_t operand, const std::int32_t num_tiles, const std::int32_t num_words) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -38,7 +38,7 @@ inline void llk_setup_operands() {
 
 // Wait for N tiles available in the incoming stream
 inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
-    kernel_profiler::mark_function_sum_start(CB_WAIT_FRONT_MARKER);
+    //kernel_profiler::mark_function_sum_start(CB_WAIT_FRONT_MARKER);
     std::uint32_t input = operand;
     volatile tt_l1_ptr std::uint32_t * tiles_received_ptr = get_cb_tiles_received_ptr(operand);
     std::uint16_t num_tiles_u = (std::uint16_t)num_tiles;
@@ -50,7 +50,7 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
         tiles_received = (std::uint16_t) reg_read((std::uint32_t)tiles_received_ptr);
         num_tiles_recv = tiles_received - cb_interface[input].tiles_acked;
     } while (num_tiles_recv < num_tiles_u);
-    kernel_profiler::mark_function_sum_end(CB_WAIT_FRONT_MARKER);
+    //kernel_profiler::mark_function_sum_end(CB_WAIT_FRONT_MARKER);
 }
 
 // Pop N tiles from the incoming stream

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -284,7 +284,7 @@ inline void wait_for_sync_register_value(uint32_t addr, int32_t val) {
  */
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
-    kernel_profiler::mark_function_sum_start(CB_RESERVE_BACK_MARKER);
+    //kernel_profiler::mark_function_sum_start(CB_RESERVE_BACK_MARKER);
     uint32_t pages_acked_ptr = (uint32_t) get_cb_tiles_acked_ptr(operand);
 
     // while the producer (write-side interface) is waiting for space to free up "tiles_pushed" is not changing
@@ -308,7 +308,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
         free_space_pages = (int32_t)free_space_pages_wrap;
     } while (free_space_pages < num_pages);
     DEBUG_STATUS('C', 'R', 'B', 'D');
-    kernel_profiler::mark_function_sum_end(CB_RESERVE_BACK_MARKER);
+    //kernel_profiler::mark_function_sum_end(CB_RESERVE_BACK_MARKER);
 }
 
 /**
@@ -335,7 +335,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
  * */
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
-    kernel_profiler::mark_function_sum_start(CB_WAIT_FRONT_MARKER);
+    //kernel_profiler::mark_function_sum_start(CB_WAIT_FRONT_MARKER);
     uint32_t pages_acked = get_cb_tiles_acked_ptr(operand)[0];
     uint32_t pages_received_ptr = (uint32_t) get_cb_tiles_received_ptr(operand);
 
@@ -346,7 +346,7 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
         pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     } while (pages_received < num_pages);
     DEBUG_STATUS('C', 'W', 'F', 'D');
-    kernel_profiler::mark_function_sum_end(CB_WAIT_FRONT_MARKER);
+    //kernel_profiler::mark_function_sum_end(CB_WAIT_FRONT_MARKER);
 }
 
 // NOC transfers


### PR DESCRIPTION
Removed cb wait markers as temp workaround for https://github.com/tenstorrent-metal/tt-metal/issues/6619 
Updated resnet perf targets after max pool updates 