### PR TITLE
Add data parallel (multi-chip) for Falcon7b (prefill/decode) model and corresponding tests

### DIFF
--- a/models/demos/falcon7b/demo/demo.py
+++ b/models/demos/falcon7b/demo/demo.py
@@ -81,7 +81,7 @@ def initialize_kv_cache(configuration, num_layers, batch_size, max_seq_len, devi
         v_cache = torch.zeros(batch_size, 1, max_seq_len, head_dim)
         tt_k_cache = torch2tt_tensor(k_cache, device)
         tt_v_cache = torch2tt_tensor(v_cache, device)
-        kv_cache += ((tt_k_cache, tt_v_cache),)
+        kv_cache += ([(tt_k_cache, tt_v_cache)],)
     return kv_cache
 
 
@@ -135,7 +135,7 @@ def run_falcon_demo_kv(
 
     base_url = ""
     tt_FalconCausalLM_singlelayer = TtFalconCausalLM(
-        device,
+        [device],
         state_dict,
         base_url,
         1,
@@ -195,12 +195,12 @@ def run_falcon_demo_kv(
         time_prefill_compile_end = time.time()
         time_prefill_compile += time_prefill_compile_end - time_prefill_compile_start
 
-        tt_prefill_embeddings.deallocate()
+        tt_prefill_embeddings[0].deallocate()
         if tt_prefill_attention_mask is not None:
-            tt_prefill_attention_mask.deallocate()
+            tt_prefill_attention_mask[0].deallocate()
 
-        logits = tt2torch_tensor(tt_logits).squeeze(1)
-        tt_logits.deallocate()
+        logits = tt2torch_tensor(tt_logits[0]).squeeze(1)
+        tt_logits[0].deallocate()
 
         user_output_ids = post_processor(logits=logits, index=num_input_tokens - 1)
         output_ids[user_id] = user_output_ids
@@ -242,12 +242,12 @@ def run_falcon_demo_kv(
         time_decode_compile_end = time.time()
         time_decode_compile += time_decode_compile_end - time_decode_compile_start
 
-        tt_decode_embeddings.deallocate()
+        tt_decode_embeddings[0].deallocate()
         if tt_decode_attention_mask is not None:
-            tt_decode_attention_mask.deallocate()
+            tt_decode_attention_mask[0].deallocate()
 
-        logits = tt2torch_tensor(tt_logits).squeeze(1)
-        tt_logits.deallocate()
+        logits = tt2torch_tensor(tt_logits[0]).squeeze(1)
+        tt_logits[0].deallocate()
 
         decode_ids = post_processor(logits=logits, index=...).reshape(batch_size, 1)
 
@@ -270,7 +270,7 @@ def run_falcon_demo_kv(
     del kv_cache_singlelayer
 
     tt_FalconCausalLM = TtFalconCausalLM(
-        device,
+        [device],
         state_dict,
         base_url,
         num_layers,
@@ -311,12 +311,12 @@ def run_falcon_demo_kv(
         time_prefill_inference_end = time.time()
         time_prefill_inference += time_prefill_inference_end - time_prefill_inference_start
 
-        tt_prefill_embeddings.deallocate()
+        tt_prefill_embeddings[0].deallocate()
         if tt_prefill_attention_mask is not None:
-            tt_prefill_attention_mask.deallocate()
+            tt_prefill_attention_mask[0].deallocate()
 
-        logits = tt2torch_tensor(tt_logits).squeeze(1)
-        tt_logits.deallocate()
+        logits = tt2torch_tensor(tt_logits[0]).squeeze(1)
+        tt_logits[0].deallocate()
 
         user_output_ids = post_processor(logits=logits, index=num_input_tokens - 1)
         output_ids[user_id] = user_output_ids
@@ -357,12 +357,12 @@ def run_falcon_demo_kv(
         time_decode_inference_end = time.time()
         time_decode_inference += time_decode_inference_end - time_decode_inference_start
 
-        tt_decode_embeddings.deallocate()
+        tt_decode_embeddings[0].deallocate()
         if tt_decode_attention_mask is not None:
-            tt_decode_attention_mask.deallocate()
+            tt_decode_attention_mask[0].deallocate()
 
-        logits = tt2torch_tensor(tt_logits).squeeze(1)
-        tt_logits.deallocate()
+        logits = tt2torch_tensor(tt_logits[0]).squeeze(1)
+        tt_logits[0].deallocate()
 
         decode_ids = post_processor(logits=logits, index=...).reshape(batch_size, 1)
 

--- a/models/demos/falcon7b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon7b/tests/test_falcon_decoder.py
@@ -15,11 +15,12 @@ from models.demos.falcon7b.tt.model_config import (
     get_model_config,
     get_tt_cache_path,
 )
+from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_outputs
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,
     comp_pcc,
 )
-from models.utility_functions import torch2tt_tensor, tt2torch_tensor
+from models.utility_functions import get_devices_for_t3000
 
 
 class PytorchFalconDecoderModel(torch.nn.Module):
@@ -42,7 +43,7 @@ class PytorchFalconDecoderModel(torch.nn.Module):
 
 
 def run_test_FalconDecoder_inference(
-    device,
+    devices,
     model_version,
     llm_mode,
     batch,
@@ -54,6 +55,8 @@ def run_test_FalconDecoder_inference(
     tt_cache_path,
     model_location_generator,
 ):
+    num_devices = len(devices)
+    global_batch = batch * num_devices
     model_name = model_location_generator(model_version, model_subdir="Falcon")
 
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name)
@@ -71,65 +74,21 @@ def run_test_FalconDecoder_inference(
     user_id = 0
 
     # Generate input, attention_mask, and kv_cache --------------------------------------
-    # TODO: Generate attention_mask on device
-    if llm_mode == "prefill":
-        q_len, kv_len = seq_len, seq_len
-        assert batch == 1, "For prefill, batch must be 1!"
-        assert q_len % 32 == 0, "For prefill, seq_len must be multiple of 32!"
-        assert kv_cache_len == 0, "For prefill, no kv_cache is passed in!"
-
-        decoder_input = (torch.rand(batch, q_len, configuration.hidden_size) * 2) - 1
-        attention_mask_bool = torch.ones(batch, 1, q_len, kv_len, dtype=bool).triu(diagonal=1)
-        layer_past = None
-
-        tt_decoder_input = torch2tt_tensor(decoder_input.unsqueeze(1), device)
-        tt_attention_mask = torch2tt_tensor(
-            (attention_mask_bool * -100000).expand(-1, configuration.num_attention_heads, -1, -1),
-            device,
-        )
-        tt_k_cache = torch.zeros(batch, max_position_embeddings, head_dim)
-        tt_v_cache = torch.zeros(batch, max_position_embeddings, head_dim)
-        tt_k_cache = torch2tt_tensor(tt_k_cache.unsqueeze(1), device)
-        tt_v_cache = torch2tt_tensor(tt_v_cache.unsqueeze(1), device)
-        tt_layer_past = (tt_k_cache, tt_v_cache)
-
-    elif llm_mode == "decode":
-        q_len, kv_len = seq_len, kv_cache_len + 1
-        assert batch % 32 == 0, "For decode, batch must be multiple of 32!"
-        assert q_len == 1, "For decode, q_len must be 1!"
-
-        decoder_input = (torch.rand(batch, q_len, configuration.hidden_size) * 2) - 1
-        attention_mask_bool = torch.zeros(batch, 1, q_len, kv_len, dtype=bool)
-        k_cache = torch.rand(batch, kv_cache_len, head_dim)
-        v_cache = torch.rand(batch, kv_cache_len, head_dim)
-        layer_past = (k_cache, v_cache)
-
-        tt_decoder_input = torch2tt_tensor(decoder_input.unsqueeze(1).transpose(0, 2), device)
-
-        kv_len_padded = (kv_len + 31) // 32 * 32
-        attention_mask_bool_padded = torch.cat(
-            (
-                attention_mask_bool,
-                torch.ones(batch, 1, q_len, kv_len_padded - kv_len, dtype=bool),
-            ),
-            dim=-1,
-        )
-        tt_attention_mask = torch2tt_tensor(
-            (attention_mask_bool_padded.transpose(0, 2) * -100000).expand(
-                -1, configuration.num_attention_heads, -1, -1
-            ),
-            device,
-        )
-        tt_k_cache = torch.zeros(batch, max_position_embeddings, head_dim)
-        tt_v_cache = torch.zeros(batch, max_position_embeddings, head_dim)
-        tt_k_cache[:, :kv_cache_len, :] = k_cache
-        tt_v_cache[:, :kv_cache_len, :] = v_cache
-        tt_k_cache = torch2tt_tensor(tt_k_cache.unsqueeze(1), device)
-        tt_v_cache = torch2tt_tensor(tt_v_cache.unsqueeze(1), device)
-        tt_layer_past = (tt_k_cache, tt_v_cache)
-
-    else:
-        raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
+    (
+        decoder_input,
+        attention_mask_bool,
+        layer_past,
+        tt_decoder_input,
+        tt_attention_mask,
+        tt_layer_past,
+        kv_len,
+    ) = get_rand_falcon_inputs(
+        llm_mode, seq_len, batch, kv_cache_len, devices, global_batch, head_dim, max_position_embeddings, configuration
+    )
+    if layer_past is not None:
+        layer_past = layer_past[0]
+        layer_past = (layer_past[0].squeeze(1), layer_past[1].squeeze(1))
+    tt_layer_past = tt_layer_past[0]
 
     # PyTorch output =======================================================================
     pytorch_FalconDecoder_model = PytorchFalconDecoderModel(hugging_face_reference_model, layer_num)
@@ -143,7 +102,7 @@ def run_test_FalconDecoder_inference(
 
     # TT hardware execution =================================================================
     tt_FalconDecoder_model = TtFalconDecoderLayer(
-        device,
+        devices,
         state_dict,
         base_url,
         layer_num,
@@ -163,18 +122,7 @@ def run_test_FalconDecoder_inference(
         layer_past_len=kv_cache_len,
         use_cache=use_cache,
     )
-    tt_out = tt2torch_tensor(tt_out).squeeze(1)
-
-    tt_layer_present = (
-        tt2torch_tensor(tt_layer_present[0]).squeeze(1),
-        tt2torch_tensor(tt_layer_present[1]).squeeze(1),
-    )
-    if llm_mode == "decode":
-        tt_out = tt_out.transpose(0, 1)
-    tt_layer_present = (
-        tt_layer_present[0][:, :kv_len, :],
-        tt_layer_present[1][:, :kv_len, :],
-    )
+    tt_out, tt_layer_present = concat_device_outputs(num_devices, tt_out, llm_mode, tt_layer_present, kv_len)
 
     # check outputs ----------------------------------------------------------------------
     does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
@@ -197,6 +145,7 @@ def run_test_FalconDecoder_inference(
         assert does_pass, f"PCC value is lower than {pcc}"
 
 
+@pytest.mark.parametrize("num_devices", (1, 2, 4))
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
@@ -211,6 +160,7 @@ def run_test_FalconDecoder_inference(
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
 def test_FalconDecoder_inference(
+    num_devices,
     model_version,
     llm_mode,
     batch,
@@ -220,13 +170,15 @@ def test_FalconDecoder_inference(
     pcc,
     model_config_str,
     model_location_generator,
-    device,
+    all_devices,
 ):
+    devices = get_devices_for_t3000(all_devices, num_devices)
+
     model_config = get_model_config(model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)
 
     run_test_FalconDecoder_inference(
-        device,
+        devices,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/falcon7b/tests/test_falcon_model.py
+++ b/models/demos/falcon7b/tests/test_falcon_model.py
@@ -14,11 +14,12 @@ from models.demos.falcon7b.tt.model_config import (
     get_model_config,
     get_tt_cache_path,
 )
+from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_out_layer_present
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,
     comp_pcc,
 )
-from models.utility_functions import torch2tt_tensor, tt2torch_tensor
+from models.utility_functions import tt2torch_tensor, get_devices_for_t3000
 
 
 class PytorchFalconModel(torch.nn.Module):
@@ -40,7 +41,7 @@ class PytorchFalconModel(torch.nn.Module):
 
 
 def run_test_FalconModel_inference(
-    device,
+    devices,
     model_version,
     llm_mode,
     batch,
@@ -52,6 +53,8 @@ def run_test_FalconModel_inference(
     tt_cache_path,
     model_location_generator,
 ):
+    num_devices = len(devices)
+    global_batch = batch * num_devices
     model_name = model_location_generator(model_version, model_subdir="Falcon")
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
     hugging_face_reference_model.eval()
@@ -66,59 +69,41 @@ def run_test_FalconModel_inference(
     use_cache = True
 
     if 1:
-        model_input = torch.arange(seq_len * batch).reshape(batch, seq_len)
+        model_input = torch.arange(seq_len * global_batch).reshape(global_batch, seq_len)
     else:
         # batch identical sequences for debugging
-        model_input = torch.stack([torch.arange(seq_len)] * batch).reshape(batch, seq_len)
+        model_input = torch.stack([torch.arange(seq_len)] * global_batch).reshape(global_batch, seq_len)
 
     # Generate dummy kv_cache --------------------------------------------------------------
-    if llm_mode == "prefill":
-        q_len, kv_len = seq_len, seq_len
-        assert q_len % 32 == 0, "For prefill, seq_len must be multiple of 32!"
-        assert kv_cache_len == 0, "For prefill, no kv_cache is passed in!"
-
-        past_key_values = None
-        tt_layer_past = ()
-        k_cache = torch.zeros(batch, max_position_embeddings, head_dim).unsqueeze(1)
-        v_cache = torch.zeros(batch, max_position_embeddings, head_dim).unsqueeze(1)
-        for i in range(num_layers):
-            tt_k_cache = torch2tt_tensor(k_cache, device)
-            tt_v_cache = torch2tt_tensor(v_cache, device)
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
-    elif llm_mode == "decode":
-        q_len, kv_len = seq_len, kv_cache_len + 1
-        assert batch % 32 == 0, "For decode, batch must be multiple of 32!"
-        assert q_len == 1, "For decode, q_len must be 1!"
-
-        past_key_values = ()
-        tt_layer_past = ()
-        for i in range(num_layers):
-            k_cache = torch.rand(batch, 1, kv_cache_len, head_dim)
-            v_cache = torch.rand(batch, 1, kv_cache_len, head_dim)
-            past_key_values += ((k_cache, v_cache),)
-
-            tt_k_cache = torch.zeros(batch, 1, max_position_embeddings, head_dim)
-            tt_v_cache = torch.zeros(batch, 1, max_position_embeddings, head_dim)
-            tt_k_cache[:, :, :kv_cache_len, :] = k_cache
-            tt_v_cache[:, :, :kv_cache_len, :] = v_cache
-            tt_k_cache = torch2tt_tensor(tt_k_cache, device)
-            tt_v_cache = torch2tt_tensor(tt_v_cache, device)
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
-    else:
-        raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
+    (
+        past_key_values,
+        tt_layer_past,
+        kv_len,
+    ) = get_rand_falcon_inputs(
+        llm_mode,
+        seq_len,
+        batch,
+        kv_cache_len,
+        devices,
+        global_batch,
+        head_dim,
+        max_position_embeddings,
+        configuration,
+        num_layers=num_layers,
+        generate_attention_inputs=False,
+    )
 
     # Prepare output -----------------------------------------------------------------------
     pytorch_FalconModel = PytorchFalconModel(hugging_face_reference_model, num_layers)
     pytorch_out, pytorch_layer_present = pytorch_FalconModel(
         input_ids=model_input, past_key_values=past_key_values, use_cache=use_cache
     )
+
     # NOTE: Passing in pytorch tensor here instead of ll buda tensor
     # since we don't yet have embedding support on device
     # device, state_dict, base_url, max_position_embeddings, config, num_decoders
     tt_FalconModel = TtFalconModel(
-        device,
+        devices,
         state_dict,
         base_url,
         num_layers,
@@ -129,12 +114,14 @@ def run_test_FalconModel_inference(
     )
     # TODO: Generate embeddings and attention_mask on device
     if llm_mode == "prefill":
-        tt_outs = []
-        model_inputs = torch.split(model_input, 1)
+        tt_outs = torch.zeros(global_batch, seq_len, configuration.hidden_size)  # Output tensor to overwrite
         tt_embeddings, tt_attention_mask = zip(
             *[
-                tt_FalconModel.model_preprocessing(llm_mode, m_i, kv_cache_len, num_input_tokens=seq_len)
-                for m_i in model_inputs
+                # Get embeddings and attention_mask for each device
+                tt_FalconModel.model_preprocessing(
+                    llm_mode, model_input[i::batch], kv_cache_len, num_input_tokens=seq_len
+                )
+                for i in range(batch)
             ]
         )
         for user_id in range(batch):
@@ -147,8 +134,9 @@ def run_test_FalconModel_inference(
                 layer_past_len=kv_cache_len,
                 use_cache=use_cache,
             )
-            tt_outs.append(tt2torch_tensor(tt_out).squeeze(1))
-        tt_out = torch.vstack(tt_outs)
+            # Get outputs from all devices
+            tt_outs[user_id::batch] = torch.concat([tt2torch_tensor(tt_out[i]).squeeze(1) for i in range(num_devices)])
+        tt_out = tt_outs
 
     elif llm_mode == "decode":
         tt_embeddings, tt_attention_mask = tt_FalconModel.model_preprocessing(
@@ -162,32 +150,25 @@ def run_test_FalconModel_inference(
             layer_past_len=kv_cache_len,
             use_cache=use_cache,
         )
-        tt_out = tt2torch_tensor(tt_out).squeeze(1)
-        tt_out = tt_out.transpose(0, 1)
+        for i in range(num_devices):
+            tt_out[i] = tt2torch_tensor(tt_out[i]).squeeze(1).transpose(0, 1)
+        tt_out = torch.concat(tt_out)
 
     # check outputs ----------------------------------------------------------------------
     does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
     logger.info(f"Output: {output_pcc}")
 
     for i in range(num_layers):
-        tt_layer_pres = (
-            tt2torch_tensor(tt_layer_present[i][0]),
-            tt2torch_tensor(tt_layer_present[i][1]),
-        )
         if llm_mode == "prefill":
-            pytorch_layer_pres = pytorch_layer_present[i]
-            tt_layer_pres = (
-                tt_layer_pres[0][:, :, :kv_len, :],
-                tt_layer_pres[1][:, :, :kv_len, :],
-            )
+            pytorch_layer_pres = (pytorch_layer_present[i][0].squeeze(1), pytorch_layer_present[i][1].squeeze(1))
+            tt_layer_pres = concat_device_out_layer_present(num_devices, tt_layer_present[i], kv_len)
         elif llm_mode == "decode":
             pytorch_layer_pres = (
-                pytorch_layer_present[i][0][:, :, kv_cache_len, :],
-                pytorch_layer_present[i][1][:, :, kv_cache_len, :],
+                pytorch_layer_present[i][0].squeeze(1)[:, kv_cache_len, :],
+                pytorch_layer_present[i][1].squeeze(1)[:, kv_cache_len, :],
             )
-            tt_layer_pres = (
-                tt_layer_pres[0][:, :, kv_cache_len, :],
-                tt_layer_pres[1][:, :, kv_cache_len, :],
+            tt_layer_pres = concat_device_out_layer_present(
+                num_devices, tt_layer_present[i], kv_cache_len, end_idx_only=True
             )
 
         does_pass2, output_pcc = comp_pcc(pytorch_layer_pres[0], tt_layer_pres[0], pcc)
@@ -207,13 +188,14 @@ def run_test_FalconModel_inference(
         assert does_pass, f"PCC value is lower than {pcc}"
 
 
+@pytest.mark.parametrize("num_devices", (1, 2, 4))
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
-        ("prefill", 2, 128, 0),
+        ("prefill", 1, 128, 0),
         ("decode", 32, 1, 128),
     ),
-    ids=["prefill_seq128_batch32", "decode_batch32"],
+    ids=["prefill_seq128_batch1", "decode_batch32"],
 )
 @pytest.mark.parametrize(
     "num_layers, pcc",
@@ -227,6 +209,7 @@ def run_test_FalconModel_inference(
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
 def test_FalconModel_inference(
+    num_devices,
     model_version,
     llm_mode,
     batch,
@@ -236,12 +219,14 @@ def test_FalconModel_inference(
     pcc,
     model_config_str,
     model_location_generator,
-    device,
+    all_devices,
 ):
+    devices = get_devices_for_t3000(all_devices, num_devices)
+
     model_config = get_model_config(model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)
     run_test_FalconModel_inference(
-        device,
+        devices,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
+++ b/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
@@ -87,7 +87,7 @@ def run_test_FalconCausalLM_inference(
     for i in range(num_layers):
         tt_k_cache = torch2tt_tensor(k_cache, device)
         tt_v_cache = torch2tt_tensor(v_cache, device)
-        tt_layer_past += ((tt_k_cache, tt_v_cache),)
+        tt_layer_past += ([(tt_k_cache, tt_v_cache)],)
 
     # CPU REFERENCE ------------------------------------------------------------------------
     logger.info("Setting up CPU model")
@@ -116,7 +116,7 @@ def run_test_FalconCausalLM_inference(
     # device, state_dict, base_url, max_position_embeddings, config, num_decoders
     logger.info("Setting up Falcon model")
     tt_FalconCausalLM = TtFalconCausalLM(
-        device,
+        [device],
         state_dict,
         base_url,
         num_layers,
@@ -161,7 +161,7 @@ def run_test_FalconCausalLM_inference(
         layer_past_len=kv_cache_len,
         use_cache=use_cache,
     )
-    tt_out = tt2torch_tensor(tt_out).squeeze(1).transpose(0, 1)
+    tt_out = tt2torch_tensor(tt_out[0]).squeeze(1).transpose(0, 1)
 
     # check outputs for first user only --------------------------------------------------
     does_pass, output_pcc = comp_pcc(pytorch_out[0], tt_out[0], pcc)
@@ -170,8 +170,8 @@ def run_test_FalconCausalLM_inference(
     for i in range(num_layers):
         pytorch_layer_pres = pytorch_layer_present[i]
         tt_layer_pres = (
-            tt2torch_tensor(tt_layer_present[i][0]),
-            tt2torch_tensor(tt_layer_present[i][1]),
+            tt2torch_tensor(tt_layer_present[i][0][0]),
+            tt2torch_tensor(tt_layer_present[i][0][1]),
         )
         tt_layer_pres = (
             tt_layer_pres[0][:, :, : kv_cache_len + 1, :],

--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -286,8 +286,8 @@ def run_test_FalconCausalLM_end_to_end(
     does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
     logger.info(f"Output: {output_pcc}")
 
-    reference_logits = pytorch_out.view(batch, -1).float().detach().numpy()
-    eval_logits = tt_out.view(batch, -1).float().detach().numpy()
+    reference_logits = pytorch_out.view(batch*seq_len, -1).float().detach().numpy()
+    eval_logits = tt_out.view(batch*seq_len, -1).float().detach().numpy()
     reference_top1 = np.argmax(reference_logits, axis=-1)
     top1_acc = top_k_accuracy_score(reference_top1, eval_logits, k=1, labels=np.arange(eval_logits.shape[-1]))
     top5_acc = top_k_accuracy_score(reference_top1, eval_logits, k=5, labels=np.arange(eval_logits.shape[-1]))

--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -23,7 +23,7 @@ from models.demos.falcon7b.tt.model_config import (
     get_model_config,
     get_tt_cache_path,
 )
-
+from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_out_layer_present
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
@@ -39,13 +39,31 @@ from models.utility_functions import (
     is_wormhole_b0,
     skip_for_grayskull,
     skip_for_wormhole_b0,
+    get_devices_for_t3000,
 )
 from models.perf.perf_utils import prep_perf_report
 
 
+def generate_embeddings(llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len):
+    if llm_mode == "prefill":
+        tt_embeddings, tt_attention_mask = zip(
+            *[
+                tt_FalconCausalLM.model_preprocessing(
+                    llm_mode, model_input[i::batch], kv_cache_len, num_input_tokens=seq_len
+                )
+                for i in range(batch)
+            ]
+        )
+    elif llm_mode == "decode":
+        tt_embeddings, tt_attention_mask = tt_FalconCausalLM.model_preprocessing(
+            llm_mode, model_input, kv_cache_len, num_input_tokens=kv_len
+        )
+    return tt_embeddings, tt_attention_mask
+
+
 # TODO: Replace this with actual Falcon application-level tests
 def run_test_FalconCausalLM_end_to_end(
-    device,
+    devices,
     model_version,
     llm_mode,
     batch,
@@ -61,6 +79,8 @@ def run_test_FalconCausalLM_end_to_end(
     # Clear global profiler state before starting measurements
     profiler.clear()
 
+    num_devices = len(devices)
+    global_batch = batch * num_devices
     model_name = model_location_generator(model_version, model_subdir="Falcon")
 
     profiler.start("hugging_face_model_setup")
@@ -79,55 +99,29 @@ def run_test_FalconCausalLM_end_to_end(
     use_cache = True
 
     if True:
-        model_input = torch.arange(seq_len * batch).reshape(batch, seq_len)
+        model_input = torch.arange(seq_len * global_batch).reshape(global_batch, seq_len)
     else:
         # batch identical sequences for debugging
-        model_input = torch.stack([torch.arange(seq_len)] * batch).reshape(batch, seq_len)
+        model_input = torch.stack([torch.arange(seq_len)] * global_batch).reshape(global_batch, seq_len)
 
     # Generate dummy kv_cache --------------------------------------------------------------
-    if llm_mode == "prefill":
-        kv_len = seq_len
-        assert seq_len % 32 == 0, "For prefill, seq_len must be multiple of 32!"
-        assert kv_cache_len == 0, "For prefill, no kv_cache is passed in!"
-
-        past_key_values = None
-        tt_layer_past = ()
-        k_cache = torch.zeros(batch, max_position_embeddings, head_dim).unsqueeze(1)
-        v_cache = torch.zeros(batch, max_position_embeddings, head_dim).unsqueeze(1)
-        for i in range(num_layers):
-            tt_k_cache = torch2tt_tensor(k_cache, device)
-            tt_v_cache = torch2tt_tensor(v_cache, device)
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
-    elif llm_mode == "decode":
-        kv_len = kv_cache_len + 1
-        assert batch % 32 == 0, "For decode, batch must be multiple of 32!"
-        assert seq_len == 1, "For decode, seq_len must be 1!"
-
-        past_key_values = ()
-        tt_layer_past = ()
-        for i in range(num_layers):
-            k_cache = torch.rand(batch, 1, kv_cache_len, head_dim)
-            v_cache = torch.rand(batch, 1, kv_cache_len, head_dim)
-            past_key_values += ((k_cache, v_cache),)
-
-            tt_k_cache = torch.zeros(batch, 1, max_position_embeddings, head_dim)
-            tt_v_cache = torch.zeros(batch, 1, max_position_embeddings, head_dim)
-            tt_k_cache[:, :, :kv_cache_len, :] = k_cache
-            tt_v_cache[:, :, :kv_cache_len, :] = v_cache
-            tt_k_cache = torch2tt_tensor(tt_k_cache, device)
-            tt_v_cache = torch2tt_tensor(tt_v_cache, device)
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
-    else:
-        raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
-
-    # Prepare output -----------------------------------------------------------------------
-    profiler.start("hugging_face_reference_model")
-    pytorch_out, pytorch_layer_present = pytorch_FalconCausalLM(
-        input_ids=model_input, past_key_values=past_key_values, use_cache=use_cache
+    (
+        past_key_values,
+        tt_layer_past,
+        kv_len,
+    ) = get_rand_falcon_inputs(
+        llm_mode,
+        seq_len,
+        batch,
+        kv_cache_len,
+        devices,
+        global_batch,
+        head_dim,
+        max_position_embeddings,
+        configuration,
+        num_layers=num_layers,
+        generate_attention_inputs=False,
     )
-    profiler.end("hugging_face_reference_model")
 
     # NOTE: Passing in pytorch tensor here instead of ll buda tensor
     # since we don't yet have embedding support on device
@@ -135,7 +129,7 @@ def run_test_FalconCausalLM_end_to_end(
 
     profiler.start("TtFalcon_model_setup")
     tt_FalconCausalLM = TtFalconCausalLM(
-        device,
+        devices,
         state_dict,
         base_url,
         num_layers,
@@ -148,18 +142,9 @@ def run_test_FalconCausalLM_end_to_end(
 
     profiler.start("processing_of_input")
     # TODO: Generate embeddings and attention_mask on device
-    if llm_mode == "prefill":
-        model_inputs = torch.split(model_input, 1)
-        tt_embeddings, tt_attention_mask = zip(
-            *[
-                tt_FalconCausalLM.model_preprocessing(llm_mode, m_i, kv_cache_len, num_input_tokens=seq_len)
-                for m_i in model_inputs
-            ]
-        )
-    elif llm_mode == "decode":
-        tt_embeddings, tt_attention_mask = tt_FalconCausalLM.model_preprocessing(
-            llm_mode, model_input, kv_cache_len, num_input_tokens=kv_len
-        )
+    tt_embeddings, tt_attention_mask = generate_embeddings(
+        llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len
+    )
     profiler.end("processing_of_input")
 
     # First run to fill compile cache ----------------------------------------------------
@@ -170,12 +155,9 @@ def run_test_FalconCausalLM_end_to_end(
     profiler.start("first_model_run_with_compile", force_enable=True)
     if llm_mode == "prefill":
         tt_outs = []
-        model_inputs = torch.split(model_input, 1)
-        tt_embeddings, tt_attention_mask = zip(
-            *[
-                tt_FalconCausalLM.model_preprocessing(llm_mode, m_i, kv_cache_len, num_input_tokens=seq_len)
-                for m_i in model_inputs
-            ]
+        # Embedding time is included in model run time for prefill
+        tt_embeddings, tt_attention_mask = generate_embeddings(
+            llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len
         )
         for user_id in range(batch):
             tt_out, tt_layer_present = tt_FalconCausalLM(
@@ -199,7 +181,8 @@ def run_test_FalconCausalLM_end_to_end(
             layer_past_len=kv_cache_len,
             use_cache=use_cache,
         )
-    tt_lib.device.Synchronize(device)
+    for device in devices:
+        tt_lib.device.Synchronize(device)
     profiler.end("first_model_run_with_compile", force_enable=True)
     del tt_out
     del tt_layer_past
@@ -207,50 +190,50 @@ def run_test_FalconCausalLM_end_to_end(
     del tt_embeddings
     del tt_attention_mask
 
+    # Re-generate dummy kv_cache ------------------------------------------------------------
+    (
+        past_key_values,
+        tt_layer_past,
+        kv_len,
+    ) = get_rand_falcon_inputs(
+        llm_mode,
+        seq_len,
+        batch,
+        kv_cache_len,
+        devices,
+        global_batch,
+        head_dim,
+        max_position_embeddings,
+        configuration,
+        num_layers=num_layers,
+        generate_attention_inputs=False,
+    )
+
+    # Prepare reference output -----------------------------------------------------------
+
+    profiler.start("hugging_face_reference_model")
+    pytorch_out, pytorch_layer_present = pytorch_FalconCausalLM(
+        input_ids=model_input, past_key_values=past_key_values, use_cache=use_cache
+    )
+    profiler.end("hugging_face_reference_model")
+
     # Second run for perf ----------------------------------------------------------------
+
     logger.info(f"Enable profiler and enable binary and compile cache")
     profiler.enable()
     enable_persistent_kernel_cache()
-    if llm_mode == "prefill":
-        tt_layer_past = ()
-        for i in range(num_layers):
-            tt_k_cache = torch2tt_tensor(k_cache, device)
-            tt_v_cache = torch2tt_tensor(v_cache, device)
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
 
-    elif llm_mode == "decode":
-        tt_layer_past = ()
-        for i in range(num_layers):
-            tt_k_cache = torch.zeros(batch, 1, max_position_embeddings, head_dim)
-            tt_v_cache = torch.zeros(batch, 1, max_position_embeddings, head_dim)
-            tt_k_cache[:, :, :kv_cache_len, :] = past_key_values[i][0]
-            tt_v_cache[:, :, :kv_cache_len, :] = past_key_values[i][1]
-            tt_k_cache = torch2tt_tensor(tt_k_cache, device)
-            tt_v_cache = torch2tt_tensor(tt_v_cache, device)
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
-    if llm_mode == "prefill":
-        model_inputs = torch.split(model_input, 1)
-        tt_embeddings, tt_attention_mask = zip(
-            *[
-                tt_FalconCausalLM.model_preprocessing(llm_mode, m_i, kv_cache_len, num_input_tokens=seq_len)
-                for m_i in model_inputs
-            ]
-        )
-    elif llm_mode == "decode":
-        tt_embeddings, tt_attention_mask = tt_FalconCausalLM.model_preprocessing(
-            llm_mode, model_input, kv_cache_len, num_input_tokens=kv_len
-        )
+    # Regenerate embeddings and attention_mask
+    tt_embeddings, tt_attention_mask = generate_embeddings(
+        llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len
+    )
 
     profiler.start(f"model_run_for_inference")
     if llm_mode == "prefill":
         tt_outs = []
-        model_inputs = torch.split(model_input, 1)
-        tt_embeddings, tt_attention_mask = zip(
-            *[
-                tt_FalconCausalLM.model_preprocessing(llm_mode, m_i, kv_cache_len, num_input_tokens=seq_len)
-                for m_i in model_inputs
-            ]
+        # Embedding time is included in model run time for prefill
+        tt_embeddings, tt_attention_mask = generate_embeddings(
+            llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len
         )
         for user_id in range(batch):
             tt_out, tt_layer_present = tt_FalconCausalLM(
@@ -273,21 +256,29 @@ def run_test_FalconCausalLM_end_to_end(
             layer_past_len=kv_cache_len,
             use_cache=use_cache,
         )
-    tt_lib.device.Synchronize(device)
+    for device in devices:
+        tt_lib.device.Synchronize(device)
     profiler.end(f"model_run_for_inference")
 
     if llm_mode == "prefill":
-        tt_out = torch.vstack([tt2torch_tensor(tt_out).squeeze(1) for tt_out in tt_outs])
+        tt_out_tmp = torch.zeros(global_batch, seq_len, configuration.vocab_size)  # Output tensor to overwrite
+        for user_id, tt_out in enumerate(tt_outs):
+            # Get outputs from all devices
+            tt_out_tmp[user_id::batch] = torch.concat(
+                [tt2torch_tensor(tt_out[i]).squeeze(1) for i in range(num_devices)]
+            )
+        tt_out = tt_out_tmp
     elif llm_mode == "decode":
-        tt_out = tt2torch_tensor(tt_out).squeeze(1)
-        tt_out = tt_out.transpose(0, 1)
+        for i in range(num_devices):
+            tt_out[i] = tt2torch_tensor(tt_out[i]).squeeze(1).transpose(0, 1)
+        tt_out = torch.concat(tt_out)
 
     # check outputs ----------------------------------------------------------------------
     does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
     logger.info(f"Output: {output_pcc}")
 
-    reference_logits = pytorch_out.view(batch*seq_len, -1).float().detach().numpy()
-    eval_logits = tt_out.view(batch*seq_len, -1).float().detach().numpy()
+    reference_logits = pytorch_out.view(global_batch * seq_len, -1).float().detach().numpy()
+    eval_logits = tt_out.view(global_batch * seq_len, -1).float().detach().numpy()
     reference_top1 = np.argmax(reference_logits, axis=-1)
     top1_acc = top_k_accuracy_score(reference_top1, eval_logits, k=1, labels=np.arange(eval_logits.shape[-1]))
     top5_acc = top_k_accuracy_score(reference_top1, eval_logits, k=5, labels=np.arange(eval_logits.shape[-1]))
@@ -295,24 +286,16 @@ def run_test_FalconCausalLM_end_to_end(
     logger.info(f"Top-5 Accuracy: {top5_acc}")
 
     for i in range(num_layers):
-        tt_layer_pres = (
-            tt2torch_tensor(tt_layer_present[i][0]),
-            tt2torch_tensor(tt_layer_present[i][1]),
-        )
         if llm_mode == "prefill":
-            pytorch_layer_pres = pytorch_layer_present[i]
-            tt_layer_pres = (
-                tt_layer_pres[0][:, :, :kv_len, :],
-                tt_layer_pres[1][:, :, :kv_len, :],
-            )
+            pytorch_layer_pres = (pytorch_layer_present[i][0].squeeze(1), pytorch_layer_present[i][1].squeeze(1))
+            tt_layer_pres = concat_device_out_layer_present(num_devices, tt_layer_present[i], kv_len)
         elif llm_mode == "decode":
             pytorch_layer_pres = (
-                pytorch_layer_present[i][0][:, :, kv_cache_len, :],
-                pytorch_layer_present[i][1][:, :, kv_cache_len, :],
+                pytorch_layer_present[i][0].squeeze(1)[:, kv_cache_len, :],
+                pytorch_layer_present[i][1].squeeze(1)[:, kv_cache_len, :],
             )
-            tt_layer_pres = (
-                tt_layer_pres[0][:, :, kv_cache_len, :],
-                tt_layer_pres[1][:, :, kv_cache_len, :],
+            tt_layer_pres = concat_device_out_layer_present(
+                num_devices, tt_layer_present[i], kv_cache_len, end_idx_only=True
             )
 
         does_pass2, output_pcc = comp_pcc(pytorch_layer_pres[0], tt_layer_pres[0], pcc)
@@ -358,7 +341,7 @@ def run_test_FalconCausalLM_end_to_end(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "num_layers, pcc",
-    ((32, 0.89),),
+    ((32, 0.88),),
     ids=["layers_32"],
 )
 @pytest.mark.parametrize(
@@ -413,7 +396,7 @@ class TestParametrized:
         tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
 
         run_test_FalconCausalLM_end_to_end(
-            device,
+            [device],
             model_version,
             llm_mode,
             batch,
@@ -427,6 +410,7 @@ class TestParametrized:
             expected_inference_time,
         )
 
+    @pytest.mark.parametrize("num_devices", (1, 2, 4))
     @pytest.mark.parametrize(
         "llm_mode, batch, seq_len, kv_cache_len, expected_inference_time",
         (
@@ -448,6 +432,7 @@ class TestParametrized:
     def test_perf_wh_bare_metal(
         use_program_cache,
         model_version,
+        num_devices,
         llm_mode,
         batch,
         seq_len,
@@ -458,8 +443,12 @@ class TestParametrized:
         request,
         model_config_str,
         model_location_generator,
-        device,
+        all_devices,
     ):
+        if num_devices > 1:
+            pytest.skip(f"num_devices={num_devices} is not supported on CI yet")
+        devices = get_devices_for_t3000(all_devices, num_devices)
+
         model_config = get_model_config(model_config_str)
         tt_cache_path = get_tt_cache_path(model_version)
 
@@ -469,7 +458,7 @@ class TestParametrized:
         tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
 
         run_test_FalconCausalLM_end_to_end(
-            device,
+            devices,
             model_version,
             llm_mode,
             batch,
@@ -536,7 +525,7 @@ def test_perf_virtual_machine(
     tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
 
     run_test_FalconCausalLM_end_to_end(
-        device,
+        [device],
         model_version,
         llm_mode,
         batch,

--- a/models/demos/falcon7b/tests/test_utils.py
+++ b/models/demos/falcon7b/tests/test_utils.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor
+
+
+def get_rand_falcon_inputs(
+    llm_mode,
+    seq_len,
+    batch,
+    kv_cache_len,
+    devices,
+    global_batch,
+    head_dim,
+    max_position_embeddings,
+    configuration,
+    num_layers=1,
+    generate_attention_inputs=True,
+):
+    # Generate input, attention_mask, and kv_cache --------------------------------------
+    # TODO: Generate attention_mask on device
+    tt_attention_input = []
+    tt_attention_mask = []
+    if llm_mode == "prefill":
+        q_len, kv_len = seq_len, seq_len
+        # assert batch == 1, "For prefill, batch must be 1!"
+        assert q_len % 32 == 0, "For prefill, seq_len must be multiple of 32!"
+        assert kv_cache_len == 0, "For prefill, no kv_cache is passed in!"
+
+        if generate_attention_inputs:
+            attention_input = (torch.rand(global_batch, q_len, configuration.hidden_size) * 2) - 1
+            attention_mask_bool = torch.ones(global_batch, 1, q_len, kv_len, dtype=bool).triu(diagonal=1)
+        layer_past = None
+
+        tt_layer_past = ()
+        for layer in range(num_layers):
+            tt_layer_past_cur = []
+            for i, device in enumerate(devices):
+                # Generate kvcache for each layer and attention mask once
+                if generate_attention_inputs and layer == 0:
+                    attention_input_i = attention_input[batch * i : batch * (i + 1)]
+                    attention_mask_bool_i = attention_mask_bool[batch * i : batch * (i + 1)]
+                    tt_attention_input.append(torch2tt_tensor(attention_input_i.unsqueeze(1), device))
+                    tt_attention_mask.append(
+                        torch2tt_tensor(
+                            (attention_mask_bool_i * -100000).expand(-1, configuration.num_attention_heads, -1, -1),
+                            device,
+                        )
+                    )
+                tt_k_cache = torch.zeros(batch, max_position_embeddings, head_dim)
+                tt_v_cache = torch.zeros(batch, max_position_embeddings, head_dim)
+                tt_k_cache = torch2tt_tensor(tt_k_cache.unsqueeze(1), device)
+                tt_v_cache = torch2tt_tensor(tt_v_cache.unsqueeze(1), device)
+                tt_layer_past_cur.append((tt_k_cache, tt_v_cache))
+            tt_layer_past += (tt_layer_past_cur,)
+
+    elif llm_mode == "decode":
+        q_len, kv_len = seq_len, kv_cache_len + 1
+        assert batch % 32 == 0, "For decode, batch must be multiple of 32!"
+        assert q_len == 1, "For decode, q_len must be 1!"
+
+        if generate_attention_inputs:
+            attention_input = (torch.rand(global_batch, q_len, configuration.hidden_size) * 2) - 1
+            # attention_input = (torch.rand(batch, q_len, 4544) * 2) - 1
+            attention_mask_bool = torch.zeros(global_batch, 1, q_len, kv_len, dtype=bool)
+        layer_past = ()
+        tt_layer_past = ()
+        for layer in range(num_layers):
+            k_cache = torch.rand(global_batch, kv_cache_len, head_dim)
+            v_cache = torch.rand(global_batch, kv_cache_len, head_dim)
+            layer_past += ((k_cache.unsqueeze(1), v_cache.unsqueeze(1)),)
+
+            tt_layer_past_cur = []
+            for i, device in enumerate(devices):
+                # Generate kvcache for each layer and attention mask once
+                if generate_attention_inputs and layer == 0:
+                    tt_attention_input.append(
+                        torch2tt_tensor(
+                            attention_input[batch * i : batch * (i + 1)].unsqueeze(1).transpose(0, 2), device
+                        )
+                    )
+
+                    kv_len_padded = (kv_len + 31) // 32 * 32
+                    attention_mask_bool_padded = torch.cat(
+                        (
+                            attention_mask_bool[batch * i : batch * (i + 1)],
+                            torch.ones(batch, 1, q_len, kv_len_padded - kv_len, dtype=bool),
+                        ),
+                        dim=-1,
+                    )
+                    tt_attention_mask.append(
+                        torch2tt_tensor(
+                            (attention_mask_bool_padded.transpose(0, 2) * -100000).expand(
+                                -1,
+                                configuration.num_attention_heads,
+                                -1,
+                                -1
+                                # -1, 71, -1, -1
+                            ),
+                            device,
+                        )
+                    )
+                tt_k_cache = torch.zeros(batch, max_position_embeddings, head_dim)
+                tt_v_cache = torch.zeros(batch, max_position_embeddings, head_dim)
+                tt_k_cache[:, :kv_cache_len, :] = k_cache[batch * i : batch * (i + 1)]
+                tt_v_cache[:, :kv_cache_len, :] = v_cache[batch * i : batch * (i + 1)]
+                tt_k_cache = torch2tt_tensor(tt_k_cache.unsqueeze(1), device)
+                tt_v_cache = torch2tt_tensor(tt_v_cache.unsqueeze(1), device)
+                tt_layer_past_cur.append((tt_k_cache, tt_v_cache))
+            tt_layer_past += (tt_layer_past_cur,)
+
+    else:
+        raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
+
+    if not generate_attention_inputs:
+        return (layer_past, tt_layer_past, kv_len)
+    else:
+        return (
+            attention_input,
+            attention_mask_bool,
+            layer_past,
+            tt_attention_input,
+            tt_attention_mask,
+            tt_layer_past,
+            kv_len,
+        )
+
+
+def concat_device_out_layer_present(num_devices, tt_layer_present, seq_end_idx, end_idx_only=False):
+    for i in range(num_devices):
+        tt_layer_present[i] = (
+            tt2torch_tensor(tt_layer_present[i][0]).squeeze(1),
+            tt2torch_tensor(tt_layer_present[i][1]).squeeze(1),
+        )
+        if not end_idx_only:
+            tt_layer_present[i] = (
+                tt_layer_present[i][0][:, :seq_end_idx, :],
+                tt_layer_present[i][1][:, :seq_end_idx, :],
+            )
+        else:
+            tt_layer_present[i] = (
+                tt_layer_present[i][0][:, seq_end_idx, :],
+                tt_layer_present[i][1][:, seq_end_idx, :],
+            )
+    tt_layer_present = (torch.concat([x[0] for x in tt_layer_present]), torch.concat([x[1] for x in tt_layer_present]))
+    return tt_layer_present
+
+
+def concat_device_outputs(num_devices, tt_out, llm_mode, tt_layer_present, seq_end_idx):
+    for i in range(num_devices):
+        tt_out[i] = tt2torch_tensor(tt_out[i]).squeeze(1)
+        if llm_mode == "decode":
+            tt_out[i] = tt_out[i].transpose(0, 1)
+    tt_out = torch.concat(tt_out)
+    tt_layer_present = concat_device_out_layer_present(num_devices, tt_layer_present, seq_end_idx)
+    return tt_out, tt_layer_present

--- a/models/demos/falcon7b/tt/falcon_mlp.py
+++ b/models/demos/falcon7b/tt/falcon_mlp.py
@@ -7,12 +7,13 @@ from torch import nn
 import tt_lib
 
 from models.utility_functions import torch2tt_tensor
+from models.demos.falcon7b.tt.model_utils import get_weights_cached
 
 
 class TtFalconMLP(nn.Module):
     def __init__(
         self,
-        device,
+        devices,
         state_dict,
         base_url,
         layer_num,
@@ -23,88 +24,52 @@ class TtFalconMLP(nn.Module):
         super().__init__()
 
         self.state_dict = state_dict
-        self.device = device
+        self.devices = devices
         self.hidden_size = hidden_size
         self.model_config = model_config
 
         layer_name = f"{base_url}.{layer_num}"
-
         dense_h_to_4h_str = f"{layer_name}.mlp.dense_h_to_4h.weight"
         dense_4h_to_h_str = f"{layer_name}.mlp.dense_4h_to_h.weight"
 
-        if (
-            tt_cache_path / f"{dense_h_to_4h_str}_{self.model_config['DENSE_H_TO_4H_MM_WEIGHTS_DTYPE'].name}.bin"
-        ).exists():
-            self.dense_h_to_4h_weights = tt_lib.tensor.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{dense_h_to_4h_str}_{self.model_config['DENSE_H_TO_4H_MM_WEIGHTS_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["DENSE_H_TO_4H_MM_WEIGHTS_MEMCFG"])
-        else:
-            self.dense_h_to_4h_weights = torch2tt_tensor(
-                torch.transpose(
-                    self.state_dict[dense_h_to_4h_str],
-                    -2,
-                    -1,
-                ),
-                self.device,
-                tt_memory_config=self.model_config["DENSE_H_TO_4H_MM_WEIGHTS_MEMCFG"],
-                tt_dtype=self.model_config["DENSE_H_TO_4H_MM_WEIGHTS_DTYPE"],
-            )
-            tt_lib.tensor.dump_tensor(
-                str(
-                    tt_cache_path
-                    / f"{dense_h_to_4h_str}_{self.model_config['DENSE_H_TO_4H_MM_WEIGHTS_DTYPE'].name}.bin"
-                ),
-                self.dense_h_to_4h_weights.cpu(),
-            )
-
-        if (
-            tt_cache_path / f"{dense_4h_to_h_str}_{self.model_config['DENSE_4H_TO_H_MM_WEIGHTS_DTYPE'].name}.bin"
-        ).exists():
-            self.dense_4h_to_h_weights = tt_lib.tensor.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{dense_4h_to_h_str}_{self.model_config['DENSE_4H_TO_H_MM_WEIGHTS_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["DENSE_4H_TO_H_MM_WEIGHTS_MEMCFG"])
-        else:
-            self.dense_4h_to_h_weights = torch2tt_tensor(
-                torch.transpose(
-                    self.state_dict[dense_4h_to_h_str],
-                    -2,
-                    -1,
-                ),
-                self.device,
-                tt_memory_config=self.model_config["DENSE_4H_TO_H_MM_WEIGHTS_MEMCFG"],
-                tt_dtype=self.model_config["DENSE_4H_TO_H_MM_WEIGHTS_DTYPE"],
-            )
-            tt_lib.tensor.dump_tensor(
-                str(
-                    tt_cache_path
-                    / f"{dense_4h_to_h_str}_{self.model_config['DENSE_4H_TO_H_MM_WEIGHTS_DTYPE'].name}.bin"
-                ),
-                self.dense_4h_to_h_weights.cpu(),
-            )
+        self.dense_h_to_4h_weights = get_weights_cached(
+            devices,
+            model_config,
+            tt_cache_path,
+            dense_h_to_4h_str,
+            weight_config_str="DENSE_H_TO_4H_MM_WEIGHTS",
+            weights_to_cache=(torch.transpose(state_dict[dense_h_to_4h_str], -2, -1) if state_dict else None),
+        )
+        self.dense_4h_to_h_weights = get_weights_cached(
+            devices,
+            model_config,
+            tt_cache_path,
+            dense_4h_to_h_str,
+            weight_config_str="DENSE_4H_TO_H_MM_WEIGHTS",
+            weights_to_cache=(torch.transpose(state_dict[dense_4h_to_h_str], -2, -1) if state_dict else None),
+        )
 
     def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
-        hidden_states = tt_lib.tensor.falcon_dense_h_to_4h_matmul(
-            x,
-            self.dense_h_to_4h_weights,
-            fused_activation=[tt_lib.tensor.FusibleActivation.GELU, True],
-            output_mem_config=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"],
-            output_dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
-        )
-        x.deallocate()
-
-        hidden_states = tt_lib.tensor.falcon_dense_4h_to_h_matmul(
-            hidden_states,
-            self.dense_4h_to_h_weights,
-            output_mem_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
-            output_dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
-            packer_l1_acc=True,
-        )
+        hidden_states = []
+        for device_id in range(len(x)):
+            hidden_states.append(
+                tt_lib.tensor.falcon_dense_h_to_4h_matmul(
+                    x[device_id],
+                    self.dense_h_to_4h_weights[device_id],
+                    fused_activation=[tt_lib.tensor.FusibleActivation.GELU, True],
+                    output_mem_config=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"],
+                    output_dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
+                )
+            )
+            x[device_id].deallocate()
+        for device_id in range(len(x)):
+            hidden_states[device_id] = tt_lib.tensor.falcon_dense_4h_to_h_matmul(
+                hidden_states[device_id],
+                self.dense_4h_to_h_weights[device_id],
+                output_mem_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
+                output_dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
+                packer_l1_acc=True,
+            )
 
         # return TT Tensor
         return hidden_states

--- a/models/demos/falcon7b/tt/falcon_model.py
+++ b/models/demos/falcon7b/tt/falcon_model.py
@@ -14,13 +14,14 @@ from models.utility_functions import (
     pad_by_zero,
     nearest_32,
 )
+from models.demos.falcon7b.tt.model_utils import get_weights_cached
 
 
 class TtFalconModelShared(torch.nn.Module):
     @abstractmethod
     def __init__(
         self,
-        device,
+        devices,
         state_dict,
         base_url,
         num_layers,
@@ -33,7 +34,8 @@ class TtFalconModelShared(torch.nn.Module):
 
         # NOTE: Once we make embeddings run on device, pass in state dict
         # instead of model itself
-        self.device = device
+        self.devices = devices
+        self.num_devices = len(devices)
         self.state_dict = state_dict
         self.base_url = base_url
         self.config = config
@@ -50,7 +52,7 @@ class TtFalconModelShared(torch.nn.Module):
         self.layers = torch.nn.ModuleList(
             [
                 TtFalconDecoderLayer(
-                    device=device,
+                    devices=devices,
                     state_dict=state_dict,
                     base_url=f"{base_url}.h",
                     layer_num=layer_num,
@@ -68,43 +70,31 @@ class TtFalconModelShared(torch.nn.Module):
         layernorm_weights_str = f"{layer_name}.ln_f.weight"
         layernorm_bias_str = f"{layer_name}.ln_f.bias"
 
-        if (tt_cache_path / f"{layernorm_weights_str}_{self.model_config['LN_F_WEIGHTS_DTYPE'].name}.bin").exists():
-            self.layernorm_gamma = tt_lib.tensor.load_tensor(
-                str(tt_cache_path / f"{layernorm_weights_str}_{self.model_config['LN_F_WEIGHTS_DTYPE'].name}.bin")
-            ).to(device, self.model_config["LN_F_WEIGHTS_MEMCFG"])
-        else:
-            self.layernorm_gamma = pad_by_zero(
-                self.state_dict[layernorm_weights_str],
-                device,
-                tt_memory_config=self.model_config["LN_F_WEIGHTS_MEMCFG"],
-                tt_dtype=self.model_config["LN_F_WEIGHTS_DTYPE"],
-            )[0]
-            tt_lib.tensor.dump_tensor(
-                str(tt_cache_path / f"{layernorm_weights_str}_{self.model_config['LN_F_WEIGHTS_DTYPE'].name}.bin"),
-                self.layernorm_gamma.cpu(),
-            )
-
-        if (tt_cache_path / f"{layernorm_bias_str}_{self.model_config['LN_F_BIAS_DTYPE'].name}.bin").exists():
-            self.layernorm_beta = tt_lib.tensor.load_tensor(
-                str(tt_cache_path / f"{layernorm_bias_str}_{self.model_config['LN_F_BIAS_DTYPE'].name}.bin")
-            ).to(device, self.model_config["LN_F_BIAS_MEMCFG"])
-        else:
-            self.layernorm_beta = pad_by_zero(
-                self.state_dict[layernorm_bias_str],
-                device,
-                tt_memory_config=self.model_config["LN_F_BIAS_MEMCFG"],
-                tt_dtype=self.model_config["LN_F_BIAS_DTYPE"],
-            )[0]
-            tt_lib.tensor.dump_tensor(
-                str(tt_cache_path / f"{layernorm_bias_str}_{self.model_config['LN_F_BIAS_DTYPE'].name}.bin"),
-                self.layernorm_beta.cpu(),
-            )
+        self.layernorm_gamma = get_weights_cached(
+            devices,
+            model_config,
+            tt_cache_path,
+            layernorm_weights_str,
+            weight_config_str="LN_F_WEIGHTS",
+            weights_to_cache=(self.state_dict[layernorm_weights_str] if self.state_dict else None),
+            padzero=True,
+        )
+        self.layernorm_beta = get_weights_cached(
+            devices,
+            model_config,
+            tt_cache_path,
+            layernorm_bias_str,
+            weight_config_str="LN_F_BIAS",
+            weights_to_cache=(self.state_dict[layernorm_bias_str] if self.state_dict else None),
+            padzero=True,
+        )
 
         self.layernorm_eps = config.layer_norm_epsilon
 
     def model_preprocessing(self, llm_mode, input_ids, kv_cache_len, num_input_tokens):
         assert input_ids.dim() == 2
-        batch_size, sequence_size = input_ids.shape
+        global_batch_size, sequence_size = input_ids.shape
+        batch_size = global_batch_size // self.num_devices
 
         embeddings = self.embeddings(input_ids)
 
@@ -114,60 +104,74 @@ class TtFalconModelShared(torch.nn.Module):
             assert sequence_size % 32 == 0, "For prefill, sequence_size must be multiple of 32!"
             assert kv_cache_len == 0, "For prefill, no kv_cache is passed in!"
 
-            tt_embeddings = torch2tt_tensor(
-                embeddings.unsqueeze(1),
-                self.device,
-                tt_memory_config=self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"],
-                tt_dtype=self.model_config["WORD_EMBEDDING_OUTPUT_DTYPE"],
-            )
+            tt_embeddings, tt_attention_mask = [], []
+            for i, device in enumerate(self.devices):
+                tt_embeddings.append(
+                    torch2tt_tensor(
+                        embeddings[i : i + 1].unsqueeze(1),
+                        device,
+                        tt_memory_config=self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"],
+                        tt_dtype=self.model_config["WORD_EMBEDDING_OUTPUT_DTYPE"],
+                    )
+                )
 
-            attention_mask_bool = torch.ones(batch_size, 1, sequence_size, num_input_tokens, dtype=bool)
-            attention_mask_bool = attention_mask_bool.triu(diagonal=1)
+                attention_mask_bool = torch.ones(batch_size, 1, sequence_size, num_input_tokens, dtype=bool)
+                attention_mask_bool = attention_mask_bool.triu(diagonal=1)
 
-            attention_mask_bool_padded = torch.cat(
-                (
-                    attention_mask_bool,
-                    torch.ones(batch_size, 1, sequence_size, sequence_size - num_input_tokens, dtype=bool),
-                ),
-                dim=-1,
-            )
+                attention_mask_bool_padded = torch.cat(
+                    (
+                        attention_mask_bool,
+                        torch.ones(batch_size, 1, sequence_size, sequence_size - num_input_tokens, dtype=bool),
+                    ),
+                    dim=-1,
+                )
 
-            tt_attention_mask = torch2tt_tensor(
-                (attention_mask_bool_padded * -1e3).expand(-1, self.config.num_attention_heads, -1, -1),
-                self.device,
-                tt_memory_config=self.model_config["ATTN_MASK_MEMCFG"],
-                tt_dtype=self.model_config["ATTN_MASK_DTYPE"],
-            )
+                tt_attention_mask.append(
+                    torch2tt_tensor(
+                        (attention_mask_bool_padded * -1e3).expand(-1, self.config.num_attention_heads, -1, -1),
+                        device,
+                        tt_memory_config=self.model_config["ATTN_MASK_MEMCFG"],
+                        tt_dtype=self.model_config["ATTN_MASK_DTYPE"],
+                    )
+                )
 
         elif llm_mode == "decode":
             assert batch_size % 32 == 0, "For decode, batch_size must be multiple of 32!"
             assert sequence_size == 1, "For decode, q_len must be 1!"
 
-            tt_embeddings = torch2tt_tensor(
-                embeddings.unsqueeze(1).transpose(0, 2),
-                self.device,
-                tt_memory_config=self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"],
-                tt_dtype=self.model_config["WORD_EMBEDDING_OUTPUT_DTYPE"],
-            )
+            tt_embeddings, tt_attention_mask = [], []
+            for i, device in enumerate(self.devices):
+                tt_embeddings.append(
+                    torch2tt_tensor(
+                        embeddings[batch_size * i : batch_size * (i + 1)].unsqueeze(1).transpose(0, 2),
+                        device,
+                        tt_memory_config=self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"],
+                        tt_dtype=self.model_config["WORD_EMBEDDING_OUTPUT_DTYPE"],
+                    )
+                )
 
-            attention_mask_bool = torch.zeros(batch_size, 1, sequence_size, num_input_tokens, dtype=bool)
+                attention_mask_bool = torch.zeros(batch_size, 1, sequence_size, num_input_tokens, dtype=bool)
 
-            num_max_tokens = nearest_32(
-                kv_cache_len + 1
-            )  # Potentially, num_max_tokens must be provided as a separate argument
-            attention_mask_bool_padded = torch.cat(
-                (
-                    attention_mask_bool,
-                    torch.ones(batch_size, 1, sequence_size, num_max_tokens - num_input_tokens, dtype=bool),
-                ),
-                dim=-1,
-            )
-            tt_attention_mask = torch2tt_tensor(
-                (attention_mask_bool_padded.transpose(0, 2) * -1e3).expand(-1, self.config.num_attention_heads, -1, -1),
-                self.device,
-                tt_memory_config=self.model_config["ATTN_MASK_MEMCFG"],
-                tt_dtype=self.model_config["ATTN_MASK_DTYPE"],
-            )
+                num_max_tokens = nearest_32(
+                    kv_cache_len + 1
+                )  # Potentially, num_max_tokens must be provided as a separate argument
+                attention_mask_bool_padded = torch.cat(
+                    (
+                        attention_mask_bool,
+                        torch.ones(batch_size, 1, sequence_size, num_max_tokens - num_input_tokens, dtype=bool),
+                    ),
+                    dim=-1,
+                )
+                tt_attention_mask.append(
+                    torch2tt_tensor(
+                        (attention_mask_bool_padded.transpose(0, 2) * -1e3).expand(
+                            -1, self.config.num_attention_heads, -1, -1
+                        ),
+                        device,
+                        tt_memory_config=self.model_config["ATTN_MASK_MEMCFG"],
+                        tt_dtype=self.model_config["ATTN_MASK_DTYPE"],
+                    )
+                )
 
         else:
             raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
@@ -198,29 +202,32 @@ class TtFalconModelShared(torch.nn.Module):
                 layer_past_len=layer_past_len,
                 use_cache=use_cache,
             )
-            presents += layer_output[1:]
+            presents += (layer_output[1],)
             layer_output = layer_output[0]
 
         # apply final norm layer
-        layer_output = tt_lib.tensor.layernorm(
-            layer_output,
-            self.layernorm_eps,
-            output_mem_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
-        )
-        layer_output = tt_lib.tensor.bcast(
-            layer_output,
-            self.layernorm_gamma,
-            tt_lib.tensor.BcastOpMath.MUL,
-            tt_lib.tensor.BcastOpDim.H,
-            output_mem_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
-        )
-        layer_output = tt_lib.tensor.bcast(
-            layer_output,
-            self.layernorm_beta,
-            tt_lib.tensor.BcastOpMath.ADD,
-            tt_lib.tensor.BcastOpDim.H,
-            output_mem_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
-        )
+        for i in range(self.num_devices):
+            layer_output[i] = tt_lib.tensor.layernorm(
+                layer_output[i],
+                self.layernorm_eps,
+                output_mem_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
+            )
+        for i in range(self.num_devices):
+            layer_output[i] = tt_lib.tensor.bcast(
+                layer_output[i],
+                self.layernorm_gamma[i],
+                tt_lib.tensor.BcastOpMath.MUL,
+                tt_lib.tensor.BcastOpDim.H,
+                output_mem_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
+            )
+        for i in range(self.num_devices):
+            layer_output[i] = tt_lib.tensor.bcast(
+                layer_output[i],
+                self.layernorm_beta[i],
+                tt_lib.tensor.BcastOpMath.ADD,
+                tt_lib.tensor.BcastOpDim.H,
+                output_mem_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
+            )
 
         return layer_output, presents
 
@@ -228,7 +235,7 @@ class TtFalconModelShared(torch.nn.Module):
 class TtFalconModel(TtFalconModelShared):
     def __init__(
         self,
-        device,
+        devices,
         state_dict,
         base_url,
         num_layers,
@@ -238,7 +245,7 @@ class TtFalconModel(TtFalconModelShared):
         tt_cache_path,
     ):
         super().__init__(
-            device=device,
+            devices=devices,
             state_dict=state_dict,
             base_url=base_url,
             num_layers=num_layers,

--- a/models/demos/falcon7b/tt/model_utils.py
+++ b/models/demos/falcon7b/tt/model_utils.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import tt_lib
+
+from models.utility_functions import torch2tt_tensor, pad_by_zero
+
+
+def get_weights_cached(
+    devices,
+    model_config,
+    tt_cache_path,
+    weight_cache_str,
+    weight_config_str,
+    weights_to_cache,
+    overwrite=False,
+    padzero=False,
+):
+    """Load cached weights and duplicate per device. Store if not cached."""
+    if (
+        not overwrite
+        and (tt_cache_path / f"{weight_cache_str}_{model_config[f'{weight_config_str}_DTYPE'].name}.bin").exists()
+    ):
+        # Load cached weights
+        weights_host = tt_lib.tensor.load_tensor(
+            str(tt_cache_path / f"{weight_cache_str}_{model_config[f'{weight_config_str}_DTYPE'].name}.bin")
+        )
+        # Duplicate weights on all devices
+        weights = [weights_host.to(device, model_config[f"{weight_config_str}_MEMCFG"]) for device in devices]
+    else:
+        # Duplicate weights on all devices
+        if padzero:
+            weights = [
+                pad_by_zero(
+                    weights_to_cache,
+                    device,
+                    tt_memory_config=model_config[f"{weight_config_str}_MEMCFG"],
+                    tt_dtype=model_config[f"{weight_config_str}_DTYPE"],
+                )[0]
+                for device in devices
+            ]
+        else:
+            weights = [
+                torch2tt_tensor(
+                    weights_to_cache,
+                    device,
+                    tt_memory_config=model_config[f"{weight_config_str}_MEMCFG"],
+                    tt_dtype=model_config[f"{weight_config_str}_DTYPE"],
+                )
+                for device in devices
+            ]
+        # Store weights (from first device)
+        tt_lib.tensor.dump_tensor(
+            str(tt_cache_path / f"{weight_cache_str}_{model_config[f'{weight_config_str}_DTYPE'].name}.bin"),
+            weights[0].cpu(),
+        )
+    return weights


### PR DESCRIPTION
- Add data parallel weights and forward pass for all Falcon7b modules (decode and prefill)
- Update tests for mlp,attention,decoder,model,causallm,perf to be able to run on multiple chips (decode and prefill)
- Create new file model_utils.py with utility function for loading/caching weights to remove excessive duplicate code
- Create new file test_utils.py with utility functions for preparing random inputs and transferring outputs to remove excessive duplicate code
- Note: demo still runs on a single device (todo: create separate pr later with multi-chip support for demo)