### PR TITLE
CQ_DISPATCH_CMD_WRITE_PAGED support in test_dispatcher and passing tests

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <unordered_map>
+#include "core_coord.h"
+#include "logger.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_cmds.hpp"
@@ -25,22 +28,67 @@ struct one_worker_data_t {
     vector<uint32_t> data;
 };
 
-typedef unordered_map<CoreCoord, one_worker_data_t> worker_data_t;
+typedef unordered_map<CoreCoord, unordered_map<uint32_t, one_worker_data_t>> worker_data_t;
 
 inline void reset_worker_data(worker_data_t& awd) {
-    for (auto& wd : awd) {
-        wd.second.valid.resize(0);
-        wd.second.data.resize(0);
+    for (auto& it : awd) {
+        for (auto &wd : it.second) {
+            wd.second.valid.resize(0);
+            wd.second.data.resize(0);
+        }
     }
 }
 
+// Arbitrary, just get first worker, and bank_id whatever that is and return num datums. Probably this
+// should be tweaked to only return valid datums, and perhaps consider all workers, banks.
 inline uint32_t worker_data_size(worker_data_t& awd) {
-    return awd[first_worker_g].data.size();
-
+    TT_ASSERT(awd.size() > 0, "Worker data is empty, not expected");
+    auto first_worker = awd.begin()->first;
+    TT_ASSERT(awd[first_worker].size() > 0, "Worker data for core: {} is empty, not expected.", first_worker.str());
+    auto first_bank_id = awd[first_worker].begin()->first;
+    auto size = awd[first_worker_g][first_bank_id].data.size();
+    log_debug(tt::LogTest, "{} - returning size: {} from worker: {} bank_id: {}", __FUNCTION__, size, first_worker.str(), first_bank_id);
+    return size;
 }
 
 inline uint32_t padded_size(uint32_t size, uint32_t alignment) {
     return (size + alignment - 1) / alignment * alignment;
+}
+
+// Return a vector of core coordinates that are used as interleaved paged banks (L1 or DRAM)
+inline std::vector<CoreCoord> get_cores_per_bank_id(Device *device, bool is_dram){
+    uint32_t num_banks = device->num_banks(is_dram ? BufferType::DRAM : BufferType::L1);
+    std::vector<CoreCoord> bank_cores;
+
+    for (int bank_id = 0; bank_id < num_banks; bank_id++) {
+        auto core = is_dram ?
+            device->core_from_dram_channel(device->dram_channel_from_bank_id(bank_id)) :
+            device->logical_core_from_bank_id(bank_id);
+        bank_cores.push_back(core);
+    }
+
+    return bank_cores;
+}
+
+// Specific to this test. This test doesn't use Buffers, and for Storage cores in L1 that have 2 banks, they are intended
+// to be allocated top-down and carry "negative" offsets via bank_to_l1_offset for cores that have 2 banks. This function
+// will scan through all banks bank_to_l1_offset and return the minimum required buffer addr to avoid bank_to_l1_offset
+// being applied and underflowing.  In GS this is basically 512B or half the L1 Bank size.
+inline uint32_t get_min_required_buffer_addr(Device *device, bool is_dram){
+
+    int32_t smallest_offset = std::numeric_limits<int32_t>::max();
+    uint32_t num_banks = device->num_banks(is_dram ? BufferType::DRAM : BufferType::L1);
+
+    for (int bank_id = 0; bank_id < num_banks; bank_id++) {
+        int32_t offset = is_dram ? device->dram_bank_offset_from_bank_id(bank_id) : device->l1_bank_offset_from_bank_id(bank_id);
+        smallest_offset = offset < smallest_offset ? offset : smallest_offset;
+    }
+
+    // If negative, flip it and this becomes the min required positive offset for a buffer in bank.
+    uint32_t min_required_positive_offset = smallest_offset < 0 ? 0 - smallest_offset : 0;
+    log_debug(tt::LogTest, "{} - smallest_offset: {} min_required_positive_offset: {}", __FUNCTION__, smallest_offset, min_required_positive_offset);
+
+    return min_required_positive_offset;
 }
 
 inline void generate_random_payload(vector<uint32_t>& cmds,
@@ -58,6 +106,7 @@ inline void generate_random_payload(vector<uint32_t>& cmds,
                                     uint32_t length_words) {
 
     static uint32_t coherent_count = 0;
+    const uint32_t bank_id = 0; // No interleaved pages here.
 
     // Note: the dst address marches in unison regardless of weather or not a core is written to
     for (uint32_t i = 0; i < length_words; i++) {
@@ -66,10 +115,55 @@ inline void generate_random_payload(vector<uint32_t>& cmds,
         for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
             for (uint32_t x = all_workers_g.start.x; x <= all_workers_g.end.x; x++) {
                 CoreCoord core(x, y);
-                data[core].data.push_back(datum);
-                data[core].valid.push_back(workers.contains(core));
+                data[core][bank_id].data.push_back(datum);
+                data[core][bank_id].valid.push_back(workers.contains(core));
             }
         }
+    }
+}
+
+// Generate a random payload for a paged write command. Note: Doesn't currently support using the base_addr here.
+inline void generate_random_paged_payload(Device *device,
+                                          CQDispatchCmd cmd,
+                                          vector<uint32_t>& cmds,
+                                          worker_data_t& data,
+                                          uint32_t start_page,
+                                          bool is_dram) {
+
+    static uint32_t coherent_count = 0;
+    auto buf_type = is_dram ? BufferType::DRAM : BufferType::L1;
+    uint32_t num_banks = device->num_banks(buf_type);
+    uint32_t words_per_page = cmd.write_paged.page_size / sizeof(uint32_t);
+
+    // Note: the dst address marches in unison regardless of weather or not a core is written to
+    for (uint32_t page_id = start_page; page_id < start_page + cmd.write_paged.pages; page_id++) {
+
+        // 32B alignment taken from InterleavedAddrGen. If 16B page size, pad to 32B.
+        const uint32_t page_size_alignment_bytes = 32;
+        CoreCoord bank_core;
+        uint32_t bank_id = page_id % num_banks;
+        uint32_t bank_offset = align(cmd.write_paged.page_size, page_size_alignment_bytes) * (page_id / num_banks);
+
+        if (is_dram) {
+            auto dram_channel = device->dram_channel_from_bank_id(bank_id);
+            bank_core = device->core_from_dram_channel(dram_channel);
+        } else {
+            bank_core = device->logical_core_from_bank_id(bank_id);
+        }
+
+        // Generate data and add to cmd for sending to device, and worker_data for correctness checking.
+        for (uint32_t i = 0; i < words_per_page; i++) {
+            uint32_t datum = (use_coherent_data_g) ? coherent_count++ : std::rand();
+            log_debug(tt::LogTest, "{} - Setting {} page_id: {} word: {} on core: {} (bank_id: {} bank_offset: {}) => datum: 0x{:x}",
+                __FUNCTION__, is_dram ? "DRAM" : "L1", page_id, i, bank_core.str(), bank_id, bank_offset, datum);
+            cmds.push_back(datum); // Push to device.
+            data[bank_core][bank_id].data.push_back(datum); // Checking
+            data[bank_core][bank_id].valid.push_back(true);
+        }
+
+        data[bank_core][bank_id].data.resize(padded_size(data[bank_core][bank_id].data.size(), page_size_alignment_bytes / sizeof(uint32_t)));
+        data[bank_core][bank_id].valid.resize(padded_size(data[bank_core][bank_id].valid.size(), page_size_alignment_bytes / sizeof(uint32_t)));
+
     }
 }
 
@@ -79,6 +173,7 @@ inline void generate_random_packed_payload(vector<uint32_t>& cmds,
                                            uint32_t size_words) {
 
     static uint32_t coherent_count = 0;
+    const uint32_t bank_id = 0; // No interleaved pages here.
 
     // Note: the dst address marches in unison regardless of weather or not a core is written to
     for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
@@ -96,17 +191,17 @@ inline void generate_random_packed_payload(vector<uint32_t>& cmds,
                     uint32_t datum = (use_coherent_data_g) ? ((x << 16) | (y << 24) | coherent_count++) : std::rand();
 
                     cmds.push_back(datum);
-                    data[core].data.push_back(datum);
-                    data[core].valid.push_back(true);
+                    data[core][bank_id].data.push_back(datum);
+                    data[core][bank_id].valid.push_back(true);
                 } else {
-                    data[core].data.push_back(0xbaadf00d);
-                    data[core].valid.push_back(false);
+                    data[core][bank_id].data.push_back(0xbaadf00d);
+                    data[core][bank_id].valid.push_back(false);
                 }
             }
 
             cmds.resize(padded_size(cmds.size(), 4)); // XXXXX L1_ALIGNMENT16/sizeof(uint)
-            data[core].data.resize(padded_size(data[core].data.size(), 4)); // XXXXX L1_ALIGNMENT16/sizeof(uint)
-            data[core].valid.resize(padded_size(data[core].valid.size(), 4)); // XXXXX L1_ALIGNMENT16/sizeof(uint)
+            data[core][bank_id].data.resize(padded_size(data[core][bank_id].data.size(), 4)); // XXXXX L1_ALIGNMENT16/sizeof(uint)
+            data[core][bank_id].valid.resize(padded_size(data[core][bank_id].valid.size(), 4)); // XXXXX L1_ALIGNMENT16/sizeof(uint)
         }
     }
 }
@@ -184,6 +279,19 @@ inline void add_dispatcher_cmd(vector<uint32_t>& cmds,
     debug_epilogue(cmds, prior_end);
 }
 
+inline void add_dispatcher_paged_cmd(Device *device,
+                                     vector<uint32_t>& cmds,
+                                     worker_data_t& worker_data,
+                                     CQDispatchCmd cmd,
+                                     uint32_t start_page,
+                                     bool is_dram) {
+
+    size_t prior_end = debug_prologue(cmds);
+    add_bare_dispatcher_cmd(cmds, cmd);
+    generate_random_paged_payload(device, cmd, cmds, worker_data, start_page, is_dram);
+    debug_epilogue(cmds, prior_end);
+}
+
 inline void add_dispatcher_packed_cmd(Device *device,
                                       vector<uint32_t>& cmds,
                                       vector<CoreCoord>& worker_cores,
@@ -236,10 +344,11 @@ inline void gen_dispatcher_unicast_write_cmd(Device *device,
     CQDispatchCmd cmd;
 
     CoreCoord phys_worker_core = device->worker_core_from_logical_core(worker_core);
+    const uint32_t bank_id = 0; // No interleaved pages here.
 
     cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
     cmd.write_linear.noc_xy_addr = NOC_XY_ENCODING(phys_worker_core.x, phys_worker_core.y);
-    cmd.write_linear.addr = dst_addr + worker_data[worker_core].data.size() * sizeof(uint32_t);
+    cmd.write_linear.addr = dst_addr + worker_data[worker_core][bank_id].data.size() * sizeof(uint32_t);
     cmd.write_linear.length = length;
     cmd.write_linear.num_mcast_dests = 0;
 
@@ -257,6 +366,7 @@ inline void gen_dispatcher_multicast_write_cmd(Device *device,
 
     CoreCoord physical_start = device->physical_core_from_logical_core(worker_core_range.start, CoreType::WORKER);
     CoreCoord physical_end = device->physical_core_from_logical_core(worker_core_range.end, CoreType::WORKER);
+    const uint32_t bank_id = 0; // No interleaved pages here.
 
     // Sanity check that worker_data covers all cores being targeted.
     for (uint32_t y = worker_core_range.start.y; y <= worker_core_range.end.y; y++) {
@@ -268,12 +378,58 @@ inline void gen_dispatcher_multicast_write_cmd(Device *device,
 
     cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
     cmd.write_linear.noc_xy_addr = NOC_MULTICAST_ENCODING(physical_start.x, physical_start.y, physical_end.x, physical_end.y);
-    cmd.write_linear.addr = dst_addr + worker_data[worker_core_range.start].data.size() * sizeof(uint32_t);
+    cmd.write_linear.addr = dst_addr + worker_data[worker_core_range.start][bank_id].data.size() * sizeof(uint32_t);
     cmd.write_linear.length = length;
     cmd.write_linear.num_mcast_dests = worker_core_range.size();
+    log_debug(tt::LogTest, "{} Setting addr: {} from dst_addr: {} and worker_data[{}][{}].data.size(): {}",
+        __FUNCTION__, (uint32_t) cmd.write_linear.addr, dst_addr, worker_core_range.start.str(), bank_id,
+        worker_data[worker_core_range.start][bank_id].data.size() * sizeof(uint32_t));
 
     add_dispatcher_cmd(cmds, worker_core_range, worker_data, cmd, length);
 }
+
+inline void gen_dispatcher_paged_write_cmd(Device *device,
+                                             vector<uint32_t>& cmds,
+                                             worker_data_t& worker_data,
+                                             bool is_dram,
+                                             uint32_t start_page,
+                                             uint32_t dst_addr,
+                                             uint32_t page_size,
+                                             uint32_t pages) {
+
+    const uint32_t page_size_alignment_bytes = 32;
+    uint32_t num_banks = device->num_banks(is_dram ? BufferType::DRAM : BufferType::L1);
+
+    // Not safe to mix paged L1 and paged DRAM writes currently in this test since same book-keeping.
+    static uint32_t prev_is_dram = -1;
+    TT_ASSERT(prev_is_dram == -1 || prev_is_dram == is_dram, "Mixing paged L1 and paged DRAM writes not supported in this test.");
+    prev_is_dram = is_dram;
+
+    // Assumption embedded in this function (seems reasonable, true with a single buffer) that paged size will never change.
+    static uint32_t prev_page_size = -1;
+    TT_ASSERT(prev_page_size == -1 || prev_page_size == page_size, "Page size changed between calls to gen_dispatcher_paged_write_cmd - not supported.");
+    prev_page_size = page_size;
+
+    // For the CMD generation, start_page is 8 bits, so much wrap around, and increase base_addr instead based on page size,
+    // which assumes page size never changed between calls to this function (checked above).
+    uint32_t bank_offset = align(page_size, page_size_alignment_bytes) * (start_page / num_banks);
+    uint32_t base_addr = dst_addr + bank_offset;
+    uint8_t start_page_cmd = start_page % num_banks;
+
+    CQDispatchCmd cmd;
+    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_PAGED;
+    cmd.write_paged.is_dram = is_dram;
+    cmd.write_paged.start_page = start_page_cmd;
+    cmd.write_paged.base_addr = base_addr;
+    cmd.write_paged.page_size = page_size;
+    cmd.write_paged.pages = pages;
+
+    log_debug(tt::LogTest, "Adding CQ_DISPATCH_CMD_WRITE_PAGED - is_dram: {} start_page: {} start_page_cmd: {} base_addr: 0x{:x} bank_offset: 0x{:x} page_size: {} pages: {})",
+        is_dram, start_page, start_page_cmd, base_addr, bank_offset, page_size, pages);
+
+    add_dispatcher_paged_cmd(device, cmds, worker_data, cmd, start_page, is_dram);
+}
+
 
 inline void gen_dispatcher_packed_write_cmd(Device *device,
                                             vector<uint32_t>& cmds,
@@ -344,6 +500,65 @@ inline void gen_dispatcher_terminate_cmd(vector<uint32_t>& cmds) {
     add_dispatcher_cmd(cmds, cmd, 0);
 }
 
+
+// Validate a single core's worth of results vs expected. bank_id is purely informational, can pass -1 for non-paged testing.
+inline bool validate_core_data(std::unordered_set<CoreCoord> &validated_cores, Device *device, const worker_data_t& worker_data, CoreCoord core, uint32_t base_addr, bool is_paged, uint32_t bank_id, bool is_dram) {
+
+    int fail_count = 0;
+    const vector<uint32_t>& dev_data = worker_data.at(core).at(bank_id).data;
+    const vector<bool>& dev_valid = worker_data.at(core).at(bank_id).valid;
+    uint32_t size_bytes =  dev_data.size() * sizeof(uint32_t);
+
+    // If we had SOC desc, could get core type this way. Revisit this.
+    // soc_desc.cores.at(core).type
+    auto core_type = is_dram ? CoreType::DRAM : CoreType::WORKER;
+    CoreCoord phys_core;
+    int32_t bank_offset = 0;
+
+    if (is_paged){
+        if (is_dram) {
+            auto channel = device->dram_channel_from_bank_id(bank_id);
+            phys_core = device->core_from_dram_channel(channel);
+            bank_offset = device->dram_bank_offset_from_bank_id(bank_id);
+        } else {
+            phys_core = device->physical_core_from_logical_core(core, core_type);
+            bank_offset = device->l1_bank_offset_from_bank_id(bank_id);
+        }
+
+        log_debug(tt::LogTest, "Paged-{} for bank_id: {} has base_addr: (0x{:x}) and DRAM bank offset: {:x})",
+            is_dram ? "DRAM" : "L1", bank_id, base_addr, bank_offset);
+
+        base_addr += bank_offset;
+    } else {
+        TT_ASSERT(core_type == CoreType::WORKER, "Non-Paged write tests expected to target L1 only for now and not DRAM.");
+        phys_core = device->physical_core_from_logical_core(core, core_type);
+    }
+
+    // Read results from device and compare to expected for this core.
+    vector<uint32_t> results = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, base_addr, size_bytes);
+
+    log_info(tt::LogTest, "Validating {} bytes from {} (paged bank_id: {}) from logical_core: {} / physical: {} at addr: 0x{:x}",
+        size_bytes, is_dram ? "DRAM" : "L1", bank_id, core.str(), phys_core.str(), base_addr);
+
+    for (int i = 0; i < dev_data.size(); i++) {
+        if (!dev_valid[i]) continue;
+        validated_cores.insert(core);
+
+        if (results[i] != dev_data[i]) {
+            if (!fail_count) {
+                log_fatal(tt::LogTest, "Data mismatch - First 20 failures for logical_core: {} (physical: {})", core.str(), phys_core.str());
+            }
+            log_fatal(tt::LogTest, "[{:02d}] (Fail) Expected: 0x{:08x} Observed: 0x{:08x}", i, (unsigned int)dev_data[i], (unsigned int)results[i]);
+            if (fail_count++ > 20) {
+                break;
+            }
+        } else {
+            log_debug(tt::LogTest, "[{:02d}] (Pass) Expected: 0x{:08x} Observed: 0x{:08x}", i, (unsigned int)dev_data[i], (unsigned int)results[i]);
+        }
+    }
+    return fail_count;
+}
+
 inline bool validate_results(Device *device, CoreRange workers, const worker_data_t& worker_data, uint64_t l1_buf_base) {
 
     bool failed = false;
@@ -351,47 +566,33 @@ inline bool validate_results(Device *device, CoreRange workers, const worker_dat
     for (uint32_t y = workers.start.y; y <= workers.end.y; y++) {
         for (uint32_t x = workers.start.x; x <= workers.end.x; x++) {
             CoreCoord worker(x, y);
-            CoreCoord phys_worker = device->worker_core_from_logical_core(worker);
-
-            const vector<uint32_t>& dev_data = worker_data.at(worker).data;
-            const vector<bool>& dev_valid = worker_data.at(worker).valid;
-            log_info(tt::LogTest, "Validating {} bytes for core {}", dev_data.size() * sizeof(uint32_t), worker.str());
-
-            vector<uint32_t> results =
-                tt::llrt::read_hex_vec_from_core(device->id(), phys_worker, l1_buf_base, dev_data.size() * sizeof(uint32_t));
-
-            int fail_count = 0;
-
-            for (int i = 0; i < dev_data.size(); i++) {
-                if (dev_valid[i]) {
-                    validated_cores.insert(worker);
-                }
-
-                if (dev_valid[i] && results[i] != dev_data[i]) {
-                    if (!failed) {
-                        tt::log_fatal("Data mismatch");
-                        fprintf(stderr, "First 20 failures for each core: [idx] expected->read\n");
-                    }
-                    if (fail_count == 0) {
-                        fprintf(stderr, "Failures logical core: (%ld,%ld)\n", worker.x, worker.y);
-                    }
-
-                    fprintf(stderr, "  [%02d] 0x%08x->0x%08x\n", i, (unsigned int)dev_data[i], (unsigned int)results[i]);
-
-                    failed = true;
-                    fail_count++;
-                    if (fail_count > 20) {
-                        break;
-                    }
-                }
-            }
+            failed |= validate_core_data(validated_cores, device, worker_data, worker, l1_buf_base, false, 0, false);
         }
     }
 
     log_info(tt::LogTest, "Validated {} cores total.", validated_cores.size());
-    if (validated_cores.size() != workers.size()) {
-        tt::log_warning("Mismatch in number of cores. Total: {} Validated: {}", workers.size(), validated_cores.size());
+    return !failed;
+}
+
+// Validate paged writes to DRAM or L1 by iterating over just the banks/cores that are valid for the worker date based on prior writes.
+inline bool validate_results_paged(Device *device, const worker_data_t& worker_data, uint64_t l1_buf_base, bool is_dram) {
+
+    // Get banks, to be able to iterate over them in order here, since worker_data is umap.
+    auto bank_cores = get_cores_per_bank_id(device, is_dram);
+    std::unordered_set<CoreCoord> validated_cores;
+    bool failed = false;
+
+    for (int bank_id = 0; bank_id < bank_cores.size(); bank_id++) {
+        auto bank_core = bank_cores.at(bank_id);
+        if ((worker_data.find(bank_core) == worker_data.end()) ||
+            (worker_data.at(bank_core).find(bank_id) == worker_data.at(bank_core).end())) {
+            log_debug(tt::LogTest, "Skipping bank_id: {} bank_core: {} as it has no data", bank_id, bank_core.str());
+            continue;
+        }
+
+        failed |= validate_core_data(validated_cores, device, worker_data, bank_core, l1_buf_base, true, bank_id, is_dram);
     }
 
+    log_info(tt::LogTest, "{} - Validated {} cores total.", __FUNCTION__, validated_cores.size());
     return !failed;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/run_paged_tests.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/run_paged_tests.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/bash
+
+# Just a quick script to run bunch of latest passing paged write tests targeting DRAM and L1
+
+SUFFIX=$(date +%Y%m%d%H%M%S)
+
+# Define the test numbers to iterate over
+TEST_IDS=(2 3)
+
+# Loop over the modes
+for TEST_ID in ${TEST_IDS[@]}; do
+
+    LABEL=""
+    if [ $TEST_ID -eq 2 ]; then
+        LABEL="DRAM"
+    elif [ $TEST_ID -eq 3 ]; then
+        LABEL="L1"
+    fi
+
+    DIR="${TT_METAL_HOME}/paged_write_tests_sanity_${LABEL}_${SUFFIX}"
+    mkdir -p $DIR
+
+    echo "Running tests for ${DIR} now..."
+
+    #################################################################################
+    # SANITY TESTS : CQDispatchWritePagedCmd.page_size = 16 B                       #
+    #################################################################################
+
+    # Testcase: Simplest case, 1 page, CQDispatchWritePagedCmd.page_size is 16B, same as dispatch buffer.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 16 -max 16 -lps 4 -pbs 1 -np 1 -c |& tee ${DIR}/write_1_page_16b_size_dispatch_buffer_16b_pages.log
+
+    # Testcase: 128 page, CQDispatchWritePagedCmd.page_size is 16B, same as dispatch buffer.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 16 -max 16 -lps 4 -pbs 1 -np 128 -c |& tee ${DIR}/write_128_page_16b_size_dispatch_buffer_16b_pages.log
+
+    # Testcase: 512 page, CQDispatchWritePagedCmd.page_size is 16B, same as dispatch buffer.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 16 -max 16 -lps 4 -pbs 1 -np 512 -c |& tee ${DIR}/write_512_page_16b_size_dispatch_buffer_16b_pages.log
+
+
+    #################################################################################
+    # VARYING PAGE SIZES : CQDispatchWritePagedCmd.page_size                        #
+    #################################################################################
+
+    # Matching page sizes (least interesting)
+    #########################################
+
+    # How to make dispatch buffer, prefetch buffer not be required to hold all the data (right now prefetch buffer is required to hold everything) - need to break the data into multiple writes (?)
+
+    # Testcase: 140 Pages, Matching CQDispatchWritePagedCmd.page_size and dispatch buffer page size. Both are 2048 Bytes.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 2048 -max 2048 -lps 12 -pbs 1 -np 140 -c |& tee ${DIR}/write_140_page_2048b_size_dispatch_buffer_2048b_pages.log
+
+    # Testcase: 70 Pages, Matching CQDispatchWritePagedCmd.page_size and dispatch buffer page size. Both are 4096 Bytes.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 4096 -max 4096 -lps 12 -pbs 1 -np 70 -c |& tee ${DIR}/write_70_page_4096b_size_dispatch_buffer_4096b_pages.log
+
+
+    # Paged write page size is smaller than dispatch buffer  (not too interesting, but good to check)
+    #################################################################################################
+
+    # Testcase: 256 Pages, Smaller CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 16 Bytes dispatch buffer is 32 Bytes
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 16 -max 16 -lps 5 -pbs 1 -np 256 -c |& tee ${DIR}/write_256_page_16b_size_dispatch_buffer_32b_pages.log
+
+    # Testcase: 256 Pages, Smaller CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 32 Bytes dispatch buffer is 64 Bytes
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 32 -max 32 -lps 6 -pbs 1 -np 256 -c |& tee ${DIR}/write_256_page_32b_size_dispatch_buffer_64b_pages.log
+
+    # Testcase: 256 Pages, Smaller CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 496 Bytes dispatch buffer is 4096 Bytes
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 496 -max 496 -lps 12 -pbs 1 -np 256 -c |& tee ${DIR}/write_256_page_496b_size_dispatch_buffer_4096b_pages.log
+
+
+    # Paged write page size is larger than dispatch buffer (more interesting)
+    #########################################################################
+
+    # Testcase: 256 Pages, Bigger CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 32 Bytes dispatch buffer is 16 Bytes
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 32 -max 32 -lps 4 -pbs 1 -np 256 -c |& tee ${DIR}/write_256_page_32b_size_dispatch_buffer_16b_pages.log
+
+    # Testcase: 256 Pages, Bigger CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 48 Bytes dispatch buffer is 16 Bytes
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 48 -max 48 -lps 4 -pbs 1 -np 256 -c |& tee ${DIR}/write_256_page_48b_size_dispatch_buffer_16b_pages.log
+
+    # Testcase: 256 Pages, Bigger CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 2048 Bytes dispatch buffer is 16 Bytes
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 2048 -max 2048 -lps 4 -pbs 1 -np 128 -c |& tee ${DIR}/write_128_page_2048b_size_dispatch_buffer_16b_pages.log
+
+    # Testcase: 256 Pages, Bigger CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 2048 Bytes dispatch buffer is 1024 Bytes
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 2048 -max 2048 -lps 10 -pbs 1 -np 128 -c |& tee ${DIR}/write_128_page_2048b_size_dispatch_buffer_1024b_pages.log
+
+
+    #################################################################################
+    # VARYING BASE_ADDR : CQDispatchWritePagedCmd.base_addr                         #
+    #################################################################################
+
+    # Testcase: 256 Pages, Bigger CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 48 Bytes dispatch buffer is 16 Bytes. Base addr is 513 KB.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 48 -max 48 -lps 4 -pbs 1 -np 256 -min-addr 525312 -max-addr 525312 -c |& tee ${DIR}/write_256_page_48b_size_dispatch_buffer_16b_pages_525312_base.log
+
+    # Testcase: 256 Pages, Bigger CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 48 Bytes dispatch buffer is 16 Bytes. Base addr is 515 KB + 16 bytes.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 48 -max 48 -lps 4 -pbs 1 -np 256 -min-addr 527376 -max-addr 527376 -c |& tee ${DIR}/write_256_page_48b_size_dispatch_buffer_16b_pages_527376_base.log
+
+    # Testcase: 256 Pages, Bigger CQDispatchWritePagedCmd.page_size than dispatch buffer page size. Write page size is 48 Bytes dispatch buffer is 16 Bytes. Base addr is 521 KB + 48 bytes.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 48 -max 48 -lps 4 -pbs 1 -np 256 -min-addr 533552 -max-addr 533552 -c |& tee ${DIR}/write_256_page_48b_size_dispatch_buffer_16b_pages_533552_base.log
+
+    #################################################################################
+    # MULTIPLE WRITE CMDS using start_page to write to mem without gaps             #
+    #################################################################################
+
+    # Testcase: Increase prefetcher buffer size to 6 pages so that 2 paged write cmds (3 pages each) are needed to fill buffer. End at small even page number.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 16 -max 16 -lps 4 -pbs 6 -np 3 -c |& tee ${DIR}/write_3_page_2x_16b_size_dispatch_buffer_16b_pages_pbs6.log
+
+    # Testcase: Increase prefetcher buffer size to 15 pages so that 5 paged write cmds (3 pages each) are needed to fill buffer. End at small even page number.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 16 -max 16 -lps 4 -pbs 15 -np 3 -c |& tee ${DIR}/write_3_page_5x_16b_size_dispatch_buffer_16b_pages_pbs15.log
+
+    # Testcase: Increase prefetcher buffer size to 280 pages so that 20 paged write cmds (14 pages each) are needed to fill buffer. Wrap around and finish writes on lower banks before starting the next.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 16 -max 16 -lps 4 -pbs 280 -np 14 -c |& tee ${DIR}/write_14_page_20x_16b_size_dispatch_buffer_16b_pages_pbs280.log
+
+    # Testcase: Arbitrary non-even numbers. This caught some test issues with overflowing start_page one test implementation.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 16 -max 16 -lps 5 -pbs 275 -np 13 -c |& tee ${DIR}/write_13_page_21x_16b_size_dispatch_buffer_16b_pages_pbs275.log
+
+    #################################################################################
+    # MISC                                                                          #
+    #################################################################################
+
+    # Multiple warmup iterations and test iterations
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 10 -w 10 -t $TEST_ID -wx 0 -wy 1 -min 32 -max 32 -lps 4 -pbs 1 -np 256 -c |& tee ${DIR}/write_256_page_32b_size_dispatch_buffer_16b_pages_10warmup_10iter.log
+
+    # Increase prefetch buffer size.
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 32 -max 32 -lps 4 -pbs 2 -np 256 -c |& tee ${DIR}/write_256_page_32b_size_dispatch_buffer_16b_pages_pbs2.log
+    ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 1 -w 0 -t $TEST_ID -wx 0 -wy 1 -min 64 -max 64 -lps 4 -pbs 4 -np 230 -c |& tee ${DIR}/write_230_page_64b_size_dispatch_buffer_16b_pages_pbs4.log
+
+done
+
+
+###############################################
+# PERF                                        #
+###############################################
+
+DIR="${TT_METAL_HOME}/paged_write_tests_sanity_perf_dram_${SUFFIX}"
+mkdir -p $DIR
+
+# 3.3 GB/s whb0
+${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 1000 -t 2 -wx 0 -wy 1 -min 1024 -max 1024 -lps 10 -pbs 2 -np 128 -c -i 1000 |& tee ${DIR}/perf_write_128_page_1024b_size_dispatch_buffer_1024b_pages_1000_iter_dram_pbs2.log
+
+# 5.7 GB/s whb0
+${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 1000 -t 2 -wx 0 -wy 1 -min 2048 -max 2048 -lps 11 -pbs 2 -np 128 -c -i 1000 |& tee ${DIR}/perf_write_128_page_2048b_size_dispatch_buffer_2048b_pages_1000_iter_dram_pbs2.log
+
+# 8.6 GB/s whb0
+${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 1000 -t 2 -wx 0 -wy 1 -min 4096 -max 4096 -lps 12 -pbs 2 -np 128 -c -i 1000 |& tee ${DIR}/perf_write_128_page_4096b_size_dispatch_buffer_4096b_pages_1000_iter_dram_pbs2.log
+
+# 11.7 GB/s whb0
+${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 1000 -t 2 -wx 0 -wy 1 -min 8192 -max 8192 -lps 13 -pbs 2 -np 128 -c -i 1000 |& tee ${DIR}/perf_write_128_page_8192b_size_dispatch_buffer_8192b_pages_1000_iter_dram_pbs2.log

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <random>
 
+#include "logger.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
@@ -17,11 +18,16 @@ constexpr uint32_t DEFAULT_ITERATIONS = 10000;
 constexpr uint32_t DEFAULT_WARMUP_ITERATIONS = 100;
 constexpr uint32_t DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE = 12;
 constexpr uint32_t DEFAULT_DISPATCH_BUFFER_SIZE_BLOCKS = 4;
-constexpr uint32_t DEFAULT_DISPATCH_BUFFER_BLOCK_SIZE_PAGES = 768 * 1024 / (1 << DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE) / DEFAULT_DISPATCH_BUFFER_SIZE_BLOCKS;
-constexpr uint32_t DEFAULT_PREFETCHER_BUFFER_SIZE_PAGES = 768 * 1024 / (1 << DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE);
+constexpr uint32_t DEFAULT_DISPATCH_BUFFER_SIZE_BYTES = 768 * 1024;
+constexpr uint32_t DEFAULT_DISPATCH_BUFFER_BLOCK_SIZE_PAGES = DEFAULT_DISPATCH_BUFFER_SIZE_BYTES / (1 << DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE) / DEFAULT_DISPATCH_BUFFER_SIZE_BLOCKS;
+constexpr uint32_t DEFAULT_PREFETCHER_BUFFER_SIZE_PAGES = DEFAULT_DISPATCH_BUFFER_SIZE_BYTES / (1 << DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE);
 constexpr uint32_t MAX_XFER_SIZE_16B = 4 * 1024;
 constexpr uint32_t MIN_XFER_SIZE_16B = 1;
 constexpr uint32_t DEFAULT_PREFETCHER_PAGE_BATCH_SIZE = 1;
+
+constexpr uint32_t DEFAULT_PAGED_WRITE_PAGES = 4;
+constexpr uint32_t MAX_PAGED_WRITE_ADDR = 512 * 1024;
+constexpr uint32_t MIN_PAGED_WRITE_ADDR = 512 * 1024; // Disable randomization by default. 512 KB - 612 KB might be reasonable.
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Test dispatch program performance
@@ -44,6 +50,11 @@ uint32_t prefetcher_page_batch_size_g = DEFAULT_PREFETCHER_PAGE_BATCH_SIZE;
 uint32_t max_xfer_size_bytes_g = MAX_XFER_SIZE_16B << 4;
 uint32_t min_xfer_size_bytes_g = MIN_XFER_SIZE_16B << 4;
 uint32_t test_type_g;
+
+uint32_t max_paged_write_base_addr_g = MAX_PAGED_WRITE_ADDR;
+uint32_t min_paged_write_base_addr_g = MIN_PAGED_WRITE_ADDR;
+uint32_t num_pages_g = DEFAULT_PAGED_WRITE_PAGES;
+
 bool debug_g;
 bool lazy_g;
 bool fire_once_g;
@@ -75,12 +86,18 @@ void init(int argc, char **argv) {
         log_info(LogTest, "    -b: dispatcher buffer size in blocks (default {})", DEFAULT_DISPATCH_BUFFER_SIZE_BLOCKS);
         log_info(LogTest, "  -pbs: prefetcher buffer size pages (default {})", DEFAULT_PREFETCHER_BUFFER_SIZE_PAGES);
         log_info(LogTest, " -ppbs: prefetcher page batch size (process pages in batches of N to reduce overhead) (default {})", DEFAULT_PREFETCHER_PAGE_BATCH_SIZE);
-        log_info(LogTest, "  -max: max transfer size bytes (default {})", MAX_XFER_SIZE_16B << 4);
-        log_info(LogTest, "  -min: min transfer size bytes (default {})", MIN_XFER_SIZE_16B << 4);
         log_info(LogTest, "    -f: prefetcher fire once, use to measure dispatcher perf w/ prefetcher out of the way (default disabled)");
-        log_info(LogTest, "    -d: wrap all commands in debug commands (default disabled)");
+        log_info(LogTest, "    -d: wrap all commands in debug commands and clear DRAM to known state (default disabled)");
         log_info(LogTest, "    -c: use coherent data as payload (default false)");
         log_info(LogTest, "    -z: enable dispatch lazy mode (default disabled)");
+        log_info(LogTest, "   -np: paged-write number of pages (default {})", num_pages_g);
+
+        log_info(LogTest, "Random Test args:");
+        log_info(LogTest, "  -max: max transfer size bytes (default {})", max_xfer_size_bytes_g);
+        log_info(LogTest, "  -min: min transfer size bytes (default {})", min_xfer_size_bytes_g);
+        log_info(LogTest, "  -max-addr: max paged-write dst base addr (default {})", max_paged_write_base_addr_g);
+        log_info(LogTest, "  -min-addr: min paged-write dst base addr (default {})", min_paged_write_base_addr_g);
+
         exit(0);
     }
 
@@ -105,8 +122,10 @@ void init(int argc, char **argv) {
     pbs_pages = pbs_pages / prefetcher_page_batch_size_g * prefetcher_page_batch_size_g + terminate_cmd_pages;
     prefetcher_buffer_size_g = pbs_pages * dispatch_buffer_page_size_g;
 
-    max_xfer_size_bytes_g = test_args::get_command_option_uint32(input_args, "-max", MAX_XFER_SIZE_16B << 4);
-    min_xfer_size_bytes_g = test_args::get_command_option_uint32(input_args, "-min", MIN_XFER_SIZE_16B << 4);
+    max_xfer_size_bytes_g = test_args::get_command_option_uint32(input_args, "-max", max_xfer_size_bytes_g);
+    min_xfer_size_bytes_g = test_args::get_command_option_uint32(input_args, "-min", min_xfer_size_bytes_g);
+    max_paged_write_base_addr_g = test_args::get_command_option_uint32(input_args, "-max-addr", max_paged_write_base_addr_g);
+    min_paged_write_base_addr_g = test_args::get_command_option_uint32(input_args, "-min-addr", min_paged_write_base_addr_g);
 
     send_to_all_g = test_args::has_command_option(input_args, "-a");
 
@@ -122,21 +141,42 @@ void init(int argc, char **argv) {
 
     debug_g = test_args::has_command_option(input_args, "-d");
     lazy_g = test_args::has_command_option(input_args, "-z");
+    num_pages_g = test_args::get_command_option_uint32(input_args, "-np", num_pages_g);
 
     perf_test_g = (send_to_all_g && iterations_g == 1); // XXXX find a better way?
 }
 
-void gen_cmds(Device *device,
-              vector<uint32_t>& dispatch_cmds,
-              CoreRange worker_cores,
-              worker_data_t& worker_data,
-              uint32_t worker_data_addr,
-              uint32_t page_size) {
+// Keep these updated. One single place, for code to use.
+bool is_paged_dram_test() {
+    return (test_type_g == 2);
+}
+
+bool is_paged_l1_test() {
+    return (test_type_g == 3);
+}
+
+bool is_paged_test() {
+    bool is_paged_dram = is_paged_dram_test();
+    bool is_paged_l1 = is_paged_l1_test();
+    return (is_paged_dram || is_paged_l1);
+}
+
+
+// Unicast or Multicast Linear Write Test.
+void gen_linear_or_packed_write_test(uint32_t& cmd_count,
+                                bool is_linear_write,
+                                bool is_linear_multicast,
+                                Device *device,
+                                vector<uint32_t>& dispatch_cmds,
+                                CoreRange worker_cores,
+                                worker_data_t& worker_data,
+                                uint32_t worker_data_addr,
+                                uint32_t page_size) {
 
     uint32_t total_size_bytes = 0;
     uint32_t total_data_size_bytes = 0;
     uint32_t buffer_size = prefetcher_buffer_size_g - page_size; // for terminate
-    uint32_t cmd_count = 0;
+    log_info(tt::LogTest, "Generating linear: {} multicast: {} Write Test with dispatch buffer page_size: {}", is_linear_write, is_linear_multicast, page_size);
 
     while (total_size_bytes < buffer_size) {
         total_size_bytes += sizeof(CQDispatchCmd);
@@ -146,42 +186,24 @@ void gen_cmds(Device *device,
 
         uint32_t xfer_size_bytes = 0;
 
-        switch (test_type_g) {
-        case 0:
-            {
-                if (all_workers_g.size() != 1) {
-                    log_fatal("Should use single core for unicast write test. Other cores ignored.");
-                }
-
-                uint32_t xfer_size_16B = (std::rand() & (MAX_XFER_SIZE_16B - 1));
-                if (total_size_bytes + (xfer_size_16B << 4) > buffer_size) {
-                    xfer_size_16B = (buffer_size - total_size_bytes) >> 4;
-                }
-                xfer_size_bytes = xfer_size_16B << 4;
-                if (xfer_size_bytes > max_xfer_size_bytes_g) xfer_size_bytes = max_xfer_size_bytes_g;
-                if (xfer_size_bytes < min_xfer_size_bytes_g) xfer_size_bytes = min_xfer_size_bytes_g;
-                gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_cores.start, worker_data,
-                                                 worker_data_addr, xfer_size_bytes);
+        // Test specific stuff starts here.
+        if (is_linear_write) {
+            uint32_t xfer_size_16B = (std::rand() & (MAX_XFER_SIZE_16B - 1));
+            if (total_size_bytes + (xfer_size_16B << 4) > buffer_size) {
+                xfer_size_16B = (buffer_size - total_size_bytes) >> 4;
             }
-            break;
-        case 1:
-            {
-                uint32_t xfer_size_16B = (std::rand() & (MAX_XFER_SIZE_16B - 1));
-                if (total_size_bytes + (xfer_size_16B << 4) > buffer_size) {
-                    xfer_size_16B = (buffer_size - total_size_bytes) >> 4;
-                }
-                xfer_size_bytes = xfer_size_16B << 4;
-                if (xfer_size_bytes > max_xfer_size_bytes_g) xfer_size_bytes = max_xfer_size_bytes_g;
-                if (xfer_size_bytes < min_xfer_size_bytes_g) xfer_size_bytes = min_xfer_size_bytes_g;
-                gen_dispatcher_multicast_write_cmd(device, dispatch_cmds, worker_cores, worker_data,
-                                                 worker_data_addr, xfer_size_bytes);
 
+            xfer_size_bytes = xfer_size_16B << 4;
+            if (xfer_size_bytes > max_xfer_size_bytes_g) xfer_size_bytes = max_xfer_size_bytes_g;
+            if (xfer_size_bytes < min_xfer_size_bytes_g) xfer_size_bytes = min_xfer_size_bytes_g;
+
+            if (is_linear_multicast) {
+                gen_dispatcher_multicast_write_cmd(device, dispatch_cmds, worker_cores, worker_data, worker_data_addr, xfer_size_bytes);
+            } else {
+                gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_cores.start, worker_data, worker_data_addr, xfer_size_bytes);
             }
-            break;
-
-        case 2:
+        } else {
             xfer_size_bytes = gen_rnd_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_data, worker_data_addr);
-            break;
         }
 
         uint32_t page_size_words = page_size / sizeof(uint32_t);
@@ -196,14 +218,123 @@ void gen_cmds(Device *device,
     uint32_t page_size_words = page_size / sizeof(uint32_t);
     dispatch_cmds.resize((dispatch_cmds.size() + page_size_words - 1) / page_size_words * page_size_words);    // pad to page
     cmd_count++;
+}
+
+// DRAM or L1 Paged Write Test.
+void gen_paged_write_test(uint32_t& cmd_count,
+                        bool is_dram,
+                        Device *device,
+                        vector<uint32_t>& dispatch_cmds,
+                        CoreRange worker_cores,
+                        worker_data_t& worker_data,
+                        uint32_t worker_data_addr,
+                        uint32_t page_size) {
+
+    uint32_t total_size_bytes = 0;
+    uint32_t total_data_size_bytes = 0;
+    uint32_t buffer_size = prefetcher_buffer_size_g - page_size; // for terminate
+    uint32_t start_page = 0;
+    TT_ASSERT(is_paged_test()); // Ensure test-numbers kept up to date in this function.
+
+    uint32_t xfer_size_16B = (std::rand() & (MAX_XFER_SIZE_16B - 1));
+    if (total_size_bytes + (xfer_size_16B << 4) > buffer_size) {
+        xfer_size_16B = (buffer_size - total_size_bytes) >> 4;
+    }
+
+    // Treat xfer size test in test as page write page size here. Keep consistend for all cmds.
+    uint32_t page_size_bytes = xfer_size_16B << 4;
+    if (page_size_bytes > max_xfer_size_bytes_g) page_size_bytes = max_xfer_size_bytes_g;
+    if (page_size_bytes < min_xfer_size_bytes_g) page_size_bytes = min_xfer_size_bytes_g;
+
+    log_info(tt::LogTest, "Generating Paged Write test to {} for dispatch buffer page_size: {} write_cmd_page_size: {} start_page: {}",
+        is_dram ? "DRAM" : "L1", page_size, page_size_bytes, start_page);
+
+    while (total_size_bytes < buffer_size) {
+        total_size_bytes += sizeof(CQDispatchCmd);
+        if (debug_g) {
+            total_size_bytes += sizeof(CQDispatchCmd);
+        }
+
+        log_info(tt::LogTest, "Generating paged write cmds (is_dram: {} for total_size_bytes: {} buffer_size: {} page_size_bytes: {})",
+            is_dram, total_size_bytes, buffer_size, page_size_bytes);
+
+        gen_dispatcher_paged_write_cmd(device, dispatch_cmds, worker_data,
+                                        is_dram, start_page, worker_data_addr, page_size_bytes, num_pages_g);
+
+        // Offset start page by number of pages written, and use as next cmd start page to have writes to memory without gaps
+        start_page += num_pages_g;
+        uint32_t page_size_words = page_size / sizeof(uint32_t);
+        dispatch_cmds.resize((dispatch_cmds.size() + page_size_words - 1) / page_size_words * page_size_words); // pad to page
+
+        total_data_size_bytes += page_size_bytes;
+        total_size_bytes = dispatch_cmds.size() * sizeof(uint32_t);
+        cmd_count++;
+    }
+
+    gen_dispatcher_terminate_cmd(dispatch_cmds);
+    uint32_t page_size_words = page_size / sizeof(uint32_t);
+    dispatch_cmds.resize((dispatch_cmds.size() + page_size_words - 1) / page_size_words * page_size_words); // pad to page
+    cmd_count++;
+
+}
+
+// Generate Dispatcher Commands based on the type of test.
+void gen_cmds(Device *device,
+              vector<uint32_t>& dispatch_cmds,
+              CoreRange worker_cores,
+              worker_data_t& worker_data,
+              uint32_t worker_data_addr,
+              uint32_t page_size) {
+
+    uint32_t total_size_bytes = 0;
+    uint32_t total_data_size_bytes = 0;
+    uint32_t buffer_size = prefetcher_buffer_size_g - page_size; // for terminate
+    uint32_t cmd_count = 0;
+
+    switch (test_type_g) {
+    case 0:
+        if (all_workers_g.size() != 1) log_fatal("Should use single core for unicast write test. Other cores ignored.");
+        gen_linear_or_packed_write_test(cmd_count, true, false, device, dispatch_cmds, worker_cores, worker_data, worker_data_addr, page_size);
+        break;
+    case 1:
+        gen_linear_or_packed_write_test(cmd_count, true, true, device, dispatch_cmds, worker_cores, worker_data, worker_data_addr, page_size);
+        break;
+    case 2:
+    case 3:
+        gen_paged_write_test(cmd_count, is_paged_dram_test(), device, dispatch_cmds, worker_cores, worker_data, worker_data_addr, page_size);
+        break;
+    case 4:
+        gen_linear_or_packed_write_test(cmd_count, false, false, device, dispatch_cmds, worker_cores, worker_data, worker_data_addr, page_size);
+        break;
+    }
 
     log_info(LogTest, "Generated {} commands", cmd_count);
 }
 
+
+// Clear DRAM (helpful for paged write to DRAM debug to have a fresh slate)
+void initialize_dram_banks(Device *device)
+{
+
+    auto num_banks = device->num_banks(BufferType::DRAM);
+    auto bank_size = device->bank_size(BufferType::DRAM); // Or can hardcode to subset like 16MB.
+    auto fill = std::vector<uint32_t>(bank_size / sizeof(uint32_t), 0xBADDF00D);
+
+    for (int bank_id = 0; bank_id < num_banks; bank_id++) {
+        auto offset = device->dram_bank_offset_from_bank_id(bank_id);
+        auto dram_channel = device->dram_channel_from_bank_id(bank_id);
+        auto bank_core = device->core_from_dram_channel(dram_channel);
+        log_info(tt::LogTest, "Initializing DRAM {} bytes for bank_id: {} core: {} at addr: 0x{:x}", bank_size, bank_id, bank_core, offset);
+        tt::Cluster::instance().write_core(static_cast<const void*>(fill.data()), fill.size() * sizeof(uint32_t), tt_cxy_pair(device->id(), bank_core), offset);
+    }
+}
+
 int main(int argc, char **argv) {
     init(argc, argv);
+    std::srand(std::time(nullptr)); // Seed the RNG
 
     uint32_t dispatch_buffer_pages = dispatch_buffer_size_g / dispatch_buffer_page_size_g;
+    bool paged_test = is_paged_test();
 
     bool pass = true;
     try {
@@ -227,18 +358,59 @@ int main(int argc, char **argv) {
             log_fatal(LogTest, "Error, prefetcher buffer size too large\n");
             exit(-1);
         }
+
+        uint32_t write_buffer_addr = l1_buf_base;
+
+        // Seperate Buffer space for paged write testing to not conflict with dispatch or prefetch buffers in L1
+        if (paged_test) {
+            // Seems like 16B alignment is required otherwise mismatches in readback. Linear writes only target 16B aligned transfer sizes too.
+            // It's okay for these not to be, the random calc below will align final address.
+            if (max_paged_write_base_addr_g % 16 != 0) log_warning(tt::LogTest, "max_paged_write_base_addr_g should be 16B aligned.");
+            if (min_paged_write_base_addr_g % 16 != 0) log_warning(tt::LogTest, "min_paged_write_base_addr_g should be 16B aligned.");
+
+            // Need to be careful with write buffer address, especially for cases where L1 banks have negative offset (occurs for storage cores)
+            // so find minmum required bank offset such that the negative offsets will not cause underflow and bump up range to not be less.
+            bool is_dram = is_paged_dram_test();
+            uint32_t min_buffer_addr = get_min_required_buffer_addr(device, is_dram);
+
+            // Just avoid hazard by bumping up min, max - and let user know with a warning.
+            if (min_paged_write_base_addr_g < min_buffer_addr) {
+                log_warning("min_paged_write_base_addr_g: {:x} is too low. Increasing to min_buffer_addr: {:x}", min_paged_write_base_addr_g, min_buffer_addr);
+                min_paged_write_base_addr_g = min_buffer_addr;
+            }
+            if (max_paged_write_base_addr_g < min_buffer_addr || max_paged_write_base_addr_g < min_paged_write_base_addr_g) {
+                log_warning("max_paged_write_base_addr_g: {:x} is too low. Increasing to min_buffer_addr: {:x}", max_paged_write_base_addr_g, min_buffer_addr);
+                max_paged_write_base_addr_g = min_buffer_addr;
+            }
+
+            auto range = 1 + max_paged_write_base_addr_g - min_paged_write_base_addr_g;
+            write_buffer_addr = ((min_paged_write_base_addr_g + (std::rand() % range)) >> 4) << 4;
+        }
+
+        log_info(tt::LogTest, "Using write buffer at 0x{:x} (paged_test: {}) l1_buf_base: {:x}", write_buffer_addr, paged_test, l1_buf_base);
+
 #if 0
         Buffer l1_buf(device, prefetcher_buffer_size_g, prefetcher_buffer_size_g, BufferType::L1, TensorMemoryLayout::SINGLE_BANK);
 #endif
         vector<uint32_t> cmds;
         worker_data_t worker_data;
-        for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
-            for (uint32_t x = all_workers_g.start.x; x <= all_workers_g.end.x; x++) {
-                one_worker_data_t one;
-                worker_data.insert({CoreCoord(x, y), one});
+
+        // No need to add entries for worker cores in paged test. They will be added as needed for L1 or DRAM.
+        if (!paged_test){
+            const uint32_t bank_id = 0; // No interleaved pages here.
+            for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
+                for (uint32_t x = all_workers_g.start.x; x <= all_workers_g.end.x; x++) {
+                    worker_data[CoreCoord(x,y)][bank_id] = one_worker_data_t();
+                }
             }
         }
-        gen_cmds(device, cmds, all_workers_g, worker_data, l1_buf_base, dispatch_buffer_page_size_g);
+
+        if (is_paged_dram_test() && debug_g) {
+            initialize_dram_banks(device);
+        }
+
+        // Generate commands once and write them to prefetcher core.
+        gen_cmds(device, cmds, all_workers_g, worker_data, write_buffer_addr, dispatch_buffer_page_size_g);
         llrt::write_hex_vec_to_core(device->id(), phys_spoof_prefetch_core, cmds, l1_buf_base);
 
         std::map<string, string> defines = {
@@ -315,7 +487,8 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Dispatch buffer base {}", std::to_string(l1_buf_base));
         log_info(LogTest, "Dispatch buffer end {}", std::to_string(l1_buf_base + dispatch_buffer_page_size_g * dispatch_buffer_pages));
         log_info(LogTest, "Prefetcher CMD Buffer size {}", std::to_string(prefetcher_buffer_size_g));
-        log_info(LogTest, "Worker result data size {} bytes", std::to_string(worker_data[first_worker_g].data.size() * sizeof(uint32_t)));
+        log_info(LogTest, "Worker result data size {} bytes (single core)", std::to_string(worker_data_size(worker_data) * sizeof(uint32_t)));
+        log_info(LogTest, "Buffer addr for writes: {:x}", write_buffer_addr);
 
         // Cache stuff
         for (int i = 0; i < warmup_iterations_g; i++) {
@@ -337,7 +510,13 @@ int main(int argc, char **argv) {
         Finish(cq);
         auto end = std::chrono::system_clock::now();
 
-        pass &= validate_results(device, all_workers_g, worker_data, l1_buf_base);
+        if (paged_test) {
+            bool is_dram = is_paged_dram_test(); // Would like to get rid of this but following function needs to know CoreType.
+            pass &= validate_results_paged(device, worker_data, write_buffer_addr, is_dram);
+        } else {
+            pass &= validate_results(device, all_workers_g, worker_data, write_buffer_addr);
+        }
+
         std::chrono::duration<double> elapsed_seconds = (end-start);
         log_info(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);
         log_info(LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / iterations_g);
@@ -348,12 +527,19 @@ int main(int argc, char **argv) {
             }
             switch (test_type_g) {
             case 0:
-                total_words = worker_data_size(worker_data);
-                break;
             case 1:
                 total_words = worker_data_size(worker_data);
                 break;
             case 2:
+            case 3:
+                // Hacky.. for now, just compute based on pages written. Ideally iterate over all worker_data.
+                if (max_xfer_size_bytes_g == min_xfer_size_bytes_g) {
+                    total_words = (num_pages_g * max_xfer_size_bytes_g) / sizeof(uint32_t);
+                } else {
+                    log_fatal("Set max_xfer_size_bytes_g to min_xfer_size_bytes_g to calculate perf accurately");
+                }
+                break;
+            case 4:
                 if (!send_to_all_g) {
                     log_fatal("Set send_to_all to true for reliable perf data");
                 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -99,15 +99,15 @@ void init(int argc, char **argv) {
         log_info(LogTest, " -wy: bottom-most worker in grid (default {})", all_workers_g.end.y);
         log_info(LogTest, "  -b: run a \"big\" test (fills memory w/ fewer transactions) (default false)", DEFAULT_TEST_TYPE);
         log_info(LogTest, " -rb: gen data, readback and test every iteration - disable for perf measurements (default true)");
-        log_info(LogTest, "  -d: wrap all commands in debug commands (default disabled)");
+        log_info(LogTest, "  -d: wrap all commands in debug commands and clear DRAM to known state (default disabled)");
         log_info(LogTest, "  -hp: host huge page buffer size (default {})", DEFAULT_HUGEPAGE_BUFFER_SIZE);
         log_info(LogTest, "  -pq: prefetch queue entries (default {})", DEFAULT_PREFETCH_Q_ENTRIES);
         log_info(LogTest, "  -cs: max cmddat q size (default {})", DEFAULT_CMDDAT_Q_SIZE);
         log_info(LogTest, "  -ss: max scratch cb size (default {})", DEFAULT_SCRATCH_DB_SIZE);
         log_info(LogTest, "  -mc: max command size (default {})", DEFAULT_MAX_PREFETCH_COMMAND_SIZE);
         log_info(LogTest, "  -pcies: size of data to transfer in pcie bw test type (default )", PCIE_TRANSFER_SIZE_DEFAULT);
-        log_info(LogTest, "  -dpgs: dram page size in dram bw test type (default )", DRAM_PAGE_SIZE_DEFAULT);
-        log_info(LogTest, "  -dpgr: dram pages to read in dram bw test type (default )", DRAM_PAGES_TO_READ_DEFAULT);
+        log_info(LogTest, "  -dpgs: dram page size in dram bw test type (default: {} )", DRAM_PAGE_SIZE_DEFAULT);
+        log_info(LogTest, "  -dpgr: dram pages to read in dram bw test type (default: {} )", DRAM_PAGES_TO_READ_DEFAULT);
         log_info(LogTest, "  -c: use coherent data as payload (default false)");
         log_info(LogTest, "  -s: seed for randomized tests (default 1)");
         exit(0);
@@ -160,21 +160,24 @@ void add_bare_prefetcher_cmd(vector<uint32_t>& cmds,
     }
 }
 
-void add_prefetcher_dram_cmd(vector<uint32_t>& cmds,
+void add_prefetcher_paged_read_cmd(vector<uint32_t>& cmds,
                              vector<uint16_t>& sizes,
                              uint32_t start_page,
                              uint32_t base_addr,
                              uint32_t page_size,
-                             uint32_t pages) {
+                             uint32_t pages,
+                             bool is_dram) {
 
     CQPrefetchCmd cmd;
     cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_PAGED;
 
-    cmd.relay_paged.is_dram = true;
+    cmd.relay_paged.is_dram = is_dram;
     cmd.relay_paged.start_page = start_page;
     cmd.relay_paged.base_addr = base_addr;
     cmd.relay_paged.page_size = page_size;
     cmd.relay_paged.pages = pages;
+    log_debug(tt::LogTest, "Generating CQ_PREFETCH_CMD_RELAY_PAGED w/ is_dram: {} start_page: {} base_addr: {} page_size: {} pages: {}",
+        is_dram, start_page, base_addr, page_size, pages);
 
     add_bare_prefetcher_cmd(cmds, cmd, true);
 }
@@ -291,7 +294,6 @@ void add_paged_dram_data_to_worker_data(const unordered_map<uint32_t, vector<uin
 
     uint32_t base_addr_words = base_addr / sizeof(uint32_t);
     uint32_t page_size_words = page_size / sizeof(uint32_t);
-    const uint32_t bank_id = 0; // No interleaved pages here.
 
     // Get data from DRAM map, add to all workers, but only set valid for cores included in workers range.
     TT_ASSERT(start_page < num_dram_banks_g);
@@ -312,6 +314,45 @@ void add_paged_dram_data_to_worker_data(const unordered_map<uint32_t, vector<uin
     }
 }
 
+// Model a paged write to DRAM by updating dram data with interleaved/paged data from worker data, for validation later.
+void add_paged_write_data_to_dram_data(Device *device,
+                                    unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                                    const worker_data_t& worker_data,
+                                    uint32_t start_page,
+                                    uint32_t base_addr,
+                                    uint32_t page_size,
+                                    uint32_t pages) {
+
+    uint32_t base_addr_words = base_addr / sizeof(uint32_t);
+    uint32_t page_size_words = page_size / sizeof(uint32_t);
+
+    // Get data from DRAM map, add to all workers, but only set valid for cores included in workers range.
+    TT_ASSERT(start_page < num_dram_banks_g);
+    for (uint32_t page_idx = start_page; page_idx < start_page + pages; page_idx++) {
+
+        uint32_t dram_bank_id = page_idx % num_dram_banks_g;
+        uint32_t bank_offset = base_addr_words + page_size_words * (page_idx / num_dram_banks_g);
+
+        auto dram_channel = device->dram_channel_from_bank_id(dram_bank_id);
+        auto bank_core = device->core_from_dram_channel(dram_channel);
+        log_debug(tt::LogTest, "{} - Starting base_addr: {} base_addr_words: {} page_idx: {} of pages: {} dram_bank_id: {} dram_channel: {} bank_core: {} page_size_words: {} => bank_offset: {}",
+            __FUNCTION__, base_addr, base_addr_words, page_idx, pages, dram_bank_id, dram_channel, bank_core.str(), page_size_words, bank_offset);
+
+        // Can hit this if we start off with start_page > 0.
+        TT_ASSERT(bank_offset + page_size_words <= worker_data.at(bank_core).at(dram_bank_id).data.size(),
+            "Worker data for bank core is not large enough for paged write. Make sure to start with start_page: 0.");
+
+        for (uint32_t j = 0; j  < page_size_words; j++) {
+            const uint32_t& datum = worker_data.at(bank_core).at(dram_bank_id).data.at(bank_offset + j);
+            dram_data_map.at(dram_bank_id)[bank_offset + j] = datum;
+            log_trace(tt::LogTest, "{} - Set page_idx: {} dram_bank_id: {} bank_offset: {} from base_addr: 0x{:x} => j: {} data: 0x{:x}",
+                __FUNCTION__, page_idx, dram_bank_id, bank_offset, base_addr, j, dram_data_map.at(dram_bank_id)[bank_offset + j]);
+        }
+    }
+}
+
+
+// Interleaved/Paged Read of DRAM to Worker L1
 void gen_dram_read_cmd(Device *device,
                        vector<uint32_t>& prefetch_cmds,
                        vector<uint16_t>& cmd_sizes,
@@ -325,14 +366,17 @@ void gen_dram_read_cmd(Device *device,
                        uint32_t pages) {
 
     vector<uint32_t> dispatch_cmds;
+    const bool is_dram = true;
 
     uint32_t worker_data_size = page_size * pages;
-    gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, worker_data_size);
+    log_trace(tt::LogTest, "Starting {} with worker_core: {} dst_addr: 0x{:x} start_page: {} base_addr: 0x{:x} page_size: {} pages: {}. worker_data_size: 0x{:x}",
+        __FUNCTION__, worker_core.str(), dst_addr, start_page, base_addr, page_size, pages, worker_data_size);
 
+    gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, worker_data_size);
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
 
     auto prior_end = prefetch_cmds.size();
-    add_prefetcher_dram_cmd(prefetch_cmds, cmd_sizes, start_page, base_addr + DRAM_HACKED_BASE_ADDR, page_size, pages);
+    add_prefetcher_paged_read_cmd(prefetch_cmds, cmd_sizes, start_page, base_addr + DRAM_HACKED_BASE_ADDR, page_size, pages, is_dram);
 
     uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
     TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
@@ -342,6 +386,31 @@ void gen_dram_read_cmd(Device *device,
     // Model the paged read in this function by updating worker data with interleaved/paged DRAM data, for validation later.
     add_paged_dram_data_to_worker_data(dram_data_map, worker_core, worker_data, start_page, base_addr, page_size, pages);
 }
+
+
+// Interleaved/Paged Write to DRAM.
+void gen_dram_write_cmd(Device *device,
+                    vector<uint32_t>& prefetch_cmds,
+                    vector<uint16_t>& cmd_sizes,
+                    unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                    worker_data_t& worker_data,
+                    uint32_t start_page,
+                    uint32_t base_addr,
+                    uint32_t page_size,
+                    uint32_t pages) {
+
+    vector<uint32_t> dispatch_cmds;
+    const bool is_dram = true;
+    log_trace(tt::LogTest, "Starting {} with is_dram: {} start_page: {} base_addr: {} page_size: {} pages: {}", __FUNCTION__, is_dram, start_page, base_addr, page_size, pages);
+
+    gen_dispatcher_paged_write_cmd(device, dispatch_cmds, worker_data, is_dram, start_page, base_addr + DRAM_HACKED_BASE_ADDR, page_size, pages);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    // Model the paged write in this function by updating dram data with interleaved/paged DRAM data, for validation later.
+    add_paged_write_data_to_dram_data(device, dram_data_map, worker_data, start_page, base_addr, page_size, pages);
+
+}
+
 
 // This is pretty much a blit: copies from worker core's start of data back to the end of data
 void gen_linear_read_cmd(Device *device,
@@ -421,7 +490,7 @@ void gen_dispatcher_delay_cmd(Device *device,
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
 }
 
-void gen_dram_test(Device *device,
+void gen_paged_read_dram_test(Device *device,
                    vector<uint32_t>& prefetch_cmds,
                    vector<uint16_t>& cmd_sizes,
                    const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
@@ -429,16 +498,63 @@ void gen_dram_test(Device *device,
                    CoreCoord worker_core,
                    uint32_t dst_addr) {
 
-    vector<uint32_t> dispatch_cmds;
+    uint32_t pages_read = 0;
+    bool finished = false;
 
-    while (worker_data_size(worker_data) * sizeof(uint32_t) < WORKER_DATA_SIZE) {
-        dispatch_cmds.resize(0);
-        uint32_t start_page = 0;
-        uint32_t base_addr = 0;
+    log_info(tt::LogTest, "Running Paged Read DRAM test with num_pages: {} page_size: {} to worker_core: {}", dram_pages_to_read_g, dram_page_size_g, worker_core.str());
+    while (!finished) {
+
+        uint32_t start_page = pages_read % num_dram_banks_g;
+        uint32_t base_addr = (pages_read / num_dram_banks_g) * dram_page_size_g;
+
         gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                           start_page, base_addr, dram_page_size_g, dram_pages_to_read_g);
 
         bytes_of_data_g += dram_page_size_g * dram_pages_to_read_g;
+        pages_read += dram_pages_to_read_g;
+
+        uint32_t all_valid_worker_data_size = worker_data_size(worker_data, true) * sizeof(uint32_t);
+        finished = all_valid_worker_data_size >= WORKER_DATA_SIZE;
+    }
+}
+
+// End-To-End Paged/Interleaved Write+Read test that does the following:
+//  1. Paged Write of host data to DRAM banks by dispatcher cmd, followed by stall to avoid RAW hazard
+//  2. Paged Read of DRAM banks by prefetcher, relay data to dispatcher for linear write to L1.
+//  3. Do previous 2 steps in a loop, reading and writing new data until WORKER_DATA_SIZE bytes is written to worker core.
+void gen_paged_write_read_dram_test(Device *device,
+                   vector<uint32_t>& prefetch_cmds,
+                   vector<uint16_t>& cmd_sizes,
+                   unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                   worker_data_t& worker_data,
+                   CoreCoord worker_core,
+                   uint32_t dst_addr) {
+
+    // Keep a running total, to correctly calculate start page, base addr, write addr based on num banks.
+    uint32_t pages_written = 0;
+    bool finished = false;
+
+    log_info(tt::LogTest, "Running Paged Write+Read DRAM test with num_pages: {} page_size: {} to worker_core: {}", dram_pages_to_read_g, dram_page_size_g, worker_core.str());
+    while (!finished) {
+
+        uint32_t start_page = pages_written % num_dram_banks_g;                         // For paged read/write
+        uint32_t base_addr = (pages_written / num_dram_banks_g) * dram_page_size_g;     // For paged read/write
+        uint32_t write_addr = dst_addr + (pages_written * dram_page_size_g);            // For linear write to L1.
+
+        gen_dram_write_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data,
+                          start_page, base_addr, dram_page_size_g, dram_pages_to_read_g);
+        gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
+        gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, write_addr,
+                          start_page, base_addr, dram_page_size_g, dram_pages_to_read_g);
+
+        bytes_of_data_g += dram_page_size_g * dram_pages_to_read_g;
+        pages_written += dram_pages_to_read_g;
+
+        uint32_t all_valid_worker_data_size = worker_data_size(worker_data, true) * sizeof(uint32_t);
+        finished = all_valid_worker_data_size >= WORKER_DATA_SIZE;
+
+        log_debug(tt::LogTest, "{} - Finished gen cmds w/ worker_data_size: 0x{:x} finished: {} pages_written: {} num_banks: {} (start_page: {} base_addr: 0x{:x} write_addr: 0x{:x})",
+            __FUNCTION__, all_valid_worker_data_size, finished, pages_written, num_dram_banks_g, start_page, base_addr, write_addr);
     }
 }
 
@@ -573,7 +689,7 @@ void gen_rnd_test(Device *device,
 void gen_smoke_test(Device *device,
                     vector<uint32_t>& prefetch_cmds,
                     vector<uint16_t>& cmd_sizes,
-                    const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                    unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                     worker_data_t& worker_data,
                     CoreCoord worker_core,
                     uint32_t dst_addr) {
@@ -681,12 +797,18 @@ void gen_smoke_test(Device *device,
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
     gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
     gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr, 32, worker_data[worker_core][0].data.size() - 32 / sizeof(uint32_t));
+
+    // Test Paged DRAM Write and Read. FIXME - Needs work - hits asserts.
+    // gen_dram_write_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, 0, 32, 64, 128);
+    // gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
+    // gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr, 0, 32, 64, 128);
+
 }
 
 void gen_prefetcher_cmds(Device *device,
                          vector<uint32_t>& prefetch_cmds,
                          vector<uint16_t>& cmd_sizes,
-                         const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                         unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                          worker_data_t& worker_data,
                          uint32_t dst_addr) {
 
@@ -701,7 +823,10 @@ void gen_prefetcher_cmds(Device *device,
         gen_pcie_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
         break;
     case 3:
-        gen_dram_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
+        gen_paged_read_dram_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
+        break;
+    case 4:
+        gen_paged_write_read_dram_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
         break;
     }
 }
@@ -835,6 +960,24 @@ void populate_interleaved_dram(Device *device, unordered_map<uint32_t, vector<ui
     }
 }
 
+// Clear DRAM (helpful for paged write to DRAM debug to have a fresh slate)
+void initialize_dram_banks(Device *device)
+{
+
+    auto num_banks = device->num_banks(BufferType::DRAM);
+    auto bank_size = DRAM_DATA_SIZE_WORDS * sizeof(uint32_t); // device->bank_size(BufferType::DRAM);
+    auto fill = std::vector<uint32_t>(bank_size / sizeof(uint32_t), 0xBADDF00D);
+
+    for (int bank_id = 0; bank_id < num_banks; bank_id++) {
+        auto offset = device->dram_bank_offset_from_bank_id(bank_id);
+        auto dram_channel = device->dram_channel_from_bank_id(bank_id);
+        auto bank_core = device->core_from_dram_channel(dram_channel);
+
+        log_info(tt::LogTest, "Initializing DRAM {} bytes for bank_id: {} core: {} at addr: 0x{:x}", bank_size, bank_id, bank_core.str(), offset);
+        tt::Cluster::instance().write_core(static_cast<const void*>(fill.data()), fill.size() * sizeof(uint32_t), tt_cxy_pair(device->id(), bank_core), offset);
+    }
+}
+
 std::chrono::duration<double> run_test(uint32_t iterations,
                                        Device *device,
                                        Program& program,
@@ -927,14 +1070,16 @@ int main(int argc, char **argv) {
             }
         }
 
+        if (debug_g) {
+            initialize_dram_banks(device);
+        }
+
         // Model of interleaved DRAM memory by bank id
         unordered_map<uint32_t, vector<uint32_t>> dram_data_map;
         populate_interleaved_dram(device, dram_data_map);
 
         tt::Cluster::instance().l1_barrier(device->id());
         tt::Cluster::instance().dram_barrier(device->id());
-        gen_prefetcher_cmds(device, cmds, cmd_sizes, dram_data_map, worker_data, l1_buf_base);
-        gen_terminate_cmds(terminate_cmds, terminate_sizes);
 
         std::map<string, string> defines = {
             {"PREFETCH_NOC_X", std::to_string(phys_prefetch_core.x)},
@@ -1028,6 +1173,7 @@ int main(int argc, char **argv) {
 
         // Cache stuff
         if (warmup_g) {
+            log_info(tt::LogTest, "Warming up cache now...");
             std::thread t1 ([&]() {
                 write_prefetcher_cmds(1, device, cmds, cmd_sizes, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
                 write_prefetcher_cmds(1, device, terminate_cmds, terminate_sizes, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
@@ -1037,7 +1183,9 @@ int main(int argc, char **argv) {
             initialize_device_g = true;
         }
 
+        log_info(tt::LogTest, "Generating cmds and running {} iterations (readback_every_iter: {}) now...", iterations_g, readback_every_iteration_g);
         if (readback_every_iteration_g) {
+            gen_terminate_cmds(terminate_cmds, terminate_sizes);
             for (int i = 0; i < iterations_g; i++) {
                 log_info(LogTest, "Iteration: {}", std::to_string(i));
                 initialize_device_g = true;
@@ -1052,6 +1200,8 @@ int main(int argc, char **argv) {
                 }
             }
         } else {
+            gen_prefetcher_cmds(device, cmds, cmd_sizes, dram_data_map, worker_data, l1_buf_base);
+            gen_terminate_cmds(terminate_cmds, terminate_sizes);
             auto elapsed_seconds = run_test(iterations_g, device, program, cmd_sizes, terminate_sizes, cmds, terminate_cmds, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
 
             log_info(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);


### PR DESCRIPTION
Including the test_dispatcher/infra changes for testing CQ_DISPATCH_CMD_WRITE_PAGED that are (now passing more cases) that I excluded from previous merge. 

- Dispatcher test/infra updates (mostly new functions for paged write handling) for L1, DRAM and perf testing.
- A script for bunch of interesting testcases I've tried so far crossed with DRAM/L1, for easy verif, and comparisons (since these tests are not yet in CI, will work on that later and include a few of the more interesting cases here).

Thinking of keeping as 3 different commits, but can squash if we feel strongly.

WIP (Not included here) test_prefetcher.cpp changes.