### PR TITLE
Release trace buffer mechanism

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
@@ -8,6 +8,7 @@
 #include "command_queue_fixture.hpp"
 #include "tt_metal/common/env_lib.hpp"
 #include "gtest/gtest.h"
+#include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/program/program.hpp"
 #include "tt_metal/common/logger.hpp"
 #include "tt_metal/common/scoped_timer.hpp"
@@ -88,6 +89,79 @@ namespace basic_tests {
 constexpr bool kBlocking = true;
 constexpr bool kNonBlocking = false;
 vector<bool> blocking_flags = {kBlocking, kNonBlocking};
+
+TEST_F(CommandQueueFixture, TraceInstanceManagement) {
+    CommandQueue& cq = this->device_->command_queue();
+    vector<uint64_t> trace_size = {32*1024, 32};
+    vector<uint64_t> page_size = {DeviceCommand::PROGRAM_PAGE_SIZE, 32};
+    vector<uint64_t> buf_size_per_bank;
+
+    for (int i=0; i<trace_size.size(); i++) {
+        int banks = cq.device()->num_banks(BufferType::DRAM);
+        int pages = trace_size.at(i) / page_size.at(i);
+        int pages_per_bank = pages / banks + (pages % banks ? 1 : 0);
+        buf_size_per_bank.push_back(pages_per_bank * page_size.at(i));
+    }
+
+    auto mem_idle = cq.device()->get_memory_allocation_statistics(BufferType::DRAM);
+    log_debug(LogTest, "DRAM usage before trace buffer allocation: {}, {}, {}",
+        mem_idle.total_allocatable_size_bytes,
+        mem_idle.total_free_bytes,
+        mem_idle.total_allocated_bytes);
+
+    // Add instances scope, trace buffers go out of scope yet remain cached in memory
+    {
+        auto trace_buffer0 = std::make_shared<Buffer>(cq.device(), trace_size.at(0), page_size.at(0), BufferType::DRAM, TensorMemoryLayout::INTERLEAVED);
+        auto trace_buffer1 = std::make_shared<Buffer>(cq.device(), trace_size.at(1), page_size.at(1), BufferType::DRAM, TensorMemoryLayout::INTERLEAVED);
+        auto mem_multi_trace = cq.device()->get_memory_allocation_statistics(BufferType::DRAM);
+        log_debug(
+            LogTest,
+            "DRAM usage post trace buffer allocation: {}, {}, {}",
+            mem_multi_trace.total_allocatable_size_bytes,
+            mem_multi_trace.total_free_bytes,
+            mem_multi_trace.total_allocated_bytes);
+
+        // Cache the trace buffer in memory via instance pinning calls
+        Trace::add_instance(0, trace_buffer0);
+        Trace::add_instance(1, trace_buffer1);
+    }
+
+    // Some user interaction with traces, unimportant... check that traces are still cached
+    auto mem_multi_trace = cq.device()->get_memory_allocation_statistics(BufferType::DRAM);
+    EXPECT_EQ(mem_idle.total_allocated_bytes, mem_multi_trace.total_allocated_bytes - buf_size_per_bank.at(0) - buf_size_per_bank.at(1));
+    EXPECT_EQ(mem_idle.total_free_bytes, mem_multi_trace.total_free_bytes + buf_size_per_bank.at(0) + buf_size_per_bank.at(1));
+
+    // Release instances scope, trace buffers remain cached in memory until released by user
+    {
+        ReleaseTrace(1);
+        auto mem_release_one = cq.device()->get_memory_allocation_statistics(BufferType::DRAM);
+        EXPECT_EQ(mem_idle.total_allocated_bytes, mem_release_one.total_allocated_bytes - buf_size_per_bank.at(0));
+        EXPECT_EQ(mem_idle.total_free_bytes, mem_release_one.total_free_bytes + buf_size_per_bank.at(0));
+
+        ReleaseTrace(0);
+        auto mem_release_two = cq.device()->get_memory_allocation_statistics(BufferType::DRAM);
+        EXPECT_EQ(mem_idle.total_allocatable_size_bytes, mem_release_two.total_allocatable_size_bytes);
+        EXPECT_EQ(mem_idle.total_free_bytes, mem_release_two.total_free_bytes);
+        EXPECT_EQ(mem_idle.total_allocated_bytes, mem_release_two.total_allocated_bytes);
+    }
+
+    // Add instances scope, trace buffers go out of scope yet remain cached in memory
+    {
+        auto trace_buffer0 = std::make_shared<Buffer>(cq.device(), trace_size.at(0), page_size.at(0), BufferType::DRAM, TensorMemoryLayout::INTERLEAVED);
+        auto trace_buffer1 = std::make_shared<Buffer>(cq.device(), trace_size.at(1), page_size.at(1), BufferType::DRAM, TensorMemoryLayout::INTERLEAVED);
+        auto mem_multi_trace = cq.device()->get_memory_allocation_statistics(BufferType::DRAM);
+
+        // Cache the trace buffer in memory via instance pinning calls
+        Trace::add_instance(0, trace_buffer0);
+        Trace::add_instance(1, trace_buffer1);
+    }
+
+    ReleaseTrace(-1);
+    auto mem_release_all = cq.device()->get_memory_allocation_statistics(BufferType::DRAM);
+    EXPECT_EQ(mem_idle.total_allocatable_size_bytes, mem_release_all.total_allocatable_size_bytes);
+    EXPECT_EQ(mem_idle.total_free_bytes, mem_release_all.total_free_bytes);
+    EXPECT_EQ(mem_idle.total_allocated_bytes, mem_release_all.total_allocated_bytes);
+}
 
 TEST_F(CommandQueueFixture, InstantiateTraceSanity) {
     CommandQueue& command_queue = this->device_->command_queue();

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -455,6 +455,20 @@ uint32_t InstantiateTrace(Trace &trace, CommandQueue &cq);
  */
 void EnqueueTrace(CommandQueue &cq, uint32_t trace_id, bool blocking);
 
+
+/**
+ * Release a previously instantiated trace, deallocating the associated trace buffers on device
+ * This operation is not thread-safe, user must ensure that the trace being released is no longer needed by device threads
+ *
+ * Return value: void
+ *
+ * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | trace_id     | A unique id representing an existing on-device trace, which has been   | uint32_t                      |                                    | Yes      |
+ * |              | instantiated via InstantiateTrace where the trace_id is returned       |                               |                                    |          |
+ */
+void ReleaseTrace(uint32_t trace_id);
+
 /**
  * Read device side profiler data and dump results into device side CSV log
  *

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -738,9 +738,16 @@ void EndTrace(Trace& trace) {
 }
 
 uint32_t InstantiateTrace(Trace& trace, CommandQueue& cq) {
-    detail::DispatchStateCheck(true);
     uint32_t trace_id = trace.instantiate(cq);
     return trace_id;
+}
+
+void ReleaseTrace(uint32_t trace_id) {
+    if (trace_id == -1) {
+        Trace::release_all();
+    } else if (Trace::has_instance(trace_id)) {
+        Trace::remove_instance(trace_id);
+    }
 }
 
 void EnqueueTrace(CommandQueue& cq, uint32_t trace_id, bool blocking) {

--- a/tt_metal/impl/trace/trace.cpp
+++ b/tt_metal/impl/trace/trace.cpp
@@ -131,4 +131,17 @@ void Trace::remove_instance(const uint32_t tid) {
     });
 }
 
+void Trace::release_all() {
+    _safe_pool([&] {
+        Trace::buffer_pool.clear();
+    });
+}
+
+shared_ptr<Buffer> Trace::get_instance(const uint32_t tid) {
+    return _safe_pool([&] {
+        TT_FATAL(Trace::buffer_pool.find(tid) != Trace::buffer_pool.end());
+        return Trace::buffer_pool[tid];
+    });
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/trace/trace.hpp
+++ b/tt_metal/impl/trace/trace.hpp
@@ -99,6 +99,8 @@ class Trace {
     static bool has_instance(const uint32_t tid);
     static void add_instance(const uint32_t tid, shared_ptr<Buffer> buffer);
     static void remove_instance(const uint32_t tid);
+    static void release_all();  // note all instances across all devices are released
+    static shared_ptr<Buffer> get_instance(const uint32_t tid);
 };
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
Added a mechanism for releasing traces so that they're not pinned in device memory indefinitely allowing user controlled memory management