### PR TITLE
#5337: Small perf fix to Mistral7B softmax scaling

### DIFF
--- a/models/demos/mistral7b/tests/test_mistral_attention.py
+++ b/models/demos/mistral7b/tests/test_mistral_attention.py
@@ -26,7 +26,7 @@ from models.utility_functions import skip_for_grayskull
     "iterations",
     ((1),),
 )
-def test_mistral_attention_inference(iterations, device, use_program_cache):
+def test_mistral_attention_inference(iterations, device, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
     pcc = 0.99
 

--- a/models/demos/mistral7b/tests/test_mistral_decoder.py
+++ b/models/demos/mistral7b/tests/test_mistral_decoder.py
@@ -25,7 +25,7 @@ from models.utility_functions import skip_for_grayskull
     "iterations",
     ((1),),
 )
-def test_mistral_decoder_inference(device, iterations, use_program_cache):
+def test_mistral_decoder_inference(device, iterations, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
 
     model_args = TtModelArgs(device)

--- a/models/demos/mistral7b/tests/test_mistral_embedding.py
+++ b/models/demos/mistral7b/tests/test_mistral_embedding.py
@@ -25,7 +25,7 @@ class Emb(torch.nn.Module):
         return self.emb(x)
 
 
-def test_mistral_embedding(device, use_program_cache):
+def test_mistral_embedding(device, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat16
 
     model_args = TtModelArgs(device)

--- a/models/demos/mistral7b/tests/test_mistral_mlp.py
+++ b/models/demos/mistral7b/tests/test_mistral_mlp.py
@@ -17,7 +17,7 @@ from models.utility_functions import skip_for_grayskull
 
 
 @skip_for_grayskull("Requires wormhole_b0 to run")
-def test_mistral_mlp_inference(device, use_program_cache):
+def test_mistral_mlp_inference(device, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(device=device)
     state_dict = torch.load(model_args.consolidated_weights_path)

--- a/models/demos/mistral7b/tests/test_mistral_model.py
+++ b/models/demos/mistral7b/tests/test_mistral_model.py
@@ -44,7 +44,7 @@ class Emb(torch.nn.Module):
     "iterations",
     (17,),
 )
-def test_mistral_model_inference(device, iterations, version, use_program_cache):
+def test_mistral_model_inference(device, iterations, version, use_program_cache, reset_seeds):
     if version == "generative":
         instruct = False
     elif version == "instruct":

--- a/models/demos/mistral7b/tests/test_mistral_perf.py
+++ b/models/demos/mistral7b/tests/test_mistral_perf.py
@@ -38,7 +38,7 @@ class Emb(torch.nn.Module):
     ((32, 12, 15, 0.16),),
 )
 def test_mistral_model_perf(
-    device, batch, iterations, expected_compile_time, expected_inference_time, use_program_cache
+    device, batch, iterations, expected_compile_time, expected_inference_time, use_program_cache, reset_seeds
 ):
     dtype = ttnn.bfloat8_b
 
@@ -213,7 +213,7 @@ def test_mistral_model_perf(
     "batch, iterations, expected_perf",
     ((32, 17, 0.16),),
 )
-def test_mistral_perf_device(batch, iterations, expected_perf):
+def test_mistral_perf_device(batch, iterations, expected_perf, reset_seeds):
     subdir = "ttnn_mistral7b"
     margin = 0.03
     command = f"pytest models/demos/mistral7b/tests/test_mistral_model.py::test_mistral_model_inference[{iterations}-generative]"
@@ -229,5 +229,4 @@ def test_mistral_perf_device(batch, iterations, expected_perf):
         batch_size=batch,
         post_processed_results=post_processed_results,
         expected_results=expected_results,
-        comments=test.replace("/", "_"),
     )

--- a/models/demos/mistral7b/tests/test_mistral_rms_norm.py
+++ b/models/demos/mistral7b/tests/test_mistral_rms_norm.py
@@ -16,7 +16,7 @@ from models.utility_functions import skip_for_grayskull
 
 
 @skip_for_grayskull("Requires wormhole_b0 to run")
-def test_mistral_rms_norm_inference(device, use_program_cache):
+def test_mistral_rms_norm_inference(device, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
 
     model_args = TtModelArgs(device)


### PR DESCRIPTION
This fix changes the softmax scalling to a tensor and applies it to q_heads, avoiding fallback to host.

Also updated Mistral7b test prefixes to use `reset_seeds`.

All mistral tests passing in fast nightly and perf:
- https://github.com/tenstorrent-metal/tt-metal/actions/runs/8556741157/job/23447307952
- https://github.com/tenstorrent-metal/tt-metal/actions/runs/8556737907/job/23447479230