### PR TITLE
#0: changing all `#include common/*` to `#include tt_metal/common/*`

### DIFF
--- a/tests/tt_metal/llrt/test_libs/conv_pattern.hpp
+++ b/tests/tt_metal/llrt/test_libs/conv_pattern.hpp
@@ -5,8 +5,8 @@
 #pragma once
 #include<map>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
-#include "common/assert.hpp"
-#include "common/constants.hpp"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/constants.hpp"
 using namespace tt::constants;
 class ConvParameters {
     public:

--- a/tests/tt_metal/test_utils/comparison.hpp
+++ b/tests/tt_metal/test_utils/comparison.hpp
@@ -7,7 +7,7 @@
 #include <functional>
 #include <random>
 
-#include "common/logger.hpp"
+#include "tt_metal/common/logger.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 
 namespace tt {

--- a/tests/tt_metal/test_utils/df/bfloat16.hpp
+++ b/tests/tt_metal/test_utils/df/bfloat16.hpp
@@ -5,7 +5,7 @@
 #pragma once
 #include <iostream>
 
-#include "common/logger.hpp"
+#include "tt_metal/common/logger.hpp"
 
 using namespace std;
 

--- a/tests/tt_metal/test_utils/df/float32.hpp
+++ b/tests/tt_metal/test_utils/df/float32.hpp
@@ -5,7 +5,7 @@
 #pragma once
 #include <iostream>
 
-#include "common/logger.hpp"
+#include "tt_metal/common/logger.hpp"
 
 using namespace std;
 

--- a/tests/tt_metal/test_utils/packing.hpp
+++ b/tests/tt_metal/test_utils/packing.hpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <random>
 
-#include "common/logger.hpp"
+#include "tt_metal/common/logger.hpp"
 
 namespace tt {
 namespace test_utils {

--- a/tests/tt_metal/test_utils/stimulus.hpp
+++ b/tests/tt_metal/test_utils/stimulus.hpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <random>
 
-#include "common/logger.hpp"
+#include "tt_metal/common/logger.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 
 namespace tt {

--- a/tests/tt_metal/test_utils/tilization.hpp
+++ b/tests/tt_metal/test_utils/tilization.hpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <random>
 
-#include "common/logger.hpp"
+#include "tt_metal/common/logger.hpp"
 
 namespace tt {
 namespace test_utils {

--- a/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
@@ -8,8 +8,8 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
-#include "common/bfloat16.hpp"
-#include "common/logger.hpp"
+#include "tt_metal/common/bfloat16.hpp"
+#include "tt_metal/common/logger.hpp"
 
 
 using namespace tt;

--- a/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram_to_l1_multicast.cpp
@@ -8,8 +8,8 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
-#include "common/bfloat16.hpp"
-#include "common/logger.hpp"
+#include "tt_metal/common/bfloat16.hpp"
+#include "tt_metal/common/logger.hpp"
 
 using namespace tt;
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
@@ -6,10 +6,10 @@
 #include <memory>
 
 #include "command_queue_fixture.hpp"
-#include "common/env_lib.hpp"
+#include "tt_metal/common/env_lib.hpp"
 #include "gtest/gtest.h"
-#include "impl/program/program.hpp"
-#include "logger.hpp"
+#include "tt_metal/impl/program/program.hpp"
+#include "tt_metal/common/logger.hpp"
 #include "tt_metal/common/scoped_timer.hpp"
 #include "tt_metal/host_api.hpp"
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
@@ -12,7 +12,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 #include <gtest/gtest.h>
 
-#include "common/bfloat16.hpp"
+#include "tt_metal/common/bfloat16.hpp"
 #include "tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/host_api.hpp"

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWaitForEvent.cpp
@@ -5,7 +5,7 @@
 #include <memory>
 
 #include "command_queue_fixture.hpp"
-#include "common/logger.hpp"
+#include "tt_metal/common/logger.hpp"
 #include "gtest/gtest.h"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"

--- a/tt_eager/tt_dnn/op_library/all_gather/multi_core/all_gather_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/multi_core/all_gather_op_multi_core.cpp
@@ -4,7 +4,7 @@
 ///
 #include <algorithm>
 
-#include "common/core_coord.h"
+#include "tt_metal/common/core_coord.h"
 #include "eth_l1_address_map.h"
 #include "impl/buffers/buffer.hpp"
 #include "tensor/tensor_impl.hpp"

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 #include <type_traits>
-#include "common/constants.hpp"
+#include "tt_metal/common/constants.hpp"
 
 #include "tt_dnn/op_library/bcast/bcast_op.hpp"
 #include "tensor/tensor.hpp"

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -5,7 +5,7 @@
 #pragma once
 #include <type_traits>
 
-#include "common/constants.hpp"
+#include "tt_metal/common/constants.hpp"
 #include "tensor/owned_buffer_functions.hpp"
 #include "tensor/tensor.hpp"
 #include "tensor/tensor_utils.hpp"

--- a/tt_eager/tt_dnn/op_library/copy/single_core/copy_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/copy/single_core/copy_op_single_core.cpp
@@ -9,8 +9,8 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
-#include "common/bfloat8.hpp"
-#include "common/bfloat4.hpp"
+#include "tt_metal/common/bfloat8.hpp"
+#include "tt_metal/common/bfloat4.hpp"
 
 using namespace tt::constants;
 

--- a/tt_eager/tt_dnn/op_library/fill_rm/fill_rm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fill_rm/fill_rm_op.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_dnn/op_library/fill_rm/fill_rm_op.hpp"
-#include "common/test_tiles.hpp"
+#include "tt_metal/common/test_tiles.hpp"
 
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/common/constants.hpp"

--- a/tt_eager/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
@@ -6,7 +6,7 @@
 
 #include <cmath>
 
-#include "common/test_tiles.hpp"
+#include "tt_metal/common/test_tiles.hpp"
 #include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"

--- a/tt_eager/tt_dnn/op_library/sharded_partial/multi_core/sharded_op_partial_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded_partial/multi_core/sharded_op_partial_multi_core.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 
-#include "common/assert.hpp"
+#include "tt_metal/common/assert.hpp"
 #include "tt_dnn/op_library/math.hpp"
 #include "tt_dnn/op_library/sharded/sharded_op.hpp"
 #include "tt_dnn/op_library/sharded_partial/sharded_op_partial.hpp"

--- a/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.cpp
@@ -4,7 +4,7 @@
 
 #include "tt_dnn/op_library/sharded_partial/sharded_op_partial.hpp"
 
-#include "common/assert.hpp"
+#include "tt_metal/common/assert.hpp"
 #include "tensor/types.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
 #include "tt_metal/common/constants.hpp"

--- a/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.hpp
+++ b/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.hpp
@@ -6,7 +6,7 @@
 
 #include <optional>
 
-#include "common/assert.hpp"
+#include "tt_metal/common/assert.hpp"
 #include "impl/buffers/buffer.hpp"
 #include "tensor/tensor.hpp"
 #include "tt_dnn/op_library/run_operation.hpp"

--- a/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.cpp
+++ b/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.cpp
@@ -6,7 +6,7 @@
 
 #include <iostream>
 
-#include "common/constants.hpp"
+#include "tt_metal/common/constants.hpp"
 #include "tt_dnn/op_library/auto_format.hpp"
 #include "tt_dnn/op_library/reshape/reshape_op.hpp"
 #include "tt_dnn/op_library/transpose/transpose_op.hpp"

--- a/tt_eager/tt_dnn/op_library/split/split_tiled.cpp
+++ b/tt_eager/tt_dnn/op_library/split/split_tiled.cpp
@@ -6,7 +6,7 @@
 
 #include <iostream>
 
-#include "common/constants.hpp"
+#include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/util.hpp"
 

--- a/tt_metal/common/assert.hpp
+++ b/tt_metal/common/assert.hpp
@@ -12,7 +12,7 @@
 #include <sstream>
 #include <vector>
 
-#include "common/logger.hpp"
+#include "tt_metal/common/logger.hpp"
 
 namespace tt {
 template <typename A, typename B>

--- a/tt_metal/common/base.hpp
+++ b/tt_metal/common/base.hpp
@@ -16,8 +16,8 @@
 
 #include <boost/functional/hash.hpp>
 
-#include "common/tt_backend_api_types.hpp" // These are the types exported to frontend team...
-#include "common/assert.hpp"
+#include "tt_metal/common/tt_backend_api_types.hpp" // These are the types exported to frontend team...
+#include "tt_metal/common/assert.hpp"
 #include "hostdevcommon/kernel_structs.h"
 #include "eth_l1_address_map.h"
 #include "common/constants.hpp"

--- a/tt_metal/common/bfloat16.hpp
+++ b/tt_metal/common/bfloat16.hpp
@@ -9,8 +9,8 @@
 #include <random>
 #include <vector>
 
-#include "common/assert.hpp"
-#include "common/logger.hpp"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/logger.hpp"
 
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 using namespace std;

--- a/tt_metal/common/bfloat4.hpp
+++ b/tt_metal/common/bfloat4.hpp
@@ -9,9 +9,9 @@
 #include <vector>
 #include <immintrin.h>
 
-#include "common/assert.hpp"
-#include "common/logger.hpp"
-#include "common/tt_backend_api_types.hpp"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/logger.hpp"
+#include "tt_metal/common/tt_backend_api_types.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 #include "blockfloat_common.hpp"
 

--- a/tt_metal/common/bfloat8.hpp
+++ b/tt_metal/common/bfloat8.hpp
@@ -9,9 +9,9 @@
 #include <vector>
 #include <immintrin.h>
 
-#include "common/assert.hpp"
-#include "common/logger.hpp"
-#include "common/tt_backend_api_types.hpp"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/logger.hpp"
+#include "tt_metal/common/tt_backend_api_types.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 #include "blockfloat_common.hpp"
 

--- a/tt_metal/common/blockfloat_common.hpp
+++ b/tt_metal/common/blockfloat_common.hpp
@@ -9,9 +9,9 @@
 #include <vector>
 #include <immintrin.h>
 
-#include "common/assert.hpp"
-#include "common/logger.hpp"
-#include "common/tt_backend_api_types.hpp"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/logger.hpp"
+#include "tt_metal/common/tt_backend_api_types.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 
 using namespace std;

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -11,8 +11,8 @@
 #include <set>
 #include <string>
 
-#include "common/assert.hpp"
-#include "common/logger.hpp"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/logger.hpp"
 #include "third_party/umd/device/tt_xy_pair.h"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 

--- a/tt_metal/common/math.hpp
+++ b/tt_metal/common/math.hpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 #include <math.h>
 
-#include "common/assert.hpp"
+#include "tt_metal/common/assert.hpp"
 
 namespace tt {
 

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <string>
 
-#include "common/assert.hpp"
+#include "tt_metal/common/assert.hpp"
 #include "dev_mem_map.h"
 #include "tt_metal/third_party/umd/device/tt_device.h"
 #include "yaml-cpp/yaml.h"

--- a/tt_metal/common/test_tiles.hpp
+++ b/tt_metal/common/test_tiles.hpp
@@ -10,7 +10,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "common/assert.hpp"
+#include "tt_metal/common/assert.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 #include "math.hpp"
 

--- a/tt_metal/common/utils.hpp
+++ b/tt_metal/common/utils.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <thread>
 #include <mutex>
-#include "assert.hpp"
+#include "tt_metal/common/assert.hpp"
 
 using std::string;
 using std::cout;

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -8,7 +8,7 @@
 #include <variant>
 #include <vector>
 #include <future>
-#include "common/core_coord.h"
+#include "tt_metal/common/core_coord.h"
 #include "tt_metal/impl/program/program.hpp"
 #include "tt_metal/impl/buffers/buffer.hpp"
 #include "tt_metal/impl/event/event.hpp"

--- a/tt_metal/impl/allocator/algorithms/free_list.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/impl/allocator/algorithms/free_list.hpp"
-#include "common/assert.hpp"
+#include "tt_metal/common/assert.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -10,8 +10,8 @@
 #include <unordered_set>
 
 #include "allocator_types.hpp"
-#include "common/assert.hpp"
-#include "common/core_coord.h"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/core_coord.h"
 #include "tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp"
 
 namespace tt {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -4,7 +4,7 @@
 
 #include "tt_metal/impl/buffers/buffer.hpp"
 
-#include "common/assert.hpp"
+#include "tt_metal/common/assert.hpp"
 #include "llrt/llrt.hpp"
 #include "tt_metal/common/math.hpp"
 #include "tt_metal/detail/tt_metal.hpp"

--- a/tt_metal/impl/device/program_cache.hpp
+++ b/tt_metal/impl/device/program_cache.hpp
@@ -6,7 +6,7 @@
 
 #include <unordered_map>
 #include <memory>
-#include "common/logger.hpp"
+#include "tt_metal/common/logger.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -12,7 +12,7 @@
 #include "allocator/allocator.hpp"
 #include "debug_tools.hpp"
 #include "dev_msgs.h"
-#include "logger.hpp"
+#include "tt_metal/common/logger.hpp"
 #include "noc/noc_parameters.h"
 #include "tt_metal/detail/program.hpp"
 #include "tt_metal/detail/tt_metal.hpp"

--- a/tt_metal/impl/event/event.hpp
+++ b/tt_metal/impl/event/event.hpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 #include <thread>
-#include "common/assert.hpp"
+#include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/logger.hpp"
 namespace tt::tt_metal
 {

--- a/tt_metal/jit_build/hlk_desc.hpp
+++ b/tt_metal/jit_build/hlk_desc.hpp
@@ -8,9 +8,9 @@
 #include <boost/functional/hash.hpp>
 
 #include "hostdevcommon/kernel_structs.h"
-#include "common/base_types.hpp"
-#include "common/tt_backend_api_types.hpp"
-#include "common/assert.hpp"
+#include "tt_metal/common/base_types.hpp"
+#include "tt_metal/common/tt_backend_api_types.hpp"
+#include "tt_metal/common/assert.hpp"
 
 namespace tt
 {

--- a/tt_metal/jit_build/settings.cpp
+++ b/tt_metal/jit_build/settings.cpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "common/assert.hpp"
-#include "common/core_coord.h"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/core_coord.h"
 #include "jit_build/settings.hpp"
 #include "jit_build/build.hpp"
 #include <iostream>


### PR DESCRIPTION
pre-cleanup for moving over to cmake to make sure no confusion between `third_party/umd/common` and `tt_metal/common`