### PR TITLE
#0: Do not run slow dispatch frequent pipeline in release anymore…

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -74,9 +74,6 @@ jobs:
       environment: dev
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
-  release-run-frequent-slow-dispatch:
-    uses: ./.github/workflows/full-regressions-and-models.yaml
-    secrets: inherit
   release-run-frequent-fast-dispatch:
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models.yaml
     secrets: inherit


### PR DESCRIPTION
because it's unnecessary. We don't need to gate release on a debug feature