### PR TITLE
#0: remove use of EnqueueProgram from routing path tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,10 +46,13 @@
 
 # metal - dispatch
 # tt_metal/impl/dispatch/ @pgkeller @tooniz @tt-asaigal
+# tt_metal/impl/dispatch/kernels/packet_* @imatosevic @ucheema
+# tt_metal/impl/dispatch/kernels/eth_* @imatosevic @ucheema
 # tt_metal/impl/dispatch/**/module.mk @tt-rkim @pgkeller
 # tt_metal/kernels/dataflow/dispatch/ @tarafdarTT @pgkeller
 # docs/source/frameworks/tt_dispatch.rst @pgkeller
 # docs/source/tt_metal/apis/host_apis/ @TT-billteng
+# tests/tt_metal/tt_metal/perf_microbenchmark/routing/ @imatosevic @ucheema
 
 # metal - fw, llks, risc-v
 # tt_metal/hw/ckernels/ @davorchap

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bi_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bi_tunnel.cpp
@@ -138,9 +138,6 @@ int main(int argc, char **argv) {
         std::cout<<"Left Tunneler = "<<tunneler_logical_core.str()<<std::endl;
         std::cout<<"Right Tunneler = "<<r_tunneler_logical_core.str()<<std::endl;
 
-        CommandQueue& cq = device->command_queue();
-        CommandQueue& cq_r = device_r->command_queue();
-
         tt_metal::Program program = tt_metal::CreateProgram();
         tt_metal::Program program_r = tt_metal::CreateProgram();
 
@@ -472,11 +469,10 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
-        EnqueueProgram(cq, program, false);
-        EnqueueProgram(cq_r, program_r, false);
 
-        Finish(cq);
-        Finish(cq_r);
+        tt_metal::detail::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device_r, program_r);
+
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
@@ -113,8 +113,6 @@ int main(int argc, char **argv) {
         int device_id = 0;
         tt_metal::Device *device = tt_metal::CreateDevice(device_id);
 
-        CommandQueue& cq = device->command_queue();
-
         tt_metal::Program program = tt_metal::CreateProgram();
 
         CoreCoord mux_core = {mux_x, mux_y};
@@ -310,8 +308,7 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
-        EnqueueProgram(cq, program, false);
-        Finish(cq);
+        tt_metal::detail::LaunchProgram(device, program);
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
@@ -89,9 +89,6 @@ int main(int argc, char **argv) {
     try {
         int device_id = 0;
         tt_metal::Device *device = tt_metal::CreateDevice(device_id);
-
-        CommandQueue& cq = device->command_queue();
-
         tt_metal::Program program = tt_metal::CreateProgram();
 
         constexpr uint32_t tx_x = 0;
@@ -447,8 +444,7 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
-        EnqueueProgram(cq, program, false);
-        Finish(cq);
+        tt_metal::detail::LaunchProgram(device, program);
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
@@ -80,8 +80,6 @@ int main(int argc, char **argv) {
         int device_id = 0;
         tt_metal::Device *device = tt_metal::CreateDevice(device_id);
 
-        CommandQueue& cq = device->command_queue();
-
         tt_metal::Program program = tt_metal::CreateProgram();
 
         CoreCoord traffic_gen_tx_core = {tx_x, tx_y};
@@ -161,8 +159,9 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
-        EnqueueProgram(cq, program, false);
-        Finish(cq);
+
+        tt_metal::detail::LaunchProgram(device, program);
+
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel.cpp
@@ -138,9 +138,6 @@ int main(int argc, char **argv) {
         std::cout<<"Left Tunneler = "<<tunneler_logical_core.str()<<std::endl;
         std::cout<<"Right Tunneler = "<<r_tunneler_logical_core.str()<<std::endl;
 
-        CommandQueue& cq = device->command_queue();
-        CommandQueue& cq_r = device_r->command_queue();
-
         tt_metal::Program program = tt_metal::CreateProgram();
         tt_metal::Program program_r = tt_metal::CreateProgram();
 
@@ -410,11 +407,8 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
-        EnqueueProgram(cq, program, false);
-        EnqueueProgram(cq_r, program_r, false);
-
-        Finish(cq);
-        Finish(cq_r);
+        tt_metal::detail::LaunchProgram(device, program);
+        tt_metal::detail::LaunchProgram(device_r, program_r);
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel_single_chip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_uni_tunnel_single_chip.cpp
@@ -136,8 +136,6 @@ int main(int argc, char **argv) {
         std::cout<<"Left Tunneler = "<<tunneler_logical_core.str()<<std::endl;
         std::cout<<"Right Tunneler = "<<r_tunneler_logical_core.str()<<std::endl;
 
-        CommandQueue& cq = device->command_queue();
-
         tt_metal::Program program = tt_metal::CreateProgram();
 
         CoreCoord mux_core = {mux_x, mux_y};
@@ -408,9 +406,7 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
-        EnqueueProgram(cq, program, false);
-
-        Finish(cq);
+        tt_metal::detail::LaunchProgram(device, program);
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);


### PR DESCRIPTION
Routing tests previously used EnqueProgram. This doesn't work now that we rebased on fd-2/main. Changed the tests so we can run them with slow dispatch. 