### PR TITLE
#5544: Add output tensors parameter to  moreh_linear op

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_bmm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_bmm.py
@@ -27,7 +27,7 @@ def test_moreh_bmm(shape, device):
     output_shape = [1, shape[0], shape[1], shape[3]]
 
     # get tensors
-    tt_input, tt_mat2, _, _, _, torch_input, torch_mat2, _ = get_tensors(
+    tt_input, tt_mat2, _, _, _, _, torch_input, torch_mat2, _ = get_tensors(
         input_shape, mat2_shape, output_shape, False, False, False, device
     )
 
@@ -82,6 +82,7 @@ def test_moreh_bmm_backward(shape, requires_grad, device):
     (
         tt_input,
         tt_mat2,
+        _,
         tt_output_grad,
         tt_input_grad,
         tt_mat2_grad,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_matmul.py
@@ -11,7 +11,6 @@ from models.utility_functions import comp_allclose_and_pcc, skip_for_wormhole_b0
 
 
 def get_tensors(input_shape, other_shape, output_shape, require_input_grad, require_other_grad, is_1d, device):
-    torch.manual_seed(2023)
     npu_dtype = ttl.tensor.DataType.BFLOAT16
     cpu_dtype = torch.bfloat16
     npu_layout = ttl.tensor.Layout.TILE

--- a/tt_eager/tt_dnn/op_library/moreh_linear/moreh_linear_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear/moreh_linear_op.cpp
@@ -44,7 +44,7 @@ inline void moreh_linear_validate(
             input_shape[1] == output_shape[1] &&
             input_shape[2] == output_shape[2] &&
             weight_shape[2] == output_shape[3],
-            "shape of output should be [input_shape[0], input_shape[1], input_shape[2], wieght_shape[2]]");
+            "shape of output should be [input_shape[0], input_shape[1], input_shape[2], weight_shape[2]]");
     }
 }
 

--- a/tt_eager/tt_dnn/op_library/moreh_linear/moreh_linear_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear/moreh_linear_op.hpp
@@ -20,8 +20,10 @@ using namespace tt_metal;
 Tensor moreh_linear(
     const Tensor& input,
     const Tensor& weight,
-    std::optional<std::reference_wrapper<const Tensor>> bias = std::nullopt,
+    std::optional<const Tensor> bias = std::nullopt,
+    std::optional<const Tensor> output = std::nullopt,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 
 }  // namespace primary
 

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_h/moreh_bias_backward_multi_core_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_h/moreh_bias_backward_multi_core_h.cpp
@@ -182,8 +182,9 @@ operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &o
                                                    const std::vector<Tensor> &input_tensors,
                                                    const std::vector<std::optional<const Tensor>> &,
                                                    const std::vector<Tensor> &output_tensors) {
+        log_debug(LogOp, "{}:{} args_callback ", __func__, __LINE__);
         const auto &output_grad = input_tensors.at(0);
-        const auto &bias_grad = input_tensors.at(1);
+        const auto &bias_grad = output_tensors.at(0);
 
         Buffer *src_buffer = output_grad.buffer();
         Buffer *dst_buffer = bias_grad.buffer();
@@ -191,15 +192,13 @@ operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &o
         for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
             {
-                auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = src_buffer->address();
-                SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
             }
 
             {
-                auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = dst_buffer->address();
-                SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
             }
         }
     };

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_hw/moreh_bias_backward_single_core_hw.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_hw/moreh_bias_backward_single_core_hw.cpp
@@ -106,22 +106,21 @@ operation::ProgramWithCallbacks moreh_bias_backward_single_core_hw(const Tensor 
                                                    const std::vector<Tensor> &input_tensors,
                                                    const std::vector<std::optional<const Tensor>> &,
                                                    const std::vector<Tensor> &output_tensors) {
+        log_debug(LogOp, "{}:{} args_callback ", __func__, __LINE__);
         const auto &output_grad = input_tensors.at(0);
-        const auto &bias_grad = input_tensors.at(1);
+        const auto &bias_grad = output_tensors.at(0);
 
         Buffer *src_buffer = output_grad.buffer();
         Buffer *dst_buffer = bias_grad.buffer();
         CoreCoord core = {0, 0};
         {
-            auto runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
             runtime_args[0] = src_buffer->address();
-            SetRuntimeArgs(program, reader_kernel_id, core, runtime_args);
         }
 
         {
-            auto runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
             runtime_args[0] = dst_buffer->address();
-            SetRuntimeArgs(program, writer_kernel_id, core, runtime_args);
         }
     };
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.cpp
@@ -4,6 +4,7 @@
 
 #include "tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.hpp"
 
+#include <tuple>
 #include <type_traits>
 
 #include "tt_dnn/op_library/moreh_matmul/moreh_matmul_op.hpp"
@@ -16,105 +17,126 @@ namespace tt {
 namespace operations {
 namespace primary {
 
+namespace {
+std::tuple<bool, bool, bool> get_required_outputs(const std::vector<bool>& are_required_outputs) {
+    if (are_required_outputs.size() != 3) {
+        TT_ASSERT(are_required_outputs.size() == 3, "are_required_outputs size must be 3");
+    }
+
+    return {are_required_outputs[0], are_required_outputs[1], are_required_outputs[2]};
+}
+}  // namespace
+
 // TODO: Move bias backward code
 ////////////////////////////////////////////////////////////////////////////
-//                         MorehBiasBackward
+//                         MorehBiasAddBackward
 ////////////////////////////////////////////////////////////////////////////
-void MorehBiasBackward::validate(const std::vector<Tensor>& inputs) const {
-    const auto& bias_grad = inputs.at(1);
-    TT_ASSERT(is_scalar(bias_grad) || is_1d_tensor(bias_grad), "bias_grad tensor should be 1d or scalar");
-}
-
-std::vector<Shape> MorehBiasBackward::compute_output_shapes(const std::vector<Tensor>& inputs) const {
-    // Inplace
-    return {};
-}
-
-std::vector<Tensor> MorehBiasBackward::create_output_tensors(const std::vector<Tensor>& inputs) const {
-    // Inplace
-    return {};
-}
-
-operation::ProgramWithCallbacks MorehBiasBackward::create_program(
-    const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) const {
-    const auto& output_grad = inputs.at(0);
-    const auto& bias_grad = inputs.at(1);
-    return is_scalar(bias_grad) ? (moreh_bias_backward_single_core_hw(output_grad, bias_grad))
-                                : (moreh_bias_backward_multi_core_h(output_grad, bias_grad));
-}
-
-stl::reflection::Attributes MorehBiasBackward::attributes() const { return {}; }
-
-inline void moreh_linear_backward_validate(
-    const Tensor& output_grad,
-    const Tensor& input,
-    const Tensor& weight,
-    std::optional<std::reference_wrapper<const Tensor>> input_grad,
-    std::optional<std::reference_wrapper<const Tensor>> weight_grad,
-    std::optional<std::reference_wrapper<const Tensor>> bias_grad) {
-    if (input_grad) {
-        const auto& input_grad_tensor = input_grad->get();
-        TT_ASSERT(is_same_shape(input, input_grad_tensor), "both tensors should be the same shape");
-    }
-
-    if (weight_grad) {
-        const auto& weight_grad_tensor = weight_grad->get();
-        TT_ASSERT(is_same_shape(weight, weight_grad_tensor), "both tensors should be the same shape");
-    }
-
-    if (bias_grad) {
-        const auto& bias_grad_tensor = bias_grad->get();
+void MorehBiasAddBackward::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    const auto& bias_grad = output_tensors.at(0);
+    if (bias_grad.has_value()) {
+        const auto& bias = input_tensors.at(1);
+        const auto& bias_grad_tensor = bias_grad.value();
+        TT_ASSERT(is_same_shape(bias, bias_grad_tensor), "both tensors should be the same shape");
         TT_ASSERT(
             is_scalar(bias_grad_tensor) || is_1d_tensor(bias_grad_tensor), "bias_grad tensor should be 1d or scalar");
     }
 }
 
-[[maybe_unused]] std::vector<std::variant<tt_metal::Tensor, char*>> moreh_linear_backward(
+std::vector<Shape> MorehBiasAddBackward::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    return {input_tensors.at(1).get_legacy_shape()};
+}
+
+std::vector<Tensor> MorehBiasAddBackward::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (output_tensors.at(0).has_value()) {
+        return {output_tensors.at(0).value()};
+    }
+
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, input_tensors.at(1).get_dtype(), Layout::TILE, this->bias_grad_mem_config);
+}
+
+operation::ProgramWithCallbacks MorehBiasAddBackward::create_program(
+    const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) const {
+    const auto& output_grad = inputs.at(0);
+    const auto& bias_grad = outputs.at(0);
+    return is_scalar(bias_grad) ? (moreh_bias_backward_single_core_hw(output_grad, bias_grad))
+                                : (moreh_bias_backward_multi_core_h(output_grad, bias_grad));
+}
+
+inline void moreh_linear_backward_validate(
     const Tensor& output_grad,
     const Tensor& input,
     const Tensor& weight,
-    std::optional<std::reference_wrapper<const Tensor>> input_grad,
-    std::optional<std::reference_wrapper<const Tensor>> weight_grad,
-    std::optional<std::reference_wrapper<const Tensor>> bias_grad,
-    const MemoryConfig& output_mem_config) {
+    const std::optional<const Tensor>& input_grad,
+    const std::optional<const Tensor>& weight_grad,
+    const std::optional<const Tensor>& bias_grad) {
+    if (input_grad.has_value()) {
+        const auto& input_grad_tensor = input_grad.value();
+        TT_ASSERT(is_same_shape(input, input_grad_tensor), "both tensors should be the same shape");
+    }
+
+    if (weight_grad.has_value()) {
+        const auto& weight_grad_tensor = weight_grad.value();
+        TT_ASSERT(is_same_shape(weight, weight_grad_tensor), "both tensors should be the same shape");
+    }
+
+    if (bias_grad.has_value()) {
+        const auto& bias_grad_tensor = bias_grad.value();
+        TT_ASSERT(
+            is_scalar(bias_grad_tensor) || is_1d_tensor(bias_grad_tensor), "bias_grad tensor should be 1d or scalar");
+    }
+}
+
+std::vector<std::optional<Tensor>> moreh_linear_backward(
+    const Tensor& output_grad,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::vector<bool>& are_required_outputs,
+    std::optional<const Tensor> bias,
+    std::optional<const Tensor> input_grad,
+    std::optional<const Tensor> weight_grad,
+    std::optional<const Tensor> bias_grad,
+    const MemoryConfig& input_grad_mem_config,
+    const MemoryConfig& weight_grad_mem_config,
+    const MemoryConfig& bias_grad_mem_config) {
+    std::vector<std::optional<Tensor>> result(3);
+    const auto [input_required_grad, weight_required_grad, bias_required_grad] =
+        get_required_outputs(are_required_outputs);
+
     TT_ASSERT(
         output_grad.storage_type() == StorageType::DEVICE && input.storage_type() == StorageType::DEVICE &&
             weight.storage_type() == StorageType::DEVICE,
         "input and weight tensors need to be on device");
-    std::vector<std::variant<Tensor, char*>> outputs;
-    outputs.reserve(3);
 
     moreh_linear_backward_validate(output_grad, input, weight, input_grad, weight_grad, bias_grad);
-    if (input_grad) {
-        outputs.push_back(moreh_matmul(output_grad, weight, input_grad->get(), false, false, output_mem_config));
-    } else {
-        outputs.push_back(nullptr);
+
+    if (input_required_grad) {
+        TT_ASSERT(input_grad.has_value(), "input_grad tensor should not be std::nullopt");
+        result[0] = moreh_matmul(output_grad, weight, input_grad, false, false, input_grad_mem_config);
     }
 
-    if (weight_grad) {
+    if (weight_required_grad) {
         // TODO: Add output transpose and remove transpose wh
-        const auto& temp_weight_grad = moreh_matmul(input, output_grad, std::nullopt, true, false, output_mem_config);
-        const auto& transposed_weight_grad = transpose(temp_weight_grad, 2, 3);
-        // transpose op does not set the transposed shape.
-        auto transposed_weight_grad_shape = weight_grad->get().get_legacy_shape();
-        transposed_weight_grad_shape[0] = temp_weight_grad.get_legacy_shape()[0];
-        transposed_weight_grad_shape[1] = temp_weight_grad.get_legacy_shape()[1];
-        const auto& reshaped_weight_grad = transposed_weight_grad.reshape(transposed_weight_grad_shape);
-        std::vector<int64_t> dims {0, 1};
-        moreh_sum(reshaped_weight_grad, dims, weight_grad->get());
-        outputs.push_back(weight_grad->get());
-    } else {
-        outputs.push_back(nullptr);
+        const auto& temp_weight_grad =
+            moreh_matmul(output_grad, input, std::nullopt, true, false, weight_grad_mem_config);
+        std::vector<int64_t> dims{0, 1};
+        TT_ASSERT(weight_grad.has_value(), "weight_grad tensor should not be std::nullopt");
+        result[1] = moreh_sum(temp_weight_grad, dims, weight_grad.value());
     }
 
-    if (bias_grad) {
-        operation::run(MorehBiasBackward{}, {output_grad, bias_grad->get()});
-        outputs.push_back(bias_grad->get());
-    } else {
-        outputs.push_back(nullptr);
+    if (bias_required_grad) {
+        TT_ASSERT(bias.has_value(), "bias tensor should not be std::nullopt");
+        result[2] = operation::run(
+                        MorehBiasAddBackward{.bias_grad_mem_config = bias_grad_mem_config},
+                        {output_grad, bias.value()},
+                        {},
+                        {bias_grad})
+                        .at(0);
     }
 
-    return outputs;
+    return result;
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.hpp
@@ -17,28 +17,39 @@ namespace primary {
 
 using namespace tt_metal;
 
+////////////////////////////////////////////////////////////////////////////
+//                         MorehBiasAddBackward
+////////////////////////////////////////////////////////////////////////////
 // TODO: Move bias backward code
 operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &output_grad, const Tensor &bias_grad);
 
 operation::ProgramWithCallbacks moreh_bias_backward_single_core_hw(const Tensor &output_grad, const Tensor &bias_grad);
 
-struct MorehBiasBackward {
-    void validate(const std::vector<Tensor> &inputs) const;
-    std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &inputs) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
+struct MorehBiasAddBackward {
+    MemoryConfig bias_grad_mem_config;
+    void validate_with_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
-    stl::reflection::Attributes attributes() const;
+        const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
+    static constexpr auto attribute_names = std::make_tuple("bias_grad_mem_config");
+    const auto attribute_values() const { return std::make_tuple(std::cref(this->bias_grad_mem_config)); }
 };
 
-[[maybe_unused]] std::vector<std::variant<Tensor, char *>> moreh_linear_backward(
+std::vector<std::optional<Tensor>> moreh_linear_backward(
     const Tensor &output_grad,
     const Tensor &input,
     const Tensor &weight,
-    std::optional<std::reference_wrapper<const Tensor>> input_grad = std::nullopt,
-    std::optional<std::reference_wrapper<const Tensor>> weight_grad = std::nullopt,
-    std::optional<std::reference_wrapper<const Tensor>> bias_grad = std::nullopt,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const std::vector<bool> &are_required_outputs,
+    std::optional<const Tensor> bias = std::nullopt,
+    std::optional<const Tensor> input_grad = std::nullopt,
+    std::optional<const Tensor> weight_grad = std::nullopt,
+    std::optional<const Tensor> bias_grad = std::nullopt,
+    const MemoryConfig &input_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const MemoryConfig &weight_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const MemoryConfig &bias_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 }  // namespace primary
 }  // namespace operations

--- a/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.hpp
@@ -41,16 +41,23 @@ struct MorehMatmul {
     uint32_t input_start_tile_id = 0;
     uint32_t other_start_tile_id = 0;
     uint32_t output_start_tile_id = 0;
-    void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    void validate_with_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
-    static constexpr auto attribute_names =
-        std::make_tuple("transpose_input", "transpose_other");
+    const operation::Hash compute_program_hash(const std::vector<Tensor> &input_tensors) const;
+    static constexpr auto attribute_names = std::make_tuple(
+        "transpose_input", "transpose_other", "input_start_tile_id", "other_start_tile_id", "output_start_tile_id");
     const auto attribute_values() const {
         return std::make_tuple(
-            std::cref(this->transpose_input), std::cref(this->transpose_other));
+            std::cref(this->transpose_input),
+            std::cref(this->transpose_other),
+            std::cref(this->input_start_tile_id),
+            std::cref(this->other_start_tile_id),
+            std::cref(this->output_start_tile_id));
     }
 };
 

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -557,16 +557,20 @@ void py_module(py::module& m_primary) {
         R"doc(
         "Performs a moreh_bmm_backward operation.
     )doc");
+
     m_primary.def(
         "moreh_linear",
         &moreh_linear,
         py::arg("input").noconvert(),
         py::arg("weight").noconvert(),
+        py::kw_only(),
         py::arg("bias").noconvert() = std::nullopt,
+        py::arg("output").noconvert() = std::nullopt,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         R"doc(
         "Performs a moreh_linear operation.
     )doc");
+
     m_primary.def(
         "moreh_linear_backward",
         &moreh_linear_backward,

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -577,10 +577,15 @@ void py_module(py::module& m_primary) {
         py::arg("output_grad").noconvert(),
         py::arg("input").noconvert(),
         py::arg("weight").noconvert(),
+        py::kw_only(),
+        py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true, true},
+        py::arg("bias").noconvert() = std::nullopt,
         py::arg("input_grad").noconvert() = std::nullopt,
         py::arg("weight_grad").noconvert() = std::nullopt,
         py::arg("bias_grad").noconvert() = std::nullopt,
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("input_grad_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("weight_grad_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("bias_grad_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         R"doc(
         "Performs a moreh_linear_backward operation.
     )doc");


### PR DESCRIPTION
I added output tensor parameters to these OPs below refer to issue https://github.com/tenstorrent-metal/tt-metal/issues/5044 .

- moreh_linear
- moreh_linear_backward

Passed the relevant test below.

- tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_linear.py