### PR TITLE
#7023: Use `bfloat8` weights in Mamba block MLPs

### DIFF
--- a/models/experimental/mamba/tt_opt/full_model.py
+++ b/models/experimental/mamba/tt_opt/full_model.py
@@ -35,12 +35,12 @@ class TtTensorLoader:
                 tensor_cache_filepath = str(Path(self.tt_cache_path) / (tensor_name + postfix))
             else:
                 tensor_cache_filepath = None
+
             if torch_tensor is None:
                 torch_tensor = self.state_dict[tensor_name]
             torch_tensor = tm_fn(torch_tensor)
 
-            # Make all loaded tensors rank 4 because there are performance issues with certain
-            # ops when using with rank 1/2 tensors in ttnn
+            # All tensors need to be rank 4 because of op performance issues with rank 1/2 inputs in ttnn
             while len(torch_tensor.size()) < 4:
                 torch_tensor = torch_tensor.unsqueeze(0)
 

--- a/models/experimental/mamba/tt_opt/mamba_block.py
+++ b/models/experimental/mamba/tt_opt/mamba_block.py
@@ -29,17 +29,23 @@ class TtMambaBlock(torch.nn.Module):
 
         # ssm wt
         self.ssm_in_proj_weights = load_fn(
-            in_proj_weight_name, lambda x: x[: self.args.d_inner, :].transpose(-1, -2), postfix="ssm"
+            in_proj_weight_name,
+            lambda x: x[: self.args.d_inner, :].transpose(-1, -2),
+            postfix="ssm",
+            tt_dtype=ttnn.bfloat8_b,
         )
 
         # mlp wt
         self.mlp_proj_weights = load_fn(
-            in_proj_weight_name, lambda x: x[self.args.d_inner :, :].transpose(-1, -2), postfix="mlp"
+            in_proj_weight_name,
+            lambda x: x[self.args.d_inner :, :].transpose(-1, -2),
+            postfix="mlp",
+            tt_dtype=ttnn.bfloat8_b,
         )
 
         # down proj wt
         out_proj_weight_name = "mixer.out_proj.weight"
-        self.out_proj_weights = load_fn(out_proj_weight_name, lambda x: x.transpose(-1, -2))
+        self.out_proj_weights = load_fn(out_proj_weight_name, lambda x: x.transpose(-1, -2), tt_dtype=ttnn.bfloat8_b)
 
         # conv states
         conv1d_weight_name = "mixer.conv1d.weight"


### PR DESCRIPTION
Change weights in Mamba block MLPs to bfloat16 to bfloat8.

Closes #7023 