### PR TITLE
#6388: temporarily disable bidirectional support for all-gather

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
@@ -178,7 +178,7 @@ def run_all_gather_on_t3000_impl_tight_loop(
         ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
     ],
 )
-@pytest.mark.parametrize("num_iters", [10])  # TODO: restore to 500
+@pytest.mark.parametrize("num_iters", [100])  # TODO: restore to 500
 def test_all_gather_on_t3000_post_commit_looping(
     all_devices,
     num_devices,
@@ -435,7 +435,7 @@ def test_all_gather_on_t3000_nightly(
     )
 
 
-# @pytest.mark.skip("Not ready for prime time")
+@pytest.mark.skip("Re-enable with FD 2.0 and most recent all-gather updates/bug-fixes")
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize("dim", [3])
@@ -499,11 +499,6 @@ def test_all_gather_on_t3000_nightly(
             ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 0))}),
         ),
         (
-            # 2048 wide works
-            # 3072 wide hangs -> maybe I'm exceeding some size limit... (add asserts on buffer sizes:
-            #  - eth buffer size
-            #  - shard buffer size
-            # )
             (1, 1, 32, 3072),
             (32, 128),
             ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 2))}),

--- a/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
@@ -25,7 +25,7 @@ class AllGatherConfig {
 
         // enable_bidirectional - currently doesn't support batch dim and multi-link (some tests are flaky with those configs)
         erisc_handshake_address(eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE),
-        enable_bidirectional(dim != 0 && dim != 1),
+        enable_bidirectional(false),
 
         input_is_dram(input_tensor.buffer()->buffer_type() == BufferType::DRAM),
         output_is_dram(output_tensor.buffer()->buffer_type() == BufferType::DRAM)


### PR DESCRIPTION
This feature seems to expose a fast dispatch hang. The suspected delta between bidirectional and unidirectional that could expose an issue in the dispatcher path is the extra workers that are instantiated, and thus, the extra binaries that must be sent. The number of workers is doubled when switching to bidirectional.