### PR TITLE
FD2.0 Test fix test_prefetcher add_paged_dram_data_to_worker_data dropping start_page

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -294,7 +294,7 @@ void add_paged_dram_data_to_worker_data(const unordered_map<uint32_t, vector<uin
 
     // Get data from DRAM map, add to all workers, but only set valid for cores included in workers range.
     TT_ASSERT(start_page < num_dram_banks_g);
-    for (uint32_t page_idx = 0; page_idx < pages; page_idx++) {
+    for (uint32_t page_idx = start_page; page_idx < start_page + pages; page_idx++) {
 
         uint32_t dram_bank_id = page_idx % num_dram_banks_g;
         uint32_t bank_offset = base_addr_words + page_size_words * (page_idx / num_dram_banks_g);


### PR DESCRIPTION
A test fix, thx Paul for flagging


    #5480: FD2.0 Test fix test_prefetcher add_paged_dram_data_to_worker_data dropping start_page

     - Fixes issue in my last change, breaking -t 0 and -t 1 smoke and rnd tests (sorry!)