### PR TITLE
#6769: Disable program caching for failing Llama tests.

### DIFF
--- a/models/demos/llama2_70b/demo/demo.py
+++ b/models/demos/llama2_70b/demo/demo.py
@@ -347,9 +347,6 @@ def test_LlamaModel_demo(
 
     devices, ckpt_dir, tokenizer_path, cache_path = get_llama_path(devices, model_config, n_devices, emulated)
 
-    for device in devices:
-        device.enable_program_cache()
-
     args = construct_arg(
         implementation=implementation,
         ckpt_dir=ckpt_dir,

--- a/models/demos/llama2_70b/tests/test_llama_attention.py
+++ b/models/demos/llama2_70b/tests/test_llama_attention.py
@@ -290,9 +290,6 @@ def test_LlamaAttention_inference(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    for device in devices:
-        device.enable_program_cache()
-
     run_test_LlamaAttention_inference(
         devices,
         batch,

--- a/models/demos/llama2_70b/tests/test_llama_decoder.py
+++ b/models/demos/llama2_70b/tests/test_llama_decoder.py
@@ -291,9 +291,6 @@ def test_LlamaDecoder_inference(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    for device in devices:
-        device.enable_program_cache()
-
     run_test_LlamaDecoder_inference(
         devices,
         batch,


### PR DESCRIPTION
Enabling program cache is leading to CI failures. While we debug, I want to remove program caching from the failing tests.