### PR TITLE
#6154: 2d matmul in0 height, in1 width sharding

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -991,6 +991,104 @@ def test_sharded_matmul_2d(
     assert passing
 
 
+@pytest.mark.parametrize("in0_sharded", [True, False], ids=["in0_sharded", "in0_interleaved"])
+@pytest.mark.parametrize("in1_sharded", [True, False], ids=["in1_sharded", "in1_interleaved"])
+@pytest.mark.parametrize("out_sharded", [True, False], ids=["out_sharded", "out_interleaved"])
+@pytest.mark.parametrize("activations_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+@pytest.mark.parametrize("weights_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+@pytest.mark.parametrize("output_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+def test_sharded_matmul_2d_in0_height_sharded_in1_width_sharded(
+    device,
+    in0_sharded,
+    in1_sharded,
+    out_sharded,
+    activations_dtype,
+    weights_dtype,
+    output_dtype,
+    function_level_defaults,
+):
+    M = 6 * 32
+    N = 12 * 32
+    K = 2 * 32
+
+    in0_shape = [1, 1, M, K]
+    in1_shape = [1, 1, K, N]
+    bias_shape = [1, 1, 1, N]
+
+    grid_size = (6, 6)
+    compute_grid_size = device.compute_with_storage_grid_size()
+
+    if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
+        pytest.skip(f"Need {grid_size} grid size to run this test but core grid is {compute_grid_size}")
+
+    interleaved_mem_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttl.tensor.BufferType.DRAM,
+    )
+    sharded_block_mem_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        buffer_type=ttl.tensor.BufferType.L1,
+    )
+
+    in0 = torch.randn(in0_shape).bfloat16().float()
+    in1 = torch.randn(in1_shape).bfloat16().float()
+    bias = torch.randn(bias_shape).bfloat16().float()
+
+    # Generate the tensor
+    in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=activations_dtype)
+    in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)
+    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=weights_dtype)[0]
+
+    if in0_sharded:
+        in0_t = ttl.tensor.interleaved_to_sharded(
+            in0_t,
+            ttl.tensor.CoreCoord(1, grid_size[0]),
+            [M // grid_size[0], K],
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+        )
+
+    if in1_sharded:
+        in1_t = ttl.tensor.interleaved_to_sharded(
+            in1_t,
+            ttl.tensor.CoreCoord(grid_size[1], 1),
+            [K, N // grid_size[1]],
+            ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+        )
+
+    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        in0_block_w=K // 32,
+        out_subblock_h=1,
+        out_subblock_w=2,
+        per_core_M=M // (32 * grid_size[0]),
+        per_core_N=N // (32 * grid_size[1]),
+        transpose_mcast=False,
+        fused_activation=None,
+    )
+    output_mem_config = sharded_block_mem_config if out_sharded else interleaved_mem_config
+    output_t = ttl.operations.primary.matmul(
+        in0_t,
+        in1_t,
+        bias=bias_t,
+        program_config=program_config,
+        output_mem_config=output_mem_config,
+        output_dtype=output_dtype,
+    )
+
+    if out_sharded:
+        output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
+
+    pt_out = in0 @ in1 + bias
+
+    tt_out = tt2torch_tensor(output_t)
+
+    passing, output = comp_pcc(pt_out, tt_out)
+    logger.info(output)
+    assert passing
+
+
 @pytest.mark.parametrize("in0_sharded", [True, False], ids=["in0_sharded", "in0_unsharded"])
 @pytest.mark.parametrize("out_sharded", [True, False], ids=["out_sharded", "out_unsharded"])
 @pytest.mark.parametrize("M", [1600])
@@ -1721,6 +1819,79 @@ def test_sharded_matmul_1d_in0(
     tt_out = tt2torch_tensor(output_t)
 
     passing, output = comp_pcc(pt_out, tt_out, 0.98)
+    logger.info(output)
+    assert passing
+
+
+# Have at least one example of 1d matmul with in1 mcasted that runs on WH
+def test_sharded_matmul_1d_in1_wormhole(device, function_level_defaults):
+    M = 4096
+    K = 64
+    N = 256
+    grid_size = (8, 4)
+    num_cores = grid_size[0] * grid_size[1]
+    dtype = ttl.tensor.DataType.BFLOAT16
+
+    grid_size = device.compute_with_storage_grid_size()
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if num_cores > (compute_grid_size.x * compute_grid_size.y):
+        pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    in0_shape = [1, 1, M, K]
+    in1_shape = [1, 1, K, N]
+    bias_shape = [1, 1, 1, N]
+
+    interleaved_mem_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttl.tensor.BufferType.DRAM,
+    )
+    sharded_mem_config = ttl.tensor.MemoryConfig(
+        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=ttl.tensor.BufferType.L1,
+    )
+
+    in0 = torch.randn(in0_shape).bfloat16().float()
+    in1 = torch.randn(in1_shape).bfloat16().float()
+    bias = torch.randn(bias_shape).bfloat16().float()
+
+    in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=dtype)
+    in1_t = torch2tt_tensor(in1, device, tt_memory_config=interleaved_mem_config, tt_dtype=dtype)
+    bias_t = pad_by_zero(bias, device, tt_memory_config=interleaved_mem_config, tt_dtype=dtype)[0]
+
+    output_mem_config = sharded_mem_config
+
+    in0_t = ttl.tensor.interleaved_to_sharded(
+        in0_t,
+        grid_size,
+        [M // num_cores, K],
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttl.tensor.ShardOrientation.ROW_MAJOR,
+    )
+
+    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        in0_block_w=K // 32,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=M // 32 // num_cores,
+        per_core_N=N // 32,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+    )
+    output_t = ttl.operations.primary.matmul_1d(
+        in0_t,
+        in1_t,
+        bias=bias_t,
+        program_config=program_config,
+        output_mem_config=output_mem_config,
+        output_dtype=dtype,
+    )
+    output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
+    pt_out = in0 @ in1 + bias
+
+    tt_out = tt2torch_tensor(output_t)
+
+    passing, output = comp_pcc(pt_out, tt_out)
     logger.info(output)
     assert passing
 

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -948,27 +948,50 @@ void Matmul::validate(
                 std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>
             ) {
                 if (input_tensor_a.memory_config().is_sharded()) {
-                    TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
-                    if (program_config.transpose_mcast) {
-                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR);
-                    } else {
-                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
-                    }
-                    if (this->output_mem_config.is_sharded()) {
-                        TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
-                        TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
-                    }
-
+                    auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout;
                     uint32_t M = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
                     uint32_t K = input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH;
                     uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
                     uint32_t per_core_M = program_config.per_core_M;
                     auto shard_shape = input_tensor_a.shard_spec().value().shape;
 
+                    TT_FATAL(
+                        tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
+                        tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+
+                    if (tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+                        if (program_config.transpose_mcast) {
+                            TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR);
+                        } else {
+                            TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+                        }
+                        if (this->output_mem_config.is_sharded()) {
+                            TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
+                            TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+                        }
+
+                        TT_FATAL(K / (shard_shape[1] / TILE_WIDTH) == N / program_config.per_core_N);
+                    } else if (tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+                        TT_FATAL(K == program_config.in0_block_w);
+                        TT_FATAL(program_config.in0_block_w == (shard_shape[1] / TILE_WIDTH));
+                        TT_FATAL(
+                            input_tensor_a.shard_spec()->grid.bounding_box().start.x ==
+                            input_tensor_a.shard_spec()->grid.bounding_box().end.x);
+                    }
+
                     TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
                     TT_FATAL((shard_shape[1] / TILE_WIDTH) % program_config.in0_block_w == 0);
-                    TT_FATAL(K / (shard_shape[1] / TILE_WIDTH) == N / program_config.per_core_N);
                 }
+
+                if (input_tensor_b.memory_config().is_sharded()) {
+                    auto tensor_b_memory_layout = input_tensor_b.memory_config().memory_layout;
+                    TT_FATAL(tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
+                    TT_FATAL(program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[0] / TILE_WIDTH));
+                    TT_FATAL(
+                        input_tensor_b.shard_spec()->grid.bounding_box().start.y ==
+                        input_tensor_b.shard_spec()->grid.bounding_box().end.y);
+                }
+
                 if (this->output_mem_config.is_sharded()) {
                     TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
                     uint32_t M = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
@@ -978,7 +1001,6 @@ void Matmul::validate(
 
                     TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1);
                 }
-                TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
             } else if constexpr (
                 std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>
             ) {

--- a/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -44,16 +44,14 @@ void kernel_main() {
 
 
     constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    constexpr uint32_t in0_block_size_bytes = in0_block_num_tiles * in0_single_tile_size_bytes;
 
     #ifdef IN0_SHARDED
-    cb_reserve_back(cb_id_in0, batch * num_blocks * in0_block_h * in0_block_w);
-    cb_push_back(cb_id_in0, batch * num_blocks * in0_block_h * in0_block_w);
+    cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+    cb_push_back(cb_id_in0, in0_block_num_tiles);
     #else
-
-    const uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
-    const DataFormat in0_data_format = get_dataformat(cb_id_in0);
-
-
+    constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
     uint32_t l1_write_addr_in0;
 
     const InterleavedAddrGenFast<in0_is_dram> s0 = {
@@ -61,6 +59,7 @@ void kernel_main() {
         .page_size = in0_single_tile_size_bytes,
         .data_format = in0_data_format
     };
+    #endif
 
     #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
@@ -83,17 +82,21 @@ void kernel_main() {
         in0_mcast_dest_noc_end_x,
         in0_mcast_dest_noc_end_y,
         0);
+
+    #ifdef IN0_SHARDED
+    uint64_t in0_start_address = get_write_ptr(cb_id_in0);
+    #endif
     #endif
 
     for (uint32_t b = 0; b < batch; ++b) {
         uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;
-        for(uint32_t block = 0; block < num_blocks; ++block) {
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            #ifndef IN0_SHARDED
             // Operand 0
             cb_reserve_back(cb_id_in0, in0_block_num_tiles);
             l1_write_addr_in0 = get_write_ptr(cb_id_in0);
 
             uint64_t in0_start_address = l1_write_addr_in0; // copy start address of block, to be used for mcasting
-            uint32_t in0_block_size_bytes = 0; // can be optimized later, pass it to kernel
 
             // Copy in0 block into CB, as the default kernel
             uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_block_start_tile_id;
@@ -105,7 +108,6 @@ void kernel_main() {
                     }
                     l1_write_addr_in0 += in0_single_tile_size_bytes;
                     in0_tensor_tile_id += in0_tensor_stride_w;
-                    in0_block_size_bytes += in0_single_tile_size_bytes;
                 }
                 in0_tensor_row_start_tile_id += in0_tensor_stride_h;
             }
@@ -113,6 +115,7 @@ void kernel_main() {
 
             // Barrier! make sure the reads are done
             noc_async_read_barrier();
+            #endif
 
             #ifndef SKIP_MCAST
             // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr (i.e. its value should be in0_mcast_num_dests), then reset
@@ -134,9 +137,10 @@ void kernel_main() {
             noc_semaphore_set_multicast(in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores, false);
             #endif
 
+            #ifndef IN0_SHARDED
             cb_push_back(cb_id_in0, in0_block_num_tiles);
+            #endif
         }
         in0_tensor_start_tile_id += MtKt;
     }
-    #endif
 }


### PR DESCRIPTION
Add support to 2d systolic matmul for in0 to be
height sharded and in1 to be width sharded.
Output will be block sharded.

Implementation is leaning on existing 2d systolic
matmul implementation where both inputs are
interleaved.

In case of in0 height sharded and in1 width
sharded, the only difference is that for in0
first column of tensix core will just expect in0
to be height sharded in L1 on these cores, and
won't fetch an interleave tensore it will proceed
strait to mcasting the data to corresponding row of tensix cores.
Similar logic applies to in1 where in1 data with
be width sharded in L1 on first row of tensix cores.