### PR TITLE
Add back (and more) fd2 tests to CI under sd-unit-tests and test fixes

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -20,11 +20,13 @@ fi
 #############################################
 echo "Running test_prefetcher tests now...";
 
-# FIXME Hangs sometimes TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 3  # Smoke Test
-# FIXME comment out just in case TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 3  # Random Test
-# FIXME occasional hang/mismatch TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 3  # PCIE Test
-# FIXME comment out just in case  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 3 -i 3  # Paged DRAM Read Test
-# FIXME Failing TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 3  # Paged DRAM Write + Read Test
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 3  # TrueSmoke Test
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 3  # Smoke Test
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 3  # Random Test
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 3 -i 3  # PCIE Test
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 3  # Paged DRAM Read Test
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 5 -i 3  # Paged DRAM Write + Read Test
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 3  # Host Test
 
 # Testcase: Paged Write Cmd to DRAM. 256 pages, 224b size.
 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 1 -dpgs 224 -dpgr 256

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -275,6 +275,12 @@ inline size_t debug_prologue(vector<uint32_t>& cmds) {
     if (debug_g) {
         CQDispatchCmd debug_cmd;
         debug_cmd.base.cmd_id = CQ_DISPATCH_CMD_DEBUG;
+        // compiler compains w/o these filled in later fields
+        debug_cmd.debug.pad = 0;
+        debug_cmd.debug.key = 0;
+        debug_cmd.debug.checksum = 0;
+        debug_cmd.debug.size = 0;
+        debug_cmd.debug.stride = 0;
         add_bare_dispatcher_cmd(cmds, debug_cmd);
     }
 
@@ -514,7 +520,7 @@ inline uint32_t gen_rnd_dispatcher_packed_write_cmd(Device *device,
     uint32_t xfer_size_words = (std::rand() % (dispatch_buffer_page_size_g / sizeof(uint32_t))) + 1;
     uint32_t xfer_size_bytes = xfer_size_words * sizeof(uint32_t);
     if (perf_test_g) {
-        TT_ASSERT(max_xfer_size_bytes_g < dispatch_buffer_page_size_g);
+        TT_ASSERT(max_xfer_size_bytes_g <= dispatch_buffer_page_size_g);
         if (xfer_size_bytes > max_xfer_size_bytes_g) xfer_size_bytes = max_xfer_size_bytes_g;
         if (xfer_size_bytes < min_xfer_size_bytes_g) xfer_size_bytes = min_xfer_size_bytes_g;
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/run_paged_tests.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/run_paged_tests.sh
@@ -128,17 +128,19 @@ done
 # PERF                                        #
 ###############################################
 
+
 DIR="TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/paged_write_tests_sanity_perf_dram_${SUFFIX}"
 mkdir -p $DIR
 
-# 3.3 GB/s whb0
-TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 1000 -t 2 -wx 0 -wy 1 -min 1024 -max 1024 -lps 10 -pbs 2 -np 128 -c -i 1000 |& tee ${DIR}/perf_write_128_page_1024b_size_dispatch_buffer_1024b_pages_1000_iter_dram_pbs2.log
+# 3.845 GB/s whb0
+TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 10 -t 2 -wx 0 -wy 1 -min 1024 -max 1024 -lps 10 -pbs 2 -np 128 -c -i 1 -pi 10000 & tee ${DIR}/perf_write_128_page_1024b_size_dispatch_buffer_1024b_pages_10000_iter_dram_pbs2.log
 
-# 5.7 GB/s whb0
-TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 1000 -t 2 -wx 0 -wy 1 -min 2048 -max 2048 -lps 11 -pbs 2 -np 128 -c -i 1000 |& tee ${DIR}/perf_write_128_page_2048b_size_dispatch_buffer_2048b_pages_1000_iter_dram_pbs2.log
+# 6.374 GB/s whb0
+TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 10 -t 2 -wx 0 -wy 1 -min 2048 -max 2048 -lps 11 -pbs 2 -np 128 -c -i 1 -pi 10000 |& tee ${DIR}/perf_write_128_page_2048b_size_dispatch_buffer_2048b_pages_10000_iter_dram_pbs2.log
 
-# 8.6 GB/s whb0
-TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 1000 -t 2 -wx 0 -wy 1 -min 4096 -max 4096 -lps 12 -pbs 2 -np 128 -c -i 1000 |& tee ${DIR}/perf_write_128_page_4096b_size_dispatch_buffer_4096b_pages_1000_iter_dram_pbs2.log
+# 9.600 GB/s whb0
+TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 10 -t 2 -wx 0 -wy 1 -min 4096 -max 4096 -lps 12 -pbs 2 -np 128 -c -i 1 -pi 10000 |& tee ${DIR}/perf_write_128_page_4096b_size_dispatch_buffer_4096b_pages_10000_iter_dram_pbs2.log
 
-# 11.7 GB/s whb0 - DRAM.   Have to reduce number of pages to not exceed 1MB L1 for GS.
-TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 1000 -t 2 -wx 0 -wy 1 -min 8192 -max 8192 -lps 13 -pbs 2 -np 100 -c -i 1000 |& tee ${DIR}/perf_write_128_page_8192b_size_dispatch_buffer_8192b_pages_1000_iter_dram_pbs2.log
+# 11.7 GB/s whb0
+TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 1000 -t 2 -wx 0 -wy 1 -min 8192 -max 8192 -lps 13 -pbs 2 -np 128 -c -i 1000 |& tee ${DIR}/perf_write_128_page_8192b_size_dispatch_buffer_8192b_pages_1000_iter_dram_pbs2.log
+# FIXME Hangs TT_METAL_SLOW_DISPATCH_MODE=1 ${TT_METAL_HOME}/build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -w 10 -t 2 -wx 0 -wy 1 -min 8192 -max 8192 -lps 13 -pbs 2 -np 128 -c -i 1 -pi 10000 |& tee ${DIR}/perf_write_128_page_8192b_size_dispatch_buffer_8192b_pages_10000_iter_dram_pbs2.log

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -514,8 +514,9 @@ int main(int argc, char **argv) {
         }
 
         std::chrono::duration<double> elapsed_seconds = (end-start);
-        log_info(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);
-        log_info(LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / iterations_g);
+        uint32_t total_iterations = iterations_g * prefetcher_iterations_g;
+        log_info(LogTest, "Ran in {}us (for total iterations: {})", elapsed_seconds.count() * 1000 * 1000, total_iterations);
+        log_info(LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 /total_iterations);
         if (iterations_g > 0) {
             float total_words = 0;
             if (min_xfer_size_bytes_g != max_xfer_size_bytes_g) {
@@ -543,12 +544,12 @@ int main(int argc, char **argv) {
                 break;
             }
 
-            total_words *= iterations_g;
-            float bw = total_words * sizeof(uint32_t) * prefetcher_iterations_g / (elapsed_seconds.count() * 1024.0 * 1024.0 * 1024.0);
+            total_words *= total_iterations;
+            float bw = total_words * sizeof(uint32_t) / (elapsed_seconds.count() * 1024.0 * 1024.0 * 1024.0);
             std::stringstream ss;
             ss << std::fixed << std::setprecision(3) << bw;
-            log_info(LogTest, "BW: {} GB/s (from total_words: {} size: {} MB via host_iter: {} for num_cores: {})",
-                ss.str(), total_words, total_words * sizeof(uint32_t) / (1024.0 * 1024.0), iterations_g, all_workers_g.size());
+            log_info(LogTest, "BW: {} GB/s (from total_words: {} size: {} MB via host_iter: {} prefetcher_iter: {} for num_cores: {})",
+                ss.str(), total_words, total_words * sizeof(uint32_t) / (1024.0 * 1024.0), iterations_g, prefetcher_iterations_g, all_workers_g.size());
         } else {
             log_info(LogTest, "BW: -- GB/s (use -i 1 to report bandwidth)");
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -85,8 +85,8 @@ CoreRange all_workers_g = {
 bool send_to_all_g = false;
 bool perf_test_g = false;
 
-uint32_t max_xfer_size_bytes_g = 0xFFFFFFFF;
-uint32_t min_xfer_size_bytes_g = 0;
+uint32_t max_xfer_size_bytes_g = dispatch_buffer_page_size_g;
+uint32_t min_xfer_size_bytes_g = 4;
 
 void init(int argc, char **argv) {
     std::vector<std::string> input_args(argv, argv + argc);


### PR DESCRIPTION
- Test fix from @pgkeller  for asserts in packed-write
- Add back tests to CI with updated test numbers, and more passing tests (paged write+read, host test)
- Update BW calcs to consider on-device iterations via -pi too (not just host iterations), I think this makes sense.

Will include/update 8KB paged write perf test if I can figure out why it's hanging shortly (when using -pi > 100).