### PR TITLE
#6443: Update Unary Div backward

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_lt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_lt.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,11 +17,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_binary_lt(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.binary_lt_bw(grad_tensor, input_tensor)
     pt_y = torch.zeros_like(grad_data)
     golden_tensor = [pt_y, pt_y]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_ne.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_ne.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,11 +17,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_binary_ne(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.binary_ne_bw(grad_tensor, input_tensor)
     pt_y = torch.zeros_like(grad_data)
     golden_tensor = [pt_y, pt_y]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ge.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ge.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,12 +17,12 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_unary_ge(input_shapes, device):
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     tt_output_tensor_on_device = tt_lib.tensor.ge_bw(grad_tensor)
 
     pyt_y = torch.zeros_like(grad_data)
 
     golden_tensor = [pyt_y]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_relu.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -18,8 +18,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 # @pytest.mark.parametrize("threshold",[0.0])
 def test_bw_relu(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     pyt_y = torch.relu(in_data)
 
@@ -32,5 +32,5 @@ def test_bw_relu(input_shapes, device):
     golden_tensor = list()
     golden_tensor.append(in_data.grad)
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_square.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_square.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -17,12 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_square(input_shapes, device):
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
-    in_data = torch.Tensor(size=input_shapes).uniform_()
-    in_data.requires_grad = True
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
     pyt_y = torch.square(in_data)
 
@@ -33,5 +29,5 @@ def test_bw_square(input_shapes, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_threshold.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_threshold.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -18,16 +18,12 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 @pytest.mark.parametrize(
     "threshold",
-    [-1.0, -0.5, 0.0, 0.5, 1.0],
+    [-2.0, -0.5, 0.0, 0.5, 2.0],
 )
 @pytest.mark.parametrize("value", [1.0])
 def test_bw_threshold(input_shapes, threshold, value, device):
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
-    in_data = torch.Tensor(size=input_shapes).uniform_()
-    in_data.requires_grad = True
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device, True)
 
     pyt_y = torch.threshold(in_data, threshold=threshold, value=value)
     tt_output_tensor_on_device = tt_lib.tensor.threshold_bw(grad_tensor, input_tensor, threshold, value)
@@ -37,5 +33,5 @@ def test_bw_threshold(input_shapes, threshold, value, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_div.py
@@ -5,7 +5,14 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    data_gen_with_val,
+    data_gen_with_range,
+    compare_pcc,
+)
+from models.utility_functions import (
+    skip_for_wormhole_b0,
+)
 
 
 @pytest.mark.parametrize(
@@ -24,10 +31,11 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
         "floor",
     ),
 )
-@pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
-def test_bw_unary_div(input_shapes, scalar, round_mode, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+@pytest.mark.parametrize("scalar", [0.0])
+@skip_for_wormhole_b0()
+def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_div_bw(
         grad_tensor, input_tensor, scalar=scalar, round_mode=round_mode
@@ -43,5 +51,44 @@ def test_bw_unary_div(input_shapes, scalar, round_mode, device):
 
     golden_tensor = [in_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "round_mode",
+    (
+        "None",
+        "trunc",
+        "floor",
+    ),
+)
+@pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
+def test_bw_unary_div(input_shapes, scalar, round_mode, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.unary_div_bw(
+        grad_tensor, input_tensor, scalar=scalar, round_mode=round_mode
+    )
+
+    in_data.retain_grad()
+
+    if round_mode == "None":
+        round_mode = None
+    pyt_y = torch.div(in_data, torch.tensor(scalar), rounding_mode=round_mode)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -163,8 +163,13 @@ std::vector<Tensor> _unary_div_bw(const Tensor& grad, const Tensor& input, float
     std::vector<Tensor> grad_tensor;
     float inv_scalar = 1.0f/scalar;
     if (round_mode=="None"){
-        Tensor result = mul_unary(grad, inv_scalar, output_mem_config);
-        grad_tensor.emplace_back(result);
+        Tensor t_inf = full_like(input, std::numeric_limits<float>::infinity(), output_mem_config);
+        if(scalar == 0.0){
+            float t_nan  = std::nanf("");
+            grad_tensor.emplace_back( where(eqz(grad, output_mem_config), t_nan, mul( sign(grad, output_mem_config), t_inf, std::nullopt, output_mem_config), output_mem_config) );
+        }else{
+            grad_tensor.emplace_back( mul_unary(grad, inv_scalar, output_mem_config) );
+        }
     }
     else{
         Tensor result = zeros_like(grad, output_mem_config);


### PR DESCRIPTION
#6443  Updated logic for backward Unary Div op and updated few backward test files

Issues addressed : 
- **Unary Div** : 
   - Updated logic to get nan / inf / -inf based on input. 
   - Checked PCC and All close - both passes
   - Updated test file
- **Test file Updated for the following ops** : 
   - Square
   - Threshold
   - Where
   - Unary Div
   - Relu
   - Binary LT
   - Binary NE
   - GE

All post-commit tests - [Link](https://github.com/tenstorrent-metal/tt-metal/actions/runs/8506031588)