### PR TITLE
#6217: Async Mode Changes

### DIFF
--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -193,7 +193,7 @@ def test_multi_device_multi_op(pcie_device_mesh):
     """Multidevice API test: Running tensor-parallel multi-device multi-op"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
-    torch_input_tensor = torch.rand((1, 1, 32, 128), dtype=torch.bfloat16)
+    torch_input_tensor = torch.rand((1, 1, 32, 256), dtype=torch.bfloat16)
     torch_output_golden = torch.nn.functional.gelu(torch_input_tensor)
     torch_output_golden = torch.exp(torch_output_golden)
 

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_dnn/op_library/bmm/bmm_op.hpp"
+#include "tt_dnn/op_library/run_operation.hpp"
 #include "tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
 
@@ -1309,7 +1310,7 @@ MatmulParallelizationStrategy Matmul::get_parallelization_strategy(const std::ve
 }
 
 Tensor matmul_1d(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, std::optional<MatmulMultiCoreReuseMultiCast1DProgramConfig> program_config, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype, std::optional<const DeviceComputeKernelConfig> compute_kernel_config, bool untilize_out) {
-    std::vector<Tensor> output_tensors = {Tensor(input_tensor_a.get_workers())};
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}, {bias}))};
     operation::launch_op(
         [program_config, mem_config, output_dtype, compute_kernel_config, untilize_out] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor_a = input_tensors.at(0);

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
@@ -324,7 +324,7 @@ inline Tensor matmul(
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     bool untilize_out = false
 ) {
-    std::vector<Tensor> output_tensors = {Tensor(input_tensor_a.get_workers())};
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
     operation::launch_op(
         [program_config, mem_config, output_dtype, compute_kernel_config, untilize_out] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor_a = input_tensors.at(0);
@@ -346,7 +346,8 @@ inline Tensor matmul(
     std::optional<const DataType> output_dtype = std::nullopt,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     bool untilize_out = false) {
-    std::vector<Tensor> output_tensors = {Tensor(input_tensor_a.get_workers())};
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}, {bias}))};
+
     operation::launch_op(
         [program_config, mem_config, output_dtype, compute_kernel_config, untilize_out] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor_a = input_tensors.at(0);

--- a/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core_tilize_untilize.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core_tilize_untilize.cpp
@@ -4,6 +4,7 @@
 
 #include "tt_dnn/op_library/bmm/bmm_op.hpp"
 
+#include "tt_dnn/op_library/run_operation.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/common/constants.hpp"
 
@@ -18,7 +19,6 @@ Tensor bmm_tilize_untilize(const Tensor& a, const Tensor& b, const Tensor& bias,
                            std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
 
     // NOTE: Currently only single core implementation exists.
-    std::vector<Tensor> output_tensors = {Tensor(a.get_workers())};
     std::vector<Tensor> input_tensors = {};
     if (has_bias) {
         input_tensors = {a, b, bias};
@@ -26,6 +26,7 @@ Tensor bmm_tilize_untilize(const Tensor& a, const Tensor& b, const Tensor& bias,
         // bias contains dummy storage that may not be on device, dont send it to launch op
         input_tensors = {a, b};
     }
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output(std::move(input_tensors)))};
     operation::launch_op(
         [out_dt, a_height_nblocks, a_width_nblocks, b_width_nblocks,
          a_block_height_ntiles, a_block_width_ntiles, b_block_width_ntiles,

--- a/tt_eager/tt_dnn/op_library/run_operation.hpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.hpp
@@ -349,11 +349,20 @@ inline std::vector<Tensor> run_with_autoformat(
 }
 
 void launch_op(
-    std::function<std::vector<Tensor>(const std::vector<Tensor>&, const std::vector<std::optional<const Tensor>>&)> op_func,
+    std::function<std::vector<Tensor>(const std::vector<Tensor>&, const std::vector<std::optional<const Tensor>>&)>&& op_func,
     const std::vector<Tensor> input_tensors,
     std::vector<Tensor>& output_tensors,
     const std::vector<std::optional<const Tensor>> optional_input_tensors = {}
 );
+
+void launch_with_autoformat(
+    std::function<std::vector<Tensor>(const std::vector<Tensor>&, const std::vector<std::optional<const Tensor>>&)>&& op_func,
+    const std::vector<Tensor> input_tensors,
+    std::vector<Tensor>& output_tensors,
+    const std::vector<std::optional<const Tensor>> optional_input_tensors = {}
+);
+
+std::vector<Device*> get_workers_for_op_output(const std::vector<Tensor>&& inputs, const std::vector<std::optional<const Tensor>>&& optional_inputs = {});
 
 } //namespace operation
 

--- a/tt_eager/tt_dnn/op_library/sharded/sharded_op.hpp
+++ b/tt_eager/tt_dnn/op_library/sharded/sharded_op.hpp
@@ -57,7 +57,7 @@ inline Tensor interleaved_to_sharded(
     const TensorMemoryLayout shard_scheme,
     const ShardOrientation shard_orientation,
     const std::optional<const DataType> output_dtype = std::nullopt) {
-    std::vector<Tensor> output_tensors = {Tensor(input_tensor.get_workers())};
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     operation::launch_op(
         [grid, shard_shape, shard_scheme, shard_orientation, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) -> std::vector<Tensor> {
             const auto& input_tensor = input_tensors.at(0);
@@ -152,7 +152,7 @@ inline Tensor interleaved_to_sharded(
     const Tensor &input_tensor,
     const MemoryConfig &sharded_mem_config,
     std::optional<const DataType> output_dtype = std::nullopt) {
-    std::vector<Tensor> output_tensors = {Tensor(input_tensor.get_workers())};
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     operation::launch_op(
         [sharded_mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) -> std::vector<Tensor> {
             const auto& input_tensor = input_tensors.at(0);
@@ -176,7 +176,7 @@ inline Tensor sharded_to_interleaved(
     const Tensor &input_tensor,
     const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<const DataType> output_dtype = std::nullopt) {
-    std::vector<Tensor> output_tensors = {Tensor(input_tensor.get_workers())};
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     operation::launch_op(
         [output_mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) -> std::vector<Tensor> {
             const auto& input_tensor = input_tensors.at(0);

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
@@ -76,7 +76,7 @@ struct AttnMatmul {
 };
 
 inline Tensor attn_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const CoreCoord& compute_with_storage_grid_size, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
-    std::vector<Tensor> output_tensors = {Tensor(input_tensor_a.get_workers())};
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
     operation::launch_op(
         [compute_with_storage_grid_size, mem_config, output_dtype, compute_kernel_config] (std::vector<Tensor> input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor_a = input_tensors.at(0);
@@ -118,7 +118,7 @@ struct GroupAttnMatmul {
 };
 
 inline Tensor group_attn_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const CoreCoord& compute_with_storage_grid_size, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
-    std::vector<Tensor> output_tensors = {Tensor(input_tensor_a.get_workers())};
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
     operation::launch_op(
         [compute_with_storage_grid_size, mem_config, output_dtype, compute_kernel_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor_a = input_tensors.at(0);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -63,10 +63,6 @@ Device::Device(chip_id_t device_id, const uint8_t num_hw_cqs, const std::vector<
     ZoneScoped;
     TT_ASSERT(num_hw_cqs > 0 and num_hw_cqs < 3, "num_hw_cqs can be between 1 and 2");
     this->initialize(l1_bank_remap);
-    if (this->worker_queue_mode == WorkerQueueMode::ASYNCHRONOUS) {
-        this->worker_queue.parent_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
-        this->start_worker();
-    }
 }
 
 void Device::initialize_cluster() {
@@ -995,9 +991,6 @@ bool Device::close() {
 }
 
 Device::~Device() {
-    if (this->worker_queue_mode == WorkerQueueMode::ASYNCHRONOUS) {
-        stop_worker();
-    }
     if (this->initialized_) {
         this->close();
     }
@@ -1201,81 +1194,20 @@ CommandQueue& Device::command_queue(size_t cq_id) {
     return *sw_command_queues_[cq_id];
 }
 
-void Device::push_work(std::function<void()> work_executor, bool blocking) {
-    if (this->worker_queue_mode == WorkerQueueMode::ASYNCHRONOUS) {
-        if (std::hash<std::thread::id>{}(std::this_thread::get_id()) == worker_queue.parent_thread_id.load()) {
-            // Push function executor to worker queue
-            this->worker_queue.push(work_executor);
-            if (blocking) {
-                this->synchronize();
-            }
-        } else {
-            TT_ASSERT(std::hash<std::thread::id>{}(std::this_thread::get_id()) == worker_queue.worker_thread_id.load(), "Only main thread or worker thread can push to device worker queue.");
-            work_executor();
-        }
-    } else {
-        // Synchronous execution: Run function right away.
-        work_executor();
-    }
-}
-
-void Device::start_worker() {
-    this->worker_state = WorkerState::RUNNING;
-    this->worker_thread = std::thread(&Device::run_worker, this);
-}
-
-void Device::run_worker() {
-    worker_queue.worker_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
-    while (true) {
-        if(this->worker_queue.empty()) {
-            if (this->worker_state == WorkerState::TERMINATE) {
-                break;
-            }
-            std::this_thread::sleep_for(std::chrono::microseconds(10));
-        }
-        else {
-            auto func = this->worker_queue.pop();
-            (*func)();
-        }
-    }
-}
-
-void Device::stop_worker() {
-    if (this->worker_state == WorkerState::IDLE) {
-        return;
-    }
-    this->worker_state = WorkerState::TERMINATE;
-    this->worker_thread.join();
-    this->worker_state = WorkerState::IDLE;
+void Device::push_work(std::function<void()>&& work, bool blocking) {
+    this->work_executor.push_work(work, blocking);
 }
 
 void Device::synchronize() {
-    if (this->worker_queue_mode == WorkerQueueMode::ASYNCHRONOUS) {
-        // Blocking = wait for queue flushed
-        this->worker_queue.push([](){}); // Send flush command (i.e. empty function)
-        // Wait for queue empty, i.e. flush command picked up
-        while(not this->worker_queue.empty()) {
-            std::this_thread::sleep_for(std::chrono::microseconds(10));
-        };
-    }
+    this->work_executor.synchronize();
 }
 
-void Device::set_worker_mode(const WorkerQueueMode& mode) {
-    if (this->worker_queue_mode == mode) {
-        return;
-    }
-    this->worker_queue_mode = mode;
-    if (this->worker_queue_mode == WorkerQueueMode::ASYNCHRONOUS) {
-        this->worker_queue.parent_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
-        this->start_worker();
-    } else if (this->worker_queue_mode == WorkerQueueMode::SYNCHRONOUS) {
-        this->synchronize();
-        this->stop_worker();
-    }
+void Device::set_worker_mode(const WorkExecutorMode& mode) {
+    this->work_executor.set_worker_mode(mode);
 }
 
 void Device::enable_async(bool enable) {
-    auto mode = enable ? WorkerQueueMode::ASYNCHRONOUS : WorkerQueueMode::SYNCHRONOUS;
+    auto mode = enable ? WorkExecutorMode::ASYNCHRONOUS : WorkExecutorMode::SYNCHRONOUS;
     this->set_worker_mode(mode);
 }
 

--- a/tt_metal/impl/dispatch/work_executor.hpp
+++ b/tt_metal/impl/dispatch/work_executor.hpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <thread>
+
+#include "common/env_lib.hpp"
+#include "lock_free_queue.hpp"
+
+namespace tt {
+
+enum class WorkExecutorMode {
+    SYNCHRONOUS = 0,
+    ASYNCHRONOUS = 1,
+};
+
+enum class WorkerState {
+    RUNNING = 0,
+    TERMINATE = 1,
+    IDLE = 2,
+};
+
+class WorkExecutor {
+    // In asynchronous mode, each device has a worker thread that processes all host <--> cluster commands for this device.
+    // Commands are pushed to the worker queue and picked up + executed asyncrhonously.
+    // Higher level functions that have access to the device handle can queue up tasks asynchronously.
+    // In synchronous/pass through mode, we bypass the queue and tasks are executed immediately after being pushed.
+    public:
+    LockFreeQueue<std::function<void()>> worker_queue;
+
+    WorkExecutor() {
+        if (this->worker_queue_mode == WorkExecutorMode::ASYNCHRONOUS) {
+            this->start_worker();
+        }
+    }
+
+    WorkExecutor(WorkExecutor &&other) = default;
+    WorkExecutor& operator=(WorkExecutor &&other) = default;
+
+    ~WorkExecutor() {
+        if (this->worker_queue_mode == WorkExecutorMode::ASYNCHRONOUS) {
+            stop_worker();
+        }
+    }
+
+    inline void run_worker() {
+        this->worker_queue.worker_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
+        while (true) {
+            if(this->worker_queue.empty()) {
+                if (this->worker_state == WorkerState::TERMINATE) {
+                    break;
+                }
+                std::this_thread::sleep_for(std::chrono::microseconds(10));
+            }
+            else {
+                auto func = this->worker_queue.pop();
+                (*func)();
+            }
+        }
+    }
+
+    inline void push_work(const std::function<void()>& work_executor, bool blocking = false) {
+        if (this->worker_queue_mode == WorkExecutorMode::ASYNCHRONOUS) {
+            if (std::hash<std::thread::id>{}(std::this_thread::get_id()) == worker_queue.parent_thread_id.load()) {
+                // Push function executor to worker queue
+                this->worker_queue.push(work_executor);
+                if (blocking) {
+                    this->synchronize();
+                }
+            } else {
+                TT_ASSERT(std::hash<std::thread::id>{}(std::this_thread::get_id()) == worker_queue.worker_thread_id.load(), "Only main thread or worker thread can push to device worker queue.");
+                work_executor();
+            }
+        } else {
+            // Synchronous execution: Run function right away.
+            work_executor();
+        }
+    }
+
+    inline void synchronize() {
+        if (this->worker_queue_mode == WorkExecutorMode::ASYNCHRONOUS) {
+            // Blocking = wait for queue flushed
+            this->worker_queue.push([](){}); // Send flush command (i.e. empty function)
+            // Wait for queue empty, i.e. flush command picked up
+            while(not this->worker_queue.empty()) {
+                std::this_thread::sleep_for(std::chrono::microseconds(10));
+            };
+        }
+    }
+
+    inline void set_worker_mode(const WorkExecutorMode& mode) {
+         if (this->worker_queue_mode == mode) {
+            return;
+        }
+        this->worker_queue_mode = mode;
+        if (this->worker_queue_mode == WorkExecutorMode::ASYNCHRONOUS) {
+            this->worker_queue.parent_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
+            this->start_worker();
+        } else if (this->worker_queue_mode == WorkExecutorMode::SYNCHRONOUS) {
+            this->synchronize();
+            this->stop_worker();
+        }
+    }
+
+    static WorkExecutorMode get_worker_mode() { return worker_queue_mode; }
+
+    inline std::size_t get_parent_thread_id() { return this->worker_queue.parent_thread_id; }
+    private:
+    std::thread worker_thread;
+    WorkerState worker_state = WorkerState::IDLE;
+
+    inline void start_worker() {
+        this->worker_queue.parent_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
+        this->worker_state = WorkerState::RUNNING;
+        this->worker_thread = std::thread(&WorkExecutor::run_worker, this);
+    }
+
+    inline void stop_worker() {
+        if (this->worker_state == WorkerState::IDLE) {
+            return;
+        }
+        this->worker_state = WorkerState::TERMINATE;
+        this->worker_thread.join();
+        this->worker_state = WorkerState::IDLE;
+    }
+
+    static WorkExecutorMode default_worker_queue_mode() {
+        static int value = parse_env<int>("TT_METAL_ASYNC_DEVICE_QUEUE", static_cast<int>(WorkExecutorMode::SYNCHRONOUS));
+        return static_cast<WorkExecutorMode>(value);
+    }
+
+    inline static WorkExecutorMode worker_queue_mode = default_worker_queue_mode();
+};
+
+} // namespace tt


### PR DESCRIPTION
  - Add support for ops running through autoformat, this is done by supporting dynamic storage for outputs (can change after op is done running)
  - Add assert to ensure that workers are specified for MultiDeviceTensors
  - Move worker queue and thread outside device and to a WorkExecutor class
  - Use move semantics for launch_op to decrease function call overhead