### PR TITLE
#6838: Add tracy timeout for op reprots

### DIFF
--- a/module.mk
+++ b/module.mk
@@ -122,6 +122,8 @@ endif
 ifeq ($(ENABLE_TRACY), 1)
 CFLAGS += -DTRACY_ENABLE -fno-omit-frame-pointer -fPIC
 LDFLAGS += -ltracy -rdynamic
+TOOLS_TO_BUILD += \
+	tracy_tools
 endif
 
 LIBS_TO_BUILD =
@@ -137,7 +139,6 @@ LIBS_TO_BUILD += \
 	umd_device \
 	tools \
 	tt_metal \
-	tracy \
 	tt_eager \
 	ttnn
 
@@ -155,7 +156,7 @@ ifdef TT_METAL_ENV_IS_DEV
 include $(TT_METAL_HOME)/infra/git_hooks/module.mk
 endif
 
-build: $(LIBS_TO_BUILD)
+build: $(LIBS_TO_BUILD) $(TOOLS_TO_BUILD)
 
 clean: set_up_kernels/clean eager_package/clean
 	test -d build && find build  -mindepth 1 -maxdepth 1 ! -path "build/python_env" -exec rm -rf {} + || true

--- a/tt_metal/tools/profiler/common.py
+++ b/tt_metal/tools/profiler/common.py
@@ -20,7 +20,7 @@ PROFILER_HOST_SIDE_LOG = "profile_log_host.csv"
 PROFILER_SCRIPTS_ROOT = TT_METAL_HOME / "tt_metal/tools/profiler"
 PROFILER_ARTIFACTS_DIR = TT_METAL_HOME / "generated/profiler"
 
-PROFILER_BIN_DIR = PROFILER_ARTIFACTS_DIR / "bin"
+PROFILER_BIN_DIR = TT_METAL_HOME / "build/tools/profiler/bin"
 PROFILER_LOGS_DIR = PROFILER_ARTIFACTS_DIR / ".logs"
 PROFILER_OUTPUT_DIR = PROFILER_ARTIFACTS_DIR / "reports"
 PROFILER_OPS_LOGS_DIR = PROFILER_LOGS_DIR / "ops"
@@ -31,8 +31,8 @@ TRACY_OPS_DATA_FILE_NAME = "tracy_ops_data.csv"
 TRACY_MODULE_PATH = TT_METAL_HOME / "tt_metal/third_party/tracy"
 TRACY_FILE_NAME = "tracy_profile_log_host.tracy"
 
-TRACY_CAPTURE_TOOL = "capture"
-TRACY_CSVEXPROT_TOOL = "csvexport"
+TRACY_CAPTURE_TOOL = "capture-release"
+TRACY_CSVEXPROT_TOOL = "csvexport-release"
 
 
 def rm(path):

--- a/tt_metal/tracy.mk
+++ b/tt_metal/tracy.mk
@@ -2,6 +2,8 @@ TRACY_LIB = $(LIBDIR)/libtracy.so
 TRACY_INCLUDES = -I$(TT_METAL_HOME)/tt_metal/third_party/tracy/public/tracy/
 TRACY_LDFLAGS = $(LDFLAGS)
 TRACY_DEFINES = -DTRACY_NO_CONTEXT_SWITCH
+TRACY_BUILD_DIR = $(TT_METAL_HOME)/build/tools/profiler/bin
+TRACY_REPO = $(TT_METAL_HOME)/tt_metal/third_party/tracy
 
 #TRACY_DEFINES = -DTRACY_SAMPLING_HZ=40000 -DTRACY_NO_SYSTEM_TRACING  -DTRACY_NO_CALLSTACK -DTRACY_NO_CALLSTACK_INLINES
 TRACY_SRCS = \
@@ -21,3 +23,10 @@ $(TRACY_LIB): $(TRACY_OBJS)
 $(OBJDIR)/tt_metal/third_party/tracy/public/%.o: tt_metal/third_party/tracy/public/%.cpp
 	@mkdir -p $(@D)
 	$(CXX) $(CFLAGS) $(CXXFLAGS) $(STATIC_LIB_FLAGS) $(TRACY_INCLUDES) $(TRACY_DEFINES) -c -o $@ $<
+
+tracy_tools:
+	mkdir -p $(TRACY_BUILD_DIR)
+	cd $(TRACY_REPO)/csvexport/build/unix && $(MAKE)
+	cp $(TRACY_REPO)/csvexport/build/unix/csvexport-release $(TRACY_BUILD_DIR)
+	cd $(TRACY_REPO)/capture/build/unix && $(MAKE)
+	cp $(TRACY_REPO)/capture/build/unix/capture-release $(TRACY_BUILD_DIR)


### PR DESCRIPTION
Added 15s timeout on tracy capture. Capture actually quickly returns at that stage of the script but long timeout was added just in case. 

This avoids hanging python scripts that are waiting on any tracy data.