### PR TITLE
#6443: update backward test file for relational ops and concat op

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,11 +17,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_binary_eq(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.binary_eq_bw(grad_tensor, input_tensor)
     pt_y = torch.zeros_like(grad_data)
     golden_tensor = [pt_y, pt_y]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_gt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_gt.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,12 +17,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_unary_gt(input_shapes, device):
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
     tt_output_tensor_on_device = tt_lib.tensor.gt_bw(grad_tensor)
-
-    pyt_y = torch.zeros_like(grad_data)
-
-    golden_tensor = [pyt_y]
-
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    pt_y = torch.zeros_like(grad_data)
+    golden_tensor = [pt_y]
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_le.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_le.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,12 +17,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_unary_le(input_shapes, device):
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
     tt_output_tensor_on_device = tt_lib.tensor.le_bw(grad_tensor)
-
-    pyt_y = torch.zeros_like(grad_data)
-
-    golden_tensor = [pyt_y]
-
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    pt_y = torch.zeros_like(grad_data)
+    golden_tensor = [pt_y]
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lt.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,11 +17,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_unary_lt(input_shapes, device):
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
     tt_output_tensor_on_device = tt_lib.tensor.lt_bw(grad_tensor)
-    pyt_y = torch.zeros_like(grad_data)
-
-    golden_tensor = [pyt_y]
-
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    pt_y = torch.zeros_like(grad_data)
+    golden_tensor = [pt_y]
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_eq.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_eq.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -18,11 +18,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 @pytest.mark.parametrize("other", [1.0])
 def test_bw_unary_eq(input_shapes, other, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_eq_bw(grad_tensor, input_tensor, other)
     pt_y = torch.zeros_like(grad_data)
     golden_tensor = [pt_y]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -20,21 +20,35 @@ def data_gen_pt_tt(input_shapes, device, required_grad=False):
     return pt_tensor, tt_tensor
 
 
-def data_gen_with_range(input_shapes, low, high, device, required_grad=False):
+def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is_row_major=False):
     assert high > low, "Incorrect range provided"
     torch.manual_seed(213919)
     pt_tensor = torch.rand(input_shapes, requires_grad=required_grad).bfloat16() * (high - low) + low
-    tt_tensor = (
-        tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    if is_row_major:
+        tt_tensor = (
+            tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16)
+            .to(tt_lib.tensor.Layout.ROW_MAJOR)
+            .to(device)
+        )
+    else:
+        tt_tensor = (
+            tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+        )
     return pt_tensor, tt_tensor
 
 
-def data_gen_with_val(input_shapes, device, required_grad=False, val=1):
+def data_gen_with_val(input_shapes, device, required_grad=False, val=1, is_row_major=False):
     pt_tensor = (torch.ones(input_shapes, requires_grad=required_grad) * val).bfloat16()
-    tt_tensor = (
-        tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    if is_row_major:
+        tt_tensor = (
+            tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16)
+            .to(tt_lib.tensor.Layout.ROW_MAJOR)
+            .to(device)
+        )
+    else:
+        tt_tensor = (
+            tt_lib.tensor.Tensor(pt_tensor, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+        )
     return pt_tensor, tt_tensor
 
 


### PR DESCRIPTION
updated the following test files for backward ops:
- Binary_eq
- unary_gt
- unary_le
- unary_lt
- unary_eq
- concat (it required RM support so I modified the utility file for same reason)