### PR TITLE
Enable basic width sharding support in all-gather

### DIFF
--- a/tests/tt_eager/module.mk
+++ b/tests/tt_eager/module.mk
@@ -6,6 +6,7 @@ TT_EAGER_TESTS += \
 		 tests/tt_eager/dtx/collapse_transformations \
 		 tests/tt_eager/dtx/test_dtx \
 		 tests/tt_eager/dtx/test_dtx_tilized_row_to_col_major \
+		 tests/tt_eager/ops/ccl/test_all_gather_utils \
 		 tests/tt_eager/ops/test_average_pool \
 		 tests/tt_eager/ops/test_eltwise_binary_op \
 		 tests/tt_eager/ops/test_eltwise_unary_op \

--- a/tests/tt_eager/ops/ccl/test_all_gather_utils.cpp
+++ b/tests/tt_eager/ops/ccl/test_all_gather_utils.cpp
@@ -1,0 +1,329 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp"
+
+// Col major orientation not supported yet
+TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_GetFirstOutputShardStartingLocation_RowMajorOrientation) {
+    // tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+    //     num_workers, input_tensor_shard_grid_size, ring_index, serving_worker_index);
+
+    {
+        uint32_t ring_size = 8;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                1, 1, 0, ring_size, 0);
+        ASSERT_EQ(dest_worker_index, 0);
+        ASSERT_EQ(offset_chunk_in_worker, 0);
+    }
+    {
+        uint32_t ring_size = 8;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                1, 1, 1, ring_size, 0);
+        ASSERT_EQ(dest_worker_index, 0);
+        ASSERT_EQ(offset_chunk_in_worker, 1);
+    }
+    {
+        uint32_t ring_size = 2;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                4, 16, 0, ring_size, 0);
+        ASSERT_EQ(dest_worker_index, 0);
+        ASSERT_EQ(offset_chunk_in_worker, 0);
+    }
+    {
+        uint32_t ring_size = 2;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                4, 16, 0, ring_size, 1);
+        ASSERT_EQ(dest_worker_index, 2);
+        ASSERT_EQ(offset_chunk_in_worker, 0);
+    }
+    {
+        uint32_t ring_size = 2;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                4, 16, 1, ring_size, 0);
+        ASSERT_EQ(dest_worker_index, 8);
+        ASSERT_EQ(offset_chunk_in_worker, 0);
+    }
+    {
+        uint32_t ring_size = 2;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                4, 16, 1, ring_size, 1);
+        ASSERT_EQ(dest_worker_index, 10);
+        ASSERT_EQ(offset_chunk_in_worker, 0);
+    }
+    {
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 1;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+            // num_workers, input_tensor_shard_grid_size, ring_index, ring_size, serving_worker_index);
+                num_workers, 2, 0, ring_size, 0);
+        ASSERT_EQ(dest_worker_index, 0);
+        ASSERT_EQ(offset_chunk_in_worker, 0);
+    }
+    {
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 2;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+            // num_workers, input_tensor_shard_grid_size, ring_index, ring_size, serving_worker_index);
+                num_workers, 2, 0, ring_size, 0);
+        ASSERT_EQ(dest_worker_index, 0);
+        ASSERT_EQ(offset_chunk_in_worker, 0);
+    }
+    {
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 2;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+            // num_workers, input_tensor_shard_grid_size, ring_index, ring_size, serving_worker_index);
+                num_workers, 2, 0, ring_size, 1);
+        ASSERT_EQ(dest_worker_index, 0);
+        ASSERT_EQ(offset_chunk_in_worker, 1);
+    }
+    {
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 2;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+            // num_workers, input_tensor_shard_grid_size, ring_index, ring_size, serving_worker_index);
+                num_workers, 2, 1, ring_size, 1);
+        ASSERT_EQ(dest_worker_index, 0);
+        ASSERT_EQ(offset_chunk_in_worker, 3);
+    }
+}
+
+
+TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_ComputeWorkerDestCores_WidthSharding) {
+    // tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+    //         ccl::ShardType shard_type,
+    //         std::vector<CoreCoord> const& global_shard_dest_cores,
+    //         uint32_t input_num_shards,
+    //         uint32_t output_num_shards,
+    //         uint32_t num_workers,
+    //         uint32_t worker_index,
+    //         bool is_shard_orientation_row_major)
+
+    bool is_shard_orientation_row_major = true;
+    ccl::ShardType shard_type = ccl::ShardType::Width;
+    {
+        auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+            shard_type, {CoreCoord(0,0)}, 1, 8, 1, 0, is_shard_orientation_row_major);
+        ASSERT_EQ(dest_cores.size(), 1);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+    }
+    {
+        std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0)};
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 1;
+        auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+            shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
+        ASSERT_EQ(dest_cores.size(), 2);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+    }
+    {
+        std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0)};
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 2;
+        auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+            shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
+        ASSERT_EQ(dest_cores.size(), 2);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+        // ASSERT_EQ(dest_cores.size(), 1);
+        // ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+    }
+    {
+        std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0)};
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 2;
+        auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+            shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
+        ASSERT_EQ(dest_cores.size(), 2);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+        // ASSERT_EQ(dest_cores.size(), 1);
+        // ASSERT_EQ(dest_cores.at(0), CoreCoord(1,0));
+    }
+
+    // { // Unsupported For Now
+    //     std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0),CoreCoord(2,0),CoreCoord(3,0)};
+    //     uint32_t ring_size = 8;
+    //     uint32_t num_workers = 2;
+    //     auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+    //         shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
+    //     ASSERT_EQ(dest_cores.size(), 4);
+    //     ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+    //     ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+    //     ASSERT_EQ(dest_cores.at(1), CoreCoord(2,0));
+    //     ASSERT_EQ(dest_cores.at(2), CoreCoord(3,0));
+    // }
+    // { // Unsupported For Now
+    //     std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0),CoreCoord(2,0),CoreCoord(3,0)};
+    //     uint32_t ring_size = 8;
+    //     uint32_t num_workers = 2;
+    //     auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+    //         shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
+    //     ASSERT_EQ(dest_cores.size(), 4);
+    //     ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+    //     ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+    //     ASSERT_EQ(dest_cores.at(1), CoreCoord(2,0));
+    //     ASSERT_EQ(dest_cores.at(2), CoreCoord(3,0));
+    // }
+
+    { // shard grid size = 16, ring size = 8, num_workers = 1
+        std::vector<CoreCoord> global_shard_dest_cores =
+            {CoreCoord(0,0),CoreCoord(1,0)};
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 2;
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 2);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+            ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 2);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+            ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+        }
+    }
+    { // shard grid size = 16, ring size = 8, num_workers = 1
+        std::vector<CoreCoord> global_shard_dest_cores =
+            {CoreCoord(0,0),CoreCoord(1,0)};
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 1;
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 2);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+            ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+        }
+    }
+
+    { // shard grid size = 16, ring size = 8, num_workers = 1
+        std::vector<CoreCoord> global_shard_dest_cores =
+            {CoreCoord(0,0),CoreCoord(1,0),CoreCoord(2,0),CoreCoord(3,0),CoreCoord(4,0),CoreCoord(5,0),CoreCoord(6,0),CoreCoord(7,0),
+                CoreCoord(0,1),CoreCoord(1,1),CoreCoord(2,1),CoreCoord(3,1),CoreCoord(4,1),CoreCoord(5,1),CoreCoord(6,1),CoreCoord(7,1)};
+        uint32_t ring_size = 2;
+        uint32_t num_workers = 4;
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 4);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+            ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(0,1));
+            ASSERT_EQ(dest_cores.at(3), CoreCoord(1,1));
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 4);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(2,0));
+            ASSERT_EQ(dest_cores.at(1), CoreCoord(3,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(2,1));
+            ASSERT_EQ(dest_cores.at(3), CoreCoord(3,1));
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 2, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 4);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(4,0));
+            ASSERT_EQ(dest_cores.at(1), CoreCoord(5,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(4,1));
+            ASSERT_EQ(dest_cores.at(3), CoreCoord(5,1));
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 3, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 4);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(6,0));
+            ASSERT_EQ(dest_cores.at(1), CoreCoord(7,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(6,1));
+            ASSERT_EQ(dest_cores.at(3), CoreCoord(7,1));
+        }
+    }
+
+    { // shard grid size = 64, ring size = 8, num_workers = 4
+        std::vector<CoreCoord> global_shard_dest_cores =
+            {CoreCoord(0,0),CoreCoord(1,0),CoreCoord(2,0),CoreCoord(3,0),CoreCoord(4,0),CoreCoord(5,0),CoreCoord(6,0),CoreCoord(7,0),
+                CoreCoord(0,1),CoreCoord(1,1),CoreCoord(2,1),CoreCoord(3,1),CoreCoord(4,1),CoreCoord(5,1),CoreCoord(6,1),CoreCoord(7,1),
+                CoreCoord(0,2),CoreCoord(1,2),CoreCoord(2,2),CoreCoord(3,2),CoreCoord(4,2),CoreCoord(5,2),CoreCoord(6,2),CoreCoord(7,2),
+                CoreCoord(0,3),CoreCoord(1,3),CoreCoord(2,3),CoreCoord(3,3),CoreCoord(4,3),CoreCoord(5,3),CoreCoord(6,3),CoreCoord(7,3),
+                CoreCoord(0,4),CoreCoord(1,4),CoreCoord(2,4),CoreCoord(3,4),CoreCoord(4,4),CoreCoord(5,4),CoreCoord(6,4),CoreCoord(7,4),
+                CoreCoord(0,5),CoreCoord(1,5),CoreCoord(2,5),CoreCoord(3,5),CoreCoord(4,5),CoreCoord(5,5),CoreCoord(6,5),CoreCoord(7,5),
+                CoreCoord(0,6),CoreCoord(1,6),CoreCoord(2,6),CoreCoord(3,6),CoreCoord(4,6),CoreCoord(5,6),CoreCoord(6,6),CoreCoord(7,6),
+                CoreCoord(0,7),CoreCoord(1,7),CoreCoord(2,7),CoreCoord(3,7),CoreCoord(4,7),CoreCoord(5,7),CoreCoord(6,7),CoreCoord(7,7)};
+        EXPECT_EQ(global_shard_dest_cores.size(), 64); // otherwise I set it up wrong D:
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 4;
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 16);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(0,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(1,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(0,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(1,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(0,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(1,3));
+            ASSERT_EQ(dest_cores.at(8), CoreCoord(0,4));   ASSERT_EQ(dest_cores.at(9), CoreCoord(1,4));
+            ASSERT_EQ(dest_cores.at(10), CoreCoord(0,5));  ASSERT_EQ(dest_cores.at(11), CoreCoord(1,5));
+            ASSERT_EQ(dest_cores.at(12), CoreCoord(0,6));  ASSERT_EQ(dest_cores.at(13), CoreCoord(1,6));
+            ASSERT_EQ(dest_cores.at(14), CoreCoord(0,7));  ASSERT_EQ(dest_cores.at(15), CoreCoord(1,7));
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 16);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(2,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(3,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(2,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(3,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(2,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(3,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(2,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(3,3));
+            ASSERT_EQ(dest_cores.at(8), CoreCoord(2,4));   ASSERT_EQ(dest_cores.at(9), CoreCoord(3,4));
+            ASSERT_EQ(dest_cores.at(10), CoreCoord(2,5));  ASSERT_EQ(dest_cores.at(11), CoreCoord(3,5));
+            ASSERT_EQ(dest_cores.at(12), CoreCoord(2,6));  ASSERT_EQ(dest_cores.at(13), CoreCoord(3,6));
+            ASSERT_EQ(dest_cores.at(14), CoreCoord(2,7));  ASSERT_EQ(dest_cores.at(15), CoreCoord(3,7));
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 2, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 16);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(4,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(5,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(4,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(5,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(4,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(5,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(4,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(5,3));
+            ASSERT_EQ(dest_cores.at(8), CoreCoord(4,4));   ASSERT_EQ(dest_cores.at(9), CoreCoord(5,4));
+            ASSERT_EQ(dest_cores.at(10), CoreCoord(4,5));  ASSERT_EQ(dest_cores.at(11), CoreCoord(5,5));
+            ASSERT_EQ(dest_cores.at(12), CoreCoord(4,6));  ASSERT_EQ(dest_cores.at(13), CoreCoord(5,6));
+            ASSERT_EQ(dest_cores.at(14), CoreCoord(4,7));  ASSERT_EQ(dest_cores.at(15), CoreCoord(5,7));
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 3, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 16);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(6,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(7,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(6,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(7,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(6,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(7,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(6,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(7,3));
+            ASSERT_EQ(dest_cores.at(8), CoreCoord(6,4));   ASSERT_EQ(dest_cores.at(9), CoreCoord(7,4));
+            ASSERT_EQ(dest_cores.at(10), CoreCoord(6,5));  ASSERT_EQ(dest_cores.at(11), CoreCoord(7,5));
+            ASSERT_EQ(dest_cores.at(12), CoreCoord(6,6));  ASSERT_EQ(dest_cores.at(13), CoreCoord(7,6));
+            ASSERT_EQ(dest_cores.at(14), CoreCoord(6,7));  ASSERT_EQ(dest_cores.at(15), CoreCoord(7,7));
+        }
+    }
+
+    // TODO: Add a 64 core, 8 ring size test
+}

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
@@ -178,7 +178,7 @@ def run_all_gather_on_t3000_impl_tight_loop(
         ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
     ],
 )
-@pytest.mark.parametrize("num_iters", [100])
+@pytest.mark.parametrize("num_iters", [10])  # TODO: restore to 500
 def test_all_gather_on_t3000_post_commit_looping(
     all_devices,
     num_devices,
@@ -435,94 +435,235 @@ def test_all_gather_on_t3000_nightly(
     )
 
 
-@pytest.mark.skip("Not ready for prime time")
+# @pytest.mark.skip("Not ready for prime time")
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize(
-    "input_shape, dim, layout",
-    [
-        # Input, Selfout, Final AllGather
-        ([1, 1, 32, 8192], 3, ttl.tensor.Layout.TILE),
-    ],
-)
-@pytest.mark.parametrize("num_cores", [2])
+@pytest.mark.parametrize("num_devices", [8])
+@pytest.mark.parametrize("dim", [3])
+@pytest.mark.parametrize("tensor_layout", [ttl.tensor.Layout.TILE])
+# @pytest.mark.parametrize("num_cores", [1])
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        # ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.DataType.BFLOAT8_B,
+        ttl.tensor.DataType.BFLOAT16,
+        # ttl.tensor.DataType.BFLOAT8_B,
     ],
 )
+@pytest.mark.parametrize(
+    "tensor_mem_layout",
+    [
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+        # ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        # ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+    ],
+)
+@pytest.mark.parametrize(
+    "orientation", [ttl.tensor.ShardOrientation.ROW_MAJOR]
+)  # , ttl.tensor.ShardOrientation.COLUMN_MAJOR])
 @pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "input_shape, input_shard_shape,shard_grid",
+    (
+        (
+            (1, 1, 32, 32),
+            (32, 32),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(0, 0))}),
+        ),
+        (
+            (1, 1, 32, 64),
+            (32, 64),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(0, 0))}),
+        ),
+        (
+            (1, 1, 32, 128),
+            (32, 128),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(0, 0))}),
+        ),
+        (
+            (1, 1, 32, 64),
+            (32, 32),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(1, 0))}),
+        ),
+        (
+            (1, 1, 32, 128),
+            (32, 64),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(1, 0))}),
+        ),
+        (
+            (1, 1, 32, 256),
+            (32, 32),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 0))}),
+        ),
+        (
+            (1, 1, 32, 512),
+            (32, 64),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 0))}),
+        ),
+        (
+            # 2048 wide works
+            # 3072 wide hangs -> maybe I'm exceeding some size limit... (add asserts on buffer sizes:
+            #  - eth buffer size
+            #  - shard buffer size
+            # )
+            (1, 1, 32, 3072),
+            (32, 128),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 2))}),
+        ),
+        # LLama
+        (
+            (1, 1, 32, 1024),
+            (32, 32),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+        ),
+        (
+            (1, 1, 32, 4096),
+            (32, 128),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+        ),
+        (
+            (1, 1, 32, 4096),
+            (32, 128),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+        ),
+        (
+            (1, 1, 32, 2048),
+            (32, 64),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+        ),
+        (
+            (1, 1, 32, 1792),
+            (32, 32),
+            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 6))}),
+        ),
+    ),
+)
 def test_all_gather_post_commit_sharded(
-    pcie_devices,
+    all_devices,
+    num_devices,
     input_shape,
+    input_shard_shape,
+    shard_grid,
     dim,
     num_links,
+    orientation,
     input_dtype,
-    layout,
-    num_cores,
+    tensor_layout,
+    tensor_mem_layout,
+    # num_cores,
     use_program_cache,
     function_level_defaults,
 ):
-    if layout == ttl.tensor.Layout.ROW_MAJOR:
-        pytest.skip("All gather tests are hanging for RM in DRAM")
-    if layout == ttl.tensor.Layout.ROW_MAJOR and input_dtype == ttl.tensor.DataType.BFLOAT8_B:
-        pytest.skip("Invalid combination")
+    if len(all_devices) != 8:
+        pytest.skip("Not T3000!")
 
+    numel = input_shape[0] * input_shape[1] * input_shape[2] * input_shape[3] * num_devices
+    unchunked_input_shape = list(input_shape)
+    unchunked_input_shape[dim] *= num_devices
+    # unchunked_input_tensor = torch.arange(numel).reshape(unchunked_input_shape).bfloat16()
+    unchunked_input_tensor = torch.arange(numel).reshape(unchunked_input_shape)
+
+    id = 0
+    for w in range(unchunked_input_shape[0]):
+        for z in range(unchunked_input_shape[1]):
+            for i in range(0, unchunked_input_shape[2], 32):
+                for j in range(0, unchunked_input_shape[3], 32):
+                    for ii in range(32):
+                        for jj in range(32):
+                            unchunked_input_tensor[w][z][i + ii][j + jj] = id
+                    id += 1
+
+    unchunked_input_tensor = unchunked_input_tensor.bfloat16()
+
+    input_tensors = torch.chunk(unchunked_input_tensor, num_devices, dim)
     devices = get_devices_for_t3000(all_devices, num_devices)
 
-    input_tensor = torch.arange(32 * 8192).reshape(input_shape).bfloat16()
-    num_devices = len(devices)
+    # num_cores =
+    # compute_grid_size = devices[0].compute_with_storage_grid_size()
+
+    logger.info(f"Input shape: {input_shape}")
+    logger.info(f"unchunked_input_shape: {unchunked_input_shape}")
+    logger.info(f"dim: {dim}")
+    logger.info(f"num_devices: {num_devices}")
+    logger.info(f"num_links: {num_links}")
+    logger.info(f"input_dtype: {input_dtype}")
+    logger.info(f"tensor_layout: {tensor_layout}")
+    logger.info(f"tensor_mem_layout: {tensor_mem_layout}")
+    logger.info(f"orientation: {orientation}")
+    # logger.info(f"num_cores: {num_cores}")
+    logger.info(f"shard_grid: {shard_grid}")
+    logger.info(f"input_shard_shape: {input_shard_shape}")
+
+    # TODO: Figure out better shard spec
+    # all_cores_.size() == 1
+    # this->num_cores() == 8
+    # shard_grid = ttl.tensor.CoreRangeSet(ttl.tensor.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+
+    input_shard_spec = ttl.tensor.ShardSpec(
+        shard_grid,
+        input_shard_shape,
+        orientation,
+        False,
+    )
+    input_mem_config = ttl.tensor.MemoryConfig(
+        tensor_mem_layout, buffer_type=ttl.tensor.BufferType.L1, shard_spec=input_shard_spec
+    )
+    output_shard_shape = list(input_shard_shape)
+    if dim == 3:
+        output_shard_shape[1] *= num_devices
+    else:
+        output_shard_shape[0] *= num_devices
+    output_shard_spec = ttl.tensor.ShardSpec(
+        shard_grid,
+        output_shard_shape,
+        orientation,
+        False,
+    )
+    output_mem_config = ttl.tensor.MemoryConfig(
+        tensor_mem_layout, buffer_type=ttl.tensor.BufferType.L1, shard_spec=output_shard_spec
+    )
+
     if num_devices < 2:
         pytest.skip("Requires multiple devices to run")
     elif num_devices == 2 and num_links == 2:
         pytest.skip("Not enough links to run")
 
-    if input_shape[dim] % num_devices != 0 or (dim == 3 and input_shape[dim] // num_devices % 32 != 0):
+    if unchunked_input_shape[dim] % num_devices != 0 or (
+        dim == 3 and unchunked_input_shape[dim] // num_devices % 32 != 0
+    ):
         pytest.skip("Unsupported test case")
 
-    input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
-    compute_grid_size = devices[0].compute_with_storage_grid_size()
-    shard_grid = ttl.tensor.CoreRangeSet(ttl.tensor.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
-    input_shard_spec = ttl.tensor.ShardSpec(
-        shard_grid,
-        [
-            input_tensors[0].shape.numel() // input_tensors[0].shape[-1],
-            input_tensors[0].shape[-1] // num_cores,
-        ],
-        ttl.tensor.ShardOrientation.ROW_MAJOR,
-        False,
-    )
-    input_mem_config = ttl.tensor.MemoryConfig(
-        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED, ttl.tensor.BufferType.L1, input_shard_spec
-    )
-    output_shard_spec = ttl.tensor.ShardSpec(
-        shard_grid,
-        [
-            input_tensors[0].shape.numel() // input_tensors[0].shape[-1],
-            input_shape[-1] // num_cores,
-        ],
-        ttl.tensor.ShardOrientation.ROW_MAJOR,
-        False,
-    )
-    output_mem_config = ttl.tensor.MemoryConfig(
-        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED, ttl.tensor.BufferType.L1, output_shard_spec
-    )
+
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(layout).to(devices[i], input_mem_config))
+        tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
 
     tt_out_tensors = ttl.tensor.all_gather(tt_input_tensors, dim, num_links, output_mem_config=output_mem_config)
+    for d in devices:
+        ttl.device.Synchronize(d)
     torch.set_printoptions(sci_mode=False)
+    all_eq = True
+    reported_mismatch = False
     for i, t in enumerate(tt_out_tensors):
         tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
         # print(tt_output_tensor[...,:2048])
         # print(tt_output_tensor[...,6144:])
         # breakpoint()
         if input_dtype == ttl.tensor.DataType.BFLOAT16:
-            eq, output = comp_equal(tt_output_tensor, input_tensor)
+            eq, output = comp_equal(tt_output_tensor, unchunked_input_tensor)
         else:
-            eq, output = comp_pcc(tt_output_tensor, input_tensor)
+            eq, output = comp_pcc(tt_output_tensor, unchunked_input_tensor)
         if not eq:
             print(f"output mismatch for tensor {i}")
-        assert eq, f"{i} FAILED: {output}"
+            if not reported_mismatch:
+                reported_mismatch = True
+                for w in range(unchunked_input_shape[0]):
+                    for z in range(unchunked_input_shape[1]):
+                        for y in range(unchunked_input_shape[2]):
+                            for x in range(unchunked_input_shape[3]):
+                                if tt_output_tensor[w, z, y, x] != unchunked_input_tensor[w, z, y, x]:
+                                    print(
+                                        f"mismatch at {w} {z} {y} {x} {unchunked_input_tensor[w, z, y, x]} != {tt_output_tensor[w, z, y, x]}"
+                                    )
+            all_eq = False
+            print(f"")
+            print(f"")
+    assert all_eq, f"{i} FAILED: {output}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
@@ -277,7 +277,7 @@ bool RunWriteBWTest(
 
     auto eth_sender_kernel = tt_metal::CreateKernel(
         sender_program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover.cpp",
+        "tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp",
         eth_sender_core,
         tt_metal::EthernetConfig{
             .noc = tt_metal::NOC::NOC_0,
@@ -350,7 +350,7 @@ bool RunWriteBWTest(
     uint32_t chip1_receiver_num_channels = chip0_arg_sender_num_channels;
     auto eth_receiver_kernel = tt_metal::CreateKernel(
         receiver_program,
-        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover.cpp",
+        "tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp",
         eth_receiver_core,
         tt_metal::EthernetConfig{
             .noc = tt_metal::NOC::NOC_0,

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_forward_local_chip_data_looping_multi_channel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_l1_forward_local_chip_data_looping_multi_channel.cpp
@@ -7,7 +7,7 @@
 
 #include "dataflow_api.h"
 #include "debug/dprint.h"
-#include "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_async_datamover.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/edm/erisc_async_datamover.hpp"
 
 #define ENABLE_L1_BUFFER_OVERLAP 0
 // #define ENABLE_L1_BUFFER_OVERLAP 1

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_non_blocking_receive_fwd_to_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_non_blocking_receive_fwd_to_dram.cpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include "dataflow_api.h"
 #include "debug/dprint.h"
-#include "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_async_datamover.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/edm/erisc_async_datamover.hpp"
 
 #define DONT_STRIDE_IN_ETH_BUFFER 0
 

--- a/tt_eager/tensor/tensor_impl.cpp
+++ b/tt_eager/tensor/tensor_impl.cpp
@@ -115,6 +115,7 @@ DeviceBuffer allocate_sharded_buffer_on_device(uint32_t buffer_size_bytes, Devic
                                             const Shape& shape, DataType data_type, Layout layout,
                                             std::optional<ShardSpecBuffer> shard_params,
                                             const MemoryConfig& memory_config) {
+    TT_ASSERT(shard_params.has_value(), "Shard params are required for sharded buffer and they were not initialized");
     auto page_shape = shard_params.value().page_shape;
     uint32_t size_of_element = element_size_bytes_wrapper(data_type);
     uint32_t page_size = page_shape[0] * page_shape[1] * size_of_element;

--- a/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 
@@ -17,16 +18,22 @@ namespace tt_metal {
 
 class AllGatherConfig {
    public:
-    AllGatherConfig(Tensor const& input_tensor, uint32_t dim, uint32_t ring_size, uint32_t num_links) :
+    AllGatherConfig(Tensor const& input_tensor, Tensor const& output_tensor, uint32_t dim, uint32_t ring_size, uint32_t num_links) :
+        num_links(num_links),
         semaphore_size(32),
+        ring_size(ring_size),
 
         // enable_bidirectional - currently doesn't support batch dim and multi-link (some tests are flaky with those configs)
         erisc_handshake_address(eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE),
-        enable_bidirectional(dim != 0 && dim != 1)
+        enable_bidirectional(dim != 0 && dim != 1),
+
+        input_is_dram(input_tensor.buffer()->buffer_type() == BufferType::DRAM),
+        output_is_dram(output_tensor.buffer()->buffer_type() == BufferType::DRAM)
     {
         constexpr uint32_t total_l1_buffer_space = eth_l1_mem::address_map::MAX_L1_LOADING_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
 
-        this->num_buffers = this->enable_bidirectional ? 8 : 4;
+        this->is_sharded = input_tensor.is_sharded();
+        this->num_buffers = input_tensor.is_sharded() ? 1 : (this->enable_bidirectional ? 8 : 4);
         this->eth_sems_l1_base_byte_address = this->erisc_handshake_address + 16;
         this->semaphore_offset = this->semaphore_size * this->num_buffers; // TODO: Remove this once dedicated semaphore space for user kernels are added
         this->eth_buffers_l1_base_byte_address = this->eth_sems_l1_base_byte_address + this->semaphore_offset;
@@ -51,7 +58,8 @@ class AllGatherConfig {
     uint32_t get_erisc_handshake_address() const { return this->erisc_handshake_address; }
 
     uint32_t get_semaphores_offset() const { return this->semaphore_offset; }
-    uint32_t get_num_buffers() const { return this->num_buffers; }
+    uint32_t get_num_buffers_per_link() const { return this->num_buffers; }
+    uint32_t get_num_buffers() const { return this->num_buffers * this->num_links; }
 
     uint32_t get_eth_buffer_size() const { return this->eth_buffer_size; }
 
@@ -62,16 +70,20 @@ class AllGatherConfig {
     uint32_t get_semaphore_size() const { return this->semaphore_size; }
 
     uint32_t get_num_buffers_in_clockwise_direction() const {
+        if (this->is_sharded) {
+            return 0; // Currently only support in CCW direction to make tile ordering work out.
+        }
         return this->enable_bidirectional ?
             this->num_buffers / 2 :
             this->num_buffers;
     }
+    uint32_t get_ring_size() const { return this->ring_size; }
     bool is_buffer_in_clockwise_ring(const uint32_t buffer_index) const {
         // For now we split it as lower half => clockwise, upper half => counter-clockwise
         // This is slightly suboptimal since the non-full-chunks go to the upper half.
         // A more optimal split would be round robin
         return this->enable_bidirectional ?
-            buffer_index < (this->num_buffers - get_num_buffers_in_clockwise_direction()) :
+            buffer_index < get_num_buffers_in_clockwise_direction() :
             true;
     }
     uint32_t get_num_buffers_in_counter_clockwise_direction() const {
@@ -80,30 +92,36 @@ class AllGatherConfig {
         return this->num_buffers - this->get_num_buffers_in_clockwise_direction();
     }
 
+    bool is_input_dram() const { return input_is_dram; }
+    bool is_output_dram() const { return output_is_dram; }
+
     void print() const {
-        std::stringstream ss;
-        ss << "AllGatherConfig: {\n";
-        ss << "\terisc_handshake_address: " << erisc_handshake_address << ",\n";
-        ss << "\tnum_buffers: " << num_buffers << ",\n";
-        ss << "\teth_buffer_size: " << eth_buffer_size << ",\n";
-        ss << "\tsemaphore_size: " << semaphore_size << ",\n";
-        ss << "\tsemaphore_offset: " << semaphore_offset << ",\n";
-        ss << "\teth_buffers_l1_base_byte_address: " << eth_buffers_l1_base_byte_address << ",\n";
-        ss << "\teth_sems_l1_base_byte_address: " << eth_sems_l1_base_byte_address << ",\n";
-        ss << "\tenable_bidirectional: " << enable_bidirectional << "\n";
-        ss << "}";
-        std::cout << ss.str() << std::endl;
+        log_trace(tt::LogOp, "AllGatherConfig: {");
+        log_trace(tt::LogOp, "\terisc_handshake_address: {}", erisc_handshake_address);
+        log_trace(tt::LogOp, "\tnum_buffers: {}", num_buffers);
+        log_trace(tt::LogOp, "\teth_buffer_size: {}", eth_buffer_size);
+        log_trace(tt::LogOp, "\tsemaphore_size: {}", semaphore_size);
+        log_trace(tt::LogOp, "\tsemaphore_offset: {}", semaphore_offset);
+        log_trace(tt::LogOp, "\teth_buffers_l1_base_byte_address: {}", eth_buffers_l1_base_byte_address);
+        log_trace(tt::LogOp, "\teth_sems_l1_base_byte_address: {}", eth_sems_l1_base_byte_address);
+        log_trace(tt::LogOp, "\tenable_bidirectional: {}", enable_bidirectional);
+        log_trace(tt::LogOp, "}");
     }
 
    private:
     const uint32_t erisc_handshake_address;
+    uint32_t ring_size;
+    uint32_t num_links;
     uint32_t num_buffers;
     uint32_t eth_buffer_size;
     uint32_t semaphore_size;
     uint32_t semaphore_offset;
     uint32_t eth_buffers_l1_base_byte_address;
     uint32_t eth_sems_l1_base_byte_address;
+    bool is_sharded;
     const bool enable_bidirectional;
+    const bool input_is_dram;
+    const bool output_is_dram;
 };
 
 struct AllGather {
@@ -125,6 +143,372 @@ struct AllGather {
 operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor& input_tensor, Tensor& output_tensor, const uint32_t dim, const uint32_t num_links, const uint32_t ring_size, const uint32_t ring_index, const chip_id_t receiver_device_id, const chip_id_t sender_device_id);
 
 std::vector<Tensor> all_gather(const std::vector<Tensor> &input_tensors, const uint32_t dim, const uint32_t num_links = 1, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+
+struct ShardedAllGatherConfig {
+    ShardedAllGatherConfig(Tensor const& input_tensor, Tensor const& output_tensor, uint32_t dim)
+        {
+        this->is_sharding_enabled = input_tensor.is_sharded();
+        if (!this->is_sharding_enabled) {
+            return;
+        }
+
+        TT_ASSERT(input_tensor.get_legacy_shape()[2] / TILE_HEIGHT > 0);
+        TT_ASSERT(input_tensor.get_legacy_shape()[3] / TILE_WIDTH > 0);
+        TT_ASSERT(output_tensor.get_legacy_shape().rank() == 4, "Assumes rank 4");
+        TT_ASSERT(input_tensor.get_legacy_shape().rank() == 4, "Assumes rank 4");
+
+        switch(input_tensor.memory_config().memory_layout) {
+            case TensorMemoryLayout::WIDTH_SHARDED:
+                this->shard_type = ccl::ShardType::Width;
+                break;
+            case TensorMemoryLayout::BLOCK_SHARDED:
+                this->shard_type = ccl::ShardType::Block;
+                break;
+            case TensorMemoryLayout::HEIGHT_SHARDED:
+                this->shard_type = ccl::ShardType::Height;
+                break;
+            case TensorMemoryLayout::INTERLEAVED:
+            case TensorMemoryLayout::SINGLE_BANK:
+            default:
+                TT_ASSERT(false, "ShardedAllGatherConfig only supports sharded memory layouts");
+            break;
+        };
+
+        Shape const& output_shape = output_tensor.get_legacy_shape();
+        bool multiple_dims_are_multi_tile = std::count_if(output_shape.begin(), output_shape.end(), [](uint32_t s) { return s > 1; }) > 1;
+        this->requires_post_all_gather_reshard = !multiple_dims_are_multi_tile;
+    }
+
+    bool get_post_all_gather_reshard_required() const {
+        TT_ASSERT(is_sharding_enabled, "Tried getting sharding config for non-sharded tensor");
+        return requires_post_all_gather_reshard;
+    }
+
+    bool get_single_tile_shard_on_dim() const {
+        TT_ASSERT(is_sharding_enabled, "Tried getting sharding config for non-sharded tensor");
+        return single_tile_shard_on_dim;
+    }
+
+    ccl::ShardType get_shard_type() const {
+        TT_ASSERT(is_sharding_enabled, "Tried getting sharding config for non-sharded tensor");
+        return shard_type;
+    }
+
+    private:
+    bool requires_post_all_gather_reshard;
+    bool single_tile_shard_on_dim;
+    ccl::ShardType shard_type;
+    bool is_sharding_enabled;
+};
+
+struct ShardAddrGenArgGenerator {
+
+    using shard_cores_t = CoreRangeSet;//std::variant<std::vector<CoreCoord>, CoreRange, CoreRangeSet>;
+
+    ShardAddrGenArgGenerator(ccl::ShardAddrGenArgs<true> const& args_struct) :
+        args_struct(args_struct), initialized(true) {}
+
+    ShardAddrGenArgGenerator() : initialized(false) {}
+
+    std::vector<uint32_t> generate() const {
+        TT_ASSERT(initialized, "Didn't initialize ShardAddrGenArgGenerator before use");
+        std::vector<uint32_t> args;
+        args.reserve(7 * this->args_struct.num_dest_cores * 2);
+
+        TT_ASSERT(this->args_struct.shard_size_in_bytes != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        TT_ASSERT(this->args_struct.chunks_per_core_before_advance != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        TT_ASSERT(this->args_struct.shards_start_address != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        TT_ASSERT(this->args_struct.starting_core_index != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        TT_ASSERT(this->args_struct.starting_chunk_into_shard != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        TT_ASSERT(this->args_struct.num_dest_cores != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        TT_ASSERT(this->args_struct.dest_cores.size() != 0);
+
+        args.push_back(this->args_struct.is_clockwise);
+        args.push_back(this->args_struct.shard_size_in_bytes);
+        args.push_back(this->args_struct.chunks_per_core_before_advance);
+        args.push_back(this->args_struct.shards_start_address);
+        args.push_back(this->args_struct.starting_core_index);
+        args.push_back(this->args_struct.starting_chunk_into_shard);
+        args.push_back(this->args_struct.num_dest_cores);
+        for (ccl::WorkerXY const& core : this->args_struct.dest_cores) {
+            args.push_back(core.to_uint32());
+        }
+
+        TT_ASSERT(args.size() == args_struct.get_expected_num_args(), "Generated args size doesn't match expected size");
+
+        return args;
+    }
+
+    void dump_to_log() const {
+        log_trace(tt::LogOp, "ShardAddrGenArgGenerator:");
+        log_trace(tt::LogOp, "\tis_clockwise: {}", this->args_struct.is_clockwise);
+        log_trace(tt::LogOp, "\tshard_size_in_bytes: {}", this->args_struct.shard_size_in_bytes);
+        log_trace(tt::LogOp, "\tchunks_per_core_before_advance: {}", this->args_struct.chunks_per_core_before_advance);
+        log_trace(tt::LogOp, "\tshards_start_address: {}", this->args_struct.shards_start_address);
+        log_trace(tt::LogOp, "\tstarting_core_index: {}", this->args_struct.starting_core_index);
+        log_trace(tt::LogOp, "\tstarting_chunk_into_shard: {}", this->args_struct.starting_chunk_into_shard);
+        log_trace(tt::LogOp, "\tnum_dest_cores: {}", this->args_struct.num_dest_cores);
+        for (auto n = 0; n < this->args_struct.num_dest_cores; ++n) {
+            log_trace(tt::LogOp, "\t\tdest_core[{}]: x={},y={}", n, this->args_struct.dest_cores.at(n).x, this->args_struct.dest_cores.at(n).y);
+        }
+    }
+
+    ccl::ShardAddrGenArgs<true> args_struct;
+
+    bool initialized;
+};
+
+struct InputTensorShardAddrGenArgGenerator final : public ShardAddrGenArgGenerator {
+    InputTensorShardAddrGenArgGenerator(
+        Device const* device,
+        Tensor const& input_tensor,
+        uint32_t ring_index,
+        uint32_t ring_size,
+        uint32_t num_workers,
+        uint32_t worker_index,
+        // Which of the args_struct dest_cores to start at
+        uint32_t starting_dest_core_index,
+        uint32_t starting_chunk_into_shard,
+        bool is_worker_in_clockwise_ring
+        ) {
+        auto const& tensor_shard_grid = input_tensor.buffer()->shard_spec().grid();
+        uint32_t sharded_tensor_num_cores = tensor_shard_grid.num_cores();
+        this->args_struct.is_clockwise = is_worker_in_clockwise_ring;
+        this->args_struct.shard_size_in_bytes = input_tensor.shard_spec()->numel() * input_tensor.element_size();
+        this->args_struct.chunks_per_core_before_advance = 1;
+        this->args_struct.shards_start_address = input_tensor.buffer()->address();
+
+        this->args_struct.starting_core_index = starting_dest_core_index;
+        this->args_struct.starting_chunk_into_shard = starting_chunk_into_shard;
+        this->args_struct.num_dest_cores = sharded_tensor_num_cores / num_workers;
+        TT_ASSERT(sharded_tensor_num_cores > 0);
+
+        bool has_extra_worker = worker_index < sharded_tensor_num_cores % num_workers;
+        if (has_extra_worker) {
+            this->args_struct.num_dest_cores++;
+        }
+
+        uint32_t worker_cores_start = worker_index * sharded_tensor_num_cores / num_workers;
+        worker_cores_start += sharded_tensor_num_cores % num_workers != 0 ?
+            std::min(sharded_tensor_num_cores % num_workers, worker_index) :
+            worker_index;
+
+        std::vector<CoreCoord> const& all_shard_cores = input_tensor.buffer()->all_cores();
+        for (uint32_t c = worker_cores_start; c < worker_cores_start + this->args_struct.num_dest_cores; ++c) {
+            CoreCoord const& worker_core = all_shard_cores.at(c);
+            ccl::WorkerXY worker_xy(
+                static_cast<uint16_t>(device->worker_core_from_logical_core(worker_core).x),
+                static_cast<uint16_t>(device->worker_core_from_logical_core(worker_core).y));
+            this->args_struct.dest_cores.push_back(worker_xy);
+        }
+        TT_ASSERT(this->args_struct.dest_cores.size() > 0);
+
+        this->initialized = true;
+    }
+};
+
+
+struct OutputTensorShardAddrGenArgGenerator final : ShardAddrGenArgGenerator {
+    static std::vector<CoreCoord> compute_worker_coord_worker_dest_cores (
+        ccl::ShardType shard_type,
+        std::vector<CoreCoord> const& global_shard_dest_cores,
+        uint32_t input_num_shards,
+        uint32_t output_num_shards,
+        uint32_t num_workers,
+        uint32_t worker_index,
+        bool is_shard_orientation_row_major) {
+            TT_ASSERT(output_num_shards % input_num_shards == 0);
+
+            TT_ASSERT(output_num_shards % num_workers == 0, "Don't support otherwise");
+            TT_ASSERT(output_num_shards % global_shard_dest_cores.size() == 0, "Don't support otherwise");
+            uint32_t const output_shards_served_per_worker = (output_num_shards / num_workers);
+            uint32_t const input_shards_per_dest_core = output_num_shards / global_shard_dest_cores.size();
+            TT_ASSERT(output_shards_served_per_worker % input_shards_per_dest_core == 0, "Don't support otherwise");
+
+            uint32_t const input_shards_per_input_worker = input_num_shards / num_workers;
+            TT_ASSERT(input_shards_per_dest_core > input_shards_per_input_worker ?
+                input_shards_per_dest_core % input_shards_per_input_worker == 0:
+                input_shards_per_input_worker / input_shards_per_dest_core > 0,
+                "Don't support otherwise");
+            uint32_t const contiguous_dest_cores_before_stride = input_shards_per_input_worker < input_shards_per_dest_core ? 1 : input_shards_per_input_worker / input_shards_per_dest_core;
+            TT_ASSERT(contiguous_dest_cores_before_stride != 0);
+
+            // uint32_t current_dest_core_offset = worker_index * (input_shards_per_input_worker * contiguous_dest_cores_before_stride);
+            uint32_t const worker_input_shard_index = worker_index * input_shards_per_input_worker;
+            uint32_t current_dest_core_offset = worker_input_shard_index / input_shards_per_dest_core;
+            TT_ASSERT(current_dest_core_offset < global_shard_dest_cores.size(), "Out of bounds index generated");
+            uint32_t const stride = std::max<uint32_t>(
+                1,
+                contiguous_dest_cores_before_stride > 1
+                    ? num_workers * contiguous_dest_cores_before_stride
+                    : (num_workers * input_shards_per_input_worker / input_shards_per_dest_core));
+
+            std::vector<CoreCoord> dest_cores_of_worker;
+
+            uint32_t core_offset_into_contiguous_chunk = 0;
+            while (current_dest_core_offset + core_offset_into_contiguous_chunk < global_shard_dest_cores.size()) {
+                CoreCoord const& dest_core_coord = global_shard_dest_cores.at(current_dest_core_offset + core_offset_into_contiguous_chunk);
+                dest_cores_of_worker.push_back(dest_core_coord);
+                core_offset_into_contiguous_chunk++;
+
+                if (core_offset_into_contiguous_chunk == contiguous_dest_cores_before_stride) {
+                    current_dest_core_offset += stride;
+                    core_offset_into_contiguous_chunk = 0;
+                }
+            }
+
+            return dest_cores_of_worker;
+    }
+
+
+    static std::vector<ccl::WorkerXY> compute_worker_dest_cores (
+        ccl::ShardType shard_type,
+        Device const& device,
+        CoreRangeSet const& shard_core_range,
+        uint32_t input_num_shards,
+        uint32_t output_num_shards,
+        uint32_t num_workers,
+        uint32_t worker_index,
+        bool is_shard_orientation_row_major) {
+            auto const& worker_coord_worker_dest_cores = compute_worker_coord_worker_dest_cores (
+                shard_type,
+                corerange_to_cores(shard_core_range, std::nullopt, is_shard_orientation_row_major),
+                input_num_shards,
+                output_num_shards,
+                num_workers,
+                worker_index,
+                is_shard_orientation_row_major);
+
+            std::vector<ccl::WorkerXY> dest_cores_of_worker;
+            dest_cores_of_worker.reserve(worker_coord_worker_dest_cores.size());
+            std::transform(worker_coord_worker_dest_cores.begin(), worker_coord_worker_dest_cores.end(), std::back_inserter(dest_cores_of_worker),
+                [&device](CoreCoord const& core) {
+                    return ccl::WorkerXY(
+                        static_cast<uint16_t>(device.worker_core_from_logical_core(core).x),
+                        static_cast<uint16_t>(device.worker_core_from_logical_core(core).y)
+                        );
+                });
+            return dest_cores_of_worker;
+    }
+
+
+    static std::pair<uint32_t, uint32_t> get_first_output_shard_starting_location(
+        uint32_t num_workers,
+        uint32_t input_tensor_shard_grid_size,
+        uint32_t ring_index,
+        uint32_t ring_size,
+        uint32_t serving_worker_index) {
+        // TODO: update to support block sharding
+        // TODO: update if input grid != output grid
+
+        uint32_t const global_num_buffers_per_chip = num_workers;
+        uint32_t const num_dest_shard_cores = input_tensor_shard_grid_size;
+
+        uint32_t num_input_tensor_shards = input_tensor_shard_grid_size;
+        uint32_t global_output_shard_index = ring_index * num_input_tensor_shards;
+
+        TT_ASSERT(num_input_tensor_shards >= global_num_buffers_per_chip, "Not enough input shards to support all gather");
+        uint32_t worker_shard_offset = serving_worker_index * (num_input_tensor_shards / global_num_buffers_per_chip);
+        TT_ASSERT(num_input_tensor_shards % global_num_buffers_per_chip == 0, "Don't support this non-divisibility yet");
+        if (num_input_tensor_shards % global_num_buffers_per_chip != 0) {
+            worker_shard_offset += std::min(serving_worker_index, num_input_tensor_shards % global_num_buffers_per_chip);
+        }
+        uint32_t const num_output_tensor_shards = ring_size * num_input_tensor_shards;
+        uint32_t const input_shards_per_output_worker = (num_output_tensor_shards / num_dest_shard_cores);
+        global_output_shard_index += worker_shard_offset;
+
+        uint32_t dest_worker_index = global_output_shard_index / input_shards_per_output_worker;
+        uint32_t offset_chunk_in_worker = global_output_shard_index % input_shards_per_output_worker;
+        return {dest_worker_index, offset_chunk_in_worker};
+    }
+
+    // returns pair of <dest_worker_idx, chunk_idx> -> These are global core index and relative chunk index
+    static std::pair<uint32_t, uint32_t> get_first_output_shard_starting_location(
+        AllGatherConfig const& all_gather_config,
+        Tensor const& input_tensor,
+        Tensor const& output_tensor,
+        uint32_t ring_index,
+        uint32_t serving_worker_index) {
+        // TODO: update to support block sharding
+        // TODO: update if input grid != output grid
+        return get_first_output_shard_starting_location(
+            all_gather_config.get_num_buffers(),
+            input_tensor.shard_spec()->grid.num_cores(),
+            ring_index,
+            all_gather_config.get_ring_size(),
+            serving_worker_index);
+    }
+
+    using shard_cores_t = std::variant<std::vector<CoreCoord>, CoreRange, CoreRangeSet>;
+    // TODO: consider moving the tensors into the all gather config
+    OutputTensorShardAddrGenArgGenerator(
+        AllGatherConfig const& all_gather_config,
+        Device const* device,
+        Tensor const& input_tensor,
+        Tensor const& output_tensor,
+        uint32_t ring_index,
+        uint32_t ring_size,
+        uint32_t num_workers,
+        uint32_t worker_index,
+        uint32_t global_starting_dest_worker_index,
+        uint32_t starting_chunk_into_shard,
+        bool is_worker_in_clockwise_ring
+        ) {
+        bool is_shard_orientation_row_major = true; // hardcoded for now
+        // TODO: update to support block sharding
+
+        auto const& tensor_shard_grid = input_tensor.buffer()->shard_spec().grid();
+        uint32_t sharded_tensor_num_cores = tensor_shard_grid.num_cores();
+        TT_ASSERT(sharded_tensor_num_cores == output_tensor.buffer()->shard_spec().grid().num_cores(), "Input and output tensor must have the same number of cores");
+        this->args_struct.is_clockwise = is_worker_in_clockwise_ring;
+        this->args_struct.shard_size_in_bytes = input_tensor.shard_spec()->numel() * input_tensor.element_size();
+        this->args_struct.chunks_per_core_before_advance = ring_size;
+        this->args_struct.shards_start_address = output_tensor.buffer()->address();
+
+        this->args_struct.starting_chunk_into_shard = starting_chunk_into_shard;
+        this->args_struct.num_dest_cores = sharded_tensor_num_cores / num_workers;
+        TT_ASSERT(sharded_tensor_num_cores > 0);
+
+        bool has_extra_worker = worker_index < sharded_tensor_num_cores % num_workers;
+        if (has_extra_worker) {
+            this->args_struct.num_dest_cores++;
+        }
+
+        uint32_t worker_cores_start = worker_index * sharded_tensor_num_cores / num_workers;
+        worker_cores_start += sharded_tensor_num_cores % num_workers != 0 ?
+            std::min(sharded_tensor_num_cores % num_workers, worker_index) :
+            worker_index;
+
+        uint32_t input_num_shards = sharded_tensor_num_cores;
+        uint32_t output_num_shards = input_num_shards * ring_size;
+        this->args_struct.dest_cores = OutputTensorShardAddrGenArgGenerator::compute_worker_dest_cores (
+                ccl::ShardType::Width,
+                *device,
+                tensor_shard_grid,
+                input_num_shards,
+                output_num_shards,
+                num_workers,
+                worker_index,
+                is_shard_orientation_row_major);
+
+        TT_ASSERT(this->args_struct.dest_cores.size() > 0);
+        std::vector<CoreCoord> const& global_shard_dest_cores = corerange_to_cores(tensor_shard_grid, std::nullopt, is_shard_orientation_row_major);
+        CoreCoord const& dest_core_coord = global_shard_dest_cores.at(global_starting_dest_worker_index);
+        ccl::WorkerXY noc0_starting_dest_core_xy(
+            static_cast<uint16_t>(device->worker_core_from_logical_core(dest_core_coord).x),
+            static_cast<uint16_t>(device->worker_core_from_logical_core(dest_core_coord).y)
+            );
+        auto it = std::find(this->args_struct.dest_cores.begin(), this->args_struct.dest_cores.end(), noc0_starting_dest_core_xy);
+        TT_ASSERT(it != this->args_struct.dest_cores.end(), "Didn't find starting dest core in dest cores. Internal logic error");
+        this->args_struct.starting_core_index = std::distance(this->args_struct.dest_cores.begin(), it);
+
+        this->initialized = true;
+
+    }
+
+};
+
 
 }  // namespace tt_metal
 

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
@@ -69,11 +69,11 @@ void kernel_main() {
 
     if constexpr(num_full_chunks > 0) {
         for (uint32_t c = 0; c < num_full_chunks; ++c) {
-            read_chunk(input_page_idx, cb_id_in0, s, num_pages, page_size);
+            read_chunk_from_input_tensor(input_page_idx, cb_id_in0, s, num_pages, page_size);
         }
     }
     if constexpr(rem_num_pages > 0) {
-        read_chunk(input_page_idx, cb_id_in0, s, rem_num_pages, page_size);
+        read_chunk_from_input_tensor(input_page_idx, cb_id_in0, s, rem_num_pages, page_size);
     }
 
     uint32_t sem_idx = 1;
@@ -126,13 +126,13 @@ void kernel_main() {
             for (uint32_t c = 0; c < num_full_chunks; ++c) {
                 noc_semaphore_wait_min(sender_semaphore_addr_ptr, sem_idx);
                 sem_idx++;
-                read_chunk(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, num_pages, page_size);
+                read_chunk_from_output_tensor(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, num_pages, page_size);
             }
         }
         if constexpr(rem_num_pages > 0) {
             noc_semaphore_wait_min(sender_semaphore_addr_ptr, sem_idx);
             sem_idx++;
-            read_chunk(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, rem_num_pages, page_size);
+            read_chunk_from_output_tensor(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, rem_num_pages, page_size);
         }
     }
 

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp
@@ -1,169 +1,165 @@
-// // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-// //
-// // SPDX-License-Identifier: Apache-2.0
-
-// #include "dataflow_api.h"
-
-// FORCE_INLINE void push_filler_pages_to_cb(const uint32_t& cb_id, uint32_t num_pages) {
-//     cb_reserve_back(cb_id, num_pages);
-//     cb_push_back(cb_id, num_pages);
-// }
-// FORCE_INLINE void pop_filler_pages_from_cb(const uint32_t& cb_id, uint32_t num_pages) {
-//     cb_wait_front(cb_id, num_pages);
-//     cb_pop_front(cb_id, num_pages);
-// }
-
-
-// FORCE_INLINE void fetch_chunk(const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_read_addr, uint64_t eth_receiver_l1_semaphore_noc_addr) {
-//     cb_reserve_back(cb_id, num_pages);
-//     uint32_t l1_write_addr = get_write_ptr(cb_id);
-//     noc_async_read(remote_l1_read_addr, l1_write_addr, page_size * num_pages);
-//     noc_async_read_barrier();
-//     noc_semaphore_inc(eth_receiver_l1_semaphore_noc_addr, 1);
-//     cb_push_back(cb_id, num_pages);
-// }
-
-// FORCE_INLINE void send_chunk(const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr, uint64_t eth_l1_sender_semaphore_addr) {
-//     cb_wait_front(cb_id, num_pages);
-//     uint32_t l1_read_addr = get_read_ptr(cb_id);
-//     noc_async_write(l1_read_addr, remote_l1_write_addr, page_size * num_pages);
-//     noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
-//     noc_async_write_barrier();
-//     cb_pop_front(cb_id, num_pages);
-// }
-
-// template<typename AddrGen>
-// FORCE_INLINE void write_and_send_chunk(uint32_t& output_page_idx, uint32_t& col_idx, uint32_t& row_idx, const uint32_t& cb_id, const AddrGen& d, const uint32_t num_cols, const uint32_t num_rows, const uint32_t& col_offset, const uint32_t& row_offset, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr, uint64_t eth_l1_sender_semaphore_addr) {
-//     uint32_t l1_read_addr = get_read_ptr(cb_id);
-//     cb_wait_front(cb_id, num_pages);
-//     for (uint32_t i = 0; i < num_pages; ++i) {
-//         noc_async_write(l1_read_addr, remote_l1_write_addr, page_size);
-//         remote_l1_write_addr += page_size;
-//         #ifdef RM_INTERLEAVED
-//         uint64_t dst_noc_addr = get_noc_addr(output_page_idx, d);
-//         noc_async_write(l1_read_addr, dst_noc_addr, page_size);
-//         output_page_idx++;
-//         row_idx++;
-//         if (row_idx == num_rows) {
-//             row_idx = 0;
-//             output_page_idx += row_offset;
-//         }
-//         #elif defined TILE_INTERLEAVED
-//         noc_async_write_tile(output_page_idx, d, l1_read_addr);
-//         output_page_idx++;
-//         col_idx++;
-//         if (col_idx == num_cols) {
-//             output_page_idx += col_offset;
-//             col_idx = 0;
-//             row_idx++;
-//             if (row_idx == num_rows) {
-//                 row_idx = 0;
-//                 output_page_idx += row_offset;
-//             }
-//         }
-//         #endif
-//         l1_read_addr += page_size;
-//     }
-//     noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
-//     noc_async_write_barrier();
-//     cb_pop_front(cb_id, num_pages);
-// }
-
-
-// template<typename AddrGen>
-// FORCE_INLINE void write_chunk(uint32_t& output_page_idx, uint32_t& col_idx, uint32_t& row_idx, const uint32_t& cb_id, const AddrGen& d, const uint32_t& num_cols, const uint32_t& num_rows, const uint32_t& col_offset, const uint32_t& row_offset, const uint32_t& num_pages, const uint32_t& page_size, uint64_t worker_send_reader_semaphore_noc_addr) {
-//     uint32_t l1_read_addr = get_read_ptr(cb_id);
-//     cb_wait_front(cb_id, num_pages);
-//     for (uint32_t i = 0; i < num_pages; ++i) {
-//         #ifdef RM_INTERLEAVED
-//         uint64_t dst_noc_addr = get_noc_addr(output_page_idx, d);
-//         noc_async_write(l1_read_addr, dst_noc_addr, page_size);
-//         output_page_idx++;
-//         row_idx++;
-//         if (row_idx == num_rows) {
-//             row_idx = 0;
-//             output_page_idx += row_offset;
-//         }
-//         #elif defined TILE_INTERLEAVED
-//         noc_async_write_tile(output_page_idx, d, l1_read_addr);
-//         output_page_idx++;
-//         col_idx++;
-//         if (col_idx == num_cols) {
-//             output_page_idx += col_offset;
-//             col_idx = 0;
-//             row_idx++;
-//             if (row_idx == num_rows) {
-//                 row_idx = 0;
-//                 output_page_idx += row_offset;
-//             }
-//         }
-//         #endif
-//         l1_read_addr += page_size;
-//     }
-//     noc_semaphore_inc(worker_send_reader_semaphore_noc_addr, 1);
-//     noc_async_write_barrier();
-//     cb_pop_front(cb_id, num_pages);
-// }
-
-// template<typename AddrGen>
-// FORCE_INLINE void read_chunk(uint32_t& input_page_idx, const uint32_t& cb_id, const AddrGen& s, const uint32_t& num_pages, const uint32_t& page_size) {
-//     const uint32_t end_read_idx = input_page_idx + num_pages;
-//     cb_reserve_back(cb_id, num_pages);
-//     uint32_t local_l1_read_addr = get_write_ptr(cb_id);
-//     for (; input_page_idx < end_read_idx; ++input_page_idx) {
-//         #ifdef RM_INTERLEAVED
-//         uint64_t src_noc_addr = get_noc_addr(input_page_idx, s);
-//         noc_async_read(src_noc_addr, local_l1_read_addr, page_size);
-//         #elif defined TILE_INTERLEAVED
-//         noc_async_read_tile(input_page_idx, s, local_l1_read_addr);
-//         #endif
-//         local_l1_read_addr += page_size;
-//     }
-//     noc_async_read_barrier();
-//     cb_push_back(cb_id, num_pages);
-// }
-
-// template<typename AddrGen>
-// FORCE_INLINE void read_chunk(uint32_t& input_page_idx, uint32_t& col_idx, uint32_t& row_idx, const uint32_t &cb_id, const AddrGen& s, const uint32_t& num_cols, const uint32_t& num_rows, const uint32_t& col_offset, const uint32_t& row_offset, const uint32_t& num_pages, const uint32_t& page_size) {
-//     cb_reserve_back(cb_id, num_pages);
-//     uint32_t local_l1_read_addr = get_write_ptr(cb_id);
-//      for (uint32_t i = 0; i < num_pages; ++i) {
-//         #ifdef RM_INTERLEAVED
-//         uint64_t src_noc_addr = get_noc_addr(input_page_idx, s);
-//         noc_async_read(src_noc_addr, local_l1_read_addr, page_size);
-//         input_page_idx++;
-//         row_idx++;
-//         if (row_idx == num_rows) {
-//             row_idx = 0;
-//             input_page_idx += row_offset;
-//         }
-//         #elif defined TILE_INTERLEAVED
-//         noc_async_read_tile(input_page_idx, s, local_l1_read_addr);
-//         input_page_idx++;
-//         col_idx++;
-//         if (col_idx == num_cols) {
-//             input_page_idx += col_offset;
-//             col_idx = 0;
-//             row_idx++;
-//             if (row_idx == num_rows) {
-//                 row_idx = 0;
-//                 input_page_idx += row_offset;
-//             }
-//         }
-//         #endif
-//         local_l1_read_addr += page_size;
-//     }
-//     noc_async_read_barrier();
-//     cb_push_back(cb_id, num_pages);
-// }
-
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
+#include "debug/assert.h"
+#include "tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/ccl_common.hpp"
 
-FORCE_INLINE void fetch_chunk(const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_read_addr) {
+using ccl::ShardType;
+
+FORCE_INLINE void validate_sane_transaction_counters() {
+    ASSERT (NOC_STATUS_READ_REG(noc_index, NIU_MST_WR_ACK_RECEIVED) != 0);
+    ASSERT (NOC_STATUS_READ_REG(noc_index, NIU_MST_NONPOSTED_WR_REQ_SENT) != 0);
+    ASSERT(noc_nonposted_writes_num_issued[noc_index] != 0);
+    ASSERT(noc_nonposted_writes_acked[noc_index] != 0);
+}
+
+FORCE_INLINE void validate_sane_transaction_counters_rw() {
+    ASSERT (NOC_STATUS_READ_REG(noc_index, NIU_MST_WR_ACK_RECEIVED) != 0);
+    ASSERT (NOC_STATUS_READ_REG(noc_index, NIU_MST_NONPOSTED_WR_REQ_SENT) != 0);
+    ASSERT(noc_nonposted_writes_num_issued[noc_index] != 0);
+    ASSERT(noc_nonposted_writes_acked[noc_index] != 0);
+}
+
+
+template <ShardType TYPE>
+struct ShardAddrGen final {
+    ShardAddrGen()=default;
+
+    FORCE_INLINE static void build_with_placement_new(ShardAddrGen* placement_new_address, const uint32_t arg_index) {
+        ccl::ShardAddrGenArgs<false> input_args;
+
+        uint32_t curr_arg_index = arg_index;
+        input_args.is_clockwise = bool(get_arg_val<uint32_t>(curr_arg_index++) == 1);
+        input_args.shard_size_in_bytes = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.chunks_per_core_before_advance = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.shards_start_address = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.starting_core_index = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.starting_chunk_into_shard = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.num_dest_cores = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.dest_cores = reinterpret_cast<ccl::WorkerXY*>(get_arg_addr(curr_arg_index));
+        curr_arg_index += input_args.num_dest_cores;
+
+        ASSERT(input_args.shard_size_in_bytes != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        ASSERT(input_args.chunks_per_core_before_advance != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        ASSERT(input_args.shards_start_address != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        ASSERT(input_args.starting_core_index != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        ASSERT(input_args.starting_chunk_into_shard != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        ASSERT(input_args.num_dest_cores != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+
+        ASSERT(curr_arg_index - arg_index == input_args.get_expected_num_args());
+
+        new (placement_new_address) ShardAddrGen(
+            curr_arg_index - arg_index,
+            input_args);
+    }
+
+    // This addr gen will dump all tiles from an input shard contiguously, and dump the
+    // next input shard contiguously after it. This approach depends on a follow up
+    //
+    ShardAddrGen(
+        uint8_t num_args_consumed,
+        ccl::ShardAddrGenArgs<false> const& input_args) :
+        dest_cores(input_args.dest_cores),
+        num_dest_cores(input_args.num_dest_cores),
+        shards_start_address(input_args.shards_start_address),
+        shard_size_in_bytes(input_args.shard_size_in_bytes),
+        chunks_per_core_before_advance(input_args.chunks_per_core_before_advance),
+        curr_worker_index(input_args.starting_core_index),
+        curr_core_chunk_index(input_args.starting_chunk_into_shard),
+        num_args_consumed(num_args_consumed),
+        is_clockwise(input_args.is_clockwise),
+        completed_core_wrap(false){};
+
+    static_assert(
+        TYPE == ShardType::Width || TYPE == ShardType::Height || TYPE == ShardType::Block, "Invalid ShardType");
+
+    // Clockwise vs counter clockwise only affects worker core traversal order (relative to canonical order). Since the
+    // dest core list is a configurable list, we will, for now, require the host side kernel config code to produce the
+    // correc order per worker
+    FORCE_INLINE void advance() {
+        if constexpr (TYPE == ShardType::Width or TYPE == ShardType::Height) {
+            if (this->is_clockwise) {
+                // Read inputs in reverse order too
+                bool do_chunk_wrap = this->curr_core_chunk_index == 0;
+                if (do_chunk_wrap) {
+                    bool do_core_wrap = this->curr_worker_index == 0;
+                    this->curr_core_chunk_index = this->chunks_per_core_before_advance - 1;
+                    if (do_core_wrap) {
+                        completed_core_wrap = true;
+                        this->curr_worker_index = this->num_dest_cores - 1;
+                    } else {
+                        this->curr_worker_index--;
+                    }
+                } else {
+                    this->curr_core_chunk_index--;
+                }
+
+
+            } else {
+                // If I analyzed it properly, then we should never be wrapping back to the first dest core *and* still have
+                // tiles/input shards to move
+                this->curr_core_chunk_index++;
+                bool do_chunk_wrap = this->curr_core_chunk_index == this->chunks_per_core_before_advance;
+                if (do_chunk_wrap) {
+                    this->curr_core_chunk_index = 0;
+                    this->curr_worker_index++;
+                    bool do_core_wrap = this->curr_worker_index == this->num_dest_cores;
+                    if (do_core_wrap) {
+                        this->curr_worker_index = 0;
+                        completed_core_wrap = true;
+                    }
+                }
+            }
+        } else {
+            // Unsupported
+            ASSERT(false);
+        }
+    }
+
+    [[nodiscard]] FORCE_INLINE ccl::WorkerXY get_next_noc_xy_core() const {
+        ASSERT(this->curr_worker_index < this->num_dest_cores);
+        return this->dest_cores[this->curr_worker_index];
+    }
+
+    [[nodiscard]] FORCE_INLINE uint64_t get_next_noc_addr_and_advance() {
+        if constexpr (TYPE == ShardType::Width) {
+            ccl::WorkerXY dest_worker = this->get_next_noc_xy_core();
+            uint32_t curr_address = this->shards_start_address + this->curr_core_chunk_index * this->shard_size_in_bytes;
+            ASSERT(curr_address + this->shard_size_in_bytes <= 1499136); // L1 wraparound - oops!
+            this->advance();
+            return get_noc_addr(dest_worker.x, dest_worker.y, curr_address);
+        } else {
+            ASSERT(false);
+            // Unsupported
+            return 0;
+        }
+    }
+
+    [[nodiscard]] FORCE_INLINE uint32_t get_shard_size_in_bytes() const { return this->shard_size_in_bytes; }
+
+    [[nodiscard]] FORCE_INLINE uint32_t get_num_dest_cores() const { return this->num_dest_cores; }
+    [[nodiscard]] FORCE_INLINE uint32_t get_chunks_per_core_before_advance() const {
+        return this->chunks_per_core_before_advance;
+    }
+    [[nodiscard]] FORCE_INLINE uint32_t get_num_args_consumed() const { return this->num_args_consumed;}
+
+    ccl::WorkerXY* dest_cores;
+    uint32_t num_dest_cores;
+    uint32_t shards_start_address;
+    uint32_t shard_size_in_bytes;
+    uint32_t chunks_per_core_before_advance;
+    uint32_t curr_worker_index;
+    uint32_t curr_core_chunk_index;
+    uint8_t num_args_consumed;
+    bool is_clockwise;
+    bool completed_core_wrap;
+};
+
+FORCE_INLINE void fetch_chunk(
+    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_read_addr) {
     for (uint32_t i = 0; i < num_pages; ++i) {
         cb_reserve_back(cb_id, 1);
         uint32_t l1_write_addr = get_write_ptr(cb_id);
@@ -173,8 +169,18 @@ FORCE_INLINE void fetch_chunk(const uint32_t& cb_id, const uint32_t& num_pages, 
         cb_push_back(cb_id, 1);
     }
 }
+FORCE_INLINE void fetch_chunk_sharded(
+    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_read_addr) {
+    cb_reserve_back(cb_id, num_pages);
+    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    noc_async_read(remote_l1_read_addr, l1_write_addr, num_pages * page_size);
+    validate_sane_transaction_counters();
+    noc_async_read_barrier();
+    cb_push_back(cb_id, num_pages);
+}
 
-FORCE_INLINE void send_chunk(const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr) {
+FORCE_INLINE void send_chunk(
+    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr) {
     for (uint32_t i = 0; i < num_pages; ++i) {
         cb_wait_front(cb_id, 1);
         uint32_t l1_read_addr = get_read_ptr(cb_id);
@@ -184,15 +190,36 @@ FORCE_INLINE void send_chunk(const uint32_t& cb_id, const uint32_t& num_pages, c
         cb_pop_front(cb_id, 1);
     }
 }
+FORCE_INLINE void send_chunk_sharded(
+    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr) {
+    cb_wait_front(cb_id, num_pages);
+    uint32_t l1_read_addr = get_read_ptr(cb_id);
+    noc_async_write(l1_read_addr, remote_l1_write_addr, page_size * num_pages);
+    validate_sane_transaction_counters();
+    noc_async_write_barrier();
+    cb_pop_front(cb_id, num_pages);
+}
 
-template<typename AddrGen>
+template <ShardType T>
+FORCE_INLINE void write_and_send_chunk_sharded(
+    const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t num_pages, uint64_t remote_eth_l1_write_addr) {
+    cb_wait_front(cb_id, num_pages);
+    uint32_t l1_read_addr = get_read_ptr(cb_id);
+    uint64_t dest_worker_noc_addr = addr_gen.get_next_noc_addr_and_advance();
+    noc_async_write(l1_read_addr, remote_eth_l1_write_addr, addr_gen.get_shard_size_in_bytes());
+    noc_async_write(l1_read_addr, dest_worker_noc_addr, addr_gen.get_shard_size_in_bytes());
+    validate_sane_transaction_counters();
+    noc_async_write_barrier();
+    cb_pop_front(cb_id, num_pages);
+}
+template <typename AddrGen>
 FORCE_INLINE void write_and_send_chunk(uint32_t& output_page_idx, uint32_t& col_idx, uint32_t& row_idx, const uint32_t& cb_id, const AddrGen& d, const uint32_t num_cols, const uint32_t num_rows, const uint32_t& col_offset, const uint32_t& row_offset, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr) {
     for (uint32_t i = 0; i < num_pages; ++i) {
         cb_wait_front(cb_id, 1);
         uint32_t l1_read_addr = get_read_ptr(cb_id);
         noc_async_write(l1_read_addr, remote_l1_write_addr, page_size);
         remote_l1_write_addr += page_size;
-        #ifdef RM_INTERLEAVED
+#ifdef RM_INTERLEAVED
         uint64_t dst_noc_addr = get_noc_addr(output_page_idx, d);
         noc_async_write(l1_read_addr, dst_noc_addr, page_size);
         output_page_idx++;
@@ -201,7 +228,7 @@ FORCE_INLINE void write_and_send_chunk(uint32_t& output_page_idx, uint32_t& col_
             row_idx = 0;
             output_page_idx += row_offset;
         }
-        #elif defined TILE_INTERLEAVED
+#elif defined TILE_INTERLEAVED || defined SHARDED
         noc_async_write_tile(output_page_idx, d, l1_read_addr);
         output_page_idx++;
         col_idx++;
@@ -214,13 +241,28 @@ FORCE_INLINE void write_and_send_chunk(uint32_t& output_page_idx, uint32_t& col_
                 output_page_idx += row_offset;
             }
         }
-        #endif
+#endif
         noc_async_write_barrier();
         cb_pop_front(cb_id, 1);
     }
 }
 
-template<typename AddrGen>
+template <ShardType T>
+FORCE_INLINE void write_chunk_sharded(const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t num_pages) {
+    for (uint32_t i = 0; i < num_pages; ++i) {
+        cb_wait_front(cb_id, 1);
+        uint32_t l1_read_addr = get_read_ptr(cb_id);
+        uint64_t dest_worker_noc_addr = addr_gen.get_next_noc_addr_and_advance();
+
+        noc_async_write(l1_read_addr, dest_worker_noc_addr, addr_gen.get_shard_size_in_bytes());
+
+        // validate_sane_transaction_counters();
+        validate_sane_transaction_counters_rw();
+        noc_async_write_barrier();
+        cb_pop_front(cb_id, 1);
+    }
+}
+template <typename AddrGen>
 FORCE_INLINE void write_chunk(uint32_t& output_page_idx, uint32_t& col_idx, uint32_t& row_idx, const uint32_t& cb_id, const AddrGen& d, const uint32_t& num_cols, const uint32_t& num_rows, const uint32_t& col_offset, const uint32_t& row_offset, const uint32_t& num_pages, const uint32_t& page_size) {
     for (uint32_t i = 0; i < num_pages; ++i) {
         cb_wait_front(cb_id, 1);
@@ -253,8 +295,20 @@ FORCE_INLINE void write_chunk(uint32_t& output_page_idx, uint32_t& col_idx, uint
     }
 }
 
-template<typename AddrGen>
-FORCE_INLINE void read_chunk(uint32_t& input_page_idx, const uint32_t& cb_id, const AddrGen& s, const uint32_t& num_pages, const uint32_t& page_size) {
+template <ShardType T>
+FORCE_INLINE void read_chunk_from_input_tensor_sharded(
+    const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t num_pages) {
+    cb_reserve_back(cb_id, num_pages);
+    uint32_t local_l1_read_dest_addr = get_write_ptr(cb_id);
+    uint64_t src_noc_addr = addr_gen.get_next_noc_addr_and_advance();
+    noc_async_read(src_noc_addr, local_l1_read_dest_addr, addr_gen.get_shard_size_in_bytes());
+    validate_sane_transaction_counters();
+    noc_async_read_barrier();
+    cb_push_back(cb_id, num_pages);
+}
+// read chunk from input tensor (local chip)
+template <typename AddrGen>
+FORCE_INLINE void read_chunk_from_input_tensor(uint32_t& input_page_idx, const uint32_t& cb_id, const AddrGen& s, const uint32_t& num_pages, const uint32_t& page_size) {
     const uint32_t end_read_idx = input_page_idx + num_pages;
     for (; input_page_idx < end_read_idx; ++input_page_idx) {
         cb_reserve_back(cb_id, 1);
@@ -270,9 +324,22 @@ FORCE_INLINE void read_chunk(uint32_t& input_page_idx, const uint32_t& cb_id, co
     }
 }
 
-template<typename AddrGen>
-FORCE_INLINE void read_chunk(uint32_t& input_page_idx, uint32_t& col_idx, uint32_t& row_idx, const uint32_t &cb_id, const AddrGen& s, const uint32_t& num_cols, const uint32_t& num_rows, const uint32_t& col_offset, const uint32_t& row_offset, const uint32_t& num_pages, const uint32_t& page_size) {
-     for (uint32_t i = 0; i < num_pages; ++i) {
+// Same function - just different address generators? Commonize later
+template <ShardType T>
+FORCE_INLINE void read_chunk_from_output_tensor_sharded(
+    const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t num_pages) {
+    cb_reserve_back(cb_id, num_pages);
+    uint32_t local_l1_read_dest_addr = get_write_ptr(cb_id);
+    uint64_t src_noc_addr = addr_gen.get_next_noc_addr_and_advance();
+    noc_async_read(src_noc_addr, local_l1_read_dest_addr, addr_gen.get_shard_size_in_bytes());
+    validate_sane_transaction_counters();
+    noc_async_read_barrier();
+    cb_push_back(cb_id, num_pages);
+}
+// read chunk from output tensor (local chip)
+template <typename AddrGen>
+FORCE_INLINE void read_chunk_from_output_tensor(uint32_t& input_page_idx, uint32_t& col_idx, uint32_t& row_idx, const uint32_t& cb_id, const AddrGen& s, const uint32_t& num_cols, const uint32_t& num_rows, const uint32_t& col_offset, const uint32_t& row_offset, const uint32_t& num_pages, const uint32_t& page_size) {
+    for (uint32_t i = 0; i < num_pages; ++i) {
         cb_reserve_back(cb_id, 1);
         uint32_t local_l1_read_addr = get_write_ptr(cb_id);
         #ifdef RM_INTERLEAVED

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_reader.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "debug/assert.h"
+#include "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+void kernel_main() {
+    // Compile Time Arg(s)
+    constexpr ShardType shard_type = static_cast<ShardType>(get_compile_time_arg_val(0));
+
+    // TODO: Update the interleaver receive reader kernel invocation to just be able to use this
+    ShardAddrGen<shard_type> output_tensor_shard_writer;
+
+    // Info about the eth receiver eth core (producer of this core)
+    // TODO: Make this arch agnostic
+
+    uint32_t arg_index = 0;
+    const uint32_t eth_receiver_noc_x = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t eth_receiver_noc_y = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t eth_receiver_l1_base_addr = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t eth_receiver_l1_semaphore_addr = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t receiver_read_sem_addr = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t input_shards_per_eth_buffer = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t num_transfers = get_arg_val<uint32_t>(arg_index++);
+
+    ShardAddrGen<shard_type>::build_with_placement_new(&output_tensor_shard_writer, arg_index);
+    arg_index += output_tensor_shard_writer.get_num_args_consumed();
+    ASSERT(eth_receiver_noc_x >= 1 && eth_receiver_noc_x < 12  && (eth_receiver_noc_y == 0 || eth_receiver_noc_y == 6));
+
+
+    // Eth receiver will set this semaphore when data is available
+    volatile tt_l1_ptr uint32_t* receiver_read_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_read_sem_addr);
+
+    // Address of the buffer on the eth receiver, this is different per receiver worker core
+    const uint64_t eth_receiver_l1_base_noc_addr = get_noc_addr(eth_receiver_noc_x, eth_receiver_noc_y, eth_receiver_l1_base_addr);
+
+    // Address of the semaphore on the eth receiver, this is the same per receiver worker core
+    const uint64_t eth_receiver_l1_semaphore_noc_addr = get_noc_addr(eth_receiver_noc_x, eth_receiver_noc_y, eth_receiver_l1_semaphore_addr);
+
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
+
+    // -1 because we are not receiving from our local chip (local chip has num_dest_cores_worth of tiles already handled)
+    uint32_t shards_per_ring_index = output_tensor_shard_writer.get_num_dest_cores();
+
+    uint32_t const shard_size = output_tensor_shard_writer.get_shard_size_in_bytes();
+
+    for (uint32_t t = 0; t < num_transfers; t++) {
+        for (uint32_t i = 0; i < shards_per_ring_index; i += input_shards_per_eth_buffer) {
+            uint32_t shards_to_send = std::min(input_shards_per_eth_buffer, shards_per_ring_index - i);
+            // `shards_to_send` to CB ... need to make sure we are aware of CB wraparound
+            noc_semaphore_wait(receiver_read_semaphore_addr_ptr, 1);
+            noc_semaphore_set(receiver_read_semaphore_addr_ptr, 0);
+            for (uint32_t s = 0; s < shards_to_send; ++s) {
+                // Read page by page so that writer can be kicked off instead of being blocked waiting for full
+                // chunk to be read Look into perf/optimizations for this
+                uint64_t source_eth_buffer_noc_addr = eth_receiver_l1_base_noc_addr + s * shard_size;
+                fetch_chunk_sharded(
+                    cb_id_in0,
+                    1,
+                    shard_size,
+                    source_eth_buffer_noc_addr);
+            }
+            noc_semaphore_inc(eth_receiver_l1_semaphore_noc_addr, 1);
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_writer.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_writer.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+void kernel_main() {
+    constexpr ShardType shard_type = static_cast<ShardType>(get_compile_time_arg_val(0));
+
+    ShardAddrGen<shard_type> output_tensor_shard_writer;
+    uint32_t arg_index = 0;
+    uint32_t const remote_sender_worker_x = get_arg_val<uint32_t>(arg_index++);
+    uint32_t const remote_sender_worker_y = get_arg_val<uint32_t>(arg_index++);
+    uint32_t const remote_sender_reader_semaphore_addres = get_arg_val<uint32_t>(arg_index++);
+    uint32_t const max_shards_per_eth_buffer = get_arg_val<uint32_t>(arg_index++);
+    uint32_t const num_transfers = get_arg_val<uint32_t>(arg_index++);
+    ShardAddrGen<shard_type>::build_with_placement_new(&output_tensor_shard_writer, arg_index);
+    arg_index += output_tensor_shard_writer.get_num_args_consumed();
+
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
+    // Each worker receiver writer matches with a specific worker sender reader
+    // Used to signal that data has been committed to memory and can be read
+    const uint64_t worker_send_reader_semaphore_noc_addr =
+        get_noc_addr(remote_sender_worker_x, remote_sender_worker_y, remote_sender_reader_semaphore_addres);
+
+    uint32_t total_num_shards = output_tensor_shard_writer.get_num_dest_cores() *
+                             (output_tensor_shard_writer.get_chunks_per_core_before_advance() - 1);
+
+    for (uint32_t d = 0; d < num_transfers; d++) {
+        uint32_t num_shards_to_send = std::min(max_shards_per_eth_buffer, total_num_shards);
+
+        write_chunk_sharded(cb_id_in0, output_tensor_shard_writer, num_shards_to_send);  // 1 shard = 1 page
+
+        noc_semaphore_inc(worker_send_reader_semaphore_noc_addr, num_shards_to_send);
+        total_num_shards -= num_shards_to_send;
+
+        ASSERT(total_num_shards > 0 || d == num_transfers - 1); // If we are out of shards, make sure we are on the last transfer
+    }
+}

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_reader.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+void kernel_main() {
+    constexpr ShardType shard_type = static_cast<ShardType>(get_compile_time_arg_val(0));
+    constexpr uint32_t num_transfers = get_compile_time_arg_val(1);
+
+    ShardAddrGen<shard_type> input_tensor_shard_reader;
+    ShardAddrGen<shard_type> output_tensor_shard_reader;
+
+    uint32_t arg_index = 0;
+    volatile tt_l1_ptr uint32_t* local_semaphore_address = get_arg_val<volatile tt_l1_ptr uint32_t*>(arg_index++);
+    ShardAddrGen<shard_type>::build_with_placement_new(&input_tensor_shard_reader, arg_index);
+    arg_index += input_tensor_shard_reader.get_num_args_consumed();
+    ShardAddrGen<shard_type>::build_with_placement_new(&output_tensor_shard_reader, arg_index);
+    arg_index += output_tensor_shard_reader.get_num_args_consumed();
+
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
+
+    uint32_t num_chunks_per_transfer =
+        input_tensor_shard_reader.get_num_dest_cores() * input_tensor_shard_reader.get_chunks_per_core_before_advance();
+
+    ASSERT(output_tensor_shard_reader.get_num_dest_cores() * output_tensor_shard_reader.get_chunks_per_core_before_advance() ==
+        (num_transfers + 1) * num_chunks_per_transfer);
+
+    for (uint32_t c = 0; c < num_chunks_per_transfer; ++c) {
+        read_chunk_from_input_tensor_sharded(cb_id_in0, input_tensor_shard_reader, 1);
+    }
+
+    uint32_t sem_idx = 1;
+
+    for (uint32_t i = 1; i < num_transfers; ++i) {
+        for (uint32_t c = 0; c < num_chunks_per_transfer; ++c) {
+            noc_semaphore_wait_min(local_semaphore_address, sem_idx);
+            sem_idx++;
+            read_chunk_from_output_tensor_sharded(cb_id_in0, output_tensor_shard_reader, 1);  // 1 chunk == 1 page
+        }
+    }
+
+}

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_writer.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_writer.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp"
+
+void kernel_main() {
+    constexpr ShardType shard_type = static_cast<ShardType>(get_compile_time_arg_val(0));
+
+    uint32_t arg_index = 0;
+    ShardAddrGen<shard_type> addr_gen;
+    const uint32_t eth_sender_l1_base_addr = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t eth_sender_l1_sem_addr = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t eth_sender_noc_x = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t eth_sender_noc_y = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t shards_per_eth_l1_buffer = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t writer_send_sem_addr = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t num_transfers = get_arg_val<uint32_t>(arg_index++);
+
+    ShardAddrGen<shard_type>::build_with_placement_new(&addr_gen, arg_index);
+    arg_index += addr_gen.get_num_args_consumed();
+
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
+
+    // Used to wait until eth sender has space available
+    volatile tt_l1_ptr uint32_t* writer_send_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(writer_send_sem_addr);
+
+    // This is different per writer core
+    const uint64_t eth_l1_sender_base_noc_addr =
+        get_noc_addr(eth_sender_noc_x, eth_sender_noc_y, eth_sender_l1_base_addr);
+    // Used to signal eth sender that data is available. This is different per writer core
+    const uint64_t eth_l1_sender_semaphore_addr =
+        get_noc_addr(eth_sender_noc_x, eth_sender_noc_y, eth_sender_l1_sem_addr);
+
+    // one input shard per core for the local chip forward to output tensor
+    const uint32_t num_input_shards_from_local_ring_index = addr_gen.get_num_dest_cores();
+    const uint32_t shard_size = addr_gen.get_shard_size_in_bytes();
+    for (uint32_t i = 0; i < num_input_shards_from_local_ring_index; i += shards_per_eth_l1_buffer) {
+        uint32_t num_shards_to_send = std::min(shards_per_eth_l1_buffer, num_input_shards_from_local_ring_index - i);
+        noc_semaphore_wait(writer_send_semaphore_addr_ptr, 1);
+        noc_semaphore_set(writer_send_semaphore_addr_ptr, 0);
+        for (uint32_t c = 0; c < num_shards_to_send; c++) {
+            uint64_t eth_l1_dest_noc_addr = eth_l1_sender_base_noc_addr + shard_size * c;
+            write_and_send_chunk_sharded(
+                cb_id_in0, addr_gen, 1 /*1 page == 1 shard for this call*/,
+                eth_l1_dest_noc_addr);
+        }
+        noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
+    }
+
+    // num_transfers = num_devices - 1
+    for (uint32_t t = 1; t < num_transfers; ++t) {
+        for (uint32_t i = 0; i < num_input_shards_from_local_ring_index; i += shards_per_eth_l1_buffer) {
+            uint32_t num_shards_to_send = std::min(shards_per_eth_l1_buffer, num_input_shards_from_local_ring_index - i);
+            noc_semaphore_wait(writer_send_semaphore_addr_ptr, 1);
+            noc_semaphore_set(writer_send_semaphore_addr_ptr, 0);
+            for (uint32_t c = 0; c < num_shards_to_send; ++c) {
+                uint64_t eth_l1_dest_noc_addr = eth_l1_sender_base_noc_addr + shard_size * c;
+                send_chunk_sharded(cb_id_in0, 1, shard_size, eth_l1_dest_noc_addr);
+            }
+            noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/ccl/README.md
+++ b/tt_eager/tt_dnn/op_library/ccl/README.md
@@ -1,0 +1,44 @@
+# Collective Communication Library
+
+The Tenstorrent Metalium Collective Communication Library is a collection of high-level multi-chip
+data movement operations. These data movement operations work with a variety of topologies and
+configurations as well as deployment scenarios (N300, T3000, T7000, T7000 cluster).
+
+In this context, a configuration is a combination of memory layout, data types, kernel args (e.g. dim for
+all-reduce), allocation
+
+# Supported Operations
+
+
+## All Gather
+
+### Configurations
+For the time being, input and output configurations are expected to match
+
+Tested Configurations:
+* Layouts: {Row-Major, Tile}
+* Memory Allocation: {Interleaved, Sharded (width)}
+* Memory Locations: DRAM, L1
+* Datatypes: BFloat16, Bfloat8_b
+
+Unsupported Configurations:
+* Sharding: {Block, Height}
+* Row-Major + Bfloat8_b
+  * Bfloat8_b must be in tile format
+
+### Topologies
+Supported Topologies:
+* Ring
+
+Future Tologies:
+* Linear
+* Mesh
+* Torus (2d, 3d)
+
+# Future Operations
+* All Reduce
+* Reduce
+* Scatter
+* Gather Scatter
+* Scatter
+* Point-to-Point Send/Receive

--- a/tt_eager/tt_dnn/op_library/ccl/ccl_common.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/ccl_common.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "debug/assert.h"
+
+namespace ccl {
+
+// TODO(snijjar): Clean this up (mainly dependence on device ASSERT)
+// so I can include this from host side as well
+// template <typename ... Args>
+// class ArgListConstructible {
+//    public:
+//    void build_with_placement_new(Args &&... args) = 0;
+//    // do placement new construction with static build methods
+//     ArgListConstructible(uint16_t num_args_consumed) : num_args_consumed(num_args_consumed) {
+//         ASSERT(num_args_consumed >= 0);//, "num_args_consumed not set")
+//     }
+
+//     int16_t get_num_args_consumed() const {
+//         ASSERT(num_args_consumed >= 0);//, "num_args_consumed not set")
+//         return num_args_consumed;
+//     }
+
+//    protected:
+//     int16_t set_num_args_consumed(uint16_t num_args) {
+//         num_args_consumed = num_args;
+//     }
+
+//     int16_t num_args_consumed;
+// };
+
+} // namespace ccl

--- a/tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp
@@ -8,7 +8,7 @@
 #include "dataflow_api.h"
 #include "debug/dprint.h"
 #include "eth_l1_address_map.h"
-#include "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_async_datamover.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/edm/erisc_async_datamover.hpp"
 
 // Args Schema:
 // 1) handshake addr
@@ -125,14 +125,13 @@ void kernel_main() {
 
     uint8_t const sender_channels_start = get_arg_val<uint32_t>(args_offset++);
     uint32_t const sender_num_channels = num_senders;//get_arg_val<uint32_t>(args_offset++);
-    uint8_t num_senders_with_no_work = 0;;
+    uint8_t num_senders_with_no_work = 0;
     for (uint32_t channel = 0; channel < sender_num_channels; channel++) {
         uint32_t const sender_buffer_address = get_arg_val<uint32_t>(args_offset++);
         uint32_t const sender_num_messages_to_send = get_arg_val<uint32_t>(args_offset++);
         // Each channel buffer is at buffer_base + (channel_id * sender_channel_size)
         // Each channel currently constrained to the same buffer size
         uint32_t const sender_channel_size = get_arg_val<uint32_t>(args_offset++);
-        // TODO(snijjar): we can consider computing this instead using a helper in erisc_datamover_api.h
         // The erisc's local l1 copy of the semaphore workers remotely increment
         uint32_t const sender_semaphores_base_address = get_arg_val<uint32_t>(args_offset++);
         // worker's semaphore L1 address
@@ -148,7 +147,7 @@ void kernel_main() {
             sender_num_workers,
             sender_num_messages_to_send,
             (volatile tt_l1_ptr uint32_t *const)sender_semaphores_base_address,
-            (const erisc::datamover::WorkerXY *)workers_xy_list_addr,
+            (const ccl::WorkerXY *)workers_xy_list_addr,
             true);
         if (sender_num_messages_to_send == 0) {
             num_senders_with_no_work++;
@@ -165,7 +164,6 @@ void kernel_main() {
         // Each channel buffer is at buffer_base + (channel_id * sender_channel_size)
         // Each channel currently constrained to the same buffer size
         uint32_t const receiver_channel_size = get_arg_val<uint32_t>(args_offset++);
-        // TODO(snijjar): we can consider computing this instead using a helper in erisc_datamover_api.h
         uint32_t const receiver_semaphores_base_address = get_arg_val<uint32_t>(args_offset++);
         uint32_t const worker_semaphore_address = get_arg_val<uint32_t>(args_offset++);
         uint32_t const receiver_num_workers = get_arg_val<uint32_t>(args_offset++);
@@ -179,7 +177,7 @@ void kernel_main() {
             receiver_num_workers,
             receiver_num_messages_to_send,
             (volatile tt_l1_ptr uint32_t *const)receiver_semaphores_base_address,
-            (const erisc::datamover::WorkerXY *)workers_xy_list_addr,
+            (const ccl::WorkerXY *)workers_xy_list_addr,
             false);
 
         if (receiver_num_messages_to_send == 0) {

--- a/tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+// #include <type_traits>
+#include <vector>
+#include <limits>
+
+// #include "tt_dnn/op_library/ccl/ccl_common.hpp"
+
+namespace ccl {
+
+// TODO: let the kernel runtime args
+
+enum ShardType : uint8_t { Width = 0, Height = 1, Block = 2 };
+
+/*
+ * Worker coordinate, used by EDM and some kernels to know which workers to signal
+ */
+struct WorkerXY {
+    uint16_t x;
+    uint16_t y;
+
+    WorkerXY(uint16_t x, uint16_t y) : x(x), y(y) {}
+
+    uint32_t to_uint32() const {
+        return (y << 16) | x;
+    }
+
+    bool operator==(const WorkerXY& rhs) const {
+        return x == rhs.x && y == rhs.y;
+    }
+    bool operator!=(const WorkerXY& rhs) const {
+        return !(*this == rhs);
+    }
+};
+
+template <bool T>
+struct ArchDependentTypes;
+
+template <>
+struct ArchDependentTypes<true> {
+    using workers_list_t = std::vector<ccl::WorkerXY>;
+};
+
+template <>
+struct ArchDependentTypes<false> {
+    using workers_list_t = ccl::WorkerXY*;
+};
+
+
+template <bool IS_HOST>
+struct ShardAddrGenArgs final {
+    static constexpr uint32_t UNINITIALIZED_VALUE = std::numeric_limits<uint32_t>::max();
+
+    uint32_t shard_size_in_bytes = UNINITIALIZED_VALUE;
+    uint32_t chunks_per_core_before_advance = UNINITIALIZED_VALUE;
+    uint32_t shards_start_address = UNINITIALIZED_VALUE;
+
+    uint32_t starting_core_index = UNINITIALIZED_VALUE;
+    uint32_t starting_chunk_into_shard = UNINITIALIZED_VALUE;
+
+    uint32_t num_dest_cores = UNINITIALIZED_VALUE;
+    typename ArchDependentTypes<IS_HOST>::workers_list_t dest_cores;
+    bool is_clockwise = false;
+
+    uint32_t get_expected_num_args() const {
+        if constexpr (IS_HOST) {
+            return 7 + dest_cores.size();
+        } else {
+            return 7 + this->num_dest_cores;
+        }
+    }
+};
+
+
+}  // namespace ccl


### PR DESCRIPTION
Sorry for the noise guys. I think it included everyone here because I added an assert or two to a couple files of yours... :)

This is only _initial_ support for sharding input/output with all-gather. It's very baseline and not expected to perform well. There's a lot to go here still but wanted to get something in so model owners can atleast start to play with it.

What's included:
- Supports width sharded tensors with width dim all gather
- Single-tile-high shards only supported for now. Future work will generalize this
- Started experimenting with datastructs (sharable between host-device) to bundle/unbundle args -> keeps them consistent on both sides - helps deal with subtle bugs introduced by args accidentally being put in the wrong spot.
- Started moving some things into common CCL directories 

Limitations:
- No heigh/block sharding
- Perf will be bad (only single link, single worker, unidirectional)
  - Also missing a handful of lower level kernel optimizations
- Only light testing so far: only tested model team configs that satisfy (temporary) single-tile-high shard constraint - all passing - and a few other basic configs

(UPDATE: Decided to omit this specific change from the PR) Also @tt-rkim - wanted to draw your attention specifically to the docs make file. I made it delete HTMLDIR instead of _entire_ build directory on clean command. For some reason `make build` invokes docs clean, and I don't think it's rigtht that docs clean acts as a clean for everything (by just straight up deleting entire build). 