### PR TITLE
Enable CI tests for Mamba functional model

### DIFF
--- a/tests/scripts/run_models.sh
+++ b/tests/scripts/run_models.sh
@@ -15,6 +15,8 @@ fi
 if [[ $ARCH_NAME == "wormhole" ]]; then
   env pytest tests/ttnn/integration_tests/stable_diffusion
   env pytest tests/ttnn/integration_tests/unet
+
+  env pytest models/experimental/mamba/tests
 fi
 
 env pytest models/experimental/whisper -k whisper_attention


### PR DESCRIPTION
This adds all of our unit tests to the nightly pipeline. Some of these tests are quick (<50ms) so if we can add them to a different pipeline that will run more frequently, let me know.

We have only tested on WH, so I did not enable the GS tests. I see that some other models use `@skip_for_grayskull` decorator instead of in the `run_tests.sh` script - let me know if that is preferred. 