### PR TITLE
#6736: Improve watcher error reporting

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "debug/assert.h"
+#include "debug/ring_buffer.h"
 
 /*
  * A test for the assert feature.
@@ -24,6 +25,8 @@ void MAIN {
     (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
     (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
     (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC))
+    WATCHER_RING_BUFFER_PUSH(a);
+    WATCHER_RING_BUFFER_PUSH(b);
     ASSERT(a != b);
 #endif
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -121,28 +121,21 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
     }
 
     // We should be able to find the expected watcher error in the log as well.
-    string expected, addr;
+    string expected;
     switch(feature) {
         case SanitizeAddress:
-            expected = "Device x, Core (x=x,y=x):    NAWW,*,*,*,*  brisc using noc0 tried to access core (16,16) L1[addr=0x********,len=102400]";
-            expected[7] = '0' + device->id();
-            expected[18] = '0' + phys_core.x;
-            expected[22] = '0' + phys_core.y;
-            addr = fmt::format("{:08x}", output_dram_buffer_addr);
-            expected.replace(99, addr.length(), addr);
-            if (is_eth_core) {
-                expected[43] = 'e';
-            }
+            expected = fmt::format(
+                "Device {}, ****** Core {}[physical {}]:   NAWW,****,****,****,****  {} using noc0 tried to access core (16,16) L1[addr=0x{:08x},len=102400]",
+                device->id(), core.str(), phys_core.str(),
+                (is_eth_core) ? "erisc" : "brisc", output_dram_buffer_addr
+            );
             break;
         case SanitizeAlignment:
-            expected = "Device x, Core (x=x,y=x):    NARW,*,*,*,*  brisc using noc0 reading L1[addr=0x********,len=102400]";
-            expected[7] = '0' + device->id();
-            expected[18] = '0' + phys_core.x;
-            expected[22] = '0' + phys_core.y;
-            addr = fmt::format("{:08x}", l1_buffer_addr);
-            expected.replace(78, addr.length(), addr);
-            if (is_eth_core)
-                expected[43] = 'e';
+            expected = fmt::format(
+                "Device {}, ****** Core {}[physical {}]:   NARW,****,****,****,****  {} using noc0 reading L1[addr=0x{:08x},len=102400]",
+                device->id(), core.str(), phys_core.str(),
+                (is_eth_core) ? "erisc" : "brisc", l1_buffer_addr
+            );
             break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -125,15 +125,19 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
     switch(feature) {
         case SanitizeAddress:
             expected = fmt::format(
-                "Device {}, ****** Core {}[physical {}]:   NAWW,****,****,****,****  {} using noc0 tried to access core (16,16) L1[addr=0x{:08x},len=102400]",
-                device->id(), core.str(), phys_core.str(),
+                "Device {}, {} Core {}[physical {}]: {} using noc0 tried to access core (16,16) L1[addr=0x{:08x},len=102400]",
+                device->id(),
+                (is_eth_core) ? "Ethnet" : "Worker",
+                core.str(), phys_core.str(),
                 (is_eth_core) ? "erisc" : "brisc", output_dram_buffer_addr
             );
             break;
         case SanitizeAlignment:
             expected = fmt::format(
-                "Device {}, ****** Core {}[physical {}]:   NARW,****,****,****,****  {} using noc0 reading L1[addr=0x{:08x},len=102400]",
-                device->id(), core.str(), phys_core.str(),
+                "Device {}, {} Core {}[physical {}]: {} using noc0 reading L1[addr=0x{:08x},len=102400]",
+                device->id(),
+                (is_eth_core) ? "Ethnet" : "Worker",
+                core.str(), phys_core.str(),
                 (is_eth_core) ? "erisc" : "brisc", l1_buffer_addr
             );
             break;
@@ -143,12 +147,9 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
             break;
     }
 
-    EXPECT_TRUE(
-        FileContainsAllStrings(
-            fixture->log_file_name,
-            {expected}
-        )
-    );
+    log_info(LogTest, "Expected error: {}", expected);
+    log_info(LogTest, "Reported error: {}", watcher_server_get_exception_message());
+    EXPECT_TRUE(watcher_server_get_exception_message() == expected);
 }
 
 static void RunTestEth(WatcherFixture* fixture, Device* device) {

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -17,12 +17,11 @@ void watcher_sanitize_host_noc_write(const metal_SocDescriptor &soc_d, CoreCoord
 
 int watcher_register_kernel(const string& name);
 
-// Check whether the watcher server has been killed due to an error detected.
+// Check whether the watcher server has been killed due to an error detected, and a function to set
+// that flag. Used in test mode only.
 bool watcher_server_killed_due_to_error();
-// Function to set this flag to true/false, so that non-watcher runs can continue as normal when set to false.
-// TODO(dma): this doesn't currently clear the actual error codes on the device. Once watcher is
-// moved out of llrt we can change this to watcher_clear_errors().
 void watcher_server_set_error_flag(bool val);
+string watcher_server_get_exception_message();
 
 // Helper function to clear the watcher log file
 void watcher_clear_log();

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1024,6 +1024,14 @@ CoreCoord Device::physical_core_from_logical_core(const CoreCoord &logical_coord
     return soc_desc.get_physical_core_from_logical_core(logical_coord, core_type);
 }
 
+CoreType Device::core_type_from_physical_core(const CoreCoord &physical_coord) const {
+    const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
+    if (soc_desc.physical_cores.find(physical_coord) == soc_desc.physical_cores.end())
+        TT_THROW("Physical core {} doesn't exist in metal_SocDescriptor.", physical_coord);
+
+    return soc_desc.physical_cores.at(physical_coord).type;
+}
+
 CoreCoord Device::worker_core_from_logical_core(const CoreCoord &logical_core) const {
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
     return soc_desc.get_physical_tensix_core_from_logical(logical_core);

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -97,6 +97,7 @@ class Device {
     CoreCoord compute_with_storage_grid_size() const;
 
     CoreCoord physical_core_from_logical_core(const CoreCoord &logical_core, const CoreType &core_type) const;
+    CoreType core_type_from_physical_core(const CoreCoord &physical_core) const;
     CoreCoord worker_core_from_logical_core(const CoreCoord &logical_core) const;
 
     std::vector<CoreCoord> worker_cores_from_logical_cores(const std::vector<CoreCoord> &logical_cores) const;


### PR DESCRIPTION
- Show both logical and physical coords in the watcher log
- Clean up log alignment, stdout formatting
- Show what core illegal noc transaction was trying to access
- Show reason why illegal noc transaction was flagged
- Fix illegal noc transaction always showing memory as L1

Passing CI:
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8546067848
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8546451134
