### PR TITLE
#6443: Update backward asin and addcdiv logic

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -18,11 +18,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 @pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 5.0])
 def test_bw_addcdiv(input_shapes, value, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    tensor1_data, tensor1_tensor = data_gen_pt_tt(input_shapes, device, True)
-    tensor2_data, tensor2_tensor = data_gen_pt_tt(input_shapes, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    tensor1_data, tensor1_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    tensor2_data, tensor2_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device, False)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, False)
 
     tt_output_tensor_on_device = tt_lib.tensor.addcdiv_bw(
         grad_tensor, input_tensor, tensor1_tensor, tensor2_tensor, value
@@ -38,5 +38,5 @@ def test_bw_addcdiv(input_shapes, value, device):
 
     golden_tensor = [in_data.grad, tensor1_data.grad, tensor2_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
-    assert status
+    comp_pcc = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pcc

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_asin.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_asin.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_asin(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     pyt_y = torch.asin(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.asin_bw(grad_tensor, input_tensor)
@@ -28,5 +28,5 @@ def test_bw_asin(input_shapes, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
-    assert comp_pass
+    comp_pcc = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pcc


### PR DESCRIPTION
#6443  Updated logic for backward Asin , Addcdiv ops

Issues addressed : 
- **Addcdiv** : 
   - Updated logic to get inf / -inf if tensor_2 is 0. 
   - Checked PCC and All close - both passes
   - Updated test file to check for range ( -100, 100 )
- **Asin** : 
   - Updated logic to get nan / inf / -inf based on input tensor. 
   - Checked PCC and All close - both passes
   - Updated test file to check for range ( -100, 100 )

All post-commit tests - [Link](https://github.com/tenstorrent-metal/tt-metal/actions/runs/8403461073) - PASSED