### PR TITLE
Provide support for bcast_hw op in0 and output height sharding, as well as the option to execute the op in place. Add fused softmax variant for attention masks of shape (1, 1, seq_len, seq_len)

### DIFF
--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -217,13 +217,11 @@ def test_falcon_matmul(
 
 # Test matmul attention sequence with InterleavedToShardedPartialOp
 @skip_for_wormhole_b0("non-determinstic hang, see issue #5882")
-@pytest.mark.parametrize("seq_len", [1024], ids=["seq_len_1024"])
-@pytest.mark.parametrize("num_slices", [4], ids=["four_slices"])
+@pytest.mark.parametrize("seq_len", [128, 1024, 2048], ids=["seq_len_128", "seq_len_1024", "seq_len_2048"])
 @pytest.mark.parametrize("num_cores", [64])
 def test_falcon7b_attnention_sliced(
     device,
     seq_len,
-    num_slices,
     num_cores,
     function_level_defaults,
 ):
@@ -232,13 +230,28 @@ def test_falcon7b_attnention_sliced(
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
     grid_size = (8, 8)
 
+    num_heads = 64
+
+    if seq_len == 128:
+        num_slices = 1
+    elif seq_len == 1024:
+        num_slices = 4
+    elif seq_len == 2048:
+        num_slices = 16
+
     query_layer_shape = [1, 71, seq_len, 64]
     key_layer_transposed_shape = [1, 1, 64, seq_len]
     attention_mask_shape = [1, 71, seq_len, seq_len]
+    scalar_shape = [1, 1, 32, 32]
+    value_layer_shape = [1, 1, seq_len, 64]
+    attention_output_shape = [1, 71, seq_len, 64]
 
     torch_query_layer = torch.randn(query_layer_shape).bfloat16().float()
     torch_key_layer_transposed = torch.randn(key_layer_transposed_shape).bfloat16().float()
     torch_attention_mask = torch.randn(attention_mask_shape).bfloat16().float()
+    torch_scalar = (torch.ones(scalar_shape) * (1 / math.sqrt(num_heads))).bfloat16().float()
+    torch_value_layer = torch.randn(value_layer_shape).bfloat16().float()
+    torch_attention_output = torch.randn(attention_output_shape).bfloat16().float()
 
     dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
         memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
@@ -268,6 +281,16 @@ def test_falcon7b_attnention_sliced(
         tt_memory_config=dram_interleaved_memory_config,
         tt_dtype=ttl.tensor.DataType.BFLOAT16,
     )
+    reference_scalar = torch2tt_tensor(
+        torch_scalar, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+    )
+    reference_value_layer = torch2tt_tensor(
+        torch_value_layer,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
+
     compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
         math_fidelity=ttl.tensor.MathFidelity.HiFi4,
         math_approx_mode=True,
@@ -278,104 +301,612 @@ def test_falcon7b_attnention_sliced(
     passing = True
     output = None
 
-    # Todo: 2K seq_len
+    attention_output_concatenated = torch2tt_tensor(
+        torch_attention_output,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
+    tiles_per_shard = math.ceil((((71 * seq_len) / num_cores) / num_slices) / 32)
+    mm_activations_height_shard_spec = [tiles_per_shard * 32, 2 * 32]
+    mm_output_height_shard_spec = [tiles_per_shard * 32, seq_len]
+
+    for i in range(num_slices):
+        slice = ttl.tensor.interleaved_to_sharded_partial(
+            reference_query_layer,
+            grid_size,
+            mm_activations_height_shard_spec,
+            num_slices,  # num_slices
+            i,  # slice_index
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+        )
+
+        subblock_h = 1
+        subblock_w = 1
+        if seq_len == 2048:
+            subblock_w = 8  # best option
+        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            in0_block_w=2,
+            per_core_M=tiles_per_shard,
+            per_core_N=seq_len // 32,
+            out_subblock_h=subblock_h,
+            out_subblock_w=subblock_w,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        )
+
+        mm_slice = ttl.operations.primary.matmul(
+            slice,
+            reference_key_layer_transposed,
+            program_config=program_config,
+            output_mem_config=height_sharded_memory_config,
+            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+        mm_slice = ttl.operations.primary.bcast(
+            mm_slice,
+            reference_scalar,
+            ttl.tensor.BcastOpMath.MUL,
+            ttl.tensor.BcastOpDim.HW,
+            output_mem_config=height_sharded_memory_config,
+            in_place=True,
+        )
+
+        # Deallocating here causes pcc to drop - issue #6638
+        # So we have to move it after the entire sequence is finished
+        # slice.deallocate()
+
+        attn_mask_slice = ttl.tensor.interleaved_to_sharded_partial(
+            attention_mask,
+            grid_size,
+            mm_output_height_shard_spec,
+            num_slices,
+            i,
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+        )
+
+        mm_slice = ttl.operations.primary.add(
+            mm_slice,
+            attn_mask_slice,
+            fused_activations=None,
+            output_mem_config=height_sharded_memory_config,
+            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            in_place=True,
+        )
+
+        attn_mask_slice.deallocate()
+
+        subblock_w = 1
+        if seq_len == 2048:
+            subblock_w = 8
+        softmax_program_config = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            subblock_w=subblock_w,
+            block_h=mm_output_height_shard_spec[0] // 32,
+            block_w=mm_output_height_shard_spec[1] // 32,
+        )
+
+        mm_slice = ttl.operations.primary.softmax_in_place(
+            mm_slice, program_config=softmax_program_config, compute_kernel_config=compute_kernel_config
+        )
+
+        subblock_w = 2
+        subblock_h = 1
+        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            in0_block_w=seq_len // 32,
+            per_core_M=tiles_per_shard,
+            per_core_N=2,
+            out_subblock_h=subblock_h,
+            out_subblock_w=subblock_w,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        )
+
+        attn_out_slice = ttl.operations.primary.matmul(
+            mm_slice,
+            reference_value_layer,
+            program_config=program_config,
+            output_mem_config=height_sharded_memory_config,
+            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+        ttl.tensor.sharded_to_interleaved_partial(
+            attn_out_slice,
+            attention_output_concatenated,
+            num_slices,
+            i,
+            dram_interleaved_memory_config,
+        )
+
+        slice.deallocate()
+        mm_slice.deallocate()
+        attn_out_slice.deallocate()
+
+    attention_output_concatenated_torch = tt2torch_tensor(attention_output_concatenated)
+
+    attn_weights = ttl.tensor.matmul(
+        reference_query_layer, reference_key_layer_transposed, output_mem_config=dram_interleaved_memory_config
+    )
+
+    attn_weights = ttl.operations.primary.bcast(
+        attn_weights,
+        reference_scalar,
+        ttl.tensor.BcastOpMath.MUL,
+        ttl.tensor.BcastOpDim.HW,
+        output_mem_config=dram_interleaved_memory_config,
+    )
+    attn_weights = ttl.tensor.add(attn_weights, attention_mask, output_mem_config=dram_interleaved_memory_config)
+    attn_weights = ttl.operations.primary.softmax_in_place(attn_weights, compute_kernel_config=compute_kernel_config)
+    attn_output = ttl.tensor.matmul(attn_weights, reference_value_layer)
+    attn_output_torch = tt2torch_tensor(attn_output)
+    passing = True
+
+    attn_output_torch_reshaped = attn_output_torch.view(1, 1, 71 * seq_len, 64)
+    attention_output_concatenated_torch_reshaped = attention_output_concatenated_torch.view(1, 1, 71 * seq_len, 64)
+    slice_length = (71 * seq_len) // num_slices
+    for slice_index in range(num_slices):
+        print("Comparing slice ", slice_index, "...")
+        slice_passing = False
+        slice_passing, output = comp_pcc(
+            attn_output_torch_reshaped[:, :, (slice_length) * slice_index : (slice_length) * (slice_index + 1), :],
+            attention_output_concatenated_torch_reshaped[
+                :, :, (slice_length) * slice_index : (slice_length) * (slice_index + 1), :
+            ],
+        )
+        passing = passing and slice_passing
+        print("Slice PCC is: ", output)
+
+    # Compare entire tensors as well
+    entire_tensor_passing, output = comp_pcc(attn_output_torch, attention_output_concatenated_torch)
+    passing = entire_tensor_passing and passing
+
+    print(output)
+    assert passing
+
+
+@pytest.mark.parametrize("seq_len", [128, 1024, 2048], ids=["seq_len_128", "seq_len_1024", "seq_len_2048"])
+@pytest.mark.parametrize("num_cores", [64])
+@skip_for_wormhole_b0("non-determinstic hang, see issue #5882")
+def test_falcon7b_attention_softmax_sequence(
+    device,
+    seq_len,
+    num_cores,
+    function_level_defaults,
+):
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if num_cores > (compute_grid_size.x * compute_grid_size.y):
+        pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    grid_size = (8, 8)
+
+    num_heads = 64
+
     if seq_len == 1024:
-        mm_out = torch2tt_tensor(
-            torch_attention_mask,
+        num_slices = 4
+    elif seq_len == 2048:
+        num_slices = 16
+    elif seq_len == 128:
+        num_slices = 1
+
+    query_layer_shape = [1, 71, seq_len, 64]
+    key_layer_transposed_shape = [1, 1, 64, seq_len]
+    attention_mask_shape = [1, 71, seq_len, seq_len]
+    attention_mask_proper_dim_shape = [1, 1, seq_len, seq_len]
+    scalar_shape = [1, 1, 32, 32]
+    value_layer_shape = [1, 1, seq_len, 64]
+    attention_output_shape = [1, 71, seq_len, 64]
+
+    torch_query_layer = torch.randn(query_layer_shape).bfloat16().float()
+    torch_key_layer_transposed = torch.randn(key_layer_transposed_shape).bfloat16().float()
+    torch_attention_mask_proper_dim = torch.randn(attention_mask_proper_dim_shape).bfloat16().float()
+    torch_attention_mask = torch_attention_mask_proper_dim.repeat(1, attention_mask_shape[1], 1, 1)
+    scalar_value = 1 / math.sqrt(num_heads)
+    torch_scalar = (torch.ones(scalar_shape) * scalar_value).bfloat16().float()
+    torch_value_layer = torch.randn(value_layer_shape).bfloat16().float()
+    torch_attention_output = torch.randn(attention_output_shape).bfloat16().float()
+
+    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttl.tensor.BufferType.DRAM,
+    )
+
+    height_sharded_memory_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttl.tensor.BufferType.L1
+    )
+
+    # compare output to regular case
+    reference_query_layer = torch2tt_tensor(
+        torch_query_layer,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
+    reference_key_layer_transposed = torch2tt_tensor(
+        torch_key_layer_transposed,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
+    attention_mask = torch2tt_tensor(
+        torch_attention_mask,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
+    attention_mask_proper_dim = torch2tt_tensor(
+        torch_attention_mask_proper_dim,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
+
+    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttl.tensor.MathFidelity.HiFi4,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+
+    # We need to create attention masks per slice
+    attention_masks_per_slice = []
+    attention_mask_starting_index_per_slice = 0
+    slice_length = (71 * seq_len) // num_slices
+    number_of_attention_mask_elements_used_per_slice = slice_length - seq_len * (slice_length // seq_len)
+    # print("Slice length is: ", slice_length)
+    # print("Number of attention mask elements per slice = ", number_of_attention_mask_elements_used_per_slice)
+    for slice_index in range(num_slices):
+        print("Slice attention mask starting index: ", attention_mask_starting_index_per_slice)
+        torch_attention_mask_per_slice = torch.cat(
+            [
+                torch_attention_mask_proper_dim[:, :, attention_mask_starting_index_per_slice:, :],
+                torch_attention_mask_proper_dim[:, :, :attention_mask_starting_index_per_slice, :],
+            ],
+            dim=2,
+        )
+        tt_attention_slice = torch2tt_tensor(
+            torch_attention_mask_per_slice,
             device,
             tt_memory_config=dram_interleaved_memory_config,
             tt_dtype=ttl.tensor.DataType.BFLOAT16,
         )
-        tiles_per_shard = math.ceil((((71 * seq_len) / num_cores) / num_slices) / 32)
-        mm_activations_height_shard_spec = [tiles_per_shard * 32, 2 * 32]
-        mm_output_height_shard_spec = [tiles_per_shard * 32, seq_len]
+        attention_masks_per_slice.append(tt_attention_slice)
+        attention_mask_starting_index_per_slice = (
+            attention_mask_starting_index_per_slice + number_of_attention_mask_elements_used_per_slice
+        ) % seq_len  # mod attention_mask.height
 
-        for i in range(num_slices):
-            slice = ttl.tensor.interleaved_to_sharded_partial(
-                reference_query_layer,
-                grid_size,
-                mm_activations_height_shard_spec,
-                num_slices,  # num_slices
-                i,  # slice_index
-                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttl.tensor.ShardOrientation.ROW_MAJOR,
-            )
+    reference_scalar = torch2tt_tensor(
+        torch_scalar, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+    )
+    reference_value_layer = torch2tt_tensor(
+        torch_value_layer,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
 
-            program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=grid_size,
-                in0_block_w=2,
-                per_core_M=tiles_per_shard,
-                per_core_N=32,
-                out_subblock_h=1,
-                out_subblock_w=1,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=False,
-            )
+    passing = True
+    output = None
 
-            # [1, 1, 71, 32, 2] * [2, 32]
-            mm_slice = ttl.operations.primary.matmul(
-                slice,
-                reference_key_layer_transposed,
-                program_config=program_config,
-                output_mem_config=height_sharded_memory_config,
-                output_dtype=ttl.tensor.DataType.BFLOAT16,
-                compute_kernel_config=compute_kernel_config,
-            )
+    attention_output_concatenated = torch2tt_tensor(
+        torch_attention_output,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
+    tiles_per_shard = math.ceil((((71 * seq_len) / num_cores) / num_slices) / 32)
+    mm_activations_height_shard_spec = [tiles_per_shard * 32, 2 * 32]
+    mm_output_height_shard_spec = [tiles_per_shard * 32, seq_len]
 
-            slice.deallocate()
-
-            attn_mask_slice = ttl.tensor.interleaved_to_sharded_partial(
-                attention_mask,
-                grid_size,
-                mm_output_height_shard_spec,
-                num_slices,
-                i,
-                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttl.tensor.ShardOrientation.ROW_MAJOR,
-            )
-
-            mm_slice = ttl.operations.primary.add(
-                mm_slice,
-                attn_mask_slice,
-                fused_activations=None,
-                output_mem_config=height_sharded_memory_config,
-                output_dtype=ttl.tensor.DataType.BFLOAT16,
-                in_place=True,
-            )
-
-            attn_mask_slice.deallocate()
-
-            softmax_program_config = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
-                compute_with_storage_grid_size=grid_size,
-                subblock_w=1,
-                block_h=mm_output_height_shard_spec[0] // 32,
-                block_w=mm_output_height_shard_spec[1] // 32,
-            )
-
-            mm_slice = ttl.operations.primary.softmax_in_place(mm_slice, program_config=softmax_program_config)
-
-            ttl.tensor.sharded_to_interleaved_partial(
-                mm_slice,
-                mm_out,
-                num_slices,
-                i,
-                dram_interleaved_memory_config,
-            )
-
-            mm_slice.deallocate()
-
-        mm_out_torch = tt2torch_tensor(mm_out)
-
-        attn_weights = ttl.tensor.matmul(
-            reference_query_layer, reference_key_layer_transposed, output_mem_config=dram_interleaved_memory_config
+    for i in range(num_slices):
+        slice = ttl.tensor.interleaved_to_sharded_partial(
+            reference_query_layer,
+            grid_size,
+            mm_activations_height_shard_spec,
+            num_slices,  # num_slices
+            i,  # slice_index
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-        attn_weights = ttl.tensor.add(attn_weights, attention_mask, output_mem_config=dram_interleaved_memory_config)
-        attn_weights = ttl.operations.primary.softmax_in_place(attn_weights)
+        subblock_h = 1
+        subblock_w = 1
+        if seq_len == 2048:
+            subblock_w = 8  # best option
+        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            in0_block_w=2,
+            per_core_M=tiles_per_shard,
+            per_core_N=seq_len // 32,
+            out_subblock_h=subblock_h,
+            out_subblock_w=subblock_w,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        )
 
-        attn_weights_torch = tt2torch_tensor(attn_weights)
-        passing, output = comp_pcc(mm_out_torch, attn_weights_torch)
+        mm_slice = ttl.operations.primary.matmul(
+            slice,
+            reference_key_layer_transposed,
+            program_config=program_config,
+            output_mem_config=height_sharded_memory_config,
+            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+        # Deallocating here causes pcc to drop - issue #6638
+        # So we have to move it after the entire sequence is finished
+        # slice.deallocate()
+
+        subblock_w = 1
+        if seq_len == 2048:
+            subblock_w = 8
+        softmax_program_config = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            subblock_w=subblock_w,
+            block_h=mm_output_height_shard_spec[0] // 32,
+            block_w=mm_output_height_shard_spec[1] // 32,
+        )
+
+        mm_slice = ttl.operations.primary.transformers.scale_causal_mask_hw_dims_softmax_in_place(
+            mm_slice,
+            scalar_value,
+            attention_masks_per_slice[i],
+            program_config=softmax_program_config,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+        subblock_w = 2
+        subblock_h = 1
+        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            in0_block_w=seq_len // 32,
+            per_core_M=tiles_per_shard,
+            per_core_N=2,
+            out_subblock_h=subblock_h,
+            out_subblock_w=subblock_w,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+        )
+
+        attn_out_slice = ttl.operations.primary.matmul(
+            mm_slice,
+            reference_value_layer,
+            program_config=program_config,
+            output_mem_config=height_sharded_memory_config,
+            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+        ttl.tensor.sharded_to_interleaved_partial(
+            attn_out_slice,
+            attention_output_concatenated,
+            num_slices,
+            i,
+            dram_interleaved_memory_config,
+        )
+
+        slice.deallocate()
+        mm_slice.deallocate()
+        attn_out_slice.deallocate()
+
+    attention_output_concatenated_torch = tt2torch_tensor(attention_output_concatenated)
+
+    attn_weights = ttl.tensor.matmul(
+        reference_query_layer, reference_key_layer_transposed, output_mem_config=dram_interleaved_memory_config
+    )
+
+    attn_weights = ttl.operations.primary.transformers.scale_mask_softmax_in_place(
+        attn_weights,
+        scalar_value,
+        attention_mask_proper_dim,
+        program_config=ttl.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
+        is_causal_mask=True,
+        compute_kernel_config=compute_kernel_config,
+    )
+
+    attn_output = ttl.tensor.matmul(attn_weights, reference_value_layer)
+    attn_output_torch = tt2torch_tensor(attn_output)
+    passing = True
+
+    attn_output_torch_reshaped = attn_output_torch.view(1, 1, 71 * seq_len, 64)
+    attention_output_concatenated_torch_reshaped = attention_output_concatenated_torch.view(1, 1, 71 * seq_len, 64)
+    for slice_index in range(num_slices):
+        print("Comparing slice ", slice_index, "...")
+        slice_passing = False
+        slice_passing, output = comp_pcc(
+            attn_output_torch_reshaped[:, :, (slice_length) * slice_index : (slice_length) * (slice_index + 1), :],
+            attention_output_concatenated_torch_reshaped[
+                :, :, (slice_length) * slice_index : (slice_length) * (slice_index + 1), :
+            ],
+        )
+        passing = passing and slice_passing
+        print("Slice PCC is: ", output)
+
+    # Compare entire tensors as well
+    entire_tensor_passing, output = comp_pcc(attn_output_torch, attention_output_concatenated_torch)
+    passing = entire_tensor_passing and passing
+
+    print(output)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "seq_len",
+    (32, 64, 128, 1024, 2048),
+    ids=["seq_len_32", "seq_len_64", "seq_len_128", "seq_len_1024", "seq_len_2048"],
+)
+@pytest.mark.parametrize("num_cores", [64])
+def test_softmax(device, num_cores, seq_len):
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if num_cores > (compute_grid_size.x * compute_grid_size.y):
+        pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    grid_size = (8, 8)
+
+    head_dim = 71
+    num_heads = 64
+    torch.manual_seed(0)
+
+    input_shape = [1, head_dim, seq_len, seq_len]
+    attention_mask_shape = [1, 1, seq_len, seq_len]
+    scalar_shape = [1, 1, 32, 32]
+
+    scalar_value = 1 / math.sqrt(num_heads)
+    torch_input = torch.randn(input_shape).bfloat16().float()
+    torch_attention_mask = torch.randn(attention_mask_shape).bfloat16().float()
+    torch_attention_mask_full = torch_attention_mask.repeat(1, head_dim, 1, 1)
+    torch_scalar = (torch.ones(scalar_shape) * scalar_value).bfloat16().float()
+
+    num_slices = 1
+    if seq_len == 1024:
+        num_slices = 4
+    elif seq_len == 2048:
+        num_slices = 16
+
+    slice_length = (head_dim * seq_len) // num_slices
+
+    torch_outputs = torch.zeros(input_shape).bfloat16().float()
+
+    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttl.tensor.BufferType.DRAM,
+    )
+
+    tt_input = torch2tt_tensor(
+        torch_input,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
+
+    tt_attention_mask_full = torch2tt_tensor(
+        torch_attention_mask_full,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+    )
+
+    tt_scalar = torch2tt_tensor(
+        torch_scalar, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+    )
+
+    tt_attention_masks_per_slice = []
+    attention_mask_starting_index_per_slice = 0
+    number_of_attention_mask_elements_used_per_slice = slice_length - seq_len * (slice_length // seq_len)
+    # print("Slice length is: ", slice_length)
+    # print("Number of attention mask elements per slice = ", number_of_attention_mask_elements_used_per_slice)
+    for slice_index in range(num_slices):
+        # print("Slice attention mask starting index: ", attention_mask_starting_index_per_slice)
+        torch_attention_mask_per_slice = torch.cat(
+            [
+                torch_attention_mask[:, :, attention_mask_starting_index_per_slice:, :],
+                torch_attention_mask[:, :, :attention_mask_starting_index_per_slice, :],
+            ],
+            dim=2,
+        )
+        tt_attention_slice = torch2tt_tensor(
+            torch_attention_mask_per_slice,
+            device,
+            tt_memory_config=dram_interleaved_memory_config,
+            tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        )
+        tt_attention_masks_per_slice.append(tt_attention_slice)
+        attention_mask_starting_index_per_slice = (
+            attention_mask_starting_index_per_slice + number_of_attention_mask_elements_used_per_slice
+        ) % seq_len  # mod attention_mask.height
+
+    tt_output_sharded_softmax = torch2tt_tensor(
+        torch_outputs, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+    )
+
+    # Sharded softmax
+    tiles_per_shard = math.ceil((((head_dim * seq_len) / num_cores) / num_slices) / 32)
+    height_shard_spec = [tiles_per_shard * 32, seq_len]
+
+    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttl.tensor.MathFidelity.HiFi4,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+
+    for i in range(num_slices):
+        input_slice = ttl.tensor.interleaved_to_sharded_partial(
+            tt_input,
+            grid_size,
+            height_shard_spec,
+            num_slices,
+            i,
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+        )
+
+        softmax_program_config = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            subblock_w=1,
+            block_h=height_shard_spec[0] // 32,
+            block_w=height_shard_spec[1] // 32,
+        )
+
+        input_slice = ttl.operations.primary.transformers.scale_causal_mask_hw_dims_softmax_in_place(
+            input_slice,
+            scalar_value,
+            tt_attention_masks_per_slice[i],
+            program_config=softmax_program_config,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+        ttl.tensor.sharded_to_interleaved_partial(
+            input_slice, tt_output_sharded_softmax, num_slices, i, dram_interleaved_memory_config
+        )
+        input_slice.deallocate()
+
+    out = ttl.operations.primary.bcast(
+        tt_input,
+        tt_scalar,
+        ttl.tensor.BcastOpMath.MUL,
+        ttl.tensor.BcastOpDim.HW,
+        output_mem_config=dram_interleaved_memory_config,
+    )
+
+    out = ttl.tensor.add(
+        out,
+        tt_attention_mask_full,
+        output_mem_config=dram_interleaved_memory_config,
+    )
+
+    out = ttl.operations.primary.softmax_in_place(out, compute_kernel_config=compute_kernel_config)
+
+    out_torch = tt2torch_tensor(out)
+    out_torch_view = out_torch.view(1, 1, out_torch.shape[1] * out_torch.shape[2], out_torch.shape[3])
+
+    out_torch_softmax = tt2torch_tensor(tt_output_sharded_softmax)
+    out_torch_softmax_view = out_torch_softmax.view(
+        1, 1, out_torch_softmax.shape[1] * out_torch_softmax.shape[2], out_torch_softmax.shape[3]
+    )
+
+    # Compare slice pcc
+    passing = True
+    for slice_index in range(num_slices):
+        print("Comparing slice ", slice_index, "...")
+        slice_passing = False
+        slice_passing, output = comp_pcc(
+            out_torch_view[:, :, (slice_length) * slice_index : (slice_length) * (slice_index + 1), :],
+            out_torch_softmax_view[:, :, (slice_length) * slice_index : (slice_length) * (slice_index + 1), :],
+        )
+        passing = passing and slice_passing
+        print("Slice PCC is: ", output)
+
+    # Compare entire tensors as well
+    entire_tensor_passing, output = comp_pcc(out_torch_view, out_torch_softmax_view)
+    passing = entire_tensor_passing and passing
 
     print(output)
     assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -572,6 +572,95 @@ def test_block_sharded_partial_op(
     assert passing
 
 
+@pytest.mark.parametrize("num_cores", [64, 1], ids=["multi_core", "single_core"])
+@pytest.mark.parametrize("in0_height_sharded", [True, False], ids=["in0_height_sharded", "in0_dram_interleaved"])
+@pytest.mark.parametrize("out_height_sharded", [True, False], ids=["out_height_sharded", "out_dram_interleaved"])
+@pytest.mark.parametrize("in_place", [True, False], ids=["in_place", "not_in_place"])
+def test_bcast_hw(device, num_cores, in0_height_sharded, out_height_sharded, in_place):
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if num_cores > (compute_grid_size.x * compute_grid_size.y):
+        pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+
+    if in0_height_sharded != out_height_sharded:
+        pytest.skip(f"Currently bcast hw op supports sharding if both inputs and outputs are sharded")
+
+    scalar_shape = [1, 1, 32, 32]
+    in0_shape = [1, 1, num_cores * 32, 128]
+    height_shard_spec = [32, 128]
+
+    torch_scalar = torch.randn(scalar_shape).bfloat16().float()
+    torch_in0 = torch.randn(in0_shape).bfloat16().float()
+
+    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttl.tensor.BufferType.DRAM,
+    )
+
+    height_sharded_memory_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttl.tensor.BufferType.L1
+    )
+
+    tt_scalar_dram = torch2tt_tensor(
+        torch_scalar, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+    )
+
+    tt_in0_dram = torch2tt_tensor(
+        torch_in0, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+    )
+
+    if out_height_sharded:
+        out_mem_config = height_sharded_memory_config
+    else:
+        out_mem_config = dram_interleaved_memory_config
+
+    if in0_height_sharded:
+        tt_in0_height_sharded = ttl.tensor.interleaved_to_sharded(
+            tt_in0_dram,
+            device.compute_with_storage_grid_size(),
+            height_shard_spec,
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+        )
+        tt_out = ttl.operations.primary.bcast(
+            tt_in0_height_sharded,
+            tt_scalar_dram,
+            ttl.tensor.BcastOpMath.MUL,
+            ttl.tensor.BcastOpDim.HW,
+            output_mem_config=out_mem_config,
+            in_place=in_place,
+        )
+        tt_in0_height_sharded.deallocate()
+    else:
+        tt_out = ttl.operations.primary.bcast(
+            tt_in0_dram,
+            tt_scalar_dram,
+            ttl.tensor.BcastOpMath.MUL,
+            ttl.tensor.BcastOpDim.HW,
+            output_mem_config=out_mem_config,
+            in_place=in_place,
+        )
+
+    if out_height_sharded:
+        tt_out = ttl.tensor.sharded_to_interleaved(tt_out, output_mem_config=dram_interleaved_memory_config)
+
+    # Reference is out and input dram interleaved
+    tt_out_ref = ttl.operations.primary.bcast(
+        tt_in0_dram,
+        tt_scalar_dram,
+        ttl.tensor.BcastOpMath.MUL,
+        ttl.tensor.BcastOpDim.HW,
+        output_mem_config=dram_interleaved_memory_config,
+        in_place=in_place,
+    )
+
+    tt_out_torch = tt2torch_tensor(tt_out)
+    tt_ref_torch = tt2torch_tensor(tt_out_ref)
+
+    passing, output = comp_pcc(tt_out_torch, tt_ref_torch)
+    logger.info(output)
+    assert passing
+
+
 @pytest.mark.parametrize("H, W, num_cores, num_slices", [[4 * 32, 32 * 32, 64, 2]])
 @pytest.mark.parametrize(
     "activations_dtype",

--- a/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_dnn/op_library/bcast/bcast_op.hpp"
+#include "common/assert.hpp"
+#include "impl/buffers/buffer.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
 
 #include "tensor/tensor.hpp"
@@ -89,7 +91,24 @@ void EltwiseBinaryBroadcast::validate(const std::vector<Tensor> &input_tensors) 
     TT_FATAL(input_tensor_b.get_layout() == Layout::TILE);
     TT_FATAL(input_tensor_a.get_dtype() == input_tensor_b.get_dtype());
     TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
-    TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED && input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED && this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Bcast does not currently support sharding");
+    if (this->in_place) {
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+        TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
+    }
+    if (this->dim != BcastOpDim::HW) {
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED &&
+                this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "Bcast does not currently support input0 sharding, except if dim is HW");
+    } else {
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED ||
+                input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+            "HW bcast in0 supports Height Sharding or Interleaving");
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout,
+            "Input and output mem layouts must be the same for bcast HW op!");
+    }
 
     auto batch_size_a = input_shape_a[0];
     auto num_channels_a = input_shape_a[1];
@@ -119,14 +138,28 @@ std::vector<Shape> EltwiseBinaryBroadcast::compute_output_shapes(const std::vect
 
 
 std::vector<Tensor> EltwiseBinaryBroadcast::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
+    if (this->in_place) {
+        return {};
+    }
     const auto& input_tensor = input_tensors.at(0);
-    return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.get_dtype(), Layout::TILE, this->output_mem_config);
+    if (this->output_mem_config.is_sharded()) {
+        ShardSpec shard_spec{CoreRangeSet({}), {0, 0}};
+        if (input_tensor.memory_config().is_sharded()) {
+            // Derive output shard_spec based on input
+            shard_spec = input_tensor.shard_spec().value();
+        }
+        auto mem_config = this->output_mem_config;
+        mem_config.shard_spec = shard_spec;
+        return {create_sharded_device_tensor(this->compute_output_shapes(input_tensors).at(0), input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config)};
+    } else {
+        return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.get_dtype(), Layout::TILE, this->output_mem_config);
+    }
 }
 
 operation::ProgramWithCallbacks EltwiseBinaryBroadcast::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
-    auto& output_tensor = output_tensors.at(0);
+    const auto& output_tensor = this->in_place ? input_tensor_a : output_tensors.at(0);
 
     auto parallelization_strategy = this->get_parallelization_strategy(input_tensors);
 
@@ -154,7 +187,8 @@ const operation::Hash EltwiseBinaryBroadcast::compute_program_hash(
         input_tensors.at(0).get_dtype(),
         input_tensors.at(1).memory_config(),
         input_tensors.at(1).get_dtype(),
-        bcast_scalar);
+        bcast_scalar,
+        this->in_place);
 }
 
 BcastOpParallelizationStrategy EltwiseBinaryBroadcast::get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const {

--- a/tt_eager/tt_dnn/op_library/bcast/kernels/dataflow/reader_bcast_hw_interleaved.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/kernels/dataflow/reader_bcast_hw_interleaved.cpp
@@ -16,7 +16,10 @@ void kernel_main() {
     uint32_t Wt         = get_arg_val<uint32_t>(11);
     uint32_t nc1        = get_arg_val<uint32_t>(12); // if 1 we expect the bcast tensor to have NC=1 and wrap around in NC
 
+    #ifndef IN0_SHARDED
     constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    #endif
+
     constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
 
     constexpr uint32_t cb_id_in0 = 0;
@@ -33,14 +36,19 @@ void kernel_main() {
     uint32_t l1_write_addr_in1;
 
     uint32_t num_tiles = src0_num_tiles;
-    uint32_t i = 0;
     uint32_t i1 = 0;
 
+    #ifndef IN0_SHARDED
+    uint32_t i = 0;
     const InterleavedAddrGenFast<src0_is_dram> s0 = {
         .bank_base_address = src0_addr,
         .page_size = in0_tile_bytes,
         .data_format = in0_data_format
     };
+    #else
+        cb_reserve_back(cb_id_in0, num_tiles);
+        cb_push_back(cb_id_in0, num_tiles);
+    #endif
 
     const InterleavedAddrGenFast<src1_is_dram> s1 = {
         .bank_base_address = src1_addr,
@@ -59,12 +67,14 @@ void kernel_main() {
     for (uint32_t nc = 0; nc < NC; nc++) {
         for (uint32_t ht = 0; ht < Ht; ht++) {
             for (uint32_t wt = 0; wt < Wt; wt++) {
+                #ifndef IN0_SHARDED
                 cb_reserve_back(cb_id_in0, onetile);
                 l1_write_addr_in0 = get_write_ptr(cb_id_in0);
                 noc_async_read_tile(i, s0, l1_write_addr_in0);
                 noc_async_read_barrier();
                 cb_push_back(cb_id_in0, onetile);
                 i++; // input tile iterates over NC Ht Wt
+                #endif
 
                 #ifndef BCAST_SCALAR
                 // for each H,W-tile of the first tensor we push one tile from the second arg tile list

--- a/tt_eager/tt_dnn/op_library/bcast/multi_core_h/bcast_op_multi_core_h.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/multi_core_h/bcast_op_multi_core_h.cpp
@@ -19,7 +19,7 @@ namespace tt {
 
 namespace tt_metal {
 
-operation::ProgramWithCallbacks bcast_multi_core_h(const Tensor &a, const Tensor &b, Tensor& output, BcastOpMath bcast_math, BcastOpDim bcast_dim) {
+operation::ProgramWithCallbacks bcast_multi_core_h(const Tensor &a, const Tensor &b, const Tensor& output, BcastOpMath bcast_math, BcastOpDim bcast_dim) {
     TT_ASSERT(bcast_dim == BcastOpDim::H);
 
     const auto ashape = a.get_legacy_shape();

--- a/tt_eager/tt_dnn/op_library/bcast/multi_core_hw/bcast_op_multi_core_hw.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/multi_core_hw/bcast_op_multi_core_hw.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <optional>
+#include "impl/buffers/buffer.hpp"
 #include "tt_dnn/op_library/bcast/bcast_op.hpp"
 #include "tt_dnn/op_library/work_split.hpp"
 #include "tensor/tensor.hpp"
@@ -19,7 +21,7 @@ namespace tt {
 
 namespace tt_metal {
 
-operation::ProgramWithCallbacks bcast_multi_core_hw(const Tensor &a, const Tensor &b, Tensor& output, BcastOpMath bcast_math, BcastOpDim bcast_dim) {
+operation::ProgramWithCallbacks bcast_multi_core_hw(const Tensor &a, const Tensor &b, const Tensor& output, BcastOpMath bcast_math, BcastOpDim bcast_dim) {
     TT_ASSERT(bcast_dim == BcastOpDim::HW);
 
     const auto ashape = a.get_legacy_shape();
@@ -31,20 +33,28 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(const Tensor &a, const Tenso
 
     uint32_t Wt = W/TILE_WIDTH;
     uint32_t Ht = H/TILE_HEIGHT;
-	uint32_t HtWt = Ht * Wt;
+    uint32_t HtWt = Ht * Wt;
 
     uint32_t num_tensor_tiles = NC*Ht*Wt;
 
-	uint32_t bnc1 = (bN*bC == 1);
+    uint32_t bnc1 = (bN*bC == 1);
 
     tt_metal::Program program = tt_metal::CreateProgram();
 
     tt_metal::Device *device = a.device();
 
-	tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    std::optional<ShardSpec> shard_spec = std::nullopt;
+    bool src0_sharded = a.memory_config().is_sharded();
+    bool output_sharded = output.memory_config().is_sharded();
+    if (src0_sharded) {
+        shard_spec = a.shard_spec().value();
+    } else if (output_sharded) {
+        shard_spec = output.shard_spec().value();
+    }
+
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
     uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
-
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -53,33 +63,50 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(const Tensor &a, const Tenso
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
 
-	auto src0_buffer = a.buffer();
-	auto src1_buffer = b.buffer();
-	auto dst_buffer = output.buffer();
-	TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    auto src0_buffer = a.buffer();
+    auto src1_buffer = b.buffer();
+    auto dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     const char* reader_name = bcast_op_utils::get_reader_name(bcast_dim, BcastOpParallelizationStrategy::MULTI_CORE_HW);
     const char* compute_name = bcast_op_utils::get_compute_name(bcast_dim);
 
-	uint32_t src0_cb_index = 0;
-	uint32_t num_input_tiles = 2;
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+    uint32_t num_tiles_per_shard = 0;
+    if (shard_spec.has_value()) {
+        num_tiles_per_shard = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
+        num_tiles_per_core_group_1 = num_tiles_per_shard;
+        num_tiles_per_core_group_2 = 0;
+        all_cores = shard_spec.value().grid;
+        core_group_1 = all_cores;
+        core_group_2 = CoreRangeSet({});
+    }
 
-	tt_metal::CircularBufferConfig src0_cb_config = tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-		.set_page_size(src0_cb_index, single_tile_size);
-	auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_device_cores, src0_cb_config);
+    uint32_t num_input_tiles_cb0 = src0_sharded ? num_tiles_per_shard : num_input_tiles;
 
-	uint32_t src1_cb_index = 1;
-	tt_metal::CircularBufferConfig src1_cb_config = tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
-		.set_page_size(src1_cb_index, single_tile_size);
-	auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_device_cores, src1_cb_config);
+    tt_metal::CircularBufferConfig src0_cb_config = tt_metal::CircularBufferConfig(num_input_tiles_cb0 * single_tile_size, {{src0_cb_index, cb_data_format}})
+        .set_page_size(src0_cb_index, single_tile_size);
+    if (src0_sharded) {
+        src0_cb_config = src0_cb_config.set_globally_allocated_address(*a.buffer());
+    }
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_device_cores, src0_cb_config);
 
-	uint32_t output_cb_index = 16; // output operands start at index 16
-	uint32_t num_output_tiles = 2;
-	tt_metal::CircularBufferConfig output_cb_config = tt_metal::CircularBufferConfig(num_output_tiles * single_tile_size, {{output_cb_index, cb_data_format}})
-		.set_page_size(output_cb_index, single_tile_size);
-	auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, output_cb_config);
+    uint32_t src1_cb_index = 1;
+    tt_metal::CircularBufferConfig src1_cb_config = tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
+        .set_page_size(src1_cb_index, single_tile_size);
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_device_cores, src1_cb_config);
 
-	bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    uint32_t output_cb_index = 16; // output operands start at index 16
+    uint32_t num_output_tiles = output_sharded ? num_tiles_per_shard : 2;
+    tt_metal::CircularBufferConfig output_cb_config = tt_metal::CircularBufferConfig(num_output_tiles * single_tile_size, {{output_cb_index, cb_data_format}})
+        .set_page_size(output_cb_index, single_tile_size);
+    if (output_sharded) {
+        output_cb_config = output_cb_config.set_globally_allocated_address(*output.buffer());
+    }
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_device_cores, output_cb_config);
+
+    bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool src1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src0_is_dram, (uint32_t)src1_is_dram};
 
@@ -89,170 +116,209 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(const Tensor &a, const Tenso
         (std::uint32_t) dst_is_dram
     };
 
-	std::map<string, string> reader_defines;
-	std::map<string, string> bcast_compute_defines = bcast_op_utils::get_defines(bcast_dim, bcast_math);
-	if(bnc1) {
-		reader_defines["BCAST_SCALAR"] = "1";
-		bcast_compute_defines["BCAST_SCALAR"] = "1";
-	}
-	KernelHandle binary_reader_kernel_id = tt_metal::CreateKernel(
-		program,
-		reader_name,
-		all_device_cores,
-		tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+    std::map<string, string> reader_defines;
+    std::map<string, string> bcast_compute_defines = bcast_op_utils::get_defines(bcast_dim, bcast_math);
+    if(bnc1) {
+        reader_defines["BCAST_SCALAR"] = "1";
+        bcast_compute_defines["BCAST_SCALAR"] = "1";
+    }
+    if (src0_sharded) {
+        reader_defines["IN0_SHARDED"] = "1";
+    }
+    KernelHandle binary_reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        reader_name,
+        all_device_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
 
-	KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
-		program,
-		"tt_eager/tt_dnn/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-		all_device_cores,
-		tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    std::map<string, string> writer_defines;
+    if (output_sharded) {
+        writer_defines["OUT_SHARDED"] = "1";
+    }
+    KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        all_device_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_defines));
 
-	auto bcast_kernel_id = tt_metal::CreateKernel(
-		program,
-		compute_name,
-		all_device_cores,
-		tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_compute_defines}
-	);
+    auto bcast_kernel_id = tt_metal::CreateKernel(
+        program,
+        compute_name,
+        all_device_cores,
+        tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_compute_defines}
+    );
 
-	for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_y * num_cores_x; i++){
-		CoreCoord core = {i / num_cores_y, i % num_cores_y};
-		uint32_t num_tensor_tiles_per_core;
-		if (core_group_1.core_coord_in_core_ranges(core)) {
-			num_tensor_tiles_per_core = num_tiles_per_core_group_1;
-		} else if (core_group_2.core_coord_in_core_ranges(core)) {
-			num_tensor_tiles_per_core = num_tiles_per_core_group_2;
-		} else {
-			tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(7, 0));
-			tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, std::vector<uint32_t>(3, 0));
-			tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, std::vector<uint32_t>(3, 0));
-			continue;
-		}
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_y * num_cores_x; i++){
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_tensor_tiles_per_core;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_tensor_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_tensor_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(7, 0));
+            tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, std::vector<uint32_t>(3, 0));
+            tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, std::vector<uint32_t>(3, 0));
+            continue;
+        }
 
-		tt_metal::SetRuntimeArgs(
-			program,
-			binary_reader_kernel_id,
-			core,
-			{
-				a.buffer()->address(), // 0
-				b.buffer()->address(),
-				num_tensor_tiles_per_core,
-				HtWt,
-				num_tiles_read / HtWt * HtWt,
-				num_tiles_read % HtWt,
-				bnc1 ? 0 : num_tiles_read / HtWt
-			}
-		);
+        tt_metal::SetRuntimeArgs(
+            program,
+            binary_reader_kernel_id,
+            core,
+            {
+                a.buffer()->address(), // 0
+                b.buffer()->address(),
+                num_tensor_tiles_per_core,
+                HtWt,
+                num_tiles_read / HtWt * HtWt,
+                num_tiles_read % HtWt,
+                bnc1 ? 0 : num_tiles_read / HtWt
+            }
+        );
 
-		tt_metal::SetRuntimeArgs(
-			program,
-			bcast_kernel_id,
-			core,
-			{
-				1, // B
-				1, // Ht
-				num_tensor_tiles_per_core  // Wt
-			}
-		);
+        tt_metal::SetRuntimeArgs(
+            program,
+            bcast_kernel_id,
+            core,
+            {
+                1, // B
+                1, // Ht
+                num_tensor_tiles_per_core  // Wt
+            }
+        );
 
-		tt_metal::SetRuntimeArgs(
-			program, unary_writer_kernel_id, core,
-			{
-				output.buffer()->address(),
-				num_tensor_tiles_per_core,
-				num_tiles_read,
-			}
-		);
-		num_tiles_read += num_tensor_tiles_per_core;
-	}
+        tt_metal::SetRuntimeArgs(
+            program, unary_writer_kernel_id, core,
+            {
+                output.buffer()->address(),
+                num_tensor_tiles_per_core,
+                num_tiles_read,
+            }
+        );
+        num_tiles_read += num_tensor_tiles_per_core;
+    }
 
     auto override_runtime_arguments_callback = [
             binary_reader_kernel_id,
             unary_writer_kernel_id,
-			bcast_kernel_id,
-            compute_with_storage_grid_size
+            bcast_kernel_id,
+            compute_with_storage_grid_size,
+            cb_src0,
+            single_tile_size,
+            cb_output
         ]
     (
         const void* operation,
-        const Program& program,
+        Program& program,
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>&,
         const std::vector<Tensor>& output_tensors
     ) {
-		uint32_t num_cores_x = compute_with_storage_grid_size.x;
-		uint32_t num_cores_y = compute_with_storage_grid_size.y;
+        uint32_t num_cores_x = compute_with_storage_grid_size.x;
+        uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
-        auto src_dram_buffer_a = input_tensors.at(0).buffer();
+        auto src_buffer_a = input_tensors.at(0).buffer();
         auto src_dram_buffer_b = input_tensors.at(1).buffer();
+        std::optional<ShardSpec> shard_spec = std::nullopt;
+        bool src0_sharded = input_tensors.at(0).memory_config().is_sharded();
+        bool out_sharded = output_tensors.at(0).memory_config().is_sharded();
 
-        auto dst_dram_buffer = output_tensors.at(0).buffer();
+        if (src0_sharded) {
+            shard_spec = input_tensors.at(0).shard_spec().value();
+        } else if (out_sharded) {
+            shard_spec = output_tensors.at(0).shard_spec().value();
+        }
 
-		const auto ashape = input_tensors.at(0).get_legacy_shape();
-		const auto bshape = input_tensors.at(1).get_legacy_shape();
-		uint32_t N  = ashape[0], C  = ashape[1], H  = ashape[2], W  = ashape[3];
-		uint32_t bN = bshape[0], bC = bshape[1], bH = bshape[2], bW = bshape[3];
-		uint32_t NC = N*C;
-		uint32_t HW = H*W;
+        auto dst_buffer= output_tensors.at(0).buffer();
 
-		uint32_t Wt = W/TILE_WIDTH;
-		uint32_t Ht = H/TILE_HEIGHT;
-		uint32_t HtWt = Ht * Wt;
+        const auto ashape = input_tensors.at(0).get_legacy_shape();
+        const auto bshape = input_tensors.at(1).get_legacy_shape();
+        uint32_t N  = ashape[0], C  = ashape[1], H  = ashape[2], W  = ashape[3];
+        uint32_t bN = bshape[0], bC = bshape[1], bH = bshape[2], bW = bshape[3];
+        uint32_t NC = N*C;
+        uint32_t HW = H*W;
 
-		uint32_t num_tensor_tiles = NC*Ht*Wt;
+        uint32_t Wt = W/TILE_WIDTH;
+        uint32_t Ht = H/TILE_HEIGHT;
+        uint32_t HtWt = Ht * Wt;
 
-		uint32_t bnc1 = (bN*bC == 1);
+        uint32_t num_tensor_tiles = NC*Ht*Wt;
 
-   	 	auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
+        uint32_t bnc1 = (bN*bC == 1);
+
+        auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
+
+        if (shard_spec.has_value()) {
+            uint32_t num_tiles_per_shard = 0;
+            num_tiles_per_shard = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
+            num_tiles_per_core_group_1 = num_tiles_per_shard;
+            num_tiles_per_core_group_2 = 0;
+            all_cores = shard_spec.value().grid;
+            core_group_1 = all_cores;
+            core_group_2 = CoreRangeSet({});
+        }
 
         for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_y * num_cores_x; i++){
-			CoreCoord core = {i / num_cores_y, i % num_cores_y};
-			uint32_t num_tensor_tiles_per_core;
-			if (core_group_1.core_coord_in_core_ranges(core)) {
-				num_tensor_tiles_per_core = num_tiles_per_core_group_1;
-			} else if (core_group_2.core_coord_in_core_ranges(core)) {
-				num_tensor_tiles_per_core = num_tiles_per_core_group_2;
-			} else {
-				tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(7, 0));
-				tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, std::vector<uint32_t>(3, 0));
-				tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, std::vector<uint32_t>(3, 0));
-				continue;
-			}
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+            uint32_t num_tensor_tiles_per_core;
+            if (core_group_1.core_coord_in_core_ranges(core)) {
+                num_tensor_tiles_per_core = num_tiles_per_core_group_1;
+            } else if (core_group_2.core_coord_in_core_ranges(core)) {
+                num_tensor_tiles_per_core = num_tiles_per_core_group_2;
+            } else {
+                tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(7, 0));
+                tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, std::vector<uint32_t>(3, 0));
+                tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, std::vector<uint32_t>(3, 0));
+                continue;
+            }
 
-			tt_metal::SetRuntimeArgs(
-				program,
-				binary_reader_kernel_id,
-				core,
-				{
-					src_dram_buffer_a->address(), // 0
-					src_dram_buffer_b->address(),
-					num_tensor_tiles_per_core,
-					HtWt,
-					num_tiles_read / HtWt * HtWt,
-					num_tiles_read % HtWt,
-					bnc1 ? 0 : num_tiles_read / HtWt
-				}
-			);
+            tt_metal::SetRuntimeArgs(
+                program,
+                binary_reader_kernel_id,
+                core,
+                {
+                    src_buffer_a->address(), // 0
+                    src_dram_buffer_b->address(),
+                    num_tensor_tiles_per_core,
+                    HtWt,
+                    num_tiles_read / HtWt * HtWt,
+                    num_tiles_read % HtWt,
+                    bnc1 ? 0 : num_tiles_read / HtWt
+                }
+            );
 
-			tt_metal::SetRuntimeArgs(
-				program,
-				bcast_kernel_id,
-				core,
-				{
-					1, // B
-					1, // Ht
-					num_tensor_tiles_per_core  // Wt
-				}
-			);
+            tt_metal::SetRuntimeArgs(
+                program,
+                bcast_kernel_id,
+                core,
+                {
+                    1, // B
+                    1, // Ht
+                    num_tensor_tiles_per_core  // Wt
+                }
+            );
 
-			tt_metal::SetRuntimeArgs(
-				program, unary_writer_kernel_id, core,
-				{
-					dst_dram_buffer->address(),
-					num_tensor_tiles_per_core,
-					num_tiles_read,
-				}
-			);
-			num_tiles_read += num_tensor_tiles_per_core;
-		}
+            tt_metal::SetRuntimeArgs(
+                program, unary_writer_kernel_id, core,
+                {
+                    dst_buffer->address(),
+                    num_tensor_tiles_per_core,
+                    num_tiles_read,
+                }
+            );
+            num_tiles_read += num_tensor_tiles_per_core;
+        }
+
+        if (src0_sharded) {
+            UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer_a);
+            UpdateCircularBufferTotalSize(program, cb_src0, num_tiles_per_core_group_1 * single_tile_size);
+        }
+
+        if (out_sharded) {
+            UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+            UpdateCircularBufferTotalSize(program, cb_output, num_tiles_per_core_group_1 * single_tile_size);
+        }
     };
 
     return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};

--- a/tt_eager/tt_dnn/op_library/bcast/multi_core_w/bcast_op_multi_core_w.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/multi_core_w/bcast_op_multi_core_w.cpp
@@ -19,7 +19,7 @@ namespace tt {
 
 namespace tt_metal {
 
-operation::ProgramWithCallbacks bcast_multi_core_w(const Tensor &a, const Tensor &b, Tensor& output, BcastOpMath bcast_math, BcastOpDim bcast_dim) {
+operation::ProgramWithCallbacks bcast_multi_core_w(const Tensor &a, const Tensor &b, const Tensor& output, BcastOpMath bcast_math, BcastOpDim bcast_dim) {
     TT_ASSERT(bcast_dim == BcastOpDim::W);
 
     const auto ashape = a.get_legacy_shape();

--- a/tt_eager/tt_dnn/op_library/bcast/single_core/bcast_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/single_core/bcast_op_single_core.cpp
@@ -18,7 +18,7 @@ namespace tt {
 
 namespace tt_metal {
 
-operation::ProgramWithCallbacks bcast_single_core(const Tensor &a, const Tensor &b, Tensor& output, BcastOpMath bcast_math, BcastOpDim bcast_dim) {
+operation::ProgramWithCallbacks bcast_single_core(const Tensor &a, const Tensor &b, const Tensor& output, BcastOpMath bcast_math, BcastOpDim bcast_dim) {
 
     const auto ashape = a.get_legacy_shape();
     const auto bshape = b.get_legacy_shape();

--- a/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.cpp
@@ -22,6 +22,7 @@ void ShardedPartial::validate(const std::vector<Tensor>& input_tensors) const {
     // Validate output tensor
     TT_FATAL(slice_index >= 0 && slice_index < num_slices, "Slice index and num_slices don't match! Index = {} num_slices = {}", slice_index, num_slices);
     TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Currently, only tile layout is supported for partial I->S");
+    TT_FATAL((input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % num_slices == 0, "Total height of a tensor must be divisible by num_slices!");
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");

--- a/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.hpp
+++ b/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.hpp
@@ -82,7 +82,6 @@ inline Tensor interleaved_to_sharded_partial(
                     case TensorMemoryLayout::WIDTH_SHARDED: num_cores = div_up(total_width, shard_shape[1]); break;
                     case TensorMemoryLayout::BLOCK_SHARDED:
                         num_cores = div_up(total_height, shard_shape[0]) * div_up(total_width, shard_shape[1]);
-                        log_info("Selected number of cores for I->S partial op is {}", num_cores);
                         break;
                     default: TT_ASSERT(false, "Unsupported sharding scheme");
                 }

--- a/tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/readed_unary_sharded_sm_causal_mask_hw_dims.cpp
+++ b/tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/readed_unary_sharded_sm_causal_mask_hw_dims.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+#include "tt_eager/tt_dnn/kernels/dataflow/generate_bcast_scalar.hpp"
+
+// HW-bcast scale for fused scale-attn-softmax
+FORCE_INLINE void generate_inv_sqrt_hw_bcast_tile() {
+    constexpr auto cb_fused_scale = tt::CB::c_in2;
+    uint32_t u = get_arg_val<uint32_t>(1);
+    cb_reserve_back(cb_fused_scale, 1);
+    auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_fused_scale));
+    ptr[0] = u >> 16;
+    cb_push_back(cb_fused_scale, 1);
+}
+
+void kernel_main() {
+    constexpr uint32_t cb_reduce_scaler = tt::CB::c_in1;
+    const uint32_t reduce_scaler = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t block_wt = get_compile_time_arg_val(0);
+    constexpr bool is_dram_mask = get_compile_time_arg_val(1) == 1;
+
+    const uint32_t mask_addr = get_arg_val<uint32_t>(2);
+    const uint32_t mask_start_tile_id = get_arg_val<uint32_t>(3);
+    uint32_t mask_num_tiles = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t cb_attn = tt::CB::c_in3;
+    uint32_t mask_tile_bytes = get_tile_size(cb_attn);
+    const DataFormat mask_data_format = get_dataformat(cb_attn);
+    uint32_t mask_id = mask_start_tile_id;
+
+    const InterleavedAddrGenFast<is_dram_mask> addr_mask = {
+        .bank_base_address = mask_addr, .page_size = mask_tile_bytes, .data_format = mask_data_format};
+
+    constexpr auto cb_fused_scale = tt::CB::c_in2;
+    const uint32_t pre_scale = get_arg_val<uint32_t>(1);
+    generate_bcast_unary_scalar(cb_fused_scale, pre_scale);
+
+    constexpr uint32_t block_ht = get_compile_time_arg_val(4);
+    for (uint32_t h = 0; h < block_ht; h++) {
+        cb_reserve_back(cb_attn, block_wt);
+        uint32_t l1_write_addr = get_write_ptr(cb_attn);
+        for (uint32_t w = 0; w < block_wt; w++) {
+            noc_async_read_tile(mask_id, addr_mask, l1_write_addr);
+            l1_write_addr += mask_tile_bytes;
+            ++mask_id;
+
+            if (h == 0 && w == 0) {
+                generate_reduce_scaler(cb_reduce_scaler, reduce_scaler);
+            }
+        }
+        noc_async_read_barrier();
+
+        cb_push_back(cb_attn, block_wt);
+        if (mask_id == mask_num_tiles) {
+            mask_id = 0;
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/softmax/multi_core/softmax_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/softmax/multi_core/softmax_op_multi_core.cpp
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "common/logger.hpp"
+#include "impl/buffers/buffer.hpp"
+#include "tt_dnn/op_library/operation.hpp"
 #include "tt_eager/tt_dnn/op_library/softmax/softmax_op.hpp"
 #include "tt_eager/tt_dnn/op_library/math.hpp"
 #include "tt_eager/tt_dnn/op_library/work_split.hpp"
@@ -377,6 +380,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     const std::optional<const Tensor> mask,
     std::optional<float> scale,
     bool causal_mask,
+    bool hw_dims_only_causal_mask,
     CoreCoord grid_size,
     uint32_t subblock_wt,
     uint32_t block_ht,
@@ -469,7 +473,16 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     // attention mask
     uint32_t in3_CB_size;
     if (causal_mask) {
-        in3_CB_size = mask.value().is_sharded() ? block_wt * block_ht * mask_tile_size : block_wt * mask_tile_size * 2;
+        if (mask.value().is_sharded()) {
+            in3_CB_size = block_wt * block_ht * mask_tile_size;
+        } else {
+            in3_CB_size = block_wt * mask_tile_size;
+            if (!hw_dims_only_causal_mask) {
+                // For some reason, if we have hw_dims_causal_mask version, single buffering is up to ~20% faster
+                // Then double buffering CB3.
+                in3_CB_size *= 2;
+            }
+        }
     } else {
         in3_CB_size = block_wt * mask_tile_size;
     }
@@ -505,6 +518,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
         (std::uint32_t) is_dram_mask
     };
     std::map<string, string> softmax_defines;
+    // hw_dims_only_causal_mask does not support RM Layout atm
     bool use_row_major_kernel = (mask.has_value() and mask.value().get_layout() == Layout::ROW_MAJOR);
     if (use_row_major_kernel) {
         auto mask_stick_size = mask.value().get_legacy_shape()[3] * mask.value().element_size();
@@ -521,7 +535,11 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
         reader_compile_time_args.push_back(0);
     }
     if (causal_mask) {
-        reader_compile_time_args.push_back((std::uint32_t) block_ht / block_wt); // fused head
+        if (!hw_dims_only_causal_mask) {
+            reader_compile_time_args.push_back((std::uint32_t) block_ht / block_wt); // fused head
+        } else {
+            reader_compile_time_args.push_back((std::uint32_t) block_ht);
+        }
     }
     reader_compile_time_args.push_back((std::uint32_t) (mask_cb_data_format == tt::DataFormat::Float32)); // mask float32
 
@@ -533,9 +551,17 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
         if (mask.value().is_sharded())
             softmax_defines["SHARDED_CAUSAL_MASK"] =  "1";
     }
+    std::string reader_kernel_path;
+    if (use_row_major_kernel) {
+        reader_kernel_path = "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/reader_unary_sharded_sm_rm_mask.cpp";
+    } else if (!hw_dims_only_causal_mask) {
+        reader_kernel_path = "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/reader_unary_sharded_sm.cpp";
+    } else {
+        reader_kernel_path = "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/readed_unary_sharded_sm_causal_mask_hw_dims.cpp";
+    }
     auto reader_kernels_id = CreateKernel(
         program,
-        use_row_major_kernel ? "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/reader_unary_sharded_sm_rm_mask.cpp" : "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/reader_unary_sharded_sm.cpp",
+        reader_kernel_path,
         all_device_cores,
         tt_metal::ReaderDataMovementConfig(
             reader_compile_time_args,
@@ -608,9 +634,16 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     uint32_t mask_addr = mask.has_value() ? mask.value().buffer()->address() : 0;
     union { float f; uint32_t u; } s; s.f = scale.value_or(1.0f); // scale for fused scale-mask-softmax
     uint32_t mask_start_tile_id = 0;
+
+    uint32_t num_tiles_in_attn_mask = 0;
+    uint32_t num_tiles_of_attn_mask_needed_per_core = 0;
+    if (hw_dims_only_causal_mask) {
+        num_tiles_in_attn_mask = mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_HW;
+        num_tiles_of_attn_mask_needed_per_core = block_ht * block_wt;
+    }
     for(int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
 
-        if (shard_orient == ShardOrientation::COL_MAJOR) {
+        if (shard_orient == ShardOrientation::COL_MAJOR && !hw_dims_only_causal_mask) {
             mask_start_tile_id = 0;
         }
 
@@ -623,22 +656,30 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
             reader_args.push_back(s.u);
             reader_args.push_back(mask_addr);
             reader_args.push_back(mask_start_tile_id);
-            tt_metal::SetRuntimeArgs(program, reader_kernels_id, core, reader_args);
+            if (hw_dims_only_causal_mask) {
+                reader_args.push_back(num_tiles_in_attn_mask);
+            }
 
-            if (shard_orient == ShardOrientation::COL_MAJOR) {
-                if (mask.has_value()) {
-                    if (causal_mask) {
-                        mask_start_tile_id += mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
-                    } else {
-                        mask_start_tile_id += use_row_major_kernel ? mask.value().get_legacy_shape()[-2] : mask.value().get_legacy_shape()[-1] / TILE_WIDTH;
+            tt_metal::SetRuntimeArgs(program, reader_kernels_id, core, reader_args);
+            if (hw_dims_only_causal_mask) {
+                uint32_t mask_tile_id_end = (mask_start_tile_id + num_tiles_of_attn_mask_needed_per_core) % num_tiles_in_attn_mask;
+                mask_start_tile_id = mask_tile_id_end;
+            } else {
+                if (shard_orient == ShardOrientation::COL_MAJOR) {
+                    if (mask.has_value()) {
+                        if (causal_mask) {
+                            mask_start_tile_id += mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
+                        } else {
+                            mask_start_tile_id += use_row_major_kernel ? mask.value().get_legacy_shape()[-2] : mask.value().get_legacy_shape()[-1] / TILE_WIDTH;
+                        }
                     }
-                }
-            } else if (core_idx_x == num_cores_c - 1) {
-                if (mask.has_value()) {
-                    if (causal_mask) {
-                        mask_start_tile_id += mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
-                    } else {
-                        mask_start_tile_id += use_row_major_kernel ? mask.value().get_legacy_shape()[-2] : mask.value().get_legacy_shape()[-1] / TILE_WIDTH;
+                } else if (core_idx_x == num_cores_c - 1) {
+                    if (mask.has_value()) {
+                        if (causal_mask) {
+                            mask_start_tile_id += mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
+                        } else {
+                            mask_start_tile_id += use_row_major_kernel ? mask.value().get_legacy_shape()[-2] : mask.value().get_legacy_shape()[-1] / TILE_WIDTH;
+                        }
                     }
                 }
             }

--- a/tt_eager/tt_dnn/op_library/softmax/softmax_op.cpp
+++ b/tt_eager/tt_dnn/op_library/softmax/softmax_op.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_eager/tt_dnn/op_library/softmax/softmax_op.hpp"
+#include "common/assert.hpp"
+#include "common/base_types.hpp"
+#include "tensor/types.hpp"
 #include "tt_eager/tt_dnn/op_library/math.hpp"
 #include "tt_eager/tt_dnn/op_library/work_split.hpp"
 #include "tt_dnn/op_library/run_operation.hpp"
@@ -13,6 +16,7 @@
 #include "tt_metal/detail/util.hpp"
 
 #include <optional>
+#include <type_traits>
 
 using uint32_t = std::uint32_t;
 using namespace tt::constants;
@@ -54,27 +58,34 @@ void Softmax::validate(const std::vector<Tensor> &input_tensors, const std::vect
                         std::is_same_v<ProgramConfigType, tt::operations::primary::transformers::SoftmaxDefaultProgramConfig>
                     ) {
                         TT_FATAL(input_tensor.get_legacy_shape()[0] == mask.get_legacy_shape()[0]);
+                        TT_FATAL(!this->is_scale_causal_mask_hw_dims_softmax);
                     } else if constexpr (
                         std::is_same_v<ProgramConfigType, tt::operations::primary::transformers::SoftmaxShardedMultiCoreProgramConfig>
                     ) {
                         const auto shape = input_tensor.get_legacy_shape();
                         uint32_t M = input_tensor.volume() / shape[-1];
                         uint32_t K = shape[-1];
-                        // block
-                        uint32_t block_w = program_config.block_w * TILE_WIDTH;
-                        uint32_t block_h = program_config.block_h * TILE_HEIGHT;
-                        uint32_t num_subblocks_w = program_config.block_w / program_config.subblock_w;
-                        // grid
-                        auto num_cores_c = program_config.compute_with_storage_grid_size.x;
-                        auto num_cores_r = program_config.compute_with_storage_grid_size.y;
-                        // check dims
-                        TT_FATAL(program_config.block_w % program_config.subblock_w == 0, "block_w must be divisible by subblock_w.");
+
                         TT_FATAL(M % TILE_HEIGHT == 0, "M must be divisible by tile height.");
                         TT_FATAL(K % TILE_WIDTH == 0, "K must be divisible by tile width.");
-                        TT_FATAL(M * K / (block_w * block_h) == num_cores_r * num_cores_c, "number of shards must equal to number of cores");
+                        TT_FATAL(program_config.block_w % program_config.subblock_w == 0, "block_w must be divisible by subblock_w.");
+                        TT_FATAL(program_config.block_w * TILE_WIDTH == shape[3], "shard width must equal to input tensor shape[3]!");
                         TT_FATAL(this->inplace);
-                        // check sharding dim
-                        TT_FATAL(block_w == shape[3], "shard width must equal to input tensor shape[3]!");
+                        if (!this->is_scale_causal_mask_hw_dims_softmax) {
+                            // grid
+                            auto num_cores_c = program_config.compute_with_storage_grid_size.x;
+                            auto num_cores_r = program_config.compute_with_storage_grid_size.y;
+                            // check dims
+                            TT_FATAL(M * K / ((program_config.block_w * program_config.block_h) * TILE_HW) == num_cores_r * num_cores_c, "number of shards must equal to number of cores. M = {}, K = {}, block_w = {}, block_h = {}, num_cores = {}", M, K, program_config.block_w, program_config.block_h, num_cores_r * num_cores_c);
+                        } else {
+                            TT_FATAL(this->is_causal_mask);
+                            TT_FATAL(mask.get_layout() == Layout::TILE);
+                            TT_FATAL(mask.is_sharded() == false);
+                            TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+                            TT_FATAL(input_tensor.is_sharded());
+                            TT_FATAL(input_tensor.shard_spec()->orientation == ShardOrientation::ROW_MAJOR);
+                            TT_FATAL(this->scale.has_value());
+                        }
                     }
                 },
                 this->program_config
@@ -84,6 +95,7 @@ void Softmax::validate(const std::vector<Tensor> &input_tensors, const std::vect
         }
     } else {
         TT_FATAL(not this->scale.has_value());
+        TT_FATAL(not this->is_scale_causal_mask_hw_dims_softmax);
     }
 }
 
@@ -123,14 +135,19 @@ operation::ProgramWithCallbacks Softmax::create_program(
                 std::is_same_v<ProgramConfigType, tt::operations::primary::transformers::SoftmaxShardedMultiCoreProgramConfig>
             ) {
                 return scale_mask_softmax_sharded_multi_core(
-                                            input_tensor, output_tensor, mask, this->scale, causal_mask,
-                                            program_config.compute_with_storage_grid_size,
-                                            program_config.subblock_w,
-                                            program_config.block_h,
-                                            program_config.block_w,
-                                            this->compute_kernel_config
-                                            );
-            } else {
+                    input_tensor,
+                    output_tensor,
+                    mask,
+                    this->scale,
+                    causal_mask,
+                    this->is_scale_causal_mask_hw_dims_softmax,
+                    program_config.compute_with_storage_grid_size,
+                    program_config.subblock_w,
+                    program_config.block_h,
+                    program_config.block_w,
+                    this->compute_kernel_config);
+            }
+            else {
                 return scale_mask_softmax_multi_core(input_tensor, output_tensor, mask, this->scale, causal_mask, this->compute_kernel_config);
             }
         },
@@ -167,7 +184,13 @@ Tensor softmax_in_place(Tensor& input_tensor, const transformers::SoftmaxProgram
 namespace transformers {
 Tensor scale_mask_softmax_in_place(Tensor& input_tensor, std::optional<float> scale, std::optional<const Tensor> mask, const SoftmaxProgramConfig& program_config, const bool is_causal_mask, std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
-    operation::run(Softmax{.scale=scale, .inplace=true, .output_mem_config=input_tensor.memory_config(), .program_config=program_config, .is_causal_mask=is_causal_mask, .compute_kernel_config=kernel_config_val}, {input_tensor}, {mask});
+    operation::run(Softmax{.scale=scale, .inplace=true, .output_mem_config=input_tensor.memory_config(), .program_config=program_config, .is_causal_mask=is_causal_mask, .compute_kernel_config=kernel_config_val, .is_scale_causal_mask_hw_dims_softmax=false}, {input_tensor}, {mask});
+    return input_tensor;
+}
+
+Tensor scale_causal_mask_hw_dims_softmax_in_place(Tensor& input_tensor, std::optional<float> scale, std::optional<const Tensor> mask, const SoftmaxProgramConfig& program_config, std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+    operation::run(Softmax{.scale=scale, .inplace=true, .output_mem_config=input_tensor.memory_config(), .program_config=program_config, .is_causal_mask=true, .compute_kernel_config=kernel_config_val, .is_scale_causal_mask_hw_dims_softmax=true}, {input_tensor}, {mask});
     return input_tensor;
 }
 
@@ -196,7 +219,7 @@ Tensor scale_mask_softmax(const Tensor& input_tensor, std::optional<float> scale
         mask_format_params = {.pad_shape=mask_pad_shape, .pad_value=-std::numeric_limits<float>::infinity(), .target_layout=Layout::TILE};
     }
     auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
-    return operation::run_with_autoformat(tt::operations::primary::Softmax{.scale=scale, .inplace=false, .output_mem_config=output_mem_config, .is_causal_mask=is_causal_mask, .compute_kernel_config=kernel_config_val}, {input_tensor}, {input_format_params}, {Layout::TILE}, {mask}, {mask_format_params}).at(0);
+    return operation::run_with_autoformat(tt::operations::primary::Softmax{.scale=scale, .inplace=false, .output_mem_config=output_mem_config, .is_causal_mask=is_causal_mask, .compute_kernel_config=kernel_config_val, .is_scale_causal_mask_hw_dims_softmax=false}, {input_tensor}, {input_format_params}, {Layout::TILE}, {mask}, {mask_format_params}).at(0);
 }
 }  // namespace transformers
 }  // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/softmax/softmax_op.hpp
+++ b/tt_eager/tt_dnn/op_library/softmax/softmax_op.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include "common/base_types.hpp"
+#include "common/core_coord.h"
+#include "tensor/types.hpp"
 #include "tt_eager/tensor/tensor.hpp"
 
 #include "tt_dnn/op_library/operation.hpp"
@@ -40,6 +43,7 @@ using SoftmaxProgramConfig = std::variant<
     SoftmaxDefaultProgramConfig,
     SoftmaxShardedMultiCoreProgramConfig
 >;
+
 }  // namespace transformers
 
 struct Softmax {
@@ -49,6 +53,7 @@ struct Softmax {
     const tt::operations::primary::transformers::SoftmaxProgramConfig program_config;
     const bool is_causal_mask;
     const DeviceComputeKernelConfig compute_kernel_config;
+    const bool is_scale_causal_mask_hw_dims_softmax;
 
     void validate(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -74,12 +79,15 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     DeviceComputeKernelConfig compute_kernel_config
 );
 
+// hw_dims_only_causal_mask - represents if the causal mask is of shape [1, 1, h, w]
+// valid only if causal_mask == true, and is interleaved
 operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     const Tensor &input_tensor,
     const Tensor &output_tensor,
     const std::optional<const Tensor> mask,
     std::optional<float> scale,
     bool causal_mask,
+    bool hw_dims_only_causal_mask,
     CoreCoord grid_size,
     uint32_t subblock_wt,
     uint32_t block_ht,
@@ -97,6 +105,13 @@ namespace transformers {
 // y = softmax(tmp2)              ; r=result
 // If scale == 0.0f then just y = softmax(x) is computed
 Tensor scale_mask_softmax_in_place(Tensor& input_tensor, std::optional<float> scale = std::nullopt, std::optional<const Tensor> mask = std::nullopt, const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{}, const bool is_causal_mask = false, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+
+// Experimental feature. Does the same same as above, with the following assumptions:
+// 1. Input must be sharded
+// 2. Scale must exist
+// 3. Attention mask must be interleaved and be of this shape [1, 1, H, W]
+// 4. Causal mask argument is set to true.
+Tensor scale_causal_mask_hw_dims_softmax_in_place(Tensor& input_tensor, std::optional<float> scale, std::optional<const Tensor> mask, const SoftmaxProgramConfig& program_config = SoftmaxShardedMultiCoreProgramConfig{}, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 }  // namespace transformers
 
 }  // namespace primary

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -725,7 +725,7 @@ void py_module(py::module& m_primary) {
     )doc");
 
     m_primary.def("bcast", &tt::operations::primary::bcast,
-        py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("math_op"), py::arg("dim"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+        py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("math_op"), py::arg("dim"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("in_place") = false, R"doc(
         Perform a binary elementwise operation ``math_op`` between tensors ``input_a`` and ``input_b``, where values from tensor ``input_b`` are broadcast.
 
         Let tensor ``input_a`` have shape ``[W0, Z0, Y0, X0]`` and tensor ``input_b`` shape ``[W1, Z1, Y1, X1]``. ``dim`` determines the type of broadcast performed.
@@ -750,6 +750,7 @@ void py_module(py::module& m_primary) {
             "math_op", "Aggregating math operation", " BcastOpMath", "ADD, SUB, MUL", "Yes"
             "dim", "Dimension on which to broadcast", "BcastOpDim", "W, H, HW", "Yes"
             "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+            "in_place", "Whether to perform bcast in place, without allocating space for output tensor", "Bool", "Default is false", "No"
     )doc");
 
     py::enum_<MorehSoftmaxOpParallelizationStrategy>(m_primary, "MorehSoftmaxOpParallelizationStrategy")

--- a/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
@@ -75,6 +75,19 @@ void py_module(py::module& m_transformers) {
         py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs a fused scale->attention_mask->softmax operation. Returns a reference to the input tensor modified in place."
         );
+
+    m_transformers.def(
+        "scale_causal_mask_hw_dims_softmax_in_place",
+        &scale_causal_mask_hw_dims_softmax_in_place,
+        py::arg("input_tensor").noconvert(),
+        py::arg("scale").noconvert(),
+        py::arg("mask").noconvert(),
+        py::arg("program_config").noconvert() = SoftmaxShardedMultiCoreProgramConfig{},
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
+        "Performs a fused scale->attention_mask->softmax operation. Returns a reference to the input tensor modified "
+        "in place. Input must be sharded, and attention mask interleaved and of shape [1, 1, H, W]"
+        );
+
 }
 
 }  // namespace transformers


### PR DESCRIPTION
Bcast op (HW version only) got support for in0/out height sharding. Other variants did not receive that support, as I'm not aware of the use case. One more limitation is that either both input0 and output must be dram-interleaved or height_sharded (one can't be sharded, while the other is dram-interleaved). Will fix this when I get time.
Provide option to perform op in place, without allocating additional memory.

Height shard attention sequence from falcon7b prefill, and provide a test for it.
This is the sequence that is now fully height-sharded: matmul -> bcast -> add -> softmax -> matmul.
In original implementation, at 2k seq length, this took around 45 mil ns, with height sharding (and running 16 slices of the tensor consecutively), this got down to ~14.75 mil ns.

Furthermore, attention sequence was optimised even further by providing a new softmax implementation (height sharded input, attn_mask of shape (1, 1, seq_len, seq_len) (Currently existing softmax implementation requires attn_mask shape to be == input shape (which is (1, 71, seq_len, seq_len). That got the attention sequence down to ~11.4 mil ns.
