### PR TITLE
Add mistral-7b correctness test to CI

### DIFF
--- a/models/demos/mistral7b/tests/test_mistral_attention.py
+++ b/models/demos/mistral7b/tests/test_mistral_attention.py
@@ -18,8 +18,10 @@ from models.utility_functions import (
     comp_pcc,
     comp_allclose,
 )
+from models.utility_functions import skip_for_grayskull
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "iterations",
     ((1),),

--- a/models/demos/mistral7b/tests/test_mistral_decoder.py
+++ b/models/demos/mistral7b/tests/test_mistral_decoder.py
@@ -17,8 +17,10 @@ from models.utility_functions import (
     comp_pcc,
     comp_allclose,
 )
+from models.utility_functions import skip_for_grayskull
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "iterations",
     ((1),),

--- a/models/demos/mistral7b/tests/test_mistral_embedding.py
+++ b/models/demos/mistral7b/tests/test_mistral_embedding.py
@@ -12,8 +12,10 @@ from models.utility_functions import (
     comp_pcc,
     comp_allclose,
 )
+from models.utility_functions import skip_for_grayskull
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
 class Emb(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/models/demos/mistral7b/tests/test_mistral_mlp.py
+++ b/models/demos/mistral7b/tests/test_mistral_mlp.py
@@ -13,8 +13,10 @@ from models.utility_functions import (
     comp_pcc,
     comp_allclose,
 )
+from models.utility_functions import skip_for_grayskull
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
 def test_mistral_mlp_inference(device, use_program_cache):
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(device=device)

--- a/models/demos/mistral7b/tests/test_mistral_model.py
+++ b/models/demos/mistral7b/tests/test_mistral_model.py
@@ -19,6 +19,7 @@ from models.utility_functions import (
     comp_pcc,
     comp_allclose,
 )
+from models.utility_functions import skip_for_grayskull
 
 
 class Emb(torch.nn.Module):
@@ -30,6 +31,8 @@ class Emb(torch.nn.Module):
         return self.emb(x)
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
+@pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "version",
     (
@@ -39,10 +42,7 @@ class Emb(torch.nn.Module):
 )
 @pytest.mark.parametrize(
     "iterations",
-    (
-        1,
-        17,
-    ),
+    (17,),
 )
 def test_mistral_model_inference(device, iterations, version, use_program_cache):
     if version == "generative":

--- a/models/demos/mistral7b/tests/test_mistral_rms_norm.py
+++ b/models/demos/mistral7b/tests/test_mistral_rms_norm.py
@@ -12,8 +12,10 @@ from models.utility_functions import (
     comp_pcc,
     comp_allclose,
 )
+from models.utility_functions import skip_for_grayskull
 
 
+@skip_for_grayskull("Requires wormhole_b0 to run")
 def test_mistral_rms_norm_inference(device, use_program_cache):
     dtype = ttnn.bfloat8_b
 

--- a/tests/scripts/run_models.sh
+++ b/tests/scripts/run_models.sh
@@ -22,6 +22,12 @@ if [[ $ARCH_NAME == "wormhole_b0" ]]; then
   env pytest models/experimental/mamba/tests_opt/test_full_model.py
   env pytest models/experimental/mamba/tests/test_benchmarks.py
   env pytest models/experimental/mamba/tests/test_demo.py
+
+  env pytest models/demos/mistral7b/tests/test_mistral_embedding.py
+  env pytest models/demos/mistral7b/tests/test_mistral_rms_norm.py
+  env pytest models/demos/mistral7b/tests/test_mistral_mlp.py
+  env pytest models/demos/mistral7b/tests/test_mistral_attention.py
+  env pytest models/demos/mistral7b/tests/test_mistral_decoder.py
 fi
 
 env pytest models/experimental/whisper -k whisper_attention
@@ -81,10 +87,6 @@ env pytest models/demos/falcon7b/tests/test_falcon_end_to_end.py::test_FalconCau
 
 env pytest models/experimental/stable_diffusion/tests/test_embedding.py
 
-env pytest models/experimental/mistral/tests/test_mistral_feed_forward.py
-env pytest models/experimental/mistral/tests/test_mistral_rms_norm.py
-env pytest models/experimental/mistral/tests/test_mistral_transformer_block.py
-
 env pytest models/demos/ttnn_falcon7b/tests -k falcon_mlp
 env pytest models/demos/ttnn_falcon7b/tests -k falcon_rotary_embeddings
 env pytest models/demos/ttnn_falcon7b/tests -k falcon_attention
@@ -140,8 +142,6 @@ env pytest models/experimental/nanogpt/tests -k nanogpt_attention
 env pytest models/experimental/nanogpt/tests -k nanogpt_block
 env pytest models/experimental/nanogpt/tests -k nanogpt_mlp
 env pytest models/experimental/nanogpt/tests -k nanogpt_model
-
-env pytest models/experimental/mistral/tests/test_mistral_attention.py
 
 env pytest models/demos/resnet/tests/test_metal_resnet50.py::test_run_resnet50_inference[HiFi4-activations_BFLOAT16-weights_BFLOAT16-batch_1]
 env pytest models/demos/resnet/tests/test_metal_resnet50.py::test_run_resnet50_inference[HiFi4-activations_BFLOAT16-weights_BFLOAT16-batch_2]


### PR DESCRIPTION
Adds full mistral-7b test to CI.

This test runs both on host CPU and on device and compares PCC for all 32 layers.