### PR TITLE
#5785: Watcher ringbuffer implementation

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/ring_buffer.h"
+
+/*
+ * A test for the watcher waypointing feature.
+*/
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC)
+void kernel_main() {
+#else
+#include "compute_kernel_api/common.h"
+namespace NAMESPACE {
+void MAIN {
+#endif
+
+    // Conditionally enable using defines for each trisc
+#if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
+    (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
+    (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
+    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC))
+    for (uint32_t idx = 0; idx < 40; idx++) {
+        WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
+    }
+#endif
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC)
+}
+#else
+}
+}
+#endif

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_ringbuf.cpp
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "watcher_fixture.hpp"
+#include "test_utils.hpp"
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// A test for checking debug ring buffer feature.
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+using namespace tt::tt_metal;
+
+std::vector<std::string> expected = {
+    "debug_ring_buffer(latest_written_idx=8)=[",
+    "[0x001f0020,0x00200021,0x00210022,0x00220023,0x00230024,0x00240025,0x00250026,0x00260027,",
+    " 0x00270028,0x0009000a,0x000a000b,0x000b000c,0x000c000d,0x000d000e,0x000e000f,0x000f0010,",
+    " 0x00100011,0x00110012,0x00120013,0x00130014,0x00140015,0x00150016,0x00160017,0x00170018,",
+    "0x00180019,0x0019001a,0x001a001b,0x001b001c,0x001c001d,0x001d001e,0x001e001f]"
+};
+
+static void RunTest(WatcherFixture *fixture, Device *device, riscv_id_t riscv_type) {
+    // Set up program
+    Program program = Program();
+
+    // Depending on riscv type, choose one core to run the test on.
+    CoreCoord logical_core, phys_core;
+    if (riscv_type == DebugErisc) {
+        if (device->get_active_ethernet_cores().empty()) {
+            log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+            GTEST_SKIP();
+        }
+        logical_core = *(device->get_active_ethernet_cores().begin());
+        phys_core = device->ethernet_core_from_logical_core(logical_core);
+    } else {
+        logical_core = CoreCoord{0, 0};
+        phys_core = device->worker_core_from_logical_core(logical_core);
+    }
+    log_info(LogTest, "Running test on device {} core {}...", device->id(), phys_core.str());
+
+
+    // Set up the kernel on the correct risc
+    KernelHandle assert_kernel;
+    switch(riscv_type) {
+        case DebugBrisc:
+            assert_kernel = CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                logical_core,
+                DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default
+                }
+            );
+            break;
+        case DebugNCrisc:
+            assert_kernel = CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                logical_core,
+                DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = tt_metal::NOC::RISCV_1_default
+                }
+            );
+            break;
+        case DebugTrisc0:
+            assert_kernel = CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                logical_core,
+                ComputeConfig{
+                    .defines = {{"TRISC0", "1"}}
+                }
+            );
+            break;
+        case DebugTrisc1:
+            assert_kernel = CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                logical_core,
+                ComputeConfig{
+                    .defines = {{"TRISC1", "1"}}
+                }
+            );
+            break;
+        case DebugTrisc2:
+            assert_kernel = CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                logical_core,
+                ComputeConfig{
+                    .defines = {{"TRISC2", "1"}}
+                }
+            );
+            break;
+        case DebugErisc:
+            assert_kernel = CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                logical_core,
+                EthernetConfig{
+                    .noc = tt_metal::NOC::NOC_0
+                }
+            );
+            break;
+        default:
+            log_info("Unsupported risc type: {}, skipping test...", riscv_type);
+            GTEST_SKIP();
+    }
+
+    // Run the program
+    fixture->RunProgram(device, program);
+
+    // Check log
+    EXPECT_TRUE(
+        FileContainsAllStringsInOrder(
+            fixture->log_file_name,
+            {expected}
+        )
+    );
+}
+
+TEST_F(WatcherFixture, TestWatcherRingBufferBrisc) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(
+            [](WatcherFixture *fixture, Device *device){RunTest(fixture, device, DebugBrisc);},
+            device
+        );
+    }
+}
+TEST_F(WatcherFixture, TestWatcherRingBufferNCrisc) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(
+            [](WatcherFixture *fixture, Device *device){RunTest(fixture, device, DebugNCrisc);},
+            device
+        );
+    }
+}
+TEST_F(WatcherFixture, TestWatcherRingBufferTrisc0) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(
+            [](WatcherFixture *fixture, Device *device){RunTest(fixture, device, DebugTrisc0);},
+            device
+        );
+    }
+}
+TEST_F(WatcherFixture, TestWatcherRingBufferTrisc1) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(
+            [](WatcherFixture *fixture, Device *device){RunTest(fixture, device, DebugTrisc1);},
+            device
+        );
+    }
+}
+TEST_F(WatcherFixture, TestWatcherRingBufferTrisc2) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(
+            [](WatcherFixture *fixture, Device *device){RunTest(fixture, device, DebugTrisc2);},
+            device
+        );
+    }
+}
+TEST_F(WatcherFixture, TestWatcherRingBufferErisc) {
+    for (Device* device : this->devices_) {
+        this->RunTestOnDevice(
+            [](WatcherFixture *fixture, Device *device){RunTest(fixture, device, DebugErisc);},
+            device
+        );
+    }
+}

--- a/tt_metal/hostdevcommon/common_runtime_address_map.h
+++ b/tt_metal/hostdevcommon/common_runtime_address_map.h
@@ -49,6 +49,9 @@ constexpr static std::uint32_t PRINT_BUFFER_T2 = PRINT_BUFFER_T1 + PRINT_BUFFER_
 constexpr static std::uint32_t PRINT_BUFFER_BR = PRINT_BUFFER_T2 + PRINT_BUFFER_SIZE; // BRISC
 constexpr static std::uint32_t PRINT_BUFFER_IDLE_ER = PRINT_BUFFER_START; // Idle ERISC
 
+// Debug ring buffer, shared between all cores
+constexpr static std::uint32_t RING_BUFFER_ADDR = PRINT_BUFFER_START + PRINT_BUFFER_MAX_SIZE;
+constexpr static std::uint32_t RING_BUFFER_SIZE = 128;
 
 // Breakpoint regions
 constexpr static std::uint32_t NCRISC_BREAKPOINT = PRINT_BUFFER_START; //107 * 1024
@@ -85,7 +88,7 @@ constexpr static std::uint32_t TRISC2_BP_LNUM = TRISC2_BP_LNUM_MACRO;
 constexpr static std::uint32_t BRISC_BP_LNUM = BRISC_BP_LNUM_MACRO;
 
 // Dispatch message address
-constexpr static std::uint32_t DISPATCH_MESSAGE_ADDR = PRINT_BUFFER_START + PRINT_BUFFER_MAX_SIZE;
+constexpr static std::uint32_t DISPATCH_MESSAGE_ADDR = RING_BUFFER_ADDR + RING_BUFFER_SIZE;
 constexpr static std::uint32_t DISPATCH_MESSAGE_ADDR_RESERVATION = 32;
 constexpr static std::uint64_t DISPATCH_MESSAGE_REMOTE_SENDER_ADDR = DISPATCH_MESSAGE_ADDR + DISPATCH_MESSAGE_ADDR_RESERVATION;
 

--- a/tt_metal/hostdevcommon/debug_ring_buffer_common.h
+++ b/tt_metal/hostdevcommon/debug_ring_buffer_common.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// We use a magic value to initialize the ring buffer to, so that we can avoid printing it to the
+// watcher log if no ring buffer data has been written. Choose -1 so that we can increment it to
+// 0 and immediately use it as an index for the first write.
+constexpr static int DEBUG_RING_BUFFER_STARTING_INDEX = -1;
+
+constexpr static int RING_BUFFER_ELEMENTS = RING_BUFFER_SIZE / sizeof(uint32_t) - 1;
+struct DebugRingBufMemLayout {
+    int32_t current_ptr;
+    uint32_t data[RING_BUFFER_ELEMENTS];
+};
+static_assert(sizeof(DebugRingBufMemLayout) == RING_BUFFER_SIZE);

--- a/tt_metal/hw/inc/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/debug/ring_buffer.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(WATCHER_ENABLED)
+
+#include "hostdevcommon/debug_ring_buffer_common.h"
+
+// Returns the buffer address for current thread+core. Differs for NC/BR/ER/TR0-2.
+inline uint32_t* get_debug_ring_buffer() {
+#if defined(COMPILE_FOR_ERISC)
+    return reinterpret_cast<uint32_t*>(eth_l1_mem::address_map::ERISC_RING_BUFFER_ADDR);
+#else
+    return reinterpret_cast<uint32_t*>(RING_BUFFER_ADDR);
+#endif
+}
+
+void push_to_ring_buffer(uint32_t val) {
+    auto buf = get_debug_ring_buffer();
+    volatile tt_l1_ptr int32_t* curr_ptr = &reinterpret_cast<DebugRingBufMemLayout *>(buf)->current_ptr;
+    uint32_t* data = reinterpret_cast<DebugRingBufMemLayout *>(buf)->data;
+
+    // Bounds check, set to -1 to wrap since we increment before using.
+    if (*curr_ptr >= RING_BUFFER_ELEMENTS - 1)
+        *curr_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
+    data[++(*curr_ptr)] = val;
+}
+
+#define WATCHER_RING_BUFFER_PUSH(x) push_to_ring_buffer(x)
+#else  // !defined(WATCHER_ENABLED)
+#define WATCHER_RING_BUFFER_PUSH(x)
+#endif  // defined(WATCHER_ENABLED)

--- a/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/grayskull/eth_l1_address_map.h
@@ -34,6 +34,7 @@ struct address_map {
   static constexpr std::int32_t LAUNCH_ERISC_APP_FLAG = 0;
   static constexpr std::uint32_t FW_VERSION_ADDR = 0;
   static constexpr std::int32_t PRINT_BUFFER_ER = 0;
+  static constexpr std::int32_t ERISC_RING_BUFFER_ADDR = 0;
 
   static constexpr std::int32_t ERISC_BARRIER_BASE = 0;
   static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1;

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -30,8 +30,10 @@ struct address_map {
   static constexpr std::int32_t COMMAND_Q_BASE = L1_EPOCH_Q_BASE + FIRMWARE_SIZE;
   static constexpr std::int32_t DATA_BUFFER_BASE = COMMAND_Q_BASE + COMMAND_Q_SIZE;
   static constexpr std::int32_t TILE_HEADER_BUFFER_BASE = DATA_BUFFER_BASE + DATA_BUFFER_SIZE;
-  static constexpr std::int32_t ERISC_MEM_MAILBOX_BASE = 0x10e94;  // See dev_msgs.h and dev_mem_map.h for restrictions
-  static constexpr std::int32_t PRINT_BUFFER_ER = ERISC_MEM_MAILBOX_BASE + 128 + 12;
+  static constexpr std::int32_t ERISC_RING_BUFFER_ADDR = COMMAND_Q_BASE - 128;
+  static constexpr std::int32_t PRINT_BUFFER_ER = ERISC_RING_BUFFER_ADDR - 256;
+  // Extra 12 bytes is to make sure that the launch message is properly aligned.
+  static constexpr std::int32_t ERISC_MEM_MAILBOX_BASE = PRINT_BUFFER_ER - 128 - 12;
   // erisc early exit functionality re-uses mailboxes_t::ncrisc_halt_msg_t::stack_save memory
   static constexpr std::int32_t ERISC_MEM_MAILBOX_STACK_SAVE = ERISC_MEM_MAILBOX_BASE + 4;
 


### PR DESCRIPTION
Passing CI: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8379095588

Note that CI currently has n300 gtests disabled, I've run all watcher tests locally on a n300 bm and they pass.