### PR TITLE
#7050: Add yolov4 downsample4 and downsample5 sub-modules

### DIFF
--- a/models/experimental/functional_yolov4/reference/downsample4.py
+++ b/models/experimental/functional_yolov4/reference/downsample4.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+import torch.nn as nn
+from models.experimental.functional_yolov4.reference.resblock import ResBlock
+
+
+class DownSample4(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.c1 = nn.Conv2d(256, 512, 3, 2, 1, bias=False)
+        self.b1 = nn.BatchNorm2d(512)
+        self.relu = nn.ReLU(inplace=True)
+
+        self.c2 = nn.Conv2d(512, 256, 1, 1, 0, bias=False)
+        self.b2 = nn.BatchNorm2d(256)
+
+        self.c3 = nn.Conv2d(512, 256, 1, 1, 0, bias=False)
+        self.b3 = nn.BatchNorm2d(256)
+
+        self.res = ResBlock(256, 8)
+
+        self.c4 = nn.Conv2d(256, 256, 1, 1, 0, bias=False)
+        self.b4 = nn.BatchNorm2d(256)
+
+        self.c5 = nn.Conv2d(512, 512, 1, 1, 0, bias=False)
+        self.b5 = nn.BatchNorm2d(512)
+
+    def forward(self, input: torch.Tensor):
+        x1 = self.c1(input)
+        x1_b = self.b1(x1)
+        x1_m = self.relu(x1_b)
+
+        x2 = self.c2(x1_m)
+        x2_b = self.b2(x2)
+        x2_m = self.relu(x2_b)
+
+        x3 = self.c3(x1_m)
+        x3_b = self.b3(x3)
+        x3_m = self.relu(x3_b)
+
+        # resblock
+        r = self.res(x3_m)
+
+        x4 = self.c4(r)
+        x4_b = self.b4(x4)
+        x4_m = self.relu(x4_b)
+
+        x4_m = torch.cat([x4_m, x2_m], dim=1)
+
+        x5 = self.c5(x4_m)
+        x5_b = self.b5(x5)
+        x5_m = self.relu(x5_b)
+
+        return x5_m

--- a/models/experimental/functional_yolov4/reference/downsample5.py
+++ b/models/experimental/functional_yolov4/reference/downsample5.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+import torch.nn as nn
+from models.experimental.functional_yolov4.reference.resblock import ResBlock
+
+
+class DownSample5(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.c1 = nn.Conv2d(512, 1024, 3, 2, 1, bias=False)
+        self.b1 = nn.BatchNorm2d(1024)
+        self.relu = nn.ReLU(inplace=True)
+
+        self.c2 = nn.Conv2d(1024, 512, 1, 1, bias=False)
+        self.b2 = nn.BatchNorm2d(512)
+
+        self.c3 = nn.Conv2d(1024, 512, 1, 1, bias=False)
+        self.b3 = nn.BatchNorm2d(512)
+
+        self.res = ResBlock(512, 4)
+
+        self.c4 = nn.Conv2d(512, 512, 1, 1, bias=False)
+        self.b4 = nn.BatchNorm2d(512)
+        self.relu = nn.ReLU(inplace=True)
+
+        self.c5 = nn.Conv2d(1024, 1024, 1, 1, bias=False)
+        self.b5 = nn.BatchNorm2d(1024)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, input: torch.Tensor):
+        x1 = self.c1(input)
+        x1_b = self.b1(x1)
+        x1_m = self.relu(x1_b)
+
+        x2 = self.c2(x1_m)
+        x2_b = self.b2(x2)
+        x2_m = self.relu(x2_b)
+
+        x3 = self.c3(x1_m)
+        x3_b = self.b3(x3)
+        x3_m = self.relu(x3_b)
+
+        # resblock
+        r = self.res(x3_m)
+
+        x4 = self.c4(r)
+        x4_b = self.b4(x4)
+        x4_m = self.relu(x4_b)
+
+        x4_m = torch.cat([x4_m, x2_m], dim=1)
+
+        x5 = self.c5(x4_m)
+        x5_b = self.b5(x5)
+        x5_m = self.relu(x5_b)
+
+        return x5_m

--- a/models/experimental/functional_yolov4/reference/resblock.py
+++ b/models/experimental/functional_yolov4/reference/resblock.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch.nn as nn
+
+
+class ResBlock(nn.Module):
+    def __init__(self, ch, nblocks=1, shortcut=True):
+        super().__init__()
+        self.shortcut = shortcut
+        self.module_list = nn.ModuleList()
+        for i in range(nblocks):
+            conv1 = nn.Conv2d(ch, ch, 1, 1, 0, bias=False)
+            bn1 = nn.BatchNorm2d(ch)
+            relu1 = nn.ReLU(inplace=True)
+            conv2 = nn.Conv2d(ch, ch, 3, 1, 1, bias=False)
+            bn2 = nn.BatchNorm2d(ch)
+            relu2 = nn.ReLU(inplace=True)
+            resblock_one = nn.ModuleList([conv1, bn1, relu1, conv2, bn2, relu2])
+            self.module_list.append(resblock_one)
+
+    def forward(self, x):
+        for module in self.module_list:
+            h = x
+            for res in module:
+                h = res(h)
+            x = x + h if self.shortcut else h
+        return x

--- a/models/experimental/functional_yolov4/tt/ttnn_downsample4.py
+++ b/models/experimental/functional_yolov4/tt/ttnn_downsample4.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from models.experimental.functional_yolov4.tt.ttnn_resblock import TtResBlock
+
+import ttnn
+import tt_lib
+
+
+class TtDownSample4:
+    def __init__(
+        self,
+        parameters,
+    ) -> None:
+        self.c1 = parameters.c1
+        self.c2 = parameters.c2
+        self.c3 = parameters.c3
+        self.res = TtResBlock(parameters.res, 8, True)
+        self.c4 = parameters.c4
+        self.c5 = parameters.c5
+
+    def __call__(self, device, input_tensor):
+        input_tensor = input_tensor.to(device, self.c1.conv.input_sharded_memory_config)
+        output_tensor = self.c1(input_tensor)
+        output_tensor_c1 = output_tensor
+        output_tensor = self.c2(output_tensor)
+        output_tensor_c2 = output_tensor
+        output_tensor = self.c3(output_tensor_c1)
+        output_tensor = self.res(device, output_tensor)
+        output_tensor = output_tensor.to(device, self.c4.conv.input_sharded_memory_config)
+        output_tensor = self.c4(output_tensor)
+
+        output_tensor = tt_lib.tensor.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
+        output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.TILE_LAYOUT)
+        output_tensor = ttnn.concat([output_tensor, output_tensor_c2], dim=3)
+        output_tensor = output_tensor.to(device, self.c5.conv.input_sharded_memory_config)
+
+        output_tensor = self.c5(output_tensor)
+        output_tensor = tt_lib.tensor.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
+        output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.TILE_LAYOUT)
+        return ttnn.from_device(output_tensor)

--- a/models/experimental/functional_yolov4/tt/ttnn_downsample5.py
+++ b/models/experimental/functional_yolov4/tt/ttnn_downsample5.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+from models.experimental.functional_yolov4.tt.ttnn_resblock import TtResBlock
+
+import ttnn
+import tt_lib
+
+
+class TtDownSample5:
+    def __init__(
+        self,
+        parameters,
+    ) -> None:
+        self.c1 = parameters.c1
+        self.c2 = parameters.c2
+        self.c3 = parameters.c3
+        self.res = TtResBlock(parameters.res, 4, True)
+        self.c4 = parameters.c4
+        self.c5 = parameters.c5
+
+    def __call__(self, device, input_tensor):
+        input_tensor = input_tensor.to(device, self.c1.conv.input_sharded_memory_config)
+        output_tensor = self.c1(input_tensor)
+        output_tensor_c1 = output_tensor
+        output_tensor = self.c2(output_tensor)
+        output_tensor_c2 = output_tensor
+        output_tensor = self.c3(output_tensor_c1)
+        output_tensor = self.res(device, output_tensor)
+        output_tensor = output_tensor.to(device, self.c4.conv.input_sharded_memory_config)
+        output_tensor = self.c4(output_tensor)
+
+        output_tensor = tt_lib.tensor.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
+        output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.TILE_LAYOUT)
+        output_tensor = ttnn.concat([output_tensor, output_tensor_c2], dim=3)
+        output_tensor = output_tensor.to(device, self.c5.conv.input_sharded_memory_config)
+
+        output_tensor = self.c5(output_tensor)
+        output_tensor = tt_lib.tensor.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
+        output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.TILE_LAYOUT)
+        return ttnn.from_device(output_tensor)

--- a/models/experimental/functional_yolov4/tt/ttnn_resblock.py
+++ b/models/experimental/functional_yolov4/tt/ttnn_resblock.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import ttnn
+import tt_lib
+
+
+class TtResBlock:
+    def __init__(self, parameters, nblocks, shortcut) -> None:
+        self.shortcut = shortcut
+        self.nblocks = nblocks
+        self.module_list = []
+        for i in range(nblocks):
+            conv1 = parameters[f"resblock_{i}_conv1"]
+            conv2 = parameters[f"resblock_{i}_conv2"]
+            resblock_one = [conv1, conv2]
+            self.module_list.append(resblock_one)
+
+    def __call__(self, device, input_tensor):
+        input_tensor = tt_lib.tensor.sharded_to_interleaved(input_tensor, ttnn.L1_MEMORY_CONFIG)
+        input_tensor = ttnn.to_layout(input_tensor, layout=ttnn.TILE_LAYOUT)
+        for i in range(self.nblocks):
+            output_tensor_h = input_tensor
+            output_tensor_h = output_tensor_h.to(device, self.module_list[i][0].conv.input_sharded_memory_config)
+            output_tensor_1 = self.module_list[i][0](output_tensor_h)
+            output_tensor_h = self.module_list[i][1](output_tensor_1)
+            output_tensor_h = tt_lib.tensor.sharded_to_interleaved(output_tensor_h, ttnn.L1_MEMORY_CONFIG)
+            output_tensor_h = ttnn.to_layout(output_tensor_h, layout=ttnn.TILE_LAYOUT)
+
+            input_tensor = (input_tensor + output_tensor_h) if self.shortcut else output_tensor_h
+        return ttnn.from_device(input_tensor)

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample4.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample4.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+
+from ttnn.model_preprocessing import preprocess_model, preprocess_conv2d, fold_batch_norm2d_into_conv2d
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import skip_for_wormhole_b0
+from models.experimental.functional_yolov4.reference.downsample4 import DownSample4
+from models.experimental.functional_yolov4.tt.ttnn_downsample4 import TtDownSample4
+
+
+import ttnn
+from ttnn.model_preprocessing import preprocess_conv2d, fold_batch_norm2d_into_conv2d
+
+
+def update_ttnn_module_args(ttnn_module_args):
+    ttnn_module_args["use_1d_systolic_array"] = True  # ttnn_module_args.in_channels <= 256
+    ttnn_module_args["math_fidelity"] = ttnn.MathFidelity.LoFi
+    ttnn_module_args["dtype"] = ttnn.bfloat8_b
+    ttnn_module_args["weights_dtype"] = ttnn.bfloat8_b
+    ttnn_module_args["deallocate_activation"] = True
+    ttnn_module_args["conv_blocking_and_parallelization_config_override"] = None
+    ttnn_module_args["activation"] = "relu"
+
+
+def create_custom_preprocessor(device):
+    def custom_preprocessor(model, name, ttnn_module_args):
+        parameters = {}
+        if isinstance(model, DownSample4):
+            ttnn_module_args.c1["use_shallow_conv_variant"] = False
+            conv1_weight, conv1_bias = fold_batch_norm2d_into_conv2d(model.c1, model.b1)
+            update_ttnn_module_args(ttnn_module_args.c1)
+            parameters["c1"], c1_parallel_config = preprocess_conv2d(
+                conv1_weight, conv1_bias, ttnn_module_args.c1, return_parallel_config=True
+            )
+
+            ttnn_module_args.c2["use_shallow_conv_variant"] = False
+            ttnn_module_args.c2["weights_dtype"] = ttnn.bfloat8_b
+            conv2_weight, conv2_bias = fold_batch_norm2d_into_conv2d(model.c2, model.b2)
+            update_ttnn_module_args(ttnn_module_args.c2)
+            parameters["c2"], c2_parallel_config = preprocess_conv2d(
+                conv2_weight, conv2_bias, ttnn_module_args.c2, return_parallel_config=True
+            )
+
+            ttnn_module_args.c3["use_shallow_conv_variant"] = False
+            ttnn_module_args.c3["weights_dtype"] = ttnn.bfloat8_b
+            conv3_weight, conv3_bias = fold_batch_norm2d_into_conv2d(model.c3, model.b3)
+            update_ttnn_module_args(ttnn_module_args.c3)
+            parameters["c3"], c3_parallel_config = preprocess_conv2d(
+                conv3_weight, conv3_bias, ttnn_module_args.c3, return_parallel_config=True
+            )
+
+            parameters["res"] = {}
+            for i, block in enumerate(model.res.module_list):
+                conv1 = block[0]
+                bn1 = block[1]
+                conv2 = block[3]
+                bn2 = block[4]
+
+                ttnn_module_args["res"][f"resblock_{i}_conv1"] = ttnn_module_args["res"]["0"]
+                ttnn_module_args["res"][f"resblock_{i}_conv1"]["weights_dtype"] = ttnn.bfloat8_b
+                weight1, bias1 = fold_batch_norm2d_into_conv2d(conv1, bn1)
+                update_ttnn_module_args(ttnn_module_args["res"][f"resblock_{i}_conv1"])
+                parameters["res"][f"resblock_{i}_conv1"], _ = preprocess_conv2d(
+                    weight1, bias1, ttnn_module_args["res"][f"resblock_{i}_conv1"], return_parallel_config=True
+                )
+
+                ttnn_module_args["res"][f"resblock_{i}_conv2"] = ttnn_module_args["res"]["3"]
+                ttnn_module_args["res"][f"resblock_{i}_conv2"]["weights_dtype"] = ttnn.bfloat8_b
+                weight2, bias2 = fold_batch_norm2d_into_conv2d(conv2, bn2)
+                update_ttnn_module_args(ttnn_module_args["res"][f"resblock_{i}_conv2"])
+                parameters["res"][f"resblock_{i}_conv2"], _ = preprocess_conv2d(
+                    weight2, bias2, ttnn_module_args["res"][f"resblock_{i}_conv2"], return_parallel_config=True
+                )
+
+            ttnn_module_args.c4["use_shallow_conv_variant"] = False
+            ttnn_module_args.c4["weights_dtype"] = ttnn.bfloat8_b
+            conv4_weight, conv4_bias = fold_batch_norm2d_into_conv2d(model.c4, model.b4)
+            update_ttnn_module_args(ttnn_module_args.c4)
+            parameters["c4"], c4_parallel_config = preprocess_conv2d(
+                conv4_weight, conv4_bias, ttnn_module_args.c4, return_parallel_config=True
+            )
+
+            ttnn_module_args.c5["use_shallow_conv_variant"] = False
+            ttnn_module_args.c5["weights_dtype"] = ttnn.bfloat8_b
+            conv5_weight, conv5_bias = fold_batch_norm2d_into_conv2d(model.c5, model.b5)
+            update_ttnn_module_args(ttnn_module_args.c5)
+            parameters["c5"], c5_parallel_config = preprocess_conv2d(
+                conv5_weight, conv5_bias, ttnn_module_args.c5, return_parallel_config=True
+            )
+
+        return parameters
+
+    return custom_preprocessor
+
+
+@skip_for_wormhole_b0()
+def test_downsample4(device, reset_seeds, model_location_generator):
+    model_path = model_location_generator("models", model_subdir="Yolo")
+    weights_pth = str(model_path / "yolov4.pth")
+    state_dict = torch.load(weights_pth)
+    ds_state_dict = {k: v for k, v in state_dict.items() if (k.startswith("down4."))}
+
+    torch_model = DownSample4()
+
+    for layer in torch_model.children():
+        print(layer)
+
+    new_state_dict = {}
+    keys = [name for name, parameter in torch_model.state_dict().items()]
+    values = [parameter for name, parameter in ds_state_dict.items()]
+    for i in range(len(keys)):
+        new_state_dict[keys[i]] = values[i]
+
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+    torch_input_tensor = torch.randn(1, 256, 40, 40)  # Batch size of 1, 256 input channels, 40x40 height and width
+    torch_output_tensor = torch_model(torch_input_tensor)
+
+    reader_patterns_cache = {}
+    parameters = preprocess_model(
+        initialize_model=lambda: torch_model,
+        run_model=lambda model: model(torch_input_tensor),
+        custom_preprocessor=create_custom_preprocessor(device),
+        reader_patterns_cache=reader_patterns_cache,
+        device=device,
+    )
+    ttnn_model = TtDownSample4(parameters)
+    # Tensor Preprocessing
+    #
+    input_shape = torch_input_tensor.shape
+    input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
+
+    input_tensor = input_tensor.reshape(
+        input_tensor.shape[0], 1, input_tensor.shape[1] * input_tensor.shape[2], input_tensor.shape[3]
+    )
+    input_tensor = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT)
+    with ttnn.tracer.trace():
+        output_tensor = ttnn_model(device, input_tensor)
+    ttnn.tracer.visualize(output_tensor, file_name="downsample4.svg")
+    # output_tensor = ttnn_model(device, input_tensor)
+
+    #
+    # Tensor Postprocessing
+    #
+    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = output_tensor.reshape(1, 20, 20, 512)
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+    output_tensor = output_tensor.to(torch_input_tensor.dtype)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample5.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_downsample5.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+
+from ttnn.model_preprocessing import preprocess_model, preprocess_conv2d, fold_batch_norm2d_into_conv2d
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import skip_for_wormhole_b0
+from models.experimental.functional_yolov4.reference.downsample5 import DownSample5
+from models.experimental.functional_yolov4.tt.ttnn_downsample5 import TtDownSample5
+
+import ttnn
+from ttnn.model_preprocessing import preprocess_conv2d, fold_batch_norm2d_into_conv2d
+
+
+def update_ttnn_module_args(ttnn_module_args):
+    ttnn_module_args["use_1d_systolic_array"] = False  # ttnn_module_args.in_channels <= 256
+    ttnn_module_args["math_fidelity"] = ttnn.MathFidelity.LoFi
+    ttnn_module_args["dtype"] = ttnn.bfloat8_b
+    ttnn_module_args["weights_dtype"] = ttnn.bfloat8_b
+    ttnn_module_args["deallocate_activation"] = True
+    ttnn_module_args["conv_blocking_and_parallelization_config_override"] = None
+    ttnn_module_args["activation"] = "relu"
+
+
+def create_custom_preprocessor(device):
+    def custom_preprocessor(model, name, ttnn_module_args):
+        parameters = {}
+        if isinstance(model, DownSample5):
+            ttnn_module_args.c1["use_shallow_conv_variant"] = False
+            conv1_weight, conv1_bias = fold_batch_norm2d_into_conv2d(model.c1, model.b1)
+            update_ttnn_module_args(ttnn_module_args.c1)
+            parameters["c1"], c1_parallel_config = preprocess_conv2d(
+                conv1_weight, conv1_bias, ttnn_module_args.c1, return_parallel_config=True
+            )
+
+            ttnn_module_args.c2["use_shallow_conv_variant"] = False
+            ttnn_module_args.c2["weights_dtype"] = ttnn.bfloat8_b
+            conv2_weight, conv2_bias = fold_batch_norm2d_into_conv2d(model.c2, model.b2)
+            update_ttnn_module_args(ttnn_module_args.c2)
+            parameters["c2"], c2_parallel_config = preprocess_conv2d(
+                conv2_weight, conv2_bias, ttnn_module_args.c2, return_parallel_config=True
+            )
+
+            ttnn_module_args.c3["use_shallow_conv_variant"] = False
+            ttnn_module_args.c3["weights_dtype"] = ttnn.bfloat8_b
+            conv3_weight, conv3_bias = fold_batch_norm2d_into_conv2d(model.c3, model.b3)
+            update_ttnn_module_args(ttnn_module_args.c3)
+            parameters["c3"], c3_parallel_config = preprocess_conv2d(
+                conv3_weight, conv3_bias, ttnn_module_args.c3, return_parallel_config=True
+            )
+
+            parameters["res"] = {}
+            for i, block in enumerate(model.res.module_list):
+                conv1 = block[0]
+                bn1 = block[1]
+                conv2 = block[3]
+                bn2 = block[4]
+
+                ttnn_module_args["res"][f"resblock_{i}_conv1"] = ttnn_module_args["res"]["0"]
+                ttnn_module_args["res"][f"resblock_{i}_conv1"]["weights_dtype"] = ttnn.bfloat8_b
+                weight1, bias1 = fold_batch_norm2d_into_conv2d(conv1, bn1)
+                update_ttnn_module_args(ttnn_module_args["res"][f"resblock_{i}_conv1"])
+                parameters["res"][f"resblock_{i}_conv1"], _ = preprocess_conv2d(
+                    weight1, bias1, ttnn_module_args["res"][f"resblock_{i}_conv1"], return_parallel_config=True
+                )
+
+                ttnn_module_args["res"][f"resblock_{i}_conv2"] = ttnn_module_args["res"]["3"]
+                ttnn_module_args["res"][f"resblock_{i}_conv2"]["weights_dtype"] = ttnn.bfloat8_b
+                weight2, bias2 = fold_batch_norm2d_into_conv2d(conv2, bn2)
+                update_ttnn_module_args(ttnn_module_args["res"][f"resblock_{i}_conv2"])
+                parameters["res"][f"resblock_{i}_conv2"], _ = preprocess_conv2d(
+                    weight2, bias2, ttnn_module_args["res"][f"resblock_{i}_conv2"], return_parallel_config=True
+                )
+
+            ttnn_module_args.c4["use_shallow_conv_variant"] = False
+            ttnn_module_args.c4["weights_dtype"] = ttnn.bfloat8_b
+            conv4_weight, conv4_bias = fold_batch_norm2d_into_conv2d(model.c4, model.b4)
+            update_ttnn_module_args(ttnn_module_args.c4)
+            parameters["c4"], c4_parallel_config = preprocess_conv2d(
+                conv4_weight, conv4_bias, ttnn_module_args.c4, return_parallel_config=True
+            )
+
+            ttnn_module_args.c5["use_shallow_conv_variant"] = False
+            ttnn_module_args.c5["weights_dtype"] = ttnn.bfloat8_b
+            conv5_weight, conv5_bias = fold_batch_norm2d_into_conv2d(model.c5, model.b5)
+            update_ttnn_module_args(ttnn_module_args.c5)
+            parameters["c5"], c5_parallel_config = preprocess_conv2d(
+                conv5_weight, conv5_bias, ttnn_module_args.c5, return_parallel_config=True
+            )
+
+        return parameters
+
+    return custom_preprocessor
+
+
+@skip_for_wormhole_b0()
+def test_downsample5(device, reset_seeds, model_location_generator):
+    model_path = model_location_generator("models", model_subdir="Yolo")
+    weights_pth = str(model_path / "yolov4.pth")
+    state_dict = torch.load(weights_pth)
+    ds_state_dict = {k: v for k, v in state_dict.items() if (k.startswith("down5."))}
+
+    torch_model = DownSample5()
+
+    for layer in torch_model.children():
+        print(layer)
+
+    new_state_dict = {}
+    keys = [name for name, parameter in torch_model.state_dict().items()]
+    values = [parameter for name, parameter in ds_state_dict.items()]
+    for i in range(len(keys)):
+        new_state_dict[keys[i]] = values[i]
+
+    torch_model.load_state_dict(new_state_dict)
+    torch_model.eval()
+    torch_input_tensor = torch.randn(1, 512, 20, 20)  # Batch size of 1, 512 input channels, 20x20 height and width
+    torch_output_tensor = torch_model(torch_input_tensor)
+
+    reader_patterns_cache = {}
+    parameters = preprocess_model(
+        initialize_model=lambda: torch_model,
+        run_model=lambda model: model(torch_input_tensor),
+        custom_preprocessor=create_custom_preprocessor(device),
+        reader_patterns_cache=reader_patterns_cache,
+        device=device,
+    )
+    ttnn_model = TtDownSample5(parameters)
+    # Tensor Preprocessing
+    #
+    input_shape = torch_input_tensor.shape
+    input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
+
+    input_tensor = input_tensor.reshape(
+        input_tensor.shape[0], 1, input_tensor.shape[1] * input_tensor.shape[2], input_tensor.shape[3]
+    )
+    input_tensor = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT)
+    with ttnn.tracer.trace():
+        output_tensor = ttnn_model(device, input_tensor)
+    ttnn.tracer.visualize(output_tensor, file_name="downsample5.svg")
+    # output_tensor = ttnn_model(device, input_tensor)
+
+    #
+    # Tensor Postprocessing
+    #
+    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = output_tensor.reshape(1, 10, 10, 1024)
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+    output_tensor = output_tensor.to(torch_input_tensor.dtype)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)


### PR DESCRIPTION
This is a draft PR for the downsample4 and downsample5 sub-modules implementation of yolov4 and unit test.

ResBlock has been replaced with direct layer implementation instead of Separate class.
Once the sub-module is available from https://github.com/tenstorrent-metal/tt-metal/issues/7051, we will integrate resBlock into Downsample4 and Downsample5 sub-modules.

Currently, both the tests are hanging after checkpoint 5 -> during the ttnn.concat operation for Downsample4 sub-module. We are debugging this issue.