### PR TITLE
#5480: FD2.0 Test - Fix test_prefetcher for dram paged read test (-t 3) on whb0

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -280,7 +280,8 @@ void add_prefetcher_cmd(vector<uint32_t>& cmds,
     }
 }
 
-void add_dram_data_to_worker_data(const vector<uint32_t>& dram_data,
+// Model a paged read by updating worker data with interleaved/paged DRAM data, for validation later.
+void add_paged_dram_data_to_worker_data(const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                                   const CoreRange& workers,
                                   worker_data_t& worker_data,
                                   uint32_t start_page,
@@ -291,23 +292,21 @@ void add_dram_data_to_worker_data(const vector<uint32_t>& dram_data,
     uint32_t base_addr_words = base_addr / sizeof(uint32_t);
     uint32_t page_size_words = page_size / sizeof(uint32_t);
 
+    // Get data from DRAM map, add to all workers, but only set valid for cores included in workers range.
     TT_ASSERT(start_page < num_dram_banks_g);
-    uint32_t page = start_page;
-    for (uint32_t i = 0; i < pages; i++) {
-        uint32_t index = base_addr_words + page * DRAM_DATA_SIZE_WORDS;
+    for (uint32_t page_idx = 0; page_idx < pages; page_idx++) {
+
+        uint32_t dram_bank_id = page_idx % num_dram_banks_g;
+        uint32_t bank_offset = base_addr_words + page_size_words * (page_idx / num_dram_banks_g);
+
         for (uint32_t j = 0; j  < page_size_words; j++) {
             for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
                 for (uint32_t x = all_workers_g.start.x; x <= all_workers_g.end.x; x++) {
                     CoreCoord core(x, y);
-                    worker_data[core].data.push_back(dram_data[index + j]);
+                    worker_data[core].data.push_back(dram_data_map.at(dram_bank_id)[bank_offset + j]);
                     worker_data[core].valid.push_back(workers.contains(core));
                 }
             }
-        }
-        page++;
-        if (page == num_dram_banks_g) {
-            base_addr_words += page_size_words;
-            page = 0;
         }
     }
 }
@@ -315,7 +314,7 @@ void add_dram_data_to_worker_data(const vector<uint32_t>& dram_data,
 void gen_dram_read_cmd(Device *device,
                        vector<uint32_t>& prefetch_cmds,
                        vector<uint16_t>& cmd_sizes,
-                       const vector<uint32_t>& dram_data,
+                       const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                        worker_data_t& worker_data,
                        CoreCoord worker_core,
                        uint32_t dst_addr,
@@ -339,14 +338,15 @@ void gen_dram_read_cmd(Device *device,
     TT_ASSERT((new_size >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
     cmd_sizes.push_back(new_size >> PREFETCH_Q_LOG_MINSIZE);
 
-    add_dram_data_to_worker_data(dram_data, worker_core, worker_data, start_page, base_addr, page_size, pages);
+    // Model the paged read in this function by updating worker data with interleaved/paged DRAM data, for validation later.
+    add_paged_dram_data_to_worker_data(dram_data_map, worker_core, worker_data, start_page, base_addr, page_size, pages);
 }
 
 // This is pretty much a blit: copies from worker core's start of data back to the end of data
 void gen_linear_read_cmd(Device *device,
                          vector<uint32_t>& prefetch_cmds,
                          vector<uint16_t>& cmd_sizes,
-                         const vector<uint32_t>& dram_data,
+                         const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                          worker_data_t& worker_data,
                          CoreCoord worker_core,
                          uint32_t addr,
@@ -422,7 +422,7 @@ void gen_dispatcher_delay_cmd(Device *device,
 void gen_dram_test(Device *device,
                    vector<uint32_t>& prefetch_cmds,
                    vector<uint16_t>& cmd_sizes,
-                   const vector<uint32_t>& dram_data,
+                   const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                    worker_data_t& worker_data,
                    CoreCoord worker_core,
                    uint32_t dst_addr) {
@@ -433,7 +433,7 @@ void gen_dram_test(Device *device,
         dispatch_cmds.resize(0);
         uint32_t start_page = 0;
         uint32_t base_addr = 0;
-        gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr,
+        gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                           start_page, base_addr, dram_page_size_g, dram_pages_to_read_g);
 
         bytes_of_data_g += dram_page_size_g * dram_pages_to_read_g;
@@ -443,7 +443,7 @@ void gen_dram_test(Device *device,
 void gen_pcie_test(Device *device,
                    vector<uint32_t>& prefetch_cmds,
                    vector<uint16_t>& cmd_sizes,
-                   const vector<uint32_t>& dram_data,
+                   const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                    worker_data_t& worker_data,
                    CoreCoord worker_core,
                    uint32_t dst_addr) {
@@ -461,7 +461,7 @@ void gen_pcie_test(Device *device,
 void gen_rnd_dram_paged_cmd(Device *device,
                             vector<uint32_t>& prefetch_cmds,
                             vector<uint16_t>& cmd_sizes,
-                            const vector<uint32_t>& dram_data,
+                            const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                             worker_data_t& worker_data,
                             CoreCoord worker_core,
                             uint32_t dst_addr) {
@@ -481,7 +481,7 @@ void gen_rnd_dram_paged_cmd(Device *device,
     if (size < page_size) size = page_size;
     uint32_t pages = size / page_size;
     TT_ASSERT(base_addr + (start_page * page_size + pages * page_size / num_dram_banks_g) < DRAM_DATA_SIZE_BYTES);
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr,
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                       start_page, base_addr, page_size, pages);
 }
 
@@ -538,7 +538,7 @@ void gen_rnd_debug_cmd(vector<uint32_t>& prefetch_cmds,
 void gen_rnd_test(Device *device,
                   vector<uint32_t>& prefetch_cmds,
                   vector<uint16_t>& cmd_sizes,
-                  const vector<uint32_t>& dram_data,
+                  const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                   worker_data_t& worker_data,
                   uint32_t dst_addr) {
 
@@ -552,7 +552,7 @@ void gen_rnd_test(Device *device,
 
         switch (cmd) {
         case CQ_PREFETCH_CMD_RELAY_PAGED:
-            gen_rnd_dram_paged_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr);
+            gen_rnd_dram_paged_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr);
             break;
         case CQ_PREFETCH_CMD_RELAY_INLINE:
             gen_rnd_inline_cmd(device, prefetch_cmds, cmd_sizes, worker_data, worker_core, dst_addr);
@@ -571,7 +571,7 @@ void gen_rnd_test(Device *device,
 void gen_smoke_test(Device *device,
                     vector<uint32_t>& prefetch_cmds,
                     vector<uint16_t>& cmd_sizes,
-                    const vector<uint32_t>& dram_data,
+                    const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                     worker_data_t& worker_data,
                     CoreCoord worker_core,
                     uint32_t dst_addr) {
@@ -627,20 +627,20 @@ void gen_smoke_test(Device *device,
 
     // Read from dram, write to worker
     // start_page, base addr, page_size, pages
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr,
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                       0, 0, 32, num_dram_banks_g);
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr,
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                       0, 0, 32, num_dram_banks_g);
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr,
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                       4, 32, 64, num_dram_banks_g);
 
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr,
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                       0, 0, 128, 128);
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr,
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                       4, 32, 2048, num_dram_banks_g * 8);
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr,
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                       5, 32, 2048, num_dram_banks_g * 8 + 1);
-    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr,
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
                       3, 128, 6144, num_dram_banks_g * 8 + 7);
 
     // Send inline data to (maybe) multiple cores
@@ -669,8 +669,8 @@ void gen_smoke_test(Device *device,
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
 
     // These tests copy data from earlier tests so can't run first
-    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr, 32);
-    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr, 65 * 1024);
+    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr, 32);
+    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr, 65 * 1024);
 
     // Test wait/stall
     gen_dispatcher_delay_cmd(device, prefetch_cmds, cmd_sizes, 1024 * 1024);
@@ -678,28 +678,28 @@ void gen_smoke_test(Device *device,
     gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, 2048);
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
     gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
-    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, worker_core, dst_addr, 32, worker_data[worker_core].data.size() - 32 / sizeof(uint32_t));
+    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr, 32, worker_data[worker_core].data.size() - 32 / sizeof(uint32_t));
 }
 
 void gen_prefetcher_cmds(Device *device,
                          vector<uint32_t>& prefetch_cmds,
                          vector<uint16_t>& cmd_sizes,
-                         const vector<uint32_t>& dram_data,
+                         const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
                          worker_data_t& worker_data,
                          uint32_t dst_addr) {
 
     switch (test_type_g) {
     case 0:
-        gen_smoke_test(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, first_worker_g, dst_addr);
+        gen_smoke_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
         break;
     case 1:
-        gen_rnd_test(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, dst_addr);
+        gen_rnd_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, dst_addr);
         break;
     case 2:
-        gen_pcie_test(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, first_worker_g, dst_addr);
+        gen_pcie_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
         break;
     case 3:
-        gen_dram_test(device, prefetch_cmds, cmd_sizes, dram_data, worker_data, first_worker_g, dst_addr);
+        gen_dram_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
         break;
     }
 }
@@ -806,21 +806,30 @@ void write_prefetcher_cmds(uint32_t iterations,
     }
 }
 
-void populate_dram(Device *device, vector<uint32_t>& dram_data)
+// Populate interleaved DRAM with data for later readback.  Can we extended to L1 if needed.
+void populate_interleaved_dram(Device *device, unordered_map<uint32_t, vector<uint32_t>>& dram_data_map)
 {
-    const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device->id());
-    vector<CoreCoord> dram_cores = soc_d.get_dram_cores();
-    num_dram_banks_g = dram_cores.size();
 
-    for (uint32_t i = 0; i < DRAM_DATA_SIZE_WORDS * num_dram_banks_g; i++) {
-        uint32_t datum = (use_coherent_data_g) ? i : std::rand();
-        dram_data.push_back(datum);
-    }
+    num_dram_banks_g = device->num_banks(BufferType::DRAM);;
 
-    uint32_t offset = 0;
-    for (auto core : dram_cores) {
-        tt::Cluster::instance().write_core((void *)&dram_data[offset], DRAM_DATA_SIZE_BYTES, tt_cxy_pair(device->id(), core), DRAM_HACKED_BASE_ADDR);
-        offset += DRAM_DATA_SIZE_WORDS;
+    for (int bank_id = 0; bank_id < num_dram_banks_g; bank_id++) {
+        auto offset = device->dram_bank_offset_from_bank_id(bank_id);
+        auto dram_channel = device->dram_channel_from_bank_id(bank_id);
+        auto bank_core = device->core_from_dram_channel(dram_channel);
+
+        // Generate random or coherent data per bank of specific size.
+        for (uint32_t i = 0; i < DRAM_DATA_SIZE_WORDS; i++) {
+            uint32_t datum = (use_coherent_data_g) ? (((bank_id & 0xFF) << 24) | i) : std::rand();
+            dram_data_map[bank_id].push_back(datum);
+            if (i < 10) {
+                log_debug(tt::LogTest, "{} - bank_id: {:2d} core: {} offset: 0x{:08x} using i: {:2d} datum: 0x{:08x}",
+                    __FUNCTION__, bank_id, bank_core.str(), offset, i, datum);
+            }
+        }
+
+        // Write to device once per bank (appropriate core and offset)
+        tt::Cluster::instance().write_core(static_cast<const void*>(dram_data_map[bank_id].data()),
+            dram_data_map[bank_id].size() * sizeof(uint32_t), tt_cxy_pair(device->id(), bank_core), DRAM_HACKED_BASE_ADDR + offset);
     }
 }
 
@@ -915,12 +924,13 @@ int main(int argc, char **argv) {
             }
         }
 
-        vector<uint32_t> dram_data;
-        populate_dram(device, dram_data);
+        // Model of interleaved DRAM memory by bank id
+        unordered_map<uint32_t, vector<uint32_t>> dram_data_map;
+        populate_interleaved_dram(device, dram_data_map);
 
         tt::Cluster::instance().l1_barrier(device->id());
         tt::Cluster::instance().dram_barrier(device->id());
-        gen_prefetcher_cmds(device, cmds, cmd_sizes, dram_data, worker_data, l1_buf_base);
+        gen_prefetcher_cmds(device, cmds, cmd_sizes, dram_data_map, worker_data, l1_buf_base);
         gen_terminate_cmds(terminate_cmds, terminate_sizes);
 
         std::map<string, string> defines = {
@@ -1028,7 +1038,7 @@ int main(int argc, char **argv) {
                 cmds.resize(0);
                 cmd_sizes.resize(0);
                 reset_worker_data(worker_data);
-                gen_prefetcher_cmds(device, cmds, cmd_sizes, dram_data, worker_data, l1_buf_base);
+                gen_prefetcher_cmds(device, cmds, cmd_sizes, dram_data_map, worker_data, l1_buf_base);
                 run_test(1, device, program, cmd_sizes, terminate_sizes, cmds, terminate_cmds, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
                 pass &= validate_results(device, all_workers_g, worker_data, l1_buf_base);
                 if (!pass) {


### PR DESCRIPTION
Test fix (now passes for whb0) for paged-reads and rename function to be a tiny bit more clear.  And bundle in bank_id into the coherent data.

 - Was using 36 DRAM cores, issuing 36 different sets of unique data and populating dram_data as if they were unique memory when really there are only 12 DRAM banks (3 subch per bank are same memory)

 - Make dram_data a map now called dram_data_map indexed first by bank_id.