### PR TITLE
#5249: Various Falcon40b test and demo cleanup

### DIFF
--- a/models/demos/falcon40b/demo/demo.py
+++ b/models/demos/falcon40b/demo/demo.py
@@ -346,7 +346,7 @@ def run_falcon_demo_kv(
     ### First run decode stage with compile ###
     # Update model_config for decode
     model_config = get_model_config(model_config_str, "decode", [batch_size, 1], len(devices))
-    tt_FalconCausalLM.model_config = model_config
+    tt_FalconCausalLM.set_model_config(model_config)
 
     attention_mask_memconfig = model_config["ATTN_MASK_MEMCFG"]
     if attention_mask_memconfig.is_sharded():
@@ -593,7 +593,7 @@ def test_demo(
     all_devices,
     use_program_cache,
 ):
-    num_devices = 4
+    num_devices = 8
     devices = get_devices_for_t3000(all_devices, num_devices)
 
     # disable_persistent_kernel_cache()

--- a/models/demos/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/falcon40b/tests/test_falcon_attention.py
@@ -320,7 +320,7 @@ def run_test_FalconAttention_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8))
+@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (

--- a/models/demos/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon40b/tests/test_falcon_causallm.py
@@ -306,7 +306,7 @@ def run_test_FalconCausalLM_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8))
+@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (

--- a/models/demos/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon40b/tests/test_falcon_decoder.py
@@ -332,7 +332,7 @@ def run_test_FalconDecoder_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8))
+@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (

--- a/models/demos/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon40b/tests/test_falcon_end_to_end.py
@@ -95,14 +95,14 @@ def run_test_FalconCausalLM_end_to_end(
         tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
         tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
 
-        for i in range(num_layers):
+        for _ in range(num_layers):
             tt_k_cache = []
             tt_v_cache = []
-            for i in range(len(devices)):
+            for j in range(len(devices)):
                 tt_k_cache.append(
                     torch2tt_tensor(
-                        tt_k_cache_host[i],
-                        devices[i],
+                        tt_k_cache_host[j],
+                        devices[j],
                         tt_lib.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
@@ -110,8 +110,8 @@ def run_test_FalconCausalLM_end_to_end(
                 )
                 tt_v_cache.append(
                     torch2tt_tensor(
-                        tt_v_cache_host[i],
-                        devices[i],
+                        tt_v_cache_host[j],
+                        devices[j],
                         tt_lib.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
@@ -393,7 +393,7 @@ def run_test_FalconCausalLM_end_to_end(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8))
+@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (

--- a/models/demos/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/falcon40b/tests/test_falcon_mlp.py
@@ -98,7 +98,7 @@ def run_test_FalconMLP_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8))
+@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len",
     (

--- a/models/demos/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/falcon40b/tests/test_falcon_model.py
@@ -96,14 +96,14 @@ def run_test_FalconModel_inference(
         tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
         tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
 
-        for i in range(num_layers):
+        for _ in range(num_layers):
             tt_k_cache = []
             tt_v_cache = []
-            for i in range(len(devices)):
+            for j in range(len(devices)):
                 tt_k_cache.append(
                     torch2tt_tensor(
-                        tt_k_cache_host[i],
-                        devices[i],
+                        tt_k_cache_host[j],
+                        devices[j],
                         tt_lib.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
@@ -111,8 +111,8 @@ def run_test_FalconModel_inference(
                 )
                 tt_v_cache.append(
                     torch2tt_tensor(
-                        tt_v_cache_host[i],
-                        devices[i],
+                        tt_v_cache_host[j],
+                        devices[j],
                         tt_lib.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
@@ -303,7 +303,7 @@ def run_test_FalconModel_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8))
+@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (

--- a/models/demos/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/falcon40b/tests/test_perf_falcon.py
@@ -97,14 +97,14 @@ def run_test_FalconCausalLM_end_to_end(
         tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
         tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
 
-        for i in range(num_layers):
+        for _ in range(num_layers):
             tt_k_cache = []
             tt_v_cache = []
-            for i in range(len(devices)):
+            for j in range(len(devices)):
                 tt_k_cache.append(
                     torch2tt_tensor(
-                        tt_k_cache_host[i],
-                        devices[i],
+                        tt_k_cache_host[j],
+                        devices[j],
                         tt_lib.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
@@ -112,8 +112,8 @@ def run_test_FalconCausalLM_end_to_end(
                 )
                 tt_v_cache.append(
                     torch2tt_tensor(
-                        tt_v_cache_host[i],
-                        devices[i],
+                        tt_v_cache_host[j],
+                        devices[j],
                         tt_lib.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
@@ -413,7 +413,7 @@ def run_test_FalconCausalLM_end_to_end(
 
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize("num_devices", (4, 8))
+@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len, expected_compile_time, expected_inference_time, inference_iterations",
     (

--- a/models/demos/falcon40b/tt/falcon_attention.py
+++ b/models/demos/falcon40b/tt/falcon_attention.py
@@ -242,6 +242,9 @@ class TtFalconAttention:
         # self.scalar = pad_by_zero(torch.Tensor([1 / math.sqrt(self.head_dim)]), self.device)[0]
         self.scalar = 1 / math.sqrt(self.head_dim)
 
+    def set_model_config(self, model_config):
+        self.model_config = model_config
+
     # TODO: Remove hack for GQA for 8 chip since it would be MQA
     def prefill_grouped_attention_matmul_for_4_chips(self, query_layer, kv_layer, output_mem_config):
         _, num_q_heads, M, K = query_layer[0].get_legacy_shape()

--- a/models/demos/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/falcon40b/tt/falcon_decoder.py
@@ -150,6 +150,11 @@ class TtFalconDecoderLayer:
 
         self.layernorm_eps = config.layer_norm_epsilon
 
+    def set_model_config(self, model_config):
+        self.model_config = model_config
+        self.self_attn.set_model_config(model_config)
+        self.mlp.set_model_config(model_config)
+
     def __call__(
         self,
         hidden_states: tt_lib.tensor.Tensor,

--- a/models/demos/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/falcon40b/tt/falcon_mlp.py
@@ -94,6 +94,9 @@ class TtFalconMLP:
                     dense_4h_to_h_weights_host,
                 )
 
+    def set_model_config(self, model_config):
+        self.model_config = model_config
+
     def __call__(self, x: List[tt_lib.tensor.Tensor]) -> List[tt_lib.tensor.Tensor]:
         hidden_states = []
         for i in range(len(x)):

--- a/models/demos/falcon40b/tt/falcon_model.py
+++ b/models/demos/falcon40b/tt/falcon_model.py
@@ -41,6 +41,7 @@ class TtFalconModelShared:
         self.config = config
         self.max_position_embeddings = max_position_embeddings
         self.model_config = model_config
+        self.num_layers = num_layers
 
         # So far on CPU until we add embeddings support on device
         self.embeddings = torch.nn.Embedding(config.vocab_size, config.hidden_size)
@@ -129,6 +130,11 @@ class TtFalconModelShared:
             )
 
         self.layernorm_eps = config.layer_norm_epsilon
+
+    def set_model_config(self, model_config):
+        self.model_config = model_config
+        for layer_num in range(self.num_layers):
+            self.layers[layer_num].set_model_config(model_config)
 
     def model_preprocessing(self, llm_mode, input_ids, kv_cache_len, num_input_tokens):
         assert input_ids.dim() == 2

--- a/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
@@ -26,13 +26,13 @@ TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_fast_dispatch --g
 pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k post_commit
 
 # Falcon40B 4 chip tests
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-prefill_seq32-4]
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-4]
-pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-4]
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-prefill_seq32-4chips]
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-4chips]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-4chips]
 
 # Falcon40B 8 chip tests
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-prefill_seq32-8]
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8]
-pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8]
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-prefill_seq32-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips]
 
 pytest tests/ttnn/unit_tests/test_multi_device.py


### PR DESCRIPTION
- Set model config in the demo for all components instead just for FalconModel
- Run demo on 8 devices by default 
- Add 4/8 chip parametrization id
- Fix loop indices in end-to-end and model tests

Post commit tests: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8422587018