### PR TITLE
Fix minor grammatical errors in METALIUM-GUIDE.md

### DIFF
--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -7,16 +7,12 @@
 
 ## TT Architecture and Metalium Overview
 
-Tenstorrent has built the future of AI architecture and parallel programming. 
-It achieves high performance on current AI models but is flexible and programmable to enable invention of future AI models and HPC applications without the constraints of current architectures.
-It is designed for both inference and training, and is from ground up designed for scale-out of AI workloads, while allowing to be scaled down to a couple of cores.
+Tenstorrent has built the future of AI architecture and parallel programming.
+It achieves high performance on current AI models but is flexible and programmable, enabling the invention of future AI models and HPC (High-Performance Computing) applications without the constraints of current architectures.
+It is designed for both inference and training and is, from the ground up, designed for the scale-out of AI workloads, while also allowing for scaling down to just a couple of cores.
 Additionally, it is built using cost-effective components: simple packages, GDDR memory and Ethernet.
-This document desribes it. 
+This document describes it.
 
-* [All you need is a Tensix core and a mesh](#all-you-need-is-a-tensix-core-and-a-mesh)
-  - [Near Memory Compute and Efficient use of SRAM](#near-memory-compute-and-efficient-use-of-SRAM)
-  - [Distributed Shared Memory and In-Place Compute](#distributed-memory-and-in-place-compute)
-  - [Explicit Data Movement](#explicit-data-movement)
   - [Native Tile-Based Compute](#native-tile-based-compute)
   - [Think Bare Metal Cores, Not Threads](#native-tile-processing)
 * [Scalable Architecture](#scalable-architecture)
@@ -24,10 +20,10 @@ This document desribes it.
   - [Compute Density via Scale-Out](#compute-desnsity-via-scale-out)
 * [MIMD and Control of Both Compute and Data](#mimd-and-control-of-both-compute-and-data)
 * [Everything is a RISCV kernel](#everything-is-a-riscv-kernel)
-  - Bare Metal C/C++ kernels on RISCV 
+  - Bare Metal C/C++ kernels on RISCV
   - [User Kernels: Explicit and Decoupled Data Movement and Compute](#user-kernels-explicit-and-decoupled-data-movement-and-compute)
     - Data Movement Kernels
-    - Compute Kernels 
+    - Compute Kernels
     - Ethernet Data Movement Kernels
     - Read-Compute-Write kernel pipeline
   - Dispatch Kernels
@@ -35,16 +31,16 @@ This document desribes it.
 * [Interleaved and Sharded Buffers](#interleaved-and-sharded-buffers)
 * [Fast Kernel Dispatch](#fast-kernel-dispatch)
 * [FAQ](#FAQ)
-  - [What about CUDA, scalar threads, and caches?](#what-about-cuda-scalar-threads-and-caches)  
+  - [What about CUDA, scalar threads, and caches?](#what-about-cuda-scalar-threads-and-caches)
   - [What about HBM?](#what-about-HBM)
   - [For GPU, CPU, FPGA, TPU experts](#for-gpu-cpu-fpga-tpu-experts)
   - [First Principles Summary](#first-principles-summary)
 
-### All you need is a Tensix core and a mesh 
+### All you need is a Tensix core and a mesh
  A Tensix Core is:
  - **5 small RISC-V processors** (aka "Baby RISCVs") that run C/C++ kernels and dispatch instructions to the compute and data movement engines
  - **1 MB SRAM memory**, (aka L1) a scratch pad accessible by all RISCVs and engines within the core
- - **Matrix engine (aka FPU)** that performs Matrix multiplication, elementwise, and dot product operations on small matricies (or tiles) of shape 32x32 and similar
+ - **Matrix engine (aka FPU)** that performs Matrix multiplication, elementwise, and dot product operations on small matrices (or tiles) of shape 32x32 and similar
  - **Vector engine (aka SFPU)** for vectorized kernels such as Top-k, Sort and special functions such as GELU, Exp, and Sqrt
  - **Data Movement engine** connected to 2 Networks on Chip (NoCs)
 
@@ -58,61 +54,61 @@ A chips is a collection of cores and I/O blocks, connected into a mesh via a NoC
 <img width="900" alt="image" src="https://github.com/tenstorrent-metal/tt-metal/assets/3885633/78d64b36-bb68-4d41-b2ca-5e3ed7ccda8f">
 
 #### Near Memory Compute and Efficient use of SRAM
-The **high BW and large capacity SRAM** in each Tensix core is a form of **near memory compute**. A Tensix core operating on its local SRAM achieves **"silicon peak"** of what current technology node allows for. 
+The **high BW and large capacity SRAM** in each Tensix core is a form of **near memory compute**. A Tensix core operating on its local SRAM achieves **"silicon peak"** of what current technology node allows for.
 Tensix cores are connected into a mesh via 2 NOCs, and each Tensix core can communicate with any other Tensix core in the mesh, and with off-chip DRAM, as well as Ethernet cores.
-GPU fracture SRAM across levels within the chip: large register files, small L1, and L2. SRAM is primarily used for re-use and pre-fetch on the way to off-chip DRAM, not as a primary form of Tensor storage and large parts of it not at the peak silicon speed. 
-In contract, in TT architecture, entire SRAM in one single level, and its significant capacity allows it be used as intermediates between operations, w/o relaying on HBM as the primary storage to hand-off data between operations.    
+GPU fracture SRAM across levels within the chip: large register files, small L1, and L2. SRAM is primarily used for re-use and pre-fetch on the way to off-chip DRAM, not as a primary form of Tensor storage and large parts of it not at the peak silicon speed.
+In contrast, in TT architecture, the entire SRAM is in one single level, and its significant capacity allows it be used as intermediates between operations, w/o relaying on HBM as the primary storage to hand-off data between operations.
 
 #### Distributed Shared Memory and In-Place Compute
-The mesh of Tensix cores architecture is the first one to efficiently implement distributed shared memory within the chip and **enable programmers and compilers to optimize both layout and movement of the data**. 
-In many AI and HPC operations, such as as elementwise, the tensors can be laid out (ie "sharded") across SRAMs so that compute can operate on the local data **in-place** without any data movement. 
-Further elaboration in [Scalable Architecture](#scalable-architecture) section.  
+The mesh of Tensix cores architecture is the first one to efficiently implement distributed shared memory within the chip and **enable programmers and compilers to optimize both layout and movement of the data**.
+In many AI and HPC operations, such as as elementwise, the tensors can be laid out (ie "sharded") across SRAMs so that compute can operate on the local data **in-place** without any data movement.
+Further elaboration in [Scalable Architecture](#scalable-architecture) section.
 
 #### Explicit Data Movement
-The performance and efficiency of data movement in AI and HPC application is as important as raw compute capacity of the math engines. 
-In Tenix, data movemenet is explicit and decoupled from compute. The data movement kernels use the data movement engine in each Tensix to bring data from neighbouring cores or off-chip DRAM to the local SRAM of the Tensix core, and trigger the compute engine to operate on the data. The data movement in TT architecture can be pre-planned, optimized and debugged separately from the compute.
-There is no caches, no global crossbars, no memory access coalesing or other complex mechanisms that are used in traditional architectures that hide the data movement from the programmer or compiler.
+The performance and efficiency of data movement in AI and HPC application is as important as raw compute capacity of the math engines.
+In Tenix, data movement is explicit and decoupled from compute. The data movement kernels use the data movement engine in each Tensix to bring data from neighbouring cores or off-chip DRAM to the local SRAM of the Tensix core, and trigger the compute engine to operate on the data. The data movement in TT architecture can be pre-planned, optimized and debugged separately from the compute.
+There is no caches, no global crossbars, no memory access coalescing or other complex mechanisms that are used in traditional architectures that hide the data movement from the programmer or compiler.
 For deeper insight see section [User Kernels: Explicit and Decoupled Data Movement and Compute](#user-kernels-explicit-and-decoupled-data-movement-and-compute).
 
 #### Native Tile-Based Compute
-In Tensix, compute instructions operate on tiles -- 32x32 matrix of scalars. Operating on coarse chunks of data allows for use of a simple single-threaded RISCVs processors to dispatch these instructions. 
-Similarly, data movement RISCVs issue asynchronous tile-sized data movement instructions to bring data into the scratch SRAM, allowing for large number of outstanding transfers generated by a single RISC-V data movement processor, concurrently with the compute engine. 
+In Tensix, compute instructions operate on tiles -- 32x32 matrix of scalars. Operating on coarse chunks of data allows for use of a simple single-threaded RISCVs processors to dispatch these instructions.
+Similarly, data movement RISCVs issue asynchronous tile-sized data movement instructions to bring data into the scratch SRAM, allowing for large number of outstanding transfers generated by a single RISC-V data movement processor, concurrently with the compute engine.
 
 #### Think Bare Metal Cores, Not Threads
 Each RISCV processor runs single-threaded and Core-to-Thread mapping is 1:1. Thus, the parallelization involves breaking the work across cores and dispatching the kernels directly to cores. This is in contrast to a complex thread scheduling scheme where a very large number of threads is time-slice scheduled onto a limited number of cores. As a result, in TT architecture there is no context switching or complex thread scheduling. Once the kernel is dispatched to a core it runs to completion without interruption or preemption by another thread. This simplifies reasoning about performance: it boils down to direct cycle couting of sections of a C/C++ kernel running on a bare metal RISCV core.
-Equally important, it simplifies direct debug of kernels via gdb step-through, breakpoints, and printf from cores. 
+Equally important, it simplifies direct debug of kernels via `gdb` step-through, breakpoints, and `printf` from cores.
 
 ### Scalable Architecture
 AI workloads operate on tensors (N-dimensional data) and exhibit a high degree of locality and regularity in the fundamental compute operations:
 - **Elementwise operations** are entirely local on each element in the tensor (in-place), and can be achieved without any data movement
 - **Matrix multiplication operations** have regular communication across the rows and columns of the matrix
 - **Reduction operation** can be decomposed across dimensions, such as columns, rows, and nearest neighbours in a matrix
-- **Window based (stencil) operations** such as convolutions exchage data with their neigbours
+- **Window based (stencil) operations** such as convolutions exchange data with their neighbours
 
 These data movement patterns (local, row/column, nearest neighbour) are most efficiently implemented via a regular and scalable mesh architecture.
 
-Tenstorrent architecture is a mesh of cores within a chip and mesh of chips at the cluster level. 
+Tenstorrent architecture is a mesh of cores within a chip and mesh of chips at the cluster level.
 <img width="900" alt="image" src="https://github.com/tenstorrent-metal/tt-metal/assets/3885633/0f40ace9-e2b3-4740-a89c-3e8a3580da8a">
 TODO: Describe Galaxy, break up the slide into two slides
 
 #### Two levels of memory
 
-TODO: Describe SRAM and DRAM as two levels of memory hierachy within the mesh, both distributed and explicit data movement.
+TODO: Describe SRAM and DRAM as two levels of memory hierarchy within the mesh, both distributed and explicit data movement.
 
 #### Compute Density via Scale-Out
 
-TODO: Describe that TT wins at scale-out, best compute density at the server and cluster level 
+TODO: Describe that TT wins at scale-out, best compute density at the server and cluster level
 
 ### MIMD and Control of Both Compute and Data
 
-- "Program cores not threads" 
+- "Program cores not threads"
 
 ### Everything is a RISCV kernel
 
- - Bare Metal C/C++ kernels on RISCV 
+ - Bare Metal C/C++ kernels on RISCV
   - User Kernels
     - Data Movement Kernels
-    - Compute Kernels 
+    - Compute Kernels
     - Ethernet Data Movement Kernels
   - Dispatch Kernels
   <img width="1176" alt="image" src="https://github.com/tenstorrent-metal/tt-metal/assets/3885633/d3c89155-6e4d-49cb-a95c-85654ac29e7d">
@@ -129,7 +125,7 @@ TODO: Describe that TT wins at scale-out, best compute density at the server an
 ### Fast Kernel Dispatch
 
 ### FAQ
-#### Where is CUDA, scalar threads, and caches? 
+#### Where is CUDA, scalar threads, and caches?
 #### Where is HBM?
 #### For GPU, CPU, FPGA, TPU experts
  - GPU
@@ -137,13 +133,13 @@ TODO: Describe that TT wins at scale-out, best compute density at the server an
  - FPGA
  - TPU
 #### First Principles Summary
-  
+
 
 
 
 ## TT Architecture deep dive
 
-TODO: 1) TOC, write it 
+TODO: 1) TOC, write it
 
 ## Learn Metalium in 7 steps
 
@@ -203,4 +199,3 @@ void MAIN {
 }
 }
 ```
-


### PR DESCRIPTION
This change fixes the following:
- Correct misspelled words and improve flow in a few sections
- Fix line endings as required by pre-commit hooks.