### PR TITLE
#6217: Async Mode for Data Parallel/Tensor Parallel

### DIFF
--- a/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_multi_device.sh
@@ -42,3 +42,4 @@ pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_i
 pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips]
 
 pytest tests/ttnn/unit_tests/test_multi_device.py
+pytest tests/ttnn/unit_tests/test_multi_device_async.py

--- a/tests/tt_eager/tensors/test_async_tensor_apis.cpp
+++ b/tests/tt_eager/tensors/test_async_tensor_apis.cpp
@@ -29,7 +29,7 @@ TEST_F(CommonFixture, TestTensorOwnershipSanity) {
     // Ensure that tensor data is copied and owned as expected
     Device* device = this->devices_[0];
     Tensor host_tensor = tt::numpy::arange<float>(0, 32 * 32 * 4, 1);
-    Tensor readback_tensor;
+    Tensor readback_tensor({}, 1);
 
     auto func = [device, host_tensor, readback_tensor]() mutable {
         // Ensure that both the lambda and global scope have ownership to this tensor
@@ -55,7 +55,7 @@ TEST_F(CommonFixture, TestTensorOwnershipSanity) {
         readback_tensor.set_shape(thread_local_tensor.get_shape());
         readback_tensor.set_dtype(thread_local_tensor.get_dtype());
         readback_tensor.set_layout(thread_local_tensor.get_layout());
-        readback_tensor.set_metadata_populated();
+        readback_tensor.set_populated();
         // Ensure that the readback buffer is owned inside and outside the lambda
         std::visit([](auto&& storage) {
             using T = std::decay_t<decltype(storage)>;
@@ -186,7 +186,7 @@ TEST_F(CommonFixture, TestTensorAsyncDataMovement) {
     uint32_t tensor_start = 0;
     uint32_t num_tiles = 128;
     uint32_t tensor_stop = TILE_HEIGHT * TILE_WIDTH * num_tiles;
-    Tensor readback_tensor;
+    Tensor readback_tensor({}, 1);;
     std::thread worker;
 
     {
@@ -223,7 +223,7 @@ TEST_F(CommonFixture, TestTensorAsyncDataMovement) {
             readback_tensor.set_shape(thread_local_tensor.get_shape());
             readback_tensor.set_dtype(thread_local_tensor.get_dtype());
             readback_tensor.set_layout(thread_local_tensor.get_layout());
-            readback_tensor.set_metadata_populated();
+            readback_tensor.set_populated();
             // Ensure that this buffer is currently owned by both the thread_local and read_back tensors
             // This is because we explictly pass in the buffer to a new tensor_attr object
             std::visit([](auto&& storage) {

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -242,8 +242,8 @@ def test_multi_device_data_parallel_matmul_op(device_mesh):
     """Multidevice API: Data Parallel on matmul"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
 
-    torch_input_a_tensor = torch.rand((4, 1, 32, 32 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
-    torch_input_b_tensor = torch.rand((1, 1, 32 * device_mesh.get_num_devices(), 32), dtype=torch.bfloat16)
+    torch_input_a_tensor = torch.rand((device_mesh.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
+    torch_input_b_tensor = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
     torch_output_golden = torch_input_a_tensor @ torch_input_b_tensor
 
     ttnn_input_a_tensor = ttnn.from_torch(

--- a/tests/ttnn/unit_tests/test_multi_device_async.py
+++ b/tests/ttnn/unit_tests/test_multi_device_async.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import typing
+import pytest
+import ttnn
+from loguru import logger
+from tests.ttnn.utils_for_testing import assert_with_pcc
+import transformers
+
+
+#######
+# Multi-Device Tensor tests running in async mode
+#######
+
+
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_ttnn_to_and_from_multi_device_shard(pcie_device_mesh, layout, memory_config, dtype):
+    """Shard a tensor across devices, compose it back and verify loopback tensor is same as the original tensor"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor
+
+    if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(True)
+
+    for i in range(100):
+        torch_tensor = torch.rand((1, 1, 256, 512), dtype=torch.bfloat16)
+        ttnn_tensor = ttnn.from_torch(
+            torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3)
+        )
+        ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_device_mesh, memory_config=memory_config)
+        ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
+        torch_loop_back_tensor = ttnn.to_torch(
+            ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=3)
+        )
+        assert_with_pcc(torch_tensor, torch_loop_back_tensor, pcc=0.9999)
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(False)
+
+
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+def test_multi_device_check_per_device_shard(pcie_device_mesh, layout, memory_config, dtype):
+    """This test checks if the tensor is correctly sharded across devices"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor
+
+    if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(True)
+
+    num_loops = 50
+    if dtype == ttnn.bfloat8_b:
+        # On host bfloat8_b conversion is slow. Decrease num loops.
+        num_loops = 10
+    for i in range(num_loops):
+        torch_tensor = torch.rand((8, 1, 1024, 1024), dtype=torch.bfloat16)
+
+        ttnn_tensor = ttnn.from_torch(
+            torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3)
+        )
+        ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_device_mesh, memory_config=memory_config)
+        ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
+
+        shard_offset, shard_size = 0, int(1024 / len(pcie_device_mesh.get_device_ids()))
+        for device_tensor in ttnn.get_device_tensors(ttnn_loop_back_tensor):
+            device_tensor_torch = ttnn.to_torch(device_tensor)
+            assert_with_pcc(
+                device_tensor_torch, torch_tensor[..., shard_offset : shard_offset + shard_size], pcc=0.9999
+            )
+            shard_offset += shard_size
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(False)
+
+
+@pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 1040, 1040)])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+def test_multi_device_replicate(pcie_device_mesh, shape, layout, memory_config):
+    """Test ReplicateTensorToMesh to broadcast a tensor across multiple devices"""
+    from ttnn import ReplicateTensorToMesh, ListMeshToTensor
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(True)
+
+    for i in range(100):
+        full_tensor = torch.rand(shape, dtype=torch.bfloat16)
+
+        ttnn_tensor = ttnn.from_torch(
+            full_tensor,
+            mesh_mapper=ReplicateTensorToMesh(pcie_device_mesh),
+            layout=layout,
+            memory_config=memory_config,
+            device=pcie_device_mesh,
+        )
+        ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_device_mesh)
+        ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
+        loopback_replicated_tensors = ttnn.to_torch(
+            ttnn_loop_back_tensor, mesh_composer=ListMeshToTensor(pcie_device_mesh)
+        )
+        for loopback_replicated_tensor in loopback_replicated_tensors:
+            assert torch.all(full_tensor == loopback_replicated_tensor)
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(False)
+
+
+@pytest.mark.parametrize("program_cache", [False, True])
+@pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 3, 1024, 1024)])
+def test_multi_device_unary_binary_op_chain(pcie_device_mesh, program_cache, shape):
+    """Multidevice API test: Running tensor-parallel multi-device chain of eltwise ops"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(True)
+        if program_cache:
+            pcie_device_mesh.get_device(device).enable_program_cache()
+
+    torch_silu = torch.nn.SiLU()
+    for i in range(50):
+        torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
+        torch_output_golden = torch.add(
+            torch.subtract(
+                torch.exp(torch.nn.functional.relu(torch.nn.functional.gelu(torch_input_tensor))),
+                torch.exp(torch_input_tensor),
+            ),
+            torch_silu(torch_input_tensor),
+        )
+
+        ttnn_input_tensor = ttnn.from_torch(
+            torch_input_tensor,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3),
+            device=pcie_device_mesh,
+        )
+        ttnn_output_tensor = ttnn.add(
+            ttnn.sub(ttnn.exp(ttnn.relu(ttnn.gelu(ttnn_input_tensor))), ttnn.exp(ttnn_input_tensor)),
+            ttnn.silu(ttnn_input_tensor),
+        )
+        ttnn_output_tensor = ttnn.from_device(ttnn_output_tensor)
+        ttnn_torch_output_tensor = ttnn.to_torch(
+            ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=3)
+        )
+        assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.98)
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(False)
+
+
+@pytest.mark.parametrize("program_cache", [False, True])
+@pytest.mark.parametrize("input_a_shape", [(4, 1, 512, 512), (16, 1, 512, 512)])
+def test_multi_device_data_parallel_op_chain(pcie_device_mesh, program_cache, input_a_shape):
+    """Multidevice API: Running data-parallel chain of ops with matmul"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(True)
+        if program_cache:
+            pcie_device_mesh.get_device(device).enable_program_cache()
+
+    torch_silu = torch.nn.SiLU()
+    for i in range(5):
+        torch_input_a_tensor = torch.rand(input_a_shape, dtype=torch.bfloat16)
+        torch_input_b_tensor = torch.rand((1, 1, 512, 512), dtype=torch.bfloat16)
+        torch_output_golden = torch_silu(
+            torch.nn.functional.relu(torch.nn.functional.gelu(torch_input_a_tensor @ torch_input_b_tensor))
+            @ torch.exp(torch_input_a_tensor)
+        )
+
+        ttnn_input_a_tensor = ttnn.from_torch(
+            torch_input_a_tensor,
+            layout=ttnn.TILE_LAYOUT,
+            device=pcie_device_mesh,
+            mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0),
+        )
+        ttnn_input_b_tensor = ttnn.from_torch(
+            torch_input_b_tensor,
+            layout=ttnn.TILE_LAYOUT,
+            device=pcie_device_mesh,
+            mesh_mapper=ReplicateTensorToMesh(pcie_device_mesh),
+        )
+        ttnn_output_tensor = ttnn.from_device(
+            ttnn.silu(ttnn.relu(ttnn.gelu(ttnn_input_a_tensor @ ttnn_input_b_tensor)) @ ttnn.exp(ttnn_input_a_tensor))
+        )
+        ttnn_torch_output_tensor = ttnn.to_torch(
+            ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+        )
+        assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.97)
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(False)
+
+
+@pytest.mark.parametrize("pcie_device_mesh", [2], indirect=True)
+def test_multi_device_explicit_dealloc(pcie_device_mesh):
+    """Multidevice API: Ensure that deallocating multi-device tensors works as expected"""
+    from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(True)
+
+    # Create input tensors that cause OOM during op execution
+    # Explictly deallocate buffers after each op to ensure we don't run OOM.
+    torch_input_a_tensor = torch.rand((512, 1, 2048, 2048), dtype=torch.bfloat16)
+    torch_input_b_tensor = torch.rand((1, 1, 2048, 2048), dtype=torch.bfloat16)
+
+    ttnn_input_a_tensor = ttnn.from_torch(
+        torch_input_a_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=pcie_device_mesh,
+        mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0),
+    )
+    ttnn_input_b_tensor = ttnn.from_torch(
+        torch_input_b_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=pcie_device_mesh,
+        mesh_mapper=ReplicateTensorToMesh(pcie_device_mesh),
+    )
+    ttnn_output_tensor_1 = ttnn_input_a_tensor @ ttnn_input_b_tensor
+    ttnn_output_tensor_2 = ttnn.gelu(ttnn_output_tensor_1)
+    ttnn_output_tensor_1.deallocate()
+    ttnn_input_b_tensor.deallocate()
+    ttnn_output_tensor_3 = ttnn.relu(ttnn_output_tensor_2)
+    ttnn_output_tensor_2.deallocate()
+    ttnn_output_tensor_4 = ttnn_output_tensor_3 @ ttnn_input_a_tensor
+    ttnn_output_tensor_3.deallocate()
+    ttnn_output_tensor = ttnn.from_device(ttnn_output_tensor_4)
+    ttnn_torch_output_tensor = ttnn.to_torch(
+        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+    )
+
+    for device in pcie_device_mesh.get_device_ids():
+        pcie_device_mesh.get_device(device).enable_async(False)

--- a/tt_eager/tensor/borrowed_buffer.hpp
+++ b/tt_eager/tensor/borrowed_buffer.hpp
@@ -32,7 +32,6 @@ struct Buffer {
 
     inline void* data() noexcept { return static_cast<void*>(this->data_ptr_); }
     inline const void* data() const noexcept { return static_cast<void*>(this->data_ptr_); }
-
    private:
     T* data_ptr_;
     std::size_t size_;

--- a/tt_eager/tensor/tensor_utils.hpp
+++ b/tt_eager/tensor/tensor_utils.hpp
@@ -55,7 +55,7 @@ namespace tt_metal {
    bool is_device_tensor(const Tensor& tensor);
 
 // Given a multi-device tensor and a device, returns the tensor on the given device.
-Tensor get_device_tensor(const Device* device, const Tensor& multi_device_tensor);
+Tensor get_device_tensor(Device* device, const Tensor& multi_device_tensor);
 
 // Returns true has MultiDeviceHost/MultiDevice Storage
 bool is_multi_device_tensor(const Tensor& tensor);
@@ -74,6 +74,14 @@ void apply(const Tensor& tensor, std::function<void(const Tensor&)> callable);
 
 // Given a multi-device tensor, return all the devices it is mapped to.
 std::vector<Device*> get_devices(const Tensor& multi_device_tensor);
+
+uint32_t num_buffers_in_tensor(const Tensor& tensor);
+
+Tensor get_shard_for_device(const Tensor& tensor, Device* target_device);
+
+void insert_buffer_and_shape_for_device(Device* target_device, const Tensor& shard, Tensor& tensor_to_modify);
+
+Tensor copy_borrowed_tensor_in_async_mode(Device* worker, const Tensor& tensor);
 
 template<typename TensorContainer>
 auto get_device_tensors(Device* device, const TensorContainer& input_tensors) {

--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -317,34 +317,139 @@ struct OwnedStorage {
     struct MultiDeviceHostStorage {
         std::vector<OwnedBuffer> buffers;
         std::vector<Shape> shapes;
-
+        std::mutex mtx;
         MultiDeviceHostStorage() = default;
+        MultiDeviceHostStorage(std::vector<OwnedBuffer> buffers_, std::vector<Shape> shapes_) : buffers(buffers_), shapes(shapes_) {}
+        MultiDeviceHostStorage(MultiDeviceHostStorage &&other) {
+            buffers = other.buffers;
+            shapes = other.shapes;
+        }
+
+        MultiDeviceHostStorage(const MultiDeviceHostStorage &other) {
+            buffers = other.buffers;
+            shapes = other.shapes;
+        }
+
+        MultiDeviceHostStorage &operator=(const MultiDeviceHostStorage &other) {
+            buffers = other.buffers;
+            shapes = other.shapes;
+            return *this;
+        }
+
+        MultiDeviceHostStorage &operator=( MultiDeviceHostStorage &&other) {
+            buffers = other.buffers;
+            shapes = other.shapes;
+            return *this;
+        }
+
+        bool operator == (const MultiDeviceHostStorage& other) {
+            return this->buffers == other.buffers and this->shapes == other.shapes;
+        }
+
         static constexpr auto attribute_names = std::make_tuple();
         const auto attribute_values() const { return std::make_tuple(); }
+
+        // Helper Functions - Getters and setters to get/modify storage attributes. These are needed to
+        // preinitialize empty tensor handles and use/populate them in the worker threads.
+        void insert_buffer_and_shape_for_device(Device* device, const OwnedBuffer buffer, const Shape shape) {
+            std::lock_guard<std::mutex> lock(mtx);
+            buffers[device->id()] = buffer;
+            shapes[device->id()] = shape;
+        }
+
+        OwnedBuffer get_buffer_for_device(Device* device) {
+            std::lock_guard<std::mutex> lock(mtx);
+            TT_FATAL(device->id() < buffers.size(), "Buffer not found for device " + std::to_string(device->id()));
+            return buffers[device->id()];;
+        }
+
+        Shape get_tensor_shape_for_device(Device* device) {
+            std::lock_guard<std::mutex> lock(mtx);
+            TT_FATAL(device->id() < shapes.size(), "Buffer not found for device " + std::to_string(device->id()));
+            return shapes[device->id()];
+        }
+        
+        uint32_t num_buffers() {
+            std::lock_guard<std::mutex> lock(mtx);
+            return buffers.size();
+        }
     };
 
     struct MultiDeviceStorage {
-        std::vector<DeviceBuffer> buffers;
-        std::vector<Shape> shapes;
-
-    MultiDeviceStorage() = default;
-    const MemoryConfig memory_config() const {
-        if (this->buffers.at(0).get() == nullptr) {
-            TT_THROW("MemoryConfig can only be obtained if the buffer is not null");
+        std::unordered_map<int, DeviceBuffer> buffers;
+        std::unordered_map<int, Shape> shapes;
+        mutable std::mutex mtx;
+        MultiDeviceStorage() = default;
+        MultiDeviceStorage(std::unordered_map<int, DeviceBuffer> buffers_, std::unordered_map<int, Shape> shapes_) : buffers(buffers_), shapes(shapes_) {}
+        MultiDeviceStorage(MultiDeviceStorage &&other) {
+            buffers = other.buffers;
+            shapes = other.shapes;
+        }
+        MultiDeviceStorage(const MultiDeviceStorage &other) {
+            buffers = other.buffers;
+            shapes = other.shapes;
         }
 
-        std::optional<ShardSpec> shard_spec = std::nullopt;
-        if (is_sharded(this->buffers.at(0)->buffer_layout())) {
-            shard_spec = this->buffers.at(0)->shard_spec().tensor_shard_spec;
+        MultiDeviceStorage &operator=(const MultiDeviceStorage &other) {
+            buffers = other.buffers;
+            shapes = other.shapes;
+            return *this;
         }
-        return MemoryConfig{
-            .memory_layout = this->buffers.at(0)->buffer_layout(),
-            .buffer_type = this->buffers.at(0)->buffer_type(),
-            .shard_spec = shard_spec};
-    }
-    static constexpr auto attribute_names = std::make_tuple();
-    const auto attribute_values() const { return std::make_tuple(); }
-};
+
+        MultiDeviceStorage &operator=( MultiDeviceStorage &&other) {
+            buffers = other.buffers;
+            shapes = other.shapes;
+            return *this;
+        }
+
+        bool operator == (const MultiDeviceStorage& other) {
+            return this->buffers == other.buffers and this->shapes == other.shapes;
+        }
+
+        const MemoryConfig memory_config() const {
+            std::lock_guard<std::mutex> lock(mtx);
+            if (this->buffers.at(0).get() == nullptr) {
+                TT_THROW("MemoryConfig can only be obtained if the buffer is not null");
+            }
+            std::optional<ShardSpec> shard_spec = std::nullopt;
+            if (is_sharded(this->buffers.at(0)->buffer_layout())) {
+                shard_spec = this->buffers.at(0)->shard_spec().tensor_shard_spec;
+            }
+            return MemoryConfig{
+                .memory_layout = this->buffers.at(0)->buffer_layout(),
+                .buffer_type = this->buffers.at(0)->buffer_type(),
+                .shard_spec = shard_spec};
+
+        }
+
+        static constexpr auto attribute_names = std::make_tuple();
+        const auto attribute_values() const { return std::make_tuple(); }
+
+        // Helper Functions - Getters and setters to get/modify storage attributes. These are needed to
+        // preinitialize empty tensor handles and use/populate them in the worker threads.
+        void insert_buffer_and_shape_for_device(Device* device, const DeviceBuffer buffer, const Shape shape) {
+            std::lock_guard<std::mutex> lock(mtx);
+            buffers.insert({device->id(), buffer});
+            shapes.insert({device->id(), shape});
+        }
+
+        DeviceBuffer get_buffer_for_device(Device* device) {
+            std::lock_guard<std::mutex> lock(mtx);
+            TT_FATAL(buffers.find(device->id()) != buffers.end(), "Buffer not found for device " + std::to_string(device->id()));
+            return buffers.at(device->id());
+        }
+
+        Shape get_tensor_shape_for_device(Device* device) {
+            std::lock_guard<std::mutex> lock(mtx);
+            TT_FATAL(shapes.find(device->id()) != shapes.end(), "Shape not found for device " + std::to_string(device->id()));
+            return shapes.at(device->id());
+        }
+
+        uint32_t num_buffers() {
+            std::lock_guard<std::mutex> lock(mtx);
+            return buffers.size();
+        }
+    };
 
     using Storage =
         std::variant<OwnedStorage, DeviceStorage, BorrowedStorage, MultiDeviceHostStorage, MultiDeviceStorage>;

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
@@ -403,73 +403,85 @@ namespace tt {
 namespace tt_metal {
 
 inline Tensor matmul (const Tensor &input_tensor_a, const Tensor &input_tensor_b, const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt, bool untilize_out = false) {
-    TT_FATAL(input_tensor_a.get_dtype() == input_tensor_b.get_dtype());
-    TT_FATAL(input_tensor_a.get_legacy_shape()[3] == input_tensor_b.get_legacy_shape()[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
-    TT_FATAL(input_tensor_b.get_legacy_shape()[0]*input_tensor_b.get_legacy_shape()[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
+    operation::launch_op(
+        [mem_config, compute_kernel_config, untilize_out] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor_a = input_tensors.at(0);
+            const auto& input_tensor_b = input_tensors.at(1);
+            TT_FATAL(input_tensor_a.get_dtype() == input_tensor_b.get_dtype());
+            TT_FATAL(input_tensor_a.get_legacy_shape()[3] == input_tensor_b.get_legacy_shape()[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
+            TT_FATAL(input_tensor_b.get_legacy_shape()[0]*input_tensor_b.get_legacy_shape()[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
 
-    auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
-    auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4);
+            auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
+            auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4);
 
-    // TODO: Uplift interleaved path to call tt::operation::primary::Matmul and deprecate old tt::tt_metal::Matmul
-    if (input_tensor_a.is_sharded()) {
-        auto matmul_program_config = bmm_op_utils::get_matmul_program_config(input_tensor_a, input_tensor_b, mem_config, std::nullopt, true);
-        return operation::run(
-                   tt::operations::primary::Matmul{
-                       .program_config = matmul_program_config,
-                       .output_mem_config = mem_config,
-                       .output_dtype = input_tensor_a.get_dtype(),
-                       .compute_kernel_config = kernel_config_val,
-                       .untilize_out = untilize_out,
-                   },
-                   {input_tensor_a, input_tensor_b},
-                   {std::nullopt})
-            .at(0);
-    } else {
-        return operation::run_with_autoformat(
-                   Matmul{
-                       .bcast_batch = true,
-                       .output_mem_config = mem_config,
-                       .output_dtype = input_tensor_a.get_dtype(),
-                       .compute_kernel_config = kernel_config_val,
-                       .untilize_out = untilize_out,
-                   },
-                   {input_tensor_a, input_tensor_b},
-                   {std::nullopt})
-            .at(0);
-    }
+            // TODO: Uplift interleaved path to call tt::operation::primary::Matmul and deprecate old tt::tt_metal::Matmul
+            if (input_tensor_a.is_sharded()) {
+                auto matmul_program_config = bmm_op_utils::get_matmul_program_config(input_tensor_a, input_tensor_b, mem_config, std::nullopt, true);
+                return operation::run(
+                        tt::operations::primary::Matmul{
+                            .program_config = matmul_program_config,
+                            .output_mem_config = mem_config,
+                            .output_dtype = input_tensor_a.get_dtype(),
+                            .compute_kernel_config = kernel_config_val,
+                            .untilize_out = untilize_out,
+                        },
+                        {input_tensor_a, input_tensor_b},
+                        {std::nullopt});
+            }
+            return operation::run_with_autoformat(
+                    Matmul{
+                        .bcast_batch = true,
+                        .output_mem_config = mem_config,
+                        .output_dtype = input_tensor_a.get_dtype(),
+                        .compute_kernel_config = kernel_config_val,
+                        .untilize_out = untilize_out,
+                    },
+                    {input_tensor_a, input_tensor_b},
+                    {std::nullopt});
+        },
+    {input_tensor_a, input_tensor_b}, output_tensors);
+    return output_tensors.at(0);
 }
 // TODO: Should we merge this with matmul and expose an option (or infer it from shape) to bcast_batch
 inline Tensor bmm    (const Tensor &input_tensor_a, const Tensor &input_tensor_b, const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt, bool untilize_out = false) {
-    TT_FATAL(input_tensor_a.get_dtype() == input_tensor_b.get_dtype());
-    TT_FATAL(input_tensor_a.get_legacy_shape()[3] == input_tensor_b.get_legacy_shape()[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
-    TT_FATAL(input_tensor_a.get_legacy_shape()[1] == input_tensor_b.get_legacy_shape()[1] && input_tensor_a.get_legacy_shape()[0] == input_tensor_b.get_legacy_shape()[0]
-        && "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
+    operation::launch_op(
+        [mem_config, compute_kernel_config, untilize_out] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor_a = input_tensors.at(0);
+            const auto& input_tensor_b = input_tensors.at(1);
+            TT_FATAL(input_tensor_a.get_dtype() == input_tensor_b.get_dtype());
+            TT_FATAL(input_tensor_a.get_legacy_shape()[3] == input_tensor_b.get_legacy_shape()[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
+            TT_FATAL(input_tensor_a.get_legacy_shape()[1] == input_tensor_b.get_legacy_shape()[1] && input_tensor_a.get_legacy_shape()[0] == input_tensor_b.get_legacy_shape()[0]
+                && "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
 
-    auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
-    auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4);
+            auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
+            auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4);
 
-    if (input_tensor_a.is_sharded()) {
-        auto matmul_program_config = bmm_op_utils::get_matmul_program_config(input_tensor_a, input_tensor_b, mem_config, std::nullopt, false);
-        return operation::run(tt::operations::primary::Matmul{
-            .program_config=matmul_program_config,
-            .output_mem_config=mem_config,
-            .output_dtype=input_tensor_a.get_dtype(),
-            .compute_kernel_config=kernel_config_val,
-            .untilize_out=untilize_out
-        }, {input_tensor_a, input_tensor_b}, {std::nullopt}).at(0);
-    } else {
-        return operation::run_with_autoformat(
-                   Matmul{
-                       .bcast_batch = false,
-                       .output_mem_config = mem_config,
-                       .output_dtype = input_tensor_a.get_dtype(),
-                       .compute_kernel_config = kernel_config_val,
-                       .untilize_out = untilize_out,
-                   },
-                   {input_tensor_a, input_tensor_b},
-                   {std::nullopt})
-            .at(0);
-    }
+            if (input_tensor_a.is_sharded()) {
+                auto matmul_program_config = bmm_op_utils::get_matmul_program_config(input_tensor_a, input_tensor_b, mem_config, std::nullopt, false);
+                return operation::run(tt::operations::primary::Matmul{
+                    .program_config=matmul_program_config,
+                    .output_mem_config=mem_config,
+                    .output_dtype=input_tensor_a.get_dtype(),
+                    .compute_kernel_config=kernel_config_val,
+                    .untilize_out=untilize_out
+                }, {input_tensor_a, input_tensor_b}, {std::nullopt});
+            } else {
+                return operation::run_with_autoformat(
+                        Matmul{
+                            .bcast_batch = false,
+                            .output_mem_config = mem_config,
+                            .output_dtype = input_tensor_a.get_dtype(),
+                            .compute_kernel_config = kernel_config_val,
+                            .untilize_out = untilize_out,
+                        },
+                        {input_tensor_a, input_tensor_b},
+                        {std::nullopt});
+            }
+        },
+    {input_tensor_a, input_tensor_b}, output_tensors);
+    return output_tensors.at(0);
 }
 
 }  // namespace tt_metal

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
@@ -318,7 +318,7 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
         host_owned_buffers.push_back(std::get<OwnedStorage>(shard.get_storage()).buffer);
         host_owned_shapes.push_back(shard.get_legacy_shape());
     }
-    auto storage = MultiDeviceHostStorage{std::move(host_owned_buffers), host_owned_shapes};
+    auto storage = MultiDeviceHostStorage(std::move(host_owned_buffers), host_owned_shapes);
 
     return Tensor(std::move(storage), tt_shards.at(0).get_legacy_shape(), tt_shards.at(0).get_dtype(), Layout::ROW_MAJOR);
 }

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -198,7 +198,7 @@ void Buffer::allocate() {
     // L1 buffers are allocated top down!
     bool bottom_up = this->buffer_type_ == BufferType::DRAM;
     detail::AllocateBuffer(this, bottom_up);
-    detail::BUFFER_MAP[{this->device_->id(), this->address_}] = this;
+    detail::BUFFER_MAP.insert({this->device_->id(), this->address_}, this);
 }
 
 uint32_t Buffer::dram_channel_from_bank_id(uint32_t bank_id) const {

--- a/tt_metal/impl/device/multi_device.cpp
+++ b/tt_metal/impl/device/multi_device.cpp
@@ -67,3 +67,20 @@ int DeviceMesh::num_devices() const
 }  // namespace multi_device
 
 }  // namespace ttnn
+
+namespace tt {
+
+namespace tt_metal {
+
+bool validate_worker_modes(const std::vector<Device*>& workers) {
+    bool worker_modes_match = true;
+    auto first_worker_mode = workers.at(0)->get_worker_mode();
+    for (auto worker : workers) {
+        worker_modes_match &= (worker->get_worker_mode() == first_worker_mode);
+    }
+    return worker_modes_match;
+}
+
+}
+
+}

--- a/tt_metal/impl/device/multi_device.hpp
+++ b/tt_metal/impl/device/multi_device.hpp
@@ -48,5 +48,6 @@ public:
 namespace tt {
 namespace tt_metal {
     using DeviceMesh = ttnn::multi_device::DeviceMesh;
+    bool validate_worker_modes(const std::vector<Device*>& workers);
 } // namespace tt_metal
 } // namespace tt

--- a/tt_metal/impl/dispatch/work_executor.hpp
+++ b/tt_metal/impl/dispatch/work_executor.hpp
@@ -47,7 +47,6 @@ class WorkExecutor {
     }
 
     inline void run_worker() {
-        this->worker_queue.worker_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
         while (true) {
             if(this->worker_queue.empty()) {
                 if (this->worker_state == WorkerState::TERMINATE) {
@@ -97,7 +96,6 @@ class WorkExecutor {
         }
         this->worker_queue_mode = mode;
         if (this->worker_queue_mode == WorkExecutorMode::ASYNCHRONOUS) {
-            this->worker_queue.parent_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
             this->start_worker();
         } else if (this->worker_queue_mode == WorkExecutorMode::SYNCHRONOUS) {
             this->synchronize();
@@ -105,7 +103,7 @@ class WorkExecutor {
         }
     }
 
-    static WorkExecutorMode get_worker_mode() { return worker_queue_mode; }
+    WorkExecutorMode get_worker_mode() { return worker_queue_mode; }
 
     inline std::size_t get_parent_thread_id() { return this->worker_queue.parent_thread_id; }
     private:
@@ -116,6 +114,7 @@ class WorkExecutor {
         this->worker_queue.parent_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
         this->worker_state = WorkerState::RUNNING;
         this->worker_thread = std::thread(&WorkExecutor::run_worker, this);
+        this->worker_queue.worker_thread_id = std::hash<std::thread::id>{}(this->worker_thread.get_id());
     }
 
     inline void stop_worker() {
@@ -132,7 +131,7 @@ class WorkExecutor {
         return static_cast<WorkExecutorMode>(value);
     }
 
-    inline static WorkExecutorMode worker_queue_mode = default_worker_queue_mode();
+    WorkExecutorMode worker_queue_mode = default_worker_queue_mode();
 };
 
 } // namespace tt

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -63,7 +63,7 @@ struct BufferInfo {
 
 std::vector<BufferInfo> get_buffers() {
     std::vector<BufferInfo> buffer_infos;
-    for (const auto &[key, buffer] : tt::tt_metal::detail::BUFFER_MAP) {
+    for (const auto &[key, buffer] : tt::tt_metal::detail::BUFFER_MAP.value()) {
         if (buffer->buffer_type() != BufferType::L1) {
             continue;
         }
@@ -127,7 +127,7 @@ struct BufferPageInfo {
 
 std::vector<BufferPageInfo> get_buffer_pages() {
     std::vector<BufferPageInfo> buffer_page_infos;
-    for (const auto &[key, buffer] : tt::tt_metal::detail::BUFFER_MAP) {
+    for (const auto &[key, buffer] : tt::tt_metal::detail::BUFFER_MAP.value()) {
         if (buffer->buffer_type() != BufferType::L1) {
             continue;
         }


### PR DESCRIPTION
  - Integrate async mode with existing multi-device funcitonality
  - Add multi device tests running in async mode
  - Add asserts inside run_operation* functions to ensure that launch_op is always used in async mode
  - Add asserts to ensure that all devices are interfaced with the same worker mode
  - Make BUFFER_MAP a thread safe structure, since multiple worker threads can modify it