### PR TITLE
#7063: Leverage git cache for Python test env.

### DIFF
--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -1,0 +1,26 @@
+name: "Install Python Dependencies"
+description: "Installs Python Dependencies from cache or from PyPI if cache is not available.
+Uses pyproject.toml and requirements-dev.txt as cache keys."
+inputs:
+  python-version:
+    description: 'Which version of Python to use to run the tests.'
+    required: true
+    default: '3.8'
+runs:
+  using: "composite"
+  steps:
+    - name: "Install Cached Python Dependencies"
+      uses: getsentry/action-setup-venv@v2.1.0
+      id: venv
+      with:
+        python-version: ${{ inputs.python-version }}
+        venv-dir: ${{ github.workspace }}/python_env
+        cache-dependency-path: |
+          tt_metal/python_env/requirements-dev.txt
+          pyproject.toml
+        install-cmd: make python_env/dev PYTHON_ENV=${{ github.workspace }}/python_env -B
+    - name: Install Editable Python dependencies (TTNN, Stubs)
+      shell: bash
+      run: |
+        source ${{ github.workspace }}/python_env/bin/activate
+        make python_env/dev/editable PYTHON_ENV=${{ github.workspace }}/python_env -B

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -37,11 +37,9 @@ jobs:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
       - name: Extract files
         run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
-      - name: Build python env
-        run: |
-          make python_env/dev PYTHON_ENV=$HOME/python_env -B
+      - uses: ./.github/actions/install-python-deps
       - name: Run pre/post regression tests
         timeout-minutes: 15
         run: |
-          source $HOME/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type post_commit --dispatch-mode slow

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -21,9 +21,10 @@ jobs:
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - uses: ./.github/actions/install-python-deps
       - name: Build tt-metal and libs
         run: |
-          make build PYTHON_ENV=$HOME/python_env
+          make build PYTHON_ENV=${{ github.workspace }}/python_env
           make tests
       - name: 'Tar files'
         run: tar -cvf ttm_${{ matrix.arch }}.tar build/hw build/lib tt_eager/tt_lib/*.so ttnn/ttnn/*.so build/programming_examples build/test

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -39,13 +39,11 @@ jobs:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
       - name: Extract files
         run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
-      - name: Build python env
-        run: |
-          make python_env/dev PYTHON_ENV=$HOME/python_env -B
+      - uses: ./.github/actions/install-python-deps
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: 15
         run: |
-          source $HOME/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -52,13 +52,11 @@ jobs:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
       - name: Extract files
         run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
-      - name: Build python env
-        run: |
-          make python_env/dev PYTHON_ENV=$HOME/python_env -B
+      - uses: ./.github/actions/install-python-deps
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: 45
         run: |
-          source $HOME/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}
@@ -92,13 +90,11 @@ jobs:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
       - name: Extract files
         run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
-      - name: Build python env
-        run: |
-          make python_env/dev PYTHON_ENV=$HOME/python_env -B
+      - uses: ./.github/actions/install-python-deps
       - name: Build Docs
         timeout-minutes: 15
         run: |
-          source $HOME/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ./tests/scripts/run_build_docs.sh
@@ -129,12 +125,10 @@ jobs:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
       - name: Extract files
         run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
-      - name: Build python env
-        run: |
-          make python_env/dev PYTHON_ENV=$HOME/python_env -B
+      - uses: ./.github/actions/install-python-deps
       - name: multi-queue-single-device
         timeout-minutes: 5
         run: |
-          source $HOME/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           export PYTHONPATH=$TT_METAL_HOME
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type post_commit --dispatch-mode fast-multi-queue-single-device

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -41,13 +41,11 @@ jobs:
           name: TTMetal_build_${{ matrix.arch }}
       - name: Extract files
         run: tar -xvf ttm_${{ matrix.arch }}.tar
-      - name: Build python env
-        run: |
-          make python_env/dev PYTHON_ENV=$HOME/python_env -B
+      - uses: ./.github/actions/install-python-deps
       - name: Run frequent reg tests scripts
         timeout-minutes: 165
         run: |
-          source $HOME/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ./tests/scripts/run_tests.sh --tt-arch ${{ matrix.arch }} --pipeline-type frequent_${{ matrix.frequent-type }} --dispatch-mode fast

--- a/.github/workflows/full-regressions-and-models.yaml
+++ b/.github/workflows/full-regressions-and-models.yaml
@@ -41,13 +41,11 @@ jobs:
           name: TTMetal_build_${{ matrix.arch }}
       - name: Extract files
         run: tar -xvf ttm_${{ matrix.arch }}.tar
-      - name: Build python env
-        run: |
-          make python_env/dev PYTHON_ENV=$HOME/python_env -B
+      - uses: ./.github/actions/install-python-deps
       - name: Run frequent reg tests scripts
         timeout-minutes: 210
         run: |
-          source $HOME/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ./tests/scripts/run_tests.sh --tt-arch ${{ matrix.arch }} --pipeline-type frequent_${{ matrix.frequent-type }} --dispatch-mode slow

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -39,13 +39,11 @@ jobs:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
       - name: Extract files
         run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
-      - name: Build python env
-        run: |
-          make python_env/dev PYTHON_ENV=$HOME/python_env -B
+      - uses: ./.github/actions/install-python-deps
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: 45
         run: |
-          source $HOME/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -41,13 +41,11 @@ jobs:
           name: TTMetal_build_${{ matrix.runner-info.arch }}
       - name: Extract files
         run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
-      - name: Build python env
-        run: |
-          make python_env/dev PYTHON_ENV=$HOME/python_env -B
+      - uses: ./.github/actions/install-python-deps
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: 45
         run: |
-          source $HOME/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}

--- a/module.mk
+++ b/module.mk
@@ -134,6 +134,8 @@ LIBS_TO_BUILD =
 ifdef TT_METAL_ENV_IS_DEV
 LIBS_TO_BUILD += \
 	python_env/dev \
+	python_env/dev/editable \
+	python_env/dev/stubs \
 	git_hooks
 endif
 

--- a/tt_metal/python_env/module.mk
+++ b/tt_metal/python_env/module.mk
@@ -6,6 +6,10 @@ python_env: $(PYTHON_ENV)/.installed
 
 python_env/dev: $(PYTHON_ENV)/.installed-dev
 
+python_env/dev/editable: $(PYTHON_ENV)/.installed-dev-editable
+
+python_env/dev/stubs: $(PYTHON_ENV)/.installed-stubs
+
 python_env/clean:
 	rm -rf $(PYTHON_ENV)
 
@@ -30,10 +34,14 @@ endif
 	bash -c "source $(PYTHON_ENV)/bin/activate && python3 -m pip install -r tt_metal/python_env/requirements-dev.txt"
 	echo "Installing editable dev version of tt_eager packages..."
 	bash -c "source $(PYTHON_ENV)/bin/activate && pip install -e ."
+
+$(PYTHON_ENV)/.installed-dev-editable:
 	echo "Installing editable dev version of ttnn package..."
 	bash -c "source $(PYTHON_ENV)/bin/activate && pip install -e ttnn"
+	touch $@
+
+$(PYTHON_ENV)/.installed-stubs: $(PYTHON_ENV)/.installed-dev $(PYTHON_ENV)/.installed-dev-editable
 	echo "Generating stubs..."
 	bash -c "source $(PYTHON_ENV)/bin/activate && stubgen -m tt_lib -m tt_lib.device -m tt_lib.profiler -m tt_lib.tensor -m tt_lib.operations -m tt_lib.operations.primary -m tt_lib.operations.primary.transformers -o tt_eager"
 	bash -c "source $(PYTHON_ENV)/bin/activate && stubgen -p ttnn._ttnn -o ttnn"
 	bash -c "sed -i 's/\._C/tt_lib/g' tt_eager/tt_lib/__init__.pyi"
-	touch $@


### PR DESCRIPTION
Related issue #7063 

The purpose of this PR is to start using GitHub actions cache to create and restore Python virtual environment.
The code is using Github action written by Sentry https://github.com/getsentry/action-setup-venv/blob/main/action.yml though we can easily replicate the code within our repository.

The cache invalidation depends on the hash of contents of two files : `pyproject.toml` and `tt_metal/python_env/requirements-dev.txt`.

I have also split Makefile target called `python_env/dev` into additional two sections that are responsible for generating C++ stubs `python_env/dev/stubs` (not useful for CI/CD) and `python/dev/editable`. Specifically, the last target `python_env/dev/editable` could not be part of cache as it installs `ttnn` which could be changing with every commit and therefore does not belong in cache.

We recently had an outage when the library `torchtrail` was upgraded and downgraded and this will be the main test for this code change. https://github.com/tenstorrent-metal/tt-metal/actions/runs/8510651249/job/23310229372


