### PR TITLE
Falcon40b prefill bringup

### DIFF
--- a/models/demos/falcon40b/demo/demo.py
+++ b/models/demos/falcon40b/demo/demo.py
@@ -184,7 +184,7 @@ def print_output_prompts(generated_ids, tokenizer, num_users_to_display=None):
 def run_falcon_demo_kv(
     user_input,
     model_version,
-    model_config_str,
+    model_config_str_for_decode,
     model_config,
     batch_size,
     num_layers,
@@ -195,8 +195,6 @@ def run_falcon_demo_kv(
     prefill_on_host,
 ):
     torch.manual_seed(0)
-    for device in devices:
-        device.enable_program_cache()
 
     configuration = FalconConfig(**model_config_entries)
 
@@ -343,9 +341,12 @@ def run_falcon_demo_kv(
         tt_lib.device.Synchronize(device)
     logger.info("Finished 1st run prefill stage with compile!")
 
+    for device in devices:
+        device.enable_program_cache()
+
     ### First run decode stage with compile ###
     # Update model_config for decode
-    model_config = get_model_config(model_config_str, "decode", [batch_size, 1], len(devices))
+    model_config = get_model_config(model_config_str_for_decode, "decode", [batch_size, 1], len(devices))
     tt_FalconCausalLM.set_model_config(model_config)
 
     attention_mask_memconfig = model_config["ATTN_MASK_MEMCFG"]
@@ -591,7 +592,7 @@ def test_demo(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    use_program_cache,
+    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed; remove manually enabling for decode in test
 ):
     num_devices = 8
     devices = get_devices_for_t3000(all_devices, num_devices)
@@ -600,8 +601,8 @@ def test_demo(
     disable_compilation_reports()
 
     # Set it up for prefill initially and change the model_config to decode
-    model_config_str = "BFLOAT8_B-SHARDED"
-    model_config = get_model_config("BFLOAT8_B-SHARDED", "prefill", [1, 32], num_devices)
+    model_config_str_for_decode = "BFLOAT8_B-SHARDED"  # Decode model config
+    model_config = get_model_config("BFLOAT8_B-DRAM", "prefill", [1, 32], num_devices)  # Prefill model config
     model_version = model_config_entries["_name_or_path"]
     tt_cache_path = get_tt_cache_path(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
@@ -610,7 +611,7 @@ def test_demo(
     return run_falcon_demo_kv(
         user_input=user_input,
         model_version=model_version,
-        model_config_str=model_config_str,
+        model_config_str_for_decode=model_config_str_for_decode,
         model_config=model_config,
         batch_size=32,
         num_layers=model_config_entries["num_hidden_layers"],
@@ -618,5 +619,5 @@ def test_demo(
         model_location_generator=model_location_generator,
         tt_cache_path=tt_cache_path,
         devices=devices,
-        prefill_on_host=True,
+        prefill_on_host=False,
     )

--- a/models/demos/falcon40b/tests/ops/test_falcon_layernorm.py
+++ b/models/demos/falcon40b/tests/ops/test_falcon_layernorm.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import math
+from loguru import logger
+
+import tt_lib as ttl
+import ttnn
+from models.demos.falcon40b.tt.ops.falcon_layernorm import TtFalconLayernorm
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_pcc,
+)
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor, skip_for_grayskull, get_devices_for_t3000
+from models.demos.falcon40b.tt.model_config import (
+    get_model_config,
+)
+
+from models.demos.falcon40b.reference.hf_modeling_falcon import (
+    FalconForCausalLM,
+)
+
+from models.demos.falcon40b.tt.model_utils import (
+    convert_to_layout,
+)
+
+
+class PytorchFalconLayernorm(torch.nn.Module):
+    def __init__(self, hf_reference_model, layer_num=0):
+        super().__init__()
+        self.ln_attn = hf_reference_model.transformer.h[layer_num].ln_attn
+
+        # Disable dropout
+        self.ln_attn.eval()
+
+    def forward(self, x):
+        result = self.ln_attn(x)
+        return result
+
+
+def run_test_FalconLayernorm_inference(pcc, devices, model_location_generator, get_tt_cache_path):
+    is_sharded = True
+
+    seqlen = 1024
+    num_chips = 8
+
+    # Prepare input
+    torch.manual_seed(0)
+    model_input_shape = [1, seqlen]
+
+    model_version = "tiiuae/falcon-40b-instruct"
+
+    if is_sharded:
+        # model_config = get_model_config("BFLOAT8_B-SHARDED", "prefill", model_input_shape, num_chips) # Decode sharding
+        model_config = get_model_config(
+            "BFLOAT8_B-DRAM", "prefill", model_input_shape, num_chips
+        )  # Block sharding for layernorm to work around PCC issue
+    else:
+        model_config = get_model_config("BFLOAT8_B-DRAM", "prefill", model_input_shape, num_chips)
+
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
+
+    model_name = model_location_generator(model_version, model_subdir="Falcon")
+
+    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
+        model_name, low_cpu_mem_usage=True, num_hidden_layers=1
+    )
+    hugging_face_reference_model.eval()
+    config = hugging_face_reference_model.config
+
+    input_shape = [1, 1, seqlen, config.hidden_size]  # 4544 for 7b
+
+    input_torch = (torch.rand(input_shape) * 2) - 1
+    input = torch2tt_tensor(
+        input_torch, None, tt_dtype=ttl.tensor.DataType.BFLOAT8_B
+    )  # ttl.tensor.DataType.BFLOAT16 # TODO: should be BF16!!
+    input = input.to(devices[0], model_config["DEFAULT_MEMCFG"])
+
+    if is_sharded:
+        # # Option1 : width sharded; produces bad PCC
+        # shard_spec_32_cores_grid = ttl.tensor.CoreRangeSet(
+        #     {
+        #         ttl.tensor.CoreRange(
+        #             ttl.tensor.CoreCoord(0, 0),
+        #             ttl.tensor.CoreCoord(7, 3),
+        #         ),
+        #     }
+        # )
+        # input = ttl.tensor.interleaved_to_sharded(
+        #     input,
+        #     sharded_mem_config=ttl.tensor.MemoryConfig(
+        #         ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+        #         ttl.tensor.BufferType.L1,
+        #         ttl.tensor.ShardSpec(
+        #             shard_spec_32_cores_grid,
+        #             [
+        #                 seqlen,
+        #                 config.hidden_size // 32,
+        #             ],
+        #             ttl.tensor.ShardOrientation.ROW_MAJOR,
+        #             False,
+        #         ),
+        #     ),
+        # )
+
+        # # Option 2: block sharded hardcoded for S=128 and 8x4 grid of cores; produces good PCC!
+        # shard_spec_32_cores_grid = ttl.tensor.CoreRangeSet(
+        #         {
+        #             ttl.tensor.CoreRange(
+        #                 ttl.tensor.CoreCoord(0, 0),
+        #                 ttl.tensor.CoreCoord(7, 3),
+        #             ),
+        #         }
+        #     )
+        # input = ttl.tensor.interleaved_to_sharded(
+        #     input,
+        #     sharded_mem_config=ttl.tensor.MemoryConfig(
+        #     ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        #     ttl.tensor.BufferType.L1,
+        #     ttl.tensor.ShardSpec(
+        #         shard_spec_32_cores_grid,
+        #         [
+        #             32,
+        #             1024,
+        #         ],
+        #         ttl.tensor.ShardOrientation.ROW_MAJOR,
+        #         False,
+        #     ),
+        #     )
+        # )
+
+        # # Version according to model_config for debug
+        input = ttl.tensor.interleaved_to_sharded(
+            input,
+            sharded_mem_config=model_config["DECODER_ALL_GATHER_OUTPUT_MEMCFG"],
+        )
+
+    # PyTorch output --------------------------------------------------------------------
+    pytorch_FalconLayernorm_model = PytorchFalconLayernorm(hugging_face_reference_model)
+    torch_out = pytorch_FalconLayernorm_model(input_torch)
+
+    # TT hardware execution -------------------------------------------------------------
+    tt_Falcon_layernorm_model = TtFalconLayernorm(devices, model_config, config, tt_cache_path, is_sharded=is_sharded)
+
+    tt_out = tt_Falcon_layernorm_model(input)
+
+    if is_sharded:
+        tt_out = convert_to_layout(tt_out, model_config["LN_ATTN_OUTPUT_MEMCFG"], model_config["DEFAULT_MEMCFG"])
+
+    tt_out = tt2torch_tensor(tt_out)
+
+    # check outputs ----------------------------------------------------------------------
+    does_pass, output_pcc = comp_pcc(torch_out, tt_out, pcc)
+    logger.info(f"PCC value: {output_pcc}")
+
+    if does_pass:
+        logger.info("Falcon MLP output Passed!")
+    else:
+        logger.warning("Falcon MLP output Failed!")
+        assert does_pass, f"PCC value is lower than {pcc}"
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("pcc", [(0.99)])
+def test_FalconLayernorm_inference(
+    pcc,
+    all_devices,
+    model_location_generator,
+    get_tt_cache_path,
+):
+    devices = all_devices
+
+    run_test_FalconLayernorm_inference(pcc, devices, model_location_generator, get_tt_cache_path)

--- a/models/demos/falcon40b/tests/scripts/run_all_falcon40b_tests.sh
+++ b/models/demos/falcon40b/tests/scripts/run_all_falcon40b_tests.sh
@@ -1,0 +1,24 @@
+#/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$TT_METAL_HOME" ]]; then
+  echo "Must provide TT_METAL_HOME in environment" 1>&2
+  exit 1
+fi
+
+if [[ -z "$ARCH_NAME" ]]; then
+  echo "Must provide ARCH_NAME in environment" 1>&2
+  exit 1
+fi
+
+cd $TT_METAL_HOME
+export PYTHONPATH=$TT_METAL_HOME
+
+# Run all component tests
+pytest models/demos/falcon40b/tests/test_falcon_mlp.py -k test_FalconMLP_inference
+pytest models/demos/falcon40b/tests/test_falcon_attention.py -k test_FalconAttention_inference
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py -k run_test_FalconDecoder_inference
+pytest models/demos/falcon40b/tests/test_falcon_model.py -k test_FalconModel_inference
+pytest models/demos/falcon40b/tests/test_falcon_causallm.py -k test_FalconCausalLM_inference
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py -k test_FalconCausalLM_end_to_end_with_program_cache

--- a/models/demos/falcon40b/tests/scripts/run_representative_falcon40b_tests.sh
+++ b/models/demos/falcon40b/tests/scripts/run_representative_falcon40b_tests.sh
@@ -1,0 +1,50 @@
+#/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$TT_METAL_HOME" ]]; then
+  echo "Must provide TT_METAL_HOME in environment" 1>&2
+  exit 1
+fi
+
+if [[ -z "$ARCH_NAME" ]]; then
+  echo "Must provide ARCH_NAME in environment" 1>&2
+  exit 1
+fi
+
+cd $TT_METAL_HOME
+export PYTHONPATH=$TT_METAL_HOME
+
+# Run one of each component tests for prefill
+pytest models/demos/falcon40b/tests/test_falcon_mlp.py::test_FalconMLP_inference[BFLOAT8_B-DRAM-falcon_40b-prefill_seq128-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_attention.py::test_FalconAttention_inference[BFLOAT8_B-DRAM-falcon_40b-prefill_seq128-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-DRAM-falcon_40b-layer_0-prefill_seq128-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_model.py::test_FalconModel_inference[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_causallm.py::test_FalconCausalLM_inference[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips]
+
+
+# # Run one of each component tests for decode
+pytest models/demos/falcon40b/tests/test_falcon_mlp.py::test_FalconMLP_inference[BFLOAT8_B-SHARDED-falcon_40b-decode_batch32-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_attention.py::test_FalconAttention_inference[BFLOAT8_B-SHARDED-falcon_40b-decode_batch32-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_model.py::test_FalconModel_inference[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_causallm.py::test_FalconCausalLM_inference[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips]
+
+# Run a 4 chip test for decode
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-4chips]
+
+# Run prefill with sequence lengths = {32, 64, 128 (done above), 256, 512, 1024, 2048}
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq32-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq64-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq256-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq512-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq1024-8chips]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq2048-8chips]
+
+# Run prefill S=128 with 60L
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_60-prefill_seq128-8chips]
+
+# Run prefill S=2048 with 60L
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_60-prefill_seq2048-8chips]

--- a/models/demos/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/falcon40b/tests/test_falcon_attention.py
@@ -85,14 +85,18 @@ def run_test_FalconAttention_inference(
         layer_past = None
 
         tt_attention_input_host = torch2tt_tensor(
-            attention_input.unsqueeze(1), None, tt_dtype=model_config["LN_ATTN_OUTPUT_DTYPE"]
+            attention_input.unsqueeze(1), None, tt_dtype=model_config["ATTN_INPUT_DTYPE"]
         )
         tt_attention_input = []
         for device in devices:
-            tt_attention_input.append(tt_attention_input_host.to(device, model_config["LN_ATTN_OUTPUT_MEMCFG"]))
+            tt_attention_input.append(tt_attention_input_host.to(device, model_config["ATTN_INPUT_MEMCFG"]))
+
+        attention_mask_heads_dim = (
+            configuration.num_attention_heads if model_config["ATTN_MASK_MEMCFG"].is_sharded() else len(devices)
+        )
 
         attention_mask_bool_chunks = torch.chunk(
-            (attention_mask_bool * -100000).expand(-1, configuration.num_attention_heads, -1, -1),
+            (attention_mask_bool * -100000).expand(-1, attention_mask_heads_dim, -1, -1),
             len(devices),
             1,
         )
@@ -325,10 +329,11 @@ def run_test_FalconAttention_inference(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
         ("prefill", 1, 32, 0),
-        ("prefill", 1, 64, 0),
+        ("prefill", 1, 128, 0),
+        ("prefill", 1, 2048, 0),
         ("decode", 32, 1, 128),
     ),
-    ids=["prefill_seq32", "prefill_seq64", "decode_batch32"],
+    ids=["prefill_seq32", "prefill_seq128", "prefill_seq2048", "decode_batch32"],
 )
 @pytest.mark.parametrize(
     "model_version",
@@ -337,8 +342,12 @@ def run_test_FalconAttention_inference(
 )
 @pytest.mark.parametrize(
     "model_config_str, out_pcc, cache_pcc, token_pcc",
-    [("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99), ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99)],
-    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"],
+    [
+        ("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99),
+        ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99),
+        ("BFLOAT8_B-DRAM", 0.99, 0.99, 0.99),
+    ],
+    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM"],
 )
 def test_FalconAttention_inference(
     num_devices,
@@ -354,10 +363,12 @@ def test_FalconAttention_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    use_program_cache,
+    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
-    if llm_mode == "prefill" and model_config_str == "BFLOAT16-SHARDED":
-        pytest.skip("Prefill is only tested for BFLOAT8_B!")
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
+    if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
+        pytest.skip("Decode is only supported for SHARDED memory config!")
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)

--- a/models/demos/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon40b/tests/test_falcon_decoder.py
@@ -97,8 +97,12 @@ def run_test_FalconDecoder_inference(
                 )
             )
 
+        attention_mask_heads_dim = (
+            configuration.num_attention_heads if model_config["ATTN_MASK_MEMCFG"].is_sharded() else len(devices)
+        )
+
         attention_mask_bool_chunks = torch.chunk(
-            (attention_mask_bool * -100000).expand(-1, configuration.num_attention_heads, -1, -1),
+            (attention_mask_bool * -100000).expand(-1, attention_mask_heads_dim, -1, -1),
             len(devices),
             1,
         )
@@ -332,16 +336,22 @@ def run_test_FalconDecoder_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("enable_program_cache", (True, False), ids=["enable_program_cache", "disable_program_cache"])
 @pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
         ("prefill", 1, 32, 0),
-        ("prefill", 1, 64, 0),
         ("prefill", 1, 128, 0),
+        ("prefill", 1, 2048, 0),
         ("decode", 32, 1, 128),
     ),
-    ids=["prefill_seq32", "prefill_seq64", "prefill_seq128", "decode_batch32"],
+    ids=[
+        "prefill_seq32",
+        "prefill_seq128",
+        "prefill_seq2048",
+        "decode_batch32",
+    ],
 )
 @pytest.mark.parametrize(
     "layer_num",
@@ -355,8 +365,12 @@ def run_test_FalconDecoder_inference(
 )
 @pytest.mark.parametrize(
     "model_config_str, out_pcc, cache_pcc, token_pcc",
-    [("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99), ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99)],
-    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"],
+    [
+        ("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99),
+        ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99),
+        ("BFLOAT8_B-DRAM", 0.99, 0.99, 0.99),
+    ],
+    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM"],
 )
 def test_FalconDecoder_inference(
     num_devices,
@@ -370,13 +384,16 @@ def test_FalconDecoder_inference(
     cache_pcc,
     token_pcc,
     model_config_str,
+    enable_program_cache,
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    use_program_cache,
+    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
-    if llm_mode == "prefill" and model_config_str == "BFLOAT16-SHARDED":
-        pytest.skip("Prefill is only tested for BFLOAT8_B!")
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
+    if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
+        pytest.skip("Decode is only supported for SHARDED memory config!")
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
@@ -388,6 +405,10 @@ def test_FalconDecoder_inference(
     tt_cache_path = get_tt_cache_path(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
     )
+
+    if enable_program_cache:
+        for device in devices:
+            device.enable_program_cache()
 
     run_test_FalconDecoder_inference(
         devices,
@@ -404,3 +425,7 @@ def test_FalconDecoder_inference(
         tt_cache_path,
         model_location_generator,
     )
+
+    if enable_program_cache:
+        for device in devices:
+            device.disable_and_clear_program_cache()

--- a/models/demos/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon40b/tests/test_falcon_end_to_end.py
@@ -12,7 +12,6 @@ from models.demos.falcon40b.reference.hf_modeling_falcon import (
 )
 from models.demos.falcon40b.tt.falcon_causallm import TtFalconCausalLM
 
-# TODO: Remove this?
 from models.demos.falcon40b.tt.falcon_common import (
     PytorchFalconCausalLM,
 )
@@ -393,27 +392,44 @@ def run_test_FalconCausalLM_end_to_end(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("enable_program_cache", (True, False), ids=["enable_program_cache", "disable_program_cache"])
 @pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
+        ("prefill", 1, 32, 0),
         ("prefill", 2, 32, 0),
-        ("prefill", 2, 64, 0),
+        ("prefill", 1, 64, 0),
+        ("prefill", 1, 128, 0),
+        ("prefill", 1, 256, 0),
+        ("prefill", 1, 512, 0),
+        ("prefill", 1, 1024, 0),
+        ("prefill", 1, 2048, 0),
         ("decode", 32, 1, 128),
     ),
-    ids=["prefill_seq32", "prefill_seq64", "decode_batch32"],
+    ids=[
+        "prefill_seq32",
+        "prefill_seq32_batch2",
+        "prefill_seq64",
+        "prefill_seq128",
+        "prefill_seq256",
+        "prefill_seq512",
+        "prefill_seq1024",
+        "prefill_seq2048",
+        "decode_batch32",
+    ],
 )
 @pytest.mark.parametrize(
     "num_layers, out_pcc, cache_pcc, token_pcc",
-    ((1, 0.99, 0.99, 0.99), (2, 0.99, 0.99, 0.99), (60, 0.92, 0.99, 0.85)),
-    ids=["layers_1", "layers_2", "layers_60"],
+    ((1, 0.99, 0.99, 0.99), (60, 0.92, 0.99, 0.85)),
+    ids=["layers_1", "layers_60"],
 )
 @pytest.mark.parametrize(
     "model_version",
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
-@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-SHARDED",))
+@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-SHARDED", "BFLOAT8_B-DRAM"))
 def test_FalconCausalLM_end_to_end_with_program_cache(
     num_devices,
     model_version,
@@ -427,24 +443,28 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     token_pcc,
     request,
     model_config_str,
+    enable_program_cache,
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    use_program_cache,
+    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config and 8 chips!")
+    if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
+        pytest.skip("Decode is only supported for SHARDED memory config!")
+
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config and 8 chips!")
+
     if llm_mode == "prefill":
-        if model_config_str == "BFLOAT16-SHARDED":
-            pytest.skip("Prefill is only tested for BFLOAT8_B!")
-        elif model_config_str == "BFLOAT8_B-SHARDED":
-            # TODO: Investigate why PCC is lower for prefill?
-            if num_layers == 1:
+        if num_layers == 60:
+            if seq_len == 2048:
+                out_pcc = 0.93
+                cache_pcc = 0.92
+            else:
                 out_pcc = 0.92
-            elif num_layers == 2:
-                out_pcc = 0.88
-                cache_pcc = 0.91
-            elif num_layers == 60:
-                out_pcc = 0.75
-                cache_pcc = 0.32
+                cache_pcc = 0.94
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
@@ -459,6 +479,10 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
 
     disable_persistent_kernel_cache()
     disable_compilation_reports()
+
+    if enable_program_cache:
+        for device in devices:
+            device.enable_program_cache()
 
     run_test_FalconCausalLM_end_to_end(
         devices,
@@ -475,3 +499,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
         tt_cache_path,
         model_location_generator,
     )
+
+    if enable_program_cache:
+        for device in devices:
+            device.disable_and_clear_program_cache()

--- a/models/demos/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/falcon40b/tests/test_falcon_model.py
@@ -307,10 +307,13 @@ def run_test_FalconModel_inference(
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
+        ("prefill", 1, 32, 0),
         ("prefill", 2, 32, 0),
+        ("prefill", 1, 128, 0),
+        ("prefill", 1, 2048, 0),
         ("decode", 32, 1, 128),
     ),
-    ids=["prefill_seq32", "decode_batch32"],
+    ids=["prefill_seq32", "prefill_seq32_batch2", "prefill_seq128", "prefill_seq2048", "decode_batch32"],
 )
 @pytest.mark.parametrize(
     "num_layers",
@@ -324,7 +327,12 @@ def run_test_FalconModel_inference(
 )
 @pytest.mark.parametrize(
     "model_config_str, out_pcc, cache_pcc, token_pcc",
-    [("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99), ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99)],
+    [
+        ("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99),
+        ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99),
+        ("BFLOAT8_B-DRAM", 0.99, 0.99, 0.99),
+    ],
+    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM"],
 )
 def test_FalconModel_inference(
     num_devices,
@@ -341,14 +349,12 @@ def test_FalconModel_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    use_program_cache,
+    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
-    if llm_mode == "prefill":
-        if model_config_str == "BFLOAT16-SHARDED":
-            pytest.skip("Prefill is only tested for BFLOAT8_B!")
-        elif model_config_str == "BFLOAT8_B-SHARDED":
-            # TODO: Investigate why PCC is lower for prefill?
-            out_pcc = 0.95
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config and 8 chips!")
+    if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
+        pytest.skip("Decode is only supported for SHARDED memory config!")
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)

--- a/models/demos/falcon40b/tt/model_config.py
+++ b/models/demos/falcon40b/tt/model_config.py
@@ -25,9 +25,13 @@ OP_KEYS = (
     "SIN_CACHED_WEIGHTS",
     "COS_CACHED_WEIGHTS",
     # Attention
+    "ATTN_INPUT",
     "FUSED_QKV_MM_WEIGHTS",
+    "FUSED_QKV_MM_INPUT",
     "FUSED_QKV_MM_OUTPUT",
+    "CREATE_QKV_HEADS_INPUT",
     "CREATE_QKV_HEADS_OUTPUT",
+    "CREATE_KV_HEADS_OUTPUT",
     "ROTARY_EMBEDDING_OUTPUT",
     "K_CACHE_SLICE_OUTPUT",
     "V_CACHE_SLICE_OUTPUT",
@@ -42,11 +46,14 @@ OP_KEYS = (
     "SELFOUT_MM_OUTPUT",
     "DENSE_H_TO_4H_MM_WEIGHTS",
     "DENSE_H_TO_4H_MM_OUTPUT",
+    "MLP_ALL_GATHER_OUTPUT",
     "DENSE_4H_TO_H_MM_WEIGHTS",
     "DENSE_4H_TO_H_MM_OUTPUT",
+    "ATTN_ALL_GATHER_OUTPUT",
     # Decoder Cont
     "PARALLEL_ATTN_ADD_OUTPUT",
     "DROPOUT_ADD_OUTPUT",
+    "DECODER_ALL_GATHER_OUTPUT",
     # Model
     "LN_F_WEIGHTS",
     "LN_F_BIAS",
@@ -54,6 +61,7 @@ OP_KEYS = (
     # LM Head
     "LM_HEAD_MM_WEIGHTS",
     "LM_HEAD_MM_OUTPUT",
+    "FINAL_ALL_GATHER_OUTPUT",
 )
 
 NO_MEMCFG = ("SOFTMAX_OUTPUT",)
@@ -74,7 +82,8 @@ NO_DTYPE = (
     "DROPOUT_ADD_OUTPUT",
 )
 
-ACCEPTABLE_MODEL_CONFIG_STRS = ("BFLOAT16-SHARDED", "BFLOAT8_B-SHARDED")
+ACCEPTABLE_DECODE_MODEL_CONFIG_STRS = ("BFLOAT16-SHARDED", "BFLOAT8_B-SHARDED")
+ACCEPTABLE_PREFILL_MODEL_CONFIG_STRS = ("BFLOAT8_B-DRAM", "BFLOAT16-DRAM")
 
 model_config_entries = {
     "_name_or_path": "tiiuae/falcon-40b-instruct",
@@ -127,8 +136,19 @@ def pretty_print_model_config(model_config):
 
 
 def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
-    assert model_config_str in ACCEPTABLE_MODEL_CONFIG_STRS
     assert llm_mode in ("prefill", "decode")
+    assert len(input_shape) == 2
+    assert num_devices in (4, 8)
+
+    if llm_mode == "prefill":
+        return get_prefill_model_config(model_config_str, input_shape, num_devices)
+    elif llm_mode == "decode":
+        return get_decode_model_config(model_config_str, input_shape, num_devices)
+    assert False
+
+
+def get_decode_model_config(model_config_str, input_shape, num_devices):
+    assert model_config_str in ACCEPTABLE_DECODE_MODEL_CONFIG_STRS
     assert len(input_shape) == 2
     assert num_devices in (4, 8)
 
@@ -144,7 +164,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
     BFP8_DTYPE = ttl.tensor.DataType.BFLOAT8_B
 
     # Set default dtype and mem_config based on model_config_str
-    if model_config_str in ACCEPTABLE_MODEL_CONFIG_STRS:
+    if model_config_str in ACCEPTABLE_DECODE_MODEL_CONFIG_STRS:
         dtype_str, mem_config_str = model_config_str.split("-")
         # TODO: Set default memcfg for BFLOAT16-L1 to L1
         mem_config = DRAM_MEMCFG if mem_config_str == "DRAM" else L1_MEMCFG
@@ -167,6 +187,14 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         ),
+        "COMPUTE_KERNEL_FP16_ACC_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        ),
+        "DRAM_MEMCFG": DRAM_MEMCFG,
+        "L1_MEMCFG": L1_MEMCFG,
     }
     model_config.update({f"{key}_MEMCFG": mem_config for key in OP_KEYS if key not in NO_MEMCFG})
     model_config.update({f"{key}_DTYPE": dtype for key in OP_KEYS if key not in NO_DTYPE})
@@ -184,6 +212,20 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
     model_config["KV_CACHE_MEMCFG"] = DRAM_MEMCFG
     model_config["KV_CACHE_DTYPE"] = BFP8_DTYPE
 
+    # # TODO: use BFLOAT16 for the attention mask!
+    # # model_config["KV_CACHE_MEMCFG"] = DRAM_MEMCFG
+    # model_config["ATTN_MASK_DTYPE"] = BFLOAT16_DTYPE
+
+    head_dim = 64
+    hidden_size = model_config_entries["hidden_size"]
+    vocab_size = model_config_entries["vocab_size"]
+    num_attention_heads = model_config_entries["num_attention_heads"]
+    num_kv_heads = model_config_entries["num_kv_heads"]
+
+    batch, seq_len = input_shape
+    assert batch == 32
+    row_height = batch
+
     if model_config_str in ("BFLOAT16-L1",):
         model_config["ROTARY_EMBEDDING_OUTPUT_MEMCFG"] = L1_MEMCFG
         model_config["K_CACHE_SLICE_OUTPUT_MEMCFG"] = L1_MEMCFG
@@ -195,19 +237,6 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
         model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"] = L1_MEMCFG
 
     if mem_config_str == "SHARDED":
-        head_dim = 64
-        hidden_size = model_config_entries["hidden_size"]
-        vocab_size = model_config_entries["vocab_size"]
-        num_attention_heads = model_config_entries["num_attention_heads"]
-        num_kv_heads = model_config_entries["num_kv_heads"]
-
-        batch, seq_len = input_shape
-        if llm_mode == "prefill":
-            shard_height = seq_len
-        elif llm_mode == "decode":
-            assert batch == 32
-            shard_height = batch
-
         shard_spec_32_cores_grid = ttl.tensor.CoreRangeSet(
             {
                 ttl.tensor.CoreRange(
@@ -271,7 +300,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_hidden_dim_per_device_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -284,7 +313,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     1,  # Dynamic
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -297,7 +326,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_hidden_dim_per_device_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -310,7 +339,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_hidden_dim_per_device_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -325,7 +354,20 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
+                    shard_width_hidden_dim_across_32_cores,
+                ],
+                ttl.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
+        model_config["LN_ATTN_INPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+            ttl.tensor.BufferType.L1,
+            ttl.tensor.ShardSpec(
+                shard_spec_32_cores_grid,
+                [
+                    row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -338,7 +380,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -365,7 +407,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -380,7 +422,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_8_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_hidden_dim_across_8_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -393,7 +435,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=32,  # TODO: Can this be larger
                 out_subblock_h=1,  # TODO: Can this be larger
                 out_subblock_w=3,
-                per_core_M=shard_height // 32,
+                per_core_M=row_height // 32,
                 per_core_N=9,
                 fuse_batch=True,
                 fused_activation=None,
@@ -405,7 +447,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=32,  # TODO: Can this be larger
                 out_subblock_h=1,  # TODO: Can this be larger
                 out_subblock_w=1,
-                per_core_M=shard_height // 32,
+                per_core_M=row_height // 32,
                 per_core_N=5,
                 fuse_batch=True,
                 fused_activation=None,
@@ -417,7 +459,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_8_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_qkv_heads_per_device_across_8_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -431,7 +473,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 ttl.tensor.ShardSpec(
                     shard_spec_2_cores_grid,
                     [
-                        shard_height,
+                        row_height,
                         total_width_per_group_of_qkv_heads,  # Must always be minimum a full group
                     ],
                     ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -445,7 +487,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 ttl.tensor.ShardSpec(
                     shard_spec_1_cores_grid,
                     [
-                        shard_height,
+                        row_height,
                         total_width_per_group_of_qkv_heads,  # Must always be minimum a full group
                     ],
                     ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -461,7 +503,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 ttl.tensor.ShardSpec(
                     shard_spec_32_cores_grid,
                     [
-                        shard_height,
+                        row_height,
                         head_dim,
                     ],
                     ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -474,7 +516,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 ttl.tensor.ShardSpec(
                     shard_spec_2_cores_grid,
                     [
-                        shard_height,
+                        row_height,
                         head_dim,
                     ],
                     ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -488,7 +530,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 ttl.tensor.ShardSpec(
                     shard_spec_16_cores_grid,
                     [
-                        shard_height,
+                        row_height,
                         head_dim,
                     ],
                     ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -501,7 +543,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 ttl.tensor.ShardSpec(
                     shard_spec_1_cores_grid,
                     [
-                        shard_height,
+                        row_height,
                         head_dim,
                     ],
                     ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -524,45 +566,18 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
         )
         model_config["K_TRANSPOSED_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
         model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
-        # TODO: Remove if we can update prefill matmul to directly output sharded
-        model_config["PREFILL_4CHIPS_PRE_SOFTMAX_MM_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.BufferType.L1,
-            ttl.tensor.ShardSpec(
-                shard_spec_32_cores_grid,
-                [
-                    shard_height,
-                    shard_height,
-                ],
-                ttl.tensor.ShardOrientation.ROW_MAJOR,
-                False,
-            ),
-        )
-        model_config["PREFILL_4CHIPS_POST_SOFTMAX_MM_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.BufferType.L1,
-            ttl.tensor.ShardSpec(
-                shard_spec_32_cores_grid,
-                [
-                    shard_height,
-                    head_dim,
-                ],
-                ttl.tensor.ShardOrientation.ROW_MAJOR,
-                False,
-            ),
-        )
         if num_devices == 4:
             model_config["SOFTMAX_PROGCFG"] = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 subblock_w=1,
-                block_h=shard_height // 32,
+                block_h=row_height // 32,
                 block_w=1,  # Dynamic
             )
         elif num_devices == 8:
             model_config["SOFTMAX_PROGCFG"] = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
                 compute_with_storage_grid_size=(8, 2),
                 subblock_w=1,
-                block_h=shard_height // 32,
+                block_h=row_height // 32,
                 block_w=1,  # Dynamic
             )
         model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
@@ -573,7 +588,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -588,7 +603,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_4x_hidden_dim_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -602,7 +617,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=8,  # TODO: Can this be larger
                 out_subblock_h=1,  # TODO: Can this be larger
                 out_subblock_w=2,
-                per_core_M=shard_height // 32,
+                per_core_M=row_height // 32,
                 per_core_N=2,
                 fuse_batch=True,
                 fused_activation=None,
@@ -616,7 +631,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=8,  # TODO: Can this be larger
                 out_subblock_h=1,  # TODO: Can this be larger
                 out_subblock_w=4,
-                per_core_M=shard_height // 32,
+                per_core_M=row_height // 32,
                 per_core_N=8,
                 fuse_batch=True,
                 fused_activation=[ttl.tensor.FusibleActivation.GELU, True],
@@ -629,7 +644,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=32,  # TODO: Can this be larger
                 out_subblock_h=1,  # TODO: Can this be larger
                 out_subblock_w=2,
-                per_core_M=shard_height // 32,
+                per_core_M=row_height // 32,
                 per_core_N=2,
                 fuse_batch=True,
                 fused_activation=None,
@@ -641,7 +656,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=8,  # TODO: Can this be larger
                 out_subblock_h=1,  # TODO: Can this be larger
                 out_subblock_w=1,
-                per_core_M=shard_height // 32,
+                per_core_M=row_height // 32,
                 per_core_N=1,
                 fuse_batch=True,
                 fused_activation=None,
@@ -655,7 +670,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=8,  # TODO: Can this be larger
                 out_subblock_h=1,  # TODO: Can this be larger
                 out_subblock_w=4,
-                per_core_M=shard_height // 32,
+                per_core_M=row_height // 32,
                 per_core_N=4,
                 fuse_batch=True,
                 fused_activation=[ttl.tensor.FusibleActivation.GELU, True],
@@ -668,7 +683,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=32,  # TODO: Can this be larger
                 out_subblock_h=1,  # TODO: Can this be larger
                 out_subblock_w=1,
-                per_core_M=shard_height // 32,
+                per_core_M=row_height // 32,
                 per_core_N=1,
                 fuse_batch=True,
                 fused_activation=None,
@@ -681,7 +696,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -694,7 +709,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
             ttl.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
-                    shard_height,
+                    row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
                 ttl.tensor.ShardOrientation.ROW_MAJOR,
@@ -717,7 +732,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=8,
                 out_subblock_h=1,
                 out_subblock_w=4,
-                per_core_M=1,
+                per_core_M=row_height // 32,
                 per_core_N=16,
                 fuse_batch=True,
                 fused_activation=None,
@@ -729,7 +744,7 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
                 in0_block_w=8,
                 out_subblock_h=1,
                 out_subblock_w=4,
-                per_core_M=1,
+                per_core_M=row_height // 32,
                 per_core_N=8,
                 fuse_batch=True,
                 fused_activation=None,
@@ -740,3 +755,254 @@ def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
     # logger.debug(f"Falcon model config: \n{pretty_print_model_config(model_config)}")
 
     return model_config
+
+
+def get_prefill_model_config(model_config_str, input_shape, num_devices):
+    assert model_config_str in ACCEPTABLE_PREFILL_MODEL_CONFIG_STRS
+    assert len(input_shape) == 2
+    assert num_devices == 8, "Prefill is only supported on 8 devicess"
+
+    DRAM_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    L1_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    WIDTH_SHARDED_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED, ttl.tensor.BufferType.L1
+    )
+    HEIGHT_SHARDED_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1
+    )
+    BFLOAT16_DTYPE = ttl.tensor.DataType.BFLOAT16
+    BFP8_DTYPE = ttl.tensor.DataType.BFLOAT8_B
+
+    # Set default dtype and mem_config based on model_config_str
+    if model_config_str in ACCEPTABLE_PREFILL_MODEL_CONFIG_STRS:
+        dtype_str, mem_config_str = model_config_str.split("-")
+        mem_config = DRAM_MEMCFG if mem_config_str == "DRAM" else L1_MEMCFG
+        dtype = getattr(ttl.tensor.DataType, dtype_str)
+    else:
+        raise NotImplementedError(f"Model config {model_config_str} is not supported!")
+
+    # Set defaults for dtype and mem_config for all ops
+    model_config = {
+        "DEFAULT_DTYPE": dtype,
+        "DEFAULT_MEMCFG": mem_config,
+        "MOVE_DECODER_OUTPUT_BOOL": False,
+        "NUM_DEVICES": num_devices,
+        "MAX_GRID_SIZE": (8, 4),
+        "ALL_GATHER_NUM_LINKS": 2 if num_devices == 4 else 1,
+        "DEFAULT_CACHE_PATH": Path(f"models/demos/falcon40b/datasets/"),
+        "COMPUTE_KERNEL_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        ),
+        "COMPUTE_KERNEL_FP16_ACC_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        ),
+        "DRAM_MEMCFG": DRAM_MEMCFG,
+        "L1_MEMCFG": L1_MEMCFG,
+    }
+    model_config.update({f"{key}_MEMCFG": mem_config for key in OP_KEYS if key not in NO_MEMCFG})
+    model_config.update({f"{key}_DTYPE": dtype for key in OP_KEYS if key not in NO_DTYPE})
+
+    # Matmul Weights must always be BFP8_B
+    # Override defaults for certain configs
+    for key in model_config.keys():
+        if "MM_WEIGHTS_DTYPE" in key:
+            model_config[key] = BFP8_DTYPE
+        elif "WEIGHTS_MEMCFG" in key or "BIAS_MEMCFG" in key:
+            model_config[key] = DRAM_MEMCFG
+        elif "LN" in key and ("WEIGHTS_DTYPE" in key or "BIAS_DTYPE" in key):
+            model_config[key] = BFLOAT16_DTYPE
+
+    model_config["KV_CACHE_MEMCFG"] = DRAM_MEMCFG
+    model_config["KV_CACHE_DTYPE"] = BFP8_DTYPE
+
+    # # TODO: use BFLOAT16 for the attention mask!
+    # # model_config["KV_CACHE_MEMCFG"] = DRAM_MEMCFG
+    # model_config["ATTN_MASK_DTYPE"] = BFLOAT16_DTYPE
+
+    head_dim = 64
+    hidden_size = model_config_entries["hidden_size"]
+    vocab_size = model_config_entries["vocab_size"]
+    num_attention_heads = model_config_entries["num_attention_heads"]
+    num_kv_heads = model_config_entries["num_kv_heads"]
+
+    row_height = input_shape[1]
+
+    # Layernorm is an exception that are sharded also here, because the interleaved OP does not fit in L1 for 40b hidden size
+    layernorm_num_cores_x = 8
+    layernorm_max_num_cores_y = 7
+
+    layernorm_slice_size = 512
+
+    (
+        layernorm_block_sharded_mem_config,
+        layernorm_block_sharded_prg_config,
+        layernorm_block_sharded_prg_config_inplace,
+        layernorm_params,
+    ) = get_sharded_layernorm_specs_for_seqlen(
+        layernorm_num_cores_x,
+        layernorm_max_num_cores_y,
+        row_height if row_height <= layernorm_slice_size else layernorm_slice_size,
+        hidden_size,
+        dtype,
+    )
+
+    # partial block sharded layernorm
+    model_config["PARTIAL_LN_MEMCFG"] = layernorm_block_sharded_mem_config
+    model_config["PARTIAL_LN_PROGCFG"] = layernorm_block_sharded_prg_config
+    model_config["PARTIAL_LN_INPLACE_PROGCFG"] = layernorm_block_sharded_prg_config_inplace
+
+    model_config["layernorm_params"] = layernorm_params
+
+    # Specify program configs
+
+    # QKV Projection
+    model_config["QKV_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(8, 4),
+        in0_block_w=16,  # TODO: Can this be larger # 256 tiles in K
+        out_subblock_h=4,  # TODO: Can this be larger
+        out_subblock_w=1,
+        per_core_M=row_height // 32 // 8,  # S2048: 8
+        per_core_N=1152 // 32 // 4,  # 9
+        fused_activation=None,
+        transpose_mcast=True,
+    )
+
+    # Softmax
+    model_config["SOFTMAX_PROGCFG"] = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=(8, 2),
+        subblock_w=1,
+        block_h=row_height // 32,
+        block_w=1,  # Dynamic
+    )
+
+    # Dense Out
+    # input: [S, 8k], weight: [8k, 1k]
+    model_config["SELFOUT_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(8, 4),
+        in0_block_w=16,  # 256 tiles in K
+        out_subblock_h=4,
+        out_subblock_w=1,
+        per_core_M=row_height // 32 // 4,  # S2048: 16
+        per_core_N=1024 // 32 // 8,  # 4
+        fused_activation=None,
+        transpose_mcast=False,
+    )
+
+    # MLP FF1
+    model_config["DENSE_H_TO_4H_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(8, 4),
+        in0_block_w=8,  # how much inner dim you take each time
+        out_subblock_h=1,  # Must be divisible by per_core_M
+        out_subblock_w=4,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
+        per_core_M=row_height // 32 // 4,  # S2048: 16 M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
+        per_core_N=16,  # N / TILE_WIDTH / Grid_Size
+        transpose_mcast=False,
+        fused_activation=[ttl.tensor.FusibleActivation.GELU, True],
+    )
+
+    # MLP FF2
+    model_config["DENSE_4H_TO_H_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(8, 4),
+        in0_block_w=8,  # how much inner dim you take each time
+        out_subblock_h=1,  # Must be divisible by per_core_M
+        out_subblock_w=4,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
+        per_core_M=row_height // 32 // 4,  # S2048: 16 # M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
+        per_core_N=4,  # N / TILE_WIDTH / Grid_Size
+        transpose_mcast=False,
+        fused_activation=None,
+    )
+
+    # LM Head
+    # input: [S, 8k], weight: [8k, 8k]
+    model_config["LM_HEAD_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(8, 8),
+        in0_block_w=1,  # how much inner dim you take each time
+        out_subblock_h=1,  # Must be divisible by per_core_M
+        out_subblock_w=4,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
+        per_core_M=row_height // 32 // 8,  # S2048: 8 M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
+        per_core_N=8192 // 32 // 8,  # 64,  # N / TILE_WIDTH / Grid_Size
+        transpose_mcast=False,
+        fused_activation=None,
+    )
+
+    # uncomment if need to see all the configs
+    # logger.debug(f"Falcon model config: \n{pretty_print_model_config(model_config)}")
+
+    return model_config
+
+
+def get_sharded_layernorm_specs_for_seqlen(
+    layernorm_num_cores_x, layernorm_max_num_cores_y, partial_seqlen, hidden_size, dtype
+):
+    for i in range(layernorm_max_num_cores_y, 0, -1):
+        if (partial_seqlen // 32) % i == 0:
+            layernorm_num_cores_y = i
+            break
+
+    num_tiles_per_core_h = partial_seqlen // 32 // layernorm_num_cores_y
+    num_tiles_per_core_w = hidden_size // 32 // layernorm_num_cores_x
+
+    layernorm_shard_height_hidden_dim = partial_seqlen // layernorm_num_cores_y
+    layernorm_shard_width_hidden_dim = hidden_size // layernorm_num_cores_x
+
+    core_range_block_sharded_layernorm = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(layernorm_num_cores_x - 1, layernorm_num_cores_y - 1),
+            ),
+        }
+    )
+
+    layernorm_block_sharded_mem_config = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            core_range_block_sharded_layernorm,
+            [
+                layernorm_shard_height_hidden_dim,
+                layernorm_shard_width_hidden_dim,
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+
+    layernorm_block_sharded_prg_config = ttl.operations.primary.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=[layernorm_num_cores_x, layernorm_max_num_cores_y],
+        subblock_w=8,
+        block_h=num_tiles_per_core_h,
+        block_w=num_tiles_per_core_w,
+        inplace=False,
+    )
+    layernorm_block_sharded_prg_config_inplace = ttl.operations.primary.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=[layernorm_num_cores_x, layernorm_max_num_cores_y],
+        subblock_w=8,
+        block_h=num_tiles_per_core_h,
+        block_w=num_tiles_per_core_w,
+        inplace=True,
+    )
+
+    layernorm_params = {
+        "slice_size": partial_seqlen,
+        "layernorm_num_cores_x": layernorm_num_cores_x,
+        "layernorm_num_cores_y": layernorm_num_cores_y,
+        "layernorm_max_num_cores_y": layernorm_max_num_cores_y,
+        "layernorm_shard_height_hidden_dim": layernorm_shard_height_hidden_dim,
+        "layernorm_shard_width_hidden_dim": layernorm_shard_width_hidden_dim,
+        "num_tiles_per_core_h": num_tiles_per_core_h,
+        "num_tiles_per_core_w": num_tiles_per_core_w,
+    }
+
+    return (
+        layernorm_block_sharded_mem_config,
+        layernorm_block_sharded_prg_config,
+        layernorm_block_sharded_prg_config_inplace,
+        layernorm_params,
+    )

--- a/models/demos/falcon40b/tt/model_utils.py
+++ b/models/demos/falcon40b/tt/model_utils.py
@@ -1,0 +1,373 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import math
+
+import tt_lib as ttl
+import ttnn
+from models.utility_functions import torch2tt_tensor
+
+
+def convert_to_layout(tensor, input_memory_layout, output_memory_layout):
+    if input_memory_layout == output_memory_layout:
+        return tensor
+    else:  # Convert layout
+        if isinstance(
+            tensor, list
+        ):  # if input is a list of tensors call convert_to_layout for each tensor individually
+            return [convert_to_layout(t, input_memory_layout, output_memory_layout) for t in tensor]
+        else:
+            if input_memory_layout.is_sharded() and not output_memory_layout.is_sharded():  # sharded_to_interleaved
+                tensor = ttl.tensor.sharded_to_interleaved(tensor, output_mem_config=output_memory_layout)
+            elif not input_memory_layout.is_sharded() and output_memory_layout.is_sharded():  # interleaved_to_sharded
+                tensor = ttl.tensor.interleaved_to_sharded(tensor, sharded_mem_config=output_memory_layout)
+            else:  # reshard
+                tensor = ttl.tensor.sharded_to_interleaved(
+                    tensor,
+                    output_mem_config=ttl.tensor.MemoryConfig(
+                        ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
+                    ),
+                )
+                tensor = ttl.tensor.interleaved_to_sharded(tensor, sharded_mem_config=output_memory_layout)
+            return tensor
+
+
+def memcfg_1d_width_sharded_from_tensor_shape(shape, grid=ttnn.CoreGrid(x=8, y=8)):
+    start_core_coord = ttl.tensor.CoreCoord(0, 0)
+    end_core_coord = ttl.tensor.CoreCoord(grid.x - 1, grid.y - 1)
+    assert shape[3] % (grid.x * grid.y) == 0, f"Tensor width must be divisible by the number of cores"
+    shard_width = int(shape[3] / (grid.x * grid.y))
+    shard_height = int(shape[0] * shape[1] * shape[2])
+    return ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            ttl.tensor.CoreRangeSet(
+                {
+                    ttl.tensor.CoreRange(
+                        start_core_coord,
+                        end_core_coord,
+                    ),
+                }
+            ),
+            [
+                shard_height,
+                shard_width,
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+
+
+def matmul_1d_config_from_tensor_shapes(
+    in0_shape, in1_shape, grid=ttnn.CoreGrid(x=8, y=8), act=None, is_fp32_accumulate=False
+):
+    m, k, n = in0_shape[0] * in0_shape[1] * in0_shape[2], in0_shape[3], in1_shape[3]
+    return matmul_1d_config(m, k, n, grid, act, is_fp32_accumulate)
+
+
+def matmul_1d_config(
+    m,
+    k,
+    n,
+    grid=ttnn.CoreGrid(x=8, y=8),
+    act=None,
+    is_fp32_accumulate=False,
+    overwrite_per_core_k=None,
+    overwrite_subblock_w=None,
+    overwrite_subblock_h=None,
+):
+    tile_width = 32
+    tile_height = 32
+
+    if n // tile_width // grid.num_cores < 1:  # use less number of cores in case we have more N num tiles than cores
+        # assert (n // tile_width) % grid.x == 0
+        grid_y = n // tile_width // grid.x
+        grid = ttnn.CoreGrid(x=grid.x, y=grid_y)
+
+    per_core_m = m // tile_height
+    per_core_k = math.ceil(k / tile_width / grid.num_cores)
+    per_core_n = math.ceil(n / tile_width / grid.num_cores)
+
+    if is_fp32_accumulate:
+        max_subblock_w_h = 4
+    else:
+        max_subblock_w_h = 8
+
+    # find the largest value between 1 and 8 that is a factor of per_core_n
+    # e.g. if per_core_n is 14, then out_subblock_w = 7
+    out_subblock_w = max([i for i in range(1, max_subblock_w_h + 1) if per_core_n % i == 0])
+
+    # find the largest value that is a factor of per_core_m such that
+    # out_subblock_w * out_subblock_h <= 8
+    out_subblock_h = max(
+        [i for i in range(1, max_subblock_w_h + 1) if per_core_m % i == 0 and i * out_subblock_w <= max_subblock_w_h]
+    )
+
+    if overwrite_per_core_k is not None:
+        per_core_k = overwrite_per_core_k
+
+    if overwrite_subblock_w is not None:
+        out_subblock_w = overwrite_subblock_w
+
+    if overwrite_subblock_h is not None:
+        out_subblock_h = overwrite_subblock_h
+
+    return ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(grid.x, grid.y),
+        in0_block_w=per_core_k,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        per_core_M=per_core_m,
+        per_core_N=per_core_n,
+        fuse_batch=True,
+        fused_activation=act,
+        mcast_in0=True,
+    )
+
+
+def matmul_2d_config_from_tensor_shapes(
+    in0_shape, in1_shape, grid=ttnn.CoreGrid(x=8, y=8), act=None, is_fp32_accumulate=False
+):
+    m, k, n = in0_shape[0] * in0_shape[1] * in0_shape[2], in0_shape[3], in1_shape[3]
+    return matmul_2d_config(m, k, n, grid, act, is_fp32_accumulate)
+
+
+def matmul_2d_config(
+    m,
+    k,
+    n,
+    grid=ttnn.CoreGrid(x=8, y=8),
+    act=None,
+    is_fp32_accumulate=False,
+    transpose_mcast=False,
+    overwrite_per_core_k=None,
+    overwrite_subblock_w=None,
+    overwrite_subblock_h=None,
+):
+    tile_width = 32
+    tile_height = 32
+
+    if transpose_mcast:
+        grid_x = grid.y
+        grid_y = grid.x
+    else:
+        grid_x = grid.x
+        grid_y = grid.y
+
+    assert m % (tile_height * grid_y) == 0, f"m: {m} // 32 not devisible by grid.y: {grid_y}"
+    # assert(k % (tile_height * grid_x) == 0), f"k: {k} // 32 not devisible by grid.x: {grid_x}"
+    # assert(n % (tile_height * grid_x) == 0), f"n: {n} // 32 not devisible by grid.x: {grid_x}"
+
+    per_core_m = m // tile_height // grid_y
+    # per_core_k = k // tile_width // grid_x
+    # per_core_n = n // tile_width // grid_x
+    per_core_k = math.ceil(k / tile_width / grid_x)
+    per_core_n = math.ceil(n / tile_width / grid_x)
+
+    if is_fp32_accumulate:
+        max_subblock_w_h = 4
+    else:
+        max_subblock_w_h = 8
+
+    # find the largest value between 1 and 8 that is a factor of per_core_n
+    # e.g. if per_core_n is 14, then out_subblock_w = 7
+    out_subblock_w = max([i for i in range(1, max_subblock_w_h + 1) if per_core_n % i == 0])
+
+    # find the largest value that is a factor of per_core_m such that
+    # out_subblock_w * out_subblock_h <= 8
+    out_subblock_h = max(
+        [i for i in range(1, max_subblock_w_h + 1) if per_core_m % i == 0 and i * out_subblock_w <= max_subblock_w_h]
+    )
+
+    if per_core_m * per_core_n >= 512:
+        max_per_core_k = 1
+    elif per_core_m * per_core_n >= 128:
+        max_per_core_k = 8
+    else:
+        max_per_core_k = 16
+
+    if overwrite_per_core_k is not None:
+        per_core_k = overwrite_per_core_k
+    else:
+        per_core_k = min(per_core_k, max_per_core_k)
+
+    if overwrite_subblock_w is not None:
+        out_subblock_w = overwrite_subblock_w
+
+    if overwrite_subblock_h is not None:
+        out_subblock_h = overwrite_subblock_h
+
+    # print(
+    #     f"per_core_m: {per_core_m}, per_core_k: {per_core_k}, per_core_n: {per_core_n}, out_subblock_h: {out_subblock_h}, out_subblock_w: {out_subblock_w}"
+    # )
+
+    return ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(grid.x, grid.y),
+        in0_block_w=per_core_k,  # how much inner dim you take each time
+        out_subblock_h=out_subblock_h,  # Must be divisible by per_core_M
+        out_subblock_w=out_subblock_w,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4 for is_fp32_accumulate otherwise <= 8
+        per_core_M=per_core_m,
+        per_core_N=per_core_n,
+        transpose_mcast=transpose_mcast,
+        fused_activation=act,
+    )
+
+
+def falcon_prefill_matmul(
+    in0,
+    in1,
+    compute_kernel_config,
+    output_mem_config=ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+    output_dtype=ttl.tensor.DataType.BFLOAT8_B,
+    grid=ttnn.CoreGrid(x=8, y=8),
+    act=None,
+    transpose_mcast=False,
+    overwrite_per_core_k=None,
+    overwrite_subblock_w=None,
+    overwrite_subblock_h=None,
+):
+    in0_shape = in0.shape
+    in1_shape = in1.shape
+    m, k, n = in0_shape[0] * in0_shape[1] * in0_shape[2], in0_shape[3], in1_shape[3]
+
+    use_2d_mm = m >= 512  # select 2d matmul for S >= 512, otherwise fall back to matmul 1d
+
+    is_fp32_accumulate = compute_kernel_config.fp32_dest_acc_en
+
+    if use_2d_mm:
+        # print("Selecting MM 2d")
+        matmul_pgmcfg = matmul_2d_config(
+            m,
+            k,
+            n,
+            grid,
+            act,
+            is_fp32_accumulate,
+            transpose_mcast,
+            overwrite_per_core_k=overwrite_per_core_k,
+            overwrite_subblock_w=overwrite_subblock_w,
+            overwrite_subblock_h=overwrite_subblock_h,
+        )
+        # print(f"Program config: {matmul_pgmcfg}")
+        return ttl.operations.primary.matmul(
+            in0,
+            in1,
+            program_config=matmul_pgmcfg,
+            output_mem_config=output_mem_config,
+            output_dtype=output_dtype,
+            compute_kernel_config=compute_kernel_config,
+        )
+    else:
+        # print("Selecting MM 1d")
+        matmul_pgmcfg = matmul_1d_config(
+            m,
+            k,
+            n,
+            grid,
+            act,
+            is_fp32_accumulate,
+            overwrite_per_core_k=overwrite_per_core_k,
+            overwrite_subblock_w=overwrite_subblock_w,
+            overwrite_subblock_h=overwrite_subblock_h,
+        )
+        # print(f"Program config: {matmul_pgmcfg}")
+        return ttl.operations.primary.matmul_1d(
+            in0,
+            in1,
+            program_config=matmul_pgmcfg,
+            output_mem_config=output_mem_config,
+            output_dtype=output_dtype,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+
+def partial_layernorm(
+    xs, ln_gamma, ln_beta, ln_eps, layernorm_params, memconfig, pgmconfig, dtype, hidden_size, devices
+):
+    # Do partial layernorm by partial sequence length of 128
+    # Input xs[0] is [1, 1, seq_len, 8192]
+    seq_len = xs[0].shape[2]
+
+    slice_size = layernorm_params["slice_size"]
+
+    layernorm_num_cores_x, layernorm_num_cores_y = (
+        layernorm_params["layernorm_num_cores_x"],
+        layernorm_params["layernorm_num_cores_y"],
+    )
+    layernorm_shard_height_hidden_dim, layernorm_shard_width_hidden_dim = (
+        layernorm_params["layernorm_shard_height_hidden_dim"],
+        layernorm_params["layernorm_shard_width_hidden_dim"],
+    )
+
+    num_devices = len(devices)
+
+    dram_memcfg = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+
+    if seq_len > slice_size:
+        assert seq_len % slice_size == 0, "Sequence length must be divisible by layernorm slice size {slice_size}"
+        num_slices = seq_len // slice_size  # we do 128 per iteration (slice), then we concat the result.
+
+        xs_output_cat = []  # this is the output we write to. Initiate as empty tensors
+        for i in range(len(xs)):
+            xs_output_cat.append(
+                torch2tt_tensor(
+                    torch.zeros([1, 1, seq_len, hidden_size]),
+                    devices[i],
+                    tt_memory_config=dram_memcfg,
+                    tt_dtype=ttl.tensor.DataType.BFLOAT16,
+                )
+            )
+
+        for slice_i in range(num_slices):
+            xs_slice = []
+            for i in range(num_devices):
+                xs_slice.append(
+                    ttl.tensor.interleaved_to_sharded_partial(
+                        xs[i],
+                        (layernorm_num_cores_x, layernorm_num_cores_y),
+                        [layernorm_shard_height_hidden_dim, layernorm_shard_width_hidden_dim],
+                        num_slices,  # num_slices
+                        slice_i,  # slice_index
+                        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+                        ttl.tensor.ShardOrientation.ROW_MAJOR,
+                    )
+                )
+
+            for i in range(num_devices):
+                xs_slice[i] = ttl.operations.primary.layernorm(
+                    xs_slice[i],
+                    ln_eps,
+                    ln_gamma[i],
+                    ln_beta[i],
+                    memconfig,
+                    pgmconfig,
+                )
+
+                ttl.tensor.sharded_to_interleaved_partial(
+                    xs_slice[i],
+                    xs_output_cat[i],
+                    num_slices,
+                    slice_i,
+                    dram_memcfg,
+                )
+                xs_slice[i].deallocate(True)
+    else:
+        xs = convert_to_layout(xs, dram_memcfg, memconfig)
+        for i in range(len(xs)):
+            xs[i] = ttl.operations.primary.layernorm(
+                xs[i],
+                ln_eps,
+                ln_gamma[i],
+                ln_beta[i],
+                memconfig,
+                pgmconfig,
+            )
+        xs = convert_to_layout(xs, memconfig, dram_memcfg)
+        xs_output_cat = xs
+    for i in range(num_devices):
+        xs_output_cat[i] = ttl.tensor.typecast(xs_output_cat[i], dtype)
+    return xs_output_cat

--- a/models/demos/falcon40b/tt/ops/falcon_layernorm.py
+++ b/models/demos/falcon40b/tt/ops/falcon_layernorm.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import math
+from torch import nn
+import tt_lib
+
+from typing import List
+from models.utility_functions import torch2tt_tensor
+
+
+class TtFalconLayernorm:
+    def __init__(self, devices, model_config, config, tt_cache_path, is_sharded=False):
+        super().__init__()
+
+        self.model_config = model_config
+        self.is_sharded = is_sharded
+
+        layer_name = f"transformer.h.0"
+
+        ln_attn_weights_str = f"{layer_name}.ln_attn.weight"
+        ln_attn_bias_str = f"{layer_name}.ln_attn.bias"
+
+        ln_attn_weights_path = (
+            tt_cache_path / f"{ln_attn_weights_str}_rm_{self.model_config['LN_ATTN_WEIGHTS_DTYPE'].name}.bin"
+        )
+        if (ln_attn_weights_path).exists():
+            ln_attn_gamma_host = tt_lib.tensor.load_tensor(str(ln_attn_weights_path))
+            self.ln_attn_gamma = [
+                ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"]) for device in devices
+            ]
+        else:
+            ln_attn_gamma_host = tt_lib.tensor.Tensor(
+                self.state_dict[ln_attn_weights_str].reshape([1, 1, -1, 32]),
+                self.model_config["LN_ATTN_WEIGHTS_DTYPE"],
+            )
+            self.ln_attn_gamma = [
+                ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"]) for device in devices
+            ]
+            tt_lib.tensor.dump_tensor(
+                str(ln_attn_weights_path),
+                ln_attn_gamma_host,
+            )
+
+        ln_attn_bias_path = tt_cache_path / f"{ln_attn_bias_str}_rm_{self.model_config['LN_ATTN_BIAS_DTYPE'].name}.bin"
+        if (ln_attn_bias_path).exists():
+            ln_attn_beta_host = tt_lib.tensor.load_tensor(str(ln_attn_bias_path))
+            self.ln_attn_beta = [
+                ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"]) for device in devices
+            ]
+        else:
+            ln_attn_beta_host = tt_lib.tensor.Tensor(
+                self.state_dict[ln_attn_bias_str].reshape([1, 1, -1, 32]),
+                self.model_config["LN_ATTN_BIAS_DTYPE"],
+            )
+            self.ln_attn_beta = [
+                ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"]) for device in devices
+            ]
+            tt_lib.tensor.dump_tensor(
+                str(ln_attn_bias_path),
+                ln_attn_beta_host,
+            )
+
+        self.layernorm_eps = config.layer_norm_epsilon
+
+    def __call__(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+        if self.is_sharded:
+            row_height = x.get_legacy_shape()[2]
+            shard_width_hidden_dim_across_32_cores = x.get_legacy_shape()[3] // 32
+            shard_spec_32_cores_grid = tt_lib.tensor.CoreRangeSet(
+                {
+                    tt_lib.tensor.CoreRange(
+                        tt_lib.tensor.CoreCoord(0, 0),
+                        tt_lib.tensor.CoreCoord(7, 3),
+                    ),
+                }
+            )
+            # # Option1 : width sharded; produces bad PCC
+            # out = tt_lib.operations.primary.layernorm(
+            #     x,
+            #     self.layernorm_eps,
+            #     self.ln_attn_gamma[0],
+            #     self.ln_attn_beta[0],
+            #     tt_lib.tensor.MemoryConfig(
+            #         tt_lib.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+            #         tt_lib.tensor.BufferType.L1,
+            #         tt_lib.tensor.ShardSpec(
+            #             shard_spec_32_cores_grid,
+            #             [
+            #                 row_height,
+            #                 shard_width_hidden_dim_across_32_cores,
+            #             ],
+            #             tt_lib.tensor.ShardOrientation.ROW_MAJOR,
+            #             False,
+            #         ),
+            #     ),
+            #     tt_lib.operations.primary.LayerNormShardedMultiCoreProgramConfig(
+            #         compute_with_storage_grid_size=[8, 4],
+            #         subblock_w=8,
+            #         block_h=row_height // 32,
+            #         block_w=8,
+            #         math_fidelity=tt_lib.tensor.MathFidelity.HiFi4,
+            #         im_data_format=tt_lib.tensor.DataType.BFLOAT16,
+            #         out_data_format=self.model_config["LN_ATTN_OUTPUT_DTYPE"],
+            #         inplace=False,
+            #     ),
+            # )
+
+            # # option 2: block sharded hardcoded for S=128 and 8x4 grid of cores; produces good PCC!
+            # out = tt_lib.operations.primary.layernorm(
+            #     x,
+            #     self.layernorm_eps,
+            #     self.ln_attn_gamma[0],
+            #     self.ln_attn_beta[0],
+            #     tt_lib.tensor.MemoryConfig(
+            #         tt_lib.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+            #         tt_lib.tensor.BufferType.L1,
+            #         tt_lib.tensor.ShardSpec(
+            #             shard_spec_32_cores_grid,
+            #             [
+            #                 32,
+            #                 1024,
+            #             ],
+            #             tt_lib.tensor.ShardOrientation.ROW_MAJOR,
+            #             False,
+            #         ),
+            #     ),
+            #     tt_lib.operations.primary.LayerNormShardedMultiCoreProgramConfig(
+            #         compute_with_storage_grid_size=[8, 4],
+            #         subblock_w=8,
+            #         block_h=1,
+            #         block_w=32, # 8
+            #         math_fidelity=tt_lib.tensor.MathFidelity.HiFi4,
+            #         im_data_format=tt_lib.tensor.DataType.BFLOAT16,
+            #         out_data_format=self.model_config["LN_ATTN_OUTPUT_DTYPE"],
+            #         inplace=False,
+            #     ),
+            # )
+
+            # version according to model_config for debug
+            out = tt_lib.operations.primary.layernorm(
+                x,
+                self.layernorm_eps,
+                self.ln_attn_gamma[0],
+                self.ln_attn_beta[0],
+                self.model_config["LN_ATTN_OUTPUT_MEMCFG"],
+                self.model_config["LN_ATTN_PROGCFG"],
+            )
+        else:  # Interleaved does not work for falcon40b dims [32, 8192] since once one core per tile-height is used to process the whole row
+            # Option 1: uses only one core; runs out of L1
+            # E           Statically allocated circular buffers on core range {} grow to {} B which is beyond max L1 size of {} B
+            # E           [(x=0,y=0) - (x=1,y=0)]
+            out = tt_lib.operations.primary.layernorm(
+                x,
+                self.layernorm_eps,
+                self.ln_attn_gamma[0],
+                self.ln_attn_beta[0],
+                # self.model_config["LN_ATTN_OUTPUT_MEMCFG"],
+                # self.model_config["LN_ATTN_PROGCFG"],
+            )
+
+            # Option 2: uses only one core?!
+            # Runs out of L1
+            # E                       Statically allocated circular buffers on core range {} grow to {} B which is beyond max L1 size of {} B
+            # E                       [(x=0,y=0) - (x=1,y=0)]
+            # out = tt_lib.operations.primary.layernorm(
+            #     x,
+            #     self.layernorm_eps,
+            #     self.ln_attn_gamma[0],
+            #     self.ln_attn_beta[0],
+            #     program_config=tt_lib.operations.primary.LayerNormInterleavedMultiCoreProgramConfig(
+            #         math_fidelity=tt_lib.tensor.MathFidelity.HiFi4,
+            #         im_data_format=tt_lib.tensor.DataType.BFLOAT16,
+            #         out_data_format=tt_lib.tensor.DataType.BFLOAT8_B,
+            #     ),
+            # )
+
+            # # Option 3: uses only one core?!
+            # # Runs out of L1
+            # # E               Statically allocated circular buffers on core range {} grow to {} B which is beyond max L1 size of {} B
+            # # E               [(x=0,y=0) - (x=1,y=0)]
+            # out = tt_lib.tensor.layernorm(
+            #     x,
+            #     self.layernorm_eps,
+            #     output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            # )
+            # out = tt_lib.tensor.bcast(
+            #     out,
+            #     self.ln_attn_gamma[0],
+            #     tt_lib.tensor.BcastOpMath.MUL,
+            #     tt_lib.tensor.BcastOpDim.H,
+            #     output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            # )
+            # out = tt_lib.tensor.bcast(
+            #     out,
+            #     self.ln_attn_beta[0],
+            #     tt_lib.tensor.BcastOpMath.ADD,
+            #     tt_lib.tensor.BcastOpDim.H,
+            #     output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            # )
+
+        return out

--- a/models/demos/falcon40b/tt/ops/falcon_nlp_create_qkv_heads.py
+++ b/models/demos/falcon40b/tt/ops/falcon_nlp_create_qkv_heads.py
@@ -2,8 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-from torch import nn
 import tt_lib as ttl
 
 from typing import List

--- a/models/demos/falcon40b/tt/ops/falcon_softmax.py
+++ b/models/demos/falcon40b/tt/ops/falcon_softmax.py
@@ -2,9 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
 import math
-from torch import nn
 import tt_lib as ttl
 
 from typing import List
@@ -12,15 +10,10 @@ from models.utility_functions import torch2tt_tensor
 
 
 class TtFalconSoftmax:
-    def __init__(
-        self,
-        device,
-        model_config,
-        head_dim: int = 64,
-        seqlen: int = 32,
-    ):
+    def __init__(self, device, model_config, head_dim: int = 64, seqlen: int = 32, is_sharded=False):
         super().__init__()
 
+        self.is_sharded = is_sharded
         self.model_config = model_config
         self.seqlen = seqlen
         self.scalar = 1 / math.sqrt(head_dim)
@@ -31,15 +24,27 @@ class TtFalconSoftmax:
             self.seqlen // 32
         )  # TODO: We can directly set this for prefill model config, but it might be confusing...
 
-        # Subtract max value from activation before softmax
-        out = ttl.operations.primary.transformers.scale_mask_softmax_in_place(
-            x,
-            self.scalar,
-            attention_mask,
-            # program_config=softmax_progcfg,
-            # output_mem_config=self.model_config["DEFAULT_MEMCFG"],
-            program_config=ttl.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
-            is_causal_mask=True,
-        )
+        if self.is_sharded:
+            # Subtract max value from activation before softmax
+            out = ttl.operations.primary.transformers.scale_mask_softmax_in_place(
+                x,
+                self.scalar,
+                attention_mask,
+                program_config=softmax_progcfg,
+                # output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+                # program_config=ttl.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
+                is_causal_mask=True,
+            )
+        else:
+            # Subtract max value from activation before softmax
+            out = ttl.operations.primary.transformers.scale_mask_softmax_in_place(
+                x,
+                self.scalar,
+                attention_mask,
+                # program_config=softmax_progcfg,
+                # output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+                program_config=ttl.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
+                is_causal_mask=True,
+            )
 
         return out

--- a/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
@@ -31,15 +31,18 @@ pytest models/demos/ttnn_falcon7b/tests/multi_chip -k test_falcon_mlp
 pytest models/demos/ttnn_falcon7b/tests/multi_chip -k test_falcon_attention
 pytest models/demos/ttnn_falcon7b/tests/multi_chip -k test_falcon_decoder
 
-# Falcon40B 4 chip tests
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-prefill_seq32-4chips]
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-4chips]
-pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-4chips]
+# Falcon40B 4 chip decode tests
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-4chips-enable_program_cache]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-4chips-enable_program_cache]
 
-# Falcon40B 8 chip tests
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-prefill_seq32-8chips]
-pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips]
-pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips]
+# Falcon40B 8 chip decode tests
+pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips-enable_program_cache]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips-enable_program_cache]
+
+# Falcon40B 8 chip prefill tests
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq32-8chips-disable_program_cache]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips-disable_program_cache]
+pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq2048-8chips-disable_program_cache]
 
 pytest tests/ttnn/unit_tests/test_multi_device.py
 pytest tests/ttnn/unit_tests/test_multi_device_async.py


### PR DESCRIPTION
Adds support for falcon40b prefill for variable sequences lengths up to S=2048.
- Uses separate fwd methods for sharded decode (unchanged) and prefill
- Prefill is mostly DRAM interleaved, exception is layernorm which is block sharded for functional reasons

**PCC**
1 layer S=128 and S=2048: 0.99 / 0.99 / 0.99
60 layer S=128: 0.92 / 0.98 / 0.94

**Performance**
60 layer S=128: 1173 tok/s
60 layer S=2048: 1961 tok/s