### PR TITLE
#6443: Update backward ops conj imag pow

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_conj.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_conj.py
@@ -8,6 +8,13 @@ import tt_lib
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results
 
 
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -17,17 +24,16 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_conj(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, dtype=torch.complex64)
+    in_data = random_complex_tensor(input_shapes, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
-    torch.manual_seed(42)
-    grad_data = torch.randn(input_shapes, dtype=torch.complex64)
+    grad_data = random_complex_tensor(input_shapes, (-50, 50), (-60, 60))
 
     in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=3)
     input_tensor = (
         tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
+
     grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=3)
     grad_tensor = (
         tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_imag.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_imag.py
@@ -8,6 +8,13 @@ import tt_lib
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
 
 
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -17,15 +24,14 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_imag(input_shapes, device):
-    torch.manual_seed(0)
-    in_data = torch.randn(input_shapes, dtype=torch.complex64)
+    in_data = random_complex_tensor(input_shapes, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
-    torch.manual_seed(42)
-    grad_data = torch.randn(input_shapes, dtype=torch.complex64)
+    grad_data = random_complex_tensor(input_shapes, (-80, 80), (-20, 20))
     grad_data = grad_data.imag
 
     in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=3)
+
     input_tensor = (
         tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
@@ -5,7 +5,10 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    data_gen_with_range,
+    compare_pcc,
+)
 
 
 @pytest.mark.parametrize(
@@ -20,8 +23,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ],
 )
 def test_negative_exponent(input_shapes, exponent, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
 
     with pytest.raises(RuntimeError) as _e:
         tt_output_tensor_on_device = tt_lib.tensor.unary_pow_bw(grad_tensor, input_tensor, exponent=exponent)
@@ -39,14 +42,14 @@ def test_negative_exponent(input_shapes, exponent, device):
     ],
 )
 def test_fw_exponent(input_shapes, exponent, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
 
     golden_tensor = [
-        torch.pow(grad_data, 0.0),
+        torch.pow(grad_data, exponent),
     ]
-    tt_output_tensor_on_device = tt_lib.tensor.pow(grad_tensor, 0.0)
-    status = compare_results([tt_output_tensor_on_device], golden_tensor)
+    tt_output_tensor_on_device = tt_lib.tensor.pow(grad_tensor, exponent)
+    status = compare_pcc([tt_output_tensor_on_device], golden_tensor)
     assert status
 
     # assert "exponent >= 0.0" in str(_e)
@@ -67,14 +70,15 @@ def test_fw_exponent(input_shapes, exponent, device):
         (1.0, 0.99),
         (2.0, 0.99),
         (5.0, 0.99),
-        (2.5, 0.60),
-        (0.5, 0.89),
+        (0.5, 0.92),
+        (1.5, 0.84),
+        (2.5, 0.57),
     ],
 )
 def test_bw_unary_pow(input_shapes, exponent_and_pcc, device):
     exponent, pcc = exponent_and_pcc
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
 
     tt_output_tensor_on_device = tt_lib.tensor.unary_pow_bw(grad_tensor, input_tensor, exponent=exponent)
 
@@ -86,5 +90,51 @@ def test_bw_unary_pow(input_shapes, exponent_and_pcc, device):
 
     golden_tensor = [in_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor, pcc=pcc)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor, pcc=pcc)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+def test_bw_unary_pow_test_inf(input_shapes, device):
+    exponent = 2
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, 1, 9, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.unary_pow_bw(grad_tensor, input_tensor, exponent=exponent)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.pow(in_data, exponent)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+def test_bw_unary_pow_test_neg_inf(input_shapes, device):
+    exponent = 2
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, -1, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.unary_pow_bw(grad_tensor, input_tensor, exponent=exponent)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.pow(in_data, exponent)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -48,6 +48,8 @@ std::vector<Tensor> unary_mul_bw(const Tensor& grad, const Tensor& input, float 
     return operation::decorate_as_composite(__func__, _unary_mul_bw)(grad, input, scalar, output_mem_config);
 }
 
+// unary_pow:
+// grad_input = grad * exponent * torch.pow(input, exponent - 1)
 std::vector<Tensor> _unary_pow_bw(const Tensor& grad, const Tensor& input, float exponent, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     const float ZERO_THRESHOLD = std::numeric_limits<float>::epsilon()*10.0f;
@@ -64,6 +66,7 @@ std::vector<Tensor> _unary_pow_bw(const Tensor& grad, const Tensor& input, float
 
     Tensor result = mul_unary(power_input, exponent, output_mem_config);
     Tensor final_result = mul(result, grad, std::nullopt, output_mem_config);
+    final_result = where(gte_unary(final_result, 3.4e+38, output_mem_config), std::numeric_limits<float>::infinity(), where(lte_unary(final_result, -3.4e+38, output_mem_config), -std::numeric_limits<float>::infinity(), final_result, output_mem_config), output_mem_config);
     grad_tensor.emplace_back(final_result);
     return grad_tensor;
 }


### PR DESCRIPTION
Updated backward test files:
conj, imag (type 1 complex), unary_pow

handled nan/inf values to match torch for beyond range (-3.4e+38, 3.4e+38)
Primary issue: #6443

CI test : https://github.com/tenstorrent-metal/tt-metal/actions/runs/8503522593