### PR TITLE
#5592: Optimize Falcon 7b lm head matmul

### DIFF
--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_lm_head_matmul_2d.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_lm_head_matmul_2d.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import pytest
+import torch
+
+import tt_lib
+
+from models.demos.falcon7b.tt.falcon_lm_head import falcon_lm_head_matmul_2d
+from models.utility_functions import comp_pcc, tt2torch_tensor, torch2tt_tensor
+
+
+def run_falcon_lm_head_matmul_2d(
+    seq_len, device, in0_mem_config, in1_mem_config, out_mem_config, in0_dtype, in1_dtype, out_dtype
+):
+    pcc = 0.99
+    torch.manual_seed(1234)
+
+    M = seq_len // 32
+    K = 142
+    N = 2032
+
+    a_shape = [1, 1, M * 32, K * 32]
+    # weights are padded on model initialization to reach 144 inner dim
+    b_shape = [1, 1, (K + 2) * 32, N * 32]
+    expected_output_shape = [1, 1, M * 32, N * 32]
+
+    # calculate parameters for the given sequence length
+    num_slices = 4 if seq_len <= 1024 else 8
+    # on n300 we have 8*7 grid size so we run out of memory and need more slices
+    if device.compute_with_storage_grid_size().y < 8:
+        num_slices *= 2
+
+    # --- prepare activations
+    A = torch.randn(a_shape)
+    padding = torch.zeros([1, 1, M * 32, 64])
+    A_padded = torch.cat([A, padding], -1)
+
+    # padd in0 tensor to have last dimension 144 * 32 instead of 142 * 32
+    a_t = torch2tt_tensor(
+        A,
+        device,
+        tt_lib.tensor.Layout.TILE,
+        in0_mem_config,
+        in0_dtype,
+    )
+
+    # --- prepare weights
+    B = torch.randn(b_shape)
+    B_slices = torch.chunk(B, num_slices, dim=-1)
+    b_t_slices = []
+    for i in range(num_slices):
+        b_t_slices.append(
+            torch2tt_tensor(
+                B_slices[i],
+                device,
+                tt_lib.tensor.Layout.TILE,
+                in1_mem_config,
+                in1_dtype,
+            )
+        )
+
+    out = falcon_lm_head_matmul_2d(a_t, b_t_slices, num_slices, in0_mem_config, in0_dtype, out_mem_config, out_dtype)
+
+    a_t.deallocate(True)
+    for i in range(num_slices):
+        b_t_slices[i].deallocate(True)
+
+    assert out.get_legacy_shape() == expected_output_shape
+
+    # check pcc
+    out = tt2torch_tensor(out)
+    ref_out = torch.matmul(A_padded, B)
+    passed, output_pcc = comp_pcc(out, ref_out, pcc)
+    logger.info(f"Output pcc={output_pcc}")
+
+    assert passed
+
+
+@pytest.mark.parametrize("seq_len", range(544, 2049, 32))
+def test_falcon_lm_head_matmul_2d(
+    seq_len,
+    device,
+):
+    in0_mem_config = tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    )
+    in1_mem_config = tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    )
+    out_mem_config = tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    )
+
+    in0_dtype = tt_lib.tensor.DataType.BFLOAT16
+    in1_dtype = tt_lib.tensor.DataType.BFLOAT8_B
+    out_dtype = tt_lib.tensor.DataType.BFLOAT16
+
+    run_falcon_lm_head_matmul_2d(
+        seq_len, device, in0_mem_config, in1_mem_config, out_mem_config, in0_dtype, in1_dtype, out_dtype
+    )

--- a/models/demos/falcon7b/tt/falcon_lm_head.py
+++ b/models/demos/falcon7b/tt/falcon_lm_head.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from typing import List
 

--- a/models/demos/falcon7b/tt/falcon_lm_head.py
+++ b/models/demos/falcon7b/tt/falcon_lm_head.py
@@ -1,0 +1,96 @@
+import torch
+from typing import List
+
+import tt_lib
+
+from models.utility_functions import nearest_y
+
+
+# this function takes activations that are assumed to be non-padded and weights that are assumed to be padded
+# (since they are pushed to device at the moment of model initialization);
+# it also takes in number of slices since this should be determined at the moment of pushing weights,
+# but in general with 512 < seq_len <= 1024 we should use 4 slices, with 1024 < seq_len <= 2048 we should use 8 slices
+def falcon_lm_head_matmul_2d(
+    hidden_states: tt_lib.tensor.Tensor,
+    weights: List[tt_lib.tensor.Tensor],
+    num_slices: int,
+    in0_mem_config: tt_lib.tensor.MemoryConfig,
+    in0_dtype: tt_lib.tensor.DataType,
+    out_mem_config: tt_lib.tensor.MemoryConfig,
+    out_dtype: tt_lib.tensor.DataType,
+):
+    assert (
+        hidden_states.device().arch() == tt_lib.device.Arch.WORMHOLE_B0
+    ), "Falcon LM head is only supported for Wormhole BO arch"
+
+    seq_len = hidden_states.get_legacy_shape()[-2]
+
+    assert seq_len % 32 == 0, f"Sequence length must be a multiple of 32, instead it is {seq_len}"
+    assert seq_len > 512, f"Falcon lm head 2d is only supported for sequence length > 512, instead it is {seq_len}"
+    assert seq_len <= 2048, f"Falcon lm head 2d is only supported for sequence length <= 2048, instead it is {seq_len}"
+
+    assert (
+        len(weights) == num_slices
+    ), f"Weights are expected to be split into {num_slices} slices, instead there are {len(weights)}"
+    weights_inner_dim_in_tiles = weights[0].get_legacy_shape()[-2] // 32
+    assert (
+        weights_inner_dim_in_tiles == 144
+    ), f"Weights are expected to be padded to the inner dim 144 in tiles, instead they are {weights_inner_dim_in_tiles}"
+
+    # pad activations to inner dim 144
+    padding = torch.zeros([1, 1, seq_len, 64])
+    padding_t = (
+        tt_lib.tensor.Tensor(padding, in0_dtype)
+        .to(tt_lib.tensor.Layout.TILE)
+        .to(hidden_states.device(), in0_mem_config)
+    )
+    hidden_states = tt_lib.tensor.concat([hidden_states, padding_t], -1)
+
+    compute_kernel_config = tt_lib.tensor.WormholeComputeKernelConfig(
+        math_fidelity=tt_lib.tensor.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+
+    grid = hidden_states.device().compute_with_storage_grid_size()
+    activations_m_in_tiles = seq_len // 32
+    weights_n_in_tiles = weights[0].get_legacy_shape()[-1] // 32
+
+    # calculate parameters for the given sequence length
+    grid = hidden_states.device().compute_with_storage_grid_size()
+    out_subblock_h = 2
+    out_subblock_w = 4
+    per_core_M = nearest_y(activations_m_in_tiles / grid.y, out_subblock_h)
+    per_core_N = nearest_y(weights_n_in_tiles / grid.x, out_subblock_w)
+    in0_block_w = 4 if seq_len <= 1024 else 8
+
+    program_config = tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=grid,
+        in0_block_w=in0_block_w,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        transpose_mcast=False,
+        fused_activation=None,
+    )
+
+    out_slices = []
+    for i in range(num_slices):
+        out_slices.append(
+            tt_lib.operations.primary.matmul(
+                hidden_states,
+                weights[i],
+                program_config=program_config,
+                output_mem_config=out_mem_config,
+                output_dtype=out_dtype,
+                compute_kernel_config=compute_kernel_config,
+            )
+        )
+
+    out = tt_lib.tensor.concat(out_slices, -1)
+    for i in range(num_slices):
+        out_slices[i].deallocate(True)
+
+    return out

--- a/models/demos/falcon7b/tt/model_utils.py
+++ b/models/demos/falcon7b/tt/model_utils.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
 import tt_lib
 
 from models.utility_functions import torch2tt_tensor, pad_by_zero

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -31,6 +31,10 @@ def _nearest_y(x, y):
     return math.ceil(x / y) * y
 
 
+def nearest_y(x, y):
+    return _nearest_y(x, y)
+
+
 def divup(a, b):
     return (a + b - 1) // b
 


### PR DESCRIPTION
Add a function for Falcon 7b lm head with seq len > 512. The function splits matmul into 4 or 8 2d matmuls, and expects the weights to be sliced accordingly. 

For 2k seq len, kernel time went from 400ms to 17ms (total kernel time for all slices and concats). For 1k seq len kernel time went from 200ms to 9ms. Other 32-multiple sequence lengths between 512 and 2048 are also supported.

The function is currently used only in the test - the idea is to incorporate it to the model with other pending optimizations; then some more optimizations and refactoring will be done (eg padding tensor will probably be reused on multiple spots, model config will be used instead of some fixed constants like grid, subblock dimensions etc.).  