### PR TITLE
Merge packetized routing path implemetnation to fd-2/main

### DIFF
--- a/tests/tt_metal/tt_metal/module.mk
+++ b/tests/tt_metal/tt_metal/module.mk
@@ -17,6 +17,9 @@ TT_METAL_TESTS += \
 		 tests/tt_metal/perf_microbenchmark/dispatch/test_prefetcher \
 		 tests/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data \
 		 tests/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional \
+		 tests/tt_metal/perf_microbenchmark/routing/test_tx_rx \
+		 tests/tt_metal/perf_microbenchmark/routing/test_mux_demux \
+		 tests/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level \
 		 tests/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1 \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1 \

--- a/tests/tt_metal/tt_metal/module.mk
+++ b/tests/tt_metal/tt_metal/module.mk
@@ -20,6 +20,9 @@ TT_METAL_TESTS += \
 		 tests/tt_metal/perf_microbenchmark/routing/test_tx_rx \
 		 tests/tt_metal/perf_microbenchmark/routing/test_mux_demux \
 		 tests/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level \
+		 tests/tt_metal/perf_microbenchmark/routing/test_uni_tunnel \
+		 tests/tt_metal/perf_microbenchmark/routing/test_uni_tunnel_single_chip \
+		 tests/tt_metal/perf_microbenchmark/routing/test_bi_tunnel \
 		 tests/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1 \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1 \

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp
@@ -49,6 +49,7 @@ void kernel_main() {
     noc_async_write(cmd_ptr, get_noc_addr_helper(dispatch_noc_xy, dispatch_cb_base), dispatch_cb_page_size);
     downstream_cb_release_pages<dispatch_noc_xy, dispatch_cb_sem>(1);
     noc_async_write_barrier();
+    noc_async_atomic_barrier();
 }
 #else
 void kernel_main() {
@@ -78,5 +79,6 @@ void kernel_main() {
     noc_async_write(cmd_ptr, get_noc_addr_helper(dispatch_noc_xy, dispatch_data_ptr), dispatch_cb_page_size);
     downstream_cb_release_pages<dispatch_noc_xy, dispatch_cb_sem>(1);
     noc_async_write_barrier();
+    noc_async_atomic_barrier();
 }
 #endif

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_packet_path.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_packet_path.cpp
@@ -1,0 +1,1330 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <functional>
+#include <random>
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_cmds.hpp"
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
+#include "common.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_test.hpp"
+
+
+constexpr uint32_t DEFAULT_TEST_TYPE = 0;
+constexpr uint32_t WORKER_DATA_SIZE = 768 * 1024;
+constexpr uint32_t MAX_PAGE_SIZE = 64 * 1024;
+constexpr uint32_t MAX_DRAM_READ_SIZE = 256 * 1024;
+constexpr uint32_t DRAM_PAGE_SIZE_DEFAULT = 1024;
+constexpr uint32_t DRAM_PAGES_TO_READ_DEFAULT = 16;
+
+constexpr uint32_t DISPATCH_BUFFER_LOG_PAGE_SIZE = 12;
+constexpr uint32_t DISPATCH_BUFFER_SIZE_BLOCKS = 4;
+// 764 to make this not divisible by 3 so we can test wrapping of dispatch buffer
+constexpr uint32_t DISPATCH_BUFFER_BLOCK_SIZE_PAGES = 764 * 1024 / (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE) / DISPATCH_BUFFER_SIZE_BLOCKS;
+
+constexpr uint32_t DEFAULT_HUGEPAGE_BUFFER_SIZE = 256 * 1024 * 1024;
+constexpr uint32_t DEFAULT_PREFETCH_Q_ENTRIES = 128;
+constexpr uint32_t DEFAULT_MAX_PREFETCH_COMMAND_SIZE = 64 * 1024;
+constexpr uint32_t DEFAULT_CMDDAT_Q_SIZE = 128 * 1024;
+constexpr uint32_t DEFAULT_SCRATCH_DB_SIZE = 128 * 1024;
+
+constexpr uint32_t DEFAULT_ITERATIONS = 10000;
+
+constexpr uint32_t PREFETCH_Q_LOG_MINSIZE = 4;
+constexpr uint32_t HUGEPAGE_ALIGNMENT = ((1 << PREFETCH_Q_LOG_MINSIZE) > CQ_PREFETCH_CMD_BARE_MIN_SIZE) ? (1 << PREFETCH_Q_LOG_MINSIZE) : CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+
+constexpr uint32_t DRAM_DATA_SIZE_BYTES = 16 * 1024 * 1024;
+constexpr uint32_t DRAM_DATA_SIZE_WORDS = DRAM_DATA_SIZE_BYTES / sizeof(uint32_t);
+constexpr uint32_t DRAM_HACKED_BASE_ADDR = 1024 * 1024;  // don't interfere w/ fast dispatch storing our kernels...
+constexpr uint32_t DRAM_DATA_ALIGNMENT = 32;
+
+constexpr uint32_t PCIE_TRANSFER_SIZE_DEFAULT = 4096;
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Test dispatch program performance
+//
+// Times dispatching program to M cores, N processors, of various sizes, CBs, runtime args
+//////////////////////////////////////////////////////////////////////////////////////////
+using namespace tt;
+
+uint32_t iterations_g = DEFAULT_ITERATIONS;
+bool warmup_g = false;
+bool debug_g;
+uint32_t max_prefetch_command_size_g;
+
+uint32_t dispatch_buffer_page_size_g = 4096;
+uint32_t prefetch_q_entries_g;
+uint32_t hugepage_buffer_size_g;
+uint32_t cmddat_q_size_g;
+uint32_t scratch_db_size_g;
+uint32_t num_dram_banks_g;
+bool use_coherent_data_g;
+uint32_t test_type_g;
+bool readback_every_iteration_g;
+uint32_t big_g;
+uint32_t pcie_transfer_size_g;
+uint32_t dram_page_size_g;
+uint32_t dram_pages_to_read_g;
+
+uint32_t bytes_of_data_g = 0;
+bool initialize_device_g = true;
+uint32_t dispatch_wait_addr_g;
+
+CoreCoord first_worker_g = { 0, 1 };
+CoreRange all_workers_g = {
+    first_worker_g,
+    {first_worker_g.x + 1, first_worker_g.y + 1},
+};
+
+bool send_to_all_g = false;
+bool perf_test_g = false;
+
+uint32_t max_xfer_size_bytes_g = 0xFFFFFFFF;
+uint32_t min_xfer_size_bytes_g = 0;
+
+
+constexpr uint32_t tx_gen_x = 3;
+constexpr uint32_t tx_gen_y = 0;
+constexpr uint32_t rx_gen_x = 3;
+constexpr uint32_t rx_gen_y = 3;
+
+constexpr uint32_t relay_mux_x = 3;
+constexpr uint32_t relay_mux_y = 1;
+constexpr uint32_t relay_demux_x = 3;
+constexpr uint32_t relay_demux_y = 2;
+
+constexpr uint32_t prng_seed = 0x100;
+constexpr uint32_t data_kb_per_tx = 16*1024;
+constexpr uint32_t max_packet_size_words = 0x100;
+
+constexpr uint32_t tx_queue_start_addr = 0x80000;
+constexpr uint32_t tx_queue_size_bytes = 0x10000;
+constexpr uint32_t rx_queue_start_addr = 0xa0000;
+constexpr uint32_t rx_queue_size_bytes = 0x20000;
+constexpr uint32_t relay_mux_queue_start_addr = 0x80000;
+constexpr uint32_t relay_mux_queue_size_bytes = 0x10000;
+constexpr uint32_t relay_demux_queue_start_addr = 0x90000;
+constexpr uint32_t relay_demux_queue_size_bytes = 0x20000;
+
+constexpr uint32_t test_results_addr = 0x100000;
+constexpr uint32_t test_results_size = 1024;
+
+constexpr uint32_t timeout_mcycles = 1000;
+constexpr uint32_t rx_disable_data_check = 0;
+
+constexpr uint32_t src_endpoint_start_id = 0xaa;
+constexpr uint32_t dest_endpoint_start_id = 0xbb;
+
+constexpr uint32_t num_src_endpoints = 1;
+constexpr uint32_t num_dest_endpoints = 1;
+
+
+void init(int argc, char **argv) {
+    std::vector<std::string> input_args(argv, argv + argc);
+
+    if (test_args::has_command_option(input_args, "-h") ||
+        test_args::has_command_option(input_args, "--help")) {
+        log_info(LogTest, "Usage:");
+        log_info(LogTest, "  -w: warm-up before starting timer (default disabled)");
+        log_info(LogTest, "  -i: host iterations (default {})", DEFAULT_ITERATIONS);
+        log_info(LogTest, "  -t: test type: 0:Smoke 1:Random 2:PCIe, 3:DRAM (default {})", DEFAULT_TEST_TYPE);
+        log_info(LogTest, " -wx: right-most worker in grid (default {})", all_workers_g.end.x);
+        log_info(LogTest, " -wy: bottom-most worker in grid (default {})", all_workers_g.end.y);
+        log_info(LogTest, "  -b: run a \"big\" test (fills memory w/ fewer transactions) (default false)", DEFAULT_TEST_TYPE);
+        log_info(LogTest, " -rb: gen data, readback and test every iteration - disable for perf measurements (default true)");
+        log_info(LogTest, "  -d: wrap all commands in debug commands (default disabled)");
+        log_info(LogTest, "  -hp: host huge page buffer size (default {})", DEFAULT_HUGEPAGE_BUFFER_SIZE);
+        log_info(LogTest, "  -pq: prefetch queue entries (default {})", DEFAULT_PREFETCH_Q_ENTRIES);
+        log_info(LogTest, "  -cs: max cmddat q size (default {})", DEFAULT_CMDDAT_Q_SIZE);
+        log_info(LogTest, "  -ss: max scratch cb size (default {})", DEFAULT_SCRATCH_DB_SIZE);
+        log_info(LogTest, "  -mc: max command size (default {})", DEFAULT_MAX_PREFETCH_COMMAND_SIZE);
+        log_info(LogTest, "  -pcies: size of data to transfer in pcie bw test type (default )", PCIE_TRANSFER_SIZE_DEFAULT);
+        log_info(LogTest, "  -dpgs: dram page size in dram bw test type (default )", DRAM_PAGE_SIZE_DEFAULT);
+        log_info(LogTest, "  -dpgr: dram pages to read in dram bw test type (default )", DRAM_PAGES_TO_READ_DEFAULT);
+        log_info(LogTest, "  -c: use coherent data as payload (default false)");
+        log_info(LogTest, "  -s: seed for randomized tests (default 1)");
+        exit(0);
+    }
+
+    warmup_g = test_args::has_command_option(input_args, "-w");
+    iterations_g = test_args::get_command_option_uint32(input_args, "-i", DEFAULT_ITERATIONS);
+    hugepage_buffer_size_g = test_args::get_command_option_uint32(input_args, "-hp", DEFAULT_HUGEPAGE_BUFFER_SIZE);
+    prefetch_q_entries_g = test_args::get_command_option_uint32(input_args, "-hq", DEFAULT_PREFETCH_Q_ENTRIES);
+    cmddat_q_size_g = test_args::get_command_option_uint32(input_args, "-cs", DEFAULT_CMDDAT_Q_SIZE);
+    scratch_db_size_g = test_args::get_command_option_uint32(input_args, "-ss", DEFAULT_SCRATCH_DB_SIZE);
+    max_prefetch_command_size_g = test_args::get_command_option_uint32(input_args, "-mc", DEFAULT_MAX_PREFETCH_COMMAND_SIZE);
+    use_coherent_data_g = test_args::has_command_option(input_args, "-c");
+    readback_every_iteration_g = !test_args::has_command_option(input_args, "-rb");
+    pcie_transfer_size_g = test_args::get_command_option_uint32(input_args, "-pcies", PCIE_TRANSFER_SIZE_DEFAULT);
+    pcie_transfer_size_g = test_args::get_command_option_uint32(input_args, "-pcies", PCIE_TRANSFER_SIZE_DEFAULT);
+    dram_page_size_g = test_args::get_command_option_uint32(input_args, "-dpgs", DRAM_PAGE_SIZE_DEFAULT);
+    dram_pages_to_read_g = test_args::get_command_option_uint32(input_args, "-dpgr", DRAM_PAGES_TO_READ_DEFAULT);
+
+    test_type_g = test_args::get_command_option_uint32(input_args, "-t", DEFAULT_TEST_TYPE);
+    all_workers_g.end.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end.x);
+    all_workers_g.end.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end.y);
+
+    uint32_t seed = test_args::get_command_option_uint32(input_args, "-s", 1);
+    std::srand(seed);
+    big_g = test_args::has_command_option(input_args, "-b");
+    debug_g = test_args::has_command_option(input_args, "-d");
+}
+
+uint32_t round_cmd_size_up(uint32_t size) {
+    constexpr uint32_t align_mask = HUGEPAGE_ALIGNMENT - 1;
+
+    return (size + align_mask) & ~align_mask;
+}
+
+void add_bare_prefetcher_cmd(vector<uint32_t>& cmds,
+                             CQPrefetchCmd& cmd,
+                             bool pad = false) {
+
+    uint32_t *ptr = (uint32_t *)&cmd;
+    for (int i = 0; i < sizeof(CQPrefetchCmd) / sizeof(uint32_t); i++) {
+        cmds.push_back(*ptr++);
+    }
+
+    if (pad) {
+        // Pad debug cmd to always be the alignment size
+        for (uint32_t i = 0; i < (CQ_PREFETCH_CMD_BARE_MIN_SIZE - sizeof(CQPrefetchCmd)) / sizeof(uint32_t); i++) {
+            cmds.push_back(std::rand());
+        }
+    }
+}
+
+void add_prefetcher_dram_cmd(vector<uint32_t>& cmds,
+                             vector<uint16_t>& sizes,
+                             uint32_t start_page,
+                             uint32_t base_addr,
+                             uint32_t page_size,
+                             uint32_t pages) {
+
+    CQPrefetchCmd cmd;
+    cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_PAGED;
+
+    cmd.relay_paged.is_dram = true;
+    cmd.relay_paged.start_page = start_page;
+    cmd.relay_paged.base_addr = base_addr;
+    cmd.relay_paged.page_size = page_size;
+    cmd.relay_paged.pages = pages;
+
+    add_bare_prefetcher_cmd(cmds, cmd, true);
+}
+
+void add_prefetcher_linear_read_cmd(Device *device,
+                                    vector<uint32_t>& cmds,
+                                    vector<uint16_t>& sizes,
+                                    CoreCoord worker_core,
+                                    uint32_t addr,
+                                    uint32_t length) {
+
+    CoreCoord phys_worker_core = device->worker_core_from_logical_core(worker_core);
+
+    CQPrefetchCmd cmd;
+    cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_LINEAR;
+
+    cmd.relay_linear.noc_xy_addr = NOC_XY_ENCODING(phys_worker_core.x, phys_worker_core.y);
+    cmd.relay_linear.addr = addr;
+    cmd.relay_linear.length = length;
+
+    add_bare_prefetcher_cmd(cmds, cmd, true);
+}
+
+void add_prefetcher_cmd(vector<uint32_t>& cmds,
+                        vector<uint16_t>& sizes,
+                        CQPrefetchCmdId id,
+                        vector<uint32_t>& payload) {
+
+    vector<uint32_t> data;
+
+    auto prior_end = cmds.size();
+
+    if (debug_g) {
+        CQPrefetchCmd debug_cmd;
+        debug_cmd.base.cmd_id = CQ_PREFETCH_CMD_DEBUG;
+        add_bare_prefetcher_cmd(cmds, debug_cmd, true);
+    }
+
+    CQPrefetchCmd cmd;
+    cmd.base.cmd_id = id;
+
+    uint32_t payload_length_bytes = payload.size() * sizeof(uint32_t);
+    switch (id) {
+    case CQ_PREFETCH_CMD_RELAY_PAGED:
+        TT_ASSERT(false);
+        break;
+
+    case CQ_PREFETCH_CMD_RELAY_INLINE:
+    case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
+        cmd.relay_inline.length = payload_length_bytes;
+        cmd.relay_inline.stride = round_cmd_size_up(payload_length_bytes + sizeof(CQPrefetchCmd));
+        break;
+
+    case CQ_PREFETCH_CMD_STALL:
+        break;
+
+    case CQ_PREFETCH_CMD_DEBUG:
+        {
+            static uint32_t key = 0;
+            cmd.debug.key = ++key;
+            cmd.debug.size = payload_length_bytes;
+            cmd.debug.stride = round_cmd_size_up(payload_length_bytes + sizeof(CQPrefetchCmd));
+            uint32_t checksum = 0;
+            for (uint32_t i = 0; i < payload.size(); i++) {
+                checksum += payload[i];
+            }
+            cmd.debug.checksum = checksum;
+        }
+        break;
+
+    case CQ_PREFETCH_CMD_TERMINATE:
+        break;
+
+    default:
+        fprintf(stderr, "Invalid prefetcher command: %d\n", id);
+        break;
+    }
+
+    add_bare_prefetcher_cmd(cmds, cmd);
+    uint32_t cmd_size_bytes = (cmds.size() - prior_end) * sizeof(uint32_t);
+    for (int i = 0; i < payload.size(); i++) {
+        cmds.push_back(payload[i]);
+    }
+    uint32_t pad_size_bytes = round_cmd_size_up(cmd_size_bytes + payload_length_bytes) - payload_length_bytes - cmd_size_bytes;
+    for (int i = 0; i < pad_size_bytes / sizeof(uint32_t); i++) {
+        cmds.push_back(0);
+    }
+    uint32_t new_size = (cmds.size() - prior_end) * sizeof(uint32_t);
+    TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
+    TT_ASSERT((new_size >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
+    sizes.push_back(new_size >> PREFETCH_Q_LOG_MINSIZE);
+
+    if (debug_g) {
+        CQPrefetchCmd* debug_cmd_ptr;
+        debug_cmd_ptr = (CQPrefetchCmd *)&cmds[prior_end];
+        debug_cmd_ptr->debug.size = (cmds.size() - prior_end) * sizeof(uint32_t) - sizeof(CQPrefetchCmd);
+        debug_cmd_ptr->debug.stride = CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+        uint32_t checksum = 0;
+        for (uint32_t i = prior_end + sizeof(CQPrefetchCmd) / sizeof(uint32_t); i < cmds.size(); i++) {
+            checksum += cmds[i];
+        }
+        debug_cmd_ptr->debug.checksum = checksum;
+    }
+}
+
+// Model a paged read by updating worker data with interleaved/paged DRAM data, for validation later.
+void add_paged_dram_data_to_worker_data(const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                                  const CoreRange& workers,
+                                  worker_data_t& worker_data,
+                                  uint32_t start_page,
+                                  uint32_t base_addr,
+                                  uint32_t page_size,
+                                  uint32_t pages) {
+
+    uint32_t base_addr_words = base_addr / sizeof(uint32_t);
+    uint32_t page_size_words = page_size / sizeof(uint32_t);
+
+    // Get data from DRAM map, add to all workers, but only set valid for cores included in workers range.
+    TT_ASSERT(start_page < num_dram_banks_g);
+    for (uint32_t page_idx = start_page; page_idx < start_page + pages; page_idx++) {
+
+        uint32_t dram_bank_id = page_idx % num_dram_banks_g;
+        uint32_t bank_offset = base_addr_words + page_size_words * (page_idx / num_dram_banks_g);
+
+        for (uint32_t j = 0; j  < page_size_words; j++) {
+            for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
+                for (uint32_t x = all_workers_g.start.x; x <= all_workers_g.end.x; x++) {
+                    CoreCoord core(x, y);
+                    worker_data[core].data.push_back(dram_data_map.at(dram_bank_id)[bank_offset + j]);
+                    worker_data[core].valid.push_back(workers.contains(core));
+                }
+            }
+        }
+    }
+}
+
+void gen_dram_read_cmd(Device *device,
+                       vector<uint32_t>& prefetch_cmds,
+                       vector<uint16_t>& cmd_sizes,
+                       const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                       worker_data_t& worker_data,
+                       CoreCoord worker_core,
+                       uint32_t dst_addr,
+                       uint32_t start_page,
+                       uint32_t base_addr,
+                       uint32_t page_size,
+                       uint32_t pages) {
+
+    vector<uint32_t> dispatch_cmds;
+
+    uint32_t worker_data_size = page_size * pages;
+    gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, worker_data_size);
+
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
+
+    auto prior_end = prefetch_cmds.size();
+    add_prefetcher_dram_cmd(prefetch_cmds, cmd_sizes, start_page, base_addr + DRAM_HACKED_BASE_ADDR, page_size, pages);
+
+    uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
+    TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
+    TT_ASSERT((new_size >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
+    cmd_sizes.push_back(new_size >> PREFETCH_Q_LOG_MINSIZE);
+
+    // Model the paged read in this function by updating worker data with interleaved/paged DRAM data, for validation later.
+    add_paged_dram_data_to_worker_data(dram_data_map, worker_core, worker_data, start_page, base_addr, page_size, pages);
+}
+
+// This is pretty much a blit: copies from worker core's start of data back to the end of data
+void gen_linear_read_cmd(Device *device,
+                         vector<uint32_t>& prefetch_cmds,
+                         vector<uint16_t>& cmd_sizes,
+                         const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                         worker_data_t& worker_data,
+                         CoreCoord worker_core,
+                         uint32_t addr,
+                         uint32_t length,
+                         uint32_t offset = 0) {
+
+    vector<uint32_t> dispatch_cmds;
+
+    gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, addr, length);
+
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
+
+    auto prior_end = prefetch_cmds.size();
+    add_prefetcher_linear_read_cmd(device, prefetch_cmds, cmd_sizes, worker_core, addr + offset * sizeof(uint32_t), length);
+
+    uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
+    TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
+    TT_ASSERT((new_size >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
+    cmd_sizes.push_back(new_size >> PREFETCH_Q_LOG_MINSIZE);
+
+    // Add linear data to worker data:
+    uint32_t length_words = length / sizeof(uint32_t);
+    for (uint32_t i = 0; i < length_words; i++) {
+        for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
+            for (uint32_t x = all_workers_g.start.x; x <= all_workers_g.end.x; x++) {
+                CoreCoord core(x, y);
+                if (core == worker_core) {
+                    uint32_t datum = worker_data[core].data[offset + i];
+                    worker_data[core].data.push_back(datum);
+                    worker_data[core].valid.push_back(true);
+                } else {
+                    worker_data[core].data.push_back(0);
+                    worker_data[core].valid.push_back(false);
+                }
+            }
+        }
+    }
+}
+
+void gen_wait_and_stall_cmd(Device *device,
+                            vector<uint32_t>& prefetch_cmds,
+                            vector<uint16_t>& cmd_sizes) {
+
+    vector<uint32_t> dispatch_cmds;
+
+    CQDispatchCmd wait;
+    wait.base.cmd_id = CQ_DISPATCH_CMD_WAIT;
+    wait.wait.barrier = true;
+    wait.wait.notify_prefetch = true;
+    wait.wait.addr = dispatch_wait_addr_g;
+    wait.wait.count = 0;
+    add_bare_dispatcher_cmd(dispatch_cmds, wait);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    vector<uint32_t> empty_payload; // don't give me grief, it is just a test
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_STALL, empty_payload);
+}
+
+void gen_dispatcher_delay_cmd(Device *device,
+                              vector<uint32_t>& prefetch_cmds,
+                              vector<uint16_t>& cmd_sizes,
+                              uint32_t count) {
+
+    vector<uint32_t> dispatch_cmds;
+
+    CQDispatchCmd delay;
+    delay.base.cmd_id = CQ_DISPATCH_CMD_DELAY;
+    delay.delay.delay = count;
+    add_bare_dispatcher_cmd(dispatch_cmds, delay);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+}
+
+void gen_dram_test(Device *device,
+                   vector<uint32_t>& prefetch_cmds,
+                   vector<uint16_t>& cmd_sizes,
+                   const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                   worker_data_t& worker_data,
+                   CoreCoord worker_core,
+                   uint32_t dst_addr) {
+
+    vector<uint32_t> dispatch_cmds;
+
+    while (worker_data_size(worker_data) * sizeof(uint32_t) < WORKER_DATA_SIZE) {
+        dispatch_cmds.resize(0);
+        uint32_t start_page = 0;
+        uint32_t base_addr = 0;
+        gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
+                          start_page, base_addr, dram_page_size_g, dram_pages_to_read_g);
+
+        bytes_of_data_g += dram_page_size_g * dram_pages_to_read_g;
+    }
+}
+
+void gen_pcie_test(Device *device,
+                   vector<uint32_t>& prefetch_cmds,
+                   vector<uint16_t>& cmd_sizes,
+                   const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                   worker_data_t& worker_data,
+                   CoreCoord worker_core,
+                   uint32_t dst_addr) {
+
+    vector<uint32_t> dispatch_cmds;
+
+    while (worker_data_size(worker_data) * sizeof(uint32_t) < WORKER_DATA_SIZE) {
+        dispatch_cmds.resize(0);
+        gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, pcie_transfer_size_g);
+        add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+        bytes_of_data_g += pcie_transfer_size_g;
+    }
+}
+
+void gen_rnd_dram_paged_cmd(Device *device,
+                            vector<uint32_t>& prefetch_cmds,
+                            vector<uint16_t>& cmd_sizes,
+                            const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                            worker_data_t& worker_data,
+                            CoreCoord worker_core,
+                            uint32_t dst_addr) {
+
+    vector<uint32_t> dispatch_cmds;
+
+    uint32_t start_page = std::rand() % num_dram_banks_g;
+    uint32_t max_page_size = big_g ? MAX_PAGE_SIZE : 4096;
+    uint32_t page_size = (std::rand() % (max_page_size + 1)) & ~(DRAM_DATA_ALIGNMENT - 1);
+    if (page_size == 0) page_size = DRAM_DATA_ALIGNMENT;
+    uint32_t max_data = big_g ? WORKER_DATA_SIZE : WORKER_DATA_SIZE / 8;
+    uint32_t max = WORKER_DATA_SIZE - worker_data_size(worker_data) * sizeof(uint32_t);
+    max = (max > max_data) ? max_data : max;
+    // start in bottom half of valid dram data to not worry about overflowing valid data
+    uint32_t base_addr = (std::rand() % (DRAM_DATA_SIZE_BYTES / 2)) & ~(DRAM_DATA_ALIGNMENT - 1);
+    uint32_t size = std::rand() % max;
+    if (size < page_size) size = page_size;
+    uint32_t pages = size / page_size;
+    TT_ASSERT(base_addr + (start_page * page_size + pages * page_size / num_dram_banks_g) < DRAM_DATA_SIZE_BYTES);
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
+                      start_page, base_addr, page_size, pages);
+}
+
+void gen_rnd_inline_cmd(Device *device,
+                        vector<uint32_t>& prefetch_cmds,
+                        vector<uint16_t>& cmd_sizes,
+                        worker_data_t& worker_data,
+                        CoreCoord worker_core,
+                        uint32_t dst_addr) {
+
+    vector<uint32_t> dispatch_cmds;
+
+    // Randomize the dispatcher command we choose to relay
+    // XXXX revisit the randomness of this, these commands get under-weighted
+
+    uint32_t which_cmd = std::rand() % 2;
+    switch (which_cmd) {
+    case 0:
+        // unicast write
+        {
+            uint32_t cmd_size_bytes = CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+            if (debug_g) {
+                cmd_size_bytes += sizeof(CQDispatchCmd);
+            }
+            uint32_t max_size = big_g ? DEFAULT_MAX_PREFETCH_COMMAND_SIZE : DEFAULT_MAX_PREFETCH_COMMAND_SIZE / 16;
+            uint32_t max_xfer_size_16b = (max_size - cmd_size_bytes) >> 4;
+            uint32_t xfer_size_16B = (std::rand() & (max_xfer_size_16b - 1));
+            // Note: this may overflow the WORKER_DATA_SIZE, but by little enough that it won't overflow L1
+            uint32_t xfer_size_bytes = xfer_size_16B << 4;
+
+            gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data,
+                                             dst_addr, xfer_size_bytes);
+        }
+        break;
+    case 1:
+        // packed unicast write
+        gen_rnd_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_data, dst_addr);
+        break;
+    }
+
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+}
+
+void gen_rnd_debug_cmd(vector<uint32_t>& prefetch_cmds,
+                       vector<uint16_t>& cmd_sizes,
+                       worker_data_t& worker_data,
+                       uint32_t dst_addr) {
+
+    vector<uint32_t> rnd_payload;
+    generate_random_payload(rnd_payload, std::rand() % (dispatch_buffer_page_size_g - sizeof(CQDispatchCmd)) + 1);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_DEBUG, rnd_payload);
+}
+
+void gen_rnd_test(Device *device,
+                  vector<uint32_t>& prefetch_cmds,
+                  vector<uint16_t>& cmd_sizes,
+                  const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                  worker_data_t& worker_data,
+                  uint32_t dst_addr) {
+
+    while (worker_data_size(worker_data) * sizeof(uint32_t) < WORKER_DATA_SIZE) {
+        // Assumes terminate is the last command...
+        uint32_t cmd = std::rand() % CQ_PREFETCH_CMD_TERMINATE;
+        uint32_t x = rand() % (all_workers_g.end.x - first_worker_g.x);
+        uint32_t y = rand() % (all_workers_g.end.y - first_worker_g.y);
+
+        CoreCoord worker_core(first_worker_g.x + x, first_worker_g.y + y);
+
+        switch (cmd) {
+        case CQ_PREFETCH_CMD_RELAY_PAGED:
+            gen_rnd_dram_paged_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr);
+            break;
+        case CQ_PREFETCH_CMD_RELAY_INLINE:
+            gen_rnd_inline_cmd(device, prefetch_cmds, cmd_sizes, worker_data, worker_core, dst_addr);
+            break;
+        case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
+            break;
+        case CQ_PREFETCH_CMD_STALL:
+            break;
+        case CQ_PREFETCH_CMD_DEBUG:
+            gen_rnd_debug_cmd(prefetch_cmds, cmd_sizes, worker_data, dst_addr);
+            break;
+        }
+    }
+}
+
+void gen_smoke_test(Device *device,
+                    vector<uint32_t>& prefetch_cmds,
+                    vector<uint16_t>& cmd_sizes,
+                    const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                    worker_data_t& worker_data,
+                    CoreCoord worker_core,
+                    uint32_t dst_addr) {
+
+    vector<uint32_t> empty_payload; // don't give me grief, it is just a test
+    vector<uint32_t> dispatch_cmds;
+
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_DEBUG, empty_payload);
+
+    vector<uint32_t> rnd_payload;
+    generate_random_payload(rnd_payload, 17);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_DEBUG, rnd_payload);
+
+    // Write to worker
+    dispatch_cmds.resize(0);
+    reset_worker_data(worker_data);
+    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, 2048);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    // Write to worker
+    dispatch_cmds.resize(0);
+    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, 1026);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    // Write to worker
+    dispatch_cmds.resize(0);
+    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, 8448);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    // Merge 4 commands in the FetchQ
+    dispatch_cmds.resize(0);
+    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, 112);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+    dispatch_cmds.resize(0);
+    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, 608);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+    dispatch_cmds.resize(0);
+    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, 64);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+    dispatch_cmds.resize(0);
+    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, 96);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    // Tests sending multiple commands w/ 1 FetchQ entry
+    uint32_t combined_size =
+        cmd_sizes[cmd_sizes.size() - 1] + cmd_sizes[cmd_sizes.size() - 2] +
+        cmd_sizes[cmd_sizes.size() - 3] + cmd_sizes[cmd_sizes.size() - 4];
+
+    cmd_sizes[cmd_sizes.size() - 4] = combined_size;
+    cmd_sizes.pop_back();
+    cmd_sizes.pop_back();
+    cmd_sizes.pop_back();
+
+    // Read from dram, write to worker
+    // start_page, base addr, page_size, pages
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
+                      0, 0, 32, num_dram_banks_g);
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
+                      0, 0, 32, num_dram_banks_g);
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
+                      4, 32, 64, num_dram_banks_g);
+
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
+                      0, 0, 128, 128);
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
+                      4, 32, 2048, num_dram_banks_g * 8);
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
+                      5, 32, 2048, num_dram_banks_g * 8 + 1);
+    gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr,
+                      3, 128, 6144, num_dram_banks_g * 8 + 7);
+
+    // Send inline data to (maybe) multiple cores
+    dispatch_cmds.resize(0);
+    vector<CoreCoord> worker_cores;
+    worker_cores.push_back(first_worker_g);
+    gen_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_cores, worker_data, dst_addr, 4);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    dispatch_cmds.resize(0);
+    worker_cores.resize(0);
+    for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
+        for (uint32_t x = all_workers_g.start.x; x <= all_workers_g.end.x; x++) {
+            CoreCoord worker_core(x, y);
+            worker_cores.push_back(worker_core);
+        }
+    }
+    gen_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_cores, worker_data, dst_addr, 12);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    dispatch_cmds.resize(0);
+    worker_cores.resize(0);
+    worker_cores.push_back(first_worker_g);
+    worker_cores.push_back({first_worker_g.x + 3, first_worker_g.y});
+    gen_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_cores, worker_data, dst_addr, 156);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    // These tests copy data from earlier tests so can't run first
+    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr, 32);
+    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr, 65 * 1024);
+
+    // Test wait/stall
+    gen_dispatcher_delay_cmd(device, prefetch_cmds, cmd_sizes, 1024 * 1024);
+    dispatch_cmds.resize(0);
+    gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, worker_data, dst_addr, 2048);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+    gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
+    gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, worker_core, dst_addr, 32, worker_data[worker_core].data.size() - 32 / sizeof(uint32_t));
+}
+
+void gen_prefetcher_cmds(Device *device,
+                         vector<uint32_t>& prefetch_cmds,
+                         vector<uint16_t>& cmd_sizes,
+                         const unordered_map<uint32_t, vector<uint32_t>>& dram_data_map,
+                         worker_data_t& worker_data,
+                         uint32_t dst_addr) {
+
+    switch (test_type_g) {
+    case 0:
+        gen_smoke_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
+        break;
+    case 1:
+        gen_rnd_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, dst_addr);
+        break;
+    case 2:
+        gen_pcie_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
+        break;
+    case 3:
+        gen_dram_test(device, prefetch_cmds, cmd_sizes, dram_data_map, worker_data, first_worker_g, dst_addr);
+        break;
+    }
+}
+
+void gen_terminate_cmds(vector<uint32_t>& prefetch_cmds,
+                        vector<uint16_t>& cmd_sizes) {
+    vector<uint32_t> empty_payload; // don't give me grief, it is just a test
+    vector<uint32_t> dispatch_cmds;
+
+    // Terminate dispatcher
+    dispatch_cmds.resize(0);
+    gen_dispatcher_terminate_cmd(dispatch_cmds);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
+    // Terminate prefetcher
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_TERMINATE, empty_payload);
+}
+
+void write_prefetcher_cmd(Device *device,
+                          vector<uint32_t>& cmds,
+                          uint32_t& cmd_offset,
+                          uint16_t cmd_size16b,
+                          uint32_t*& host_mem_ptr,
+                          uint32_t& prefetch_q_dev_ptr,
+                          uint32_t& prefetch_q_dev_fence,
+                          uint32_t prefetch_q_base,
+                          uint32_t prefetch_q_rd_ptr_addr,
+                          CoreCoord phys_prefetch_core) {
+
+    static vector<uint32_t> read_vec;  // static to avoid realloc
+
+    uint32_t cmd_size_bytes = (uint32_t)cmd_size16b << PREFETCH_Q_LOG_MINSIZE;
+    uint32_t cmd_size_words = cmd_size_bytes / sizeof(uint32_t);
+    for (uint32_t i = 0; i < cmd_size_words; i++) {
+        *host_mem_ptr = cmds[cmd_offset];
+        host_mem_ptr++;
+        cmd_offset++;
+    }
+    // Not clear to me if this is needed, writing to cached PCIe memory
+    tt_driver_atomics::sfence();
+
+    // wait for space
+    while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
+        tt::Cluster::instance().read_core(read_vec, sizeof(uint32_t), tt_cxy_pair(device->id(), phys_prefetch_core), prefetch_q_rd_ptr_addr);
+        prefetch_q_dev_fence = read_vec[0];
+    }
+
+    // wrap
+    if (prefetch_q_dev_ptr == prefetch_q_base + prefetch_q_entries_g * sizeof(uint16_t)) {
+        prefetch_q_dev_ptr = prefetch_q_base;
+
+        while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
+            tt::Cluster::instance().read_core(read_vec, sizeof(uint32_t), tt_cxy_pair(device->id(), phys_prefetch_core), prefetch_q_rd_ptr_addr);
+            prefetch_q_dev_fence = read_vec[0];
+        }
+    }
+
+    tt::Cluster::instance().write_core((void *)&cmd_size16b, sizeof(uint16_t), tt_cxy_pair(device->id(), phys_prefetch_core), prefetch_q_dev_ptr, true);
+
+    prefetch_q_dev_ptr += sizeof(uint16_t);
+}
+
+void write_prefetcher_cmds(uint32_t iterations,
+                           Device *device,
+                           vector<uint32_t>& prefetch_cmds,
+                           vector<uint16_t>& cmd_sizes,
+                           void * host_hugepage_base,
+                           uint32_t dev_hugepage_base,
+                           uint32_t prefetch_q_base,
+                           uint32_t prefetch_q_rd_ptr_addr,
+                           CoreCoord phys_prefetch_core) {
+
+    static uint32_t *host_mem_ptr;
+    static uint32_t prefetch_q_dev_ptr;
+    static uint32_t prefetch_q_dev_fence;
+
+    if (initialize_device_g) {
+        vector<uint32_t> prefetch_q(DEFAULT_PREFETCH_Q_ENTRIES, 0);
+        vector<uint32_t> prefetch_q_rd_ptr_addr_data;
+
+        prefetch_q_rd_ptr_addr_data.push_back(prefetch_q_base + prefetch_q_entries_g * sizeof(uint16_t));
+        llrt::write_hex_vec_to_core(device->id(), phys_prefetch_core, prefetch_q_rd_ptr_addr_data, prefetch_q_rd_ptr_addr);
+        llrt::write_hex_vec_to_core(device->id(), phys_prefetch_core, prefetch_q, prefetch_q_base);
+
+        host_mem_ptr = (uint32_t *)host_hugepage_base;
+        prefetch_q_dev_ptr = prefetch_q_base;
+        prefetch_q_dev_fence = prefetch_q_base + prefetch_q_entries_g * sizeof(uint16_t);
+        initialize_device_g = false;
+    }
+
+    for (uint32_t i = 0; i < iterations; i++) {
+        uint32_t cmd_ptr = 0;
+        for (uint32_t j = 0; j < cmd_sizes.size(); j++) {
+            uint32_t cmd_size_words = ((uint32_t)cmd_sizes[j] << PREFETCH_Q_LOG_MINSIZE) / sizeof(uint32_t);
+            uint32_t space_at_end_for_wrap_words = CQ_PREFETCH_CMD_BARE_MIN_SIZE / sizeof(uint32_t);
+            if ((void *)(host_mem_ptr + cmd_size_words) > (void *)((uint8_t *)host_hugepage_base + hugepage_buffer_size_g)) {
+                // Wrap huge page
+                uint32_t offset = 0;
+                host_mem_ptr = (uint32_t *)host_hugepage_base;
+            }
+            write_prefetcher_cmd(device, prefetch_cmds, cmd_ptr, cmd_sizes[j],
+                                 host_mem_ptr, prefetch_q_dev_ptr, prefetch_q_dev_fence, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
+        }
+    }
+}
+
+// Populate interleaved DRAM with data for later readback.  Can we extended to L1 if needed.
+void populate_interleaved_dram(Device *device, unordered_map<uint32_t, vector<uint32_t>>& dram_data_map)
+{
+
+    num_dram_banks_g = device->num_banks(BufferType::DRAM);;
+
+    for (int bank_id = 0; bank_id < num_dram_banks_g; bank_id++) {
+        auto offset = device->dram_bank_offset_from_bank_id(bank_id);
+        auto dram_channel = device->dram_channel_from_bank_id(bank_id);
+        auto bank_core = device->core_from_dram_channel(dram_channel);
+
+        // Generate random or coherent data per bank of specific size.
+        for (uint32_t i = 0; i < DRAM_DATA_SIZE_WORDS; i++) {
+            uint32_t datum = (use_coherent_data_g) ? (((bank_id & 0xFF) << 24) | i) : std::rand();
+            dram_data_map[bank_id].push_back(datum);
+            if (i < 10) {
+                log_debug(tt::LogTest, "{} - bank_id: {:2d} core: {} offset: 0x{:08x} using i: {:2d} datum: 0x{:08x}",
+                    __FUNCTION__, bank_id, bank_core.str(), offset, i, datum);
+            }
+        }
+
+        // Write to device once per bank (appropriate core and offset)
+        tt::Cluster::instance().write_core(static_cast<const void*>(dram_data_map[bank_id].data()),
+            dram_data_map[bank_id].size() * sizeof(uint32_t), tt_cxy_pair(device->id(), bank_core), DRAM_HACKED_BASE_ADDR + offset);
+    }
+}
+
+std::chrono::duration<double> run_test(uint32_t iterations,
+                                       Device *device,
+                                       Program& program,
+                                       vector<uint16_t>& cmd_sizes,
+                                       vector<uint16_t>& terminate_sizes,
+                                       vector<uint32_t>& cmds,
+                                       vector<uint32_t>& terminate_cmds,
+                                       void * host_hugepage_base,
+                                       uint32_t dev_hugepage_base,
+                                       uint32_t prefetch_q_base,
+                                       uint32_t prefetch_q_rd_ptr_addr,
+                                       CoreCoord phys_prefetch_core) {
+
+    auto start = std::chrono::system_clock::now();
+
+    std::thread t1 ([&]() {
+        write_prefetcher_cmds(iterations, device, cmds, cmd_sizes, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
+        write_prefetcher_cmds(1, device, terminate_cmds, terminate_sizes, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
+    });
+    tt_metal::detail::LaunchProgram(device, program);
+    t1.join();
+
+    auto end = std::chrono::system_clock::now();
+
+    return end-start;
+}
+
+int main(int argc, char **argv) {
+    auto slow_dispatch_mode = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+    TT_FATAL(slow_dispatch_mode, "This test only supports TT_METAL_SLOW_DISPATCH_MODE");
+
+    init(argc, argv);
+
+    uint32_t dispatch_buffer_pages = DISPATCH_BUFFER_BLOCK_SIZE_PAGES * DISPATCH_BUFFER_SIZE_BLOCKS;
+
+    bool pass = true;
+    try {
+        int device_id = 0;
+        tt_metal::Device *device = tt_metal::CreateDevice(device_id);
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        CoreCoord prefetch_core = {0, 0};
+        CoreCoord dispatch_core = {4, 0};
+
+        CoreCoord phys_prefetch_core = device->worker_core_from_logical_core(prefetch_core);
+        CoreCoord phys_dispatch_core = device->worker_core_from_logical_core(dispatch_core);
+
+        ////
+
+        CoreCoord tx_gen_core = {tx_gen_x, tx_gen_y};
+        CoreCoord rx_gen_core = {rx_gen_x, rx_gen_y};
+        CoreCoord relay_mux_core = {relay_mux_x, relay_mux_y};
+        CoreCoord relay_demux_core = {relay_demux_x, relay_demux_y};
+
+        CoreCoord phys_tx_gen_core = device->worker_core_from_logical_core(tx_gen_core);
+        CoreCoord phys_rx_gen_core = device->worker_core_from_logical_core(rx_gen_core);
+        CoreCoord phys_relay_mux_core = device->worker_core_from_logical_core(relay_mux_core);
+        CoreCoord phys_relay_demux_core = device->worker_core_from_logical_core(relay_demux_core);
+
+        std::vector<uint32_t> tx_gen_compile_args =
+        {
+            src_endpoint_start_id, // 0: src_endpoint_id
+            num_dest_endpoints, // 1: num_dest_endpoints
+            (tx_queue_start_addr >> 4), // 2: queue_start_addr_words
+            (tx_queue_size_bytes >> 4), // 3: queue_size_words
+            (relay_mux_queue_start_addr >> 4), // 4: remote_rx_queue_start_addr_words
+            (relay_mux_queue_size_bytes >> 4), // 5: remote_rx_queue_size_words
+            (uint32_t)phys_relay_mux_core.x, // 6: remote_rx_x
+            (uint32_t)phys_relay_mux_core.y, // 7: remote_rx_y
+            0, // 8: remote_rx_queue_id
+            (uint32_t)DispatchRemoteNetworkType::NOC0, // 9: tx_network_type
+            test_results_addr, // 10: test_results_addr
+            test_results_size, // 11: test_results_size
+            prng_seed, // 12: prng_seed
+            data_kb_per_tx, // 13: total_data_kb
+            max_packet_size_words, // 14: max_packet_size_words
+            src_endpoint_start_id, // 15: src_endpoint_start_id
+            dest_endpoint_start_id, // 16: dest_endpoint_start_id
+            timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+        };
+
+        log_info(LogTest, "run traffic_gen_tx at x={},y={}", tx_gen_core.x, tx_gen_core.y);
+        auto tx_gen_kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
+            {tx_gen_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = tx_gen_compile_args,
+                .defines = {}
+            }
+        );
+
+        std::vector<uint32_t> rx_gen_compile_args =
+        {
+            dest_endpoint_start_id, // 0: dest_endpoint_id
+            num_src_endpoints, // 1: num_src_endpoints
+            num_dest_endpoints, // 2: num_dest_endpoints
+            (rx_queue_start_addr >> 4), // 3: queue_start_addr_words
+            (rx_queue_size_bytes >> 4), // 4: queue_size_words
+            (uint32_t)phys_relay_demux_core.x, // 5: remote_tx_x
+            (uint32_t)phys_relay_demux_core.y, // 6: remote_tx_y
+            0, // 7: remote_tx_queue_id
+            (uint32_t)DispatchRemoteNetworkType::NOC0, // 8: rx_rptr_update_network_type
+            test_results_addr, // 9: test_results_addr
+            test_results_size, // 10: test_results_size
+            prng_seed, // 11: prng_seed
+            0, // 12: reserved
+            max_packet_size_words, // 13: max_packet_size_words
+            rx_disable_data_check, // 14: disable data check
+            src_endpoint_start_id, // 15: src_endpoint_start_id
+            dest_endpoint_start_id, // 16: dest_endpoint_start_id
+            timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+        };
+
+        log_info(LogTest, "run traffic_gen_rx at x={},y={}", rx_gen_core.x, rx_gen_core.y);
+        auto rx_kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
+            {rx_gen_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = rx_gen_compile_args,
+                .defines = {}
+            }
+        );
+
+        std::vector<uint32_t> relay_mux_compile_args =
+        {
+            0, // 0: reserved
+            (relay_mux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+            (relay_mux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+            num_src_endpoints, // 3: mux_fan_in
+            packet_switch_4B_pack((uint32_t)phys_tx_gen_core.x,
+                                    (uint32_t)phys_tx_gen_core.y,
+                                    1,
+                                    (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: src 0 info
+            packet_switch_4B_pack(0,
+                                    0,
+                                    1,
+                                    (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: src 1 info
+            packet_switch_4B_pack(0,
+                                    0,
+                                    1,
+                                    (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: src 2 info
+            packet_switch_4B_pack(0,
+                                    0,
+                                    1,
+                                    (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: src 3 info
+            (relay_demux_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words
+            (relay_demux_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words
+            (uint32_t)phys_relay_demux_core.x, // 10: remote_tx_x
+            (uint32_t)phys_relay_demux_core.y, // 11: remote_tx_y
+            num_dest_endpoints, // 12: remote_tx_queue_id
+            (uint32_t)DispatchRemoteNetworkType::NOC0, // 13: tx_network_type
+            test_results_addr, // 14: test_results_addr
+            test_results_size, // 15: test_results_size
+            timeout_mcycles * 1000 * 1000, // 16: timeout_cycles
+        };
+
+        log_info(LogTest, "run relay mux at x={},y={}", relay_mux_core.x, relay_mux_core.y);
+        auto mux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_mux.cpp",
+            {relay_mux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = relay_mux_compile_args,
+                .defines = {}
+            }
+        );
+
+        uint32_t dest_map_array[4] = {0, 1, 2, 3};
+        uint64_t dest_endpoint_output_map = packet_switch_dest_pack(dest_map_array, 4);
+        std::vector<uint32_t> demux_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                (relay_demux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (relay_demux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                num_dest_endpoints, // 3: demux_fan_out
+                packet_switch_4B_pack(phys_rx_gen_core.x,
+                                      phys_rx_gen_core.y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_tx_0_info
+                packet_switch_4B_pack(0,
+                                      0,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: remote_tx_1_info
+                packet_switch_4B_pack(0,
+                                      0,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: remote_tx_2_info
+                packet_switch_4B_pack(0,
+                                      0,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: remote_tx_3_info
+                (rx_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words 0
+                (rx_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words 0
+                (rx_queue_start_addr >> 4), // 10: remote_tx_queue_start_addr_words 1
+                (rx_queue_size_bytes >> 4), // 11: remote_tx_queue_size_words 1
+                (rx_queue_start_addr >> 4), // 12: remote_tx_queue_start_addr_words 2
+                (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
+                (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
+                (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
+                (uint32_t)phys_relay_mux_core.x, // 16: remote_rx_x
+                (uint32_t)phys_relay_mux_core.y, // 17: remote_rx_y
+                num_dest_endpoints, // 18: remote_rx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
+                (uint32_t)(dest_endpoint_output_map >> 32), // 20: dest_endpoint_output_map_hi
+                (uint32_t)(dest_endpoint_output_map & 0xFFFFFFFF), // 21: dest_endpoint_output_map_lo
+                test_results_addr, // 22: test_results_addr
+                test_results_size, // 23: test_results_size
+                timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
+            };
+
+        log_info(LogTest, "run demux at x={},y={}", relay_demux_core.x, relay_demux_core.y);
+        auto demux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_demux.cpp",
+            {relay_demux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = demux_compile_args,
+                .defines = {}
+            }
+        );
+
+        ////
+
+        // Want different buffers on each core, instead use big buffer and self-manage it
+        uint32_t l1_unreserved_base_aligned = align(L1_UNRESERVED_BASE, (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE)); // Was not aligned, lately.
+        uint32_t l1_buf_base = l1_unreserved_base_aligned + (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE); // Reserve a page.
+        TT_ASSERT((l1_buf_base & ((1 << DISPATCH_BUFFER_LOG_PAGE_SIZE) - 1)) == 0);
+
+        uint32_t dispatch_buffer_base = l1_buf_base;
+        uint32_t dev_hugepage_base = 0;
+        uint32_t prefetch_q_base = l1_buf_base;
+        uint32_t prefetch_q_rd_ptr_addr = l1_unreserved_base_aligned;
+        dispatch_wait_addr_g = l1_unreserved_base_aligned + 16;
+        vector<uint32_t>zero_data(0);
+        llrt::write_hex_vec_to_core(device->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
+
+        uint32_t prefetch_q_size = prefetch_q_entries_g * sizeof(uint16_t);
+        uint32_t noc_read_alignment = 32;
+        uint32_t cmddat_q_base = prefetch_q_base + ((prefetch_q_size + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
+        uint32_t scratch_db_base = cmddat_q_base + ((cmddat_q_size_g + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
+        TT_ASSERT(scratch_db_base < 1024 * 1024); // L1 size
+
+        // Implementation syncs w/ device on prefetch_q but not on hugepage, ie, assumes we can't run
+        // so far ahead in the hugepage that we overright un-read commands since we'll first
+        // stall on the prefetch_q
+        TT_ASSERT(hugepage_buffer_size_g > prefetch_q_entries_g * max_prefetch_command_size_g, "Shrink the max command size or grow the hugepage buffer size or shrink the prefetch_q size");
+        TT_ASSERT(cmddat_q_size_g >= 2 * max_prefetch_command_size_g);
+        TT_ASSERT(scratch_db_size_g >= MAX_PAGE_SIZE);
+
+        // NOTE: this test hijacks hugepage
+        void *host_hugepage_base;
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
+        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+        host_hugepage_base = (void*) tt::Cluster::instance().host_dma_address(0, mmio_device_id, channel);
+        host_hugepage_base = (void *)((uint8_t *)host_hugepage_base + dev_hugepage_base);
+
+        vector<uint32_t> cmds, terminate_cmds;
+        vector<uint16_t> cmd_sizes, terminate_sizes;
+        worker_data_t worker_data;
+        for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
+            for (uint32_t x = all_workers_g.start.x; x <= all_workers_g.end.x; x++) {
+                one_worker_data_t one;
+                worker_data.insert({CoreCoord(x, y), one});
+            }
+        }
+
+        // Model of interleaved DRAM memory by bank id
+        unordered_map<uint32_t, vector<uint32_t>> dram_data_map;
+        populate_interleaved_dram(device, dram_data_map);
+
+        tt::Cluster::instance().l1_barrier(device->id());
+        tt::Cluster::instance().dram_barrier(device->id());
+        gen_prefetcher_cmds(device, cmds, cmd_sizes, dram_data_map, worker_data, l1_buf_base);
+        gen_terminate_cmds(terminate_cmds, terminate_sizes);
+
+        std::map<string, string> defines = {
+            {"PREFETCH_NOC_X", std::to_string(phys_prefetch_core.x)},
+            {"PREFETCH_NOC_Y", std::to_string(phys_prefetch_core.y)},
+            {"DISPATCH_NOC_X", std::to_string(phys_dispatch_core.x)},
+            {"DISPATCH_NOC_Y", std::to_string(phys_dispatch_core.y)},
+        };
+
+        constexpr uint32_t dispatch_cb_sem = 0;
+        tt_metal::CreateSemaphore(program, {prefetch_core}, dispatch_buffer_pages);
+        tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
+
+        constexpr uint32_t prefetch_sync_sem = 1;
+        tt_metal::CreateSemaphore(program, {prefetch_core}, 0);
+        tt_metal::CreateSemaphore(program, {dispatch_core}, 0);
+
+        std::vector<uint32_t> dispatch_compile_args = {
+             dispatch_buffer_base,
+             DISPATCH_BUFFER_LOG_PAGE_SIZE,
+             DISPATCH_BUFFER_SIZE_BLOCKS * DISPATCH_BUFFER_BLOCK_SIZE_PAGES,
+             dispatch_cb_sem,
+             DISPATCH_BUFFER_SIZE_BLOCKS,
+             prefetch_sync_sem,
+             // Hugepage compile args aren't used in this test since WriteHost is not tested here
+             0,
+             0,
+        };
+
+        std::vector<uint32_t> prefetch_compile_args = {
+             dispatch_buffer_base,
+             DISPATCH_BUFFER_LOG_PAGE_SIZE,
+             dispatch_buffer_pages,
+             dispatch_cb_sem,
+             dev_hugepage_base,
+             hugepage_buffer_size_g,
+             prefetch_q_base,
+             prefetch_q_entries_g * (uint32_t)sizeof(uint16_t),
+             prefetch_q_rd_ptr_addr,
+             cmddat_q_base,
+             cmddat_q_size_g,
+             scratch_db_base,
+             scratch_db_size_g,
+             prefetch_sync_sem,
+        };
+
+        auto sp1 = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/cq_prefetch_hd.cpp",
+            {prefetch_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = prefetch_compile_args,
+                .defines = defines
+            }
+        );
+
+        auto d1 = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
+            {dispatch_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = dispatch_compile_args,
+                .defines = defines
+            }
+        );
+
+        log_info(LogTest, "Hugepage buffer size {}", std::to_string(hugepage_buffer_size_g));
+        log_info(LogTest, "Prefetch prefetch_q entries {}", std::to_string(prefetch_q_entries_g));
+        log_info(LogTest, "CmdDat buffer size {}", std::to_string(cmddat_q_size_g));
+        log_info(LogTest, "Prefetch scratch buffer size {}", std::to_string(scratch_db_size_g));
+        log_info(LogTest, "Max command size {}", std::to_string(max_prefetch_command_size_g));
+        if (test_type_g >= 2) {
+            perf_test_g = true;
+        }
+        if (test_type_g == 2) {
+            perf_test_g = true;
+            log_info(LogTest, "PCIE transfer size {}", std::to_string(pcie_transfer_size_g));
+        }
+        if (test_type_g == 3) {
+            perf_test_g = true;
+            log_info(LogTest, "DRAM page size {}", std::to_string(dram_page_size_g));
+            log_info(LogTest, "DRAM pages to read {}", std::to_string(dram_pages_to_read_g));
+        }
+        if (debug_g) {
+            log_info(LogTest, "Debug mode enabled");
+        }
+        log_info(LogTest, "Iterations: {}", iterations_g);
+
+        // Cache stuff
+        if (warmup_g) {
+            std::thread t1 ([&]() {
+                write_prefetcher_cmds(1, device, cmds, cmd_sizes, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
+                write_prefetcher_cmds(1, device, terminate_cmds, terminate_sizes, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
+            });
+            tt_metal::detail::LaunchProgram(device, program);
+            t1.join();
+            initialize_device_g = true;
+        }
+
+        if (readback_every_iteration_g) {
+            for (int i = 0; i < iterations_g; i++) {
+                log_info(LogTest, "Iteration: {}", std::to_string(i));
+                initialize_device_g = true;
+                cmds.resize(0);
+                cmd_sizes.resize(0);
+                reset_worker_data(worker_data);
+                gen_prefetcher_cmds(device, cmds, cmd_sizes, dram_data_map, worker_data, l1_buf_base);
+                run_test(1, device, program, cmd_sizes, terminate_sizes, cmds, terminate_cmds, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
+                pass &= validate_results(device, all_workers_g, worker_data, l1_buf_base);
+                if (!pass) {
+                    break;
+                }
+            }
+        } else {
+            auto elapsed_seconds = run_test(iterations_g, device, program, cmd_sizes, terminate_sizes, cmds, terminate_cmds, host_hugepage_base, dev_hugepage_base, prefetch_q_base, prefetch_q_rd_ptr_addr, phys_prefetch_core);
+
+            log_info(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);
+            log_info(LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / iterations_g);
+            log_warning(LogTest, "Performance mode, not validating results");
+            if (test_type_g == 2 || test_type_g == 3) {
+                float bw = bytes_of_data_g * iterations_g / (elapsed_seconds.count() * 1000.0 * 1000.0 * 1000.0);
+                std::stringstream ss;
+                ss << std::fixed << std::setprecision(3) << bw;
+                log_info(LogTest, "BW: {} GB/s", ss.str());
+            }
+        }
+
+        vector<uint32_t> tx_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), phys_tx_gen_core, test_results_addr, test_results_size);
+        log_info(LogTest, "TX status = {}", packet_queue_test_status_to_string(tx_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (tx_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+
+        vector<uint32_t> rx_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), phys_rx_gen_core, test_results_addr, test_results_size);
+        log_info(LogTest, "RX status = {}", packet_queue_test_status_to_string(rx_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (rx_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+
+        vector<uint32_t> mux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), phys_relay_mux_core, test_results_addr, test_results_size);
+        log_info(LogTest, "relay mux status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+
+        vector<uint32_t> demux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), phys_relay_demux_core, test_results_addr, test_results_size);
+        log_info(LogTest, "relay demux status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
+
+        pass &= tt_metal::CloseDevice(device);
+    } catch (const std::exception& e) {
+        pass = false;
+        log_fatal(e.what());
+    }
+
+    tt::llrt::OptionsG.set_kernels_nullified(false);
+
+    if (pass) {
+        log_info(LogTest, "Test Passed");
+        return 0;
+    } else {
+        log_fatal(LogTest, "Test Failed\n");
+        return 1;
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp
@@ -6,7 +6,7 @@
 
 #include "debug/dprint.h"
 
-FORCE_INLINE uint32_t prng_next(uint32_t n) {
+inline uint32_t prng_next(uint32_t n) {
     uint32_t x = n;
     x ^= x << 13;
     x ^= x >> 17;
@@ -14,7 +14,7 @@ FORCE_INLINE uint32_t prng_next(uint32_t n) {
     return x;
 }
 
-FORCE_INLINE uint32_t packet_rnd_seed_to_size(uint32_t rnd_seed, uint32_t max_packet_size_words) {
+inline uint32_t packet_rnd_seed_to_size(uint32_t rnd_seed, uint32_t max_packet_size_words) {
     uint32_t packet_size = (rnd_seed & (max_packet_size_words-1)) + 1;
     if (packet_size < 2) {
         packet_size = 2;
@@ -48,7 +48,7 @@ typedef struct {
         this->num_dests_sent_last_packet = 0;
     }
 
-    FORCE_INLINE void rnd_packet_update(uint32_t num_dest_endpoints,
+    inline void rnd_packet_update(uint32_t num_dest_endpoints,
                                   uint32_t dest_endpoint_start_id,
                                   uint32_t max_packet_size_words,
                                   uint64_t total_data_words) {
@@ -61,7 +61,7 @@ typedef struct {
         this->num_packets++;
     }
 
-    FORCE_INLINE void next_packet_rnd(uint32_t num_dest_endpoints,
+    inline void next_packet_rnd(uint32_t num_dest_endpoints,
                                 uint32_t dest_endpoint_start_id,
                                 uint32_t max_packet_size_words,
                                 uint64_t total_data_words) {
@@ -84,7 +84,7 @@ typedef struct {
         }
     }
 
-    FORCE_INLINE void next_packet_rnd_to_dest(uint32_t num_dest_endpoints,
+    inline void next_packet_rnd_to_dest(uint32_t num_dest_endpoints,
                                         uint32_t dest_endpoint_id,
                                         uint32_t dest_endpoint_start_id,
                                         uint32_t max_packet_size_words,
@@ -100,23 +100,23 @@ typedef struct {
                                 max_packet_size_words, total_data_words);
     }
 
-    FORCE_INLINE bool start_of_packet() {
+    inline bool start_of_packet() {
         return this->curr_packet_words_remaining == this->curr_packet_size_words;
     }
 
-    FORCE_INLINE bool packet_active() {
+    inline bool packet_active() {
         return this->curr_packet_words_remaining != 0;
     }
 
-    FORCE_INLINE bool all_packets_done() {
+    inline bool all_packets_done() {
         return this->data_and_last_packets_done && !this->packet_active();
     }
 
-    FORCE_INLINE uint64_t get_data_words_input() {
+    inline uint64_t get_data_words_input() {
         return this->data_words_input;
     }
 
-    FORCE_INLINE uint64_t get_num_packets() {
+    inline uint64_t get_num_packets() {
         return this->num_packets;
     }
 
@@ -136,7 +136,7 @@ typedef struct {
 } input_queue_rnd_state_t;
 
 
-FORCE_INLINE void fill_packet_data(tt_l1_ptr uint32_t* start_addr, uint32_t num_words, uint32_t start_val) {
+inline void fill_packet_data(tt_l1_ptr uint32_t* start_addr, uint32_t num_words, uint32_t start_val) {
     tt_l1_ptr uint32_t* addr = start_addr + (PACKET_WORD_SIZE_BYTES/4 - 1);
     for (uint32_t i = 0; i < num_words; i++) {
         *addr = start_val++;
@@ -145,7 +145,7 @@ FORCE_INLINE void fill_packet_data(tt_l1_ptr uint32_t* start_addr, uint32_t num_
 }
 
 
-FORCE_INLINE bool check_packet_data(tt_l1_ptr uint32_t* start_addr, uint32_t num_words, uint32_t start_val,
+inline bool check_packet_data(tt_l1_ptr uint32_t* start_addr, uint32_t num_words, uint32_t start_val,
                               uint32_t& mismatch_addr, uint32_t& mismatch_val, uint32_t& expected_val) {
     tt_l1_ptr uint32_t* addr = start_addr + (PACKET_WORD_SIZE_BYTES/4 - 1);
     for (uint32_t i = 0; i < num_words; i++) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp
@@ -120,19 +120,6 @@ typedef struct {
         return this->num_packets;
     }
 
-    void dprint_object() {
-        DPRINT << "input_queue_rnd_state_t: " << ENDL();
-        DPRINT << "  data_words_input: " << DEC() << this->data_words_input << ENDL();
-        DPRINT << "  num_packets: " << DEC() << this->num_packets << ENDL();
-        DPRINT << "  packet_rnd_seed: 0x" << HEX() << this->packet_rnd_seed << ENDL();
-        DPRINT << "  curr_packet_size_words: " << DEC() << this->curr_packet_size_words << ENDL();
-        DPRINT << "  curr_packet_dest: 0x" << HEX() << this->curr_packet_dest << ENDL();
-        DPRINT << "  curr_packet_flags: 0x" << HEX() << this->curr_packet_flags << ENDL();
-        DPRINT << "  curr_packet_words_remaining: " << DEC() << this->curr_packet_words_remaining << ENDL();
-        DPRINT << "  data_and_last_packets_done: " << DEC() << this->data_and_last_packets_done << ENDL();
-        DPRINT << "  data_packets_done: " << DEC() << this->data_packets_done << ENDL();
-    }
-
 } input_queue_rnd_state_t;
 
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "debug/dprint.h"
+
+FORCE_INLINE uint32_t prng_next(uint32_t n) {
+    uint32_t x = n;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    return x;
+}
+
+FORCE_INLINE uint32_t packet_rnd_seed_to_size(uint32_t rnd_seed, uint32_t max_packet_size_words) {
+    uint32_t packet_size = (rnd_seed & (max_packet_size_words-1)) + 1;
+    if (packet_size < 2) {
+        packet_size = 2;
+    }
+    return packet_size;
+}
+
+// Structure used for randomizing packet sequences based on a starting random seed.
+// Used on the TX generator side to generate traffic and on the RX side to verify
+// the correcntess of received packets.
+typedef struct {
+
+    uint64_t data_words_input;
+    uint64_t num_packets;
+    uint32_t packet_rnd_seed;
+    uint32_t curr_packet_size_words;
+    uint32_t curr_packet_words_remaining;
+    uint32_t curr_packet_dest;
+    uint32_t curr_packet_flags;
+    uint32_t num_dests_sent_last_packet;
+    bool data_packets_done;
+    bool data_and_last_packets_done;
+
+    void init(uint32_t prng_seed, uint32_t endpoint_id) {
+        this->packet_rnd_seed = prng_seed ^ endpoint_id;
+        this->curr_packet_words_remaining = 0;
+        this->data_packets_done = false;
+        this->data_and_last_packets_done = false;
+        this->num_packets = 0;
+        this->data_words_input = 0;
+        this->num_dests_sent_last_packet = 0;
+    }
+
+    FORCE_INLINE void rnd_packet_update(uint32_t num_dest_endpoints,
+                                  uint32_t dest_endpoint_start_id,
+                                  uint32_t max_packet_size_words,
+                                  uint64_t total_data_words) {
+        this->curr_packet_dest = ((this->packet_rnd_seed >> 16) & (num_dest_endpoints-1)) + dest_endpoint_start_id;
+        this->curr_packet_size_words = packet_rnd_seed_to_size(this->packet_rnd_seed, max_packet_size_words);
+        this->curr_packet_flags = 0;
+        this->curr_packet_words_remaining = this->curr_packet_size_words;
+        this->data_words_input += this->curr_packet_size_words;
+        this->data_packets_done = this->data_words_input >= total_data_words;
+        this->num_packets++;
+    }
+
+    FORCE_INLINE void next_packet_rnd(uint32_t num_dest_endpoints,
+                                uint32_t dest_endpoint_start_id,
+                                uint32_t max_packet_size_words,
+                                uint64_t total_data_words) {
+        if (!this->data_packets_done) {
+            this->packet_rnd_seed = prng_next(this->packet_rnd_seed);
+            this->rnd_packet_update(num_dest_endpoints, dest_endpoint_start_id,
+                                    max_packet_size_words, total_data_words);
+        } else {
+            this->packet_rnd_seed = 0xffffffff;
+            this->curr_packet_dest = this->num_dests_sent_last_packet + dest_endpoint_start_id;
+            this->curr_packet_flags = DispatchPacketFlag::PACKET_TEST_LAST;
+            this->curr_packet_size_words = 2;
+            this->curr_packet_words_remaining = this->curr_packet_size_words;
+            this->data_words_input += 2;
+            this->num_packets++;
+            this->num_dests_sent_last_packet++;
+            if (this->num_dests_sent_last_packet == num_dest_endpoints) {
+                this->data_and_last_packets_done = true;
+            }
+        }
+    }
+
+    FORCE_INLINE void next_packet_rnd_to_dest(uint32_t num_dest_endpoints,
+                                        uint32_t dest_endpoint_id,
+                                        uint32_t dest_endpoint_start_id,
+                                        uint32_t max_packet_size_words,
+                                        uint64_t total_data_words) {
+        uint32_t rnd = this->packet_rnd_seed;
+        uint32_t dest;
+        do {
+            rnd = prng_next(rnd);
+            dest = (rnd >> 16) & (num_dest_endpoints-1);
+        } while (dest != (dest_endpoint_id - dest_endpoint_start_id));
+        this->packet_rnd_seed = rnd;
+        this->rnd_packet_update(num_dest_endpoints, dest_endpoint_start_id,
+                                max_packet_size_words, total_data_words);
+    }
+
+    FORCE_INLINE bool start_of_packet() {
+        return this->curr_packet_words_remaining == this->curr_packet_size_words;
+    }
+
+    FORCE_INLINE bool packet_active() {
+        return this->curr_packet_words_remaining != 0;
+    }
+
+    FORCE_INLINE bool all_packets_done() {
+        return this->data_and_last_packets_done && !this->packet_active();
+    }
+
+    FORCE_INLINE uint64_t get_data_words_input() {
+        return this->data_words_input;
+    }
+
+    FORCE_INLINE uint64_t get_num_packets() {
+        return this->num_packets;
+    }
+
+    void dprint_object() {
+        DPRINT << "input_queue_rnd_state_t: " << ENDL();
+        DPRINT << "  data_words_input: " << DEC() << this->data_words_input << ENDL();
+        DPRINT << "  num_packets: " << DEC() << this->num_packets << ENDL();
+        DPRINT << "  packet_rnd_seed: 0x" << HEX() << this->packet_rnd_seed << ENDL();
+        DPRINT << "  curr_packet_size_words: " << DEC() << this->curr_packet_size_words << ENDL();
+        DPRINT << "  curr_packet_dest: 0x" << HEX() << this->curr_packet_dest << ENDL();
+        DPRINT << "  curr_packet_flags: 0x" << HEX() << this->curr_packet_flags << ENDL();
+        DPRINT << "  curr_packet_words_remaining: " << DEC() << this->curr_packet_words_remaining << ENDL();
+        DPRINT << "  data_and_last_packets_done: " << DEC() << this->data_and_last_packets_done << ENDL();
+        DPRINT << "  data_packets_done: " << DEC() << this->data_packets_done << ENDL();
+    }
+
+} input_queue_rnd_state_t;
+
+
+FORCE_INLINE void fill_packet_data(tt_l1_ptr uint32_t* start_addr, uint32_t num_words, uint32_t start_val) {
+    tt_l1_ptr uint32_t* addr = start_addr + (PACKET_WORD_SIZE_BYTES/4 - 1);
+    for (uint32_t i = 0; i < num_words; i++) {
+        *addr = start_val++;
+        addr += (PACKET_WORD_SIZE_BYTES/4);
+    }
+}
+
+
+FORCE_INLINE bool check_packet_data(tt_l1_ptr uint32_t* start_addr, uint32_t num_words, uint32_t start_val,
+                              uint32_t& mismatch_addr, uint32_t& mismatch_val, uint32_t& expected_val) {
+    tt_l1_ptr uint32_t* addr = start_addr + (PACKET_WORD_SIZE_BYTES/4 - 1);
+    for (uint32_t i = 0; i < num_words; i++) {
+        if (*addr != start_val) {
+            mismatch_addr = reinterpret_cast<uint32_t>(addr);
+            mismatch_val = *addr;
+            expected_val = start_val;
+            return false;
+        }
+        start_val++;
+        addr += (PACKET_WORD_SIZE_BYTES/4);
+    }
+    return true;
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue.hpp"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp"
+
+packet_input_queue_state_t input_queues[MAX_SWITCH_FAN_IN];
+
+constexpr uint32_t endpoint_id = get_compile_time_arg_val(0);
+
+constexpr uint32_t num_src_endpoints = get_compile_time_arg_val(1);
+constexpr uint32_t num_dest_endpoints = get_compile_time_arg_val(2);
+
+static_assert(is_power_of_2(num_src_endpoints), "num_src_endpoints must be a power of 2");
+static_assert(is_power_of_2(num_dest_endpoints), "num_dest_endpoints must be a power of 2");
+
+constexpr uint32_t input_queue_id = 0;
+
+constexpr uint32_t queue_start_addr_words = get_compile_time_arg_val(3);
+constexpr uint32_t queue_size_words = get_compile_time_arg_val(4);
+
+static_assert(is_power_of_2(queue_size_words), "queue_size_words must be a power of 2");
+
+constexpr uint32_t remote_tx_x = get_compile_time_arg_val(5);
+constexpr uint32_t remote_tx_y = get_compile_time_arg_val(6);
+constexpr uint32_t remote_tx_queue_id = get_compile_time_arg_val(7);
+
+constexpr DispatchRemoteNetworkType rx_rptr_update_network_type = static_cast<DispatchRemoteNetworkType>(get_compile_time_arg_val(8));
+
+constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(9);
+constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(10);
+
+tt_l1_ptr uint32_t* const test_results =
+    reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_addr_arg);
+
+constexpr uint32_t prng_seed = get_compile_time_arg_val(11);
+
+constexpr uint32_t reserved = get_compile_time_arg_val(12);
+
+constexpr uint32_t max_packet_size_words = get_compile_time_arg_val(13);
+
+constexpr uint32_t disable_data_check = get_compile_time_arg_val(14);
+
+constexpr uint32_t src_endpoint_start_id = get_compile_time_arg_val(15);
+constexpr uint32_t dest_endpoint_start_id = get_compile_time_arg_val(16);
+
+constexpr uint32_t timeout_cycles = get_compile_time_arg_val(17);
+
+
+// predicts size and payload of packets from each destination, should have
+// the same random seed as the corresponding traffic_gen_tx
+input_queue_rnd_state_t src_rnd_state[num_src_endpoints];
+
+
+void kernel_main() {
+
+    zero_l1_buf(test_results, test_results_size_bytes);
+    test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_STARTED;
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000000;
+    test_results[PQ_TEST_MISC_INDEX+1] = 0xdd000000 | endpoint_id;
+
+    zero_l1_buf(reinterpret_cast<tt_l1_ptr uint32_t*>(queue_start_addr_words*PACKET_WORD_SIZE_BYTES),
+                queue_size_words);
+    noc_init();
+
+    for (uint32_t i = 0; i < num_src_endpoints; i++) {
+        src_rnd_state[i].init(prng_seed, src_endpoint_start_id+i);
+    }
+
+    packet_input_queue_state_t* input_queue = &(input_queues[input_queue_id]);
+
+    input_queue->init(input_queue_id, queue_start_addr_words, queue_size_words,
+                      remote_tx_x, remote_tx_y, remote_tx_queue_id,
+                      rx_rptr_update_network_type);
+
+    wait_all_src_dest_ready(input_queue, 1, NULL, 0, timeout_cycles);
+
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000001;
+
+    uint64_t num_words_checked = 0;
+    uint32_t curr_packet_payload_words_remaining_to_check = 0;
+
+    uint64_t iter = 0;
+    bool timeout = false;
+    bool check_failed = false;
+    bool all_src_endpoints_last_packet = false;
+    bool src_endpoint_last_packet[num_src_endpoints] = {false};
+    uint32_t mismatch_addr, mismatch_val, expected_val;
+    tt_l1_ptr dispatch_packet_header_t* curr_packet_header_ptr;
+    input_queue_rnd_state_t* src_endpoint_rnd_state;
+    uint64_t words_sent = 0;
+    uint64_t words_cleared = 0;
+    uint64_t start_timestamp = get_timestamp();
+    uint32_t progress_timestamp = start_timestamp & 0xFFFFFFFF;
+
+    while (!all_src_endpoints_last_packet) {
+
+        iter++;
+
+        bool packet_available = false;
+        while (!packet_available) {
+            uint32_t cycles_since_progress = get_timestamp_32b() - progress_timestamp;
+            if (cycles_since_progress > timeout_cycles) {
+                test_results[PQ_TEST_MISC_INDEX] = 0xff000006;
+                timeout = true;
+                break;
+            }
+            uint32_t num_words_available;
+            packet_available = input_queue->input_queue_full_packet_available_to_send(num_words_available);
+            if (!packet_available) {
+                // Mark works as "sent" immediately to keep pipeline from stalling.
+                // This is OK since num_words_available comes from the call above, so
+                // it's guaranteed to be smaller than the full next packet.
+                input_queue->input_queue_advance_words_sent(num_words_available);
+                words_sent += num_words_available;
+            }
+        }
+
+        if (timeout) {
+            break;
+        }
+
+        curr_packet_header_ptr = input_queue->get_curr_packet_header_ptr();
+        uint32_t src_endpoint_id = input_queue->get_curr_packet_src();
+        uint32_t src_endpoint_index = src_endpoint_id - src_endpoint_start_id;
+        uint32_t curr_packet_size_words = input_queue->get_curr_packet_size_words();
+        uint32_t curr_packet_dest = input_queue->get_curr_packet_dest();
+        uint32_t curr_packet_tag = input_queue->get_curr_packet_tag();
+        uint32_t curr_packet_flags = input_queue->get_curr_packet_flags();
+
+        if (src_endpoint_index >= num_src_endpoints ||
+            curr_packet_size_words > max_packet_size_words ||
+            endpoint_id != curr_packet_dest) {
+                check_failed = true;
+                mismatch_addr = reinterpret_cast<uint32_t>(curr_packet_header_ptr);
+                mismatch_val = 0;
+                expected_val = 0;
+                test_results[PQ_TEST_MISC_INDEX+3] = 0xee000001;
+                break;
+        }
+
+        if (curr_packet_flags & PACKET_TEST_LAST) {
+            if (src_endpoint_last_packet[src_endpoint_index] ||
+                curr_packet_size_words != 2 ||
+                curr_packet_tag != 0xffffffff) {
+                    check_failed = true;
+                    mismatch_addr = reinterpret_cast<uint32_t>(curr_packet_header_ptr);
+                    mismatch_val = 0;
+                    expected_val = 0;
+                    test_results[PQ_TEST_MISC_INDEX+3] = 0xee000002;
+                    break;
+            }
+            src_endpoint_last_packet[src_endpoint_index] = true;
+        } else {
+            src_endpoint_rnd_state = &(src_rnd_state[src_endpoint_index]);
+            src_endpoint_rnd_state->next_packet_rnd_to_dest(num_dest_endpoints, endpoint_id, dest_endpoint_start_id,
+                                                            max_packet_size_words, UINT64_MAX);
+            if (src_endpoint_rnd_state->curr_packet_size_words != curr_packet_size_words ||
+                src_endpoint_rnd_state->packet_rnd_seed != curr_packet_tag) {
+                    check_failed = true;
+                    mismatch_addr = reinterpret_cast<uint32_t>(curr_packet_header_ptr);
+                    mismatch_val = curr_packet_tag;
+                    expected_val = src_endpoint_rnd_state->packet_rnd_seed;
+                    test_results[PQ_TEST_MISC_INDEX+3] = 0xee000003;
+                    break;
+            }
+        }
+
+        uint32_t num_words_available = input_queue->input_queue_curr_packet_num_words_available_to_send();
+        // we have the packet header info for checking, input queue can now switch to the next packet
+        input_queue->input_queue_advance_words_sent(num_words_available);
+        words_sent += num_words_available;
+
+        // move rptr_cleared to the packet payload
+        input_queue->input_queue_advance_words_cleared(1);
+        words_cleared++;
+
+        uint32_t curr_packet_payload_words = curr_packet_size_words-1;
+        if (!disable_data_check) {
+            uint32_t words_before_wrap = input_queue->get_queue_words_before_rptr_cleared_wrap();
+            uint32_t words_after_wrap = 0;
+            if (words_before_wrap < curr_packet_payload_words) {
+                words_after_wrap = curr_packet_payload_words - words_before_wrap;
+            } else {
+                words_before_wrap = curr_packet_payload_words;
+            }
+            if (!check_packet_data(reinterpret_cast<tt_l1_ptr uint32_t*>(input_queue->get_queue_rptr_cleared_addr_bytes()),
+                                   words_before_wrap,
+                                   (curr_packet_tag & 0xFFFF0000)+1,
+                                   mismatch_addr, mismatch_val, expected_val)) {
+                check_failed = true;
+                test_results[PQ_TEST_MISC_INDEX+3] = 0xee000005;
+                test_results[PQ_TEST_MISC_INDEX+4] = words_before_wrap;
+                test_results[PQ_TEST_MISC_INDEX+5] = words_after_wrap;
+                break;
+            }
+            input_queue->input_queue_advance_words_cleared(words_before_wrap);
+            words_cleared += words_before_wrap;
+            if (words_after_wrap > 0) {
+                if (!check_packet_data(reinterpret_cast<tt_l1_ptr uint32_t*>(input_queue->get_queue_rptr_cleared_addr_bytes()),
+                                       words_after_wrap,
+                                       (curr_packet_tag & 0xFFFF0000) + 1 + words_before_wrap,
+                                       mismatch_addr, mismatch_val, expected_val)) {
+                    check_failed = true;
+                    test_results[PQ_TEST_MISC_INDEX+3] = 0xee000006;
+                    test_results[PQ_TEST_MISC_INDEX+4] = words_before_wrap;
+                    test_results[PQ_TEST_MISC_INDEX+5] = words_after_wrap;
+                    break;
+                }
+                input_queue->input_queue_advance_words_cleared(words_after_wrap);
+                words_cleared += words_after_wrap;
+            }
+        } else {
+            input_queue->input_queue_advance_words_cleared(curr_packet_payload_words);
+            words_cleared += curr_packet_payload_words;
+        }
+        progress_timestamp = get_timestamp_32b();
+        num_words_checked += curr_packet_size_words;
+        all_src_endpoints_last_packet = true;
+        uint32_t src_endpoint_last_index_dbg = 0xe0000000;
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            all_src_endpoints_last_packet &= src_endpoint_last_packet[i];
+            if (src_endpoint_last_packet[i]) {
+                src_endpoint_last_index_dbg |= (0x1 << i);
+            }
+        }
+        test_results[PQ_TEST_MISC_INDEX+6] = src_endpoint_last_index_dbg;
+    }
+
+    uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
+
+    if (!timeout && !check_failed) {
+        test_results[PQ_TEST_MISC_INDEX] = 0xff000002;
+        input_queue->send_remote_finished_notification();
+    }
+
+    set_64b_result(test_results, num_words_checked, PQ_TEST_WORD_CNT_INDEX);
+    set_64b_result(test_results, cycles_elapsed, PQ_TEST_CYCLES_INDEX);
+    set_64b_result(test_results, iter, PQ_TEST_ITER_INDEX);
+
+    if (timeout) {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_TIMEOUT;
+        set_64b_result(test_results, words_sent, PQ_TEST_MISC_INDEX+12);
+        set_64b_result(test_results, words_cleared, PQ_TEST_MISC_INDEX+14);
+        input_queue->dprint_object();
+    } else if (check_failed) {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_DATA_MISMATCH;
+        test_results[PQ_TEST_MISC_INDEX+12] = mismatch_addr;
+        test_results[PQ_TEST_MISC_INDEX+12] = mismatch_val;
+        test_results[PQ_TEST_MISC_INDEX+12] = expected_val;
+        src_endpoint_rnd_state->dprint_object();
+        input_queue->dprint_object();
+    } else {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_PASS;
+        test_results[PQ_TEST_MISC_INDEX] = 0xff000005;
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp
@@ -251,7 +251,6 @@ void kernel_main() {
         test_results[PQ_TEST_MISC_INDEX+12] = mismatch_addr;
         test_results[PQ_TEST_MISC_INDEX+12] = mismatch_val;
         test_results[PQ_TEST_MISC_INDEX+12] = expected_val;
-        src_endpoint_rnd_state->dprint_object();
         input_queue->dprint_object();
     } else {
         test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_PASS;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_test.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_test.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+
+inline const char *packet_queue_test_status_to_string(uint32_t status) {
+    switch (status) {
+    case PACKET_QUEUE_TEST_STARTED:
+        return "STARTED";
+    case PACKET_QUEUE_TEST_PASS:
+        return "PASS";
+    case PACKET_QUEUE_TEST_TIMEOUT:
+        return "TIMEOUT";
+    case PACKET_QUEUE_TEST_DATA_MISMATCH:
+        return "DATA_MISMATCH";
+    default:
+        return "UNKNOWN";
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue.hpp"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp"
+
+packet_input_queue_state_t input_queues[MAX_SWITCH_FAN_IN];
+packet_output_queue_state_t output_queues[MAX_SWITCH_FAN_OUT];
+
+constexpr uint32_t src_endpoint_id = get_compile_time_arg_val(0);
+constexpr uint32_t num_dest_endpoints = get_compile_time_arg_val(1);
+
+static_assert(is_power_of_2(num_dest_endpoints), "num_dest_endpoints must be a power of 2");
+
+constexpr uint32_t queue_start_addr_words = get_compile_time_arg_val(2);
+constexpr uint32_t queue_size_words = get_compile_time_arg_val(3);
+constexpr uint32_t queue_size_bytes = queue_size_words*PACKET_WORD_SIZE_BYTES;
+
+static_assert(is_power_of_2(queue_size_words), "queue_size_words must be a power of 2");
+
+constexpr uint32_t remote_rx_queue_start_addr_words = get_compile_time_arg_val(4);
+constexpr uint32_t remote_rx_queue_size_words = get_compile_time_arg_val(5);
+
+static_assert(is_power_of_2(remote_rx_queue_size_words), "remote_rx_queue_size_words must be a power of 2");
+
+constexpr uint32_t remote_rx_x = get_compile_time_arg_val(6);
+constexpr uint32_t remote_rx_y = get_compile_time_arg_val(7);
+constexpr uint32_t remote_rx_queue_id = get_compile_time_arg_val(8);
+
+constexpr DispatchRemoteNetworkType
+    tx_network_type =
+        static_cast<DispatchRemoteNetworkType>(get_compile_time_arg_val(9));
+
+constexpr uint32_t test_results_addr_arg = get_compile_time_arg_val(10);
+constexpr uint32_t test_results_size_bytes = get_compile_time_arg_val(11);
+
+tt_l1_ptr uint32_t* const test_results =
+    reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_addr_arg);
+
+constexpr uint32_t prng_seed = get_compile_time_arg_val(12);
+
+constexpr uint32_t total_data_kb = get_compile_time_arg_val(13);
+constexpr uint64_t total_data_words = ((uint64_t)total_data_kb) * 1024 / PACKET_WORD_SIZE_BYTES;
+
+constexpr uint32_t max_packet_size_words = get_compile_time_arg_val(14);
+
+static_assert(is_power_of_2(max_packet_size_words), "max_packet_size_words must be a power of 2");
+static_assert(max_packet_size_words < queue_size_words, "max_packet_size_words must be less than queue_size_words");
+static_assert(max_packet_size_words > 2, "max_packet_size_words must be greater than 2");
+
+constexpr uint32_t src_endpoint_start_id = get_compile_time_arg_val(15);
+constexpr uint32_t dest_endpoint_start_id = get_compile_time_arg_val(16);
+
+constexpr uint32_t timeout_cycles = get_compile_time_arg_val(17);
+
+constexpr uint32_t input_queue_id = 0;
+constexpr uint32_t output_queue_id = 1;
+
+constexpr packet_input_queue_state_t* input_queue_ptr = &(input_queues[input_queue_id]);
+constexpr packet_output_queue_state_t* output_queue_ptr = &(output_queues[output_queue_id]);
+
+input_queue_rnd_state_t input_queue_rnd_state;
+
+
+// generates packets with ranom size and payload on the input side
+FORCE_INLINE bool input_queue_handler() {
+
+    if (input_queue_rnd_state.all_packets_done()) {
+        return true;
+    }
+
+    uint32_t free_words = input_queue_ptr->get_queue_data_num_words_free();
+    if (free_words == 0) {
+        return false;
+    }
+
+    // Each call to input_queue_handler initializes only up to the end
+    // of the queue buffer, so we don't need to handle wrapping.
+    uint32_t byte_wr_addr = input_queue_ptr->get_queue_wptr_addr_bytes();
+    uint32_t words_to_init = std::min(free_words,
+                                      input_queue_ptr->get_queue_words_before_wptr_wrap());
+    uint32_t words_initialized = 0;
+
+    while (words_initialized < words_to_init) {
+        if (input_queue_rnd_state.all_packets_done()) {
+            break;
+        }
+        else if (!input_queue_rnd_state.packet_active()) {
+            input_queue_rnd_state.next_packet_rnd(num_dest_endpoints,
+                                                  dest_endpoint_start_id,
+                                                  max_packet_size_words,
+                                                  total_data_words);
+
+            tt_l1_ptr dispatch_packet_header_t* header_ptr =
+                reinterpret_cast<tt_l1_ptr dispatch_packet_header_t*>(byte_wr_addr);
+            header_ptr->packet_size_words = input_queue_rnd_state.curr_packet_size_words;
+            header_ptr->packet_src = src_endpoint_id;
+            header_ptr->packet_dest = input_queue_rnd_state.curr_packet_dest;
+            header_ptr->packet_flags = input_queue_rnd_state.curr_packet_flags;
+            header_ptr->num_cmds = 0;
+            header_ptr->tag = input_queue_rnd_state.packet_rnd_seed;
+            words_initialized++;
+            input_queue_rnd_state.curr_packet_words_remaining--;
+            byte_wr_addr += PACKET_WORD_SIZE_BYTES;
+        }
+        else {
+            uint32_t words_remaining = words_to_init - words_initialized;
+            uint32_t num_words = std::min(words_remaining, input_queue_rnd_state.curr_packet_words_remaining);
+            uint32_t start_val =
+                (input_queue_rnd_state.packet_rnd_seed & 0xFFFF0000) +
+                (input_queue_rnd_state.curr_packet_size_words - input_queue_rnd_state.curr_packet_words_remaining);
+            fill_packet_data(reinterpret_cast<tt_l1_ptr uint32_t*>(byte_wr_addr),
+                             num_words,
+                             start_val);
+            words_initialized += num_words;
+            input_queue_rnd_state.curr_packet_words_remaining -= num_words;
+            byte_wr_addr += num_words*PACKET_WORD_SIZE_BYTES;
+        }
+    }
+    input_queue_ptr->advance_queue_local_wptr(words_initialized);
+    return false;
+}
+
+
+void kernel_main() {
+
+    zero_l1_buf(test_results, test_results_size_bytes);
+    test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_STARTED;
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000000;
+    test_results[PQ_TEST_MISC_INDEX+1] = 0xcc000000 | src_endpoint_id;
+
+    noc_init();
+    zero_l1_buf(reinterpret_cast<tt_l1_ptr uint32_t*>(queue_start_addr_words*PACKET_WORD_SIZE_BYTES),
+                queue_size_words);
+
+    input_queue_rnd_state.init(prng_seed, src_endpoint_id);
+
+    input_queue_ptr->init(input_queue_id, queue_start_addr_words, queue_size_words,
+                          // remote_x, remote_y, remote_queue_id, remote_update_network_type:
+                          0, 0, 0, DispatchRemoteNetworkType::NONE);
+
+    output_queue_ptr->init(output_queue_id, remote_rx_queue_start_addr_words, remote_rx_queue_size_words,
+                           remote_rx_x, remote_rx_y, remote_rx_queue_id, tx_network_type,
+                           input_queues, 1);
+
+    wait_all_src_dest_ready(NULL, 0, output_queue_ptr, 1, timeout_cycles);
+
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000001;
+
+    uint64_t data_words_sent = 0;
+    uint64_t iter = 0;
+    uint64_t words_flushed = 0;
+    bool timeout = false;
+    uint64_t start_timestamp = get_timestamp();
+    uint32_t progress_timestamp = start_timestamp & 0xFFFFFFFF;
+
+    while (true) {
+        iter++;
+        uint32_t cycles_since_progress = get_timestamp_32b() - progress_timestamp;
+        if (cycles_since_progress > timeout_cycles) {
+            timeout = true;
+            break;
+        }
+        bool all_packets_initialized = input_queue_handler();
+        if (input_queue_ptr->get_curr_packet_valid()) {
+            bool full_packet_sent;
+            uint32_t curr_data_words_sent = output_queue_ptr->forward_data_from_input(input_queue_id, full_packet_sent);
+            data_words_sent += curr_data_words_sent;
+            progress_timestamp = (curr_data_words_sent > 0) ? get_timestamp_32b() : progress_timestamp;
+        } else if (all_packets_initialized) {
+            break;
+        }
+        words_flushed += output_queue_ptr->prev_words_in_flight_check_flush();
+    }
+
+    if (!timeout) {
+        test_results[PQ_TEST_MISC_INDEX] = 0xff00002;
+        if (!output_queue_ptr->output_barrier(timeout_cycles)) {
+            timeout = true;
+        }
+    }
+
+    uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
+
+    if (!timeout) {
+        test_results[PQ_TEST_MISC_INDEX] = 0xff00003;
+        progress_timestamp = get_timestamp_32b();
+        while (!output_queue_ptr->is_remote_finished()) {
+            uint32_t cycles_since_progress = get_timestamp_32b() - progress_timestamp;
+            if (cycles_since_progress > timeout_cycles) {
+                timeout = true;
+                break;
+            }
+        }
+    }
+
+    uint64_t num_packets = input_queue_rnd_state.get_num_packets();
+    set_64b_result(test_results, data_words_sent, PQ_TEST_WORD_CNT_INDEX);
+    set_64b_result(test_results, cycles_elapsed, PQ_TEST_CYCLES_INDEX);
+    set_64b_result(test_results, iter, PQ_TEST_ITER_INDEX);
+    set_64b_result(test_results, total_data_words, PQ_TEST_MISC_INDEX+4);
+    set_64b_result(test_results, num_packets, PQ_TEST_MISC_INDEX+6);
+
+    if (!timeout) {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_PASS;
+        test_results[PQ_TEST_MISC_INDEX] = 0xff00004;
+    } else {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_TIMEOUT;
+        set_64b_result(test_results, words_flushed, PQ_TEST_MISC_INDEX+10);
+        input_queue_ptr->dprint_object();
+        output_queue_ptr->dprint_object();
+    }
+
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
@@ -210,8 +210,9 @@ void kernel_main() {
     } else {
         test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_TIMEOUT;
         set_64b_result(test_results, words_flushed, PQ_TEST_MISC_INDEX+10);
-        input_queue_ptr->dprint_object();
-        output_queue_ptr->dprint_object();
+        // these calls lead to code size issues?
+        // input_queue_ptr->dprint_object();
+        // output_queue_ptr->dprint_object();
     }
 
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp
@@ -66,7 +66,7 @@ input_queue_rnd_state_t input_queue_rnd_state;
 
 
 // generates packets with ranom size and payload on the input side
-FORCE_INLINE bool input_queue_handler() {
+inline bool input_queue_handler() {
 
     if (input_queue_rnd_state.all_packets_done()) {
         return true;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bi_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bi_tunnel.cpp
@@ -1,0 +1,603 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_cmds.hpp"
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "kernels/traffic_gen_test.hpp"
+
+using namespace tt;
+
+
+int main(int argc, char **argv) {
+
+    constexpr uint32_t default_tx_x = 0;
+    constexpr uint32_t default_tx_y = 0;
+    constexpr uint32_t default_rx_x = 0;
+    constexpr uint32_t default_rx_y = 3;
+
+    constexpr uint32_t default_mux_x = 0;
+    constexpr uint32_t default_mux_y = 1;
+    constexpr uint32_t default_demux_x = 0;
+    constexpr uint32_t default_demux_y = 2;
+
+    constexpr uint32_t default_tunneler_x = 0;
+    constexpr uint32_t default_tunneler_y = 0;
+
+    constexpr uint32_t default_prng_seed = 0x100;
+    constexpr uint32_t default_data_kb_per_tx = 16*1024;
+    constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_tx_queue_start_addr = 0x80000;
+    constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_rx_queue_start_addr = 0xa0000;
+    constexpr uint32_t default_rx_queue_size_bytes = 0x20000;
+    constexpr uint32_t default_mux_queue_start_addr = 0x80000;
+    constexpr uint32_t default_mux_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_demux_queue_start_addr = 0x90000;
+    constexpr uint32_t default_demux_queue_size_bytes = 0x20000;
+
+    constexpr uint32_t default_tunneler_queue_start_addr = 0x19000;
+    constexpr uint32_t default_tunneler_queue_size_bytes = 0x10000;
+
+    constexpr uint32_t default_test_results_addr = 0x100000;
+    constexpr uint32_t default_test_results_size = 0x40000;
+
+    constexpr uint32_t default_tunneler_test_results_addr = 0x39000;
+    constexpr uint32_t default_tunneler_test_results_size = 0x7000;
+
+    constexpr uint32_t default_timeout_mcycles = 1000;
+    constexpr uint32_t default_rx_disable_data_check = 0;
+
+    constexpr uint32_t src_endpoint_start_id = 0xaa;
+    constexpr uint32_t dest_endpoint_start_id = 0xbb;
+
+    constexpr uint32_t num_src_endpoints = 4;
+    constexpr uint32_t num_dest_endpoints = 4;
+
+    std::vector<std::string> input_args(argv, argv + argc);
+    if (test_args::has_command_option(input_args, "-h") ||
+        test_args::has_command_option(input_args, "--help")) {
+        log_info(LogTest, "Usage:");
+        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
+        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        return 0;
+    }
+
+    uint32_t tx_x = test_args::get_command_option_uint32(input_args, "--tx_x", default_tx_x);
+    uint32_t tx_y = test_args::get_command_option_uint32(input_args, "--tx_y", default_tx_y);
+    uint32_t rx_x = test_args::get_command_option_uint32(input_args, "--rx_x", default_rx_x);
+    uint32_t rx_y = test_args::get_command_option_uint32(input_args, "--rx_y", default_rx_y);
+    uint32_t mux_x = test_args::get_command_option_uint32(input_args, "--mux_x", default_mux_x);
+    uint32_t mux_y = test_args::get_command_option_uint32(input_args, "--mux_y", default_mux_y);
+    uint32_t demux_x = test_args::get_command_option_uint32(input_args, "--demux_x", default_demux_x);
+    uint32_t demux_y = test_args::get_command_option_uint32(input_args, "--demux_y", default_demux_y);
+    uint32_t tunneler_x = test_args::get_command_option_uint32(input_args, "--tunneler_x", default_tunneler_x);
+    uint32_t tunneler_y = test_args::get_command_option_uint32(input_args, "--tunneler_y", default_tunneler_y);
+    uint32_t prng_seed = test_args::get_command_option_uint32(input_args, "--prng_seed", default_prng_seed);
+    uint32_t data_kb_per_tx = test_args::get_command_option_uint32(input_args, "--data_kb_per_tx", default_data_kb_per_tx);
+    uint32_t max_packet_size_words = test_args::get_command_option_uint32(input_args, "--max_packet_size_words", default_max_packet_size_words);
+    uint32_t tx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--tx_queue_start_addr", default_tx_queue_start_addr);
+    uint32_t tx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--tx_queue_size_bytes", default_tx_queue_size_bytes);
+    uint32_t rx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--rx_queue_start_addr", default_rx_queue_start_addr);
+    uint32_t rx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--rx_queue_size_bytes", default_rx_queue_size_bytes);
+    uint32_t mux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--mux_queue_start_addr", default_mux_queue_start_addr);
+    uint32_t mux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--mux_queue_size_bytes", default_mux_queue_size_bytes);
+    uint32_t demux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--demux_queue_start_addr", default_demux_queue_start_addr);
+    uint32_t demux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--demux_queue_size_bytes", default_demux_queue_size_bytes);
+    uint32_t tunneler_queue_start_addr = test_args::get_command_option_uint32(input_args, "--tunneler_queue_start_addr", default_tunneler_queue_start_addr);
+    uint32_t tunneler_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--tunneler_queue_size_bytes", default_tunneler_queue_size_bytes);
+    uint32_t test_results_addr = test_args::get_command_option_uint32(input_args, "--test_results_addr", default_test_results_addr);
+    uint32_t test_results_size = test_args::get_command_option_uint32(input_args, "--test_results_size", default_test_results_size);
+    uint32_t tunneler_test_results_addr = test_args::get_command_option_uint32(input_args, "--tunneler_test_results_addr", default_tunneler_test_results_addr);
+    uint32_t tunneler_test_results_size = test_args::get_command_option_uint32(input_args, "--tunneler_test_results_size", default_tunneler_test_results_size);
+    uint32_t timeout_mcycles = test_args::get_command_option_uint32(input_args, "--timeout_mcycles", default_timeout_mcycles);
+    uint32_t rx_disable_data_check = test_args::get_command_option_uint32(input_args, "--rx_disable_data_check", default_rx_disable_data_check);
+
+    bool pass = true;
+    try {
+        int device_id_l = 0;
+        int device_id_r = 1;
+
+        tt_metal::Device *device = tt_metal::CreateDevice(device_id_l);
+        tt_metal::Device *device_r = tt_metal::CreateDevice(device_id_r);
+
+        CoreCoord tunneler_logical_core = device->get_ethernet_sockets(1)[0];
+        CoreCoord tunneler_phys_core = device->ethernet_core_from_logical_core(tunneler_logical_core);
+
+        CoreCoord r_tunneler_logical_core = device_r->get_ethernet_sockets(0)[0];
+        CoreCoord r_tunneler_phys_core = device_r->ethernet_core_from_logical_core(r_tunneler_logical_core);
+
+
+
+        std::cout<<"Left Tunneler = "<<tunneler_logical_core.str()<<std::endl;
+        std::cout<<"Right Tunneler = "<<r_tunneler_logical_core.str()<<std::endl;
+
+        CommandQueue& cq = device->command_queue();
+        CommandQueue& cq_r = device_r->command_queue();
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+        tt_metal::Program program_r = tt_metal::CreateProgram();
+
+        CoreCoord mux_core = {mux_x, mux_y};
+        CoreCoord mux_phys_core = device->worker_core_from_logical_core(mux_core);
+
+        CoreCoord demux_core = {demux_x, demux_y};
+        CoreCoord demux_phys_core = device->worker_core_from_logical_core(demux_core);
+
+        CoreCoord loopback_mux_core = {mux_x, mux_y};
+        CoreCoord loopback_mux_phys_core = device_r->worker_core_from_logical_core(loopback_mux_core);
+
+        std::vector<CoreCoord> tx_phys_core;
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            CoreCoord core = {tx_x+i, tx_y};
+            tx_phys_core.push_back(device->worker_core_from_logical_core(core));
+            std::vector<uint32_t> compile_args =
+                {
+                    src_endpoint_start_id + i, // 0: src_endpoint_id
+                    num_dest_endpoints, // 1: num_dest_endpoints
+                    (tx_queue_start_addr >> 4), // 2: queue_start_addr_words
+                    (tx_queue_size_bytes >> 4), // 3: queue_size_words
+                    ((mux_queue_start_addr + i*mux_queue_size_bytes) >> 4), // 4: remote_rx_queue_start_addr_words
+                    (mux_queue_size_bytes >> 4), // 5: remote_rx_queue_size_words
+                    (uint32_t)mux_phys_core.x, // 6: remote_rx_x
+                    (uint32_t)mux_phys_core.y, // 7: remote_rx_y
+                    i, // 8: remote_rx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 9: tx_network_type
+                    test_results_addr, // 10: test_results_addr
+                    test_results_size, // 11: test_results_size
+                    prng_seed, // 12: prng_seed
+                    data_kb_per_tx, // 13: total_data_kb
+                    max_packet_size_words, // 14: max_packet_size_words
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000 * 4, // 17: timeout_cycles
+                };
+
+            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            auto kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
+                {core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        // Mux
+        std::vector<uint32_t> mux_compile_args =
+            {
+                0, // 0: reserved
+                (mux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (mux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                num_src_endpoints, // 3: mux_fan_in
+                packet_switch_4B_pack((uint32_t)tx_phys_core[0].x,
+                                      (uint32_t)tx_phys_core[0].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: src 0 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[1].x,
+                                      (uint32_t)tx_phys_core[1].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: src 1 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[2].x,
+                                      (uint32_t)tx_phys_core[2].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: src 2 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[3].x,
+                                      (uint32_t)tx_phys_core[3].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: src 3 info
+                (tunneler_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words
+                (uint32_t)tunneler_phys_core.x, // 10: remote_tx_x
+                (uint32_t)tunneler_phys_core.y, // 11: remote_tx_y
+                0, // 12: remote_tx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 13: tx_network_type
+                test_results_addr, // 14: test_results_addr
+                test_results_size, // 15: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 16: timeout_cycles
+            };
+
+        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        auto mux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_mux.cpp",
+            {mux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = mux_compile_args,
+                .defines = {}
+            }
+        );
+
+        std::vector<uint32_t> tunneler_l_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                2, // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
+                (tunneler_queue_start_addr >> 4), // 2: rx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 3: rx_queue_size_words
+                packet_switch_4B_pack(r_tunneler_phys_core.x,
+                                      r_tunneler_phys_core.y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::ETH), // 4: remote_receiver_0_info
+                packet_switch_4B_pack(demux_phys_core.x,
+                                      demux_phys_core.y,
+                                      num_dest_endpoints,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: remote_receiver_1_info
+                (tunneler_queue_start_addr >> 4), // 6: remote_receiver_queue_start_addr_words 0
+                (tunneler_queue_size_bytes >> 4), // 7: remote_receiver_queue_size_words 0
+                (demux_queue_start_addr >> 4), // 8: remote_receiver_queue_start_addr_words 1
+                (demux_queue_size_bytes >> 4), // 9: remote_receiver_queue_size_words 1
+                packet_switch_4B_pack(mux_phys_core.x,
+                                      mux_phys_core.y,
+                                      num_dest_endpoints,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 10: remote_sender_0_info
+                packet_switch_4B_pack(r_tunneler_phys_core.x,
+                                      r_tunneler_phys_core.y,
+                                      3,
+                                      (uint32_t)DispatchRemoteNetworkType::ETH), // 11: remote_sender_1_info
+                tunneler_test_results_addr, // 12: test_results_addr
+                tunneler_test_results_size, // 13: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 14: timeout_cycles
+            };
+
+        auto tunneler_l_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/eth_tunneler.cpp",
+            tunneler_logical_core,
+            tt_metal::EthernetConfig{
+                .noc = tt_metal::NOC::NOC_0,
+                .compile_args = tunneler_l_compile_args
+            }
+        );
+
+
+        std::vector<uint32_t> tunneler_r_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                2, // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
+                (tunneler_queue_start_addr >> 4), // 2: rx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 3: rx_queue_size_words
+                packet_switch_4B_pack(loopback_mux_phys_core.x,
+                                      loopback_mux_phys_core.y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_receiver_0_info
+                packet_switch_4B_pack(tunneler_phys_core.x,
+                                      tunneler_phys_core.y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::ETH), // 5: remote_receiver_1_info
+                (mux_queue_start_addr >> 4), // 6: remote_receiver_queue_start_addr_words 0
+                (mux_queue_size_bytes >> 4), // 7: remote_receiver_queue_size_words 0
+                ((tunneler_queue_start_addr + tunneler_queue_size_bytes) >> 4), // 8: remote_receiver_queue_start_addr_words 0
+                (tunneler_queue_size_bytes >> 4), // 9: remote_receiver_queue_size_words 0
+
+                packet_switch_4B_pack(tunneler_phys_core.x,
+                                      tunneler_phys_core.y,
+                                      2,
+                                      (uint32_t)DispatchRemoteNetworkType::ETH), // 10: remote_sender_0_info
+                packet_switch_4B_pack(loopback_mux_phys_core.x,
+                                      loopback_mux_phys_core.y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 11: remote_sender_1_info
+                tunneler_test_results_addr, // 12: test_results_addr
+                tunneler_test_results_size, // 13: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 14: timeout_cycles
+            };
+
+        auto tunneler_r_kernel = tt_metal::CreateKernel(
+            program_r,
+            "tt_metal/impl/dispatch/kernels/eth_tunneler.cpp",
+            r_tunneler_logical_core,
+            tt_metal::EthernetConfig{
+                .noc = tt_metal::NOC::NOC_0,
+                .compile_args = tunneler_r_compile_args
+            }
+        );
+
+        // Loopback 1-1 Mux On R Chip
+        std::vector<uint32_t> loopback_mux_compile_args =
+            {
+                0, // 0: reserved
+                (mux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (mux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                1, // 3: mux_fan_in
+                packet_switch_4B_pack((uint32_t)r_tunneler_phys_core.x,
+                                      (uint32_t)r_tunneler_phys_core.y,
+                                      2,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: src 0 info
+                packet_switch_4B_pack(0,
+                                      0,
+                                      0,
+                                      0), // 5: src 1 info
+                packet_switch_4B_pack(0,
+                                      0,
+                                      0,
+                                      0), // 6: src 2 info
+                packet_switch_4B_pack(0,
+                                      0,
+                                      0,
+                                      0), // 7: src 3 info
+                ((tunneler_queue_start_addr + tunneler_queue_size_bytes) >> 4), // 8: remote_tx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words
+                (uint32_t)r_tunneler_phys_core.x, // 10: remote_tx_x
+                (uint32_t)r_tunneler_phys_core.y, // 11: remote_tx_y
+                1, // 12: remote_tx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 13: tx_network_type
+                test_results_addr, // 14: test_results_addr
+                test_results_size, // 15: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 16: timeout_cycles
+            };
+
+
+        log_info(LogTest, "run loopback mux at x={},y={}", loopback_mux_core.x, loopback_mux_core.y);
+        auto loopback_mux_kernel = tt_metal::CreateKernel(
+            program_r,
+            "tt_metal/impl/dispatch/kernels/packet_mux.cpp",
+            {loopback_mux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = loopback_mux_compile_args,
+                .defines = {}
+            }
+        );
+
+        std::vector<CoreCoord> rx_phys_core;
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            CoreCoord core = {rx_x+i, rx_y};
+            rx_phys_core.push_back(device->worker_core_from_logical_core(core));
+            std::vector<uint32_t> compile_args =
+                {
+                    dest_endpoint_start_id + i, // 0: dest_endpoint_id
+                    num_src_endpoints, // 1: num_src_endpoints
+                    num_dest_endpoints, // 2: num_dest_endpoints
+                    (rx_queue_start_addr >> 4), // 3: queue_start_addr_words
+                    (rx_queue_size_bytes >> 4), // 4: queue_size_words
+                    (uint32_t)demux_phys_core.x, // 5: remote_tx_x
+                    (uint32_t)demux_phys_core.y, // 6: remote_tx_y
+                    i, // 7: remote_tx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 8: rx_rptr_update_network_type
+                    test_results_addr, // 9: test_results_addr
+                    test_results_size, // 10: test_results_size
+                    prng_seed, // 11: prng_seed
+                    0, // 12: reserved
+                    max_packet_size_words, // 13: max_packet_size_words
+                    rx_disable_data_check, // 14: disable data check
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000 * 4, // 17: timeout_cycles
+                };
+
+            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            auto kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
+                {core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        // Demux
+        uint32_t dest_map_array[4] = {0, 1, 2, 3};
+        uint64_t dest_endpoint_output_map = packet_switch_dest_pack(dest_map_array, 4);
+        std::vector<uint32_t> demux_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                (demux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (demux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                num_dest_endpoints, // 3: demux_fan_out
+                packet_switch_4B_pack(rx_phys_core[0].x,
+                                      rx_phys_core[0].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_tx_0_info
+                packet_switch_4B_pack(rx_phys_core[1].x,
+                                      rx_phys_core[1].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: remote_tx_1_info
+                packet_switch_4B_pack(rx_phys_core[2].x,
+                                      rx_phys_core[2].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: remote_tx_2_info
+                packet_switch_4B_pack(rx_phys_core[3].x,
+                                      rx_phys_core[3].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: remote_tx_3_info
+                (rx_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words 0
+                (rx_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words 0
+                (rx_queue_start_addr >> 4), // 10: remote_tx_queue_start_addr_words 1
+                (rx_queue_size_bytes >> 4), // 11: remote_tx_queue_size_words 1
+                (rx_queue_start_addr >> 4), // 12: remote_tx_queue_start_addr_words 2
+                (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
+                (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
+                (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
+                (uint32_t)tunneler_phys_core.x, // 16: remote_rx_x
+                (uint32_t)tunneler_phys_core.y, // 17: remote_rx_y
+                3, // 18: remote_rx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
+                (uint32_t)(dest_endpoint_output_map >> 32), // 20: dest_endpoint_output_map_hi
+                (uint32_t)(dest_endpoint_output_map & 0xFFFFFFFF), // 21: dest_endpoint_output_map_lo
+                test_results_addr, // 22: test_results_addr
+                test_results_size, // 23: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
+            };
+
+        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        auto demux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_demux.cpp",
+            {demux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = demux_compile_args,
+                .defines = {}
+            }
+        );
+
+        log_info(LogTest, "Starting test...");
+
+        auto start = std::chrono::system_clock::now();
+        EnqueueProgram(cq, program, false);
+        EnqueueProgram(cq_r, program_r, false);
+
+        Finish(cq);
+        Finish(cq_r);
+        auto end = std::chrono::system_clock::now();
+
+        std::chrono::duration<double> elapsed_seconds = (end-start);
+        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+
+        vector<vector<uint32_t>> tx_results;
+        vector<vector<uint32_t>> rx_results;
+
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            tx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), tx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            rx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), rx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        vector<uint32_t> mux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), mux_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+
+        vector<uint32_t> demux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), demux_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
+
+        pass &= tt_metal::CloseDevice(device);
+        pass &= tt_metal::CloseDevice(device_r);
+
+        if (pass) {
+            double total_tx_bw = 0.0;
+            uint64_t total_tx_words_sent = 0;
+            uint64_t total_rx_words_checked = 0;
+            for (uint32_t i = 0; i < num_src_endpoints; i++) {
+                uint64_t tx_words_sent = get_64b_result(tx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_tx_words_sent += tx_words_sent;
+                uint64_t tx_elapsed_cycles = get_64b_result(tx_results[i], PQ_TEST_CYCLES_INDEX);
+                double tx_bw = ((double)tx_words_sent) * PACKET_WORD_SIZE_BYTES / tx_elapsed_cycles;
+                log_info(LogTest,
+                         "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, tx_words_sent, tx_elapsed_cycles, tx_bw);
+                total_tx_bw += tx_bw;
+            }
+            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            double total_rx_bw = 0.0;
+            for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+                uint64_t rx_words_checked = get_64b_result(rx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_rx_words_checked += rx_words_checked;
+                uint64_t rx_elapsed_cycles = get_64b_result(rx_results[i], PQ_TEST_CYCLES_INDEX);
+                double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
+                log_info(LogTest,
+                         "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, rx_words_checked, rx_elapsed_cycles, rx_bw);
+                total_rx_bw += rx_bw;
+            }
+            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            if (total_tx_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+            }
+            uint64_t mux_words_sent = get_64b_result(mux_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t mux_elapsed_cycles = get_64b_result(mux_results, PQ_TEST_CYCLES_INDEX);
+            uint64_t mux_iter = get_64b_result(mux_results, PQ_TEST_ITER_INDEX);
+            double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
+            double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
+            log_info(LogTest,
+                     "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     mux_words_sent, mux_elapsed_cycles, mux_bw);
+            log_info(LogTest,
+                        "MUX iters = {} -> cycles/iter = {:.1f}",
+                        mux_iter, mux_cycles_per_iter);
+            if (mux_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "MUX words sent = {} != Total RX words checked = {}", mux_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
+            }
+
+            uint64_t demux_words_sent = get_64b_result(demux_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t demux_elapsed_cycles = get_64b_result(demux_results, PQ_TEST_CYCLES_INDEX);
+            double demux_bw = ((double)demux_words_sent) * PACKET_WORD_SIZE_BYTES / demux_elapsed_cycles;
+            uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
+            double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
+            log_info(LogTest,
+                     "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     demux_words_sent, demux_elapsed_cycles, demux_bw);
+            log_info(LogTest,
+                     "DEMUX iters = {} -> cycles/iter = {:.1f}",
+                     demux_iter, demux_cycles_per_iter);
+            if (demux_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "DEMUX words sent = {} != Total RX words checked = {}", demux_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
+            }
+        }
+
+    } catch (const std::exception& e) {
+        pass = false;
+        log_fatal(e.what());
+    }
+
+    tt::llrt::OptionsG.set_kernels_nullified(false);
+
+    if (pass) {
+        log_info(LogTest, "Test Passed");
+        return 0;
+    } else {
+        log_fatal(LogTest, "Test Failed\n");
+        return 1;
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
@@ -1,0 +1,437 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_cmds.hpp"
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "kernels/traffic_gen_test.hpp"
+
+using namespace tt;
+
+
+int main(int argc, char **argv) {
+
+    constexpr uint32_t default_tx_x = 0;
+    constexpr uint32_t default_tx_y = 0;
+    constexpr uint32_t default_rx_x = 0;
+    constexpr uint32_t default_rx_y = 3;
+
+    constexpr uint32_t default_mux_x = 0;
+    constexpr uint32_t default_mux_y = 1;
+    constexpr uint32_t default_demux_x = 0;
+    constexpr uint32_t default_demux_y = 2;
+
+    constexpr uint32_t default_prng_seed = 0x100;
+    constexpr uint32_t default_data_kb_per_tx = 16*1024;
+    constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_tx_queue_start_addr = 0x80000;
+    constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_rx_queue_start_addr = 0xa0000;
+    constexpr uint32_t default_rx_queue_size_bytes = 0x20000;
+    constexpr uint32_t default_mux_queue_start_addr = 0x80000;
+    constexpr uint32_t default_mux_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_demux_queue_start_addr = 0x90000;
+    constexpr uint32_t default_demux_queue_size_bytes = 0x20000;
+
+    constexpr uint32_t default_test_results_addr = 0x100000;
+    constexpr uint32_t default_test_results_size = 0x40000;
+
+    constexpr uint32_t default_timeout_mcycles = 1000;
+    constexpr uint32_t default_rx_disable_data_check = 0;
+
+    constexpr uint32_t src_endpoint_start_id = 0xaa;
+    constexpr uint32_t dest_endpoint_start_id = 0xbb;
+
+    constexpr uint32_t default_num_endpoints = 4;
+
+    std::vector<std::string> input_args(argv, argv + argc);
+    if (test_args::has_command_option(input_args, "-h") ||
+        test_args::has_command_option(input_args, "--help")) {
+        log_info(LogTest, "Usage:");
+        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
+        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        log_info(LogTest, "  --num_endpoints: Number of endpoints, default = {}", default_num_endpoints);
+        return 0;
+    }
+
+    uint32_t tx_x = test_args::get_command_option_uint32(input_args, "--tx_x", default_tx_x);
+    uint32_t tx_y = test_args::get_command_option_uint32(input_args, "--tx_y", default_tx_y);
+    uint32_t rx_x = test_args::get_command_option_uint32(input_args, "--rx_x", default_rx_x);
+    uint32_t rx_y = test_args::get_command_option_uint32(input_args, "--rx_y", default_rx_y);
+    uint32_t mux_x = test_args::get_command_option_uint32(input_args, "--mux_x", default_mux_x);
+    uint32_t mux_y = test_args::get_command_option_uint32(input_args, "--mux_y", default_mux_y);
+    uint32_t demux_x = test_args::get_command_option_uint32(input_args, "--demux_x", default_demux_x);
+    uint32_t demux_y = test_args::get_command_option_uint32(input_args, "--demux_y", default_demux_y);
+    uint32_t prng_seed = test_args::get_command_option_uint32(input_args, "--prng_seed", default_prng_seed);
+    uint32_t data_kb_per_tx = test_args::get_command_option_uint32(input_args, "--data_kb_per_tx", default_data_kb_per_tx);
+    uint32_t max_packet_size_words = test_args::get_command_option_uint32(input_args, "--max_packet_size_words", default_max_packet_size_words);
+    uint32_t tx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--tx_queue_start_addr", default_tx_queue_start_addr);
+    uint32_t tx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--tx_queue_size_bytes", default_tx_queue_size_bytes);
+    uint32_t rx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--rx_queue_start_addr", default_rx_queue_start_addr);
+    uint32_t rx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--rx_queue_size_bytes", default_rx_queue_size_bytes);
+    uint32_t mux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--mux_queue_start_addr", default_mux_queue_start_addr);
+    uint32_t mux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--mux_queue_size_bytes", default_mux_queue_size_bytes);
+    uint32_t demux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--demux_queue_start_addr", default_demux_queue_start_addr);
+    uint32_t demux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--demux_queue_size_bytes", default_demux_queue_size_bytes);
+    uint32_t test_results_addr = test_args::get_command_option_uint32(input_args, "--test_results_addr", default_test_results_addr);
+    uint32_t test_results_size = test_args::get_command_option_uint32(input_args, "--test_results_size", default_test_results_size);
+    uint32_t timeout_mcycles = test_args::get_command_option_uint32(input_args, "--timeout_mcycles", default_timeout_mcycles);
+    uint32_t rx_disable_data_check = test_args::get_command_option_uint32(input_args, "--rx_disable_data_check", default_rx_disable_data_check);
+    uint32_t num_endpoints = test_args::get_command_option_uint32(input_args, "--num_endpoints", default_num_endpoints);
+
+    uint32_t num_src_endpoints = num_endpoints;
+    uint32_t num_dest_endpoints = num_endpoints;
+
+    bool pass = true;
+    try {
+        int device_id = 0;
+        tt_metal::Device *device = tt_metal::CreateDevice(device_id);
+
+        CommandQueue& cq = device->command_queue();
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        CoreCoord mux_core = {mux_x, mux_y};
+        CoreCoord mux_phys_core = device->worker_core_from_logical_core(mux_core);
+
+        CoreCoord demux_core = {demux_x, demux_y};
+        CoreCoord demux_phys_core = device->worker_core_from_logical_core(demux_core);
+
+        std::vector<CoreCoord> tx_phys_core;
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            CoreCoord core = {tx_x+i, tx_y};
+            tx_phys_core.push_back(device->worker_core_from_logical_core(core));
+            std::vector<uint32_t> compile_args =
+                {
+                    src_endpoint_start_id + i, // 0: src_endpoint_id
+                    num_dest_endpoints, // 1: num_dest_endpoints
+                    (tx_queue_start_addr >> 4), // 2: queue_start_addr_words
+                    (tx_queue_size_bytes >> 4), // 3: queue_size_words
+                    ((mux_queue_start_addr + i*mux_queue_size_bytes) >> 4), // 4: remote_rx_queue_start_addr_words
+                    (mux_queue_size_bytes >> 4), // 5: remote_rx_queue_size_words
+                    (uint32_t)mux_phys_core.x, // 6: remote_rx_x
+                    (uint32_t)mux_phys_core.y, // 7: remote_rx_y
+                    i, // 8: remote_rx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 9: tx_network_type
+                    test_results_addr, // 10: test_results_addr
+                    test_results_size, // 11: test_results_size
+                    prng_seed, // 12: prng_seed
+                    data_kb_per_tx, // 13: total_data_kb
+                    max_packet_size_words, // 14: max_packet_size_words
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+                };
+
+            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            auto kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
+                {core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        // Mux
+        std::vector<uint32_t> mux_compile_args =
+            {
+                0, // 0: reserved
+                (mux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (mux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                num_src_endpoints, // 3: mux_fan_in
+                packet_switch_4B_pack((uint32_t)tx_phys_core[0].x,
+                                      (uint32_t)tx_phys_core[0].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: src 0 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[1].x,
+                                      (uint32_t)tx_phys_core[1].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: src 1 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[2].x,
+                                      (uint32_t)tx_phys_core[2].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: src 2 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[3].x,
+                                      (uint32_t)tx_phys_core[3].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: src 3 info
+                (demux_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words
+                (demux_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words
+                (uint32_t)demux_phys_core.x, // 10: remote_tx_x
+                (uint32_t)demux_phys_core.y, // 11: remote_tx_y
+                num_dest_endpoints, // 12: remote_tx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 13: tx_network_type
+                test_results_addr, // 14: test_results_addr
+                test_results_size, // 15: test_results_size
+                timeout_mcycles * 1000 * 1000, // 16: timeout_cycles
+            };
+
+        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        auto mux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_mux.cpp",
+            {mux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = mux_compile_args,
+                .defines = {}
+            }
+        );
+
+        std::vector<CoreCoord> rx_phys_core;
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            CoreCoord core = {rx_x+i, rx_y};
+            rx_phys_core.push_back(device->worker_core_from_logical_core(core));
+            std::vector<uint32_t> compile_args =
+                {
+                    dest_endpoint_start_id + i, // 0: dest_endpoint_id
+                    num_src_endpoints, // 1: num_src_endpoints
+                    num_dest_endpoints, // 2: num_dest_endpoints
+                    (rx_queue_start_addr >> 4), // 3: queue_start_addr_words
+                    (rx_queue_size_bytes >> 4), // 4: queue_size_words
+                    (uint32_t)demux_phys_core.x, // 5: remote_tx_x
+                    (uint32_t)demux_phys_core.y, // 6: remote_tx_y
+                    i, // 7: remote_tx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 8: rx_rptr_update_network_type
+                    test_results_addr, // 9: test_results_addr
+                    test_results_size, // 10: test_results_size
+                    prng_seed, // 11: prng_seed
+                    0, // 12: reserved
+                    max_packet_size_words, // 13: max_packet_size_words
+                    rx_disable_data_check, // 14: disable data check
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+                };
+
+            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            auto kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
+                {core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        // Demux
+        uint32_t dest_map_array[4] = {0, 1, 2, 3};
+        uint64_t dest_endpoint_output_map = packet_switch_dest_pack(dest_map_array, 4);
+        std::vector<uint32_t> demux_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                (demux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (demux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                num_dest_endpoints, // 3: demux_fan_out
+                packet_switch_4B_pack(rx_phys_core[0].x,
+                                      rx_phys_core[0].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_tx_0_info
+                packet_switch_4B_pack(rx_phys_core[1].x,
+                                      rx_phys_core[1].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: remote_tx_1_info
+                packet_switch_4B_pack(rx_phys_core[2].x,
+                                      rx_phys_core[2].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: remote_tx_2_info
+                packet_switch_4B_pack(rx_phys_core[3].x,
+                                      rx_phys_core[3].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: remote_tx_3_info
+                (rx_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words 0
+                (rx_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words 0
+                (rx_queue_start_addr >> 4), // 10: remote_tx_queue_start_addr_words 1
+                (rx_queue_size_bytes >> 4), // 11: remote_tx_queue_size_words 1
+                (rx_queue_start_addr >> 4), // 12: remote_tx_queue_start_addr_words 2
+                (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
+                (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
+                (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
+                (uint32_t)mux_phys_core.x, // 16: remote_rx_x
+                (uint32_t)mux_phys_core.y, // 17: remote_rx_y
+                num_dest_endpoints, // 18: remote_rx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
+                (uint32_t)(dest_endpoint_output_map >> 32), // 20: dest_endpoint_output_map_hi
+                (uint32_t)(dest_endpoint_output_map & 0xFFFFFFFF), // 21: dest_endpoint_output_map_lo
+                test_results_addr, // 22: test_results_addr
+                test_results_size, // 23: test_results_size
+                timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
+            };
+
+        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        auto demux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_demux.cpp",
+            {demux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = demux_compile_args,
+                .defines = {}
+            }
+        );
+
+        log_info(LogTest, "Starting test...");
+
+        auto start = std::chrono::system_clock::now();
+        EnqueueProgram(cq, program, false);
+        Finish(cq);
+        auto end = std::chrono::system_clock::now();
+
+        std::chrono::duration<double> elapsed_seconds = (end-start);
+        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+
+        vector<vector<uint32_t>> tx_results;
+        vector<vector<uint32_t>> rx_results;
+
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            tx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), tx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            rx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), rx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        vector<uint32_t> mux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), mux_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+
+        vector<uint32_t> demux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), demux_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
+
+        pass &= tt_metal::CloseDevice(device);
+
+        if (pass) {
+            double total_tx_bw = 0.0;
+            uint64_t total_tx_words_sent = 0;
+            uint64_t total_rx_words_checked = 0;
+            for (uint32_t i = 0; i < num_src_endpoints; i++) {
+                uint64_t tx_words_sent = get_64b_result(tx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_tx_words_sent += tx_words_sent;
+                uint64_t tx_elapsed_cycles = get_64b_result(tx_results[i], PQ_TEST_CYCLES_INDEX);
+                double tx_bw = ((double)tx_words_sent) * PACKET_WORD_SIZE_BYTES / tx_elapsed_cycles;
+                log_info(LogTest,
+                         "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, tx_words_sent, tx_elapsed_cycles, tx_bw);
+                total_tx_bw += tx_bw;
+            }
+            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            double total_rx_bw = 0.0;
+            for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+                uint64_t rx_words_checked = get_64b_result(rx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_rx_words_checked += rx_words_checked;
+                uint64_t rx_elapsed_cycles = get_64b_result(rx_results[i], PQ_TEST_CYCLES_INDEX);
+                double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
+                log_info(LogTest,
+                         "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, rx_words_checked, rx_elapsed_cycles, rx_bw);
+                total_rx_bw += rx_bw;
+            }
+            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            if (total_tx_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+            }
+            uint64_t mux_words_sent = get_64b_result(mux_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t mux_elapsed_cycles = get_64b_result(mux_results, PQ_TEST_CYCLES_INDEX);
+            uint64_t mux_iter = get_64b_result(mux_results, PQ_TEST_ITER_INDEX);
+            double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
+            double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
+            log_info(LogTest,
+                     "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     mux_words_sent, mux_elapsed_cycles, mux_bw);
+            log_info(LogTest,
+                        "MUX iters = {} -> cycles/iter = {:.1f}",
+                        mux_iter, mux_cycles_per_iter);
+            if (mux_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "MUX words sent = {} != Total RX words checked = {}", mux_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
+            }
+
+            uint64_t demux_words_sent = get_64b_result(demux_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t demux_elapsed_cycles = get_64b_result(demux_results, PQ_TEST_CYCLES_INDEX);
+            double demux_bw = ((double)demux_words_sent) * PACKET_WORD_SIZE_BYTES / demux_elapsed_cycles;
+            uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
+            double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
+            log_info(LogTest,
+                     "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     demux_words_sent, demux_elapsed_cycles, demux_bw);
+            log_info(LogTest,
+                     "DEMUX iters = {} -> cycles/iter = {:.1f}",
+                     demux_iter, demux_cycles_per_iter);
+            if (demux_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "DEMUX words sent = {} != Total RX words checked = {}", demux_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
+            }
+        }
+
+    } catch (const std::exception& e) {
+        pass = false;
+        log_fatal(e.what());
+    }
+
+    tt::llrt::OptionsG.set_kernels_nullified(false);
+
+    if (pass) {
+        log_info(LogTest, "Test Passed");
+        return 0;
+    } else {
+        log_fatal(LogTest, "Test Failed\n");
+        return 1;
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
@@ -1,0 +1,597 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_cmds.hpp"
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "kernels/traffic_gen_test.hpp"
+
+using namespace tt;
+
+
+int main(int argc, char **argv) {
+
+    constexpr uint32_t default_prng_seed = 0x100;
+    constexpr uint32_t default_data_kb_per_tx = 16*1024;
+    constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_tx_queue_start_addr = 0x80000;
+    constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_rx_queue_start_addr = 0xa0000;
+    constexpr uint32_t default_rx_queue_size_bytes = 0x20000;
+    constexpr uint32_t default_mux_queue_start_addr = 0x80000;
+    constexpr uint32_t default_mux_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_demux_queue_start_addr = 0x90000;
+    constexpr uint32_t default_demux_queue_size_bytes = 0x20000;
+
+    constexpr uint32_t default_test_results_addr = 0x100000;
+    constexpr uint32_t default_test_results_size = 0x40000;
+
+    constexpr uint32_t default_timeout_mcycles = 1000;
+    constexpr uint32_t default_rx_disable_data_check = 0;
+
+    constexpr uint32_t src_endpoint_start_id = 0xa0;
+    constexpr uint32_t dest_endpoint_start_id = 0xb0;
+
+    std::vector<std::string> input_args(argv, argv + argc);
+    if (test_args::has_command_option(input_args, "-h") ||
+        test_args::has_command_option(input_args, "--help")) {
+        log_info(LogTest, "Usage:");
+        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        log_info(LogTest, "  --test_results_addr: test results buffer address, default = 0x{:x}", default_test_results_addr);
+        log_info(LogTest, "  --test_results_size: test results buffer size, default = 0x{:x}", default_test_results_size);
+        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        return 0;
+    }
+
+    uint32_t prng_seed = test_args::get_command_option_uint32(input_args, "--prng_seed", default_prng_seed);
+    uint32_t data_kb_per_tx = test_args::get_command_option_uint32(input_args, "--data_kb_per_tx", default_data_kb_per_tx);
+    uint32_t max_packet_size_words = test_args::get_command_option_uint32(input_args, "--max_packet_size_words", default_max_packet_size_words);
+    uint32_t tx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--tx_queue_start_addr", default_tx_queue_start_addr);
+    uint32_t tx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--tx_queue_size_bytes", default_tx_queue_size_bytes);
+    uint32_t rx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--rx_queue_start_addr", default_rx_queue_start_addr);
+    uint32_t rx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--rx_queue_size_bytes", default_rx_queue_size_bytes);
+    uint32_t mux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--mux_queue_start_addr", default_mux_queue_start_addr);
+    uint32_t mux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--mux_queue_size_bytes", default_mux_queue_size_bytes);
+    uint32_t demux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--demux_queue_start_addr", default_demux_queue_start_addr);
+    uint32_t demux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--demux_queue_size_bytes", default_demux_queue_size_bytes);
+    uint32_t test_results_addr = test_args::get_command_option_uint32(input_args, "--test_results_addr", default_test_results_addr);
+    uint32_t test_results_size = test_args::get_command_option_uint32(input_args, "--test_results_size", default_test_results_size);
+    uint32_t timeout_mcycles = test_args::get_command_option_uint32(input_args, "--timeout_mcycles", default_timeout_mcycles);
+    uint32_t rx_disable_data_check = test_args::get_command_option_uint32(input_args, "--rx_disable_data_check", default_rx_disable_data_check);
+
+    constexpr uint32_t num_src_endpoints = 16;
+    constexpr uint32_t num_dest_endpoints = 16;
+    constexpr uint32_t num_mux_l1 = num_src_endpoints/MAX_SWITCH_FAN_IN;
+    constexpr uint32_t num_mux_l2 = num_mux_l1/MAX_SWITCH_FAN_IN;
+    constexpr uint32_t num_demux_l1 = num_mux_l2;
+    constexpr uint32_t num_demux_l2 = num_demux_l1*MAX_SWITCH_FAN_OUT;
+
+    static_assert(num_mux_l2 == 1 && num_demux_l1 == 1 && (num_demux_l2*MAX_SWITCH_FAN_OUT) == num_dest_endpoints,
+                 "MAX_SWITCH_FAN_IN and MAX_SWITCH_FAN_OUT expected to be 4");
+
+    bool pass = true;
+    try {
+        int device_id = 0;
+        tt_metal::Device *device = tt_metal::CreateDevice(device_id);
+
+        CommandQueue& cq = device->command_queue();
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        constexpr uint32_t tx_x = 0;
+        constexpr uint32_t tx_y = 0;
+        std::vector<CoreCoord> tx_core;
+        std::vector<CoreCoord> tx_phys_core;
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            CoreCoord core = {tx_x+(i%8), tx_y+(i/8)};
+            tx_core.push_back(core);
+            tx_phys_core.push_back(device->worker_core_from_logical_core(core));
+        }
+
+        constexpr uint32_t rx_x = 0;
+        constexpr uint32_t rx_y = 6;
+        std::vector<CoreCoord> rx_core;
+        std::vector<CoreCoord> rx_phys_core;
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            CoreCoord core = {rx_x+(i%8), rx_y+(i/8)};
+            rx_core.push_back(core);
+            rx_phys_core.push_back(device->worker_core_from_logical_core(core));
+        }
+
+        constexpr uint32_t mux_l1_x = 0;
+        constexpr uint32_t mux_l1_y = 2;
+        std::vector<CoreCoord> mux_l1_core;
+        std::vector<CoreCoord> mux_l1_phys_core;
+        for (uint32_t i = 0; i < num_mux_l1; i++) {
+            CoreCoord core = {mux_l1_x+i, mux_l1_y};
+            mux_l1_core.push_back(core);
+            mux_l1_phys_core.push_back(device->worker_core_from_logical_core(core));
+        }
+
+        constexpr uint32_t mux_l2_x = 0;
+        constexpr uint32_t mux_l2_y = 3;
+        CoreCoord mux_l2_core = {mux_l2_x, mux_l2_y};
+        CoreCoord mux_l2_phys_core = device->worker_core_from_logical_core(mux_l2_core);
+
+        constexpr uint32_t demux_l1_x = 0;
+        constexpr uint32_t demux_l1_y = 4;
+        CoreCoord demux_l1_core = {demux_l1_x, demux_l1_y};
+        CoreCoord demux_l1_phys_core = device->worker_core_from_logical_core(demux_l1_core);
+
+        constexpr uint32_t demux_l2_x = 0;
+        constexpr uint32_t demux_l2_y = 5;
+        std::vector<CoreCoord> demux_l2_core;
+        std::vector<CoreCoord> demux_l2_phys_core;
+        for (uint32_t i = 0; i < num_demux_l2; i++) {
+            CoreCoord core = {demux_l2_x+i, demux_l2_y};
+            demux_l2_core.push_back(core);
+            demux_l2_phys_core.push_back(device->worker_core_from_logical_core(core));
+        }
+
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            uint32_t mux_index = i / MAX_SWITCH_FAN_IN;
+            uint32_t mux_queue_index = i % MAX_SWITCH_FAN_IN;
+            std::vector<uint32_t> compile_args =
+                {
+                    src_endpoint_start_id + i, // 0: src_endpoint_id
+                    num_dest_endpoints, // 1: num_dest_endpoints
+                    (tx_queue_start_addr >> 4), // 2: queue_start_addr_words
+                    (tx_queue_size_bytes >> 4), // 3: queue_size_words
+                    ((mux_queue_start_addr + mux_queue_index*mux_queue_size_bytes) >> 4), // 4: remote_rx_queue_start_addr_words
+                    (mux_queue_size_bytes >> 4), // 5: remote_rx_queue_size_words
+                    (uint32_t)mux_l1_phys_core[mux_index].x, // 6: remote_rx_x
+                    (uint32_t)mux_l1_phys_core[mux_index].y, // 7: remote_rx_y
+                    mux_queue_index, // 8: remote_rx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 9: tx_network_type
+                    test_results_addr, // 10: test_results_addr
+                    test_results_size, // 11: test_results_size
+                    prng_seed, // 12: prng_seed
+                    data_kb_per_tx, // 13: total_data_kb
+                    max_packet_size_words, // 14: max_packet_size_words
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+                };
+            log_info(LogTest, "run TX {} at x={},y={} (phys x={},y={})",
+                            i, tx_core[i].x, tx_core[i].y, tx_phys_core[i].x, tx_phys_core[i].y);
+            auto kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
+                {tx_core[i]},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            uint32_t demux_index = i / MAX_SWITCH_FAN_OUT;
+            uint32_t demux_queue_index = i % MAX_SWITCH_FAN_OUT;
+            std::vector<uint32_t> compile_args =
+                {
+                    dest_endpoint_start_id + i, // 0: dest_endpoint_id
+                    num_src_endpoints, // 1: num_src_endpoints
+                    num_dest_endpoints, // 2: num_dest_endpoints
+                    (rx_queue_start_addr >> 4), // 3: queue_start_addr_words
+                    (rx_queue_size_bytes >> 4), // 4: queue_size_words
+                    (uint32_t)demux_l2_phys_core[demux_index].x, // 5: remote_tx_x
+                    (uint32_t)demux_l2_phys_core[demux_index].y, // 6: remote_tx_y
+                    demux_queue_index, // 7: remote_tx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 8: rx_rptr_update_network_type
+                    test_results_addr, // 9: test_results_addr
+                    test_results_size, // 10: test_results_size
+                    prng_seed, // 11: prng_seed
+                    0, // 12: reserved
+                    max_packet_size_words, // 13: max_packet_size_words
+                    rx_disable_data_check, // 14: disable data check
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+                };
+            log_info(LogTest, "run RX {} at x={},y={} (phys x={},y={})",
+                    i, rx_core[i].x, rx_core[i].y, rx_phys_core[i].x, rx_phys_core[i].y);
+            auto kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
+                {rx_core[i]},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        for (uint32_t i = 0; i < num_mux_l1; i++) {
+            uint32_t tx_core_index = i*MAX_SWITCH_FAN_IN;
+            uint32_t mux_l2_port_index = i % MAX_SWITCH_FAN_IN;
+            std::vector<uint32_t> mux_l1_compile_args =
+                {
+                    0, // 0: reserved
+                    (mux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                    (mux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                    MAX_SWITCH_FAN_IN, // 3: mux_fan_in
+                    packet_switch_4B_pack((uint32_t)tx_phys_core[tx_core_index+0].x,
+                                        (uint32_t)tx_phys_core[tx_core_index+0].y,
+                                        1,
+                                        (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: src 0 info
+                    packet_switch_4B_pack((uint32_t)tx_phys_core[tx_core_index+1].x,
+                                        (uint32_t)tx_phys_core[tx_core_index+1].y,
+                                        1,
+                                        (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: src 1 info
+                    packet_switch_4B_pack((uint32_t)tx_phys_core[tx_core_index+2].x,
+                                        (uint32_t)tx_phys_core[tx_core_index+2].y,
+                                        1,
+                                        (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: src 2 info
+                    packet_switch_4B_pack((uint32_t)tx_phys_core[tx_core_index+3].x,
+                                        (uint32_t)tx_phys_core[tx_core_index+3].y,
+                                        1,
+                                        (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: src 3 info
+                    ((mux_queue_start_addr + i*mux_queue_size_bytes) >> 4), // 8: remote_tx_queue_start_addr_words
+                    (mux_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words
+                    (uint32_t)mux_l2_phys_core.x, // 10: remote_tx_x
+                    (uint32_t)mux_l2_phys_core.y, // 11: remote_tx_y
+                    mux_l2_port_index, // 12: remote_tx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 13: tx_network_type
+                    test_results_addr, // 14: test_results_addr
+                    test_results_size, // 15: test_results_size
+                    timeout_mcycles * 1000 * 1000, // 16: timeout_cycles
+                };
+            log_info(LogTest, "run L1 MUX {} at x={},y={} (phys x={},y={})",
+                            i, mux_l1_core[i].x, mux_l1_core[i].y, mux_l1_phys_core[i].x, mux_l1_phys_core[i].y);
+            auto mux_kernel = tt_metal::CreateKernel(
+                program,
+                "tt_metal/impl/dispatch/kernels/packet_mux.cpp",
+                {mux_l1_core[i]},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = mux_l1_compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        std::vector<uint32_t> mux_l2_compile_args =
+            {
+                0, // 0: reserved
+                (mux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (mux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                MAX_SWITCH_FAN_IN, // 3: mux_fan_in
+                packet_switch_4B_pack((uint32_t)mux_l1_phys_core[0].x,
+                                      (uint32_t)mux_l1_phys_core[0].y,
+                                      MAX_SWITCH_FAN_IN,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: src 0 info
+                packet_switch_4B_pack((uint32_t)mux_l1_phys_core[1].x,
+                                      (uint32_t)mux_l1_phys_core[1].y,
+                                      MAX_SWITCH_FAN_IN,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: src 1 info
+                packet_switch_4B_pack((uint32_t)mux_l1_phys_core[2].x,
+                                      (uint32_t)mux_l1_phys_core[2].y,
+                                      MAX_SWITCH_FAN_IN,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: src 2 info
+                packet_switch_4B_pack((uint32_t)mux_l1_phys_core[3].x,
+                                      (uint32_t)mux_l1_phys_core[3].y,
+                                      MAX_SWITCH_FAN_IN,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: src 3 info
+                (demux_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words
+                (demux_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words
+                (uint32_t)demux_l1_phys_core.x, // 10: remote_tx_x
+                (uint32_t)demux_l1_phys_core.y, // 11: remote_tx_y
+                MAX_SWITCH_FAN_OUT, // 12: remote_tx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 13: tx_network_type
+                test_results_addr, // 14: test_results_addr
+                test_results_size, // 15: test_results_size
+                timeout_mcycles * 1000 * 1000, // 16: timeout_cycles
+            };
+        log_info(LogTest, "run L2 MUX at x={},y={} (phys x={},y={})",
+                 mux_l2_core.x, mux_l2_core.y, mux_l2_phys_core.x, mux_l2_phys_core.y);
+        auto mux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_mux.cpp",
+            {mux_l2_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = mux_l2_compile_args,
+                .defines = {}
+            }
+        );
+
+        uint32_t demux_l1_dest_map_array[num_dest_endpoints];
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            demux_l1_dest_map_array[i] = i / MAX_SWITCH_FAN_OUT;
+        }
+        uint64_t demux_l1_dest_endpoint_output_map = packet_switch_dest_pack(demux_l1_dest_map_array, num_dest_endpoints);
+        std::vector<uint32_t> demux_l1_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                (demux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (demux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                MAX_SWITCH_FAN_OUT, // 3: demux_fan_out
+                packet_switch_4B_pack(demux_l2_phys_core[0].x,
+                                      demux_l2_phys_core[0].y,
+                                      MAX_SWITCH_FAN_OUT,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_tx_0_info
+                packet_switch_4B_pack(demux_l2_phys_core[1].x,
+                                      demux_l2_phys_core[1].y,
+                                      MAX_SWITCH_FAN_OUT,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: remote_tx_1_info
+                packet_switch_4B_pack(demux_l2_phys_core[2].x,
+                                      demux_l2_phys_core[2].y,
+                                      MAX_SWITCH_FAN_OUT,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: remote_tx_2_info
+                packet_switch_4B_pack(demux_l2_phys_core[3].x,
+                                      demux_l2_phys_core[3].y,
+                                      MAX_SWITCH_FAN_OUT,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: remote_tx_3_info
+                (demux_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words 0
+                (demux_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words 0
+                (demux_queue_start_addr >> 4), // 10: remote_tx_queue_start_addr_words 1
+                (demux_queue_size_bytes >> 4), // 11: remote_tx_queue_size_words 1
+                (demux_queue_start_addr >> 4), // 12: remote_tx_queue_start_addr_words 2
+                (demux_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
+                (demux_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
+                (demux_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
+                (uint32_t)mux_l2_phys_core.x, // 16: remote_rx_x
+                (uint32_t)mux_l2_phys_core.y, // 17: remote_rx_y
+                MAX_SWITCH_FAN_IN, // 18: remote_rx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
+                (uint32_t)(demux_l1_dest_endpoint_output_map >> 32), // 20: dest_endpoint_output_map_hi
+                (uint32_t)(demux_l1_dest_endpoint_output_map & 0xFFFFFFFF), // 21: dest_endpoint_output_map_lo
+                test_results_addr, // 22: test_results_addr
+                test_results_size, // 23: test_results_size
+                timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
+            };
+
+        log_info(LogTest, "run L1 DEMUX at x={},y={} (phys x={},y={})",
+                        demux_l1_core.x, demux_l1_core.y, demux_l1_phys_core.x, demux_l1_phys_core.y);
+        auto demux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_demux.cpp",
+            {demux_l1_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = demux_l1_compile_args,
+                .defines = {}
+            }
+        );
+
+        // this map applies to all l2 demuxes (since each covers only a subset of rx endpoints)
+        uint32_t demux_l2_dest_map_array[num_dest_endpoints];
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            demux_l2_dest_map_array[i] = i % MAX_SWITCH_FAN_OUT;
+        }
+        uint64_t demux_l2_dest_endpoint_output_map =
+            packet_switch_dest_pack(demux_l2_dest_map_array, num_dest_endpoints);
+        for (uint32_t i = 0; i < num_demux_l2; i++) {
+            uint32_t rx_index = i*MAX_SWITCH_FAN_OUT;
+            std::vector<uint32_t> demux_l2_compile_args =
+                {
+                    dest_endpoint_start_id, // 0: endpoint_id_start_index
+                    (demux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                    (demux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                    MAX_SWITCH_FAN_OUT, // 3: demux_fan_out
+                    packet_switch_4B_pack(rx_phys_core[rx_index+0].x,
+                                          rx_phys_core[rx_index+0].y,
+                                          0,
+                                          (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_tx_0_info
+                    packet_switch_4B_pack(rx_phys_core[rx_index+1].x,
+                                          rx_phys_core[rx_index+1].y,
+                                          0,
+                                          (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: remote_tx_1_info
+                    packet_switch_4B_pack(rx_phys_core[rx_index+2].x,
+                                          rx_phys_core[rx_index+2].y,
+                                          0,
+                                          (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: remote_tx_2_info
+                    packet_switch_4B_pack(rx_phys_core[rx_index+3].x,
+                                          rx_phys_core[rx_index+3].y,
+                                          0,
+                                          (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: remote_tx_3_info
+                    (rx_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words 0
+                    (rx_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words 0
+                    (rx_queue_start_addr >> 4), // 10: remote_tx_queue_start_addr_words 1
+                    (rx_queue_size_bytes >> 4), // 11: remote_tx_queue_size_words 1
+                    (rx_queue_start_addr >> 4), // 12: remote_tx_queue_start_addr_words 2
+                    (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
+                    (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
+                    (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
+                    (uint32_t)demux_l1_phys_core.x, // 16: remote_rx_x
+                    (uint32_t)demux_l1_phys_core.y, // 17: remote_rx_y
+                    i, // 18: remote_rx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
+                    (uint32_t)(demux_l2_dest_endpoint_output_map >> 32), // 20: dest_endpoint_output_map_hi
+                    (uint32_t)(demux_l2_dest_endpoint_output_map & 0xFFFFFFFF), // 21: dest_endpoint_output_map_lo
+                    test_results_addr, // 22: test_results_addr
+                    test_results_size, // 23: test_results_size
+                    timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
+                };
+
+            log_info(LogTest, "run L2 DEMUX at x={},y={} (phys x={},y={})",
+                            demux_l2_core[i].x, demux_l2_core[i].y, demux_l2_phys_core[i].x, demux_l2_phys_core[i].y);
+            auto demux_kernel = tt_metal::CreateKernel(
+                program,
+                "tt_metal/impl/dispatch/kernels/packet_demux.cpp",
+                {demux_l2_core[i]},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = demux_l2_compile_args,
+                    .defines = {}
+                }
+            );
+
+        }
+
+        log_info(LogTest, "Starting test...");
+
+        auto start = std::chrono::system_clock::now();
+        EnqueueProgram(cq, program, false);
+        Finish(cq);
+        auto end = std::chrono::system_clock::now();
+
+        std::chrono::duration<double> elapsed_seconds = (end-start);
+        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+
+        vector<vector<uint32_t>> tx_results;
+        vector<vector<uint32_t>> rx_results;
+        vector<vector<uint32_t>> mux_l1_results;
+        vector<uint32_t> mux_l2_results;
+        vector<vector<uint32_t>> demux_l2_results;
+        vector<uint32_t> demux_l1_results;
+
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            tx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), tx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            rx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), rx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        for (uint32_t i = 0; i < num_mux_l1; i++) {
+            mux_l1_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), mux_l1_phys_core[i], test_results_addr, test_results_size)
+            );
+            log_info(LogTest, "L1 MUX {} status = {}", i, packet_queue_test_status_to_string(mux_l1_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (mux_l1_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        mux_l2_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), mux_l2_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "L2 MUX status = {}", packet_queue_test_status_to_string(mux_l2_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (mux_l2_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+
+        for (uint32_t i = 0; i < num_demux_l2; i++) {
+            demux_l2_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), demux_l2_phys_core[i], test_results_addr, test_results_size)
+            );
+            log_info(LogTest, "L2 DEMUX {} status = {}", i, packet_queue_test_status_to_string(demux_l2_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (demux_l2_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        demux_l1_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), demux_l1_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "L1 DEMUX status = {}", packet_queue_test_status_to_string(demux_l1_results[0]));
+        pass &= (demux_l1_results[0] == PACKET_QUEUE_TEST_PASS);
+
+        pass &= tt_metal::CloseDevice(device);
+
+        if (pass) {
+            double total_tx_bw = 0.0;
+            uint64_t total_tx_words_sent = 0;
+            uint64_t total_rx_words_checked = 0;
+            for (uint32_t i = 0; i < num_src_endpoints; i++) {
+                uint64_t tx_words_sent = get_64b_result(tx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_tx_words_sent += tx_words_sent;
+                uint64_t tx_elapsed_cycles = get_64b_result(tx_results[i], PQ_TEST_CYCLES_INDEX);
+                double tx_bw = ((double)tx_words_sent) * PACKET_WORD_SIZE_BYTES / tx_elapsed_cycles;
+                log_info(LogTest,
+                         "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, tx_words_sent, tx_elapsed_cycles, tx_bw);
+                total_tx_bw += tx_bw;
+            }
+            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            double total_rx_bw = 0.0;
+            for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+                uint64_t rx_words_checked = get_64b_result(rx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_rx_words_checked += rx_words_checked;
+                uint64_t rx_elapsed_cycles = get_64b_result(rx_results[i], PQ_TEST_CYCLES_INDEX);
+                double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
+                log_info(LogTest,
+                         "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, rx_words_checked, rx_elapsed_cycles, rx_bw);
+                total_rx_bw += rx_bw;
+            }
+            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            if (total_tx_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+            }
+
+            uint64_t mux_l2_words_sent = get_64b_result(mux_l2_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t mux_l2_elapsed_cycles = get_64b_result(mux_l2_results, PQ_TEST_CYCLES_INDEX);
+            uint64_t mux_l2_iter = get_64b_result(mux_l2_results, PQ_TEST_ITER_INDEX);
+            double mux_l2_bw = ((double)mux_l2_words_sent) * PACKET_WORD_SIZE_BYTES / mux_l2_elapsed_cycles;
+            double mux_l2_cycles_per_iter = ((double)mux_l2_elapsed_cycles) / mux_l2_iter;
+            log_info(LogTest,
+                     "L2 MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     mux_l2_words_sent, mux_l2_elapsed_cycles, mux_l2_bw);
+            log_info(LogTest,
+                    "L2 MUX iter = {}, elapsed cycles = {} -> cycles/iter = {:.2f}",
+                    mux_l2_iter, mux_l2_elapsed_cycles, mux_l2_cycles_per_iter);
+            if (mux_l2_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "L2 MUX words sent = {} != Total RX words checked = {}", mux_l2_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "L2 MUX words sent = {} == Total RX words checked = {} -> OK", mux_l2_words_sent, total_rx_words_checked);
+            }
+
+            uint64_t demux_l1_words_sent = get_64b_result(demux_l1_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t demux_l1_elapsed_cycles = get_64b_result(demux_l1_results, PQ_TEST_CYCLES_INDEX);
+            uint64_t demux_l1_iter = get_64b_result(demux_l1_results, PQ_TEST_ITER_INDEX);
+            double demux_l1_bw = ((double)demux_l1_words_sent) * PACKET_WORD_SIZE_BYTES / demux_l1_elapsed_cycles;
+            double demux_l1_cycles_per_iter = ((double)demux_l1_elapsed_cycles) / demux_l1_iter;
+            log_info(LogTest,
+                     "L1 DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     demux_l1_words_sent, demux_l1_elapsed_cycles, demux_l1_bw);
+            log_info(LogTest,
+                    "L1 DEMUX iter = {}, elapsed cycles = {} -> cycles/iter = {:.2f}",
+                    demux_l1_iter, demux_l1_elapsed_cycles, demux_l1_cycles_per_iter);
+            if (demux_l1_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "L1 DEMUX words sent = {} != Total RX words checked = {}", demux_l1_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "L1 DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_l1_words_sent, total_rx_words_checked);
+            }
+        }
+
+    } catch (const std::exception& e) {
+        pass = false;
+        log_fatal(e.what());
+    }
+
+    tt::llrt::OptionsG.set_kernels_nullified(false);
+
+    if (pass) {
+        log_info(LogTest, "Test Passed");
+        return 0;
+    } else {
+        log_fatal(LogTest, "Test Failed\n");
+        return 1;
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_cmds.hpp"
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "kernels/traffic_gen_test.hpp"
+
+using namespace tt;
+
+
+int main(int argc, char **argv) {
+
+    constexpr uint32_t default_tx_x = 0;
+    constexpr uint32_t default_tx_y = 0;
+    constexpr uint32_t default_rx_x = 1;
+    constexpr uint32_t default_rx_y = 0;
+
+    constexpr uint32_t default_prng_seed = 0x100;
+    constexpr uint32_t default_total_data_kb = 16*1024;
+    constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_tx_queue_start_addr = L1_UNRESERVED_BASE;
+    constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_rx_queue_start_addr = L1_UNRESERVED_BASE + 0x2000;
+    constexpr uint32_t default_rx_queue_size_bytes = 0x20000;
+    constexpr uint32_t default_test_result_buf_addr = BRISC_L1_RESULT_BASE;
+    constexpr uint32_t default_test_result_buf_size = 1024;
+
+    constexpr uint32_t default_timeout_mcycles = 1000;
+    constexpr uint32_t default_rx_disable_data_check = 0;
+
+    std::vector<std::string> input_args(argv, argv + argc);
+    if (test_args::has_command_option(input_args, "-h") ||
+        test_args::has_command_option(input_args, "--help")) {
+        log_info(LogTest, "Usage:");
+        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        log_info(LogTest, "  --total_data_kb: Total data in KB, default = {}", default_total_data_kb);
+        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        log_info(LogTest, "  --tx_x: X coordinate of the TX core, default = {}", default_tx_x);
+        log_info(LogTest, "  --tx_y: Y coordinate of the TX core, default = {}", default_tx_y);
+        log_info(LogTest, "  --rx_x: X coordinate of the RX core, default = {}", default_rx_x);
+        log_info(LogTest, "  --rx_y: Y coordinate of the RX core, default = {}", default_rx_y);
+        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        log_info(LogTest, "  --test_result_buf_addr: Test results buffer address, default = 0x{:x}", default_test_result_buf_addr);
+        log_info(LogTest, "  --test_result_buf_size: Test results buffer size, default = {} bytes", default_test_result_buf_size);
+        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        return 0;
+    }
+
+    uint32_t tx_x = test_args::get_command_option_uint32(input_args, "--tx_x", default_tx_x);
+    uint32_t tx_y = test_args::get_command_option_uint32(input_args, "--tx_y", default_tx_y);
+    uint32_t rx_x = test_args::get_command_option_uint32(input_args, "--rx_x", default_rx_x);
+    uint32_t rx_y = test_args::get_command_option_uint32(input_args, "--rx_y", default_rx_y);
+    uint32_t prng_seed = test_args::get_command_option_uint32(input_args, "--prng_seed", default_prng_seed);
+    uint32_t total_data_kb = test_args::get_command_option_uint32(input_args, "--total_data_kb", default_total_data_kb);
+    uint32_t max_packet_size_words = test_args::get_command_option_uint32(input_args, "--max_packet_size_words", default_max_packet_size_words);
+    uint32_t tx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--tx_queue_start_addr", default_tx_queue_start_addr);
+    uint32_t tx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--tx_queue_size_bytes", default_tx_queue_size_bytes);
+    uint32_t rx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--rx_queue_start_addr", default_rx_queue_start_addr);
+    uint32_t rx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--rx_queue_size_bytes", default_rx_queue_size_bytes);
+    uint32_t test_result_buf_addr = test_args::get_command_option_uint32(input_args, "--test_result_buf_addr", default_test_result_buf_addr);
+    uint32_t test_result_buf_size = test_args::get_command_option_uint32(input_args, "--test_result_buf_size", default_test_result_buf_size);
+    uint32_t timeout_mcycles = test_args::get_command_option_uint32(input_args, "--timeout_mcycles", default_timeout_mcycles);
+    uint32_t rx_disable_data_check = test_args::get_command_option_uint32(input_args, "--rx_disable_data_check", default_rx_disable_data_check);
+
+    assert(is_power_of_2(tx_queue_size_bytes) && (tx_queue_size_bytes >= 1024));
+    assert(is_power_of_2(rx_queue_size_bytes) && (rx_queue_size_bytes >= 1024));
+
+    bool pass = true;
+    try {
+        int device_id = 0;
+        tt_metal::Device *device = tt_metal::CreateDevice(device_id);
+
+        CommandQueue& cq = device->command_queue();
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        CoreCoord traffic_gen_tx_core = {tx_x, tx_y};
+        CoreCoord traffic_gen_rx_core = {rx_x, rx_y};
+
+        CoreCoord phys_traffic_gen_tx_core = device->worker_core_from_logical_core(traffic_gen_tx_core);
+        CoreCoord phys_traffic_gen_rx_core = device->worker_core_from_logical_core(traffic_gen_rx_core);
+
+        std::vector<uint32_t> traffic_gen_tx_compile_args =
+            {
+                0xaa, // 0: src_endpoint_id
+                1, // 1: num_dest_endpoints
+                (tx_queue_start_addr >> 4), // 2: queue_start_addr_words
+                (tx_queue_size_bytes >> 4), // 3: queue_size_words
+                (rx_queue_start_addr >> 4), // 4: remote_rx_queue_start_addr_words
+                (rx_queue_size_bytes >> 4), // 5: remote_rx_queue_size_words
+                (uint32_t)phys_traffic_gen_rx_core.x, // 6: remote_rx_x
+                (uint32_t)phys_traffic_gen_rx_core.y, // 7: remote_rx_y
+                0x0, // 8: remote_rx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 9: tx_network_type
+                test_result_buf_addr, // 10: test_result_buf_addr
+                test_result_buf_size, // 11: test_result_buf_size
+                prng_seed, // 12: prng_seed
+                total_data_kb, // 13: total_data_kb
+                max_packet_size_words, // 14: max_packet_size_words
+                0xaa, // 15: src_endpoint_start_id
+                0xbb, // 16: dest_endpoint_start_id
+                timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+            };
+
+        std::vector<uint32_t> traffic_gen_rx_compile_args =
+            {
+                0xbb, // 0: dest_endpoint_id
+                1, // 1: num_src_endpoints
+                1, // 2: num_dest_endpoints
+                (rx_queue_start_addr >> 4), // 3: queue_start_addr_words
+                (rx_queue_size_bytes >> 4), // 4: queue_size_words
+                (uint32_t)phys_traffic_gen_tx_core.x, // 5: remote_rx_x
+                (uint32_t)phys_traffic_gen_tx_core.y, // 6: remote_rx_y
+                1, // 7: remote_tx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 8: rx_rptr_update_network_type
+                test_result_buf_addr, // 9: test_result_buf_addr
+                test_result_buf_size, // 10: test_result_buf_size
+                prng_seed, // 11: prng_seed
+                total_data_kb, // 12: total_data_kb
+                max_packet_size_words, // 13: max_packet_size_words
+                rx_disable_data_check, // 14: disable data check
+                0xaa, // 15: src_endpoint_start_id
+                0xbb, // 16: dest_endpoint_start_id
+                timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+            };
+
+        auto tg_tx = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
+            {traffic_gen_tx_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = traffic_gen_tx_compile_args,
+                .defines = {}
+            }
+        );
+
+        auto tg_rx = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
+            {traffic_gen_rx_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = traffic_gen_rx_compile_args,
+                .defines = {}
+            }
+        );
+
+        log_info(LogTest, "Starting test...");
+
+        auto start = std::chrono::system_clock::now();
+        EnqueueProgram(cq, program, false);
+        Finish(cq);
+        auto end = std::chrono::system_clock::now();
+
+        std::chrono::duration<double> elapsed_seconds = (end-start);
+        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+
+        vector<uint32_t> tx_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), phys_traffic_gen_tx_core, test_result_buf_addr, test_result_buf_size);
+
+        vector<uint32_t> rx_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), phys_traffic_gen_rx_core, test_result_buf_addr, test_result_buf_size);
+
+        log_info(LogTest, "TX status = {}",
+                packet_queue_test_status_to_string(tx_results[PQ_TEST_STATUS_INDEX]));
+        log_info(LogTest, "RX status = {}",
+                packet_queue_test_status_to_string(rx_results[PQ_TEST_STATUS_INDEX]));
+
+        pass &= (tx_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        pass &= (rx_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+
+        pass &= tt_metal::CloseDevice(device);
+
+        if (pass) {
+            uint64_t total_data_bytes = ((uint64_t)total_data_kb) * 1024;
+            uint64_t total_data_words = total_data_bytes / PACKET_WORD_SIZE_BYTES;
+            uint64_t tx_words_sent = get_64b_result(tx_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t rx_words_checked = get_64b_result(rx_results, PQ_TEST_WORD_CNT_INDEX);
+            if (tx_words_sent == rx_words_checked) {
+                log_info(LogTest, "TX words sent = {}, RX words checked = {} -> OK", tx_words_sent, rx_words_checked);
+                if (tx_words_sent < total_data_words) {
+                    log_error(LogTest, "TX words sent = {}, total_data_words = {}", tx_words_sent, total_data_words);
+                }
+            } else {
+                log_error(LogTest, "TX words sent = {}, RX words checked = {}", tx_words_sent, rx_words_checked);
+                pass = false;
+            }
+            double elapsed_us = elapsed_seconds.count() * 1000.0 * 1000.0;
+            double wall_clock_bw = ((double)total_data_bytes) / elapsed_us;
+            log_info(LogTest, "Wall clock time = {:.2f}us, bytes = {} -> wall clock BW = {:.2f} MB/s",
+                elapsed_us, total_data_bytes, wall_clock_bw);
+            uint64_t tx_elapsed_cycles = get_64b_result(tx_results, PQ_TEST_CYCLES_INDEX);
+            uint64_t rx_elapsed_cycles = get_64b_result(rx_results, PQ_TEST_CYCLES_INDEX);
+            double tx_bw = ((double)total_data_bytes) / tx_elapsed_cycles;
+            double rx_bw = ((double)total_data_bytes) / rx_elapsed_cycles;
+            log_info(LogTest, "TX elapsed cycles = {} -> TX BW = {:.2f} B/cycle", tx_elapsed_cycles, tx_bw);
+            log_info(LogTest, "RX elapsed cycles = {} -> RX BW = {:.2f} B/cycle", rx_elapsed_cycles, rx_bw);
+        }
+
+    } catch (const std::exception& e) {
+        pass = false;
+        log_fatal(e.what());
+    }
+
+    tt::llrt::OptionsG.set_kernels_nullified(false);
+
+    if (pass) {
+        log_info(LogTest, "Test Passed");
+        return 0;
+    } else {
+        log_fatal(LogTest, "Test Failed\n");
+        return 1;
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel.cpp
@@ -1,0 +1,541 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_cmds.hpp"
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "kernels/traffic_gen_test.hpp"
+
+using namespace tt;
+
+
+int main(int argc, char **argv) {
+
+    constexpr uint32_t default_tx_x = 0;
+    constexpr uint32_t default_tx_y = 0;
+    constexpr uint32_t default_rx_x = 0;
+    constexpr uint32_t default_rx_y = 3;
+
+    constexpr uint32_t default_mux_x = 0;
+    constexpr uint32_t default_mux_y = 1;
+    constexpr uint32_t default_demux_x = 0;
+    constexpr uint32_t default_demux_y = 2;
+
+    constexpr uint32_t default_tunneler_x = 0;
+    constexpr uint32_t default_tunneler_y = 0;
+
+    constexpr uint32_t default_prng_seed = 0x100;
+    constexpr uint32_t default_data_kb_per_tx = 16*1024;
+    constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_tx_queue_start_addr = 0x80000;
+    constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_rx_queue_start_addr = 0xa0000;
+    constexpr uint32_t default_rx_queue_size_bytes = 0x20000;
+    constexpr uint32_t default_mux_queue_start_addr = 0x80000;
+    constexpr uint32_t default_mux_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_demux_queue_start_addr = 0x90000;
+    constexpr uint32_t default_demux_queue_size_bytes = 0x20000;
+
+    constexpr uint32_t default_tunneler_queue_start_addr = 0x19000;
+    constexpr uint32_t default_tunneler_queue_size_bytes = 0x10000;
+
+    constexpr uint32_t default_test_results_addr = 0x100000;
+    constexpr uint32_t default_test_results_size = 0x40000;
+
+    constexpr uint32_t default_tunneler_test_results_addr = 0x29000;
+    constexpr uint32_t default_tunneler_test_results_size = 0x8000;
+
+    constexpr uint32_t default_timeout_mcycles = 1000;
+    constexpr uint32_t default_rx_disable_data_check = 0;
+
+    constexpr uint32_t src_endpoint_start_id = 0xaa;
+    constexpr uint32_t dest_endpoint_start_id = 0xbb;
+
+    constexpr uint32_t num_src_endpoints = 4;
+    constexpr uint32_t num_dest_endpoints = 4;
+
+    std::vector<std::string> input_args(argv, argv + argc);
+    if (test_args::has_command_option(input_args, "-h") ||
+        test_args::has_command_option(input_args, "--help")) {
+        log_info(LogTest, "Usage:");
+        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
+        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        return 0;
+    }
+
+    uint32_t tx_x = test_args::get_command_option_uint32(input_args, "--tx_x", default_tx_x);
+    uint32_t tx_y = test_args::get_command_option_uint32(input_args, "--tx_y", default_tx_y);
+    uint32_t rx_x = test_args::get_command_option_uint32(input_args, "--rx_x", default_rx_x);
+    uint32_t rx_y = test_args::get_command_option_uint32(input_args, "--rx_y", default_rx_y);
+    uint32_t mux_x = test_args::get_command_option_uint32(input_args, "--mux_x", default_mux_x);
+    uint32_t mux_y = test_args::get_command_option_uint32(input_args, "--mux_y", default_mux_y);
+    uint32_t demux_x = test_args::get_command_option_uint32(input_args, "--demux_x", default_demux_x);
+    uint32_t demux_y = test_args::get_command_option_uint32(input_args, "--demux_y", default_demux_y);
+    uint32_t tunneler_x = test_args::get_command_option_uint32(input_args, "--tunneler_x", default_tunneler_x);
+    uint32_t tunneler_y = test_args::get_command_option_uint32(input_args, "--tunneler_y", default_tunneler_y);
+    uint32_t prng_seed = test_args::get_command_option_uint32(input_args, "--prng_seed", default_prng_seed);
+    uint32_t data_kb_per_tx = test_args::get_command_option_uint32(input_args, "--data_kb_per_tx", default_data_kb_per_tx);
+    uint32_t max_packet_size_words = test_args::get_command_option_uint32(input_args, "--max_packet_size_words", default_max_packet_size_words);
+    uint32_t tx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--tx_queue_start_addr", default_tx_queue_start_addr);
+    uint32_t tx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--tx_queue_size_bytes", default_tx_queue_size_bytes);
+    uint32_t rx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--rx_queue_start_addr", default_rx_queue_start_addr);
+    uint32_t rx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--rx_queue_size_bytes", default_rx_queue_size_bytes);
+    uint32_t mux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--mux_queue_start_addr", default_mux_queue_start_addr);
+    uint32_t mux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--mux_queue_size_bytes", default_mux_queue_size_bytes);
+    uint32_t demux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--demux_queue_start_addr", default_demux_queue_start_addr);
+    uint32_t demux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--demux_queue_size_bytes", default_demux_queue_size_bytes);
+    uint32_t tunneler_queue_start_addr = test_args::get_command_option_uint32(input_args, "--tunneler_queue_start_addr", default_tunneler_queue_start_addr);
+    uint32_t tunneler_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--tunneler_queue_size_bytes", default_tunneler_queue_size_bytes);
+    uint32_t test_results_addr = test_args::get_command_option_uint32(input_args, "--test_results_addr", default_test_results_addr);
+    uint32_t test_results_size = test_args::get_command_option_uint32(input_args, "--test_results_size", default_test_results_size);
+    uint32_t tunneler_test_results_addr = test_args::get_command_option_uint32(input_args, "--tunneler_test_results_addr", default_tunneler_test_results_addr);
+    uint32_t tunneler_test_results_size = test_args::get_command_option_uint32(input_args, "--tunneler_test_results_size", default_tunneler_test_results_size);
+    uint32_t timeout_mcycles = test_args::get_command_option_uint32(input_args, "--timeout_mcycles", default_timeout_mcycles);
+    uint32_t rx_disable_data_check = test_args::get_command_option_uint32(input_args, "--rx_disable_data_check", default_rx_disable_data_check);
+
+    bool pass = true;
+    try {
+        int device_id_l = 0;
+        int device_id_r = 1;
+
+        tt_metal::Device *device = tt_metal::CreateDevice(device_id_l);
+        tt_metal::Device *device_r = tt_metal::CreateDevice(device_id_r);
+
+        CoreCoord tunneler_logical_core = device->get_ethernet_sockets(1)[0];
+        CoreCoord tunneler_phys_core = device->ethernet_core_from_logical_core(tunneler_logical_core);
+
+        CoreCoord r_tunneler_logical_core = device_r->get_ethernet_sockets(0)[0];
+        CoreCoord r_tunneler_phys_core = device_r->ethernet_core_from_logical_core(r_tunneler_logical_core);
+
+
+
+        std::cout<<"Left Tunneler = "<<tunneler_logical_core.str()<<std::endl;
+        std::cout<<"Right Tunneler = "<<r_tunneler_logical_core.str()<<std::endl;
+
+        CommandQueue& cq = device->command_queue();
+        CommandQueue& cq_r = device_r->command_queue();
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+        tt_metal::Program program_r = tt_metal::CreateProgram();
+
+        CoreCoord mux_core = {mux_x, mux_y};
+        CoreCoord mux_phys_core = device->worker_core_from_logical_core(mux_core);
+
+        CoreCoord demux_core = {demux_x, demux_y};
+        CoreCoord demux_phys_core = device_r->worker_core_from_logical_core(demux_core);
+
+        std::vector<CoreCoord> tx_phys_core;
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            CoreCoord core = {tx_x+i, tx_y};
+            tx_phys_core.push_back(device->worker_core_from_logical_core(core));
+            std::vector<uint32_t> compile_args =
+                {
+                    src_endpoint_start_id + i, // 0: src_endpoint_id
+                    num_dest_endpoints, // 1: num_dest_endpoints
+                    (tx_queue_start_addr >> 4), // 2: queue_start_addr_words
+                    (tx_queue_size_bytes >> 4), // 3: queue_size_words
+                    ((mux_queue_start_addr + i*mux_queue_size_bytes) >> 4), // 4: remote_rx_queue_start_addr_words
+                    (mux_queue_size_bytes >> 4), // 5: remote_rx_queue_size_words
+                    (uint32_t)mux_phys_core.x, // 6: remote_rx_x
+                    (uint32_t)mux_phys_core.y, // 7: remote_rx_y
+                    i, // 8: remote_rx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 9: tx_network_type
+                    test_results_addr, // 10: test_results_addr
+                    test_results_size, // 11: test_results_size
+                    prng_seed, // 12: prng_seed
+                    data_kb_per_tx, // 13: total_data_kb
+                    max_packet_size_words, // 14: max_packet_size_words
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000 * 4, // 17: timeout_cycles
+                };
+
+            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            auto kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
+                {core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        // Mux
+        std::vector<uint32_t> mux_compile_args =
+            {
+                0, // 0: reserved
+                (mux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (mux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                num_src_endpoints, // 3: mux_fan_in
+                packet_switch_4B_pack((uint32_t)tx_phys_core[0].x,
+                                      (uint32_t)tx_phys_core[0].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: src 0 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[1].x,
+                                      (uint32_t)tx_phys_core[1].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: src 1 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[2].x,
+                                      (uint32_t)tx_phys_core[2].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: src 2 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[3].x,
+                                      (uint32_t)tx_phys_core[3].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: src 3 info
+                (tunneler_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words
+                (uint32_t)tunneler_phys_core.x, // 10: remote_tx_x
+                (uint32_t)tunneler_phys_core.y, // 11: remote_tx_y
+                0, // 12: remote_tx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 13: tx_network_type
+                test_results_addr, // 14: test_results_addr
+                test_results_size, // 15: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 16: timeout_cycles
+            };
+
+        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        auto mux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_mux.cpp",
+            {mux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = mux_compile_args,
+                .defines = {}
+            }
+        );
+
+        std::vector<uint32_t> tunneler_l_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                1, // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
+                (tunneler_queue_start_addr >> 4), // 2: rx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 3: rx_queue_size_words
+                packet_switch_4B_pack(r_tunneler_phys_core.x,
+                                      r_tunneler_phys_core.y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::ETH), // 4: remote_receiver_0_info
+                0, // 5: remote_receiver_1_info
+                (tunneler_queue_start_addr >> 4), // 6: remote_receiver_queue_start_addr_words 0
+                (tunneler_queue_size_bytes >> 4), // 7: remote_receiver_queue_size_words 0
+                0, // 8: remote_receiver_queue_start_addr_words 1
+                2, // 9: remote_receiver_queue_size_words 1.
+                   // Unused. Setting to 2 to get around size check assertion that does not allow 0.
+                packet_switch_4B_pack(mux_phys_core.x,
+                                      mux_phys_core.y,
+                                      num_dest_endpoints,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 10: remote_sender_0_info
+                0, // 11: remote_sender_1_info
+                tunneler_test_results_addr, // 12: test_results_addr
+                tunneler_test_results_size, // 13: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 14: timeout_cycles
+            };
+
+        auto tunneler_l_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/eth_tunneler.cpp",
+            tunneler_logical_core,
+            tt_metal::EthernetConfig{
+                .noc = tt_metal::NOC::NOC_0,
+                .compile_args = tunneler_l_compile_args
+            }
+        );
+
+
+        std::vector<uint32_t> tunneler_r_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                1,  // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
+                (tunneler_queue_start_addr >> 4), // 2: rx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 3: rx_queue_size_words
+                packet_switch_4B_pack(demux_phys_core.x,
+                                      demux_phys_core.y,
+                                      num_dest_endpoints,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_receiver_0_info
+                0, // 5: remote_receiver_1_info
+                (demux_queue_start_addr >> 4), // 6: remote_receiver_queue_start_addr_words 0
+                (demux_queue_size_bytes >> 4), // 7: remote_receiver_queue_size_words 0
+                0, // 8: remote_receiver_queue_start_addr_words 1
+                2, // 9: remote_receiver_queue_size_words 1
+                   // Unused. Setting to 2 to get around size check assertion that does not allow 0.
+                packet_switch_4B_pack(tunneler_phys_core.x,
+                                      tunneler_phys_core.y,
+                                      2,
+                                      (uint32_t)DispatchRemoteNetworkType::ETH), // 10: remote_sender_0_info
+                0, // 11: remote_sender_1_info
+                tunneler_test_results_addr, // 12: test_results_addr
+                tunneler_test_results_size, // 13: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 14: timeout_cycles
+            };
+
+        auto tunneler_r_kernel = tt_metal::CreateKernel(
+            program_r,
+            "tt_metal/impl/dispatch/kernels/eth_tunneler.cpp",
+            r_tunneler_logical_core,
+            tt_metal::EthernetConfig{
+                .noc = tt_metal::NOC::NOC_0,
+                .compile_args = tunneler_r_compile_args
+            }
+        );
+
+        std::vector<CoreCoord> rx_phys_core;
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            CoreCoord core = {rx_x+i, rx_y};
+            rx_phys_core.push_back(device_r->worker_core_from_logical_core(core));
+            std::vector<uint32_t> compile_args =
+                {
+                    dest_endpoint_start_id + i, // 0: dest_endpoint_id
+                    num_src_endpoints, // 1: num_src_endpoints
+                    num_dest_endpoints, // 2: num_dest_endpoints
+                    (rx_queue_start_addr >> 4), // 3: queue_start_addr_words
+                    (rx_queue_size_bytes >> 4), // 4: queue_size_words
+                    (uint32_t)demux_phys_core.x, // 5: remote_tx_x
+                    (uint32_t)demux_phys_core.y, // 6: remote_tx_y
+                    i, // 7: remote_tx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 8: rx_rptr_update_network_type
+                    test_results_addr, // 9: test_results_addr
+                    test_results_size, // 10: test_results_size
+                    prng_seed, // 11: prng_seed
+                    0, // 12: reserved
+                    max_packet_size_words, // 13: max_packet_size_words
+                    rx_disable_data_check, // 14: disable data check
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000 * 4, // 17: timeout_cycles
+                };
+
+            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            auto kernel = tt_metal::CreateKernel(
+                program_r,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
+                {core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        // Demux
+        uint32_t dest_map_array[4] = {0, 1, 2, 3};
+        uint64_t dest_endpoint_output_map = packet_switch_dest_pack(dest_map_array, 4);
+        std::vector<uint32_t> demux_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                (demux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (demux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                num_dest_endpoints, // 3: demux_fan_out
+                packet_switch_4B_pack(rx_phys_core[0].x,
+                                      rx_phys_core[0].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_tx_0_info
+                packet_switch_4B_pack(rx_phys_core[1].x,
+                                      rx_phys_core[1].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: remote_tx_1_info
+                packet_switch_4B_pack(rx_phys_core[2].x,
+                                      rx_phys_core[2].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: remote_tx_2_info
+                packet_switch_4B_pack(rx_phys_core[3].x,
+                                      rx_phys_core[3].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: remote_tx_3_info
+                (rx_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words 0
+                (rx_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words 0
+                (rx_queue_start_addr >> 4), // 10: remote_tx_queue_start_addr_words 1
+                (rx_queue_size_bytes >> 4), // 11: remote_tx_queue_size_words 1
+                (rx_queue_start_addr >> 4), // 12: remote_tx_queue_start_addr_words 2
+                (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
+                (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
+                (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
+                (uint32_t)r_tunneler_phys_core.x, // 16: remote_rx_x
+                (uint32_t)r_tunneler_phys_core.y, // 17: remote_rx_y
+                2, // 18: remote_rx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
+                (uint32_t)(dest_endpoint_output_map >> 32), // 20: dest_endpoint_output_map_hi
+                (uint32_t)(dest_endpoint_output_map & 0xFFFFFFFF), // 21: dest_endpoint_output_map_lo
+                test_results_addr, // 22: test_results_addr
+                test_results_size, // 23: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 24: timeout_cycles
+            };
+
+        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        auto demux_kernel = tt_metal::CreateKernel(
+            program_r,
+            "tt_metal/impl/dispatch/kernels/packet_demux.cpp",
+            {demux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = demux_compile_args,
+                .defines = {}
+            }
+        );
+
+        log_info(LogTest, "Starting test...");
+
+        auto start = std::chrono::system_clock::now();
+        EnqueueProgram(cq, program, false);
+        EnqueueProgram(cq_r, program_r, false);
+
+        Finish(cq);
+        Finish(cq_r);
+        auto end = std::chrono::system_clock::now();
+
+        std::chrono::duration<double> elapsed_seconds = (end-start);
+        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+
+        vector<vector<uint32_t>> tx_results;
+        vector<vector<uint32_t>> rx_results;
+
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            tx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), tx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            rx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device_r->id(), rx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        vector<uint32_t> mux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), mux_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+
+        vector<uint32_t> demux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device_r->id(), demux_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
+
+        pass &= tt_metal::CloseDevice(device);
+        pass &= tt_metal::CloseDevice(device_r);
+
+        if (pass) {
+            double total_tx_bw = 0.0;
+            uint64_t total_tx_words_sent = 0;
+            uint64_t total_rx_words_checked = 0;
+            for (uint32_t i = 0; i < num_src_endpoints; i++) {
+                uint64_t tx_words_sent = get_64b_result(tx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_tx_words_sent += tx_words_sent;
+                uint64_t tx_elapsed_cycles = get_64b_result(tx_results[i], PQ_TEST_CYCLES_INDEX);
+                double tx_bw = ((double)tx_words_sent) * PACKET_WORD_SIZE_BYTES / tx_elapsed_cycles;
+                log_info(LogTest,
+                         "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, tx_words_sent, tx_elapsed_cycles, tx_bw);
+                total_tx_bw += tx_bw;
+            }
+            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            double total_rx_bw = 0.0;
+            for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+                uint64_t rx_words_checked = get_64b_result(rx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_rx_words_checked += rx_words_checked;
+                uint64_t rx_elapsed_cycles = get_64b_result(rx_results[i], PQ_TEST_CYCLES_INDEX);
+                double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
+                log_info(LogTest,
+                         "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, rx_words_checked, rx_elapsed_cycles, rx_bw);
+                total_rx_bw += rx_bw;
+            }
+            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            if (total_tx_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+            }
+            uint64_t mux_words_sent = get_64b_result(mux_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t mux_elapsed_cycles = get_64b_result(mux_results, PQ_TEST_CYCLES_INDEX);
+            uint64_t mux_iter = get_64b_result(mux_results, PQ_TEST_ITER_INDEX);
+            double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
+            double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
+            log_info(LogTest,
+                     "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     mux_words_sent, mux_elapsed_cycles, mux_bw);
+            log_info(LogTest,
+                        "MUX iters = {} -> cycles/iter = {:.1f}",
+                        mux_iter, mux_cycles_per_iter);
+            if (mux_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "MUX words sent = {} != Total RX words checked = {}", mux_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
+            }
+
+            uint64_t demux_words_sent = get_64b_result(demux_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t demux_elapsed_cycles = get_64b_result(demux_results, PQ_TEST_CYCLES_INDEX);
+            double demux_bw = ((double)demux_words_sent) * PACKET_WORD_SIZE_BYTES / demux_elapsed_cycles;
+            uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
+            double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
+            log_info(LogTest,
+                     "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     demux_words_sent, demux_elapsed_cycles, demux_bw);
+            log_info(LogTest,
+                     "DEMUX iters = {} -> cycles/iter = {:.1f}",
+                     demux_iter, demux_cycles_per_iter);
+            if (demux_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "DEMUX words sent = {} != Total RX words checked = {}", demux_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
+            }
+        }
+
+    } catch (const std::exception& e) {
+        pass = false;
+        log_fatal(e.what());
+    }
+
+    tt::llrt::OptionsG.set_kernels_nullified(false);
+
+    if (pass) {
+        log_info(LogTest, "Test Passed");
+        return 0;
+    } else {
+        log_fatal(LogTest, "Test Failed\n");
+        return 1;
+    }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel_single_chip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel_single_chip.cpp
@@ -1,0 +1,536 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_cmds.hpp"
+#include "tt_metal/hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+#include "kernels/traffic_gen_test.hpp"
+
+using namespace tt;
+
+
+int main(int argc, char **argv) {
+
+    constexpr uint32_t default_tx_x = 0;
+    constexpr uint32_t default_tx_y = 0;
+    constexpr uint32_t default_rx_x = 0;
+    constexpr uint32_t default_rx_y = 3;
+
+    constexpr uint32_t default_mux_x = 0;
+    constexpr uint32_t default_mux_y = 1;
+    constexpr uint32_t default_demux_x = 0;
+    constexpr uint32_t default_demux_y = 2;
+
+    constexpr uint32_t default_tunneler_x = 0;
+    constexpr uint32_t default_tunneler_y = 0;
+
+    constexpr uint32_t default_prng_seed = 0x100;
+    constexpr uint32_t default_data_kb_per_tx = 16*1024;
+    constexpr uint32_t default_max_packet_size_words = 0x100;
+
+    constexpr uint32_t default_tx_queue_start_addr = 0x80000;
+    constexpr uint32_t default_tx_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_rx_queue_start_addr = 0xa0000;
+    constexpr uint32_t default_rx_queue_size_bytes = 0x20000;
+    constexpr uint32_t default_mux_queue_start_addr = 0x80000;
+    constexpr uint32_t default_mux_queue_size_bytes = 0x10000;
+    constexpr uint32_t default_demux_queue_start_addr = 0x90000;
+    constexpr uint32_t default_demux_queue_size_bytes = 0x20000;
+
+    constexpr uint32_t default_tunneler_queue_start_addr = 0x19000;
+    constexpr uint32_t default_tunneler_queue_size_bytes = 0x10000;
+
+    constexpr uint32_t default_test_results_addr = 0x100000;
+    constexpr uint32_t default_test_results_size = 0x40000;
+
+    constexpr uint32_t default_tunneler_test_results_addr = 0x29000;
+    constexpr uint32_t default_tunneler_test_results_size = 0x8000;
+
+    constexpr uint32_t default_timeout_mcycles = 1000;
+    constexpr uint32_t default_rx_disable_data_check = 0;
+
+    constexpr uint32_t src_endpoint_start_id = 0xaa;
+    constexpr uint32_t dest_endpoint_start_id = 0xbb;
+
+    constexpr uint32_t num_src_endpoints = 4;
+    constexpr uint32_t num_dest_endpoints = 4;
+
+    std::vector<std::string> input_args(argv, argv + argc);
+    if (test_args::has_command_option(input_args, "-h") ||
+        test_args::has_command_option(input_args, "--help")) {
+        log_info(LogTest, "Usage:");
+        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
+        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        return 0;
+    }
+
+    uint32_t tx_x = test_args::get_command_option_uint32(input_args, "--tx_x", default_tx_x);
+    uint32_t tx_y = test_args::get_command_option_uint32(input_args, "--tx_y", default_tx_y);
+    uint32_t rx_x = test_args::get_command_option_uint32(input_args, "--rx_x", default_rx_x);
+    uint32_t rx_y = test_args::get_command_option_uint32(input_args, "--rx_y", default_rx_y);
+    uint32_t mux_x = test_args::get_command_option_uint32(input_args, "--mux_x", default_mux_x);
+    uint32_t mux_y = test_args::get_command_option_uint32(input_args, "--mux_y", default_mux_y);
+    uint32_t demux_x = test_args::get_command_option_uint32(input_args, "--demux_x", default_demux_x);
+    uint32_t demux_y = test_args::get_command_option_uint32(input_args, "--demux_y", default_demux_y);
+    uint32_t tunneler_x = test_args::get_command_option_uint32(input_args, "--tunneler_x", default_tunneler_x);
+    uint32_t tunneler_y = test_args::get_command_option_uint32(input_args, "--tunneler_y", default_tunneler_y);
+    uint32_t prng_seed = test_args::get_command_option_uint32(input_args, "--prng_seed", default_prng_seed);
+    uint32_t data_kb_per_tx = test_args::get_command_option_uint32(input_args, "--data_kb_per_tx", default_data_kb_per_tx);
+    uint32_t max_packet_size_words = test_args::get_command_option_uint32(input_args, "--max_packet_size_words", default_max_packet_size_words);
+    uint32_t tx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--tx_queue_start_addr", default_tx_queue_start_addr);
+    uint32_t tx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--tx_queue_size_bytes", default_tx_queue_size_bytes);
+    uint32_t rx_queue_start_addr = test_args::get_command_option_uint32(input_args, "--rx_queue_start_addr", default_rx_queue_start_addr);
+    uint32_t rx_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--rx_queue_size_bytes", default_rx_queue_size_bytes);
+    uint32_t mux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--mux_queue_start_addr", default_mux_queue_start_addr);
+    uint32_t mux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--mux_queue_size_bytes", default_mux_queue_size_bytes);
+    uint32_t demux_queue_start_addr = test_args::get_command_option_uint32(input_args, "--demux_queue_start_addr", default_demux_queue_start_addr);
+    uint32_t demux_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--demux_queue_size_bytes", default_demux_queue_size_bytes);
+    uint32_t tunneler_queue_start_addr = test_args::get_command_option_uint32(input_args, "--tunneler_queue_start_addr", default_tunneler_queue_start_addr);
+    uint32_t tunneler_queue_size_bytes = test_args::get_command_option_uint32(input_args, "--tunneler_queue_size_bytes", default_tunneler_queue_size_bytes);
+    uint32_t test_results_addr = test_args::get_command_option_uint32(input_args, "--test_results_addr", default_test_results_addr);
+    uint32_t test_results_size = test_args::get_command_option_uint32(input_args, "--test_results_size", default_test_results_size);
+    uint32_t tunneler_test_results_addr = test_args::get_command_option_uint32(input_args, "--tunneler_test_results_addr", default_tunneler_test_results_addr);
+    uint32_t tunneler_test_results_size = test_args::get_command_option_uint32(input_args, "--tunneler_test_results_size", default_tunneler_test_results_size);
+    uint32_t timeout_mcycles = test_args::get_command_option_uint32(input_args, "--timeout_mcycles", default_timeout_mcycles);
+    uint32_t rx_disable_data_check = test_args::get_command_option_uint32(input_args, "--rx_disable_data_check", default_rx_disable_data_check);
+
+    bool pass = true;
+    try {
+        int device_id = 0;
+
+        tt_metal::Device *device = tt_metal::CreateDevice(device_id);
+
+        CoreCoord tunneler_logical_core = device->get_ethernet_sockets(1)[0];
+        CoreCoord tunneler_phys_core = device->ethernet_core_from_logical_core(tunneler_logical_core);
+
+        CoreCoord r_tunneler_logical_core = device->get_ethernet_sockets(1)[1];
+        CoreCoord r_tunneler_phys_core = device->ethernet_core_from_logical_core(r_tunneler_logical_core);
+
+
+
+        std::cout<<"Left Tunneler = "<<tunneler_logical_core.str()<<std::endl;
+        std::cout<<"Right Tunneler = "<<r_tunneler_logical_core.str()<<std::endl;
+
+        CommandQueue& cq = device->command_queue();
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        CoreCoord mux_core = {mux_x, mux_y};
+        CoreCoord mux_phys_core = device->worker_core_from_logical_core(mux_core);
+
+        CoreCoord demux_core = {demux_x, demux_y};
+        CoreCoord demux_phys_core = device->worker_core_from_logical_core(demux_core);
+
+        std::vector<CoreCoord> tx_phys_core;
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            CoreCoord core = {tx_x+i, tx_y};
+            tx_phys_core.push_back(device->worker_core_from_logical_core(core));
+            std::vector<uint32_t> compile_args =
+                {
+                    src_endpoint_start_id + i, // 0: src_endpoint_id
+                    num_dest_endpoints, // 1: num_dest_endpoints
+                    (tx_queue_start_addr >> 4), // 2: queue_start_addr_words
+                    (tx_queue_size_bytes >> 4), // 3: queue_size_words
+                    ((mux_queue_start_addr + i*mux_queue_size_bytes) >> 4), // 4: remote_rx_queue_start_addr_words
+                    (mux_queue_size_bytes >> 4), // 5: remote_rx_queue_size_words
+                    (uint32_t)mux_phys_core.x, // 6: remote_rx_x
+                    (uint32_t)mux_phys_core.y, // 7: remote_rx_y
+                    i, // 8: remote_rx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 9: tx_network_type
+                    test_results_addr, // 10: test_results_addr
+                    test_results_size, // 11: test_results_size
+                    prng_seed, // 12: prng_seed
+                    data_kb_per_tx, // 13: total_data_kb
+                    max_packet_size_words, // 14: max_packet_size_words
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+                };
+
+            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            auto kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
+                {core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        // Mux
+        std::vector<uint32_t> mux_compile_args =
+            {
+                0, // 0: reserved
+                (mux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (mux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                num_src_endpoints, // 3: mux_fan_in
+                packet_switch_4B_pack((uint32_t)tx_phys_core[0].x,
+                                      (uint32_t)tx_phys_core[0].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: src 0 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[1].x,
+                                      (uint32_t)tx_phys_core[1].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: src 1 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[2].x,
+                                      (uint32_t)tx_phys_core[2].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: src 2 info
+                packet_switch_4B_pack((uint32_t)tx_phys_core[3].x,
+                                      (uint32_t)tx_phys_core[3].y,
+                                      1,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: src 3 info
+                (tunneler_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words
+                (uint32_t)tunneler_phys_core.x, // 10: remote_tx_x
+                (uint32_t)tunneler_phys_core.y, // 11: remote_tx_y
+                0, // 12: remote_tx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 13: tx_network_type
+                test_results_addr, // 14: test_results_addr
+                test_results_size, // 15: test_results_size
+                timeout_mcycles * 1000 * 1000, // 16: timeout_cycles
+            };
+
+        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        auto mux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_mux.cpp",
+            {mux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = mux_compile_args,
+                .defines = {}
+            }
+        );
+
+        std::vector<uint32_t> tunneler_l_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                1, // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
+                (tunneler_queue_start_addr >> 4), // 2: rx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 3: rx_queue_size_words
+                packet_switch_4B_pack(r_tunneler_phys_core.x,
+                                      r_tunneler_phys_core.y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_receiver_0_info
+                0, // 5: remote_receiver_1_info
+                (tunneler_queue_start_addr >> 4), // 6: remote_receiver_queue_start_addr_words 0
+                (tunneler_queue_size_bytes >> 4), // 7: remote_receiver_queue_size_words 0
+                0, // 8: remote_receiver_queue_start_addr_words 1
+                2, // 9: remote_receiver_queue_size_words 1.
+                   // Unused. Setting to 2 to get around size check assertion that does not allow 0.
+                packet_switch_4B_pack(mux_phys_core.x,
+                                      mux_phys_core.y,
+                                      num_dest_endpoints,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 10: remote_sender_0_info
+                0, // 11: remote_sender_1_info
+                tunneler_test_results_addr, // 12: test_results_addr
+                tunneler_test_results_size, // 13: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 14: timeout_cycles
+            };
+
+        auto tunneler_l_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/eth_tunneler.cpp",
+            tunneler_logical_core,
+            tt_metal::EthernetConfig{
+                .noc = tt_metal::NOC::NOC_0,
+                .compile_args = tunneler_l_compile_args
+            }
+        );
+
+
+        std::vector<uint32_t> tunneler_r_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                1,  // 1: tunnel_lanes. 1 => Unidirectional. 2 => Bidirectional.
+                (tunneler_queue_start_addr >> 4), // 2: rx_queue_start_addr_words
+                (tunneler_queue_size_bytes >> 4), // 3: rx_queue_size_words
+                packet_switch_4B_pack(demux_phys_core.x,
+                                      demux_phys_core.y,
+                                      num_dest_endpoints,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_receiver_0_info
+                0, // 5: remote_receiver_1_info
+                (demux_queue_start_addr >> 4), // 6: remote_receiver_queue_start_addr_words 0
+                (demux_queue_size_bytes >> 4), // 7: remote_receiver_queue_size_words 0
+                0, // 8: remote_receiver_queue_start_addr_words 1
+                2, // 9: remote_receiver_queue_size_words 1
+                   // Unused. Setting to 2 to get around size check assertion that does not allow 0.
+                packet_switch_4B_pack(tunneler_phys_core.x,
+                                      tunneler_phys_core.y,
+                                      2,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 10: remote_sender_0_info
+                0, // 11: remote_sender_1_info
+                tunneler_test_results_addr, // 12: test_results_addr
+                tunneler_test_results_size, // 13: test_results_size
+                timeout_mcycles * 1000 * 1000 * 4, // 14: timeout_cycles
+            };
+
+        auto tunneler_r_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/eth_tunneler.cpp",
+            r_tunneler_logical_core,
+            tt_metal::EthernetConfig{
+                .noc = tt_metal::NOC::NOC_0,
+                .compile_args = tunneler_r_compile_args
+            }
+        );
+
+        std::vector<CoreCoord> rx_phys_core;
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            CoreCoord core = {rx_x+i, rx_y};
+            rx_phys_core.push_back(device->worker_core_from_logical_core(core));
+            std::vector<uint32_t> compile_args =
+                {
+                    dest_endpoint_start_id + i, // 0: dest_endpoint_id
+                    num_src_endpoints, // 1: num_src_endpoints
+                    num_dest_endpoints, // 2: num_dest_endpoints
+                    (rx_queue_start_addr >> 4), // 3: queue_start_addr_words
+                    (rx_queue_size_bytes >> 4), // 4: queue_size_words
+                    (uint32_t)demux_phys_core.x, // 5: remote_tx_x
+                    (uint32_t)demux_phys_core.y, // 6: remote_tx_y
+                    i, // 7: remote_tx_queue_id
+                    (uint32_t)DispatchRemoteNetworkType::NOC0, // 8: rx_rptr_update_network_type
+                    test_results_addr, // 9: test_results_addr
+                    test_results_size, // 10: test_results_size
+                    prng_seed, // 11: prng_seed
+                    0, // 12: reserved
+                    max_packet_size_words, // 13: max_packet_size_words
+                    rx_disable_data_check, // 14: disable data check
+                    src_endpoint_start_id, // 15: src_endpoint_start_id
+                    dest_endpoint_start_id, // 16: dest_endpoint_start_id
+                    timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
+                };
+
+            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            auto kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
+                {core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = compile_args,
+                    .defines = {}
+                }
+            );
+        }
+
+        // Demux
+        uint32_t dest_map_array[4] = {0, 1, 2, 3};
+        uint64_t dest_endpoint_output_map = packet_switch_dest_pack(dest_map_array, 4);
+        std::vector<uint32_t> demux_compile_args =
+            {
+                dest_endpoint_start_id, // 0: endpoint_id_start_index
+                (demux_queue_start_addr >> 4), // 1: rx_queue_start_addr_words
+                (demux_queue_size_bytes >> 4), // 2: rx_queue_size_words
+                num_dest_endpoints, // 3: demux_fan_out
+                packet_switch_4B_pack(rx_phys_core[0].x,
+                                      rx_phys_core[0].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 4: remote_tx_0_info
+                packet_switch_4B_pack(rx_phys_core[1].x,
+                                      rx_phys_core[1].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 5: remote_tx_1_info
+                packet_switch_4B_pack(rx_phys_core[2].x,
+                                      rx_phys_core[2].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 6: remote_tx_2_info
+                packet_switch_4B_pack(rx_phys_core[3].x,
+                                      rx_phys_core[3].y,
+                                      0,
+                                      (uint32_t)DispatchRemoteNetworkType::NOC0), // 7: remote_tx_3_info
+                (rx_queue_start_addr >> 4), // 8: remote_tx_queue_start_addr_words 0
+                (rx_queue_size_bytes >> 4), // 9: remote_tx_queue_size_words 0
+                (rx_queue_start_addr >> 4), // 10: remote_tx_queue_start_addr_words 1
+                (rx_queue_size_bytes >> 4), // 11: remote_tx_queue_size_words 1
+                (rx_queue_start_addr >> 4), // 12: remote_tx_queue_start_addr_words 2
+                (rx_queue_size_bytes >> 4), // 13: remote_tx_queue_size_words 2
+                (rx_queue_start_addr >> 4), // 14: remote_tx_queue_start_addr_words 3
+                (rx_queue_size_bytes >> 4), // 15: remote_tx_queue_size_words 3
+                //(uint32_t)mux_phys_core.x, // 16: remote_rx_x
+                //(uint32_t)mux_phys_core.y, // 17: remote_rx_y
+                (uint32_t)r_tunneler_phys_core.x, // 16: remote_rx_x
+                (uint32_t)r_tunneler_phys_core.y, // 17: remote_rx_y
+                2, // 18: remote_rx_queue_id
+                (uint32_t)DispatchRemoteNetworkType::NOC0, // 19: tx_network_type
+                (uint32_t)(dest_endpoint_output_map >> 32), // 20: dest_endpoint_output_map_hi
+                (uint32_t)(dest_endpoint_output_map & 0xFFFFFFFF), // 21: dest_endpoint_output_map_lo
+                test_results_addr, // 22: test_results_addr
+                test_results_size, // 23: test_results_size
+                timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
+            };
+
+        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        auto demux_kernel = tt_metal::CreateKernel(
+            program,
+            "tt_metal/impl/dispatch/kernels/packet_demux.cpp",
+            {demux_core},
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = demux_compile_args,
+                .defines = {}
+            }
+        );
+
+        log_info(LogTest, "Starting test...");
+
+        auto start = std::chrono::system_clock::now();
+        EnqueueProgram(cq, program, false);
+
+        Finish(cq);
+        auto end = std::chrono::system_clock::now();
+
+        std::chrono::duration<double> elapsed_seconds = (end-start);
+        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+
+        vector<vector<uint32_t>> tx_results;
+        vector<vector<uint32_t>> rx_results;
+
+        for (uint32_t i = 0; i < num_src_endpoints; i++) {
+            tx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), tx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+            rx_results.push_back(
+                tt::llrt::read_hex_vec_from_core(
+                    device->id(), rx_phys_core[i], test_results_addr, test_results_size));
+            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+        }
+
+        vector<uint32_t> mux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), mux_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
+
+        vector<uint32_t> demux_results =
+            tt::llrt::read_hex_vec_from_core(
+                device->id(), demux_phys_core, test_results_addr, test_results_size);
+        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
+
+        pass &= tt_metal::CloseDevice(device);
+
+        if (pass) {
+            double total_tx_bw = 0.0;
+            uint64_t total_tx_words_sent = 0;
+            uint64_t total_rx_words_checked = 0;
+            for (uint32_t i = 0; i < num_src_endpoints; i++) {
+                uint64_t tx_words_sent = get_64b_result(tx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_tx_words_sent += tx_words_sent;
+                uint64_t tx_elapsed_cycles = get_64b_result(tx_results[i], PQ_TEST_CYCLES_INDEX);
+                double tx_bw = ((double)tx_words_sent) * PACKET_WORD_SIZE_BYTES / tx_elapsed_cycles;
+                log_info(LogTest,
+                         "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, tx_words_sent, tx_elapsed_cycles, tx_bw);
+                total_tx_bw += tx_bw;
+            }
+            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            double total_rx_bw = 0.0;
+            for (uint32_t i = 0; i < num_dest_endpoints; i++) {
+                uint64_t rx_words_checked = get_64b_result(rx_results[i], PQ_TEST_WORD_CNT_INDEX);
+                total_rx_words_checked += rx_words_checked;
+                uint64_t rx_elapsed_cycles = get_64b_result(rx_results[i], PQ_TEST_CYCLES_INDEX);
+                double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
+                log_info(LogTest,
+                         "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                         i, rx_words_checked, rx_elapsed_cycles, rx_bw);
+                total_rx_bw += rx_bw;
+            }
+            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            if (total_tx_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+            }
+            uint64_t mux_words_sent = get_64b_result(mux_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t mux_elapsed_cycles = get_64b_result(mux_results, PQ_TEST_CYCLES_INDEX);
+            uint64_t mux_iter = get_64b_result(mux_results, PQ_TEST_ITER_INDEX);
+            double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
+            double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
+            log_info(LogTest,
+                     "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     mux_words_sent, mux_elapsed_cycles, mux_bw);
+            log_info(LogTest,
+                        "MUX iters = {} -> cycles/iter = {:.1f}",
+                        mux_iter, mux_cycles_per_iter);
+            if (mux_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "MUX words sent = {} != Total RX words checked = {}", mux_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
+            }
+
+            uint64_t demux_words_sent = get_64b_result(demux_results, PQ_TEST_WORD_CNT_INDEX);
+            uint64_t demux_elapsed_cycles = get_64b_result(demux_results, PQ_TEST_CYCLES_INDEX);
+            double demux_bw = ((double)demux_words_sent) * PACKET_WORD_SIZE_BYTES / demux_elapsed_cycles;
+            uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
+            double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
+            log_info(LogTest,
+                     "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
+                     demux_words_sent, demux_elapsed_cycles, demux_bw);
+            log_info(LogTest,
+                     "DEMUX iters = {} -> cycles/iter = {:.1f}",
+                     demux_iter, demux_cycles_per_iter);
+            if (demux_words_sent != total_rx_words_checked) {
+                log_error(LogTest, "DEMUX words sent = {} != Total RX words checked = {}", demux_words_sent, total_rx_words_checked);
+                pass = false;
+            } else {
+                log_info(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
+            }
+        }
+
+    } catch (const std::exception& e) {
+        pass = false;
+        log_fatal(e.what());
+    }
+
+    tt::llrt::OptionsG.set_kernels_nullified(false);
+
+    if (pass) {
+        log_info(LogTest, "Test Passed");
+        return 0;
+    } else {
+        log_fatal(LogTest, "Test Failed\n");
+        return 1;
+    }
+}

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -54,6 +54,9 @@ uint8_t my_y[NUM_NOCS] __attribute__((used));
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
+uint32_t atomic_ret_val __attribute__ ((section ("l1_data"))) __attribute__((used));
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -38,6 +38,9 @@ uint8_t my_y[NUM_NOCS] __attribute__((used));
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
+uint32_t atomic_ret_val __attribute__ ((section ("l1_data"))) __attribute__((used));
 
 void __attribute__((section("code_l1"))) risc_init() {
     for (uint32_t n = 0; n < NUM_NOCS; n++) {

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -30,6 +30,9 @@
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
+uint32_t atomic_ret_val __attribute__ ((section ("l1_data"))) __attribute__((used));
 
 uint8_t my_x[NUM_NOCS] __attribute__((used));
 uint8_t my_y[NUM_NOCS] __attribute__((used));

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -25,6 +25,9 @@ uint8_t my_y[NUM_NOCS] __attribute__((used));
 uint32_t noc_reads_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
+uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
+uint32_t atomic_ret_val __attribute__ ((section ("l1_data"))) __attribute__((used));
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -25,6 +25,10 @@ uint8_t noc_index = NOC_INDEX;
 uint32_t noc_reads_num_issued[NUM_NOCS];
 uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];
 uint32_t noc_nonposted_writes_acked[NUM_NOCS];
+uint32_t noc_nonposted_atomics_acked[NUM_NOCS];
+uint32_t noc_posted_writes_num_issued[NUM_NOCS];
+uint32_t atomic_ret_val __attribute__ ((section ("l1_data")));
+
 
 void kernel_launch() {
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -628,7 +628,7 @@ void noc_async_write_one_packet(std::uint32_t src_local_l1_addr, std::uint64_t d
     DEBUG_STATUS('N', 'W', 'P', 'W');
     DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
     DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr, size);
-    while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
+    while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
     DEBUG_STATUS('N', 'W', 'P', 'D');
 
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
@@ -636,12 +636,12 @@ void noc_async_write_one_packet(std::uint32_t src_local_l1_addr, std::uint64_t d
                                 0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
                                 NOC_CMD_RESP_MARKED;
 
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CTRL, noc_cmd_field);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_MID, dst_noc_addr >> 32);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_AT_LEN_BE,  size);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID, dst_noc_addr >> 32);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE,  size);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     noc_nonposted_writes_num_issued[noc_index] += 1;
     noc_nonposted_writes_acked[noc_index] += 1;  // num_dests
  }
@@ -654,7 +654,7 @@ void noc_async_write_one_packet_set_state(std::uint64_t dst_noc_addr, std::uint3
 
     DEBUG_STATUS('N', 'W', 'P', 'W');
     DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr, size);
-    while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
+    while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
     DEBUG_STATUS('N', 'W', 'P', 'D');
 
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
@@ -662,9 +662,9 @@ void noc_async_write_one_packet_set_state(std::uint64_t dst_noc_addr, std::uint3
                                 0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
                                 (non_posted ? NOC_CMD_RESP_MARKED : 0x0);
 
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CTRL, noc_cmd_field);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_MID, dst_noc_addr >> 32);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_AT_LEN_BE,  size);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID, dst_noc_addr >> 32);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE,  size);
  }
 
 // TODO: write docs
@@ -677,12 +677,12 @@ void noc_async_write_one_packet_with_state(std::uint32_t src_local_l1_addr, std:
     // TODO: need a way sanitize size + addr w/o directly providing x/y here (grab x/y form state?)
     // DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
     // DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr, size);
-    while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
+    while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
     DEBUG_STATUS('N', 'W', 'P', 'D');
 
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_LO, dst_noc_addr);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO, dst_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
 
     if constexpr (non_posted) {
         noc_nonposted_writes_num_issued[noc_index] += 1;
@@ -902,7 +902,7 @@ struct InterleavedAddrGenFast {
         DEBUG_STATUS('N', 'W', 'T', 'W');
         DEBUG_SANITIZE_WORKER_ADDR(src_addr, this->page_size);
         DEBUG_SANITIZE_NOC_ADDR(get_noc_addr_helper(dest_noc_xy, dest_addr), this->page_size);
-        while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
+        while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
         DEBUG_STATUS('N', 'W', 'T', 'D');
 
         uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
@@ -910,12 +910,12 @@ struct InterleavedAddrGenFast {
                                  0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
                                  NOC_CMD_RESP_MARKED;
 
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CTRL, noc_cmd_field);
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);  // (uint32_t)dest_addr
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_MID, dest_noc_xy);   // dest_addr >> 32
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_AT_LEN_BE, this->page_size);  // len_bytes
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CTRL, noc_cmd_field);
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);  // (uint32_t)dest_addr
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID, dest_noc_xy);   // dest_addr >> 32
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE, this->page_size);  // len_bytes
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
         noc_nonposted_writes_num_issued[noc_index] += 1;
         noc_nonposted_writes_acked[noc_index] += 1;  // num_dests
     }
@@ -1041,7 +1041,7 @@ struct InterleavedPow2AddrGenFast {
         DEBUG_STATUS('N', 'W', 'P', 'W');
         DEBUG_SANITIZE_WORKER_ADDR(src_addr, write_size_bytes);
         DEBUG_SANITIZE_NOC_ADDR(get_noc_addr_helper(dest_noc_xy, dest_addr), write_size_bytes);
-        while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
+        while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
         DEBUG_STATUS('N', 'W', 'P', 'D');
 
         uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
@@ -1049,12 +1049,12 @@ struct InterleavedPow2AddrGenFast {
                                  0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
                                  NOC_CMD_RESP_MARKED;
 
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CTRL, noc_cmd_field);
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);  // (uint32_t)dest_addr
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_MID, dest_noc_xy);   // dest_addr >> 32
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_AT_LEN_BE,  write_size_bytes);  // len_bytes
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CTRL, noc_cmd_field);
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);  // (uint32_t)dest_addr
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID, dest_noc_xy);   // dest_addr >> 32
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE,  write_size_bytes);  // len_bytes
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
         noc_nonposted_writes_num_issued[noc_index] += 1;
         noc_nonposted_writes_acked[noc_index] += 1;  // num_dests
     }
@@ -1153,7 +1153,7 @@ void noc_async_write(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr
     DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
     ncrisc_noc_fast_write_any_len(
         noc_index,
-        NCRISC_WR_REG_CMD_BUF,
+        NCRISC_WR_CMD_BUF,
         src_local_l1_addr,
         dst_noc_addr,
         size,
@@ -1241,7 +1241,7 @@ void noc_async_write_multicast(
     DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
     ncrisc_noc_fast_write_any_len(
         noc_index,
-        NCRISC_WR_REG_CMD_BUF,
+        NCRISC_WR_CMD_BUF,
         src_local_l1_addr,
         dst_noc_addr_multicast,
         size,
@@ -1321,7 +1321,7 @@ void noc_async_write_multicast_loopback_src(
     DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
     ncrisc_noc_fast_write_any_len_loopback_src(
         noc_index,
-        NCRISC_WR_REG_CMD_BUF,
+        NCRISC_WR_CMD_BUF,
         src_local_l1_addr,
         dst_noc_addr_multicast,
         size,
@@ -1373,6 +1373,22 @@ FORCE_INLINE
 void noc_async_writes_flushed() {
     DEBUG_STATUS('N', 'W', 'B', 'W');
     while (!ncrisc_noc_nonposted_writes_sent(noc_index))
+        ;
+    DEBUG_STATUS('N', 'W', 'B', 'D');
+}
+
+/**
+ * This blocking call waits for all the outstanding enqueued *noc_async_write*
+ * calls issued on the current Tensix core to complete. After returning from
+ * this call the *noc_async_write* queue will be empty for the current Tensix
+ * core.
+ *
+ * Return value: None
+ */
+FORCE_INLINE
+void noc_async_atomic_barrier() {
+    DEBUG_STATUS('N', 'W', 'B', 'W');
+    while (!ncrisc_noc_nonposted_atomics_flushed(noc_index))
         ;
     DEBUG_STATUS('N', 'W', 'B', 'D');
 }
@@ -1438,6 +1454,47 @@ void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
     (*sem_addr) = val;
 }
 
+
+/**
+ * Initiates an asynchronous write of a 32-bit value to a NOC destination.
+ * Typically used for writing registers, but can be used for memory locations as well.
+ * The destination is specified as a 64-bit NOC address (see \a noc_async_write).
+ * The advantage over using \a noc_async_write is that we don't a Tensix L1
+ * memory source location; the write value is written directly into a register.
+ * Unlike using \a noc_async_write, there are also no address alignment concerns.
+ * Also, see \a noc_async_write_barrier.
+ *
+ * The destination node can be either a DRAM bank, Tensix core+L1 memory
+ * address or a PCIe controller.
+ *
+ * Return value: None
+ *
+ * | Argument  | Description                                                    | Type     | Valid Range                                                   | Required |
+ * |-----------|----------------------------------------------------------------|----------|---------------------------------------------------------------|----------|
+ * | addr      | Encoding of the destination location (x,y)+address             | uint64_t | DOX-TODO(insert a reference to what constitutes valid coords) | True     |
+ * | val       | The value to be written                                        | uint32_t | Any uint32_t value                                            | True     |
+ * | be        | Byte-enable                                                    | uint8_t  | 0x1-0xF                                                       | False    |
+ */
+FORCE_INLINE
+void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF) {
+
+    DEBUG_STATUS('N', 'S', 'I', 'W');
+    DEBUG_SANITIZE_NOC_ADDR(addr, 4);
+    noc_fast_write_dw_inline(
+                noc_index,
+                NCRISC_WR_REG_CMD_BUF,
+                val,
+                addr,
+                be, // byte-enable
+                NOC_UNICAST_WRITE_VC,
+                false, // mcast
+                false // posted
+            );
+    DEBUG_STATUS('N', 'S', 'I', 'D');
+}
+
+
+
 /**
  * The Tensix core executing this function call initiates an atomic increment
  * (with 32-bit wrap) of a remote Tensix core L1 memory address. This L1 memory
@@ -1459,7 +1516,7 @@ void noc_semaphore_inc(uint64_t addr, uint32_t incr) {
   */
     DEBUG_STATUS('N', 'S', 'I', 'W');
     DEBUG_SANITIZE_NOC_ADDR(addr, 4);
-    noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, addr, NOC_UNICAST_WRITE_VC, incr, 31 /*wrap*/, false /*linked*/);
+    noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, addr, NOC_UNICAST_WRITE_VC, incr, 31 /*wrap*/, false /*linked*/, false /*posted*/);
     DEBUG_STATUS('N', 'S', 'I', 'D');
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1387,10 +1387,10 @@ void noc_async_writes_flushed() {
  */
 FORCE_INLINE
 void noc_async_atomic_barrier() {
-    DEBUG_STATUS('N', 'W', 'B', 'W');
+    DEBUG_STATUS('N', 'A', 'B', 'W');
     while (!ncrisc_noc_nonposted_atomics_flushed(noc_index))
         ;
-    DEBUG_STATUS('N', 'W', 'B', 'D');
+    DEBUG_STATUS('N', 'A', 'B', 'D');
 }
 
 /**
@@ -1478,7 +1478,7 @@ void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
 FORCE_INLINE
 void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF) {
 
-    DEBUG_STATUS('N', 'S', 'I', 'W');
+    DEBUG_STATUS('N', 'W', 'I', 'W');
     DEBUG_SANITIZE_NOC_ADDR(addr, 4);
     noc_fast_write_dw_inline(
                 noc_index,
@@ -1490,7 +1490,7 @@ void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF) {
                 false, // mcast
                 false // posted
             );
-    DEBUG_STATUS('N', 'S', 'I', 'D');
+    DEBUG_STATUS('N', 'W', 'I', 'D');
 }
 
 

--- a/tt_metal/hw/inc/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/ethernet/dataflow_api.h
@@ -204,6 +204,22 @@ void eth_send_bytes_over_channel(
 
 
 /**
+ * Initiates an asynchronous write from the local ethernet core to a register of the connected
+ * remote ethernet core.
+ *
+ * Return value: None
+ *
+ * | Argument          | Description                                             | Type     | Valid Range | Required |
+ * |-------------------|---------------------------------------------------------|----------|-------------|----------|
+ * | reg_addr          | Destination address in remote eth core reg space        | uint32_t | 0xFF000000+ | True     |
+ * | value             | Value to be written                                     | uint32_t | Any value   | True     |
+ */
+FORCE_INLINE
+void eth_write_remote_reg(uint32_t reg_addr, uint32_t value) {
+    internal_::eth_write_remote_reg(0, reg_addr, value);
+}
+
+/**
  * A blocking call that waits for receiver to acknowledge that all data sent with eth_send_bytes since the last
  * reset_erisc_info call is no longer being used. Also, see \a eth_receiver_done().
  *

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -253,6 +253,7 @@ FORCE_INLINE void eth_tunnel_src_forward_one_cmd(db_cb_config_t *eth_db_cb_confi
         ((uint64_t)eth_router_noc_encoding << 32) | uint32_t(eth_db_semaphore_addr),
         -1);  // Two's complement addition
     noc_async_write_barrier();
+    noc_async_atomic_barrier();
 
     for (uint32_t i = 0; i < num_buffer_transfers; i++) {
         const uint32_t num_pages = command_ptr[2];
@@ -283,6 +284,7 @@ FORCE_INLINE void eth_tunnel_src_forward_one_cmd(db_cb_config_t *eth_db_cb_confi
 
     noc_semaphore_inc(((uint64_t)relay_noc_encoding << 32) | get_semaphore(0), 1);
     noc_async_write_barrier();  // Barrier for now
+    noc_async_atomic_barrier();
 }
 
 // Implement yielding if SENDER is not ISSUE, this may help with devices getting commands first

--- a/tt_metal/hw/inc/grayskull/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/grayskull/noc_nonblocking_api.h
@@ -10,14 +10,17 @@
 
 ////
 
-const uint32_t NCRISC_WR_CMD_BUF = 0;
-const uint32_t NCRISC_RD_CMD_BUF = 1;
-const uint32_t NCRISC_WR_REG_CMD_BUF = 2;
-const uint32_t NCRISC_AT_CMD_BUF = 3;
+const uint32_t NCRISC_WR_CMD_BUF = 0;  // for large writes
+const uint32_t NCRISC_RD_CMD_BUF = 1;  // for all reads
+const uint32_t NCRISC_WR_REG_CMD_BUF = 2;  // for small writes (e.g., registers, semaphores)
+const uint32_t NCRISC_AT_CMD_BUF = 3; // for atomics
 
 extern uint32_t noc_reads_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_acked[NUM_NOCS];
+extern uint32_t noc_nonposted_atomics_acked[NUM_NOCS];
+extern uint32_t noc_posted_writes_num_issued[NUM_NOCS];
+extern uint32_t atomic_ret_val;
 
 inline __attribute__((always_inline)) void NOC_CMD_BUF_WRITE_REG(uint32_t noc, uint32_t buf, uint32_t addr, uint32_t val) {
   uint32_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
@@ -58,7 +61,7 @@ inline __attribute__((always_inline)) bool ncrisc_noc_reads_flushed(uint32_t noc
   return (NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED) == noc_reads_num_issued[noc]);
 }
 
-inline __attribute__((always_inline)) void ncrisc_noc_fast_write(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests) {
+inline __attribute__((always_inline)) void ncrisc_noc_fast_write(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests, bool posted = false) {
   if (len_bytes > 0) {
     uint32_t noc_cmd_field =
       NOC_CMD_CPY | NOC_CMD_WR |
@@ -66,7 +69,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(uint32_t noc, u
       NOC_CMD_STATIC_VC(vc) |
       (linked ? NOC_CMD_VC_LINKED : 0x0) |
       (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0) |
-      NOC_CMD_RESP_MARKED;
+      (posted ? 0 : NOC_CMD_RESP_MARKED);
 
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
@@ -74,8 +77,12 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(uint32_t noc, u
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, dest_addr >> 32);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-    noc_nonposted_writes_num_issued[noc] += 1;
-    noc_nonposted_writes_acked[noc] += num_dests;
+    if (posted) {
+      noc_posted_writes_num_issued[noc] += 1;
+    } else {
+      noc_nonposted_writes_num_issued[noc] += 1;
+      noc_nonposted_writes_acked[noc] += num_dests;
+    }
   }
 }
 
@@ -120,8 +127,16 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_writes_sent(uint
   return (NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT) == noc_nonposted_writes_num_issued[noc]);
 }
 
+inline __attribute__((always_inline)) bool ncrisc_noc_posted_writes_sent(uint32_t noc) {
+  return (NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT) == noc_posted_writes_num_issued[noc]);
+}
+
 inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_writes_flushed(uint32_t noc) {
   return (NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED) == noc_nonposted_writes_acked[noc]);
+}
+
+inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(uint32_t noc) {
+  return (NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED) == noc_nonposted_atomics_acked[noc]);
 }
 
 inline __attribute__((always_inline)) void noc_init() {
@@ -135,8 +150,11 @@ inline __attribute__((always_inline)) void noc_init() {
     NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_MID, (uint32_t)(xy_local_addr >> 32));
     NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_MID, (uint32_t)(xy_local_addr >> 32));
 
-    uint32_t noc_rd_cmd_field = NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
+    uint64_t atomic_ret_addr = NOC_XY_ADDR(my_x, my_y, (uint32_t)(&atomic_ret_val));
+    NOC_CMD_BUF_WRITE_REG(noc, NCRISC_AT_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)(atomic_ret_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, NCRISC_AT_CMD_BUF, NOC_RET_ADDR_MID, (uint32_t)(atomic_ret_addr >> 32));
 
+    uint32_t noc_rd_cmd_field = NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
     NOC_CMD_BUF_WRITE_REG(noc, NCRISC_RD_CMD_BUF, NOC_CTRL, noc_rd_cmd_field);
     NOC_CMD_BUF_WRITE_REG(noc, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_MID, (uint32_t)(xy_local_addr >> 32));
   }
@@ -148,8 +166,29 @@ inline __attribute__((always_inline)) void noc_local_state_init(int noc) {
     noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
     noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
     noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+    noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
 }
 
+inline __attribute__((always_inline)) void ncrisc_noc_counters_init() {
+  for (int noc = 0; noc < NUM_NOCS; noc++) {
+    noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
+    noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
+    noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+    noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
+  }
+}
+
+inline __attribute__((always_inline)) void ncrisc_noc_full_sync() {
+  for (uint32_t n = 0; n < NUM_NOCS; n++) {
+    while (!ncrisc_noc_reads_flushed(n));
+    while (!ncrisc_noc_nonposted_writes_sent(n));
+    while (!ncrisc_noc_nonposted_writes_flushed(n));
+    while (!ncrisc_noc_nonposted_atomics_flushed(n));
+    while (!ncrisc_noc_posted_writes_sent(n));
+  }
+}
 
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(uint32_t noc, uint32_t cmd_buf, uint64_t src_addr, uint32_t dest_addr, uint32_t len_bytes) {
   while (len_bytes > NOC_MAX_BURST_SIZE) {
@@ -163,16 +202,16 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(uint32_t
   ncrisc_noc_fast_read(noc, cmd_buf, src_addr, dest_addr, len_bytes);
 }
 
-inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests) {
+inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests, bool posted = false) {
   while (len_bytes > NOC_MAX_BURST_SIZE) {
     while (!noc_cmd_buf_ready(noc, cmd_buf));
-    ncrisc_noc_fast_write(noc, cmd_buf, src_addr, dest_addr, NOC_MAX_BURST_SIZE, vc, mcast, linked, num_dests);
+    ncrisc_noc_fast_write(noc, cmd_buf, src_addr, dest_addr, NOC_MAX_BURST_SIZE, vc, mcast, linked, num_dests, posted);
     src_addr += NOC_MAX_BURST_SIZE;
     dest_addr += NOC_MAX_BURST_SIZE;
     len_bytes -= NOC_MAX_BURST_SIZE;
   }
   while (!noc_cmd_buf_ready(noc, cmd_buf));
-  ncrisc_noc_fast_write(noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests);
+  ncrisc_noc_fast_write(noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests, posted);
 }
 
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopback_src(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests) {
@@ -187,8 +226,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopbac
   ncrisc_noc_fast_write_loopback_src(noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests);
 }
 
-inline __attribute__((always_inline)) void noc_fast_posted_write_dw_inline(uint32_t noc, uint32_t cmd_buf, uint32_t val, uint64_t dest_addr, uint32_t be, uint32_t static_vc, bool mcast) {
-  bool posted = true;
+inline __attribute__((always_inline)) void noc_fast_write_dw_inline(uint32_t noc, uint32_t cmd_buf, uint32_t val, uint64_t dest_addr, uint32_t be, uint32_t static_vc, bool mcast, bool posted = false) {
   bool static_vc_alloc = true;
   uint32_t noc_cmd_field =
     (static_vc_alloc ? NOC_CMD_VC_STATIC : 0x0) |
@@ -202,22 +240,34 @@ inline __attribute__((always_inline)) void noc_fast_posted_write_dw_inline(uint3
   uint32_t be_shift = (dest_addr & (NOC_WORD_BYTES-1));
   be32 = (be32 << be_shift);
 
-  while (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CMD_CTRL) != NOC_CTRL_STATUS_READY);
+  while (!noc_cmd_buf_ready(noc, cmd_buf));
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, val);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
-  NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(dest_addr & ~(NOC_WORD_BYTES-1)));
+  NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr & 0xFFFFFFFF);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, dest_addr >> 32);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+  if (posted) {
+    noc_posted_writes_num_issued[noc] += 1;
+  } else {
+    noc_nonposted_writes_num_issued[noc] += 1;
+    noc_nonposted_writes_acked[noc] += 1;
+  }
 }
 
-inline __attribute__((always_inline)) void noc_fast_atomic_increment(uint32_t noc, uint32_t cmd_buf, uint64_t addr, uint32_t vc, uint32_t incr, uint32_t wrap, bool linked) {
+inline __attribute__((always_inline)) void noc_fast_atomic_increment(uint32_t noc, uint32_t cmd_buf, uint64_t addr, uint32_t vc, uint32_t incr, uint32_t wrap, bool linked, bool posted = false) {
   while (!noc_cmd_buf_ready(noc, cmd_buf));
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(addr & 0xFFFFFFFF));
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(addr >> 32));
-  NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
-                        (linked ? NOC_CMD_VC_LINKED : 0x0) | vc);
+  NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL,
+                        NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
+                        (linked ? NOC_CMD_VC_LINKED : 0x0) |
+                        (posted ? 0 : NOC_CMD_RESP_MARKED) |
+                        NOC_CMD_AT);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, NOC_AT_INS(NOC_AT_INS_INCR_GET) | NOC_AT_WRAP(wrap) | NOC_AT_IND_32((addr>>2) & 0x3) | NOC_AT_IND_32_SRC(0));
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, incr);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, 0x1);
+  if (!posted) {
+    noc_nonposted_atomics_acked[noc] += 1;
+  }
 }

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -10,14 +10,17 @@
 
 ////
 
-const uint32_t NCRISC_WR_CMD_BUF = 0;
-const uint32_t NCRISC_RD_CMD_BUF = 1;
-const uint32_t NCRISC_WR_REG_CMD_BUF = 2;
-const uint32_t NCRISC_AT_CMD_BUF = 3;
+const uint32_t NCRISC_WR_CMD_BUF = 0;  // for large writes
+const uint32_t NCRISC_RD_CMD_BUF = 1;  // for all reads
+const uint32_t NCRISC_WR_REG_CMD_BUF = 2;  // for small writes (e.g., registers, semaphores)
+const uint32_t NCRISC_AT_CMD_BUF = 3; // for atomics
 
 extern uint32_t noc_reads_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_acked[NUM_NOCS];
+extern uint32_t noc_nonposted_atomics_acked[NUM_NOCS];
+extern uint32_t noc_posted_writes_num_issued[NUM_NOCS];
+extern uint32_t atomic_ret_val;
 
 inline __attribute__((always_inline)) void NOC_CMD_BUF_WRITE_REG(uint32_t noc, uint32_t buf, uint32_t addr, uint32_t val) {
   uint32_t offset = (buf << NOC_CMD_BUF_OFFSET_BIT) + (noc << NOC_INSTANCE_OFFSET_BIT) + addr;
@@ -64,7 +67,7 @@ inline __attribute__((always_inline)) bool ncrisc_noc_reads_flushed(uint32_t noc
   return (NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED) == noc_reads_num_issued[noc]);
 }
 
-inline __attribute__((always_inline)) void ncrisc_noc_fast_write(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests) {
+inline __attribute__((always_inline)) void ncrisc_noc_fast_write(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests, bool posted = false) {
   if (len_bytes > 0) {
     uint32_t noc_cmd_field =
       NOC_CMD_CPY | NOC_CMD_WR |
@@ -72,7 +75,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(uint32_t noc, u
       NOC_CMD_STATIC_VC(vc) |
       (linked ? NOC_CMD_VC_LINKED : 0x0) |
       (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0) |
-      NOC_CMD_RESP_MARKED;
+      (posted ? 0 : NOC_CMD_RESP_MARKED);
 
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
@@ -80,8 +83,12 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(uint32_t noc, u
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, dest_addr >> 32);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-    noc_nonposted_writes_num_issued[noc] += 1;
-    noc_nonposted_writes_acked[noc] += num_dests;
+    if (posted) {
+      noc_posted_writes_num_issued[noc] += 1;
+    } else {
+      noc_nonposted_writes_num_issued[noc] += 1;
+      noc_nonposted_writes_acked[noc] += num_dests;
+    }
   }
 }
 
@@ -126,8 +133,16 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_writes_sent(uint
   return (NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT) == noc_nonposted_writes_num_issued[noc]);
 }
 
+inline __attribute__((always_inline)) bool ncrisc_noc_posted_writes_sent(uint32_t noc) {
+  return (NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT) == noc_posted_writes_num_issued[noc]);
+}
+
 inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_writes_flushed(uint32_t noc) {
   return (NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED) == noc_nonposted_writes_acked[noc]);
+}
+
+inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(uint32_t noc) {
+  return (NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED) == noc_nonposted_atomics_acked[noc]);
 }
 
 inline __attribute__((always_inline)) void noc_init() {
@@ -141,8 +156,11 @@ inline __attribute__((always_inline)) void noc_init() {
     NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_MID, (uint32_t)(xy_local_addr >> 32));
     NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_MID, (uint32_t)(xy_local_addr >> 32));
 
-    uint32_t noc_rd_cmd_field = NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
+    uint64_t atomic_ret_addr = NOC_XY_ADDR(my_x, my_y, (uint32_t)(&atomic_ret_val));
+    NOC_CMD_BUF_WRITE_REG(noc, NCRISC_AT_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)(atomic_ret_addr & 0xFFFFFFFF));
+    NOC_CMD_BUF_WRITE_REG(noc, NCRISC_AT_CMD_BUF, NOC_RET_ADDR_MID, (uint32_t)(atomic_ret_addr >> 32));
 
+    uint32_t noc_rd_cmd_field = NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
     NOC_CMD_BUF_WRITE_REG(noc, NCRISC_RD_CMD_BUF, NOC_CTRL, noc_rd_cmd_field);
     NOC_CMD_BUF_WRITE_REG(noc, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_MID, (uint32_t)(xy_local_addr >> 32));
   }
@@ -154,6 +172,8 @@ inline __attribute__((always_inline)) void noc_local_state_init(int noc) {
     noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
     noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
     noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+    noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
 }
 
 inline __attribute__((always_inline)) void ncrisc_noc_counters_init() {
@@ -161,6 +181,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_counters_init() {
     noc_reads_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_RD_RESP_RECEIVED);
     noc_nonposted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
     noc_nonposted_writes_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_WR_ACK_RECEIVED);
+    noc_nonposted_atomics_acked[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_ATOMIC_RESP_RECEIVED);
+    noc_posted_writes_num_issued[noc] = NOC_STATUS_READ_REG(noc, NIU_MST_POSTED_WR_REQ_SENT);
   }
 }
 
@@ -169,6 +191,8 @@ inline __attribute__((always_inline)) void ncrisc_noc_full_sync() {
     while (!ncrisc_noc_reads_flushed(n));
     while (!ncrisc_noc_nonposted_writes_sent(n));
     while (!ncrisc_noc_nonposted_writes_flushed(n));
+    while (!ncrisc_noc_nonposted_atomics_flushed(n));
+    while (!ncrisc_noc_posted_writes_sent(n));
   }
 }
 
@@ -184,16 +208,16 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(uint32_t
   ncrisc_noc_fast_read(noc, cmd_buf, src_addr, dest_addr, len_bytes);
 }
 
-inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests) {
+inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests, bool posted = false) {
   while (len_bytes > NOC_MAX_BURST_SIZE) {
     while (!noc_cmd_buf_ready(noc, cmd_buf));
-    ncrisc_noc_fast_write(noc, cmd_buf, src_addr, dest_addr, NOC_MAX_BURST_SIZE, vc, mcast, linked, num_dests);
+    ncrisc_noc_fast_write(noc, cmd_buf, src_addr, dest_addr, NOC_MAX_BURST_SIZE, vc, mcast, linked, num_dests, posted);
     src_addr += NOC_MAX_BURST_SIZE;
     dest_addr += NOC_MAX_BURST_SIZE;
     len_bytes -= NOC_MAX_BURST_SIZE;
   }
   while (!noc_cmd_buf_ready(noc, cmd_buf));
-  ncrisc_noc_fast_write(noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests);
+  ncrisc_noc_fast_write(noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests, posted);
 }
 
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopback_src(uint32_t noc, uint32_t cmd_buf, uint32_t src_addr, uint64_t dest_addr, uint32_t len_bytes, uint32_t vc, bool mcast, bool linked, uint32_t num_dests) {
@@ -208,8 +232,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_loopbac
   ncrisc_noc_fast_write_loopback_src(noc, cmd_buf, src_addr, dest_addr, len_bytes, vc, mcast, linked, num_dests);
 }
 
-inline __attribute__((always_inline)) void noc_fast_posted_write_dw_inline(uint32_t noc, uint32_t cmd_buf, uint32_t val, uint64_t dest_addr, uint32_t be, uint32_t static_vc, bool mcast) {
-  bool posted = true;
+inline __attribute__((always_inline)) void noc_fast_write_dw_inline(uint32_t noc, uint32_t cmd_buf, uint32_t val, uint64_t dest_addr, uint32_t be, uint32_t static_vc, bool mcast, bool posted = false) {
   bool static_vc_alloc = true;
   uint32_t noc_cmd_field =
     (static_vc_alloc ? NOC_CMD_VC_STATIC : 0x0) |
@@ -223,22 +246,34 @@ inline __attribute__((always_inline)) void noc_fast_posted_write_dw_inline(uint3
   uint32_t be_shift = (dest_addr & (NOC_WORD_BYTES-1));
   be32 = (be32 << be_shift);
 
-  while (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CMD_CTRL) != NOC_CTRL_STATUS_READY);
+  while (!noc_cmd_buf_ready(noc, cmd_buf));
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, val);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
-  NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(dest_addr & ~(NOC_WORD_BYTES-1)));
+  NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, dest_addr & 0xFFFFFFFF);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, dest_addr >> 32);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+  if (posted) {
+    noc_posted_writes_num_issued[noc] += 1;
+  } else {
+    noc_nonposted_writes_num_issued[noc] += 1;
+    noc_nonposted_writes_acked[noc] += 1;
+  }
 }
 
-inline __attribute__((always_inline)) void noc_fast_atomic_increment(uint32_t noc, uint32_t cmd_buf, uint64_t addr, uint32_t vc, uint32_t incr, uint32_t wrap, bool linked) {
+inline __attribute__((always_inline)) void noc_fast_atomic_increment(uint32_t noc, uint32_t cmd_buf, uint64_t addr, uint32_t vc, uint32_t incr, uint32_t wrap, bool linked, bool posted = false) {
   while (!noc_cmd_buf_ready(noc, cmd_buf));
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(addr & 0xFFFFFFFF));
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(addr >> 32));
-  NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
-                        (linked ? NOC_CMD_VC_LINKED : 0x0) | vc);
+  NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL,
+                        NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
+                        (linked ? NOC_CMD_VC_LINKED : 0x0) |
+                        (posted ? 0 : NOC_CMD_RESP_MARKED) |
+                        NOC_CMD_AT);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, NOC_AT_INS(NOC_AT_INS_INCR_GET) | NOC_AT_WRAP(wrap) | NOC_AT_IND_32((addr>>2) & 0x3) | NOC_AT_IND_32_SRC(0));
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, incr);
   NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, 0x1);
+  if (!posted) {
+    noc_nonposted_atomics_acked[noc] += 1;
+  }
 }

--- a/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_common.hpp
@@ -42,6 +42,7 @@ void db_acquire(volatile uint32_t* semaphore, uint64_t noc_encoding) {
     };
     noc_semaphore_inc(noc_encoding | uint32_t(semaphore), -1); // Two's complement addition
     noc_async_write_barrier();
+    noc_async_atomic_barrier();
 }
 
 // Local refers to the core that is calling this function

--- a/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
+++ b/tt_metal/impl/dispatch/kernels/command_queue_consumer.cpp
@@ -95,6 +95,7 @@ void kernel_main() {
             noc_semaphore_inc(producer_noc_encoding | get_semaphore(0), 1);
             db_buf_switch = not db_buf_switch;
             noc_async_write_barrier(); // Barrier for now
+            noc_async_atomic_barrier();
         }
     }
 }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -20,6 +20,7 @@ void downstream_cb_acquire_pages(uint32_t n) {
 
     // Ensure last sem_inc has landed
     noc_async_write_barrier(); // XXXX TODO(pgk) can we do better on wormhole?
+    noc_async_atomic_barrier();
 
     while (*sem_addr < n);
     DEBUG_STATUS('A', 'P', 'D');
@@ -48,6 +49,7 @@ uint32_t upstream_cb_acquire_pages(uint32_t cb_fence,
     if (available == 0) {
         // Ensure last sem_inc has landed
         noc_async_write_barrier(); // XXXX TODO(pgk) can we do better on wormhole?
+        noc_async_atomic_barrier();
 
         DEBUG_STATUS('A', 'P', 'W');
         while ((available = *sem_addr) == 0);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatcher.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatcher.cpp
@@ -53,6 +53,7 @@ void kernel_main() {
         // notify producer that it has completed a command
         noc_semaphore_inc(producer_noc_encoding | get_semaphore(2), 1);
         noc_async_write_barrier(); // Barrier for now
+        noc_async_atomic_barrier();
 
         db_buf_switch = not db_buf_switch;
     }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatcher.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatcher.hpp
@@ -16,19 +16,19 @@ void noc_async_write_multicast_one_packet_no_path_reserve(
     DEBUG_STATUS('N', 'W', 'P', 'W');
     DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
     DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr_multicast, size);
-    while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
+    while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
     DEBUG_STATUS('N', 'W', 'P', 'D');
 
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(NOC_DISPATCH_MULTICAST_WRITE_VC) |
                              NOC_CMD_BRCST_PACKET |
                              NOC_CMD_RESP_MARKED;
 
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CTRL, noc_cmd_field);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr_multicast);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_RET_ADDR_MID, dst_noc_addr_multicast >> 32);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_AT_LEN_BE, size);
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr_multicast);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID, dst_noc_addr_multicast >> 32);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE, size);
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     noc_nonposted_writes_num_issued[noc_index] += 1;
     noc_nonposted_writes_acked[noc_index] += num_dests;
 }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetcher.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetcher.cpp
@@ -173,6 +173,7 @@ void kernel_main() {
                 }
                 noc_semaphore_inc(my_noc_encoding | uint32_t(pull_semaphore_addr), -1); // Two's complement addition
                 noc_async_write_barrier();
+                noc_async_atomic_barrier();
                 src_noc_addr = pull_noc_encoding |  issue_cmd_eth_dst_base;
             } else if constexpr (pull_and_push_config == tt::PullAndPushConfig::PULL_FROM_REMOTE) {
                 db_acquire(pull_semaphore_addr, my_noc_encoding); // dst routers increments this semaphore when cmd is available in the dst router
@@ -421,6 +422,7 @@ void kernel_main() {
             // Signal to DST router that command has been read in
             noc_semaphore_inc(pull_noc_encoding | eth_get_semaphore(1), 1);
             noc_async_write_barrier(); // Barrier for now
+            noc_async_atomic_barrier();
 
             header->fwd_path = 0;
             if (stall) {
@@ -593,6 +595,7 @@ void kernel_main() {
             // Signal to DST router that command has been read in
             noc_semaphore_inc(pull_noc_encoding | eth_get_semaphore(1), 1);
             noc_async_write_barrier(); // Barrier for now
+            noc_async_atomic_barrier();
 
             // Read data from DST router. No special handling for programs because programs will never send data back
             if (num_buffer_transfers == 1) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetcher.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetcher.hpp
@@ -68,6 +68,7 @@ void update_producer_consumer_sync_semaphores(
     // Notify the consumer
     noc_semaphore_inc(consumer_noc_encoding | consumer_db_semaphore, 1);
     noc_async_write_barrier();  // Barrier for now
+    noc_async_atomic_barrier();
 }
 
 FORCE_INLINE

--- a/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue.hpp"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp"
+
+#define NUM_BIDIR_TUNNELS 1
+#define NUM_TUNNEL_QUEUES (NUM_BIDIR_TUNNELS * 2)
+
+packet_input_queue_state_t input_queues[NUM_TUNNEL_QUEUES];
+packet_output_queue_state_t output_queues[NUM_TUNNEL_QUEUES];
+
+constexpr uint32_t endpoint_id_start_index = get_compile_time_arg_val(0);
+constexpr uint32_t tunnel_lanes = get_compile_time_arg_val(1);
+constexpr uint32_t in_queue_start_addr_words = get_compile_time_arg_val(2);
+constexpr uint32_t in_queue_size_words = get_compile_time_arg_val(3);
+constexpr uint32_t in_queue_size_bytes = in_queue_size_words*PACKET_WORD_SIZE_BYTES;
+static_assert(is_power_of_2(in_queue_size_words), "in_queue_size_words must be a power of 2");
+static_assert(tunnel_lanes <= NUM_TUNNEL_QUEUES, "cannot have more than 2 tunnel directions.");
+static_assert(tunnel_lanes, "tunnel directions cannot be 0. 1 => Unidirectional. 2 => Bidirectional");
+
+constexpr uint32_t remote_receiver_x[NUM_TUNNEL_QUEUES] =
+    {
+        (get_compile_time_arg_val(4) & 0xFF),
+        (get_compile_time_arg_val(5) & 0xFF)
+    };
+
+constexpr uint32_t remote_receiver_y[NUM_TUNNEL_QUEUES] =
+    {
+        (get_compile_time_arg_val(4) >> 8) & 0xFF,
+        (get_compile_time_arg_val(5) >> 8) & 0xFF
+    };
+
+constexpr uint32_t remote_receiver_queue_id[NUM_TUNNEL_QUEUES] =
+    {
+        (get_compile_time_arg_val(4) >> 16) & 0xFF,
+        (get_compile_time_arg_val(5) >> 16) & 0xFF
+    };
+
+constexpr DispatchRemoteNetworkType remote_receiver_network_type[NUM_TUNNEL_QUEUES] =
+    {
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(4) >> 24) & 0xFF),
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(5) >> 24) & 0xFF)
+    };
+
+constexpr uint32_t remote_receiver_queue_start_addr_words[NUM_TUNNEL_QUEUES] =
+    {
+        get_compile_time_arg_val(6),
+        get_compile_time_arg_val(8)
+    };
+
+constexpr uint32_t remote_receiver_queue_size_words[NUM_TUNNEL_QUEUES] =
+    {
+        get_compile_time_arg_val(7),
+        get_compile_time_arg_val(9)
+    };
+
+static_assert(is_power_of_2(remote_receiver_queue_size_words[0]), "remote_receiver_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_receiver_queue_size_words[1]), "remote_receiver_queue_size_words must be a power of 2");
+
+constexpr uint32_t remote_sender_x[NUM_TUNNEL_QUEUES] =
+    {
+        (get_compile_time_arg_val(10) & 0xFF),
+        (get_compile_time_arg_val(11) & 0xFF)
+    };
+
+constexpr uint32_t remote_sender_y[NUM_TUNNEL_QUEUES] =
+    {
+        (get_compile_time_arg_val(10) >> 8) & 0xFF,
+        (get_compile_time_arg_val(11) >> 8) & 0xFF
+    };
+
+constexpr uint32_t remote_sender_queue_id[NUM_TUNNEL_QUEUES] =
+    {
+        (get_compile_time_arg_val(10) >> 16) & 0xFF,
+        (get_compile_time_arg_val(11) >> 16) & 0xFF
+    };
+
+constexpr DispatchRemoteNetworkType remote_sender_network_type[NUM_TUNNEL_QUEUES] =
+    {
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(10) >> 24) & 0xFF),
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(11) >> 24) & 0xFF)
+    };
+
+constexpr uint32_t test_results_buf_addr_arg = get_compile_time_arg_val(12);
+constexpr uint32_t test_results_buf_size_bytes = get_compile_time_arg_val(13);
+
+tt_l1_ptr uint32_t* const test_results =
+    reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_buf_addr_arg);
+
+constexpr uint32_t timeout_cycles = get_compile_time_arg_val(14);
+
+void kernel_main() {
+
+    rtos_context_switch_ptr = (void (*)())RtosTable[0];
+    noc_init(0xF);
+
+    test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_STARTED;
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000000;
+    test_results[PQ_TEST_MISC_INDEX+1] = 0xbb000000;
+    test_results[PQ_TEST_MISC_INDEX+2] = 0xAABBCCDD;
+    test_results[PQ_TEST_MISC_INDEX+3] = 0xDDCCBBAA;
+    test_results[PQ_TEST_MISC_INDEX+4] = endpoint_id_start_index;
+
+    for (uint32_t i = 0; i < tunnel_lanes; i++) {
+        input_queues[i].init(i, in_queue_start_addr_words + i*in_queue_size_words, in_queue_size_words,
+                            remote_sender_x[i], remote_sender_y[i], remote_sender_queue_id[i], remote_sender_network_type[i]);
+    }
+
+    for (uint32_t i = 0; i < tunnel_lanes; i++) {
+        output_queues[i].init(i + NUM_TUNNEL_QUEUES, remote_receiver_queue_start_addr_words[i], remote_receiver_queue_size_words[i],
+                            remote_receiver_x[i], remote_receiver_y[i], remote_receiver_queue_id[i], remote_receiver_network_type[i],
+                            &input_queues[i], 1);
+    }
+
+    wait_all_src_dest_ready(input_queues, tunnel_lanes, output_queues, tunnel_lanes, timeout_cycles);
+
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000001;
+
+    bool timeout = false;
+    bool all_outputs_finished = false;
+    uint64_t data_words_sent = 0;
+    uint64_t iter = 0;
+    uint64_t start_timestamp = get_timestamp();
+    uint32_t progress_timestamp = start_timestamp & 0xFFFFFFFF;
+    while (!all_outputs_finished && !timeout) {
+        iter++;
+        if (timeout_cycles > 0) {
+            uint32_t cycles_since_progress = get_timestamp_32b() - progress_timestamp;
+            if (cycles_since_progress > timeout_cycles) {
+                timeout = true;
+                break;
+            }
+        }
+        all_outputs_finished = true;
+        for (uint32_t i = 0; i < tunnel_lanes; i++) {
+            if (input_queues[i].get_curr_packet_valid()) {
+                bool full_packet_sent;
+                uint32_t words_sent = output_queues[i].forward_data_from_input(0, full_packet_sent);
+                //data_words_sent += words_sent;
+                //if ((words_sent > 0) && (timeout_cycles > 0)) {
+                    progress_timestamp = get_timestamp_32b();
+                //}
+            }
+            output_queues[i].prev_words_in_flight_check_flush();
+            bool output_finished = output_queues[i].is_remote_finished();
+            if (output_finished) {
+                input_queues[i].send_remote_finished_notification();
+            }
+            all_outputs_finished &= output_finished;
+        }
+
+        //need to optimize this.
+        //context switch to base fw is very costly.
+        //internal_::risc_context_switch();
+    }
+
+    if (!timeout) {
+        test_results[PQ_TEST_MISC_INDEX] = 0xff000002;
+        for (uint32_t i = 0; i < tunnel_lanes; i++) {
+            if (!output_queues[i].output_barrier(timeout_cycles)) {
+                timeout = true;
+                break;
+            }
+        }
+    }
+
+    uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
+    if (!timeout) {
+        test_results[PQ_TEST_MISC_INDEX] = 0xff000003;
+    }
+
+    set_64b_result(test_results, data_words_sent, PQ_TEST_WORD_CNT_INDEX);
+    set_64b_result(test_results, cycles_elapsed, PQ_TEST_CYCLES_INDEX);
+    set_64b_result(test_results, iter, PQ_TEST_ITER_INDEX);
+
+    if (timeout) {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_TIMEOUT;
+    } else {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_PASS;
+        test_results[PQ_TEST_MISC_INDEX] = 0xff00005;
+    }
+}

--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -140,7 +140,7 @@ tt_l1_ptr uint32_t* const test_results =
 
 constexpr uint32_t timeout_cycles = get_compile_time_arg_val(24);
 
-FORCE_INLINE uint8_t dest_output_queue_id(uint32_t dest_endpoint_id) {
+inline uint8_t dest_output_queue_id(uint32_t dest_endpoint_id) {
     uint32_t dest_endpoint_index = dest_endpoint_id - endpoint_id_start_index;
     return dest_output_queue_id_map[dest_endpoint_index];
 }

--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue.hpp"
+#include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp"
+
+
+packet_input_queue_state_t input_queue;
+packet_output_queue_state_t output_queues[MAX_SWITCH_FAN_OUT];
+
+constexpr uint32_t endpoint_id_start_index = get_compile_time_arg_val(0);
+
+constexpr uint32_t rx_queue_start_addr_words = get_compile_time_arg_val(1);
+constexpr uint32_t rx_queue_size_words = get_compile_time_arg_val(2);
+constexpr uint32_t rx_queue_size_bytes = rx_queue_size_words*PACKET_WORD_SIZE_BYTES;
+
+static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
+
+constexpr uint32_t demux_fan_out = get_compile_time_arg_val(3);
+
+// FIXME imatosevic - is there a way to do this without explicit indexes?
+static_assert(demux_fan_out <= MAX_SWITCH_FAN_OUT,
+    "demux fan-out higher than MAX_SWITCH_FAN_OUT");
+static_assert(MAX_SWITCH_FAN_OUT == 4,
+    "MAX_SWITCH_FAN_OUT must be 4 for the initialization below to work");
+
+constexpr uint32_t remote_tx_x[MAX_SWITCH_FAN_OUT] =
+    {
+        (get_compile_time_arg_val(4) & 0xFF),
+        (get_compile_time_arg_val(5) & 0xFF),
+        (get_compile_time_arg_val(6) & 0xFF),
+        (get_compile_time_arg_val(7) & 0xFF)
+    };
+
+constexpr uint32_t remote_tx_y[MAX_SWITCH_FAN_OUT] =
+    {
+        (get_compile_time_arg_val(4) >> 8) & 0xFF,
+        (get_compile_time_arg_val(5) >> 8) & 0xFF,
+        (get_compile_time_arg_val(6) >> 8) & 0xFF,
+        (get_compile_time_arg_val(7) >> 8) & 0xFF
+    };
+
+constexpr uint32_t remote_tx_queue_id[MAX_SWITCH_FAN_OUT] =
+    {
+        (get_compile_time_arg_val(4) >> 16) & 0xFF,
+        (get_compile_time_arg_val(5) >> 16) & 0xFF,
+        (get_compile_time_arg_val(6) >> 16) & 0xFF,
+        (get_compile_time_arg_val(7) >> 16) & 0xFF
+    };
+
+constexpr DispatchRemoteNetworkType remote_tx_network_type[MAX_SWITCH_FAN_OUT] =
+    {
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(4) >> 24) & 0xFF),
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(5) >> 24) & 0xFF),
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(6) >> 24) & 0xFF),
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(7) >> 24) & 0xFF)
+    };
+
+constexpr uint32_t remote_tx_queue_start_addr_words[MAX_SWITCH_FAN_OUT] =
+    {
+        get_compile_time_arg_val(8),
+        get_compile_time_arg_val(10),
+        get_compile_time_arg_val(12),
+        get_compile_time_arg_val(14)
+    };
+
+constexpr uint32_t remote_tx_queue_size_words[MAX_SWITCH_FAN_OUT] =
+    {
+        get_compile_time_arg_val(9),
+        get_compile_time_arg_val(11),
+        get_compile_time_arg_val(13),
+        get_compile_time_arg_val(15)
+    };
+
+static_assert(is_power_of_2(remote_tx_queue_size_words[0]), "remote_tx_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_tx_queue_size_words[1]), "remote_tx_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_tx_queue_size_words[2]), "remote_tx_queue_size_words must be a power of 2");
+static_assert(is_power_of_2(remote_tx_queue_size_words[3]), "remote_tx_queue_size_words must be a power of 2");
+
+constexpr uint32_t remote_rx_x = get_compile_time_arg_val(16);
+constexpr uint32_t remote_rx_y = get_compile_time_arg_val(17);
+constexpr uint32_t remote_rx_queue_id = get_compile_time_arg_val(18);
+constexpr DispatchRemoteNetworkType
+    remote_rx_network_type =
+        static_cast<DispatchRemoteNetworkType>(get_compile_time_arg_val(19));
+
+static_assert(MAX_DEST_ENDPOINTS <= 32 && MAX_SWITCH_FAN_OUT <= 4,
+    "We assume MAX_DEST_ENDPOINTS <= 32 and MAX_SWITCH_FAN_OUT <= 4 for the initialization below to work");
+
+constexpr uint32_t dest_endpoint_output_map_hi = get_compile_time_arg_val(20);
+constexpr uint32_t dest_endpoint_output_map_lo = get_compile_time_arg_val(21);
+
+constexpr uint8_t dest_output_queue_id_map[MAX_DEST_ENDPOINTS] =
+    {
+        (dest_endpoint_output_map_lo >> 0) & 0x3,
+        (dest_endpoint_output_map_lo >> 2) & 0x3,
+        (dest_endpoint_output_map_lo >> 4) & 0x3,
+        (dest_endpoint_output_map_lo >> 6) & 0x3,
+        (dest_endpoint_output_map_lo >> 8) & 0x3,
+        (dest_endpoint_output_map_lo >> 10) & 0x3,
+        (dest_endpoint_output_map_lo >> 12) & 0x3,
+        (dest_endpoint_output_map_lo >> 14) & 0x3,
+        (dest_endpoint_output_map_lo >> 16) & 0x3,
+        (dest_endpoint_output_map_lo >> 18) & 0x3,
+        (dest_endpoint_output_map_lo >> 20) & 0x3,
+        (dest_endpoint_output_map_lo >> 22) & 0x3,
+        (dest_endpoint_output_map_lo >> 24) & 0x3,
+        (dest_endpoint_output_map_lo >> 26) & 0x3,
+        (dest_endpoint_output_map_lo >> 28) & 0x3,
+        (dest_endpoint_output_map_lo >> 30) & 0x3,
+        (dest_endpoint_output_map_hi >> 0) & 0x3,
+        (dest_endpoint_output_map_hi >> 2) & 0x3,
+        (dest_endpoint_output_map_hi >> 4) & 0x3,
+        (dest_endpoint_output_map_hi >> 6) & 0x3,
+        (dest_endpoint_output_map_hi >> 8) & 0x3,
+        (dest_endpoint_output_map_hi >> 10) & 0x3,
+        (dest_endpoint_output_map_hi >> 12) & 0x3,
+        (dest_endpoint_output_map_hi >> 14) & 0x3,
+        (dest_endpoint_output_map_hi >> 16) & 0x3,
+        (dest_endpoint_output_map_hi >> 18) & 0x3,
+        (dest_endpoint_output_map_hi >> 20) & 0x3,
+        (dest_endpoint_output_map_hi >> 22) & 0x3,
+        (dest_endpoint_output_map_hi >> 24) & 0x3,
+        (dest_endpoint_output_map_hi >> 26) & 0x3,
+        (dest_endpoint_output_map_hi >> 28) & 0x3,
+        (dest_endpoint_output_map_hi >> 30) & 0x3
+    };
+
+constexpr uint32_t output_queue_index_bits = 2;
+constexpr uint32_t output_queue_index_mask = (1 << output_queue_index_bits) - 1;
+
+constexpr uint32_t test_results_buf_addr_arg = get_compile_time_arg_val(22);
+constexpr uint32_t test_results_buf_size_bytes = get_compile_time_arg_val(23);
+
+tt_l1_ptr uint32_t* const test_results =
+    reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_buf_addr_arg);
+
+constexpr uint32_t timeout_cycles = get_compile_time_arg_val(24);
+
+FORCE_INLINE uint8_t dest_output_queue_id(uint32_t dest_endpoint_id) {
+    uint32_t dest_endpoint_index = dest_endpoint_id - endpoint_id_start_index;
+    return dest_output_queue_id_map[dest_endpoint_index];
+}
+
+void kernel_main() {
+
+    noc_init();
+
+    test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_STARTED;
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000000;
+    test_results[PQ_TEST_MISC_INDEX+1] = 0xbb000000 | demux_fan_out;
+    test_results[PQ_TEST_MISC_INDEX+2] = dest_endpoint_output_map_hi;
+    test_results[PQ_TEST_MISC_INDEX+3] = dest_endpoint_output_map_lo;
+    test_results[PQ_TEST_MISC_INDEX+4] = endpoint_id_start_index;
+
+    for (uint32_t i = 0; i < demux_fan_out; i++) {
+       output_queues[i].init(i, remote_tx_queue_start_addr_words[i], remote_tx_queue_size_words[i],
+                             remote_tx_x[i], remote_tx_y[i], remote_tx_queue_id[i], remote_tx_network_type[i],
+                             &input_queue, 1);
+    }
+    input_queue.init(demux_fan_out, rx_queue_start_addr_words, rx_queue_size_words,
+                     remote_rx_x, remote_rx_y, remote_rx_queue_id, remote_rx_network_type);
+
+    wait_all_src_dest_ready(&input_queue, 1, output_queues, demux_fan_out, timeout_cycles);
+
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000001;
+
+    bool timeout = false;
+    bool all_outputs_finished = false;
+    uint64_t data_words_sent = 0;
+    uint64_t iter = 0;
+    uint64_t start_timestamp = get_timestamp();
+    uint32_t progress_timestamp = start_timestamp & 0xFFFFFFFF;
+    while (!all_outputs_finished && !timeout) {
+        iter++;
+        if (timeout_cycles > 0) {
+            uint32_t cycles_since_progress = get_timestamp_32b() - progress_timestamp;
+            if (cycles_since_progress > timeout_cycles) {
+                timeout = true;
+                break;
+            }
+        }
+        if (input_queue.get_curr_packet_valid()) {
+            uint32_t dest = input_queue.get_curr_packet_dest();
+            uint8_t output_queue_id = dest_output_queue_id(dest);
+            bool full_packet_sent;
+            uint32_t words_sent = output_queues[output_queue_id].forward_data_from_input(0, full_packet_sent);
+            data_words_sent += words_sent;
+            if ((words_sent > 0) && (timeout_cycles > 0)) {
+                progress_timestamp = get_timestamp_32b();
+            }
+        }
+        all_outputs_finished = true;
+        for (uint32_t i = 0; i < demux_fan_out; i++) {
+            output_queues[i].prev_words_in_flight_check_flush();
+            all_outputs_finished &= output_queues[i].is_remote_finished();
+        }
+    }
+
+    if (!timeout) {
+        test_results[PQ_TEST_MISC_INDEX] = 0xff000002;
+        for (uint32_t i = 0; i < demux_fan_out; i++) {
+            if (!output_queues[i].output_barrier(timeout_cycles)) {
+                timeout = true;
+                break;
+            }
+        }
+    }
+
+    uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
+    if (!timeout) {
+        test_results[PQ_TEST_MISC_INDEX] = 0xff000003;
+        input_queue.send_remote_finished_notification();
+    }
+
+    set_64b_result(test_results, data_words_sent, PQ_TEST_WORD_CNT_INDEX);
+    set_64b_result(test_results, cycles_elapsed, PQ_TEST_CYCLES_INDEX);
+    set_64b_result(test_results, iter, PQ_TEST_ITER_INDEX);
+
+    if (timeout) {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_TIMEOUT;
+    } else {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_PASS;
+        test_results[PQ_TEST_MISC_INDEX] = 0xff00005;
+    }
+}

--- a/tt_metal/impl/dispatch/kernels/packet_mux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_mux.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue.hpp"
+
+packet_input_queue_state_t input_queues[MAX_SWITCH_FAN_IN];
+packet_output_queue_state_t output_queue;
+
+constexpr uint32_t reserved = get_compile_time_arg_val(0);
+
+// assume up to MAX_SWITCH_FAN_IN queues with contiguous storage,
+// starting at rx_queue_start_addr
+constexpr uint32_t rx_queue_start_addr_words = get_compile_time_arg_val(1);
+constexpr uint32_t rx_queue_size_words = get_compile_time_arg_val(2);
+constexpr uint32_t rx_queue_size_bytes = rx_queue_size_words*PACKET_WORD_SIZE_BYTES;
+
+static_assert(is_power_of_2(rx_queue_size_words), "rx_queue_size_words must be a power of 2");
+
+constexpr uint32_t mux_fan_in = get_compile_time_arg_val(3);
+
+// FIXME imatosevic - is there a way to do this without explicit indexes?
+static_assert(mux_fan_in <= MAX_SWITCH_FAN_IN,
+    "mux fan-in higher than MAX_SWITCH_FAN_IN");
+static_assert(MAX_SWITCH_FAN_IN == 4,
+    "MAX_SWITCH_FAN_IN must be 4 for the initialization below to work");
+
+constexpr uint32_t remote_rx_x[MAX_SWITCH_FAN_IN] =
+    {
+        (get_compile_time_arg_val(4) & 0xFF),
+        (get_compile_time_arg_val(5) & 0xFF),
+        (get_compile_time_arg_val(6) & 0xFF),
+        (get_compile_time_arg_val(7) & 0xFF)
+    };
+
+constexpr uint32_t remote_rx_y[MAX_SWITCH_FAN_IN] =
+    {
+        (get_compile_time_arg_val(4) >> 8) & 0xFF,
+        (get_compile_time_arg_val(5) >> 8) & 0xFF,
+        (get_compile_time_arg_val(6) >> 8) & 0xFF,
+        (get_compile_time_arg_val(7) >> 8) & 0xFF
+    };
+
+constexpr uint32_t remote_rx_queue_id[MAX_SWITCH_FAN_IN] =
+    {
+        (get_compile_time_arg_val(4) >> 16) & 0xFF,
+        (get_compile_time_arg_val(5) >> 16) & 0xFF,
+        (get_compile_time_arg_val(6) >> 16) & 0xFF,
+        (get_compile_time_arg_val(7) >> 16) & 0xFF
+    };
+
+constexpr DispatchRemoteNetworkType remote_rx_network_type[MAX_SWITCH_FAN_IN] =
+    {
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(4) >> 24) & 0xFF),
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(5) >> 24) & 0xFF),
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(6) >> 24) & 0xFF),
+        static_cast<DispatchRemoteNetworkType>((get_compile_time_arg_val(7) >> 24) & 0xFF)
+    };
+
+constexpr uint32_t remote_tx_queue_start_addr_words = get_compile_time_arg_val(8);
+constexpr uint32_t remote_tx_queue_size_words = get_compile_time_arg_val(9);
+
+static_assert(is_power_of_2(remote_tx_queue_size_words), "remote_tx_queue_size_words must be a power of 2");
+
+constexpr uint32_t remote_tx_x = get_compile_time_arg_val(10);
+constexpr uint32_t remote_tx_y = get_compile_time_arg_val(11);
+constexpr uint32_t remote_tx_queue_id = get_compile_time_arg_val(12);
+constexpr DispatchRemoteNetworkType
+    tx_network_type =
+        static_cast<DispatchRemoteNetworkType>(get_compile_time_arg_val(13));
+
+constexpr uint32_t test_results_buf_addr_arg = get_compile_time_arg_val(14);
+constexpr uint32_t test_results_buf_size_bytes = get_compile_time_arg_val(15);
+
+tt_l1_ptr uint32_t* const test_results =
+    reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_buf_addr_arg);
+
+constexpr uint32_t timeout_cycles = get_compile_time_arg_val(16);
+
+
+void kernel_main() {
+
+    noc_init();
+
+    test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_STARTED;
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000000;
+    test_results[PQ_TEST_MISC_INDEX+1] = 0xaa000000 | mux_fan_in;
+
+    for (uint32_t i = 0; i < mux_fan_in; i++) {
+        input_queues[i].init(i, rx_queue_start_addr_words + i*rx_queue_size_words, rx_queue_size_words,
+                            remote_rx_x[i], remote_rx_y[i], remote_rx_queue_id[i], remote_rx_network_type[i]);
+    }
+    output_queue.init(mux_fan_in, remote_tx_queue_start_addr_words, remote_tx_queue_size_words,
+                      remote_tx_x, remote_tx_y, remote_tx_queue_id, tx_network_type,
+                      input_queues, mux_fan_in);
+
+    wait_all_src_dest_ready(input_queues, mux_fan_in, &output_queue, 1, timeout_cycles);
+
+    test_results[PQ_TEST_MISC_INDEX] = 0xff000001;
+
+    uint32_t curr_input = 0;
+    bool timeout = false;
+    bool dest_finished = false;
+    bool curr_input_partial_packet_sent = false;
+    uint64_t data_words_sent = 0;
+    uint64_t iter = 0;
+    uint64_t start_timestamp = get_timestamp();
+    uint32_t progress_timestamp = start_timestamp & 0xFFFFFFFF;
+    while (!dest_finished && !timeout) {
+        iter++;
+        if (timeout_cycles > 0) {
+            uint32_t cycles_since_progress = get_timestamp_32b() - progress_timestamp;
+            if (cycles_since_progress > timeout_cycles) {
+                timeout = true;
+                break;
+            }
+        }
+        if (input_queues[curr_input].get_curr_packet_valid()) {
+            bool full_packet_sent;
+            uint32_t words_sent = output_queue.forward_data_from_input(curr_input, full_packet_sent);
+            data_words_sent += words_sent;
+            if ((words_sent > 0) && (timeout_cycles > 0)) {
+                progress_timestamp = get_timestamp_32b();
+            }
+            curr_input_partial_packet_sent = !full_packet_sent;
+        }
+        if (!curr_input_partial_packet_sent) {
+            curr_input++;
+            if (curr_input == mux_fan_in) {
+                curr_input = 0;
+            }
+        }
+        output_queue.prev_words_in_flight_check_flush();
+        dest_finished = output_queue.is_remote_finished();
+    }
+
+    if (!timeout) {
+        test_results[PQ_TEST_MISC_INDEX] = 0xff000002;
+        if (!output_queue.output_barrier(timeout_cycles)) {
+            timeout = true;
+        }
+    }
+
+    uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
+    if (!timeout) {
+        test_results[PQ_TEST_MISC_INDEX] = 0xff000003;
+        for (uint32_t i = 0; i < mux_fan_in; i++) {
+            input_queues[i].send_remote_finished_notification();
+        }
+    }
+
+    set_64b_result(test_results, data_words_sent, PQ_TEST_WORD_CNT_INDEX);
+    set_64b_result(test_results, cycles_elapsed, PQ_TEST_CYCLES_INDEX);
+    set_64b_result(test_results, iter, PQ_TEST_ITER_INDEX);
+
+    if (timeout) {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_TIMEOUT;
+    } else {
+        test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_PASS;
+        test_results[PQ_TEST_MISC_INDEX] = 0xff00005;
+    }
+}

--- a/tt_metal/impl/dispatch/kernels/packet_queue.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue.hpp
@@ -22,13 +22,13 @@ constexpr uint32_t DEFAULT_MAX_ETH_SEND_WORDS = 2*1024;
 constexpr uint32_t NUM_PTR_REGS_PER_QUEUE = 3;
 
 
-FORCE_INLINE uint64_t get_timestamp() {
+inline uint64_t get_timestamp() {
     uint32_t timestamp_low = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
     uint32_t timestamp_high = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_H);
     return (((uint64_t)timestamp_high) << 32) | timestamp_low;
 }
 
-FORCE_INLINE uint64_t get_timestamp_32b() {
+inline uint64_t get_timestamp_32b() {
     return reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
 }
 
@@ -138,103 +138,103 @@ public:
             STREAM_REG_ADDR(queue_id, STREAM_REMOTE_SRC_REG_INDEX));
     }
 
-    FORCE_INLINE uint8_t get_queue_id() const {
+    inline uint8_t get_queue_id() const {
         return this->queue_id;
     }
 
-    FORCE_INLINE uint32_t get_queue_local_wptr() const {
+    inline uint32_t get_queue_local_wptr() const {
         return *this->local_wptr_val;
     }
 
-    FORCE_INLINE void reset_queue_local_wptr() {
+    inline void reset_queue_local_wptr() {
         *this->local_wptr_reset = 0;
     }
 
-    FORCE_INLINE void advance_queue_local_wptr(uint32_t num_words) {
+    inline void advance_queue_local_wptr(uint32_t num_words) {
         *this->local_wptr_update = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
     }
 
-    FORCE_INLINE uint32_t get_queue_local_rptr_sent() const {
+    inline uint32_t get_queue_local_rptr_sent() const {
         return *this->local_rptr_sent_val;
     }
 
-    FORCE_INLINE uint32_t get_queue_local_rptr_cleared() const {
+    inline uint32_t get_queue_local_rptr_cleared() const {
         return *this->local_rptr_cleared_val;
     }
 
-    FORCE_INLINE void reset_queue_local_rptr_sent()  {
+    inline void reset_queue_local_rptr_sent()  {
         *this->local_rptr_sent_reset = 0;
     }
 
-    FORCE_INLINE void reset_queue_local_rptr_cleared()  {
+    inline void reset_queue_local_rptr_cleared()  {
         *this->local_rptr_cleared_reset = 0;
     }
 
-    FORCE_INLINE void advance_queue_local_rptr_sent(uint32_t num_words)  {
+    inline void advance_queue_local_rptr_sent(uint32_t num_words)  {
         *this->local_rptr_sent_update = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
     }
 
-    FORCE_INLINE void advance_queue_local_rptr_cleared(uint32_t num_words)  {
+    inline void advance_queue_local_rptr_cleared(uint32_t num_words)  {
         *this->local_rptr_cleared_update = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
     }
 
-    FORCE_INLINE uint32_t get_queue_data_num_words_available_to_send() const {
+    inline uint32_t get_queue_data_num_words_available_to_send() const {
         return (this->get_queue_local_wptr() - this->get_queue_local_rptr_sent()) & this->queue_size_mask;
     }
 
-    FORCE_INLINE uint32_t get_queue_data_num_words_occupied() const {
+    inline uint32_t get_queue_data_num_words_occupied() const {
         return (this->get_queue_local_wptr() - this->get_queue_local_rptr_cleared()) & this->queue_size_mask;
     }
 
-    FORCE_INLINE uint32_t get_queue_data_num_words_free() const {
+    inline uint32_t get_queue_data_num_words_free() const {
         return this->queue_size_words - this->get_queue_data_num_words_occupied();
     }
 
-    FORCE_INLINE uint32_t get_num_words_sent_not_cleared() const {
+    inline uint32_t get_num_words_sent_not_cleared() const {
         return (this->get_queue_local_rptr_sent() - this->get_queue_local_rptr_cleared()) & this->queue_size_mask;
     }
 
-    FORCE_INLINE uint32_t get_num_words_written_not_sent() const {
+    inline uint32_t get_num_words_written_not_sent() const {
         return (this->get_queue_local_wptr() - this->get_queue_local_rptr_sent()) & this->queue_size_mask;
     }
 
-    FORCE_INLINE uint32_t get_queue_wptr_offset_words() const {
+    inline uint32_t get_queue_wptr_offset_words() const {
         return this->get_queue_local_wptr() & this->ptr_offset_mask;
     }
 
-    FORCE_INLINE uint32_t get_queue_rptr_sent_offset_words() const {
+    inline uint32_t get_queue_rptr_sent_offset_words() const {
         return this->get_queue_local_rptr_sent() & this->ptr_offset_mask;
     }
 
-    FORCE_INLINE uint32_t get_queue_rptr_cleared_offset_words() const {
+    inline uint32_t get_queue_rptr_cleared_offset_words() const {
         return this->get_queue_local_rptr_cleared() & this->ptr_offset_mask;
     }
 
-    FORCE_INLINE uint32_t get_queue_rptr_sent_addr_bytes() const {
+    inline uint32_t get_queue_rptr_sent_addr_bytes() const {
         return (this->queue_start_addr_words + this->get_queue_rptr_sent_offset_words())*PACKET_WORD_SIZE_BYTES;
     }
 
-    FORCE_INLINE uint32_t get_queue_rptr_cleared_addr_bytes() const {
+    inline uint32_t get_queue_rptr_cleared_addr_bytes() const {
         return (this->queue_start_addr_words + this->get_queue_rptr_cleared_offset_words())*PACKET_WORD_SIZE_BYTES;
     }
 
-    FORCE_INLINE uint32_t get_queue_wptr_addr_bytes() const {
+    inline uint32_t get_queue_wptr_addr_bytes() const {
         return (this->queue_start_addr_words + this->get_queue_wptr_offset_words())*PACKET_WORD_SIZE_BYTES;
     }
 
-    FORCE_INLINE uint32_t get_queue_words_before_rptr_sent_wrap() const {
+    inline uint32_t get_queue_words_before_rptr_sent_wrap() const {
         return queue_size_words - this->get_queue_rptr_sent_offset_words();
     }
 
-    FORCE_INLINE uint32_t get_queue_words_before_rptr_cleared_wrap() const {
+    inline uint32_t get_queue_words_before_rptr_cleared_wrap() const {
         return queue_size_words - this->get_queue_rptr_cleared_offset_words();
     }
 
-    FORCE_INLINE uint32_t get_queue_words_before_wptr_wrap() const {
+    inline uint32_t get_queue_words_before_wptr_wrap() const {
         return queue_size_words - this->get_queue_wptr_offset_words();
     }
 
-    FORCE_INLINE void remote_reg_update(uint32_t reg_addr, uint32_t val) {
+    inline void remote_reg_update(uint32_t reg_addr, uint32_t val) {
 
         if (this->remote_update_network_type == DispatchRemoteNetworkType::NONE) {
             return;
@@ -247,47 +247,47 @@ public:
         }
     }
 
-    FORCE_INLINE void advance_queue_remote_wptr(uint32_t num_words) {
+    inline void advance_queue_remote_wptr(uint32_t num_words) {
         uint32_t val = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
         uint32_t reg_addr = this->remote_wptr_update_addr;
         this->remote_reg_update(reg_addr, val);
     }
 
-    FORCE_INLINE void advance_queue_remote_rptr_sent(uint32_t num_words) {
+    inline void advance_queue_remote_rptr_sent(uint32_t num_words) {
         uint32_t val = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
         uint32_t reg_addr = this->remote_rptr_sent_update_addr;
         this->remote_reg_update(reg_addr, val);
     }
 
-    FORCE_INLINE void advance_queue_remote_rptr_cleared(uint32_t num_words) {
+    inline void advance_queue_remote_rptr_cleared(uint32_t num_words) {
         uint32_t val = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
         uint32_t reg_addr = this->remote_rptr_cleared_update_addr;
         this->remote_reg_update(reg_addr, val);
     }
 
-    FORCE_INLINE void reset_ready_flag() {
+    inline void reset_ready_flag() {
         *this->local_ready_status_ptr = 0;
     }
 
-    FORCE_INLINE void send_remote_ready_notification() {
+    inline void send_remote_ready_notification() {
         this->remote_reg_update(this->remote_ready_status_addr,
                                 PACKET_QUEUE_REMOTE_READY_FLAG);
     }
 
-    FORCE_INLINE void send_remote_finished_notification() {
+    inline void send_remote_finished_notification() {
         this->remote_reg_update(this->remote_ready_status_addr,
                                 PACKET_QUEUE_REMOTE_FINISHED_FLAG);
     }
 
-    FORCE_INLINE bool is_remote_ready() const {
+    inline bool is_remote_ready() const {
         return *this->local_ready_status_ptr == PACKET_QUEUE_REMOTE_READY_FLAG;
     }
 
-    FORCE_INLINE uint32_t get_remote_ready_status() const {
+    inline uint32_t get_remote_ready_status() const {
         return *this->local_ready_status_ptr;
     }
 
-    FORCE_INLINE bool is_remote_finished() const {
+    inline bool is_remote_finished() const {
         return *this->local_ready_status_ptr == PACKET_QUEUE_REMOTE_FINISHED_FLAG;
     }
 
@@ -324,7 +324,7 @@ protected:
     uint32_t curr_packet_tag;
     uint16_t curr_packet_flags;
 
-    FORCE_INLINE void advance_next_packet() {
+    inline void advance_next_packet() {
         if(this->get_queue_data_num_words_available_to_send() > 0) {
             tt_l1_ptr dispatch_packet_header_t* next_packet_header_ptr =
                 reinterpret_cast<tt_l1_ptr dispatch_packet_header_t*>(
@@ -368,68 +368,68 @@ public:
     }
 
 
-    FORCE_INLINE bool get_curr_packet_valid() {
+    inline bool get_curr_packet_valid() {
         if (!this->curr_packet_valid && (this->get_queue_data_num_words_available_to_send() > 0)){
             this->advance_next_packet();
         }
         return this->curr_packet_valid;
     }
 
-    FORCE_INLINE tt_l1_ptr dispatch_packet_header_t* get_curr_packet_header_ptr() {
+    inline tt_l1_ptr dispatch_packet_header_t* get_curr_packet_header_ptr() {
         if (!this->curr_packet_valid) {
             this->advance_next_packet();
         }
         return this->curr_packet_header_ptr;
     }
 
-    FORCE_INLINE uint32_t get_curr_packet_dest() {
+    inline uint32_t get_curr_packet_dest() {
         if (!this->curr_packet_valid) {
             this->advance_next_packet();
         }
         return this->curr_packet_dest;
     }
 
-    FORCE_INLINE uint32_t get_curr_packet_src() {
+    inline uint32_t get_curr_packet_src() {
         if (!this->curr_packet_valid) {
             this->advance_next_packet();
         }
         return this->curr_packet_src;
     }
 
-    FORCE_INLINE uint32_t get_curr_packet_size_words() {
+    inline uint32_t get_curr_packet_size_words() {
         if (!this->curr_packet_valid) {
             this->advance_next_packet();
         }
         return this->curr_packet_size_words;
     }
 
-    FORCE_INLINE uint32_t get_curr_packet_words_remaining() {
+    inline uint32_t get_curr_packet_words_remaining() {
         if (!this->curr_packet_valid) {
             this->advance_next_packet();
         }
         return this->curr_packet_size_words - this->curr_packet_words_sent;
     }
 
-    FORCE_INLINE uint32_t get_curr_packet_tag() {
+    inline uint32_t get_curr_packet_tag() {
         if (!this->curr_packet_valid) {
             this->advance_next_packet();
         }
         return this->curr_packet_tag;
     }
 
-    FORCE_INLINE uint32_t get_curr_packet_flags() {
+    inline uint32_t get_curr_packet_flags() {
         if (!this->curr_packet_valid) {
             this->advance_next_packet();
         }
         return this->curr_packet_flags;
     }
 
-    FORCE_INLINE bool partial_packet_sent() const {
+    inline bool partial_packet_sent() const {
         return this->curr_packet_valid && (this->curr_packet_words_sent > 0);
     }
 
 
-    FORCE_INLINE bool input_queue_full_packet_available_to_send(uint32_t& num_words_available_to_send) {
+    inline bool input_queue_full_packet_available_to_send(uint32_t& num_words_available_to_send) {
         num_words_available_to_send = this->get_queue_data_num_words_available_to_send();
         if (num_words_available_to_send == 0) {
             return false;
@@ -437,7 +437,7 @@ public:
         return num_words_available_to_send >= this->get_curr_packet_words_remaining();
     }
 
-    FORCE_INLINE uint32_t input_queue_curr_packet_num_words_available_to_send() {
+    inline uint32_t input_queue_curr_packet_num_words_available_to_send() {
         uint32_t num_words = this->get_queue_data_num_words_available_to_send();
         if (num_words == 0) {
             return 0;
@@ -446,7 +446,7 @@ public:
         return num_words;
     }
 
-    FORCE_INLINE void input_queue_advance_words_sent(uint32_t num_words) {
+    inline void input_queue_advance_words_sent(uint32_t num_words) {
         if (num_words > 0) {
             this->advance_queue_local_rptr_sent(num_words);
             this->advance_queue_remote_rptr_sent(num_words);
@@ -459,14 +459,14 @@ public:
         }
     }
 
-    FORCE_INLINE void input_queue_advance_words_cleared(uint32_t num_words) {
+    inline void input_queue_advance_words_cleared(uint32_t num_words) {
         if (num_words > 0) {
             this->advance_queue_local_rptr_cleared(num_words);
             this->advance_queue_remote_rptr_cleared(num_words);
         }
     }
 
-    FORCE_INLINE void input_queue_clear_all_words_sent() {
+    inline void input_queue_clear_all_words_sent() {
         this->input_queue_advance_words_cleared(this->get_num_words_sent_not_cleared());
     }
 
@@ -515,15 +515,15 @@ class packet_output_queue_state_t : public packet_queue_state_t {
             }
         }
 
-        FORCE_INLINE uint32_t get_curr_total_words_in_flight() const {
+        inline uint32_t get_curr_total_words_in_flight() const {
             return this->curr_total_words_in_flight;
         }
 
-        FORCE_INLINE uint32_t get_prev_total_words_in_flight() const {
+        inline uint32_t get_prev_total_words_in_flight() const {
             return this->prev_total_words_in_flight;
         }
 
-        FORCE_INLINE uint32_t prev_words_in_flight_flush() {
+        inline uint32_t prev_words_in_flight_flush() {
 
             uint32_t words_flushed = this->prev_total_words_in_flight;
             if (words_flushed > 0) {
@@ -542,7 +542,7 @@ class packet_output_queue_state_t : public packet_queue_state_t {
             return words_flushed;
         }
 
-        FORCE_INLINE void register_words_in_flight(uint32_t input_queue_id, uint32_t num_words) {
+        inline void register_words_in_flight(uint32_t input_queue_id, uint32_t num_words) {
             this->curr_input_queue_words_in_flight[input_queue_id] += num_words;
             this->curr_total_words_in_flight += num_words;
             this->input_queue_array[input_queue_id].input_queue_advance_words_sent(num_words);
@@ -593,20 +593,20 @@ public:
         this->reset_ready_flag();
     }
 
-    FORCE_INLINE void set_max_noc_send_words(uint32_t max_noc_send_words) {
+    inline void set_max_noc_send_words(uint32_t max_noc_send_words) {
         this->max_noc_send_words = max_noc_send_words;
     }
 
-    FORCE_INLINE void set_max_eth_send_words(uint32_t max_eth_send_words) {
+    inline void set_max_eth_send_words(uint32_t max_eth_send_words) {
         this->max_eth_send_words = max_eth_send_words;
     }
 
-    FORCE_INLINE uint32_t output_max_num_words_to_forward() const {
+    inline uint32_t output_max_num_words_to_forward() const {
         return (this->remote_update_network_type == DispatchRemoteNetworkType::ETH) ?
             this->max_eth_send_words : this->max_noc_send_words;
     }
 
-    FORCE_INLINE void send_data_to_remote(uint32_t src_addr, uint32_t dest_addr, uint32_t num_words) {
+    inline void send_data_to_remote(uint32_t src_addr, uint32_t dest_addr, uint32_t num_words) {
         if ((this->remote_update_network_type == DispatchRemoteNetworkType::NONE) ||
             (num_words == 0)) {
             return;
@@ -618,11 +618,11 @@ public:
         }
     }
 
-    FORCE_INLINE void remote_wptr_update(uint32_t num_words) {
+    inline void remote_wptr_update(uint32_t num_words) {
         this->advance_queue_remote_wptr(num_words);
     }
 
-    FORCE_INLINE uint32_t prev_words_in_flight_check_flush() {
+    inline uint32_t prev_words_in_flight_check_flush() {
         if (this->get_num_words_written_not_sent() <= this->input_queue_status.get_curr_total_words_in_flight()) {
             return this->input_queue_status.prev_words_in_flight_flush();
         } else {
@@ -649,7 +649,7 @@ public:
         return true;
     }
 
-    FORCE_INLINE uint32_t get_num_words_to_send(uint32_t input_queue_index) {
+    inline uint32_t get_num_words_to_send(uint32_t input_queue_index) {
 
         packet_input_queue_state_t* input_queue_ptr = &(this->input_queue_status.input_queue_array[input_queue_index]);
 
@@ -670,7 +670,7 @@ public:
         return num_words_to_forward;
     }
 
-    FORCE_INLINE uint32_t forward_data_from_input(uint32_t input_queue_index, bool& full_packet_sent) {
+    inline uint32_t forward_data_from_input(uint32_t input_queue_index, bool& full_packet_sent) {
 
         packet_input_queue_state_t* input_queue_ptr = &(this->input_queue_status.input_queue_array[input_queue_index]);
         uint32_t num_words_to_forward = this->get_num_words_to_send(input_queue_index);

--- a/tt_metal/impl/dispatch/kernels/packet_queue.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue.hpp
@@ -1,0 +1,752 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "risc_attribs.h"
+#include "tt_metal/hostdevcommon/common_values.hpp"
+#include "tt_metal/impl/dispatch/kernels/command_queue_common.hpp"
+#include "cq_cmds.hpp"
+#include "dataflow_api.h"
+#include "noc_overlay_parameters.h"
+#include "ethernet/dataflow_api.h"
+#include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
+
+
+constexpr uint32_t NUM_WR_CMD_BUFS = 4;
+
+constexpr uint32_t DEFAULT_MAX_NOC_SEND_WORDS = (NUM_WR_CMD_BUFS-1)*(NOC_MAX_BURST_WORDS*NOC_WORD_BYTES)/PACKET_WORD_SIZE_BYTES;
+constexpr uint32_t DEFAULT_MAX_ETH_SEND_WORDS = 2*1024;
+
+constexpr uint32_t NUM_PTR_REGS_PER_QUEUE = 3;
+
+
+FORCE_INLINE uint64_t get_timestamp() {
+    uint32_t timestamp_low = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
+    uint32_t timestamp_high = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_H);
+    return (((uint64_t)timestamp_high) << 32) | timestamp_low;
+}
+
+FORCE_INLINE uint64_t get_timestamp_32b() {
+    return reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
+}
+
+void zero_l1_buf(tt_l1_ptr uint32_t* buf, uint32_t size_bytes) {
+    for (uint32_t i = 0; i < size_bytes/4; i++) {
+        buf[i] = 0;
+    }
+}
+
+typedef struct dispatch_packet_header_t dispatch_packet_header_t;
+
+static_assert(sizeof(dispatch_packet_header_t) == PACKET_WORD_SIZE_BYTES);
+
+
+class packet_queue_state_t;
+class packet_input_queue_state_t;
+class packet_output_queue_state_t;
+
+class packet_queue_state_t {
+
+    volatile uint32_t* local_wptr_val;
+    volatile uint32_t* local_rptr_sent_val;
+    volatile uint32_t* local_rptr_cleared_val;
+    volatile uint32_t* local_wptr_update;
+    volatile uint32_t* local_rptr_sent_update;
+    volatile uint32_t* local_rptr_cleared_update;
+    volatile uint32_t* local_wptr_reset;
+    volatile uint32_t* local_rptr_sent_reset;
+    volatile uint32_t* local_rptr_cleared_reset;
+
+    uint32_t remote_ready_status_addr;
+    volatile uint32_t* local_ready_status_ptr;
+
+    uint32_t remote_wptr_update_addr;
+    uint32_t remote_rptr_sent_update_addr;
+    uint32_t remote_rptr_cleared_update_addr;
+
+public:
+
+    uint8_t queue_id;
+    uint32_t queue_start_addr_words;
+    uint16_t queue_size_words;
+    uint32_t ptr_offset_mask;
+    uint32_t queue_size_mask;
+
+    bool queue_is_input;
+
+    uint8_t remote_x, remote_y; // remote source for input queues, remote dest for output queues
+    uint8_t remote_queue_id;
+    DispatchRemoteNetworkType remote_update_network_type;
+
+    // For read/write pointers, we use stream credit registers with auto-increment.
+    // Pointers are in 16B units, and we assume buffer size is power of 2 so we get
+    // automatic wrapping. (If needed, we can fix the pointer advance functions later
+    // to handle non-power-of-2 buffer sizes.)
+
+    void init(uint8_t queue_id,
+              uint32_t queue_start_addr_words,
+              uint16_t queue_size_words,
+              uint8_t remote_x,
+              uint8_t remote_y,
+              uint8_t remote_queue_id,
+              DispatchRemoteNetworkType remote_update_network_type) {
+
+        this->queue_id = queue_id;
+        this->queue_start_addr_words = queue_start_addr_words;
+        this->queue_size_words = queue_size_words;
+        this->remote_x = remote_x;
+        this->remote_y = remote_y;
+        this->remote_queue_id = remote_queue_id;
+        this->remote_update_network_type = remote_update_network_type;
+
+        this->local_wptr_val = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*queue_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX));
+        this->local_rptr_sent_val = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*queue_id+1, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX));
+        this->local_rptr_cleared_val = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*queue_id+2, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX));
+
+        this->local_wptr_update = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*queue_id, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX));
+        this->local_rptr_sent_update = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*queue_id+1, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX));
+        this->local_rptr_cleared_update = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*queue_id+2, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX));
+
+        // Setting STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX resets the credit register
+        this->local_wptr_reset = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*queue_id, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX));
+        this->local_rptr_sent_reset = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*queue_id+1, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX));
+        this->local_rptr_cleared_reset = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*queue_id+2, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX));
+
+        this->remote_wptr_update_addr =
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*remote_queue_id,
+                            STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
+        this->remote_rptr_sent_update_addr =
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*remote_queue_id+1,
+                            STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
+        this->remote_rptr_cleared_update_addr =
+            STREAM_REG_ADDR(NUM_PTR_REGS_PER_QUEUE*remote_queue_id+2,
+                            STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_UPDATE_REG_INDEX);
+
+        this->remote_ready_status_addr = STREAM_REG_ADDR(remote_queue_id, STREAM_REMOTE_SRC_REG_INDEX);
+        this->local_ready_status_ptr = reinterpret_cast<volatile uint32_t*>(
+            STREAM_REG_ADDR(queue_id, STREAM_REMOTE_SRC_REG_INDEX));
+    }
+
+    FORCE_INLINE uint8_t get_queue_id() const {
+        return this->queue_id;
+    }
+
+    FORCE_INLINE uint32_t get_queue_local_wptr() const {
+        return *this->local_wptr_val;
+    }
+
+    FORCE_INLINE void reset_queue_local_wptr() {
+        *this->local_wptr_reset = 0;
+    }
+
+    FORCE_INLINE void advance_queue_local_wptr(uint32_t num_words) {
+        *this->local_wptr_update = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
+    }
+
+    FORCE_INLINE uint32_t get_queue_local_rptr_sent() const {
+        return *this->local_rptr_sent_val;
+    }
+
+    FORCE_INLINE uint32_t get_queue_local_rptr_cleared() const {
+        return *this->local_rptr_cleared_val;
+    }
+
+    FORCE_INLINE void reset_queue_local_rptr_sent()  {
+        *this->local_rptr_sent_reset = 0;
+    }
+
+    FORCE_INLINE void reset_queue_local_rptr_cleared()  {
+        *this->local_rptr_cleared_reset = 0;
+    }
+
+    FORCE_INLINE void advance_queue_local_rptr_sent(uint32_t num_words)  {
+        *this->local_rptr_sent_update = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
+    }
+
+    FORCE_INLINE void advance_queue_local_rptr_cleared(uint32_t num_words)  {
+        *this->local_rptr_cleared_update = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
+    }
+
+    FORCE_INLINE uint32_t get_queue_data_num_words_available_to_send() const {
+        return (this->get_queue_local_wptr() - this->get_queue_local_rptr_sent()) & this->queue_size_mask;
+    }
+
+    FORCE_INLINE uint32_t get_queue_data_num_words_occupied() const {
+        return (this->get_queue_local_wptr() - this->get_queue_local_rptr_cleared()) & this->queue_size_mask;
+    }
+
+    FORCE_INLINE uint32_t get_queue_data_num_words_free() const {
+        return this->queue_size_words - this->get_queue_data_num_words_occupied();
+    }
+
+    FORCE_INLINE uint32_t get_num_words_sent_not_cleared() const {
+        return (this->get_queue_local_rptr_sent() - this->get_queue_local_rptr_cleared()) & this->queue_size_mask;
+    }
+
+    FORCE_INLINE uint32_t get_num_words_written_not_sent() const {
+        return (this->get_queue_local_wptr() - this->get_queue_local_rptr_sent()) & this->queue_size_mask;
+    }
+
+    FORCE_INLINE uint32_t get_queue_wptr_offset_words() const {
+        return this->get_queue_local_wptr() & this->ptr_offset_mask;
+    }
+
+    FORCE_INLINE uint32_t get_queue_rptr_sent_offset_words() const {
+        return this->get_queue_local_rptr_sent() & this->ptr_offset_mask;
+    }
+
+    FORCE_INLINE uint32_t get_queue_rptr_cleared_offset_words() const {
+        return this->get_queue_local_rptr_cleared() & this->ptr_offset_mask;
+    }
+
+    FORCE_INLINE uint32_t get_queue_rptr_sent_addr_bytes() const {
+        return (this->queue_start_addr_words + this->get_queue_rptr_sent_offset_words())*PACKET_WORD_SIZE_BYTES;
+    }
+
+    FORCE_INLINE uint32_t get_queue_rptr_cleared_addr_bytes() const {
+        return (this->queue_start_addr_words + this->get_queue_rptr_cleared_offset_words())*PACKET_WORD_SIZE_BYTES;
+    }
+
+    FORCE_INLINE uint32_t get_queue_wptr_addr_bytes() const {
+        return (this->queue_start_addr_words + this->get_queue_wptr_offset_words())*PACKET_WORD_SIZE_BYTES;
+    }
+
+    FORCE_INLINE uint32_t get_queue_words_before_rptr_sent_wrap() const {
+        return queue_size_words - this->get_queue_rptr_sent_offset_words();
+    }
+
+    FORCE_INLINE uint32_t get_queue_words_before_rptr_cleared_wrap() const {
+        return queue_size_words - this->get_queue_rptr_cleared_offset_words();
+    }
+
+    FORCE_INLINE uint32_t get_queue_words_before_wptr_wrap() const {
+        return queue_size_words - this->get_queue_wptr_offset_words();
+    }
+
+    FORCE_INLINE void remote_reg_update(uint32_t reg_addr, uint32_t val) {
+
+        if (this->remote_update_network_type == DispatchRemoteNetworkType::NONE) {
+            return;
+        }
+        else if (this->remote_update_network_type == DispatchRemoteNetworkType::ETH) {
+            eth_write_remote_reg(reg_addr, val);
+        } else {
+            uint64_t dest_addr = NOC_XY_ADDR(this->remote_x, this->remote_y, reg_addr);
+            noc_inline_dw_write(dest_addr, val);
+        }
+    }
+
+    FORCE_INLINE void advance_queue_remote_wptr(uint32_t num_words) {
+        uint32_t val = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
+        uint32_t reg_addr = this->remote_wptr_update_addr;
+        this->remote_reg_update(reg_addr, val);
+    }
+
+    FORCE_INLINE void advance_queue_remote_rptr_sent(uint32_t num_words) {
+        uint32_t val = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
+        uint32_t reg_addr = this->remote_rptr_sent_update_addr;
+        this->remote_reg_update(reg_addr, val);
+    }
+
+    FORCE_INLINE void advance_queue_remote_rptr_cleared(uint32_t num_words) {
+        uint32_t val = num_words << REMOTE_DEST_BUF_WORDS_FREE_INC;
+        uint32_t reg_addr = this->remote_rptr_cleared_update_addr;
+        this->remote_reg_update(reg_addr, val);
+    }
+
+    FORCE_INLINE void reset_ready_flag() {
+        *this->local_ready_status_ptr = 0;
+    }
+
+    FORCE_INLINE void send_remote_ready_notification() {
+        this->remote_reg_update(this->remote_ready_status_addr,
+                                PACKET_QUEUE_REMOTE_READY_FLAG);
+    }
+
+    FORCE_INLINE void send_remote_finished_notification() {
+        this->remote_reg_update(this->remote_ready_status_addr,
+                                PACKET_QUEUE_REMOTE_FINISHED_FLAG);
+    }
+
+    FORCE_INLINE bool is_remote_ready() const {
+        return *this->local_ready_status_ptr == PACKET_QUEUE_REMOTE_READY_FLAG;
+    }
+
+    FORCE_INLINE uint32_t get_remote_ready_status() const {
+        return *this->local_ready_status_ptr;
+    }
+
+    FORCE_INLINE bool is_remote_finished() const {
+        return *this->local_ready_status_ptr == PACKET_QUEUE_REMOTE_FINISHED_FLAG;
+    }
+
+    void yield() {
+        // TODO: implement yield for ethernet here
+    }
+
+    void dprint_object() {
+        DPRINT << "  id: " << DEC() << this->queue_id << ENDL();
+        DPRINT << "  start_addr: 0x" << HEX() << (this->queue_start_addr_words*PACKET_WORD_SIZE_BYTES) << ENDL();
+        DPRINT << "  size_bytes: 0x" << HEX() << (this->queue_size_words*PACKET_WORD_SIZE_BYTES) << ENDL();
+        DPRINT << "  remote_x: " << DEC() << this->remote_x << ENDL();
+        DPRINT << "  remote_y: " << DEC() << this->remote_y << ENDL();
+        DPRINT << "  remote_queue_id: " << DEC() << this->remote_queue_id << ENDL();
+        DPRINT << "  remote_update_network_type: " << DEC() << static_cast<uint32_t>(this->remote_update_network_type) << ENDL();
+        DPRINT << "  ready_status: 0x" << HEX() << this->get_remote_ready_status() << ENDL();
+        DPRINT << "  local_wptr: 0x" << HEX() << this->get_queue_local_wptr() << ENDL();
+        DPRINT << "  local_rptr_sent: 0x" << HEX() << this->get_queue_local_rptr_sent() << ENDL();
+        DPRINT << "  local_rptr_cleared: 0x" << HEX() << this->get_queue_local_rptr_cleared() << ENDL();
+    }
+};
+
+
+class packet_input_queue_state_t : public packet_queue_state_t {
+
+protected:
+
+    bool curr_packet_valid;
+    tt_l1_ptr dispatch_packet_header_t* curr_packet_header_ptr;
+    uint16_t curr_packet_src;
+    uint16_t curr_packet_dest;
+    uint16_t curr_packet_size_words;
+    uint16_t curr_packet_words_sent;
+    uint32_t curr_packet_tag;
+    uint16_t curr_packet_flags;
+
+    FORCE_INLINE void advance_next_packet() {
+        if(this->get_queue_data_num_words_available_to_send() > 0) {
+            tt_l1_ptr dispatch_packet_header_t* next_packet_header_ptr =
+                reinterpret_cast<tt_l1_ptr dispatch_packet_header_t*>(
+                    (this->queue_start_addr_words + this->get_queue_rptr_sent_offset_words())*PACKET_WORD_SIZE_BYTES
+                );
+            this->curr_packet_header_ptr = next_packet_header_ptr;
+            this->curr_packet_dest = next_packet_header_ptr->packet_dest;
+            this->curr_packet_src = next_packet_header_ptr->packet_src;
+            this->curr_packet_size_words = next_packet_header_ptr->packet_size_words;
+            this->curr_packet_tag = next_packet_header_ptr->tag;
+            this->curr_packet_flags = next_packet_header_ptr->packet_flags;
+            this->curr_packet_words_sent = 0;
+            this->curr_packet_valid = true;
+       }
+    }
+
+public:
+
+    void init(uint8_t queue_id,
+              uint32_t queue_start_addr_words,
+              uint16_t queue_size_words,
+              uint8_t remote_x,
+              uint8_t remote_y,
+              uint8_t remote_queue_id,
+              DispatchRemoteNetworkType remote_update_network_type) {
+
+        packet_queue_state_t::init(queue_id, queue_start_addr_words, queue_size_words,
+                                   remote_x, remote_y, remote_queue_id, remote_update_network_type);
+
+        tt_l1_ptr uint32_t* queue_ptr =
+            reinterpret_cast<tt_l1_ptr uint32_t*>(queue_start_addr_words*PACKET_WORD_SIZE_BYTES);
+        zero_l1_buf(queue_ptr, queue_size_words*PACKET_WORD_SIZE_BYTES);
+
+        this->ptr_offset_mask = queue_size_words - 1;
+        this->queue_size_mask = (queue_size_words << 1) - 1;
+        this->curr_packet_valid = false;
+        this->reset_queue_local_rptr_sent();
+        this->reset_queue_local_rptr_cleared();
+        this->reset_queue_local_wptr();
+        this->reset_ready_flag();
+    }
+
+
+    FORCE_INLINE bool get_curr_packet_valid() {
+        if (!this->curr_packet_valid && (this->get_queue_data_num_words_available_to_send() > 0)){
+            this->advance_next_packet();
+        }
+        return this->curr_packet_valid;
+    }
+
+    FORCE_INLINE tt_l1_ptr dispatch_packet_header_t* get_curr_packet_header_ptr() {
+        if (!this->curr_packet_valid) {
+            this->advance_next_packet();
+        }
+        return this->curr_packet_header_ptr;
+    }
+
+    FORCE_INLINE uint32_t get_curr_packet_dest() {
+        if (!this->curr_packet_valid) {
+            this->advance_next_packet();
+        }
+        return this->curr_packet_dest;
+    }
+
+    FORCE_INLINE uint32_t get_curr_packet_src() {
+        if (!this->curr_packet_valid) {
+            this->advance_next_packet();
+        }
+        return this->curr_packet_src;
+    }
+
+    FORCE_INLINE uint32_t get_curr_packet_size_words() {
+        if (!this->curr_packet_valid) {
+            this->advance_next_packet();
+        }
+        return this->curr_packet_size_words;
+    }
+
+    FORCE_INLINE uint32_t get_curr_packet_words_remaining() {
+        if (!this->curr_packet_valid) {
+            this->advance_next_packet();
+        }
+        return this->curr_packet_size_words - this->curr_packet_words_sent;
+    }
+
+    FORCE_INLINE uint32_t get_curr_packet_tag() {
+        if (!this->curr_packet_valid) {
+            this->advance_next_packet();
+        }
+        return this->curr_packet_tag;
+    }
+
+    FORCE_INLINE uint32_t get_curr_packet_flags() {
+        if (!this->curr_packet_valid) {
+            this->advance_next_packet();
+        }
+        return this->curr_packet_flags;
+    }
+
+    FORCE_INLINE bool partial_packet_sent() const {
+        return this->curr_packet_valid && (this->curr_packet_words_sent > 0);
+    }
+
+
+    FORCE_INLINE bool input_queue_full_packet_available_to_send(uint32_t& num_words_available_to_send) {
+        num_words_available_to_send = this->get_queue_data_num_words_available_to_send();
+        if (num_words_available_to_send == 0) {
+            return false;
+        }
+        return num_words_available_to_send >= this->get_curr_packet_words_remaining();
+    }
+
+    FORCE_INLINE uint32_t input_queue_curr_packet_num_words_available_to_send() {
+        uint32_t num_words = this->get_queue_data_num_words_available_to_send();
+        if (num_words == 0) {
+            return 0;
+        }
+        num_words = std::min(num_words, this->get_curr_packet_words_remaining());
+        return num_words;
+    }
+
+    FORCE_INLINE void input_queue_advance_words_sent(uint32_t num_words) {
+        if (num_words > 0) {
+            this->advance_queue_local_rptr_sent(num_words);
+            this->advance_queue_remote_rptr_sent(num_words);
+            this->curr_packet_words_sent += num_words;
+            uint32_t curr_packet_words_remaining = this->get_curr_packet_words_remaining();
+            if (curr_packet_words_remaining == 0) {
+                this->curr_packet_valid = false;
+                this->advance_next_packet();
+            }
+        }
+    }
+
+    FORCE_INLINE void input_queue_advance_words_cleared(uint32_t num_words) {
+        if (num_words > 0) {
+            this->advance_queue_local_rptr_cleared(num_words);
+            this->advance_queue_remote_rptr_cleared(num_words);
+        }
+    }
+
+    FORCE_INLINE void input_queue_clear_all_words_sent() {
+        this->input_queue_advance_words_cleared(this->get_num_words_sent_not_cleared());
+    }
+
+    void dprint_object() {
+        DPRINT << "Input queue:" << ENDL();
+        packet_queue_state_t::dprint_object();
+        DPRINT << "  packet_valid: " << DEC() << this->curr_packet_valid << ENDL();
+        DPRINT << "  packet_tag: 0x" << HEX() << this->curr_packet_tag << ENDL();
+        DPRINT << "  packet_src: 0x" << HEX() << this->curr_packet_src << ENDL();
+        DPRINT << "  packet_dest: 0x" << HEX() << this->curr_packet_dest << ENDL();
+        DPRINT << "  packet_flags: 0x" << HEX() << this->curr_packet_flags << ENDL();
+        DPRINT << "  packet_size_words: " << DEC() << this->curr_packet_size_words << ENDL();
+        DPRINT << "  packet_words_sent: " << DEC() << this->curr_packet_words_sent << ENDL();
+    }
+
+};
+
+
+class packet_output_queue_state_t : public packet_queue_state_t {
+
+    uint32_t max_noc_send_words;
+    uint32_t max_eth_send_words;
+
+    struct {
+
+        packet_input_queue_state_t* input_queue_array;
+        uint32_t input_queue_words_in_flight[2*MAX_SWITCH_FAN_IN];
+
+        uint32_t* curr_input_queue_words_in_flight;
+        uint32_t* prev_input_queue_words_in_flight;
+        uint32_t curr_total_words_in_flight;
+        uint32_t prev_total_words_in_flight;
+
+        uint8_t num_input_queues;
+
+        void init(packet_input_queue_state_t* input_queue_array, uint32_t num_input_queues) {
+            this->num_input_queues = num_input_queues;
+            this->input_queue_array = input_queue_array;
+            this->curr_input_queue_words_in_flight = &(this->input_queue_words_in_flight[0]);
+            this->prev_input_queue_words_in_flight = &(this->input_queue_words_in_flight[MAX_SWITCH_FAN_IN]);
+            this->curr_total_words_in_flight = 0;
+            this->prev_total_words_in_flight = 0;
+            for (uint32_t i = 0; i < MAX_SWITCH_FAN_IN; i++) {
+                this->curr_input_queue_words_in_flight[i] = 0;
+                this->prev_input_queue_words_in_flight[i] = 0;
+            }
+        }
+
+        FORCE_INLINE uint32_t get_curr_total_words_in_flight() const {
+            return this->curr_total_words_in_flight;
+        }
+
+        FORCE_INLINE uint32_t get_prev_total_words_in_flight() const {
+            return this->prev_total_words_in_flight;
+        }
+
+        FORCE_INLINE uint32_t prev_words_in_flight_flush() {
+
+            uint32_t words_flushed = this->prev_total_words_in_flight;
+            if (words_flushed > 0) {
+                for (uint32_t i = 0; i < num_input_queues; i++) {
+                    this->input_queue_array[i].input_queue_advance_words_cleared(this->prev_input_queue_words_in_flight[i]);
+                    this->prev_input_queue_words_in_flight[i] = 0;
+                }
+            }
+
+            uint32_t* tmp = this->prev_input_queue_words_in_flight;
+            this->prev_input_queue_words_in_flight = this->curr_input_queue_words_in_flight;
+            this->curr_input_queue_words_in_flight = tmp;
+            this->prev_total_words_in_flight = this->curr_total_words_in_flight;
+            this->curr_total_words_in_flight = 0;
+
+            return words_flushed;
+        }
+
+        FORCE_INLINE void register_words_in_flight(uint32_t input_queue_id, uint32_t num_words) {
+            this->curr_input_queue_words_in_flight[input_queue_id] += num_words;
+            this->curr_total_words_in_flight += num_words;
+            this->input_queue_array[input_queue_id].input_queue_advance_words_sent(num_words);
+        }
+
+        void dprint_object() {
+            DPRINT << "  curr_total_words_in_flight: " << DEC() << this->curr_total_words_in_flight << ENDL();
+            for (uint32_t j = 0; j < MAX_SWITCH_FAN_IN; j++) {
+                DPRINT << "       from input queue id " << DEC() <<
+                            this->input_queue_array[j].get_queue_id() << ": "
+                            << DEC() << this->curr_input_queue_words_in_flight[j]
+                            << ENDL();
+            }
+            DPRINT << "  prev_total_words_in_flight: " << DEC() << this->prev_total_words_in_flight << ENDL();
+            for (uint32_t j = 0; j < MAX_SWITCH_FAN_IN; j++) {
+                DPRINT << "       from input queue id " << DEC() <<
+                            this->input_queue_array[j].get_queue_id() << ": "
+                            << DEC() << this->prev_input_queue_words_in_flight[j]
+                            << ENDL();
+            }
+        }
+
+    } input_queue_status;
+
+public:
+
+    void init(uint8_t queue_id,
+              uint32_t queue_start_addr_words,
+              uint16_t queue_size_words,
+              uint8_t remote_x,
+              uint8_t remote_y,
+              uint8_t remote_queue_id,
+              DispatchRemoteNetworkType remote_update_network_type,
+              packet_input_queue_state_t* input_queue_array,
+              uint8_t num_input_queues) {
+
+        packet_queue_state_t::init(queue_id, queue_start_addr_words, queue_size_words,
+                                   remote_x, remote_y, remote_queue_id, remote_update_network_type);
+
+        this->ptr_offset_mask = queue_size_words - 1;
+        this->queue_size_mask = (queue_size_words << 1) - 1;
+        this->max_noc_send_words = DEFAULT_MAX_NOC_SEND_WORDS;
+        this->max_eth_send_words = DEFAULT_MAX_ETH_SEND_WORDS;
+        this->input_queue_status.init(input_queue_array, num_input_queues);
+        this->reset_queue_local_rptr_sent();
+        this->reset_queue_local_rptr_cleared();
+        this->reset_queue_local_wptr();
+        this->reset_ready_flag();
+    }
+
+    FORCE_INLINE void set_max_noc_send_words(uint32_t max_noc_send_words) {
+        this->max_noc_send_words = max_noc_send_words;
+    }
+
+    FORCE_INLINE void set_max_eth_send_words(uint32_t max_eth_send_words) {
+        this->max_eth_send_words = max_eth_send_words;
+    }
+
+    FORCE_INLINE uint32_t output_max_num_words_to_forward() const {
+        return (this->remote_update_network_type == DispatchRemoteNetworkType::ETH) ?
+            this->max_eth_send_words : this->max_noc_send_words;
+    }
+
+    FORCE_INLINE void send_data_to_remote(uint32_t src_addr, uint32_t dest_addr, uint32_t num_words) {
+        if ((this->remote_update_network_type == DispatchRemoteNetworkType::NONE) ||
+            (num_words == 0)) {
+            return;
+        } else if (this->remote_update_network_type == DispatchRemoteNetworkType::ETH) {
+            internal_::eth_send_packet(0, src_addr/PACKET_WORD_SIZE_BYTES, dest_addr/PACKET_WORD_SIZE_BYTES, num_words);
+        } else {
+            uint64_t noc_dest_addr = NOC_XY_ADDR(this->remote_x, this->remote_y, dest_addr);
+            noc_async_write(src_addr, noc_dest_addr, num_words*PACKET_WORD_SIZE_BYTES);
+        }
+    }
+
+    FORCE_INLINE void remote_wptr_update(uint32_t num_words) {
+        this->advance_queue_remote_wptr(num_words);
+    }
+
+    FORCE_INLINE uint32_t prev_words_in_flight_check_flush() {
+        if (this->get_num_words_written_not_sent() <= this->input_queue_status.get_curr_total_words_in_flight()) {
+            return this->input_queue_status.prev_words_in_flight_flush();
+        } else {
+            return 0;
+        }
+    }
+
+    bool output_barrier(uint32_t timeout_cycles = 0) {
+        uint32_t start_timestamp = 0;
+        if (timeout_cycles > 0) {
+            start_timestamp = get_timestamp_32b();
+        }
+        while (this->get_queue_data_num_words_occupied() > 0) {
+            if (timeout_cycles > 0) {
+                uint32_t cycles_elapsed = get_timestamp_32b() - start_timestamp;
+                if (cycles_elapsed > timeout_cycles) {
+                    return false;
+                }
+            }
+            this->yield();
+        }
+        this->input_queue_status.prev_words_in_flight_flush();
+        this->input_queue_status.prev_words_in_flight_flush();
+        return true;
+    }
+
+    FORCE_INLINE uint32_t get_num_words_to_send(uint32_t input_queue_index) {
+
+        packet_input_queue_state_t* input_queue_ptr = &(this->input_queue_status.input_queue_array[input_queue_index]);
+
+        uint32_t num_words_available_in_input = input_queue_ptr->input_queue_curr_packet_num_words_available_to_send();
+        uint32_t num_words_before_input_rptr_wrap = input_queue_ptr->get_queue_words_before_rptr_sent_wrap();
+        num_words_available_in_input = std::min(num_words_available_in_input, num_words_before_input_rptr_wrap);
+        uint32_t num_words_free_in_output = this->get_queue_data_num_words_free();
+        uint32_t num_words_to_forward = std::min(num_words_available_in_input, num_words_free_in_output);
+
+        if (num_words_to_forward == 0) {
+            return 0;
+        }
+
+        uint32_t output_buf_words_before_wptr_wrap = this->get_queue_words_before_wptr_wrap();
+        num_words_to_forward = std::min(num_words_to_forward, output_buf_words_before_wptr_wrap);
+        num_words_to_forward = std::min(num_words_to_forward, this->output_max_num_words_to_forward());
+
+        return num_words_to_forward;
+    }
+
+    FORCE_INLINE uint32_t forward_data_from_input(uint32_t input_queue_index, bool& full_packet_sent) {
+
+        packet_input_queue_state_t* input_queue_ptr = &(this->input_queue_status.input_queue_array[input_queue_index]);
+        uint32_t num_words_to_forward = this->get_num_words_to_send(input_queue_index);
+        full_packet_sent = (num_words_to_forward == input_queue_ptr->get_curr_packet_words_remaining());
+        if (num_words_to_forward == 0) {
+            return 0;
+        }
+
+        uint32_t src_addr =
+            (input_queue_ptr->queue_start_addr_words +
+             input_queue_ptr->get_queue_rptr_sent_offset_words())*PACKET_WORD_SIZE_BYTES;
+        uint32_t dest_addr =
+            (this->queue_start_addr_words + this->get_queue_wptr_offset_words())*PACKET_WORD_SIZE_BYTES;
+
+        this->send_data_to_remote(src_addr, dest_addr, num_words_to_forward);
+        this->input_queue_status.register_words_in_flight(input_queue_index, num_words_to_forward);
+        this->advance_queue_local_wptr(num_words_to_forward);
+        this->remote_wptr_update(num_words_to_forward);
+
+        return num_words_to_forward;
+    }
+
+    void dprint_object() {
+        DPRINT << "Output queue:" << ENDL();
+        packet_queue_state_t::dprint_object();
+        this->input_queue_status.dprint_object();
+    }
+};
+
+
+/**
+ *  Polling for ready signal from the remote peers of all input and output queues.
+ *  Blocks until all are ready, but doesn't block polling on each individual queue.
+ *  Returns false in case of timeout.
+ */
+bool wait_all_src_dest_ready(packet_input_queue_state_t* input_queue_array, uint32_t num_input_queues,
+                             packet_output_queue_state_t* output_queue_array, uint32_t num_output_queues,
+                             uint32_t timeout_cycles = 0) {
+
+    bool all_src_dest_ready = false;
+    bool src_ready[MAX_SWITCH_FAN_IN] = {false};
+    bool dest_ready[MAX_SWITCH_FAN_OUT] = {false};
+
+    uint32_t iters = 0;
+
+    uint32_t start_timestamp = get_timestamp_32b();
+    while (!all_src_dest_ready) {
+        iters++;
+        if (timeout_cycles > 0) {
+            uint32_t cycles_since_start = get_timestamp_32b() - start_timestamp;
+            if (cycles_since_start > timeout_cycles) {
+                return false;
+            }
+        }
+        all_src_dest_ready = true;
+        for (uint32_t i = 0; i < num_input_queues; i++) {
+            if (!src_ready[i]) {
+                src_ready[i] = input_queue_array[i].is_remote_ready();
+                if (!src_ready[i]) {
+                    input_queue_array[i].send_remote_ready_notification();
+                    all_src_dest_ready = false;
+                } else {
+                    // handshake with src complete
+                }
+            }
+        }
+        for (uint32_t i = 0; i < num_output_queues; i++) {
+            if (!dest_ready[i]) {
+                dest_ready[i] = output_queue_array[i].is_remote_ready();
+                if (dest_ready[i]) {
+                    output_queue_array[i].send_remote_ready_notification();
+                } else {
+                    all_src_dest_ready = false;
+                }
+            }
+        }
+    }
+    return true;
+}

--- a/tt_metal/impl/dispatch/kernels/packet_queue.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue.hpp
@@ -296,12 +296,12 @@ public:
     }
 
     void dprint_object() {
-        DPRINT << "  id: " << DEC() << this->queue_id << ENDL();
-        DPRINT << "  start_addr: 0x" << HEX() << (this->queue_start_addr_words*PACKET_WORD_SIZE_BYTES) << ENDL();
-        DPRINT << "  size_bytes: 0x" << HEX() << (this->queue_size_words*PACKET_WORD_SIZE_BYTES) << ENDL();
-        DPRINT << "  remote_x: " << DEC() << this->remote_x << ENDL();
-        DPRINT << "  remote_y: " << DEC() << this->remote_y << ENDL();
-        DPRINT << "  remote_queue_id: " << DEC() << this->remote_queue_id << ENDL();
+        DPRINT << "  id: " << DEC() << static_cast<uint32_t>(this->queue_id) << ENDL();
+        DPRINT << "  start_addr: 0x" << HEX() << static_cast<uint32_t>(this->queue_start_addr_words*PACKET_WORD_SIZE_BYTES) << ENDL();
+        DPRINT << "  size_bytes: 0x" << HEX() << static_cast<uint32_t>(this->queue_size_words*PACKET_WORD_SIZE_BYTES) << ENDL();
+        DPRINT << "  remote_x: " << DEC() << static_cast<uint32_t>(this->remote_x) << ENDL();
+        DPRINT << "  remote_y: " << DEC() << static_cast<uint32_t>(this->remote_y) << ENDL();
+        DPRINT << "  remote_queue_id: " << DEC() << static_cast<uint32_t>(this->remote_queue_id) << ENDL();
         DPRINT << "  remote_update_network_type: " << DEC() << static_cast<uint32_t>(this->remote_update_network_type) << ENDL();
         DPRINT << "  ready_status: 0x" << HEX() << this->get_remote_ready_status() << ENDL();
         DPRINT << "  local_wptr: 0x" << HEX() << this->get_queue_local_wptr() << ENDL();
@@ -473,13 +473,13 @@ public:
     void dprint_object() {
         DPRINT << "Input queue:" << ENDL();
         packet_queue_state_t::dprint_object();
-        DPRINT << "  packet_valid: " << DEC() << this->curr_packet_valid << ENDL();
-        DPRINT << "  packet_tag: 0x" << HEX() << this->curr_packet_tag << ENDL();
-        DPRINT << "  packet_src: 0x" << HEX() << this->curr_packet_src << ENDL();
-        DPRINT << "  packet_dest: 0x" << HEX() << this->curr_packet_dest << ENDL();
-        DPRINT << "  packet_flags: 0x" << HEX() << this->curr_packet_flags << ENDL();
-        DPRINT << "  packet_size_words: " << DEC() << this->curr_packet_size_words << ENDL();
-        DPRINT << "  packet_words_sent: " << DEC() << this->curr_packet_words_sent << ENDL();
+        DPRINT << "  packet_valid: " << DEC() << static_cast<uint32_t>(this->curr_packet_valid) << ENDL();
+        DPRINT << "  packet_tag: 0x" << HEX() << static_cast<uint32_t>(this->curr_packet_tag) << ENDL();
+        DPRINT << "  packet_src: 0x" << HEX() << static_cast<uint32_t>(this->curr_packet_src) << ENDL();
+        DPRINT << "  packet_dest: 0x" << HEX() << static_cast<uint32_t>(this->curr_packet_dest) << ENDL();
+        DPRINT << "  packet_flags: 0x" << HEX() << static_cast<uint32_t>(this->curr_packet_flags) << ENDL();
+        DPRINT << "  packet_size_words: " << DEC() << static_cast<uint32_t>(this->curr_packet_size_words) << ENDL();
+        DPRINT << "  packet_words_sent: " << DEC() << static_cast<uint32_t>(this->curr_packet_words_sent) << ENDL();
     }
 
 };

--- a/tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <setjmp.h>
+
+constexpr uint32_t PACKET_WORD_SIZE_BYTES = 16;
+constexpr uint32_t MAX_SWITCH_FAN_IN = 4;
+constexpr uint32_t MAX_SWITCH_FAN_OUT = 4;
+
+constexpr uint32_t MAX_SRC_ENDPOINTS = 32;
+constexpr uint32_t MAX_DEST_ENDPOINTS = 32;
+
+constexpr uint32_t INPUT_QUEUE_START_ID = 0;
+constexpr uint32_t OUTPUT_QUEUE_START_ID = MAX_SWITCH_FAN_IN;
+
+constexpr uint32_t PACKET_QUEUE_REMOTE_READY_FLAG = 0xA;
+constexpr uint32_t PACKET_QUEUE_REMOTE_FINISHED_FLAG = 0xB;
+
+constexpr uint32_t PACKET_QUEUE_STAUS_MASK = 0xabc00000;
+constexpr uint32_t PACKET_QUEUE_TEST_STARTED = PACKET_QUEUE_STAUS_MASK | 0x0;
+constexpr uint32_t PACKET_QUEUE_TEST_PASS = PACKET_QUEUE_STAUS_MASK | 0x1;
+constexpr uint32_t PACKET_QUEUE_TEST_TIMEOUT = PACKET_QUEUE_STAUS_MASK | 0x2;
+constexpr uint32_t PACKET_QUEUE_TEST_DATA_MISMATCH = PACKET_QUEUE_STAUS_MASK | 0x3;
+
+// indexes of return values in test results buffer
+constexpr uint32_t PQ_TEST_STATUS_INDEX = 0;
+constexpr uint32_t PQ_TEST_WORD_CNT_INDEX = 2;
+constexpr uint32_t PQ_TEST_CYCLES_INDEX = 4;
+constexpr uint32_t PQ_TEST_ITER_INDEX = 6;
+constexpr uint32_t PQ_TEST_MISC_INDEX = 16;
+
+inline uint64_t get_64b_result(uint32_t* buf, uint32_t index) {
+    return (((uint64_t)buf[index]) << 32) | buf[index+1];
+}
+
+inline uint64_t get_64b_result(const std::vector<uint32_t>& vec, uint32_t index) {
+    return (((uint64_t)vec[index]) << 32) | vec[index+1];
+}
+
+inline void set_64b_result(uint32_t* buf, uint64_t val, uint32_t index = 0) {
+    buf[index] = val >> 32;
+    buf[index+1] = val & 0xFFFFFFFF;
+}
+
+enum DispatchPacketFlag : uint32_t {
+    PACKET_CMD_START = (0x1 << 1),
+    PACKET_CMD_END = (0x1 << 2),
+    PACKET_MULTI_CMD = (0x1 << 3),
+    PACKET_TEST_LAST = (0x1 << 15),  // test only
+};
+
+enum DispatchRemoteNetworkType : uint32_t {
+    NOC0 = 0,
+    NOC1 = 1,
+    ETH = 2,
+    NONE = 3
+};
+
+inline bool is_remote_network_type_noc(DispatchRemoteNetworkType type) {
+    return type == NOC0 || type == NOC1;
+}
+
+struct dispatch_packet_header_t {
+
+    uint32_t packet_size_words;
+    uint16_t packet_src;
+    uint16_t packet_dest;
+    uint16_t packet_flags;
+    uint16_t num_cmds;
+    uint32_t tag;
+
+    inline bool check_packet_flags(uint32_t flags) const {
+        return (packet_flags & flags) == flags;
+    }
+
+    inline void set_packet_flags(uint32_t flags) {
+        packet_flags |= flags;
+    }
+
+    inline void clear_packet_flags(uint32_t flags) {
+        packet_flags &= ~flags;
+    }
+};
+
+#define is_power_of_2(x) (((x) > 0) && (((x) & ((x) - 1)) == 0))
+
+inline uint32_t packet_switch_4B_pack(uint32_t b0, uint32_t b1, uint32_t b2, uint32_t b3) {
+    return (b3 << 24) | (b2 << 16) | (b1 << 8) | b0;
+}
+
+static_assert(MAX_DEST_ENDPOINTS <= 32,
+              "MAX_DEST_ENDPOINTS must be <= 32 for the packing funcitons below to work");
+
+static_assert(MAX_SWITCH_FAN_OUT <= 4,
+              "MAX_SWITCH_FAN_OUT must be <= 4 for the packing funcitons below to work");
+
+inline uint64_t packet_switch_dest_pack(uint32_t* dest_output_map_array, uint32_t num_dests) {
+    uint64_t result = 0;
+    for (uint32_t i = 0; i < num_dests; i++) {
+        result |= ((uint64_t)(dest_output_map_array[i])) << (2*i);
+    }
+    return result;
+}


### PR DESCRIPTION
This includes:

1. Implementation of packetized routing path and ethernet tunneler. 

2. Commit with #6814 fixes. (Same as this pull request to main: https://github.com/tenstorrent-metal/tt-metal/pull/6839)

