### PR TITLE
Minor EDM optimization - 0-1GBps bump

### DIFF
--- a/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
@@ -37,9 +37,10 @@ class AllGatherConfig {
         this->eth_sems_l1_base_byte_address = this->erisc_handshake_address + 16;
         this->semaphore_offset = this->semaphore_size * this->num_buffers; // TODO: Remove this once dedicated semaphore space for user kernels are added
         this->eth_buffers_l1_base_byte_address = this->eth_sems_l1_base_byte_address + this->semaphore_offset;
+        this->eth_channel_headers_size = this->num_buffers * 16;
 
         uint32_t const page_size = input_tensor.buffer()->page_size();
-        this->eth_buffer_size = round_down((total_l1_buffer_space - this->semaphore_offset) / this->num_buffers, page_size);
+        this->eth_buffer_size = round_down((total_l1_buffer_space - this->semaphore_offset - this->eth_channel_headers_size) / this->num_buffers, page_size);
 
         TT_FATAL(eth_buffer_size == 0 or num_buffers <= eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS);
         TT_FATAL(this->eth_buffer_size * this->num_buffers + this->semaphore_offset <= total_l1_buffer_space);
@@ -118,6 +119,7 @@ class AllGatherConfig {
     uint32_t semaphore_offset;
     uint32_t eth_buffers_l1_base_byte_address;
     uint32_t eth_sems_l1_base_byte_address;
+    uint32_t eth_channel_headers_size;
     bool is_sharded;
     const bool enable_bidirectional;
     const bool input_is_dram;

--- a/tt_eager/tt_dnn/op_library/all_gather/multi_core/all_gather_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/multi_core/all_gather_op_multi_core.cpp
@@ -298,7 +298,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
         eth_sem_addrs.push_back(eth_sem_addr);
         eth_sem_addr += all_gather_config.get_semaphore_size();
         eth_buffer_addrs.push_back(eth_buffer_addr);
-        eth_buffer_addr += all_gather_config.get_eth_buffer_size();
+        eth_buffer_addr += (all_gather_config.get_eth_buffer_size() + 16);
+        TT_ASSERT((eth_buffer_addr - 16) % 16 == 0);
     }
 
     for (uint32_t i = 0; i < num_links; ++i) {
@@ -405,7 +406,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                 (num_full_chunks_per_worker.at(b) + (rem_pages_per_worker.at(b) > 0 ? 1 : 0)) *
                 num_transfers);
             edm_semaphores_base_address.push_back(all_gather_config.get_eth_sems_l1_base_byte_address() + b * all_gather_config.get_semaphore_size());
-            link_buffer_sender_addresses.push_back(all_gather_config.get_eth_buffers_l1_base_byte_address() + b * all_gather_config.get_eth_buffer_size());
+            link_buffer_sender_addresses.push_back(all_gather_config.get_eth_buffers_l1_base_byte_address() + b * (all_gather_config.get_eth_buffer_size() + 16));
+            TT_ASSERT((link_buffer_sender_addresses.back() + all_gather_config.get_eth_buffer_size()) % 16 == 0);
         }
         for(uint32_t b = 0; b < all_gather_config.get_num_buffers_per_link(); ++b) {
             log_trace(tt::LogOp, "rem_pages_per_worker[{}]: {}", b, rem_pages_per_worker.at(b));
@@ -424,7 +426,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                 (num_full_chunks_per_worker.at(b) + (rem_pages_per_worker.at(b) > 0 ? 1 : 0)) *
                 num_transfers);
             receiver_semaphores_base_address.push_back(all_gather_config.get_eth_sems_l1_base_byte_address() + b * all_gather_config.get_semaphore_size());
-            link_buffer_receiver_addresses.push_back(all_gather_config.get_eth_buffers_l1_base_byte_address() + b * all_gather_config.get_eth_buffer_size());
+            link_buffer_receiver_addresses.push_back(all_gather_config.get_eth_buffers_l1_base_byte_address() + b * (all_gather_config.get_eth_buffer_size() + 16));
+            TT_ASSERT((link_buffer_sender_addresses.back() + all_gather_config.get_eth_buffer_size()) % 16 == 0);
         }
 
 

--- a/tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp
@@ -192,7 +192,7 @@ void kernel_main() {
         (sender_channels_start < receiver_channels_start || receiver_num_channels == 0) && sender_num_channels > 0;
     erisc::datamover::eth_setup_handshake(handshake_addr, act_as_sender_in_handshake);
 
-    constexpr uint32_t SWITCH_INTERVAL = 4000000;
+    constexpr uint32_t SWITCH_INTERVAL = 1000000000;
     uint32_t did_nothing_count = 0;
 
     uint32_t num_senders_complete = !enable_sender_side ? sender_num_channels : num_senders_with_no_work;


### PR DESCRIPTION
We reordered EDM receiver worker notification and EDM sender ack to minimize worker bubbles.

# TODO:

- [ ] Get full measurements for respresentative set of configs
- [ ] 
[num_numbers.csv](https://github.com/tenstorrent-metal/tt-metal/files/14729619/num_numbers.csv)


[old_numbers.csv](https://github.com/tenstorrent-metal/tt-metal/files/14729706/old_numbers.csv)
