### PR TITLE
#6757: Remove set_profiler_location

### DIFF
--- a/models/demos/bert/demo/demo.py
+++ b/models/demos/bert/demo/demo.py
@@ -274,7 +274,6 @@ def test_demo(
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 
-    tt_lib.profiler.set_profiler_location(f"tt_metal/tools/profiler/logs/bert")
     return run_bert_question_and_answering_inference(
         device=device,
         use_program_cache=use_program_cache,

--- a/models/demos/falcon40b/demo/demo.py
+++ b/models/demos/falcon40b/demo/demo.py
@@ -598,7 +598,6 @@ def test_demo(
 
     # disable_persistent_kernel_cache()
     disable_compilation_reports()
-    tt_lib.profiler.set_profiler_location(f"tt_metal/tools/profiler/logs/falcon40b")
 
     # Set it up for prefill initially and change the model_config to decode
     model_config_str = "BFLOAT8_B-SHARDED"

--- a/models/demos/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon40b/tests/test_falcon_causallm.py
@@ -366,8 +366,6 @@ def test_FalconCausalLM_inference(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
     )
 
-    tt_lib.profiler.set_profiler_location(f"falcon-40b_{request.node.callspec.id}")
-
     run_test_FalconCausalLM_inference(
         devices,
         model_version,

--- a/models/demos/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon40b/tests/test_falcon_end_to_end.py
@@ -460,8 +460,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 
-    tt_lib.profiler.set_profiler_location(f"falcon-40b_{request.node.callspec.id}")
-
     run_test_FalconCausalLM_end_to_end(
         devices,
         model_version,

--- a/models/demos/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/falcon40b/tests/test_perf_falcon.py
@@ -476,8 +476,6 @@ def test_perf_bare_metal(
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 
-    tt_lib.profiler.set_profiler_location(f"falcon-40b_{request.node.callspec.id}")
-
     run_test_FalconCausalLM_end_to_end(
         devices,
         model_version,

--- a/models/demos/falcon7b/demo/demo.py
+++ b/models/demos/falcon7b/demo/demo.py
@@ -438,7 +438,6 @@ def test_demo(
 ):
     disable_persistent_kernel_cache()
     disable_compilation_reports()
-    tt_lib.profiler.set_profiler_location(f"tt_metal/tools/profiler/logs/falcon7b")
 
     return run_falcon_demo_kv(
         user_input=user_input,

--- a/models/demos/falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon7b/tests/test_falcon_causallm.py
@@ -233,8 +233,6 @@ def test_FalconCausalLM_inference(
     model_config = get_model_config(model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)
 
-    tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
-
     run_test_FalconCausalLM_inference(
         devices,
         model_version,

--- a/models/demos/falcon7b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon7b/tests/test_falcon_end_to_end.py
@@ -346,8 +346,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 
-    tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
-
     run_test_FalconCausalLM_end_to_end(
         [device],
         model_version,

--- a/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
+++ b/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
@@ -211,8 +211,6 @@ def test_FalconCausalLM_inference(
     model_config = get_model_config(model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)
 
-    tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
-
     batch = 32
     seq_len = 128
     max_seq_len = 2048

--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -393,8 +393,6 @@ class TestParametrized:
         disable_persistent_kernel_cache()
         disable_compilation_reports()
 
-        tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
-
         run_test_FalconCausalLM_end_to_end(
             [device],
             model_version,
@@ -454,8 +452,6 @@ class TestParametrized:
 
         disable_persistent_kernel_cache()
         disable_compilation_reports()
-
-        tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
 
         run_test_FalconCausalLM_end_to_end(
             devices,
@@ -521,8 +517,6 @@ def test_perf_virtual_machine(
     tt_cache_path = get_tt_cache_path(model_version)
     disable_persistent_kernel_cache()
     disable_compilation_reports()
-
-    tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
 
     run_test_FalconCausalLM_end_to_end(
         [device],

--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
@@ -169,7 +169,6 @@ def test_falcon_matmul(
     request,
     device,
 ):
-    ttl.profiler.set_profiler_location(f"falcon_{request.node.callspec.id}")
     run_falcon_attn_matmul_test(
         falcon_op,
         transpose_hw,

--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -202,7 +202,6 @@ def test_falcon_matmul(
     if is_e75_grid_size and (seq_len == 512) and (falcon_op == ttl.tensor.falcon_lm_head_matmul):
         pytest.skip(f"LM Head does not work on E75 grid size {compute_grid_size}")
 
-    ttl.profiler.set_profiler_location(f"falcon_{request.node.callspec.id}")
     run_falcon_matmul_test(
         falcon_op,
         seq_len,

--- a/models/demos/llama2_70b/tests/test_llama_perf.py
+++ b/models/demos/llama2_70b/tests/test_llama_perf.py
@@ -298,8 +298,6 @@ def test_perf_bare_metal(
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 
-    tt_lib.profiler.set_profiler_location(f"llama2_70b_{request.node.callspec.id}")
-
     run_test_LlamaModel_end_to_end(
         devices,
         batch,

--- a/models/demos/metal_BERT_large_11/demo/demo.py
+++ b/models/demos/metal_BERT_large_11/demo/demo.py
@@ -376,8 +376,6 @@ def test_demo(
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 
-    tt_lib.profiler.set_profiler_location(f"metal_BERT_large_11")
-
     return run_bert_question_and_answering_inference(
         model_version="phiyodr/bert-large-finetuned-squad2",
         batch=batch,

--- a/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -293,8 +293,6 @@ def test_bert_batch_dram(
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 
-    tt_lib.profiler.set_profiler_location(f"BERT_large_full_{request.node.callspec.id}")
-
     run_bert_question_and_answering_inference(
         model_version,
         batch,
@@ -377,8 +375,6 @@ def test_bert_batch_dram_with_program_cache(
 
     disable_persistent_kernel_cache()
     disable_compilation_reports()
-
-    tt_lib.profiler.set_profiler_location(f"BERT_large_full_with_program_cache_{request.node.callspec.id}")
 
     run_bert_question_and_answering_inference(
         model_version,

--- a/models/demos/metal_BERT_large_11/tests/test_bert_encoder.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert_encoder.py
@@ -149,8 +149,6 @@ def test_bert_encoder_inference(
     model_config = get_model_config(batch, device.compute_with_storage_grid_size(), model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)
 
-    tt_lib.profiler.set_profiler_location(f"BERT_large_1_encoder_{request.node.callspec.id}")
-
     run_bert_encoder_inference(
         device,
         model_version,

--- a/models/demos/metal_BERT_large_11/tests/test_ffn.py
+++ b/models/demos/metal_BERT_large_11/tests/test_ffn.py
@@ -124,7 +124,6 @@ def test_ffn_inference(
     model_config = get_model_config(batch, device.compute_with_storage_grid_size(), model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)
 
-    tt_lib.profiler.set_profiler_location(f"BERT_large_ffn_{request.node.callspec.id}")
     run_ffn_inference(
         device,
         model_version,

--- a/models/demos/metal_BERT_large_11/tests/test_mha.py
+++ b/models/demos/metal_BERT_large_11/tests/test_mha.py
@@ -150,8 +150,6 @@ def test_mha_inference(
     model_config = get_model_config(batch, device.compute_with_storage_grid_size(), model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)
 
-    tt_lib.profiler.set_profiler_location(f"BERT_large_mha_{request.node.callspec.id}")
-
     run_mha_inference(
         device,
         model_version,

--- a/models/demos/ttnn_falcon7b/demo/demo.py
+++ b/models/demos/ttnn_falcon7b/demo/demo.py
@@ -422,8 +422,6 @@ def test_demo(
     disable_compilation_reports()
     import tt_lib  # to be replaced
 
-    tt_lib.profiler.set_profiler_location(f"tt_metal/tools/profiler/logs/falcon7b")
-
     return run_falcon_demo_kv(
         user_input=user_input,
         model_version="tiiuae/falcon-7b-instruct",

--- a/models/demos/ttnn_falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/test_falcon_causallm.py
@@ -222,8 +222,6 @@ def test_FalconCausalLM_inference(
     enable_persistent_kernel_cache()
     model_config = get_model_config(model_config_str)
 
-    tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
-
     run_test_FalconCausalLM_inference(
         device,
         model_version,

--- a/models/demos/ttnn_falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/ttnn_falcon7b/tests/test_perf_falcon.py
@@ -429,8 +429,6 @@ def test_perf_bare_metal(
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 
-    # tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
-
     run_test_FalconCausalLM_end_to_end(
         device,
         model_version,
@@ -495,8 +493,6 @@ def test_perf_virtual_machine(
     tt_cache_path = get_tt_cache_path(model_version)
     disable_persistent_kernel_cache()
     disable_compilation_reports()
-
-    tt_lib.profiler.set_profiler_location(f"falcon-7b_{request.node.callspec.id}")
 
     run_test_FalconCausalLM_end_to_end(
         device,

--- a/models/demos/ttnn_falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
+++ b/models/demos/ttnn_falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
@@ -169,7 +169,6 @@ def test_falcon_matmul(
     request,
     device,
 ):
-    ttl.profiler.set_profiler_location(f"falcon_{request.node.callspec.id}")
     run_falcon_attn_matmul_test(
         falcon_op,
         transpose_hw,

--- a/models/demos/ttnn_falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/ttnn_falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -200,7 +200,6 @@ def test_falcon_matmul(
     if is_e75_grid_size and (seq_len == 512) and (falcon_op == ttl.tensor.falcon_lm_head_matmul):
         pytest.skip(f"LM Head does not work on E75 grid size {compute_grid_size}")
 
-    ttl.profiler.set_profiler_location(f"falcon_{request.node.callspec.id}")
     run_falcon_matmul_test(
         falcon_op,
         seq_len,

--- a/models/experimental/bert_large_performant/unit_tests/fused_ops/test_bert_large_fused_ln.py
+++ b/models/experimental/bert_large_performant/unit_tests/fused_ops/test_bert_large_fused_ln.py
@@ -153,5 +153,4 @@ import pytest
     ids=["LN", "LN_G", "LN_GB", "add_LN_GB"],
 )
 def test_layernorm_test(device, test_id, batch, dtype, in0_mem_config, out_mem_config, request):
-    ttl.profiler.set_profiler_location(f"BERT_large_fused_layernorm_{request.node.callspec.id}")
     run_layernorm_tests(device, test_id, batch, dtype, in0_mem_config, out_mem_config)

--- a/models/experimental/bert_large_performant/unit_tests/fused_ops/test_bert_large_fused_softmax.py
+++ b/models/experimental/bert_large_performant/unit_tests/fused_ops/test_bert_large_fused_softmax.py
@@ -135,5 +135,4 @@ import pytest
     ids=["scale_mask_softmax", "softmax"],
 )
 def test_bert_large_softmax_test(device, test_id, batch, dtype, in0_mem_config, request):
-    ttl.profiler.set_profiler_location(f"BERT_large_fused_softmax_{request.node.callspec.id}")
     run_softmax_tests(device, test_id, batch, dtype, in0_mem_config)

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_concatenate_heads.py
@@ -88,7 +88,6 @@ import pytest
     ],
 )
 def test_bert_large_concatenate_heads_test(device, batch, dtype, in0_mem_config, out_mem_config, request):
-    ttl.profiler.set_profiler_location(f"BERT_large_concat_heads_tm_{request.node.callspec.id}")
     run_bert_large_concatenate_heads_test(device, batch, dtype, in0_mem_config, out_mem_config)
 
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff1_matmul.py
@@ -186,7 +186,6 @@ def test_bert_large_ff1_matmul_test(
     activation,
     request,
 ):
-    ttl.profiler.set_profiler_location(f"BERT_large_ff1_matmul_{request.node.callspec.id}")
     run_bert_large_ff1_matmul_test(
         device,
         dtype,

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_ff2_matmul.py
@@ -143,7 +143,6 @@ def test_bert_large_ff2_matmul_test(
     out_mem_config,
     request,
 ):
-    ttl.profiler.set_profiler_location(f"BERT_large_ff2_matmul_{request.node.callspec.id}")
     run_bert_large_ff2_matmul_test(device, dtype, in0_mem_config, in1_mem_config, bias_mem_config, out_mem_config)
 
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_fused_qkv_matmul.py
@@ -143,7 +143,6 @@ def test_bert_large_fused_qkv_matmul_test(
     out_mem_config,
     request,
 ):
-    ttl.profiler.set_profiler_location(f"BERT_large_fused_qkv_matmul_{request.node.callspec.id}")
     run_bert_large_fused_qkv_matmul_test(device, dtype, in0_mem_config, in1_mem_config, bias_mem_config, out_mem_config)
 
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_matmuls_and_bmms_with_mixed_precision.py
@@ -316,7 +316,6 @@ def test_bert_large_matmul(
     if compute_grid_size.x < 12:
         pytest.skip(f"Grid size {compute_grid_size} is not supported")
 
-    ttl.profiler.set_profiler_location(f"BERT_large_{request.node.callspec.id}")
     run_bert_large_matmul_test(
         bert_large_op,
         batch,
@@ -394,7 +393,6 @@ def test_bert_large_bmm(
     if compute_grid_size.x < 12:
         pytest.skip(f"Grid size {compute_grid_size} is not supported")
 
-    ttl.profiler.set_profiler_location(f"BERT_large_{request.node.callspec.id}")
     run_bert_large_bmm_test(
         bert_large_op,
         batch,

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_post_softmax_bmm.py
@@ -110,7 +110,6 @@ import pytest
     ids=["BFLOAT8_B", "BFLOAT16"],
 )
 def test_bert_large_post_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_config, out_mem_config, request):
-    ttl.profiler.set_profiler_location(f"BERT_large_post_softmax_bmm_{request.node.callspec.id}")
     run_bert_large_post_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_config, out_mem_config)
 
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_pre_softmax_bmm.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_pre_softmax_bmm.py
@@ -103,7 +103,6 @@ import pytest
     ids=["BFLOAT8_B", "BFLOAT16"],
 )
 def test_bert_large_pre_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_config, out_mem_config, request):
-    ttl.profiler.set_profiler_location(f"BERT_large_pre_softmax_bmm_{request.node.callspec.id}")
     run_bert_large_pre_softmax_bmm_test(device, dtype, in0_mem_config, in1_mem_config, out_mem_config)
 
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_selfout_matmul.py
@@ -142,7 +142,6 @@ def test_bert_large_selfout_matmul_test(
     out_mem_config,
     request,
 ):
-    ttl.profiler.set_profiler_location(f"BERT_large_selfout_matmul_{request.node.callspec.id}")
     run_bert_large_selfout_matmul_test(device, dtype, in0_mem_config, in1_mem_config, bias_mem_config, out_mem_config)
 
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_and_transform_qkv_heads.py
@@ -114,7 +114,6 @@ import pytest
     ],
 )
 def test_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem_config, out_mem_config, request):
-    ttl.profiler.set_profiler_location(f"BERT_large_create_qvk_heads_tm_{request.node.callspec.id}")
     run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem_config, out_mem_config)
 
 

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads.py
@@ -115,7 +115,6 @@ import pytest
     ],
 )
 def test_split_query_key_value_and_split_heads(device, batch, dtype, in0_mem_config, out_mem_config, request):
-    ttl.profiler.set_profiler_location(f"BERT_large_create_qvk_heads_tm_{request.node.callspec.id}")
     run_split_query_key_value_and_split_heads_test(device, batch, dtype, in0_mem_config, out_mem_config)
 
 

--- a/tests/scripts/parse_profile_logs.py
+++ b/tests/scripts/parse_profile_logs.py
@@ -9,7 +9,6 @@
 
         testLocation ="stable_diffusion_reports"
         os.system(f"rm -rf {testLocation}")
-        ttl.profiler.set_profiler_location(testLocation)
 
 
     Next we have to run post processor for the ops.

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads.py
@@ -81,7 +81,6 @@ def run_nlp_concat_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem_con
 def test_nlp_concat_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, request, device):
     if is_grayskull() and dtype == ttl.tensor.DataType.FLOAT32:
         pytest.skip("Skipping float32 tests on Grayskull")
-    ttl.profiler.set_profiler_location(f"nlp_concat_heads_tm_{request.node.callspec.id}")
     run_nlp_concat_heads_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, device)
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads.py
@@ -101,7 +101,6 @@ def run_nlp_create_qkv_heads_falcon7b_test(batch, seq_len, dtype, in0_mem_config
 def test_nlp_create_qkv_heads_falcon7b_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, request, device):
     if is_grayskull() and dtype == ttl.tensor.DataType.FLOAT32:
         pytest.skip("Skipping float32 tests on Grayskull")
-    ttl.profiler.set_profiler_location(f"nlp_create_qkv_heads_falcon7b_tm_{request.node.callspec.id}")
     run_nlp_create_qkv_heads_falcon7b_test(batch, seq_len, dtype, in0_mem_config, out_mem_config, device)
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_two_chunks_tiled.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_any_dim_two_chunks_tiled.py
@@ -61,7 +61,6 @@ def test_split_tiled_w(dim, refshape, in_mem_config, out_mem_config, device, dty
     profile_location = "splitTwoChunks/"
     os.system(f"rm -rf {profile_location}")
 
-    ttl.profiler.set_profiler_location(profile_location)
     _shape = refshape
     assert _shape[0] == 1
     num_splits = 2

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_last_dim_two_chunks_tiled.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_split_last_dim_two_chunks_tiled.py
@@ -76,8 +76,6 @@ def test_split_tiled_w(shape, in_mem_config, out_mem_config, device, dtype=ttl.t
     profile_location = "splitTwoChunks/"
     os.system(f"rm -rf {profile_location}")
 
-    ttl.profiler.set_profiler_location(profile_location)
-
     assert shape[0] == 1
     untiled_shape = [1, 2, 16, 10240]
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -173,18 +173,6 @@ void DeviceModule(py::module &m_device) {
 }
 
 void ProfilerModule(py::module &m_profiler) {
-    m_profiler.def("set_profiler_location", &op_profiler::set_profiler_location, R"doc(
-        Sets the profiling root folder.
-
-        +------------------+------------------------------------------------+-----------------------+-------------+----------+
-        | Argument         | Description                                    | Data type             | Valid range | Required |
-        +==================+================================================+=======================+=============+==========+
-        | profilerLocation | Profiling output folder under the              | string                | Valid dir   | Yes      |
-        |                  | parent folder generated/profiler/.logs         |                       |             |          |
-        |                  | Default : generated/profiler/.logs/            |                       |             |          |
-        +------------------+------------------------------------------------+-----------------------+-------------+----------+
-    )doc");
-
     m_profiler.def("start_tracy_zone",&op_profiler::start_tracy_zone,
             py::arg("source"), py::arg("functName"),py::arg("lineNum"), py::arg("color") = 0, R"doc(
         Stop profiling op with tracy.

--- a/tt_metal/tools/profiler/op_profiler.hpp
+++ b/tt_metal/tools/profiler/op_profiler.hpp
@@ -35,13 +35,6 @@ namespace op_profiler {
     };
 
 
-    static void set_profiler_location (const string& profilerLocation)
-    {
-#if defined(PROFILER)
-        tt::tt_metal::detail::SetDeviceProfilerDir(profilerLocation);
-#endif
-    }
-
 #if defined(TRACY_ENABLE)
     inline stack<TracyCZoneCtx> call_stack;
 #endif


### PR DESCRIPTION
With the new tracy based design of the profiler, `set_profiler_location` is basically irrelevant. 