### PR TITLE
Watcher alignment checking for PCIe/DRAM <-> L1

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -1,4 +1,3 @@
-
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -89,7 +88,8 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
             output_dram_noc_xy.y = 16;
             break;
         case SanitizeAlignment:
-            l1_buffer_addr += 1;
+            l1_buffer_addr += 16; // This is illegal because reading DRAM->L1 needs DRAM alignment
+                                  // requirements (32 byte aligned).
             break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -465,8 +465,7 @@ void noc_async_read(std::uint64_t src_noc_addr, std::uint32_t dst_local_l1_addr,
         Read responses - assigned VCs dynamically
     */
     DEBUG_STATUS('N', 'A', 'R', 'W');
-    DEBUG_SANITIZE_NOC_ADDR(src_noc_addr, size);
-    DEBUG_SANITIZE_WORKER_ADDR(dst_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_TRANSACTION(src_noc_addr, dst_local_l1_addr, size);
     ncrisc_noc_fast_read_any_len(noc_index, NCRISC_RD_CMD_BUF, src_noc_addr, dst_local_l1_addr, size);
     DEBUG_STATUS('N', 'A', 'R', 'D');
 }
@@ -485,8 +484,7 @@ void noc_async_read_one_packet(std::uint64_t src_noc_addr, std::uint32_t dst_loc
     DEBUG_STATUS('R', 'P', 'D');
 
     DEBUG_STATUS('N', 'A', 'R', 'W');
-    DEBUG_SANITIZE_NOC_ADDR(src_noc_addr, size);
-    DEBUG_SANITIZE_WORKER_ADDR(dst_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_TRANSACTION(src_noc_addr, dst_local_l1_addr, size);
 
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dst_local_l1_addr);
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, (uint32_t)src_noc_addr);
@@ -537,8 +535,7 @@ void noc_async_read_one_packet_with_state(std::uint32_t src_noc_addr, std::uint3
     DEBUG_STATUS('N', 'A', 'R', 'W');
 
     // TODO: need a way sanitize size + addr w/o directly providing x/y here (grab x/y form state?)
-    // DEBUG_SANITIZE_NOC_ADDR(src_noc_addr, size);
-    // DEBUG_SANITIZE_WORKER_ADDR(dst_local_l1_addr, size);
+    // DEBUG_SANITIZE_NOC_TRANSACTION(src_noc_addr, dst_local_l1_addr, size);
 
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dst_local_l1_addr);
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_noc_addr);
@@ -630,8 +627,7 @@ FORCE_INLINE
 void noc_async_write_one_packet(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size) {
 
     DEBUG_STATUS('N', 'W', 'P', 'W');
-    DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
-    DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr, size);
+    DEBUG_SANITIZE_NOC_TRANSACTION(dst_noc_addr, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
     DEBUG_STATUS('N', 'W', 'P', 'D');
 
@@ -679,8 +675,7 @@ void noc_async_write_one_packet_with_state(std::uint32_t src_local_l1_addr, std:
 
     DEBUG_STATUS('N', 'W', 'P', 'W');
     // TODO: need a way sanitize size + addr w/o directly providing x/y here (grab x/y form state?)
-    // DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
-    // DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr, size);
+    // DEBUG_SANITIZE_NOC_TRANSACTION(dst_noc_addr, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
     DEBUG_STATUS('N', 'W', 'P', 'D');
 
@@ -858,8 +853,7 @@ struct InterleavedAddrGenFast {
         }
 
         DEBUG_STATUS('N', 'R', 'T', 'W');
-        DEBUG_SANITIZE_NOC_ADDR(get_noc_addr_helper(src_noc_xy, src_addr), this->page_size);
-        DEBUG_SANITIZE_WORKER_ADDR(dest_addr, this->page_size);
+        DEBUG_SANITIZE_NOC_TRANSACTION(get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, this->page_size);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
         DEBUG_STATUS('N', 'R', 'T', 'D');
 
@@ -904,8 +898,7 @@ struct InterleavedAddrGenFast {
         }
 
         DEBUG_STATUS('N', 'W', 'T', 'W');
-        DEBUG_SANITIZE_WORKER_ADDR(src_addr, this->page_size);
-        DEBUG_SANITIZE_NOC_ADDR(get_noc_addr_helper(dest_noc_xy, dest_addr), this->page_size);
+        DEBUG_SANITIZE_NOC_TRANSACTION(get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr, this->page_size);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
         DEBUG_STATUS('N', 'W', 'T', 'D');
 
@@ -961,8 +954,7 @@ struct InterleavedPow2AddrGenFast {
         }
 
         DEBUG_STATUS('N', 'R', 'P', 'W');
-        DEBUG_SANITIZE_NOC_ADDR(get_noc_addr_helper(src_noc_xy, src_addr), log_base_2_of_page_size);
-        DEBUG_SANITIZE_WORKER_ADDR(dest_addr, this->log_base_2_of_page_size);
+        DEBUG_SANITIZE_NOC_TRANSACTION(get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, log_base_2_of_page_size);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
         DEBUG_STATUS('N', 'R', 'P', 'D');
 
@@ -1043,8 +1035,7 @@ struct InterleavedPow2AddrGenFast {
         }
 
         DEBUG_STATUS('N', 'W', 'P', 'W');
-        DEBUG_SANITIZE_WORKER_ADDR(src_addr, write_size_bytes);
-        DEBUG_SANITIZE_NOC_ADDR(get_noc_addr_helper(dest_noc_xy, dest_addr), write_size_bytes);
+        DEBUG_SANITIZE_NOC_TRANSACTION(get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr,write_size_bytes);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
         DEBUG_STATUS('N', 'W', 'P', 'D');
 
@@ -1153,8 +1144,7 @@ FORCE_INLINE void noc_async_read_tile(
 inline
 void noc_async_write(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size) {
     DEBUG_STATUS('N', 'A', 'W', 'W');
-    DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr, size);
-    DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_TRANSACTION(dst_noc_addr, src_local_l1_addr,size);
     ncrisc_noc_fast_write_any_len(
         noc_index,
         NCRISC_WR_REG_CMD_BUF,
@@ -1187,8 +1177,7 @@ uint32_t eth_get_semaphore(uint32_t semaphore_id) {
 inline
 void noc_semaphore_set_remote(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr) {
     DEBUG_STATUS('N', 'S', 'S', 'W');
-    DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr, 4);
-    DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, 4);
+    DEBUG_SANITIZE_NOC_TRANSACTION(dst_noc_addr, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len(
         noc_index,
         NCRISC_WR_REG_CMD_BUF,
@@ -1241,8 +1230,7 @@ void noc_async_write_multicast(
     std::uint32_t num_dests,
     bool linked = false) {
     DEBUG_STATUS('N', 'M', 'W', 'W');
-    DEBUG_SANITIZE_NOC_MULTI_ADDR(dst_noc_addr_multicast, size);
-    DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_MULTI_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr,size);
     ncrisc_noc_fast_write_any_len(
         noc_index,
         NCRISC_WR_REG_CMD_BUF,
@@ -1279,8 +1267,7 @@ inline
 void noc_semaphore_set_multicast(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr_multicast, std::uint32_t num_dests, bool linked = false) {
     DEBUG_STATUS('N', 'S', 'M', 'W');
-    DEBUG_SANITIZE_NOC_MULTI_ADDR(dst_noc_addr_multicast, 4);
-    DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, 4);
+    DEBUG_SANITIZE_NOC_MULTI_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len(
         noc_index,
         NCRISC_WR_REG_CMD_BUF,
@@ -1298,8 +1285,7 @@ inline
 void noc_semaphore_set_multicast_loopback_src(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr_multicast, std::uint32_t num_dests, bool linked = false) {
     DEBUG_STATUS('N', 'S', 'M', 'W');
-    DEBUG_SANITIZE_NOC_MULTI_ADDR(dst_noc_addr_multicast, 4);
-    DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, 4);
+    DEBUG_SANITIZE_NOC_MULTI_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len_loopback_src(
         noc_index,
         NCRISC_WR_REG_CMD_BUF,
@@ -1321,8 +1307,7 @@ void noc_async_write_multicast_loopback_src(
     std::uint32_t num_dests,
     bool linked = false) {
     DEBUG_STATUS('N', 'M', 'L', 'W');
-    DEBUG_SANITIZE_NOC_MULTI_ADDR(dst_noc_addr_multicast, size);
-    DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_MULTI_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, size);
     ncrisc_noc_fast_write_any_len_loopback_src(
         noc_index,
         NCRISC_WR_REG_CMD_BUF,

--- a/tt_metal/hw/inc/dataflow_internal.h
+++ b/tt_metal/hw/inc/dataflow_internal.h
@@ -29,10 +29,11 @@ void noc_fast_read_set_len(uint32_t len_bytes) {
 FORCE_INLINE
 void noc_fast_read(uint32_t src_addr, uint32_t dest_addr) {
     DEBUG_STATUS('N', 'F', 'R', 'W');
-    DEBUG_SANITIZE_NOC_ADDR((uint64_t)(src_addr) |
-                            (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32,
-                            NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
-    DEBUG_SANITIZE_WORKER_ADDR(dest_addr, NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
+    DEBUG_SANITIZE_NOC_TRANSACTION(
+        (uint64_t)(src_addr) | (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32,
+        dest_addr,
+        NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE)
+    );
     while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
     DEBUG_STATUS('N', 'F', 'R', 'D');
 
@@ -75,10 +76,11 @@ void noc_fast_write_set_len(uint32_t len_bytes) {
 // a fast write that assumes a single-dest (ie unicast)
 FORCE_INLINE
 void noc_fast_write(uint32_t src_addr, uint64_t dest_addr) {
-    DEBUG_SANITIZE_NOC_ADDR(dest_addr |
-                            (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID) << 32,
-                            NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
-    DEBUG_SANITIZE_WORKER_ADDR(dest_addr, NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
+    DEBUG_SANITIZE_NOC_TRANSACTION(
+        dest_addr | (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID) << 32,
+        dest_addr,
+        NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE)
+    );
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)dest_addr);
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -59,7 +59,10 @@ inline uint32_t get_cq_data_buffer_size(bool use_eth_l1, bool use_idle_eth) {
 inline uint32_t get_consumer_data_buffer_size() {
     uint32_t num_consumer_cmd_slots = 2;
     uint32_t producer_data_buffer_size = get_cq_data_buffer_size(false, false);
-    return (producer_data_buffer_size - DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND) / num_consumer_cmd_slots;
+    uint32_t consumer_data_buffer_size = (producer_data_buffer_size - DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND) / num_consumer_cmd_slots;
+    // The data buffer size needs to maintain DRAM/PCIe alignment
+    consumer_data_buffer_size -= consumer_data_buffer_size % DRAM_ALIGNMENT;
+    return consumer_data_buffer_size;
 }
 
 /// @brief Get offset of the command queue relative to its channel

--- a/tt_metal/impl/dispatch/kernels/cq_dispatcher.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatcher.hpp
@@ -14,8 +14,7 @@ void noc_async_write_multicast_one_packet_no_path_reserve(
     std::uint32_t num_dests) {
 
     DEBUG_STATUS('N', 'W', 'P', 'W');
-    DEBUG_SANITIZE_WORKER_ADDR(src_local_l1_addr, size);
-    DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr_multicast, size);
+    DEBUG_SANITIZE_NOC_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr,size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
     DEBUG_STATUS('N', 'W', 'P', 'D');
 


### PR DESCRIPTION
When we transfer between PCIe/DRAM and L1, the L1 address needs to have 32-byte-alignment as well. Update watcher to check for this.

Passing CI:
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8473556748
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8473999255