### PR TITLE
FD2.0 Test - Fix l1 buffer not page-size aligned in after FD-on-eth changes to L1_UNRESERVED_BASE

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
         CoreCoord phys_dispatch_core = device->worker_core_from_logical_core(dispatch_core);
 
         // Want different buffers on each core, instead use big buffer and self-manage it
-        uint32_t l1_buf_base = L1_UNRESERVED_BASE;
+        uint32_t l1_buf_base = align(L1_UNRESERVED_BASE, dispatch_buffer_page_size_g);
         TT_ASSERT((l1_buf_base & (dispatch_buffer_page_size_g - 1)) == 0);
         if (prefetcher_buffer_size_g + l1_buf_base > 1024 * 1024) {
             log_fatal(LogTest, "Error, prefetcher buffer size too large\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -873,14 +873,15 @@ int main(int argc, char **argv) {
         CoreCoord phys_dispatch_core = device->worker_core_from_logical_core(dispatch_core);
 
         // Want different buffers on each core, instead use big buffer and self-manage it
-        uint32_t l1_buf_base = L1_UNRESERVED_BASE + (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE);
+        uint32_t l1_unreserved_base_aligned = align(L1_UNRESERVED_BASE, (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE)); // Was not aligned, lately.
+        uint32_t l1_buf_base = l1_unreserved_base_aligned + (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE); // Reserve a page.
         TT_ASSERT((l1_buf_base & ((1 << DISPATCH_BUFFER_LOG_PAGE_SIZE) - 1)) == 0);
 
         uint32_t dispatch_buffer_base = l1_buf_base;
         uint32_t dev_hugepage_base = 0;
         uint32_t prefetch_q_base = l1_buf_base;
-        uint32_t prefetch_q_rd_ptr_addr = L1_UNRESERVED_BASE;
-        dispatch_wait_addr_g = L1_UNRESERVED_BASE + 16;
+        uint32_t prefetch_q_rd_ptr_addr = l1_unreserved_base_aligned;
+        dispatch_wait_addr_g = l1_unreserved_base_aligned + 16;
         vector<uint32_t>zero_data(0);
         llrt::write_hex_vec_to_core(device->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
 


### PR DESCRIPTION
solves test_dispatcher/test_prefetcher asserts seen after last night's FD-on-eth-core changes.

- Easy fix, don't just use L1_UNRESERVED_BASE and fail if it's not aligned (spoiler: it's not anymore), but use an aligned address in the first place.