### PR TITLE
#4252: Build tt-metal with clang-17 instead of gcc

### DIFF
--- a/.github/actions/install-metal-dev-deps/action.yml
+++ b/.github/actions/install-metal-dev-deps/action.yml
@@ -46,3 +46,10 @@ runs:
         cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=ON .
         make
         sudo make install
+    - name: Install clang-17
+      shell: bash
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod u+x llvm.sh
+        sudo ./llvm.sh 17
+        clang-17 --version

--- a/module.mk
+++ b/module.mk
@@ -17,17 +17,17 @@ CONFIG_LDFLAGS =
 TT_METAL_CREATE_STATIC_LIB ?= 0
 
 ifeq ($(CONFIG), release)
-CONFIG_CFLAGS += -O3
+CONFIG_CFLAGS += -O2
 else ifeq ($(CONFIG), ci)  # significantly smaller artifacts
-CONFIG_CFLAGS += -O3 -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O2 -DDEBUG=DEBUG
 CONFIG_LDFLAGS += -Wl,--verbose
 else ifeq ($(CONFIG), assert)
-CONFIG_CFLAGS += -O3 -g -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG
 else ifeq ($(CONFIG), asan)
-CONFIG_CFLAGS += -O3 -g -DDEBUG=DEBUG -fsanitize=address
+CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG -fsanitize=address
 CONFIG_LDFLAGS += -fsanitize=address
 else ifeq ($(CONFIG), ubsan)
-CONFIG_CFLAGS += -O3 -g -DDEBUG=DEBUG -fsanitize=undefined
+CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG -fsanitize=undefined
 CONFIG_LDFLAGS += -fsanitize=undefined
 else ifeq ($(CONFIG), debug)
 CONFIG_CFLAGS += -O0 -g -DDEBUG=DEBUG

--- a/module.mk
+++ b/module.mk
@@ -17,17 +17,17 @@ CONFIG_LDFLAGS =
 TT_METAL_CREATE_STATIC_LIB ?= 0
 
 ifeq ($(CONFIG), release)
-CONFIG_CFLAGS += -O2
+CONFIG_CFLAGS += -O0
 else ifeq ($(CONFIG), ci)  # significantly smaller artifacts
-CONFIG_CFLAGS += -O2 -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O0 -DDEBUG=DEBUG
 CONFIG_LDFLAGS += -Wl,--verbose
 else ifeq ($(CONFIG), assert)
-CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O0 -g -DDEBUG=DEBUG
 else ifeq ($(CONFIG), asan)
-CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG -fsanitize=address
+CONFIG_CFLAGS += -O0 -g -DDEBUG=DEBUG -fsanitize=address
 CONFIG_LDFLAGS += -fsanitize=address
 else ifeq ($(CONFIG), ubsan)
-CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG -fsanitize=undefined
+CONFIG_CFLAGS += -O0 -g -DDEBUG=DEBUG -fsanitize=undefined
 CONFIG_LDFLAGS += -fsanitize=undefined
 else ifeq ($(CONFIG), debug)
 CONFIG_CFLAGS += -O0 -g -DDEBUG=DEBUG

--- a/module.mk
+++ b/module.mk
@@ -10,27 +10,27 @@ PREFIX ?= $(OUT)
 # Disable by default, use negative instead for consistency with BBE
 TT_METAL_VERSIM_DISABLED ?= 1
 
-CONFIG_CFLAGS =
+CONFIG_CFLAGS = -fno-slp-vectorize
 CONFIG_LDFLAGS =
 
 # For production builds so the final pybinded so has all binaries + symbols
 TT_METAL_CREATE_STATIC_LIB ?= 0
 
 ifeq ($(CONFIG), release)
-CONFIG_CFLAGS += -O1
+CONFIG_CFLAGS += -O2
 else ifeq ($(CONFIG), ci)  # significantly smaller artifacts
-CONFIG_CFLAGS += -O1 -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O2 -DDEBUG=DEBUG
 CONFIG_LDFLAGS += -Wl,--verbose
 else ifeq ($(CONFIG), assert)
-CONFIG_CFLAGS += -O1 -g -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG
 else ifeq ($(CONFIG), asan)
-CONFIG_CFLAGS += -O1 -g -DDEBUG=DEBUG -fsanitize=address
+CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG -fsanitize=address
 CONFIG_LDFLAGS += -fsanitize=address
 else ifeq ($(CONFIG), ubsan)
-CONFIG_CFLAGS += -O1 -g -DDEBUG=DEBUG -fsanitize=undefined
+CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG -fsanitize=undefined
 CONFIG_LDFLAGS += -fsanitize=undefined
 else ifeq ($(CONFIG), debug)
-CONFIG_CFLAGS += -O1 -g -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O2 -g -DDEBUG=DEBUG
 else
 $(error Unknown value for CONFIG "$(CONFIG)")
 endif

--- a/module.mk
+++ b/module.mk
@@ -17,20 +17,20 @@ CONFIG_LDFLAGS =
 TT_METAL_CREATE_STATIC_LIB ?= 0
 
 ifeq ($(CONFIG), release)
-CONFIG_CFLAGS += -O0
+CONFIG_CFLAGS += -O1
 else ifeq ($(CONFIG), ci)  # significantly smaller artifacts
-CONFIG_CFLAGS += -O0 -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O1 -DDEBUG=DEBUG
 CONFIG_LDFLAGS += -Wl,--verbose
 else ifeq ($(CONFIG), assert)
-CONFIG_CFLAGS += -O0 -g -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O1 -g -DDEBUG=DEBUG
 else ifeq ($(CONFIG), asan)
-CONFIG_CFLAGS += -O0 -g -DDEBUG=DEBUG -fsanitize=address
+CONFIG_CFLAGS += -O1 -g -DDEBUG=DEBUG -fsanitize=address
 CONFIG_LDFLAGS += -fsanitize=address
 else ifeq ($(CONFIG), ubsan)
-CONFIG_CFLAGS += -O0 -g -DDEBUG=DEBUG -fsanitize=undefined
+CONFIG_CFLAGS += -O1 -g -DDEBUG=DEBUG -fsanitize=undefined
 CONFIG_LDFLAGS += -fsanitize=undefined
 else ifeq ($(CONFIG), debug)
-CONFIG_CFLAGS += -O0 -g -DDEBUG=DEBUG
+CONFIG_CFLAGS += -O1 -g -DDEBUG=DEBUG
 else
 $(error Unknown value for CONFIG "$(CONFIG)")
 endif

--- a/module.mk
+++ b/module.mk
@@ -79,8 +79,8 @@ BASE_INCLUDES+=-I./ -I./tt_metal/ -I$(UMD_HOME)/
 
 #WARNINGS ?= -Wall -Wextra
 WARNINGS ?= -Wdelete-non-virtual-dtor -Wreturn-type -Wswitch -Wuninitialized -Wno-unused-parameter
-CC ?= gcc
-CXX ?= g++
+CC=clang-17
+CXX=clang++-17
 CFLAGS ?= -MMD $(WARNINGS) -I. $(CONFIG_CFLAGS) -mavx2 -DBUILD_DIR=\"$(OUT)\"
 CXXFLAGS ?= --std=c++17 -fvisibility-inlines-hidden -Werror
 

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -905,10 +905,10 @@ Tensor xlogy(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& o
 // torch.where(x > 0, x, alpha * (torch.exp(x / alpha) - 1))
 Tensor _celu(const Tensor& input_a, float alpha, const MemoryConfig& output_mem_config) {
     float recip_val = 1.0f / alpha;
-    std::vector<UnaryWithParam> ops_chain = {UnaryWithParam{.op_type = UnaryOpType::MUL_UNARY_SFPU, recip_val},
-                                             UnaryWithParam{.op_type = UnaryOpType::EXP, 1.0f},
-                                             UnaryWithParam{.op_type = UnaryOpType::SUB_UNARY_SFPU, 1.0f},
-                                             UnaryWithParam{.op_type = UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    std::vector<UnaryWithParam> ops_chain = {UnaryWithParam{.op_type = UnaryOpType::MUL_UNARY_SFPU, .param = recip_val},
+                                             UnaryWithParam{.op_type = UnaryOpType::EXP, .param = 1.0f},
+                                             UnaryWithParam{.op_type = UnaryOpType::SUB_UNARY_SFPU, .param = 1.0f},
+                                             UnaryWithParam{.op_type = UnaryOpType::MUL_UNARY_SFPU, .param = alpha}};
     Tensor result = unary_chain(input_a, ops_chain, output_mem_config);
     result = where(gtz(input_a, output_mem_config), input_a, result, output_mem_config);
     return result;

--- a/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
@@ -158,7 +158,7 @@ static inline operation::ProgramWithCallbacks create_heads_combined_qkv_sharded(
         UpdateDynamicCircularBufferAddress(program, cb_out2_id, *out2_buffer);
     };
 
-    return {std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
 namespace tt {

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -352,14 +352,14 @@ template Tensors run_multi_device_operation(
 
 }  // namespace detail
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 OutputTensors run(const HostOperation<OutputTensors>& operation, const Tensors& input_tensors) {
     return detail::decorate_host_operation(detail::run_host_operation<OutputTensors>)(operation, input_tensors);
 }
 template Tensors run(const HostOperation<Tensors>& operation, const Tensors& input_tensors);
 template OptionalTensors run(const HostOperation<OptionalTensors>& operation, const Tensors& input_tensors);
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 OutputTensors run(
     CommandQueue& queue,
     const DeviceOperation<OutputTensors>& operation,
@@ -398,7 +398,7 @@ template OptionalTensors run(
     const OptionalConstTensors& optional_input_tensors,
     const OptionalTensors& optional_output_tensors);
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 OutputTensors run(
     const DeviceOperation<OutputTensors>& operation,
     const Tensors& input_tensors,
@@ -480,7 +480,7 @@ template OptionalTensors run_without_autoformat<OptionalTensors>(
     const OptionalConstTensors& optional_input_tensors
 );
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 OutputTensors run_without_autoformat(
     const DeviceOperation<OutputTensors>& operation,
     const Tensors& input_tensors,

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -77,7 +77,7 @@ class Device {
     Device& operator=(const Device &other) = delete;
 
     Device(Device &&other) = default;
-    Device& operator=(Device &&other) = default;
+    Device& operator=(Device &&other) = delete;
 
     tt::ARCH arch() const;
 

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -61,11 +61,17 @@ class LockFreeQueue {
         bool empty() const {
             return head.load() == tail.load();
         }
-        class Iterator : public std::iterator<std::forward_iterator_tag, T> {
+        class Iterator{
            private:
             Node* current;
 
            public:
+            using value_type = T;
+            using difference_type = std::ptrdiff_t;
+            using pointer = T*;
+            using reference = T&;
+            using iterator_category = std::forward_iterator_tag;
+
             Iterator(Node* start) : current(start) {}
 
             Iterator& operator++() {

--- a/tt_metal/impl/dispatch/work_executor.hpp
+++ b/tt_metal/impl/dispatch/work_executor.hpp
@@ -38,7 +38,7 @@ class WorkExecutor {
     }
 
     WorkExecutor(WorkExecutor &&other) = default;
-    WorkExecutor& operator=(WorkExecutor &&other) = default;
+    WorkExecutor& operator=(WorkExecutor &&other) = delete;
 
     ~WorkExecutor() {
         if (this->worker_queue_mode == WorkExecutorMode::ASYNCHRONOUS) {

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -15,7 +15,7 @@ void RunCustomCycle(tt_metal::Device *device, int fastDispatch)
     CoreCoord compute_with_storage_size = device->compute_with_storage_grid_size();
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {compute_with_storage_size.x - 1, compute_with_storage_size.y - 1};
-    CoreRange all_cores{.start=start_core, .end=end_core};
+    CoreRange all_cores(start_core, end_core);
     tt_metal::Program program = tt_metal::CreateProgram();
 
     tt_metal::KernelHandle brisc_kernel = tt_metal::CreateKernel(

--- a/ttnn/cpp/pybind11/operations/binary.hpp
+++ b/ttnn/cpp/pybind11/operations/binary.hpp
@@ -22,7 +22,7 @@ void py_module(py::module& module) {
         [](const ttnn::Tensor& input_tensor_a,
            const float scalar,
            const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-           const std::optional<const DataType> dtype) -> ttnn::Tensor {
+           const std::optional<const DataType> dtype = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::binary::add(input_tensor_a, scalar, memory_config, dtype, std::nullopt);
         },
         py::arg("input_tensor_a"),
@@ -36,7 +36,7 @@ void py_module(py::module& module) {
         [](const ttnn::Tensor& input_tensor_a,
            const ttnn::Tensor& input_tensor_b,
            const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-           const std::optional<const DataType> dtype) -> ttnn::Tensor {
+           const std::optional<const DataType> dtype = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::binary::add(input_tensor_a, input_tensor_b, memory_config, dtype, std::nullopt);
         },
         py::arg("input_tensor_a"),
@@ -50,7 +50,7 @@ void py_module(py::module& module) {
         [](const ttnn::Tensor& input_tensor_a,
            const float scalar,
            const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-           const std::optional<const DataType> dtype) -> ttnn::Tensor {
+           const std::optional<const DataType> dtype = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::binary::subtract(input_tensor_a, scalar, memory_config, dtype, std::nullopt);
         },
         py::arg("input_tensor_a"),
@@ -64,7 +64,7 @@ void py_module(py::module& module) {
         [](const ttnn::Tensor& input_tensor_a,
            const ttnn::Tensor& input_tensor_b,
            const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-           const std::optional<const DataType> dtype) -> ttnn::Tensor {
+           const std::optional<const DataType> dtype = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::binary::subtract(
                 input_tensor_a, input_tensor_b, memory_config, dtype, std::nullopt);
         },
@@ -79,7 +79,7 @@ void py_module(py::module& module) {
         [](const ttnn::Tensor& input_tensor_a,
            const float scalar,
            const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-           const std::optional<const DataType> dtype) -> ttnn::Tensor {
+           const std::optional<const DataType> dtype = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::binary::multiply(input_tensor_a, scalar, memory_config, dtype, std::nullopt);
         },
         py::arg("input_tensor_a"),
@@ -93,7 +93,7 @@ void py_module(py::module& module) {
         [](const ttnn::Tensor& input_tensor_a,
            const ttnn::Tensor& input_tensor_b,
            const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-           const std::optional<const DataType> dtype) -> ttnn::Tensor {
+           const std::optional<const DataType> dtype = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::binary::multiply(
                 input_tensor_a, input_tensor_b, memory_config, dtype, std::nullopt);
         },


### PR DESCRIPTION
Needs https://github.com/tenstorrent-metal/tt-metal/pull/6835 merged first.

PR enables building tt-metal with Clang-17