### PR TITLE
#6873: TTLIB modified sweeps GS and WH

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_clip_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_clip_test.yaml
@@ -8,8 +8,6 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -22,8 +20,10 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_clip_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
   - eltwise-clip:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,8 +32,6 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -46,5 +44,7 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_clip_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_cos_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_cos_test.yaml
@@ -8,8 +8,6 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -20,10 +18,12 @@ test-list:
       args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cos_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
   - eltwise-cos:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,8 +32,6 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -46,5 +44,7 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cos_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_cosh_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_cosh_test.yaml
@@ -22,7 +22,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cosh_sweep.csv
   - eltwise-cosh:
       shape:
@@ -46,5 +46,5 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cosh_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_deg2rad_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_deg2rad_test.yaml
@@ -22,7 +22,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_deg2rad_sweep.csv
   - eltwise-deg2rad:
       shape:
@@ -46,5 +46,5 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_deg2rad_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_eq_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_eq_test.yaml
@@ -8,8 +8,6 @@ test-list:
         num-shapes: 2
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -20,10 +18,12 @@ test-list:
       args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_eq_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
   - eltwise-eq:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,8 +32,6 @@ test-list:
         num-shapes: 2
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -46,5 +44,7 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_eq_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_hardshrink_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_hardshrink_test.yaml
@@ -8,8 +8,6 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -19,11 +17,13 @@ test-list:
         function: comp_equal
       args-gen: gen_shrink_args
       output-file: eltwise_hardshink_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", 'L1']
   - eltwise-hardshrink:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,19 +32,19 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
-        function: comp_equal
+        function: gen_rand
         args:
           low: -100
           high: 100
       comparison:
-        function: comp_pcc
+        function: comp_equal
       args-gen: gen_shrink_args
       output-file: eltwise_hardshink_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_hardswish_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_hardswish_test.yaml
@@ -8,8 +8,6 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -19,11 +17,13 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_hardswish_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-hardswish:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,8 +32,6 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -43,8 +41,10 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_hardswish_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_hardtanh_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_hardtanh_test.yaml
@@ -7,8 +7,6 @@ test-list:
         interval: [1, 1, 32, 32]
         num-shapes: 1
         num-samples: 64
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -18,11 +16,13 @@ test-list:
         function: comp_equal
       args-gen: gen_hardtanh_args
       output-file: eltwise_hardtanh_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-hardtanh:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -30,8 +30,6 @@ test-list:
         interval: [1, 1, 2, 2]
         num-shapes: 1
         num-samples: 64
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -41,8 +39,10 @@ test-list:
         function: comp_equal
       args-gen: gen_hardtanh_args
       output-file: eltwise_hardtanh_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_leaky_relu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_leaky_relu_test.yaml
@@ -20,9 +20,9 @@ test-list:
       output-file: eltwise_leaky_relu_sweep.csv
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-leaky_relu:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -45,4 +45,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_log10_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_log10_test.yaml
@@ -21,9 +21,9 @@ test-list:
       output-file: eltwise_log10_sweep.csv
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-log10:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -47,4 +47,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_log1p_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_log1p_test.yaml
@@ -23,7 +23,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-log1p:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -47,4 +47,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_log2_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_log2_test.yaml
@@ -21,9 +21,9 @@ test-list:
       output-file: eltwise_log2_sweep.csv
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-log2:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -47,4 +47,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_lt_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_lt_test.yaml
@@ -8,8 +8,6 @@ test-list:
         num-shapes: 2
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -19,11 +17,13 @@ test-list:
         function: comp_equal
       args-gen: gen_dtype_layout_device
       output-file: eltwise_lt_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-lt:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,8 +32,6 @@ test-list:
         num-shapes: 2
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -43,8 +41,10 @@ test-list:
         function: comp_equal
       args-gen: gen_dtype_layout_device
       output-file: eltwise_lt_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_lte_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_lte_test.yaml
@@ -8,8 +8,6 @@ test-list:
         num-shapes: 2
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -19,11 +17,13 @@ test-list:
         function: comp_equal
       args-gen: gen_dtype_layout_device
       output-file: eltwise_lte_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-lte:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,8 +32,6 @@ test-list:
         num-shapes: 2
         num-samples: 64
         args-sampling-strategy: "all"
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -43,8 +41,10 @@ test-list:
         function: comp_equal
       args-gen: gen_dtype_layout_device
       output-file: eltwise_lte_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_rad2deg_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_rad2deg_test.yaml
@@ -22,7 +22,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_rad2deg_sweep.csv
   - eltwise-rad2deg:
       shape:
@@ -46,5 +46,5 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_rad2deg_sweep.csv

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_softsign_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_softsign_test.yaml
@@ -23,7 +23,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-softsign:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -47,4 +47,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_tanh_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/pytorch_eltwise_tanh_test.yaml
@@ -21,9 +21,9 @@ test-list:
       output-file: eltwise_tanh_sweep.csv
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-tanh:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -47,4 +47,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_clip_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_clip_test.yaml
@@ -20,7 +20,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_clip_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -44,7 +44,7 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_clip_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_cos_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_cos_test.yaml
@@ -18,9 +18,9 @@ test-list:
       args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cos_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -44,7 +44,7 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cos_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_cosh_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_cosh_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -20,10 +22,8 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cosh_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
   - eltwise-cosh:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -44,7 +46,5 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cosh_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_deg2rad_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_deg2rad_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -20,10 +22,8 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_deg2rad_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
   - eltwise-deg2rad:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -44,7 +46,5 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_deg2rad_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_eq_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_eq_test.yaml
@@ -18,9 +18,9 @@ test-list:
       args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_eq_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -44,7 +44,7 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_eq_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_hardshrink_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_hardshrink_test.yaml
@@ -23,7 +23,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", 'L1']
   - eltwise-hardshrink:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -47,4 +47,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_hardswish_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_hardswish_test.yaml
@@ -23,7 +23,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-hardswish:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -47,4 +47,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_hardtanh_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_hardtanh_test.yaml
@@ -22,7 +22,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-hardtanh:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -45,4 +45,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_leaky_relu_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_leaky_relu_test.yaml
@@ -7,6 +7,8 @@ test-list:
         interval: [1, 1, 32, 32]
         num-shapes: 1
         num-samples: 64
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -16,13 +18,11 @@ test-list:
         function: comp_pcc
       args-gen: gen_leaky_relu_args
       output-file: eltwise_leaky_relu_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-leaky_relu:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -30,6 +30,8 @@ test-list:
         interval: [1, 1, 2, 2]
         num-shapes: 1
         num-samples: 64
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -39,10 +41,8 @@ test-list:
         function: comp_pcc
       args-gen: gen_leaky_relu_args
       output-file: eltwise_leaky_relu_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_log10_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_log10_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -17,13 +19,11 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_log10_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-log10:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -41,10 +43,8 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_log10_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_log1p_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_log1p_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -17,13 +19,11 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_log1p_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-log1p:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -41,10 +43,8 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_log1p_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_log2_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_log2_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -17,13 +19,11 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_log2_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-log2:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -41,10 +43,8 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_log2_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_lt_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_lt_test.yaml
@@ -1,50 +1,50 @@
 ---
 test-list:
-  - eltwise-lt:
+  - eltwise-log10:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
-        num-shapes: 2
+        num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
-          low: -100
+          low: 1
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_pcc
       args-gen: gen_dtype_layout_device
-      output-file: eltwise_lt_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      output-file: eltwise_log10_sweep.csv
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
-  - eltwise-lt:
+        out-buffer-type: ["DRAM", "L1"]
+  - eltwise-log10:
       shape:
         start-shape: [1, 1, 2, 2]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 2, 2]
-        num-shapes: 2
+        num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
-          low: -100
+          low: 1
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_pcc
       args-gen: gen_dtype_layout_device
-      output-file: eltwise_lt_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      output-file: eltwise_log10_sweep.csv
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_lte_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_lte_test.yaml
@@ -21,9 +21,9 @@ test-list:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-lte:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -47,4 +47,4 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_rad2deg_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_rad2deg_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -20,10 +22,8 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_rad2deg_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
   - eltwise-rad2deg:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -44,7 +46,5 @@ test-list:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_rad2deg_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_sin_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_sin_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -17,13 +19,11 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_sin_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-sin:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -41,10 +43,8 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_sin_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_softsign_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_softsign_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -17,13 +19,11 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_softsign_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-softsign:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -41,10 +43,8 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_softsign_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_tanh_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_tanh_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -17,13 +19,11 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_tanh_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]
   - eltwise-tanh:
       shape:
         start-shape: [1, 1, 2, 2]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -41,10 +43,8 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       output-file: eltwise_tanh_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_threshold_test.yaml
+++ b/tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/pytorch_eltwise_threshold_test.yaml
@@ -8,6 +8,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -17,8 +19,6 @@ test-list:
         function: comp_equal
       args-gen: gen_threshold_args
       output-file: eltwise_threshold_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -32,6 +32,8 @@ test-list:
         num-shapes: 1
         num-samples: 64
         args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
       datagen:
         function: gen_rand
         args:
@@ -41,8 +43,6 @@ test-list:
         function: comp_equal
       args-gen: gen_threshold_args
       output-file: eltwise_threshold_sweep.csv
-      env:
-        # TT_PCI_DMA_BUF_SIZE: "1048576"
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16"]


### PR DESCRIPTION
Modified sweeps for both GS and WH ops:
- clip, cos, cosh, tanh, asin, hardshrink, lt, lte, ne, eq, softsign, threshold, deg2rad, rad2deg, leaky_relu, hardtanh, hardshrink, hardswish, threshold and several others
