### PR TITLE
#6819: Add support for CreateKernel absolute file paths

### DIFF
--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -95,7 +95,7 @@ Program CreateProgram();
  * | Argument     | Description                                                                                                                          | Type                                                     | Valid Range | Required |
  * |--------------|--------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|-------------|----------|
  * | program      | The program to which this kernel will be added to                                                                                    | Program &                                                |             | Yes      |
- * | file_name    | Path to kernel src                                                                                                                   | const std::string &                                      |             | Yes      |
+ * | file_name    | Path to kernel src. Assumed to be absolute path, but will fall back to relative path from TT_METAL_HOME if file doesn't exist.       | const std::string &                                      |             | Yes      |
  * | core_spec    | Either a single logical core, a range of logical cores or a set of logical core ranges that indicate which cores kernel is placed on | const std::variant<CoreCoord, CoreRange, CoreRangeSet> & |             | Yes      |
  * | config       | Config for data movement or compute kernel                                                                                           | const std::variant<DataMovementConfig,ComputeConfig,EthernetConfig> &   |             | No       |
  */

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -417,8 +417,10 @@ void JitBuildState::copy_kernel(const string& kernel_in_path, const string& op_o
 {
     // TODO(pgk): get rid of this copy, compile kernel file in place as its own .o
     const string out_dir = this->out_path_ + op_out_path + this->target_name_;
-    const string src = env_.get_root_path() + kernel_in_path;
     const string dst = out_dir + "/kernel.cpp";
+    // Assume kernel_in_path is absolute and test if it exists, if it doesn't exist then assume
+    // it's relative to TT_METAL_HOME.
+    const string src = fs::exists(kernel_in_path) ? kernel_in_path : env_.get_root_path() + kernel_in_path;
     fs::copy(src, dst, fs::copy_options::overwrite_existing);
 }
 


### PR DESCRIPTION
Per comments on the issue, assume absolute path check if it exists, falling back to relative path if it doesn't.

Passing CI: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8485285976