### PR TITLE
  #6553: Fix ttnn.reshape(..) handling for bfloat16, TILE_LAYOUT

### DIFF
--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -109,3 +109,29 @@ def test_reshape_with_negative_dim(device):
     assert list(expected_output_shape) == list(torch_output.shape)
     assert list(expected_output_shape) == list(tt_output.shape)
     assert_with_pcc(torch_output, tt_output, 0.9999)
+
+
+def test_reshape_tile_layout_mamba(device):
+    torch_input_tensor = torch.randn((1, 1, 32, 2048 * 32), dtype=torch.bfloat16)
+    reshape_shape = (1, 32, 2048, 32)
+    torch_result = torch_input_tensor.reshape(reshape_shape)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    ttnn_output = ttnn.reshape(input_tensor, reshape_shape)
+
+    output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_result, output, 0.9999)
+
+
+def test_reshape_tile_layout_only_change_shape(device):
+    torch_input_tensor = torch.randn((1, 64, 32, 4 * 32), dtype=torch.bfloat16)
+    reshape_shape = (1, 32, 64, 4 * 32)
+    torch_result = torch_input_tensor.reshape(reshape_shape)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    ttnn_output = ttnn.reshape(input_tensor, reshape_shape)
+
+    output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_result, output, 0.9999)

--- a/ttnn/cpp/ttnn/operations/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core.hpp
@@ -58,12 +58,16 @@ inline ttnn::Tensor reshape(const ttnn::Tensor& tensor, const ttnn::Shape& shape
         const auto new_shape_with_tile_padding = shape.with_tile_padding();
         const auto new_height = new_shape_with_tile_padding[-2];
         const auto new_width = new_shape_with_tile_padding[-1];
-        if (new_height % ttnn::TILE_SIZE == 0 && new_width % ttnn::TILE_SIZE == 0) {
-            return reshape_helper(tensor, shape);
-        } else {
+
+        const auto is_tile_multiple = (new_height % ttnn::TILE_SIZE == 0 && new_width % ttnn::TILE_SIZE == 0);
+        if (not is_tile_multiple) {
             TT_THROW(
                 "Unable to reshape a tensor in TILE_LAYOUT to non-tile height and width! Please convert the tensor to "
                 "ROW_MAJOR_LAYOUT first.");
+        }
+
+        if (tensor_shape.with_tile_padding()[-1] == new_width) {
+            return reshape_helper(tensor, shape);
         }
     }
 


### PR DESCRIPTION
If layout was TILE_LAYOUT, the code previously would just invoke tensor.reshape(..) which only updates the shape. This is only correct when old_shape.width == new_shape.width.