### PR TITLE
#6861: Enable Watcher/dprint tests on T3000 CI

### DIFF
--- a/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
@@ -22,6 +22,7 @@ TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="D
 
 TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueMultiDeviceFixture.*"
+./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="WatcherFixture.*"
 pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k post_commit
 
 # Falcon40B 4 chip tests

--- a/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
@@ -22,7 +22,7 @@ TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="D
 
 TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueMultiDeviceFixture.*"
-./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="WatcherFixture.*"
+./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="DPrintFixture.*:WatcherFixture.*"
 pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k post_commit
 
 # Falcon40B 4 chip tests

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
@@ -67,8 +67,8 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
         tt::DPrintServerClearLogFile();
     }
 }
-// see issue #6659
-TEST_F(DPrintFixture, DISABLED_TestPrintEthCores) {
+
+TEST_F(DPrintFixture, TestPrintEthCores) {
     for (Device* device : this->devices_) {
         // Skip if no ethernet cores on this device
         if (device->get_active_ethernet_cores(true).size() == 0) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_invalid_print_core.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_invalid_print_core.cpp
@@ -11,8 +11,8 @@
 // A test for checking that the DPRINT server can detect an invalid core.
 //////////////////////////////////////////////////////////////////////////////////////////
 using namespace tt::tt_metal;
-// see issue #6659
-TEST(DPrintErrorChecking, DISABLED_TestPrintInvalidCore) {
+
+TEST(DPrintErrorChecking, TestPrintInvalidCore) {
     // Set DPRINT enabled on a mix of invalid and valid cores. Previously this would hang during
     // device setup, but not the print server should simply ignore the invalid cores.
     std::map<CoreType, std::vector<CoreCoord>> dprint_cores;

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_device.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_device.cpp
@@ -72,8 +72,8 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
     EXPECT_TRUE(OpenFile(file_name, log_file, std::fstream::in));
     EXPECT_TRUE(log_file.peek() == std::ifstream::traits_type::eof());
 }
-// see issue #6659
-TEST_F(DPrintFixtureDisableDevices, DISABLED_TestPrintMuteDevice) {
+
+TEST_F(DPrintFixtureDisableDevices, TestPrintMuteDevice) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_mute_print_server.cpp
@@ -61,8 +61,8 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
         )
     );
 }
-// see issue #6659
-TEST_F(DPrintFixture, DISABLED_TestPrintMuting) {
+
+TEST_F(DPrintFixture, TestPrintMuting) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_all_harts.cpp
@@ -176,8 +176,8 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
         )
     );
 }
-// see issue #6659
-TEST_F(DPrintFixture, DISABLED_TestPrintFromAllHarts) {
+
+TEST_F(DPrintFixture, TestPrintFromAllHarts) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_before_finish.cpp
@@ -56,8 +56,8 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
         )
     );
 }
-// see issue #6659
-TEST_F(DPrintFixture, DISABLED_TestPrintFinish) {
+
+TEST_F(DPrintFixture, TestPrintFinish) {
     auto devices = this->devices_;
     // Run only on the first device, as this tests disconnects devices and this can cause
     // issues on multi-device setups.

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_hanging.cpp
@@ -51,8 +51,8 @@ try {
         )
     );
 }
-// see issue #6659
-TEST_F(DPrintFixture, DISABLED_TestPrintHanging) {
+
+TEST_F(DPrintFixture, TestPrintHanging) {
     // Skip this test for slow dipatch for now. Due to how llrt currently sits below device, it's
     // tricky to check print server status from the finish loop for slow dispatch. Once issue #4363
     // is resolved, we should add a check for print server handing in slow dispatch as well.

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_raise_wait.cpp
@@ -274,8 +274,8 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
         )
     );
 }
-// see issue #6659
-TEST_F(DPrintFixture, DISABLED_TestPrintRaiseWait) {
+
+TEST_F(DPrintFixture, TestPrintRaiseWait) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }


### PR DESCRIPTION
CI Passing (w/ 5 passing runs for re-enabled dprint tests): 
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8460909086
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8460910725