### PR TITLE
#6443: Update backward ops erfinv elu hypot cos sin

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cos.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cos.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 from math import pi
 
 
@@ -18,13 +18,9 @@ from math import pi
     ),
 )
 def test_bw_cos(input_shapes, device):
-    in_data = torch.rand(input_shapes) * (2 * torch.tensor([pi]))
-    in_data.requires_grad = True
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 0, (2 * pi), device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, False)
 
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
     tt_output_tensor_on_device = tt_lib.tensor.cos_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
@@ -35,5 +31,5 @@ def test_bw_cos(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_elu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_elu.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -21,17 +21,14 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     (
         1.0,
         -1.5,
+        0.0,
         0.5,
         2.5,
     ),
 )
 def test_bw_elu(input_shapes, alpha, device):
-    in_data = torch.Tensor(size=input_shapes).uniform_()
-    in_data.requires_grad = True
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
 
     in_data.retain_grad()
 
@@ -42,5 +39,5 @@ def test_bw_elu(input_shapes, alpha, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_erfinv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_erfinv.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,16 +17,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_erfinv(input_shapes, device):
-    in_data = torch.Tensor(size=input_shapes).uniform_(-0.9, 0.9)
-    in_data.requires_grad = True
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
-
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
-    tt_output_tensor_on_device = tt_lib.tensor.erfinv_bw(grad_tensor, input_tensor)
-
+    in_data, input_tensor = data_gen_with_range(input_shapes, -110, 110, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
     in_data.retain_grad()
+
+    tt_output_tensor_on_device = tt_lib.tensor.erfinv_bw(grad_tensor, input_tensor)
 
     pyt_y = torch.erfinv(in_data)
 
@@ -34,5 +29,5 @@ def test_bw_erfinv(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_hypot.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_hypot.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,9 +17,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_hypot(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    other_data, other_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -101, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -52, 51, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True)
 
     tt_output_tensor_on_device = tt_lib.tensor.hypot_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -32,5 +32,5 @@ def test_bw_hypot(input_shapes, device):
 
     golden_tensor = [in_data.grad, other_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status


### PR DESCRIPTION
Updated: 
- backward test files for sin_bw, cos_bw, elu_bw, hypot_bw, erfinv_bw
- modified erfinv  to handle (-1,1) and beyond range values.
- sin_bw and cos_bw use the forward op cos() and sin() respectively which have a range of 0 to 2*pi. 

Primary issue - #6443
CI test : https://github.com/tenstorrent-metal/tt-metal/actions/runs/8453537972