### PR TITLE
#6217: tt_lib async mode support (single chipp tensors supported)

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import pytest
 import torch
 
@@ -31,105 +32,132 @@ def generate_input_shapes():
 @pytest.mark.parametrize("in0_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
 @pytest.mark.parametrize("in1_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
 @pytest.mark.parametrize("out_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
-def test_attn_matmul(in0_dtype, in1_dtype, out_dtype, device):
+@pytest.mark.parametrize(
+    "enable_async, num_loops",
+    ((True, 20), (False, 1)),
+)
+def test_attn_matmul(num_loops, enable_async, in0_dtype, in1_dtype, out_dtype, device):
     torch.manual_seed(0)
+    device.enable_async(enable_async)
 
     for input_shape_a, input_shape_b in generate_input_shapes():
-        input_tensor_a = torch.randn(input_shape_a).bfloat16()
-        input_tensor_b = torch.randn(input_shape_b).bfloat16()
+        for _ in range(num_loops):
+            input_tensor_a = torch.randn(input_shape_a).bfloat16()
+            input_tensor_b = torch.randn(input_shape_b).bfloat16()
+            tt_input_tensor_a = ttl.tensor.Tensor(input_tensor_a, in0_dtype).to(ttl.tensor.Layout.TILE)
+            tt_input_tensor_b = ttl.tensor.Tensor(input_tensor_b, in1_dtype).to(ttl.tensor.Layout.TILE)
+            # Test python syntax in async mode -> tensor handle for inputs should get properly updated when sending to device
+            tt_input_tensor_a = tt_input_tensor_a.to(device)
+            tt_input_tensor_b = tt_input_tensor_b.to(device)
+            compute_grid_size = device.compute_with_storage_grid_size()
+            tt_output_tensor_on_device = ttl.operations.primary.transformers.attn_matmul(
+                tt_input_tensor_a,
+                tt_input_tensor_b,
+                compute_with_storage_grid_size=ttl.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
+                output_mem_config=ttl.tensor.MemoryConfig(
+                    ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
+                ),
+                output_dtype=out_dtype,
+            )
+            tt_input_tensor_a.deallocate()
+            tt_input_tensor_b.deallocate()
+            tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+            tt_output_tensor_on_device.deallocate()
+            golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
 
-        tt_input_tensor_a = ttl.tensor.Tensor(input_tensor_a, in0_dtype).to(ttl.tensor.Layout.TILE).to(device)
-        tt_input_tensor_b = ttl.tensor.Tensor(input_tensor_b, in1_dtype).to(ttl.tensor.Layout.TILE).to(device)
+            allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+            assert allclose, f"FAILED: {output}"
 
-        compute_grid_size = device.compute_with_storage_grid_size()
-        tt_output_tensor_on_device = ttl.operations.primary.transformers.attn_matmul(
-            tt_input_tensor_a,
-            tt_input_tensor_b,
-            compute_with_storage_grid_size=ttl.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
-            output_mem_config=ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
-            ),
-            output_dtype=out_dtype,
-        )
-        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-
-        golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
-
-        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-        assert allclose, f"FAILED: {output}"
+    device.enable_async(False)
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize(
     "in_dtype", [ttl.tensor.DataType.FLOAT32, ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B]
 )
-def test_attn_matmul_fp32(in_dtype, device):
+@pytest.mark.parametrize(
+    "enable_async, num_loops",
+    ((True, 20), (False, 1)),
+)
+def test_attn_matmul_fp32(num_loops, enable_async, in_dtype, device):
     torch.manual_seed(0)
+    device.enable_async(enable_async)
 
     for input_shape_a, input_shape_b in generate_input_shapes():
-        input_tensor_a = torch.randn(input_shape_a).bfloat16()
-        input_tensor_b = torch.randn(input_shape_b).bfloat16()
+        for _ in range(num_loops):
+            input_tensor_a = torch.randn(input_shape_a).bfloat16()
+            input_tensor_b = torch.randn(input_shape_b).bfloat16()
 
-        tt_input_tensor_a = ttl.tensor.Tensor(input_tensor_a, in_dtype).to(ttl.tensor.Layout.TILE).to(device)
-        tt_input_tensor_b = ttl.tensor.Tensor(input_tensor_b, in_dtype).to(ttl.tensor.Layout.TILE).to(device)
+            tt_input_tensor_a = ttl.tensor.Tensor(input_tensor_a, in_dtype).to(ttl.tensor.Layout.TILE).to(device)
+            tt_input_tensor_b = ttl.tensor.Tensor(input_tensor_b, in_dtype).to(ttl.tensor.Layout.TILE).to(device)
 
-        compute_grid_size = device.compute_with_storage_grid_size()
+            compute_grid_size = device.compute_with_storage_grid_size()
 
-        compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttl.tensor.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=False,
-        )
+            compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+                math_fidelity=ttl.tensor.MathFidelity.LoFi,
+                math_approx_mode=True,
+                fp32_dest_acc_en=True,
+                packer_l1_acc=False,
+            )
 
-        tt_output_tensor_on_device = ttl.operations.primary.transformers.attn_matmul(
-            tt_input_tensor_a,
-            tt_input_tensor_b,
-            compute_with_storage_grid_size=ttl.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
-            output_mem_config=ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
-            ),
-            output_dtype=in_dtype,
-            compute_kernel_config=compute_kernel_config,
-        )
-        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+            tt_output_tensor_on_device = ttl.operations.primary.transformers.attn_matmul(
+                tt_input_tensor_a,
+                tt_input_tensor_b,
+                compute_with_storage_grid_size=ttl.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
+                output_mem_config=ttl.tensor.MemoryConfig(
+                    ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
+                ),
+                output_dtype=in_dtype,
+                compute_kernel_config=compute_kernel_config,
+            )
+            tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
-        golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
+            golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
 
-        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-        assert allclose, f"FAILED: {output}"
+            allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+            assert allclose, f"FAILED: {output}"
+
+    device.enable_async(False)
 
 
 @pytest.mark.parametrize("in0_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
 @pytest.mark.parametrize("in1_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
 @pytest.mark.parametrize("out_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
-def test_attn_matmul_with_program_cache(in0_dtype, in1_dtype, out_dtype, device, use_program_cache):
+@pytest.mark.parametrize(
+    "enable_async, num_loops",
+    ((True, 20), (False, 1)),
+)
+def test_attn_matmul_with_program_cache(
+    num_loops, enable_async, in0_dtype, in1_dtype, out_dtype, device, use_program_cache
+):
     torch.manual_seed(0)
-
+    device.enable_async(enable_async)
     for input_shape_a, input_shape_b in generate_input_shapes():
-        input_tensor_a = torch.randn(input_shape_a).bfloat16()
-        input_tensor_b = torch.randn(input_shape_b).bfloat16()
+        for _ in range(num_loops):
+            input_tensor_a = torch.randn(input_shape_a).bfloat16()
+            input_tensor_b = torch.randn(input_shape_b).bfloat16()
 
-        tt_input_tensor_a = ttl.tensor.Tensor(input_tensor_a, in0_dtype).to(ttl.tensor.Layout.TILE).to(device)
-        tt_input_tensor_b = ttl.tensor.Tensor(input_tensor_b, in1_dtype).to(ttl.tensor.Layout.TILE).to(device)
+            tt_input_tensor_a = ttl.tensor.Tensor(input_tensor_a, in0_dtype).to(ttl.tensor.Layout.TILE).to(device)
+            tt_input_tensor_b = ttl.tensor.Tensor(input_tensor_b, in1_dtype).to(ttl.tensor.Layout.TILE).to(device)
 
-        compute_grid_size = device.compute_with_storage_grid_size()
+            compute_grid_size = device.compute_with_storage_grid_size()
 
-        tt_output_tensor_on_device = ttl.operations.primary.transformers.attn_matmul(
-            tt_input_tensor_a,
-            tt_input_tensor_b,
-            compute_with_storage_grid_size=ttl.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
-            output_mem_config=ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
-            ),
-            output_dtype=out_dtype,
-        )
-        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+            tt_output_tensor_on_device = ttl.operations.primary.transformers.attn_matmul(
+                tt_input_tensor_a,
+                tt_input_tensor_b,
+                compute_with_storage_grid_size=ttl.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
+                output_mem_config=ttl.tensor.MemoryConfig(
+                    ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
+                ),
+                output_dtype=out_dtype,
+            )
+            tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
-        golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
+            golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
 
-        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-        assert allclose, f"FAILED: {output}"
+            allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+            assert allclose, f"FAILED: {output}"
+    device.enable_async(False)
 
 
 @pytest.mark.parametrize(
@@ -156,10 +184,27 @@ def test_attn_matmul_with_program_cache(in0_dtype, in1_dtype, out_dtype, device,
         (32, 64, 128, 16, 1),
     ),
 )
+@pytest.mark.parametrize(
+    "enable_async, num_loops",
+    ((True, 5), (False, 1)),
+)
 def test_group_attn_matmul(
-    batch, K, seq_len, q_heads, kv_heads, in0_sharded, in1_sharded, output_sharded, shard_orientation, device
+    num_loops,
+    enable_async,
+    batch,
+    K,
+    seq_len,
+    q_heads,
+    kv_heads,
+    in0_sharded,
+    in1_sharded,
+    output_sharded,
+    shard_orientation,
+    device,
 ):
     torch.manual_seed(0)
+
+    device.enable_async(enable_async)
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
@@ -175,71 +220,85 @@ def test_group_attn_matmul(
     q_len = 1
     input_shape_a = [q_len, q_heads, batch, K]
     input_shape_b = [batch, kv_heads, K, seq_len]
+    for _ in range(num_loops):
+        input_tensor_a = torch.randn(input_shape_a).bfloat16()
+        input_tensor_b = torch.randn(input_shape_b).bfloat16()
 
-    input_tensor_a = torch.randn(input_shape_a).bfloat16()
-    input_tensor_b = torch.randn(input_shape_b).bfloat16()
+        tt_input_tensor_a = (
+            ttl.tensor.Tensor(input_tensor_a, in0_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
+        )
+        tt_input_tensor_b = (
+            ttl.tensor.Tensor(input_tensor_b, in1_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
+        )
 
-    tt_input_tensor_a = (
-        ttl.tensor.Tensor(input_tensor_a, in0_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
-    )
-    tt_input_tensor_b = (
-        ttl.tensor.Tensor(input_tensor_b, in1_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
-    )
+        if in0_sharded:
+            tt_input_tensor_a = ttl.tensor.interleaved_to_sharded(
+                tt_input_tensor_a,
+                compute_grid_size,
+                [q_len * batch, K],
+                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                shard_orientation,
+            )
 
-    if in0_sharded:
-        tt_input_tensor_a = ttl.tensor.interleaved_to_sharded(
+        if in1_sharded:
+            tt_input_tensor_b = ttl.tensor.interleaved_to_sharded(
+                tt_input_tensor_b,
+                compute_grid_size,
+                [kv_heads * K, seq_len],
+                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                shard_orientation,
+            )
+
+        if output_sharded:
+            output_mem_config = ttl.tensor.MemoryConfig(
+                memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                buffer_type=ttl.tensor.BufferType.L1,
+            )
+        else:
+            output_mem_config = interleaved_mem_config
+
+        tt_output_tensor_on_device = ttl.operations.primary.transformers.group_attn_matmul(
             tt_input_tensor_a,
-            compute_grid_size,
-            [q_len * batch, K],
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            shard_orientation,
-        )
-
-    if in1_sharded:
-        tt_input_tensor_b = ttl.tensor.interleaved_to_sharded(
             tt_input_tensor_b,
-            compute_grid_size,
-            [kv_heads * K, seq_len],
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            shard_orientation,
+            compute_with_storage_grid_size=compute_grid_size,
+            output_mem_config=output_mem_config,
+            output_dtype=output_dtype,
         )
 
-    if output_sharded:
-        output_mem_config = ttl.tensor.MemoryConfig(
-            memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            buffer_type=ttl.tensor.BufferType.L1,
-        )
-    else:
-        output_mem_config = interleaved_mem_config
+        tt_input_tensor_a.deallocate()
+        tt_input_tensor_b.deallocate()
 
-    tt_output_tensor_on_device = ttl.operations.primary.transformers.group_attn_matmul(
-        tt_input_tensor_a,
-        tt_input_tensor_b,
-        compute_with_storage_grid_size=compute_grid_size,
-        output_mem_config=output_mem_config,
-        output_dtype=output_dtype,
-    )
-    if output_sharded:
-        tt_output_tensor_on_device = ttl.tensor.sharded_to_interleaved(
-            tt_output_tensor_on_device, interleaved_mem_config
-        )
+        if output_sharded:
+            tt_output_tensor_on_device = ttl.tensor.sharded_to_interleaved(
+                tt_output_tensor_on_device, interleaved_mem_config
+            )
 
-    tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        tt_output_tensor_on_device.deallocate()
+        input_tensor_a = input_tensor_a.to(torch.float)
+        input_tensor_b = torch.repeat_interleave(input_tensor_b.to(torch.float), q_heads // kv_heads, dim=1)
+        golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
 
-    input_tensor_a = input_tensor_a.to(torch.float)
-    input_tensor_b = torch.repeat_interleave(input_tensor_b.to(torch.float), q_heads // kv_heads, dim=1)
-    golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
+        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+        assert allclose, f"FAILED: {output}"
 
-    allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-    assert allclose, f"FAILED: {output}"
+    device.enable_async(False)
 
 
 @pytest.mark.parametrize("sharded", [False, True])
 @pytest.mark.parametrize("output_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
 @pytest.mark.parametrize("in1_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
 @pytest.mark.parametrize("in0_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
-def test_group_attn_matmul_with_program_cache(in0_dtype, in1_dtype, output_dtype, sharded, device, use_program_cache):
+@pytest.mark.parametrize(
+    "enable_async, num_loops",
+    ((True, 5), (False, 1)),
+)
+def test_group_attn_matmul_with_program_cache(
+    num_loops, enable_async, in0_dtype, in1_dtype, output_dtype, sharded, device, use_program_cache
+):
     torch.manual_seed(0)
+
+    device.enable_async(enable_async)
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
@@ -255,68 +314,75 @@ def test_group_attn_matmul_with_program_cache(in0_dtype, in1_dtype, output_dtype
     # NOTE: Program is cached on out_subblock_w as well, so only seq_len >= 256 (out_subblock_w = 8) will share cache
     # For seq_len < = 256, recompile at worst 8 times.
     for K, seq_len, q_heads, kv_heads in ((96, 512 + 64, 10, 2), (64, 256, 50, 5)):
-        input_shape_a = [q_len, q_heads, batch, K]
-        input_shape_b = [batch, kv_heads, K, seq_len]
+        for _ in range(num_loops):
+            input_shape_a = [q_len, q_heads, batch, K]
+            input_shape_b = [batch, kv_heads, K, seq_len]
 
-        input_tensor_a = torch.randn(input_shape_a).bfloat16()
-        input_tensor_b = torch.randn(input_shape_b).bfloat16()
+            input_tensor_a = torch.randn(input_shape_a).bfloat16()
+            input_tensor_b = torch.randn(input_shape_b).bfloat16()
 
-        tt_input_tensor_a = (
-            ttl.tensor.Tensor(input_tensor_a, in0_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
-        )
-        tt_input_tensor_b = (
-            ttl.tensor.Tensor(input_tensor_b, in1_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
-        )
+            tt_input_tensor_a = (
+                ttl.tensor.Tensor(input_tensor_a, in0_dtype)
+                .to(ttl.tensor.Layout.TILE)
+                .to(device, interleaved_mem_config)
+            )
+            tt_input_tensor_b = (
+                ttl.tensor.Tensor(input_tensor_b, in1_dtype)
+                .to(ttl.tensor.Layout.TILE)
+                .to(device, interleaved_mem_config)
+            )
 
-        if sharded:
-            tt_input_tensor_a = ttl.tensor.interleaved_to_sharded(
+            if sharded:
+                tt_input_tensor_a = ttl.tensor.interleaved_to_sharded(
+                    tt_input_tensor_a,
+                    compute_grid_size,
+                    [q_len * batch, K],
+                    ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                    shard_orientation,
+                )
+
+                tt_input_tensor_b = ttl.tensor.interleaved_to_sharded(
+                    tt_input_tensor_b,
+                    compute_grid_size,
+                    [kv_heads * K, seq_len],
+                    ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                    shard_orientation,
+                )
+
+                output_mem_config = ttl.tensor.MemoryConfig(
+                    memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                    buffer_type=ttl.tensor.BufferType.L1,
+                )
+            else:
+                output_mem_config = interleaved_mem_config
+
+            num_cache_entries_start = device.num_program_cache_entries()
+            tt_output_tensor_on_device = ttl.operations.primary.transformers.group_attn_matmul(
                 tt_input_tensor_a,
-                compute_grid_size,
-                [q_len * batch, K],
-                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                shard_orientation,
-            )
-
-            tt_input_tensor_b = ttl.tensor.interleaved_to_sharded(
                 tt_input_tensor_b,
-                compute_grid_size,
-                [kv_heads * K, seq_len],
-                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                shard_orientation,
+                compute_with_storage_grid_size=compute_grid_size,
+                output_mem_config=output_mem_config,
+                output_dtype=output_dtype,
             )
+            num_cache_entries += device.num_program_cache_entries() - num_cache_entries_start
 
-            output_mem_config = ttl.tensor.MemoryConfig(
-                memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                buffer_type=ttl.tensor.BufferType.L1,
-            )
-        else:
-            output_mem_config = interleaved_mem_config
+            if sharded:
+                tt_output_tensor_on_device = ttl.tensor.sharded_to_interleaved(
+                    tt_output_tensor_on_device, interleaved_mem_config
+                )
 
-        num_cache_entries_start = device.num_program_cache_entries()
-        tt_output_tensor_on_device = ttl.operations.primary.transformers.group_attn_matmul(
-            tt_input_tensor_a,
-            tt_input_tensor_b,
-            compute_with_storage_grid_size=compute_grid_size,
-            output_mem_config=output_mem_config,
-            output_dtype=output_dtype,
-        )
-        num_cache_entries += device.num_program_cache_entries() - num_cache_entries_start
+            tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
-        if sharded:
-            tt_output_tensor_on_device = ttl.tensor.sharded_to_interleaved(
-                tt_output_tensor_on_device, interleaved_mem_config
-            )
+            input_tensor_a = input_tensor_a.to(torch.float)
+            input_tensor_b = torch.repeat_interleave(input_tensor_b.to(torch.float), q_heads // kv_heads, dim=1)
+            golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
 
-        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-
-        input_tensor_a = input_tensor_a.to(torch.float)
-        input_tensor_b = torch.repeat_interleave(input_tensor_b.to(torch.float), q_heads // kv_heads, dim=1)
-        golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
-
-        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-        assert allclose, f"FAILED: {output}"
+            allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+            assert allclose, f"FAILED: {output}"
 
     assert num_cache_entries == 1
+
+    device.enable_async(False)
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
@@ -345,10 +411,28 @@ def test_group_attn_matmul_with_program_cache(in0_dtype, in1_dtype, output_dtype
         (32, 32, 32, 2, 1),
     ),
 )
+@pytest.mark.parametrize(
+    "enable_async, num_loops",
+    ((True, 5), (False, 1)),
+)
 def test_group_attn_matmul_fp32(
-    batch, K, seq_len, q_heads, kv_heads, in0_sharded, in1_sharded, output_sharded, shard_orientation, in_dtype, device
+    num_loops,
+    enable_async,
+    batch,
+    K,
+    seq_len,
+    q_heads,
+    kv_heads,
+    in0_sharded,
+    in1_sharded,
+    output_sharded,
+    shard_orientation,
+    in_dtype,
+    device,
 ):
     torch.manual_seed(0)
+
+    device.enable_async(enable_async)
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
@@ -364,68 +448,69 @@ def test_group_attn_matmul_fp32(
     q_len = 1
     input_shape_a = [q_len, q_heads, batch, K]
     input_shape_b = [batch, kv_heads, K, seq_len]
+    for _ in range(num_loops):
+        input_tensor_a = torch.randn(input_shape_a).bfloat16()
+        input_tensor_b = torch.randn(input_shape_b).bfloat16()
 
-    input_tensor_a = torch.randn(input_shape_a).bfloat16()
-    input_tensor_b = torch.randn(input_shape_b).bfloat16()
+        tt_input_tensor_a = (
+            ttl.tensor.Tensor(input_tensor_a, in0_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
+        )
+        tt_input_tensor_b = (
+            ttl.tensor.Tensor(input_tensor_b, in1_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
+        )
 
-    tt_input_tensor_a = (
-        ttl.tensor.Tensor(input_tensor_a, in0_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
-    )
-    tt_input_tensor_b = (
-        ttl.tensor.Tensor(input_tensor_b, in1_dtype).to(ttl.tensor.Layout.TILE).to(device, interleaved_mem_config)
-    )
+        if in0_sharded:
+            tt_input_tensor_a = ttl.tensor.interleaved_to_sharded(
+                tt_input_tensor_a,
+                compute_grid_size,
+                [q_len * batch, K],
+                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                shard_orientation,
+            )
 
-    if in0_sharded:
-        tt_input_tensor_a = ttl.tensor.interleaved_to_sharded(
+        if in1_sharded:
+            tt_input_tensor_b = ttl.tensor.interleaved_to_sharded(
+                tt_input_tensor_b,
+                compute_grid_size,
+                [kv_heads * K, seq_len],
+                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                shard_orientation,
+            )
+
+        if output_sharded:
+            output_mem_config = ttl.tensor.MemoryConfig(
+                memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                buffer_type=ttl.tensor.BufferType.L1,
+            )
+        else:
+            output_mem_config = interleaved_mem_config
+
+        compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+
+        tt_output_tensor_on_device = ttl.operations.primary.transformers.group_attn_matmul(
             tt_input_tensor_a,
-            compute_grid_size,
-            [q_len * batch, K],
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            shard_orientation,
-        )
-
-    if in1_sharded:
-        tt_input_tensor_b = ttl.tensor.interleaved_to_sharded(
             tt_input_tensor_b,
-            compute_grid_size,
-            [kv_heads * K, seq_len],
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            shard_orientation,
+            compute_with_storage_grid_size=compute_grid_size,
+            output_mem_config=output_mem_config,
+            output_dtype=output_dtype,
+            compute_kernel_config=compute_kernel_config,
         )
+        if output_sharded:
+            tt_output_tensor_on_device = ttl.tensor.sharded_to_interleaved(
+                tt_output_tensor_on_device, interleaved_mem_config
+            )
 
-    if output_sharded:
-        output_mem_config = ttl.tensor.MemoryConfig(
-            memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            buffer_type=ttl.tensor.BufferType.L1,
-        )
-    else:
-        output_mem_config = interleaved_mem_config
+        tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=True,
-        packer_l1_acc=False,
-    )
+        input_tensor_a = input_tensor_a.to(torch.float)
+        input_tensor_b = torch.repeat_interleave(input_tensor_b.to(torch.float), q_heads // kv_heads, dim=1)
+        golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
 
-    tt_output_tensor_on_device = ttl.operations.primary.transformers.group_attn_matmul(
-        tt_input_tensor_a,
-        tt_input_tensor_b,
-        compute_with_storage_grid_size=compute_grid_size,
-        output_mem_config=output_mem_config,
-        output_dtype=output_dtype,
-        compute_kernel_config=compute_kernel_config,
-    )
-    if output_sharded:
-        tt_output_tensor_on_device = ttl.tensor.sharded_to_interleaved(
-            tt_output_tensor_on_device, interleaved_mem_config
-        )
-
-    tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-
-    input_tensor_a = input_tensor_a.to(torch.float)
-    input_tensor_b = torch.repeat_interleave(input_tensor_b.to(torch.float), q_heads // kv_heads, dim=1)
-    golden_output_tensor = (input_tensor_a.transpose(0, 2) @ input_tensor_b).transpose(0, 2)
-
-    allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
-    assert allclose, f"FAILED: {output}"
+        allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
+        assert allclose, f"FAILED: {output}"
+    device.enable_async(False)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -49,7 +49,7 @@ inline std::vector<std::uint32_t> create_random_vector_of_bfloat16(
     uint64_t num_bytes, int rand_max_float, int seed, float offset = 0.0f);
 
 template <typename T>
-std::vector<T> slice(std::vector<T> const &v, int m, int n);
+std::vector<T> slice_vec(std::vector<T> const &v, int m, int n);
 
 std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
     tt_metal::Device *device,
@@ -234,7 +234,7 @@ int main(int argc, char **argv) {
                     TT_ASSERT(false, "Core not in specified core ranges");
                 }
                 auto write_size = num_reqs_at_a_time * 512;
-                auto sliced_input = slice(input_vec, input_offset, input_offset + write_size - 1);
+                auto sliced_input = slice_vec(input_vec, input_offset, input_offset + write_size - 1);
                 tt_metal::detail::WriteToDeviceL1(device, core, cb_addr, sliced_input);
                 input_offset += (num_tiles_per_core) * 512;
             }
@@ -353,7 +353,7 @@ inline std::vector<std::uint32_t> create_random_vector_of_bfloat16(
 }
 
 template <typename T>
-std::vector<T> slice(std::vector<T> const &v, int m, int n) {
+std::vector<T> slice_vec(std::vector<T> const &v, int m, int n) {
     auto first = v.cbegin() + m;
     auto last = v.cbegin() + n + 1;
 
@@ -463,7 +463,7 @@ bool validation(
             tt_metal::detail::ReadFromDeviceL1(
                 device, core, cb_addr, num_reqs_at_a_time * single_tile_size, result_vec);
             auto result_bf16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-            auto sliced_input = slice(
+            auto sliced_input = slice_vec(
                 input_bf16,
                 (input_offset + num_tiles_per_core - num_reqs_at_a_time) * constants::TILE_HW,
                 (input_offset + num_tiles_per_core) * constants::TILE_HW - 1);
@@ -494,7 +494,7 @@ bool validation(
             uint32_t num_blocks = num_tiles_per_core / num_reqs_at_a_time;
 
             auto write_size = num_reqs_at_a_time * 512;
-            auto sliced_input = slice(input_vec, input_offset, input_offset + write_size - 1);
+            auto sliced_input = slice_vec(input_vec, input_offset, input_offset + write_size - 1);
             for (int block = 0; block < num_blocks; ++block) {
                 for (int req = 0; req < num_reqs_at_a_time * 512; ++req) {
                     auto index = input_offset + block * (num_reqs_at_a_time * 512) + req;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -21,7 +21,7 @@ using std::chrono::microseconds;
 using std::chrono::steady_clock;
 
 template <typename T>
-std::vector<T> slice(std::vector<T> const &v, int m, int n) {
+std::vector<T> slice_vec(std::vector<T> const &v, int m, int n) {
     auto first = v.cbegin() + m;
     auto last = v.cbegin() + n + 1;
 
@@ -304,7 +304,7 @@ int main(int argc, char **argv) {
                     }
 
                     auto sliced_tensor =
-                        slice(tensors[tensors_idx].get_values(), (index - cb_tiles) * 1024, index * 1024 - 1);
+                        slice_vec(tensors[tensors_idx].get_values(), (index - cb_tiles) * 1024, index * 1024 - 1);
 
                     if (print_tensor) {
                         print_vec(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -21,7 +21,7 @@ using std::chrono::microseconds;
 using std::chrono::steady_clock;
 
 template <typename T>
-std::vector<T> slice(std::vector<T> const &v, int m, int n) {
+std::vector<T> slice_vec(std::vector<T> const &v, int m, int n) {
     auto first = v.cbegin() + m;
     auto last = v.cbegin() + n + 1;
 
@@ -238,7 +238,7 @@ int main(int argc, char **argv) {
                         device, core, dst_cb_addr, cb_tiles * single_tile_size, result_vec);
                     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
                     auto sliced_tensor =
-                        slice(tensors[r * num_cores_c + c].get_values(), (Nt - cb_tiles) * 1024, Nt * 1024 - 1);
+                        slice_vec(tensors[r * num_cores_c + c].get_values(), (Nt - cb_tiles) * 1024, Nt * 1024 - 1);
 
                     if (print_tensor) {
                         print_vec(

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -10,6 +10,7 @@
 #include "tensor/tensor_utils.hpp"
 #include "common/bfloat16.hpp"
 #include "llrt/llrt.hpp"
+#include "tensor/types.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/common/math.hpp"
 
@@ -27,6 +28,7 @@ namespace tt {
 namespace tt_metal {
 
 Tensor::Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, Layout layout) : tensor_attributes(std::make_shared<TensorAttributes>(storage, shape, dtype, layout)) {
+    this->set_metadata_populated();
     std::visit(
         [&] (auto&& storage) {
             using StorageType = std::decay_t<decltype(storage)>;
@@ -35,14 +37,19 @@ Tensor::Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, L
             }
             else if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
                 TT_ASSERT(storage.buffer->device() != nullptr);
+                workers = {device()};
                 tensor_impl::validate_on_device_dtype_and_layout(storage.buffer->device(), dtype, layout);
+                // Increment main thread ref count for all tensors on device
+                this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
             }
             else if constexpr (std::is_same_v<StorageType, BorrowedStorage>) {
                 // do nothing
             } else if constexpr (std::is_same_v<StorageType, MultiDeviceStorage>) {
+                workers.reserve(storage.buffers.size());
                 for (const auto& buffer : storage.buffers) {
                     TT_ASSERT(buffer->device() != nullptr);
                     tensor_impl::validate_on_device_dtype_and_layout(buffer->device(), dtype, layout);
+                    workers.push_back(buffer->device());
                 }
             } else if constexpr (std::is_same_v<StorageType, MultiDeviceHostStorage>) {
                 // do nothing
@@ -58,14 +65,19 @@ Tensor::Tensor(const Storage storage, const Shape shape, DataType dtype, Layout 
     Tensor(storage, ttnn::Shape{shape}, dtype, layout) {}
 
 Tensor::~Tensor() {
+    this->deallocate_through_destructor = true;
     this->deallocate();
+    // Decrement main thread ref count for all tensors on device
+    if (this->workers.size()) {
+        this->tensor_attributes->decrement_main_thread_ref_count(this->workers.at(0));
+    }
     tensor_attributes.reset();
 }
 
 void Tensor::deallocate(bool force) {
     if (this->tensor_attributes.use_count()) {
         // Check if the attributes didn't get moved to another tensor.
-        // If not, we can call the deallocation steps on this tensor.
+        // If not, we can deallocate this tensor.
         std::visit(
                 [force, this](auto& storage) {
                     using T = std::decay_t<decltype(storage)>;
@@ -74,17 +86,27 @@ void Tensor::deallocate(bool force) {
                             std::visit([](auto&& buffer) { buffer.reset(); }, storage.buffer);
                         }
                     } else if constexpr (std::is_same_v<T, DeviceStorage>) {
-                        if (force or (this->tensor_attributes.use_count() == 1 and storage.buffer.use_count() == 1)) {
-                            // This tensor can be force deallocated by the user. Automatic memory management policy is to deallocate
-                            // this buffer on device when there are no more users: i.e. deallocate called on the last tensor_attributes
-                            // ptr owning this buffer (buffer has use_count of 1 and tensor attribute has a single user)
-                            DeallocateBuffer(*storage.buffer);
-                        }
-                        if (force or this->tensor_attributes.use_count() == 1) {
-                            // Safe to reset this ptr when forcing deallocation (handle is invalid)
-                            // Also safe when the tensor_attributes have a single user. If any other buffer owns this tensor,
-                            // the buffer will not get deleted
-                            storage.buffer.reset();
+                        if (this->workers.at(0)->in_main_thread()) {
+                            uint32_t ref_count_to_use = (this->workers.at(0)->get_worker_mode() == Device::WorkerQueueMode::SYNCHRONOUS) ? this->tensor_attributes.use_count() : this->tensor_attributes->main_thread_ref_count;
+                            if ((force or ref_count_to_use == 1) and not this->tensor_attributes->deallocated) {
+                                this->tensor_attributes->deallocated = true;
+                                this->workers.at(0)->push_work([force, *this] () mutable {
+                                    std::visit([force, this] (auto&& s) {
+                                        using type = std::decay_t<decltype(s)>;
+                                        if constexpr (std::is_same_v<type, DeviceStorage>) {
+                                            if (force or s.buffer.use_count() == 1) {
+                                                DeallocateBuffer(*(s.buffer));
+                                            }
+                                            // Safe to reset this buf object since this is the last reference (in the main thread) to the tensor attr object holding this buffer.
+                                            // If any other tensor handles hold this buffer, it will not be deleted, until the last handle goes out of scope
+                                            // or is deallocated.
+                                            s.buffer.reset();
+                                        }
+                                    }, this->tensor_attributes->storage);
+                                });
+                            }
+                        } else {
+                            TT_FATAL(this->deallocate_through_destructor, "Device tensors cannot be explictly deallocated in worker threads.");
                         }
                     } else if constexpr (std::is_same_v<T, BorrowedStorage>) {
                         if (force) {
@@ -116,6 +138,114 @@ void Tensor::deallocate(bool force) {
     }
 }
 
+bool Tensor::metadata_populated() const {
+    // Make a list of boolens for storage
+    return (this->tensor_attributes->metadata_populated).load();
+}
+
+void Tensor::set_metadata_populated() {
+    (this->tensor_attributes->metadata_populated).store(true);
+}
+
+void Tensor::wait_for_metadata_populated() const {
+    while (not this->metadata_populated());
+}
+
+void Tensor::deepcopy(const Tensor& other) {
+    // Wait until the tensor being copied is populated
+    other.wait_for_metadata_populated();
+    // Populate tensor metadata
+    this->set_shape(other.get_shape());
+    this->set_storage(other.get_storage());
+    this->set_dtype(other.get_dtype());
+    this->set_layout(other.get_layout());
+    // Set metadata populated flag for getters
+    this->set_metadata_populated();
+}
+
+void Tensor::populate_buffers_and_metadata(const Tensor& other) {
+    // Similar to deepcopy, but to be applied on a tensor that has an empty storage
+    // container initialized. Require tensor storage to be correctly initialized.
+    // Populate storage container with buffers + shapes
+    std::visit([this] (auto&& storage) {
+        using StorageType = std::decay_t<decltype(storage)>;
+        if constexpr(std::is_same_v<StorageType, OwnedStorage> or std::is_same_v<StorageType, DeviceStorage>) {
+            std::get<StorageType>(this->tensor_attributes->storage).buffer = storage.buffer;
+        } else if constexpr(std::is_same_v<StorageType, MultiDeviceHostStorage> or std::is_same_v<StorageType, MultiDeviceStorage>) {
+            std::get<StorageType>(this->tensor_attributes->storage).buffers = storage.buffers;
+            std::get<StorageType>(this->tensor_attributes->storage).shapes = storage.shapes;
+        }
+    }, other.get_storage()); // Non blocking storage query, since this is done for tensors that get created inside the worker thread
+    // Populate remaining MD
+    this->set_shape(other.get_shape());
+    this->set_dtype(other.get_dtype());
+    this->set_layout(other.get_layout());
+    this->set_metadata_populated();
+}
+
+std::vector<Device*> Tensor::get_workers(bool blocking) const {
+    // Initialize an empty worker vector (remains empty for host side storage)
+    std::vector<Device*> workers = {};
+    std::visit([this, blocking, &workers] (auto&& storage) {
+        using StorageType = std::decay_t<decltype(storage)>;
+        // Stall allowed if explictly blocking or running in sync mode
+        bool wait_for_tensor_populated = (Device::get_worker_mode() == Device::WorkerQueueMode::SYNCHRONOUS) or blocking;
+        // Assign workers only to device tensors
+        if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
+            // Either explictly syncing or workers are pre-populated (this will happen for device tensors if using the correct APIs).
+            TT_FATAL(wait_for_tensor_populated or (this->workers.size() == 1), "Worker Handles for tensor must be populated or blocking = true must be set in get_workers().");
+            if (this->workers.size() != 1) {
+                // Not populated - sync.
+                this->wait_for_metadata_populated();
+                workers = {this->device()};
+            } else {
+                // Already populated.
+                workers = this->workers;
+            }
+        } else if constexpr (std::is_same_v<StorageType, MultiDeviceStorage>) {
+            // Either explictly syncing or workers are pre-populated (this will happen for device tensors if using the correct APIs).
+            TT_FATAL(wait_for_tensor_populated or (this->workers.size() == storage.buffers.size()), "Worker Handles for tensor must be populated or blocking = true must be set in get_workers().");
+            if (this->workers.size() != storage.buffers.size()) {
+                // Not populated - sync.
+                this->wait_for_metadata_populated();
+                workers.reserve(storage.buffers.size());
+                for (const auto& buffer : storage.buffers) {
+                    // Already populated.
+                    workers.push_back(buffer->device());
+                }
+            } else {
+                workers = this->workers;
+            }
+        }
+    }, this->tensor_attributes->storage);
+    return workers;
+}
+
+// Getters - Spin until tensor is populated before querying tensor metadata
+const Tensor::TensorAttributes& Tensor::get_attr() const {
+    this->wait_for_metadata_populated();
+    return *tensor_attributes;
+}
+
+const Shape& Tensor::get_legacy_shape() const {
+    return this->get_attr().shape.value();
+}
+
+const ttnn::Shape& Tensor::get_shape() const {
+    return this->get_attr().shape;
+}
+const DataType& Tensor::get_dtype() const {
+    return this->get_attr().dtype;
+}
+const Layout& Tensor::get_layout() const {
+    return this->get_attr().layout;
+}
+
+const Storage& Tensor::get_storage() const {
+    // Per device bool for storage population for multidevice
+    return this->get_attr().storage;
+}
+
 Tensor Tensor::to(CommandQueue & queue, const MemoryConfig & mem_config) const {
     ZoneScoped;
     if (storage_type() == StorageType::DEVICE) {
@@ -128,19 +258,35 @@ Tensor Tensor::to(CommandQueue & queue, const MemoryConfig & mem_config) const {
 
 Tensor Tensor::to(Device *target_device, const MemoryConfig &mem_config) const {
     ZoneScoped;
-
-    if (storage_type() == StorageType::DEVICE) {
-        TT_ASSERT(this->device() == target_device && "Currently do not support moving between devices");
-        return *this;
-    }
-
-    tensor_impl::validate_on_device_dtype_and_layout(target_device, this->get_dtype(), this->get_layout());
-    return tensor_impl::to_device_wrapper(*this, target_device, mem_config);
+    // Populate device storage outside of thread, so that downstream
+    // functions running in main can get storage type without blocking
+    Tensor device_tensor({target_device});
+    device_tensor.tensor_attributes->storage = DeviceStorage();
+    // Record main thread ref count for tensors before pushing to queue.
+    uint32_t device_tensor_ref_count = device_tensor.tensor_attributes->record_main_thread_ref_count();
+    uint32_t original_tensor_ref_count =this->tensor_attributes->record_main_thread_ref_count();
+    target_device->push_work([*this, device_tensor, mem_config, target_device] () mutable {
+        if (this->storage_type() == StorageType::DEVICE) {
+            TT_ASSERT(this->device() == target_device && "Currently do not support moving between devices");
+            device_tensor.populate_buffers_and_metadata(*this);
+        }
+        else {
+            tensor_impl::validate_on_device_dtype_and_layout(target_device, this->get_dtype(), this->get_layout());
+            auto local_tensor = tensor_impl::to_device_wrapper(*this, target_device, mem_config);
+            // Populate device tensor
+            device_tensor.populate_buffers_and_metadata(local_tensor);
+        }
+    });
+    // Update main thread ref count for tensors after pushing to queue (update original tensor and returned tensor,
+    // since both can be on device).
+    device_tensor.tensor_attributes->update_main_thread_ref_count(device_tensor.workers.at(0), device_tensor_ref_count);
+    this->tensor_attributes->update_main_thread_ref_count(device_tensor.workers.at(0), original_tensor_ref_count);
+    return device_tensor;
 }
 
 Tensor Tensor::to(DeviceMesh *device_mesh, const MemoryConfig &mem_config) const {
     ZoneScoped;
-
+    TT_FATAL(device_mesh->get_devices().at(0)->get_worker_mode() == Device::WorkerQueueMode::SYNCHRONOUS, "Async mode is not currently supported for multi-device tensors");
     if (storage_type() == StorageType::MULTI_DEVICE_HOST) {
         auto& host_storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(this->get_storage());
         std::vector<DeviceBuffer> device_buffers;
@@ -151,11 +297,13 @@ Tensor Tensor::to(DeviceMesh *device_mesh, const MemoryConfig &mem_config) const
             shard = shard.to(&target_device, mem_config);
             device_buffers.push_back(std::get<DeviceStorage>(shard.get_storage()).buffer);
         }
-        return Tensor(
+        Tensor multi_device_tensor = Tensor(
             MultiDeviceStorage{std::move(device_buffers), host_storage.shapes},
             this->get_shape(),
             this->get_dtype(),
             this->get_layout());
+        multi_device_tensor.workers = device_mesh->get_devices();
+        return multi_device_tensor;
     } else if (std::holds_alternative<tt::tt_metal::MultiDeviceStorage>(this->get_storage())) {
         return *this; // already on device
     }
@@ -166,10 +314,34 @@ Tensor Tensor::to(DeviceMesh *device_mesh, const MemoryConfig &mem_config) const
 
 Tensor Tensor::cpu(bool blocking) const {
     ZoneScoped;
-    if (storage_type() == StorageType::OWNED) {
+    auto workers = this->get_workers(blocking);
+    if (not workers.size()) {
+        // Tensor is on host and does not have a worker group.
+        // Return immediately. If this is a result of .cpu() called twice,
+        // tensor accessors will stall until tensor is populated.
         return *this;
     }
-    return tensor_impl::to_host_wrapper(*this, blocking);
+
+    Tensor host_tensor;
+    // Populate host storage outside of thread, so that downstream
+    // functions running in main can get storage type without blocking
+    if (workers.size() == 1) {
+        host_tensor.tensor_attributes->storage = OwnedStorage();
+    } else {
+        host_tensor.tensor_attributes->storage = MultiDeviceHostStorage();
+    }
+    // Record main_thread_ref_count for tensor before pushing to queue.
+    uint32_t original_tensor_ref_count = this->tensor_attributes->record_main_thread_ref_count();
+    workers.at(0)->push_work([*this, host_tensor, blocking] () mutable {
+        TT_ASSERT(this->storage_type() == StorageType::DEVICE or this->storage_type() == StorageType::MULTI_DEVICE, "Can only use worker queue for cpu call if tensor is on device.");
+        auto local_tensor = tensor_impl::to_host_wrapper(*this, blocking);
+        // Populate host tensor
+        host_tensor.populate_buffers_and_metadata(local_tensor);
+    }, blocking);
+
+    // Update main_thread_ref_count for tensor after pushing to queue.
+    this->tensor_attributes->update_main_thread_ref_count(workers.at(0), original_tensor_ref_count);
+    return host_tensor;
 }
 
 Tensor Tensor::cpu_sharded() const {
@@ -353,8 +525,6 @@ StorageType Tensor::storage_type() const {
         this->get_storage()
     );
 }
-
-const Storage& Tensor::get_storage() const { return this->get_attr().storage; }
 
 namespace detail {
 const Shape compute_strides(const Shape& shape) {

--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -31,16 +31,54 @@ struct Tensor {
         ttnn::Shape shape;
         DataType dtype;
         Layout layout;
-
+        std::atomic<bool> metadata_populated = false;
+        uint32_t main_thread_ref_count = 0;
+        bool deallocated = false;
         TensorAttributes(const Storage storage, const ttnn::Shape shape, DataType dtype, Layout layout) : storage(storage), shape(shape), dtype(dtype), layout(layout) {}
         TensorAttributes() : shape({0xff, 0xff, 0xff, 0xff}), dtype(DataType::INVALID), layout(Layout::INVALID) {}
         ~TensorAttributes() = default;
+
+        // Use these functions to manage the main_thread_ref_count for a tensor attr instance.
+        // This variable is used for on device memory deallocation in async mode, where the main
+        // thread owns all tensors and enqueues a deallocate command for each shard, when a tensor
+        // is implcitly or explictly dellocated.
+        // Call increment when a tensor is default, copy or assignment constructed, since an additonal
+        // object will own a tensor_attr instance.
+        // Call decrement when a tensor is destroyed and the number of owners of the tensor_attr object
+        // decreases.
+        // Record the main thread ref count before pushing to a worker queue (number of owners in main thread).
+        // Update the main thread ref count with the recorded value after the tensor is pushed to the queue(s),
+        // since pushing to the queue requires an extra datacopy in the main thread, that gets balanced by the
+        // worker, howerver the worker cannot modify main_thread_ref_count.
+        void increment_main_thread_ref_count(Device* worker) {
+            if (worker->get_worker_mode() == Device::WorkerQueueMode::ASYNCHRONOUS and worker->in_main_thread()) {
+                main_thread_ref_count++;
+            }
+        }
+
+        void decrement_main_thread_ref_count(Device* worker) {
+            if (worker->get_worker_mode() == Device::WorkerQueueMode::ASYNCHRONOUS and worker->in_main_thread()) {
+                main_thread_ref_count--;
+            }
+        }
+
+        uint32_t record_main_thread_ref_count() {
+            return main_thread_ref_count;
+        }
+
+        void update_main_thread_ref_count(Device* worker, uint32_t ref_count) {
+            if (worker->get_worker_mode() == Device::WorkerQueueMode::ASYNCHRONOUS and worker->in_main_thread()) {
+                main_thread_ref_count = ref_count;
+            }
+        }
     };
 
     // Shared pointer to all attributes associated with this tensor
     // Can be safely passed between threads when the tensor is copied
     std::shared_ptr<TensorAttributes> tensor_attributes;
-
+    // Tensor gets worker queue handle through the device
+    std::vector<Device*> workers = {};
+    bool deallocate_through_destructor = false;
     // ======================================================================================
     //                                  Hi Level APIs
     // ======================================================================================
@@ -48,17 +86,47 @@ struct Tensor {
     Tensor(const Storage storage, const Shape shape, DataType dtype, Layout layout);
 
     // Default constructor to initialize empty tensor
-    Tensor() : tensor_attributes(std::make_shared<TensorAttributes>()) {}
+    Tensor(std::vector<Device*> workers = {}) : tensor_attributes(std::make_shared<TensorAttributes>()), workers(workers) {
+        if (workers.size()) {
+            if (this->workers.at(0)->in_main_thread()) {
+                this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
+            }
+        }
+    }
 
-    Tensor(const Tensor &other) = default;
-    Tensor &operator=(const Tensor &other) = default;
+    Tensor(const Tensor &other) {
+        this->workers = other.workers;
+        this->tensor_attributes = other.tensor_attributes;
+        if (this->workers.size()) {
+            if (this->workers.at(0)->in_main_thread()) {
+                this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
+            }
+        }
+    }
 
-    Tensor(Tensor &&other) = default;
+    Tensor &operator=(const Tensor &other) {
+        this->workers = other.workers;
+        this->tensor_attributes = other.tensor_attributes;
+        if (this->workers.size()) {
+            if (this->workers.at(0)->in_main_thread()) {
+                this->tensor_attributes->increment_main_thread_ref_count(this->workers.at(0));
+            }
+        }
+        return *this;
+    }
+
+    Tensor(Tensor &&other) noexcept : tensor_attributes(std::move(other.tensor_attributes)), workers(std::move(other.workers)) {};
     Tensor &operator=(Tensor &&other) = default;
 
     ~Tensor();
 
+    void deepcopy(const Tensor& other);
+
+    void populate_buffers_and_metadata(const Tensor& other);
+
     void deallocate(bool force = false);
+
+    std::vector<Device*> get_workers(bool blocking = false) const;
 
     Tensor to(
         Device *target_device,
@@ -101,14 +169,13 @@ struct Tensor {
     // ======================================================================================
     //                                      Getters
     // ======================================================================================
-    const TensorAttributes& get_attr() const { return *tensor_attributes; }
+    const TensorAttributes& get_attr() const;
     const Storage &get_storage() const;
-    const Shape &get_legacy_shape() const { return this->get_attr().shape.value(); }
-    const ttnn::Shape &get_shape() const { return this->get_attr().shape; }
-    const DataType& get_dtype() const { return this->get_attr().dtype; }
-    const Layout& get_layout() const { return this->get_attr().layout; }
-
-
+    const Shape &get_legacy_shape() const;
+    const ttnn::Shape &get_shape() const;
+    const DataType& get_dtype() const;
+    const Layout& get_layout() const;
+    bool metadata_populated() const;
     // ======================================================================================
     //                                      Setters
     // ======================================================================================
@@ -116,11 +183,11 @@ struct Tensor {
     void set_shape (const ttnn::Shape& shape) { this->tensor_attributes->shape = shape; }
     void set_dtype(const DataType& dtype) { this->tensor_attributes->dtype = dtype; }
     void set_layout(const Layout& layout) { this->tensor_attributes->layout = layout; }
-
+    void set_metadata_populated();
     // ======================================================================================
     //                                      Extra Helper Functions
     // ======================================================================================
-
+    void wait_for_metadata_populated() const;
     StorageType storage_type() const;
     const Shape strides() const;
     uint32_t volume() const;

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
@@ -324,9 +324,17 @@ inline Tensor matmul(
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     bool untilize_out = false
 ) {
-    auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
-    auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
-    return operation::run(Matmul{program_config, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val, untilize_out}, {input_tensor_a, input_tensor_b}, {std::nullopt}).at(0);
+    std::vector<Tensor> output_tensors = {Tensor(input_tensor_a.get_workers())};
+    operation::launch_op(
+        [program_config, mem_config, output_dtype, compute_kernel_config, untilize_out] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor_a = input_tensors.at(0);
+            const auto& input_tensor_b = input_tensors.at(1);
+            auto arch = input_tensor_a.device()->arch();
+            auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
+            return operation::run(Matmul{program_config, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val, untilize_out}, {input_tensor_a, input_tensor_b}, optional_input_tensors);
+        },
+    {input_tensor_a, input_tensor_b}, output_tensors, {std::nullopt});
+    return output_tensors.at(0);
 }
 
 inline Tensor matmul(
@@ -338,9 +346,17 @@ inline Tensor matmul(
     std::optional<const DataType> output_dtype = std::nullopt,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     bool untilize_out = false) {
-    auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
-    auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
-    return operation::run(Matmul{program_config, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val, untilize_out}, {input_tensor_a, input_tensor_b}, {bias}).at(0);
+    std::vector<Tensor> output_tensors = {Tensor(input_tensor_a.get_workers())};
+    operation::launch_op(
+        [program_config, mem_config, output_dtype, compute_kernel_config, untilize_out] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor_a = input_tensors.at(0);
+            const auto& input_tensor_b = input_tensors.at(1);
+            auto arch = input_tensor_a.device()->arch();
+            auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
+            return operation::run(Matmul{program_config, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val, untilize_out}, {input_tensor_a, input_tensor_b}, optional_input_tensors);
+        },
+    {input_tensor_a, input_tensor_b}, output_tensors, {bias});
+    return output_tensors.at(0);
 }
 
 Tensor matmul_1d(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, std::optional<MatmulMultiCoreReuseMultiCast1DProgramConfig> program_config = std::nullopt, const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::optional<const DataType> output_dtype=std::nullopt, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt, bool untilize_out = false);

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.hpp
@@ -168,7 +168,6 @@ constexpr auto logical_or = make_eltwise_binary<BinaryOpType::LOGICAL_OR>{};
 namespace operations {
 
 namespace primary {
-
 // TODO: in_place should not take output args
 inline Tensor add(
     const Tensor &input_tensor_a,

--- a/tt_eager/tt_dnn/op_library/run_operation.hpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.hpp
@@ -348,6 +348,13 @@ inline std::vector<Tensor> run_with_autoformat(
     return run_with_autoformat(operation, input_tensors, input_formatting, output_layouts, optional_input_tensors, optional_input_formatting);
 }
 
+void launch_op(
+    std::function<std::vector<Tensor>(const std::vector<Tensor>&, const std::vector<std::optional<const Tensor>>&)> op_func,
+    const std::vector<Tensor> input_tensors,
+    std::vector<Tensor>& output_tensors,
+    const std::vector<std::optional<const Tensor>> optional_input_tensors = {}
+);
+
 } //namespace operation
 
 } //namespace tt::tt_metal

--- a/tt_eager/tt_dnn/op_library/sharded/sharded_op.hpp
+++ b/tt_eager/tt_dnn/op_library/sharded/sharded_op.hpp
@@ -57,44 +57,50 @@ inline Tensor interleaved_to_sharded(
     const TensorMemoryLayout shard_scheme,
     const ShardOrientation shard_orientation,
     const std::optional<const DataType> output_dtype = std::nullopt) {
-    bool row_wise = shard_orientation == ShardOrientation::ROW_MAJOR;
-    CoreCoord grid_size;
-    CoreRangeSet grid_set({});
-    std::visit(
-        [&](const auto &grid) {
-            using GridType = std::decay_t<decltype(grid)>;
-            if constexpr (std::is_same_v<GridType, CoreCoord>) {
-                grid_size = grid;
-                uint32_t num_cores = 0;
-                uint32_t total_height = input_tensor.volume() / input_tensor.get_legacy_shape()[-1];
-                uint32_t total_width = input_tensor.get_legacy_shape()[-1];
-                switch (shard_scheme) {
-                    case TensorMemoryLayout::HEIGHT_SHARDED: num_cores = div_up(total_height, shard_shape[0]); break;
-                    case TensorMemoryLayout::WIDTH_SHARDED: num_cores = div_up(total_width, shard_shape[1]); break;
-                    case TensorMemoryLayout::BLOCK_SHARDED:
-                        num_cores = div_up(total_height, shard_shape[0]) * div_up(total_width, shard_shape[1]);
-                        break;
-                    default: TT_ASSERT(false, "Unsupported sharding scheme");
-                }
-                grid_set = num_cores_to_corerange_set(num_cores, grid_size, row_wise);
-            } else if constexpr (std::is_same_v<GridType, CoreRangeSet>) {
-                auto bbox = grid.bounding_box();
-                grid_size = CoreCoord{bbox.end.x + 1, bbox.end.y + 1};
-                grid_set = grid;
-            }
+    std::vector<Tensor> output_tensors = {Tensor(input_tensor.get_workers())};
+    operation::launch_op(
+        [grid, shard_shape, shard_scheme, shard_orientation, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) -> std::vector<Tensor> {
+            const auto& input_tensor = input_tensors.at(0);
+            bool row_wise = shard_orientation == ShardOrientation::ROW_MAJOR;
+            CoreCoord grid_size;
+            CoreRangeSet grid_set({});
+            std::visit(
+                [&](const auto &grid) {
+                    using GridType = std::decay_t<decltype(grid)>;
+                    if constexpr (std::is_same_v<GridType, CoreCoord>) {
+                        grid_size = grid;
+                        uint32_t num_cores = 0;
+                        uint32_t total_height = input_tensor.volume() / input_tensor.get_legacy_shape()[-1];
+                        uint32_t total_width = input_tensor.get_legacy_shape()[-1];
+                        switch (shard_scheme) {
+                            case TensorMemoryLayout::HEIGHT_SHARDED: num_cores = div_up(total_height, shard_shape[0]); break;
+                            case TensorMemoryLayout::WIDTH_SHARDED: num_cores = div_up(total_width, shard_shape[1]); break;
+                            case TensorMemoryLayout::BLOCK_SHARDED:
+                                num_cores = div_up(total_height, shard_shape[0]) * div_up(total_width, shard_shape[1]);
+                                break;
+                            default: TT_ASSERT(false, "Unsupported sharding scheme");
+                        }
+                        grid_set = num_cores_to_corerange_set(num_cores, grid_size, row_wise);
+                    } else if constexpr (std::is_same_v<GridType, CoreRangeSet>) {
+                        auto bbox = grid.bounding_box();
+                        grid_size = CoreCoord{bbox.end.x + 1, bbox.end.y + 1};
+                        grid_set = grid;
+                    }
+                },
+                grid);
+            ShardSpec shard_spec(grid_set, shard_shape, shard_orientation);
+            MemoryConfig sharded_mem_config = MemoryConfig{.memory_layout = shard_scheme, .buffer_type = BufferType::L1};
+            return operation::run(
+                    Sharded{
+                        .grid_size = grid_size,
+                        .shard_spec = shard_spec,
+                        .sharded_op_type = ShardedOpType::InterleavedToSharded,
+                        .output_mem_config = sharded_mem_config,
+                        .output_dtype = output_dtype.value_or(input_tensor.get_dtype())},
+                    {input_tensor});
         },
-        grid);
-    ShardSpec shard_spec(grid_set, shard_shape, shard_orientation);
-    MemoryConfig sharded_mem_config = MemoryConfig{.memory_layout = shard_scheme, .buffer_type = BufferType::L1};
-    return operation::run(
-               Sharded{
-                   .grid_size = grid_size,
-                   .shard_spec = shard_spec,
-                   .sharded_op_type = ShardedOpType::InterleavedToSharded,
-                   .output_mem_config = sharded_mem_config,
-                   .output_dtype = output_dtype.value_or(input_tensor.get_dtype())},
-               {input_tensor})
-        .at(0);
+    {input_tensor}, output_tensors);
+    return output_tensors.at(0);
 }
 
 // start is inclusive, end is exclusive
@@ -127,35 +133,47 @@ inline Tensor interleaved_to_sharded(
     const Tensor &input_tensor,
     const MemoryConfig &sharded_mem_config,
     std::optional<const DataType> output_dtype = std::nullopt) {
-    TT_FATAL(sharded_mem_config.is_sharded());
-    auto bbox = sharded_mem_config.shard_spec.value().grid.bounding_box();
-    CoreCoord grid_size(bbox.end.x + 1, bbox.end.y + 1);
-    return operation::run(
-               Sharded{
-                   .grid_size = grid_size,
-                   .shard_spec = sharded_mem_config.shard_spec.value(),
-                   .sharded_op_type = ShardedOpType::InterleavedToSharded,
-                   .output_mem_config = sharded_mem_config,
-                   .output_dtype = output_dtype.value_or(input_tensor.get_dtype())},
-               {input_tensor})
-        .at(0);
+    std::vector<Tensor> output_tensors = {Tensor(input_tensor.get_workers())};
+    operation::launch_op(
+        [sharded_mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) -> std::vector<Tensor> {
+            const auto& input_tensor = input_tensors.at(0);
+            TT_FATAL(sharded_mem_config.is_sharded());
+            auto bbox = sharded_mem_config.shard_spec.value().grid.bounding_box();
+            CoreCoord grid_size(bbox.end.x + 1, bbox.end.y + 1);
+            return operation::run(
+                    Sharded{
+                        .grid_size = grid_size,
+                        .shard_spec = sharded_mem_config.shard_spec.value(),
+                        .sharded_op_type = ShardedOpType::InterleavedToSharded,
+                        .output_mem_config = sharded_mem_config,
+                        .output_dtype = output_dtype.value_or(input_tensor.get_dtype())},
+                    {input_tensor});
+        },
+    {input_tensor}, output_tensors);
+    return output_tensors.at(0);
 }
 
 inline Tensor sharded_to_interleaved(
     const Tensor &input_tensor,
     const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<const DataType> output_dtype = std::nullopt) {
-    TT_FATAL(input_tensor.shard_spec().has_value());
-    auto shard_spec = input_tensor.shard_spec().value();
-    return operation::run(
-               Sharded{
-                   .grid_size = input_tensor.device()->compute_with_storage_grid_size(),
-                   .shard_spec = shard_spec,
-                   .sharded_op_type = ShardedOpType::ShardedToInterleaved,
-                   .output_mem_config = output_mem_config,
-                   .output_dtype = output_dtype.value_or(input_tensor.get_dtype())},
-               {input_tensor})
-        .at(0);
+    std::vector<Tensor> output_tensors = {Tensor(input_tensor.get_workers())};
+    operation::launch_op(
+        [output_mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) -> std::vector<Tensor> {
+            const auto& input_tensor = input_tensors.at(0);
+            TT_FATAL(input_tensor.shard_spec().has_value());
+            auto shard_spec = input_tensor.shard_spec().value();
+            return operation::run(
+                    Sharded{
+                        .grid_size = input_tensor.device()->compute_with_storage_grid_size(),
+                        .shard_spec = shard_spec,
+                        .sharded_op_type = ShardedOpType::ShardedToInterleaved,
+                        .output_mem_config = output_mem_config,
+                        .output_dtype = output_dtype.value_or(input_tensor.get_dtype())},
+                    {input_tensor});
+        },
+    {input_tensor}, output_tensors);
+    return output_tensors.at(0);
 }
 
 inline Tensor reshard(const Tensor &input_tensor, const MemoryConfig &output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
@@ -76,9 +76,17 @@ struct AttnMatmul {
 };
 
 inline Tensor attn_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const CoreCoord& compute_with_storage_grid_size, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
-    auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
-    auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
-    return operation::run(AttnMatmul{std::nullopt, std::nullopt, compute_with_storage_grid_size, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val}, {input_tensor_a, input_tensor_b}).at(0);
+    std::vector<Tensor> output_tensors = {Tensor(input_tensor_a.get_workers())};
+    operation::launch_op(
+        [compute_with_storage_grid_size, mem_config, output_dtype, compute_kernel_config] (std::vector<Tensor> input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor_a = input_tensors.at(0);
+            const auto& input_tensor_b = input_tensors.at(1);
+            auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
+            auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
+            return operation::run(AttnMatmul{std::nullopt, std::nullopt, compute_with_storage_grid_size, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val}, {input_tensor_a, input_tensor_b});
+        },
+    {input_tensor_a, input_tensor_b}, output_tensors);
+    return output_tensors.at(0);
 }
 
 inline Tensor attn_matmul_from_cache(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const uint32_t num_tokens, const bool transpose_hw, const CoreCoord& compute_with_storage_grid_size, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
@@ -110,37 +118,45 @@ struct GroupAttnMatmul {
 };
 
 inline Tensor group_attn_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const CoreCoord& compute_with_storage_grid_size, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
-    bool row_major = false;
-    // GroupAttnMatmul::validate will check that any sharded memory configs have same orientation
-    if (input_tensor_a.is_sharded()) {
-        row_major = input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
-    } else if (input_tensor_b.is_sharded()) {
-        row_major = input_tensor_b.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
-    } else if (mem_config.is_sharded()) {
-        if (mem_config.shard_spec.has_value()) {
-            row_major = mem_config.shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
-        }
-    }
+    std::vector<Tensor> output_tensors = {Tensor(input_tensor_a.get_workers())};
+    operation::launch_op(
+        [compute_with_storage_grid_size, mem_config, output_dtype, compute_kernel_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor_a = input_tensors.at(0);
+            const auto& input_tensor_b = input_tensors.at(1);
+            bool row_major = false;
+            // GroupAttnMatmul::validate will check that any sharded memory configs have same orientation
+            if (input_tensor_a.is_sharded()) {
+                row_major = input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
+            } else if (input_tensor_b.is_sharded()) {
+                row_major = input_tensor_b.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
+            } else if (mem_config.is_sharded()) {
+                if (mem_config.shard_spec.has_value()) {
+                    row_major = mem_config.shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+                }
+            }
 
-    auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
-    auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
+            auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
+            auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
 
-    // Need to cache on out_subblock_w because it must be a compile time arg for optimal use of templated pack_untilize APIs
-    const uint32_t Nt = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
-    constexpr uint32_t HALF_DST_MAX = 8; // 8 is the max number of tiles for half DST (assuming out_subblock_h == 1)
-    constexpr uint32_t HALF_DST_MAX_FP32 = 4; // max dst tiles are 4 for fp32
-    uint32_t out_subblock_w;
+            // Need to cache on out_subblock_w because it must be a compile time arg for optimal use of templated pack_untilize APIs
+            const uint32_t Nt = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
+            constexpr uint32_t HALF_DST_MAX = 8; // 8 is the max number of tiles for half DST (assuming out_subblock_h == 1)
+            constexpr uint32_t HALF_DST_MAX_FP32 = 4; // max dst tiles are 4 for fp32
+            uint32_t out_subblock_w;
 
-    std::visit([&](auto&& kernel_config_val) {
-        using T = std::decay_t<decltype(kernel_config_val)>;
-        if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            out_subblock_w = kernel_config_val.fp32_dest_acc_en ? std::min(Nt, HALF_DST_MAX_FP32) : std::min(Nt, HALF_DST_MAX);
-        } else {
-            out_subblock_w = std::min(Nt, HALF_DST_MAX);
-        }
-    }, kernel_config_val);
+            std::visit([&](auto&& kernel_config_val) {
+                using T = std::decay_t<decltype(kernel_config_val)>;
+                if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
+                    out_subblock_w = kernel_config_val.fp32_dest_acc_en ? std::min(Nt, HALF_DST_MAX_FP32) : std::min(Nt, HALF_DST_MAX);
+                } else {
+                    out_subblock_w = std::min(Nt, HALF_DST_MAX);
+                }
+            }, kernel_config_val);
 
-    return operation::run(GroupAttnMatmul{std::nullopt, std::nullopt, out_subblock_w, compute_with_storage_grid_size, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), row_major, kernel_config_val}, {input_tensor_a, input_tensor_b}).at(0);
+            return operation::run(GroupAttnMatmul{std::nullopt, std::nullopt, out_subblock_w, compute_with_storage_grid_size, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), row_major, kernel_config_val}, {input_tensor_a, input_tensor_b});
+        },
+    {input_tensor_a, input_tensor_b}, output_tensors);
+    return output_tensors.at(0);
 }
 
 }  // namespace transformers

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -42,7 +42,8 @@ void DeviceModule(py::module &m_device) {
             "Convert a logical core coordinate into a physical worker core coordinate")
         .def("enable_program_cache", &Device::enable_program_cache, "Enable caching for all programs sent to this device")
         .def("disable_and_clear_program_cache", &Device::disable_and_clear_program_cache, "Disable and clear program cache for this device")
-        .def("num_program_cache_entries", &Device::num_program_cache_entries, "Number of entries in the program cache for this device");
+        .def("num_program_cache_entries", &Device::num_program_cache_entries, "Number of entries in the program cache for this device")
+        .def("enable_async", &Device::enable_async);
     // *** eps constant ***
     m_device.attr("EPS_GS") = EPS_GS;
     m_device.attr("EPS_WHB0") = EPS_WHB0;

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -270,7 +270,6 @@ void Buffer::deallocate() {
     // Mark as deallocated
     this->size_ = 0;
     TT_ASSERT(this->device_->allocator_ != nullptr, "Expected allocator to be initialized!");
-    // Asynchronously deallocate
     detail::BUFFER_MAP.erase({this->device_->id(), this->address_});
     detail::DeallocateBuffer(this);
 }

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include "tt_metal/common/assert.hpp"
 
@@ -29,8 +30,16 @@ class LockFreeQueue {
         }
 
     public:
+        // Optional - Set these if the worker and parent thread state needs to be tracked
+        std::atomic<uint64_t> worker_thread_id = 0;
+        std::atomic<uint64_t> parent_thread_id = 0;
         LockFreeQueue() : head(new Node), tail(head.load()) {}
-
+        LockFreeQueue(LockFreeQueue&& other) {
+            head.store(other.head.load());
+            tail.store(other.tail.load());
+            worker_thread_id.store(other.worker_thread_id.load());
+            parent_thread_id.store(other.parent_thread_id.load());
+        }
         void push(const T& value) {
             std::shared_ptr<T> newData(std::make_shared<T>(value));
             Node* newNode = new Node;


### PR DESCRIPTION
- Support for use cases with single device per tensor added
- All host <--> device data paths go through worker queue, which gets asynchronously read by worker thread
- Worker thread will populate tensor data and metadata asynchronously
- Tensor accessors made blocking -> cannot access tensor attributes until tensor is populated 
- Added C++ eltwise binary and Python attention matmul tests using async data path
- Update several ops to use async launch path (including shard, attn_matmul, bmm and eltwise binary ops)
- **Special handling for tensor deallocation** (when explicitly called by user): Need to synchronize with worker queue for now
