### PR TITLE
#0: Clean up watcher test teardown to avoid nondet ci issue

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
@@ -18,8 +18,11 @@ public:
         // Only difference is that we need to wait for the print server to catch
         // up after running a test.
         CommonFixture::RunProgram(device, program);
-        // Wait for a watcher interval to make sure that we get a reading after program finish.
-        std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
+
+        // Wait for watcher to run a full dump before finishing, need to wait for dump count to
+        // increase because we'll likely check in the middle of a dump.
+        int curr_count = tt::watcher_get_dump_count();
+        while (tt::watcher_get_dump_count() < curr_count + 2) {;}
     }
 
 protected:

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -29,4 +29,7 @@ void watcher_clear_log();
 // Helper function to get the current watcher log file name/path
 string watcher_get_log_file_name();
 
+// Helper function to get the current watcher dump count
+int watcher_get_dump_count();
+
 } // namespace tt


### PR DESCRIPTION
Issue here was that watcher sometimes slows down for t3000, and the fixture wasn't waiting long enough for the last watcher dump before checking results. Just update the waiting to be based on dump count instead of time.

Ran the problematic test 200+ times and seems ok, previously failed within 50 runs.

Passing CI:
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8560055420
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8560050958