### PR TITLE
#6443: Update div_bw and backward ops test file

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_abs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_abs.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_abs(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     pyt_y = torch.abs(in_data)
 
@@ -30,5 +30,5 @@ def test_bw_abs(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,9 +17,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_add(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.add_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -32,5 +32,5 @@ def test_bw_add(input_shapes, device):
 
     golden_tensor = [in_data.grad, other_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -18,9 +18,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 @pytest.mark.parametrize("alpha", [0.05, 1.0, 0.5, 0.12])
 def test_bw_addalpha(input_shapes, alpha, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.addalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
 
@@ -33,5 +33,5 @@ def test_bw_addalpha(input_shapes, alpha, device):
 
     golden_tensor = [in_data.grad, other_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -18,11 +18,10 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 @pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 0.12])
 def test_bw_addcmul(input_shapes, value, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    tensor1_data, tensor1_tensor = data_gen_pt_tt(input_shapes, device, True)
-    tensor2_data, tensor2_tensor = data_gen_pt_tt(input_shapes, device, True)
-
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    tensor1_data, tensor1_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    tensor2_data, tensor2_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.addcmul_bw(
         grad_tensor, input_tensor, tensor1_tensor, tensor2_tensor, value
@@ -38,5 +37,5 @@ def test_bw_addcmul(input_shapes, value, device):
 
     golden_tensor = [in_data.grad, tensor1_data.grad, tensor2_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_angle.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_angle.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_angle(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     pyt_y = torch.angle(in_data)
 
@@ -30,5 +30,5 @@ def test_bw_angle(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_assign.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_assign.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,10 +17,10 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_binary_assign(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.binary_assign_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -31,5 +31,5 @@ def test_bw_binary_assign(input_shapes, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -25,16 +25,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_div(input_shapes, round_mode, device):
-    in_data = torch.Tensor(size=input_shapes).uniform_()
-    in_data.requires_grad = True
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-    grad_data = torch.Tensor(size=input_shapes).uniform_()
-    grad_tensor = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
     pyt_y = torch.div(in_data, other_data, rounding_mode=round_mode)
 
@@ -48,5 +41,5 @@ def test_bw_div(input_shapes, round_mode, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad, other_data.grad]
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_softplus.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_softplus.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -18,15 +18,15 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 @pytest.mark.parametrize(
     "beta",
-    [0.5, -3, 1, 4],
+    [0.5, -3, 1, 4, 0],
 )
 @pytest.mark.parametrize(
     "threshold",
-    [-20, -10, 10, 20, 5],
+    [-20, -10, 10, 20, 5, 0],
 )
 def test_bw_softplus(input_shapes, beta, threshold, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     in_data.retain_grad()
 
@@ -38,5 +38,5 @@ def test_bw_softplus(input_shapes, beta, threshold, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_assign.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_assign.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_unary_assign(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_assign_bw(grad_tensor, input_tensor)
 
@@ -30,5 +30,5 @@ def test_bw_unary_assign(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status


### PR DESCRIPTION
#6443  Updated logic for backward Binary Div op and updated few backward test files

Issues addressed : 
- **Div** : 
   - Updated logic to get nan / inf / -inf based on input. 
   - Checked PCC and All close - both passes
   - Updated test file to check for range ( -100, 100 )
- **Test file Updated for the following ops** : 
   - Abs
   - Add
   - Addalpha
   - Addcmul
   - Angle
   - Binary assign
   - Unary assign
   - Div
   - Softplus

All post-commit tests - [Link](https://github.com/tenstorrent-metal/tt-metal/actions/runs/8422048331) - PASSED