### PR TITLE
#6443: Update backward ops cosh sinh polygamma

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cosh.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cosh.py
@@ -5,7 +5,13 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    data_gen_with_range,
+    compare_pcc,
+)
+from models.utility_functions import (
+    skip_for_wormhole_b0,
+)
 
 
 @pytest.mark.parametrize(
@@ -17,13 +23,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_cosh(input_shapes, device):
-    in_data = (2 * torch.rand(input_shapes) - 1) * 9
-    in_data.requires_grad = True
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -9, 9, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
 
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
     tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
@@ -34,5 +36,103 @@ def test_bw_cosh(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_cosh_inf(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 90, 95, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -7, 7, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.cosh(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_cosh_neg_inf(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -95, -89, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -7, 7, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.cosh(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@skip_for_wormhole_b0()
+def test_bw_cosh_nan_test1(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.cosh(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@skip_for_wormhole_b0()
+def test_bw_cosh_nan_test2(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.cosh(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_polygamma.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_polygamma.py
@@ -5,7 +5,14 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    data_gen_with_range,
+    compare_pcc,
+    data_gen_with_val,
+)
+from models.utility_functions import (
+    skip_for_wormhole_b0,
+)
 
 
 @pytest.mark.parametrize(
@@ -18,17 +25,13 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 @pytest.mark.parametrize(
     "order",
-    [1, 2, 3, 4, 5, 10],
+    [1, 2, 3, 6, 7, 10],
 )
 def test_bw_polygamma(input_shapes, order, device):
-    in_data = torch.rand(input_shapes) * 9 + 1
-    in_data.requires_grad = True
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
     n = order
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
 
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
     tt_output_tensor_on_device = tt_lib.tensor.polygamma_bw(grad_tensor, input_tensor, n)
 
     in_data.retain_grad()
@@ -39,5 +42,117 @@ def test_bw_polygamma(input_shapes, order, device):
 
     golden_tensor = [in_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "order",
+    [1, 4, 7, 10],
+)
+def test_bw_polygamma_range_pos(input_shapes, order, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device)
+    n = order
+
+    tt_output_tensor_on_device = tt_lib.tensor.polygamma_bw(grad_tensor, input_tensor, n)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.polygamma(n, in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+# grad and input zero
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "order",
+    [2, 5],
+)
+@skip_for_wormhole_b0()
+def test_bw_polygamma_zero(input_shapes, order, device):
+    in_data, input_tensor = data_gen_with_val(input_shapes, device, True, 0)
+    grad_data, grad_tensor = data_gen_with_val(input_shapes, device, True, 0)
+    n = order
+
+    tt_output_tensor_on_device = tt_lib.tensor.polygamma_bw(grad_tensor, input_tensor, n)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.polygamma(n, in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+# grad zero
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "order",
+    [2, 5],
+)
+def test_bw_polygamma_grad_zero(input_shapes, order, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_val(input_shapes, device, True, 0)
+    n = order
+
+    tt_output_tensor_on_device = tt_lib.tensor.polygamma_bw(grad_tensor, input_tensor, n)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.polygamma(n, in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+# input zero
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "order",
+    [1, 2, 5],
+)
+def test_bw_polygamma_input_zero(input_shapes, order, device):
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_val(input_shapes, device, True, 0)
+    n = order
+
+    tt_output_tensor_on_device = tt_lib.tensor.polygamma_bw(grad_tensor, input_tensor, n)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.polygamma(n, in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_real.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_real.py
@@ -8,6 +8,13 @@ import tt_lib
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -16,16 +23,16 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
         (torch.Size([1, 3, 320, 384])),
     ),
 )
+# testing for Type 1 complex tensor
 def test_bw_real(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, dtype=torch.complex64)
+    in_data = random_complex_tensor(input_shapes, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
-    torch.manual_seed(42)
-    grad_data = torch.randn(input_shapes, dtype=torch.complex64)
+    grad_data = random_complex_tensor(input_shapes, (-80, 80), (-20, 20))
     grad_data = grad_data.real
 
     in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=3)
+
     input_tensor = (
         tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sinh.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sinh.py
@@ -5,7 +5,13 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    data_gen_with_range,
+    compare_pcc,
+)
+from models.utility_functions import (
+    skip_for_wormhole_b0,
+)
 
 
 @pytest.mark.parametrize(
@@ -17,13 +23,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_sinh(input_shapes, device):
-    in_data = (2 * torch.rand(input_shapes) - 1) * 9
-    in_data.requires_grad = True
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -9, 9, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
 
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
     tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
@@ -34,5 +36,103 @@ def test_bw_sinh(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_sinh_inf(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 89, 96, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.sinh(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_sinh_neg_inf(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -97, -89, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.sinh(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@skip_for_wormhole_b0()
+def test_bw_sinh_nan_test1(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.sinh(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@skip_for_wormhole_b0()
+def test_bw_sinh_nan_test2(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.sinh(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_softshrink.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_softshrink.py
@@ -5,7 +5,10 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    data_gen_with_range,
+    compare_results,
+)
 
 
 @pytest.mark.parametrize(
@@ -18,9 +21,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 @pytest.mark.parametrize("lambd", [0.5, 1.0, 2.5, 5.5, 9.9])
 def test_bw_softshrink(input_shapes, lambd, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
-
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
     in_data.retain_grad()
 
     pyt_y = torch.nn.functional.softshrink(in_data, lambd=lambd)


### PR DESCRIPTION
Updated test files: 
polygamma_bw, soft shrink_bw, real_bw, cosh_bw, sinh_bw

Modified cosh_bw, sinh_bw to give **+/-inf** similar to torch for range  beyond (-88,88)
Torch (inf) and TT (nan) handles large output values ( +/- 3.4028235e+38) and beyond differently. 
Recorded observations :  https://docs.google.com/spreadsheets/d/1FNeOTyVU97URmYCfNFK_PpQEbT813Kk-5poceeyJzl4/edit#gid=0

Polygamma_bw:  handled nan/inf for zero input, grad
Primary issue: #6443 
CI test: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8517642830