### PR TITLE
#0: remove data movement ops related to silu in SD

### DIFF
--- a/models/experimental/functional_stable_diffusion/tt2/ttnn_functional_unet_2d_condition_model.py
+++ b/models/experimental/functional_stable_diffusion/tt2/ttnn_functional_unet_2d_condition_model.py
@@ -580,7 +580,6 @@ class UNet2DConditionModel:
                 memory_config=self.gn_expected_input_sharded_memory_config,
                 core_grid=self.group_norm_core_grid,
             )
-        sample = ttnn.to_memory_config(sample, ttnn.L1_MEMORY_CONFIG)
         sample = ttnn.reshape(
             sample,
             (
@@ -590,8 +589,7 @@ class UNet2DConditionModel:
                 self.conv_out.in_channels,
             ),
         )
-        sample = ttnn.to_layout(sample, ttnn.TILE_LAYOUT)
-        sample = ttnn.silu(sample)
+        sample = ttnn.silu(sample, memory_config=ttnn.get_memory_config(sample))
         if ttnn.get_memory_config(sample) != self.conv_out.conv.input_sharded_memory_config:
             sample = ttnn.to_memory_config(sample, self.conv_out.conv.input_sharded_memory_config)
         sample = self.conv_out(sample)


### PR DESCRIPTION
it passes post-commit pipeline: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8457977137 