### PR TITLE
Backward tests with updated test modules

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp2.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_exp2(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
     pyt_y = torch.exp2(in_data)
 
@@ -30,5 +30,5 @@ def test_bw_exp2(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_expm1.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_expm1.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_expm1(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
     pyt_y = torch.expm1(in_data)
 
@@ -30,5 +30,5 @@ def test_bw_expm1(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill.py
@@ -5,7 +5,10 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    data_gen_with_range,
+    compare_all_close,
+)
 
 
 @pytest.mark.parametrize(
@@ -22,8 +25,7 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 #   value: grad.sum()
 #   result: at::fill(self_t, value_t)
 def test_bw_fill(input_shapes, device):
-    # torch.manual_seed(12386)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     pyt_y = torch.zeros_like(grad_data)
     grad_sum = grad_data.sum()
     pyt_y.fill_(grad_sum)
@@ -31,5 +33,5 @@ def test_bw_fill(input_shapes, device):
     tt_output_tensor_on_device = tt_lib.tensor.fill_bw(grad_tensor)
 
     golden_tensor = [pyt_y]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=100, rtol=1e-6)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill_zero.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_fill_zero.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -21,9 +21,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 #   self: zeros_like(grad)
 #   result: at::fill(self_t, 0)
 def test_bw_fill_zero(input_shapes, device):
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     tt_output_tensor_on_device = tt_lib.tensor.fill_zero_bw(grad_tensor)
     pyt_y = torch.zeros_like(grad_data)
     golden_tensor = [pyt_y]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log10.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log10.py
@@ -5,7 +5,10 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    compare_pcc,
+    data_gen_with_range,
+)
 
 
 @pytest.mark.parametrize(
@@ -17,8 +20,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_log10(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+
     tt_output_tensor_on_device = tt_lib.tensor.log10_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
@@ -28,5 +32,5 @@ def test_bw_log10(input_shapes, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log1p.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log1p.py
@@ -5,7 +5,10 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    compare_pcc,
+    data_gen_with_range,
+)
 
 
 @pytest.mark.parametrize(
@@ -17,8 +20,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_log1p(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+
     tt_output_tensor_on_device = tt_lib.tensor.log1p_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
@@ -28,5 +32,5 @@ def test_bw_log1p(input_shapes, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_log2.py
@@ -5,7 +5,10 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    compare_pcc,
+    data_gen_with_range,
+)
 
 
 @pytest.mark.parametrize(
@@ -17,8 +20,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_log2(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+
     tt_output_tensor_on_device = tt_lib.tensor.log2_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
@@ -26,7 +30,6 @@ def test_bw_log2(input_shapes, device):
     pyt_y = torch.log2(in_data)
 
     pyt_y.backward(gradient=grad_data)
-
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -64,12 +64,13 @@ def compare_pcc(tt_tensor, golden_tensor, pcc=0.99):
     return status
 
 
-def compare_all_close(tt_tensor, golden_tensor):
+def compare_all_close(tt_tensor, golden_tensor, atol=4, rtol=1e-1):
     status = True
     for i in range(len(tt_tensor)):
         tt_out_tensor = tt_tensor[i].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
         pt_out_tensor = golden_tensor[i]
-        comp_all, _ = comparison_funcs.comp_allclose(pt_out_tensor, tt_out_tensor, atol=4, rtol=1e-1)
+        comp_all, comp_out = comparison_funcs.comp_allclose(pt_out_tensor, tt_out_tensor, atol=atol, rtol=rtol)
         logger.debug(comp_all)
+        logger.debug(comp_out)
         status = status & comp_all
     return status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1239,7 +1239,10 @@ std::vector<Tensor> erfinv_bw(const Tensor& grad, const Tensor& input, const Mem
 // bw(log10(in)) = grad/(in * 2.30258509299404568402)
 std::vector<Tensor> _log10_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    Tensor t_inf = where(ltz(grad, output_mem_config), -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(), output_mem_config);
     Tensor grad_a = mul(grad, recip(mul_unary(input, M_LN10, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
+    grad_a = where(logical_and(eqz(input, output_mem_config), eqz(grad, output_mem_config), std::nullopt, output_mem_config), std::nanf(" "),
+             where(eqz(input, output_mem_config), t_inf, grad_a, output_mem_config), output_mem_config);
     grad_tensor.emplace_back(grad_a);
     return grad_tensor;
 }

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1652,7 +1652,10 @@ std::vector<Tensor> ceil_bw(const Tensor& grad, const Tensor& input, const Memor
 // bw(log2(in)) = grad/(in * 0.69314718055994530942)
 std::vector<Tensor> _log2_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    Tensor t_inf = where(ltz(grad, output_mem_config), -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(), output_mem_config);
     Tensor grad_a = mul(grad, recip(mul_unary(input, M_LN2, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
+    grad_a = where(logical_and(eqz(input, output_mem_config), eqz(grad, output_mem_config), std::nullopt, output_mem_config), std::nanf(" "),
+             where(eqz(input, output_mem_config), t_inf, grad_a, output_mem_config), output_mem_config);
     grad_tensor.emplace_back(grad_a);
     return grad_tensor;
 }


### PR DESCRIPTION
Updated test for exp,expm1, fill,  fill zero, log1p, log2 and log10
- For fill added atol and rtol param to the modules. Fill depends on reduced sum op. For different ranges, different rotl and atol are required since the reduced sum has some difference in results compared to Pytorch version of sum