### PR TITLE
#6889: Support printing/padding/tilizing multi-device tensors

### DIFF
--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -205,6 +205,7 @@ Tensor Tensor::pad(const Shape& output_tensor_shape, const Shape& input_tensor_s
     ZoneScoped;
     TT_ASSERT(
         this->storage_type() == StorageType::OWNED or
+        this->storage_type() == StorageType::MULTI_DEVICE_HOST or
         this->storage_type() == StorageType::BORROWED && "Tensor must be on host for padding");
     TT_ASSERT(this->get_layout() == Layout::ROW_MAJOR && "Tensor layout must be ROW_MAJOR for padding");
 

--- a/tt_eager/tensor/tensor_utils.hpp
+++ b/tt_eager/tensor/tensor_utils.hpp
@@ -57,6 +57,21 @@ namespace tt_metal {
 // Given a multi-device tensor and a device, returns the tensor on the given device.
 Tensor get_device_tensor(const Device* device, const Tensor& multi_device_tensor);
 
+// Returns true has MultiDeviceHost/MultiDevice Storage
+bool is_multi_device_tensor(const Tensor& tensor);
+
+// Given a multi-device tensor and a device, returns a list of per-device tensors.
+std::vector<Tensor> get_tensors_from_multi_device_storage(const Tensor& multi_device_tensor);
+
+// Given a list of per-device shards, return a multi-device tensor
+Tensor create_multi_device_tensor(const std::vector<Tensor>& tensors);
+
+// Given a multi-device tensor, and a function that transforms a tensor, apply the function to all per-device tensors.
+Tensor transform(const Tensor& tensor, std::function<Tensor(const Tensor&)> transform_func);
+
+// Given a multi-device tensor, and a callable, apply the function to all per-device tensors.
+void apply(const Tensor& tensor, std::function<void(const Tensor&)> callable);
+
 // Given a multi-device tensor, return all the devices it is mapped to.
 std::vector<Device*> get_devices(const Tensor& multi_device_tensor);
 

--- a/tt_eager/tt_dnn/op_library/tilize/tilize_op.cpp
+++ b/tt_eager/tt_dnn/op_library/tilize/tilize_op.cpp
@@ -182,6 +182,12 @@ Tensor tilize_with_val_padding(const Tensor &input_tensor_a, const Shape &output
             TT_FATAL(false, "Cannot tilize and pad tensor that is already tilized");
         }
     }
+    if (is_multi_device_tensor(input_tensor_a)) {
+        return transform(input_tensor_a, [&](const Tensor& tensor) {
+            return tilize_with_val_padding(tensor, output_tensor_shape, input_tensor_start, pad_value, output_mem_config, output_dtype);
+        });
+    }
+
     return operation::run_without_autoformat(TilizeWithValPadding{output_tensor_shape, input_tensor_start, pad_value, output_mem_config, output_dtype.value_or(input_tensor_a.get_dtype())}, {input_tensor_a}).at(0);
 
 }

--- a/tt_metal/impl/device/multi_device.cpp
+++ b/tt_metal/impl/device/multi_device.cpp
@@ -16,12 +16,14 @@ namespace multi_device {
 DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids)
     : device_grid(device_grid)
 {
-    auto num_requested_devices = device_ids.size();
+    auto [num_rows, num_cols] = device_grid;
+    auto num_requested_devices = num_rows * num_cols;
     auto num_available_devices = tt::tt_metal::GetNumAvailableDevices();
     TT_ASSERT(num_requested_devices <= num_available_devices, "Requested more devices than available");
+    TT_ASSERT(num_requested_devices <= device_ids.size(), "User provided insufficient number of device_ids for DeviceMesh");
 
-    for (auto device_id : device_ids) {
-        managed_devices.emplace_back(device_id, std::unique_ptr<Device>(CreateDevice(device_id, 1)));
+    for (int i = 0; i < num_requested_devices; i++) {
+        managed_devices.emplace_back(device_ids[i], std::unique_ptr<Device>(CreateDevice(device_ids[i], 1)));
     }
 }
 


### PR DESCRIPTION
This introduces a few changes + adds tests:
1) Closes #6889 to allow padding for a multi-device tensor
2) Introduce utility methods for handling multi-device tensors
3) Fix DeviceMesh creation to only create a multi-device with maximum number of devices specified by the DeviceGrid.