### PR TITLE
#7161: Optimize repeat/repeat_interleave/permute transformations in Mamba

### DIFF
--- a/models/experimental/mamba/tests_opt/test_full_model.py
+++ b/models/experimental/mamba/tests_opt/test_full_model.py
@@ -47,13 +47,18 @@ class MambaPytorch(torch.nn.Module):
         (
             "state-spaces/mamba-2.8b",
             32,
-            0.99,
+            0.985,
             False,
         ),
     ),
 )
 def test_mamba_model_inference(
-    device: ttnn.Device, model_version: MambaPretrainedModelName, batch: int, pcc: float, enable_cache: bool
+    device: ttnn.Device,
+    use_program_cache,
+    model_version: MambaPretrainedModelName,
+    batch: int,
+    pcc: float,
+    enable_cache: bool,
 ):
     torch.manual_seed(10)
 
@@ -67,7 +72,6 @@ def test_mamba_model_inference(
 
     if enable_cache:
         cache_path = f"/tmp/{model_version}"
-        ttnn.enable_program_cache(device)
     else:
         cache_path = None
 
@@ -82,5 +86,5 @@ def test_mamba_model_inference(
     logger.info(f"PCC value: {output_pcc}")
 
     if not does_pass:
-        logger.warning("Mamba SSM output failed")
+        logger.warning("Mamba output failed")
         assert does_pass, f"PCC value is lower than {pcc}"

--- a/models/experimental/mamba/tests_opt/test_mamba_block.py
+++ b/models/experimental/mamba/tests_opt/test_mamba_block.py
@@ -7,7 +7,7 @@ import pytest
 from loguru import logger
 
 import ttnn
-from models.experimental.mamba.tt_opt.full_model import TtTensorLoader
+from models.experimental.mamba.tt_opt.full_model import TtTensorLoader, MambaSsmBlockTransformer
 from models.experimental.mamba.reference.decode_model import MambaDecode, MambaPretrainedModelName
 from models.experimental.mamba.tt_opt.mamba_block import TtMambaBlock
 from models.experimental.mamba.tt_opt import model_config
@@ -66,8 +66,9 @@ def test_mamba_block_inference(
     config = model_config.create_model_config(batch, d_model)
 
     loader = TtTensorLoader(reference_model.state_dict(), device, tt_cache_path=cache_path)
+    transformer = MambaSsmBlockTransformer(device, reference_model.args.d_inner, reference_model.args.d_state)
 
-    model = TtMambaBlock(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM))
+    model = TtMambaBlock(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM), transformer)
     tt_input = input.view(1, 1, batch, d_model)
     tt_input = ttnn.to_device(
         ttnn.from_torch(tt_input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16),

--- a/models/experimental/mamba/tests_opt/test_mamba_ssm.py
+++ b/models/experimental/mamba/tests_opt/test_mamba_ssm.py
@@ -7,7 +7,7 @@ import pytest
 from loguru import logger
 
 import ttnn
-from models.experimental.mamba.tt_opt.full_model import TtTensorLoader
+from models.experimental.mamba.tt_opt.full_model import TtTensorLoader, MambaSsmBlockTransformer
 from models.experimental.mamba.reference.decode_model import MambaDecode, MambaPretrainedModelName
 from models.experimental.mamba.tt_opt.mamba_one_step_ssm import TtMambaSSM
 from models.experimental.mamba.tt_opt import model_config
@@ -40,7 +40,12 @@ class PytorchMambaSSM(torch.nn.Module):
     ),
 )
 def test_mamba_ssm_inference(
-    device: ttnn.Device, model_version: MambaPretrainedModelName, batch: int, pcc: float, enable_cache: bool
+    device: ttnn.Device,
+    use_program_cache,
+    model_version: MambaPretrainedModelName,
+    batch: int,
+    pcc: float,
+    enable_cache: bool,
 ):
     torch.manual_seed(0)
 
@@ -66,8 +71,9 @@ def test_mamba_ssm_inference(
     config = model_config.create_model_config(batch, reference_model.args.d_model)
 
     loader = TtTensorLoader(reference_model.state_dict(), device, tt_cache_path=cache_path)
+    transformer = MambaSsmBlockTransformer(device, reference_model.args.d_inner, reference_model.args.d_state)
 
-    model = TtMambaSSM(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM))
+    model = TtMambaSSM(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM), transformer)
     tt_input = input.view(1, 1, batch, d_in)
     tt_input = ttnn.to_device(
         ttnn.from_torch(tt_input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16),

--- a/models/experimental/mamba/tests_opt/test_residual_block.py
+++ b/models/experimental/mamba/tests_opt/test_residual_block.py
@@ -7,7 +7,7 @@ import pytest
 from loguru import logger
 
 import ttnn
-from models.experimental.mamba.tt_opt.full_model import TtTensorLoader
+from models.experimental.mamba.tt_opt.full_model import TtTensorLoader, MambaSsmBlockTransformer
 from models.experimental.mamba.reference.decode_model import MambaDecode, MambaPretrainedModelName
 from models.experimental.mamba.tt_opt.residual_block import TtResidualBlock
 from models.experimental.mamba.tt_opt import model_config
@@ -66,8 +66,9 @@ def test_mamba_residual_block_inference(
     config = model_config.create_model_config(batch, d_model)
 
     loader = TtTensorLoader(reference_model.state_dict(), device, tt_cache_path=cache_path)
+    transformer = MambaSsmBlockTransformer(device, reference_model.args.d_inner, reference_model.args.d_state)
 
-    model = TtResidualBlock(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM))
+    model = TtResidualBlock(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM), transformer)
     tt_input = input.view(1, 1, batch, d_model)
     tt_input = ttnn.to_device(
         ttnn.from_torch(tt_input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16),

--- a/models/experimental/mamba/tests_opt/test_transforms.py
+++ b/models/experimental/mamba/tests_opt/test_transforms.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+
+import ttnn
+import tt_lib as ttl
+
+from models.experimental.mamba.tt_opt.full_model import MambaSsmBlockTransformer
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_allclose,
+    comp_pcc,
+)
+
+
+@pytest.mark.parametrize(
+    "batch, pcc",
+    (
+        (
+            32,
+            0.99,
+        ),
+    ),
+)
+def test_mamba_ssm_block_repeat_interleave(
+    device: ttnn.Device,
+    use_program_cache,
+    batch: int,
+    pcc: float,
+):
+    n = 16
+    hidden_size = 2560
+    input = torch.rand(1, 1, batch, hidden_size * 2)
+    dtype = ttnn.bfloat16
+    fidelity = ttl.tensor.MathFidelity.LoFi
+
+    expected = torch.repeat_interleave(input, n, dim=3)
+
+    transformer = MambaSsmBlockTransformer(device, hidden_size * 2, n, dtype=dtype)
+    input = ttnn.to_device(
+        ttnn.from_torch(input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16),
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+        math_fidelity=fidelity,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+    )
+    core_grid = ttnn.CoreGrid(y=7, x=8)
+    actual = transformer.repeat_interleave(input, ttnn.L1_MEMORY_CONFIG, compute_kernel_config, core_grid)
+
+    print(comp_allclose(expected, ttnn.to_torch(actual)))
+
+
+@pytest.mark.parametrize(
+    "batch, pcc",
+    (
+        (
+            32,
+            0.99,
+        ),
+    ),
+)
+def test_mamba_ssm_block_repeat(
+    device: ttnn.Device,
+    use_program_cache,
+    batch: int,
+    pcc: float,
+):
+    n = 16
+    hidden_size = 2560
+    input = torch.rand(1, 1, batch, n)
+    dtype = ttnn.bfloat16
+    fidelity = ttl.tensor.MathFidelity.LoFi
+
+    # (1, 1, B, n) -> (1, 1, B, hidden * 2 * n)
+    expected = input.repeat((1, 1, 1, hidden_size * 2))
+
+    transformer = MambaSsmBlockTransformer(device, hidden_size * 2, n, dtype=dtype)
+    input = ttnn.to_device(
+        ttnn.from_torch(input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16),
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+        math_fidelity=fidelity,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+    )
+    core_grid = ttnn.CoreGrid(y=7, x=8)
+    actual = transformer.repeat(input, ttnn.L1_MEMORY_CONFIG, compute_kernel_config, core_grid)
+
+    print(comp_allclose(expected, ttnn.to_torch(actual)))
+
+
+@pytest.mark.parametrize(
+    "batch, pcc",
+    (
+        (
+            32,
+            0.99,
+        ),
+    ),
+)
+def test_mamba_ssm_block_reduce(
+    device: ttnn.Device,
+    use_program_cache,
+    batch: int,
+    pcc: float,
+):
+    n = 16
+    hidden_size = 2560
+    input = torch.rand(1, 1, batch, hidden_size * 2 * n)
+    dtype = ttnn.bfloat16
+    fidelity = ttl.tensor.MathFidelity.LoFi
+
+    # (1, 1, b, hidden_size * 2 * n) -> (1, b, hidden_size * 2)
+    expected = torch.sum(torch.reshape(input, (1, batch, hidden_size * 2, n)), dim=-1).unsqueeze(0)
+
+    transformer = MambaSsmBlockTransformer(device, hidden_size * 2, n, dtype=dtype)
+    input = ttnn.to_device(
+        ttnn.from_torch(input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16),
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+        math_fidelity=fidelity,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+    )
+    core_grid = ttnn.CoreGrid(y=7, x=8)
+    actual = transformer.reduce(input, ttnn.L1_MEMORY_CONFIG, compute_kernel_config, core_grid)
+
+    print(comp_allclose(expected, ttnn.to_torch(actual)))

--- a/models/experimental/mamba/tt_opt/full_model.py
+++ b/models/experimental/mamba/tt_opt/full_model.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from models.experimental.mamba.tt_opt.residual_block import TtResidualBlock
+from models.experimental.mamba.tt_opt.transforms import MambaSsmBlockTransformer
 
 
 class TtTensorLoader:
@@ -76,8 +77,11 @@ class MambaTT(torch.nn.Module):
 
         loader = TtTensorLoader(reference_model.state_dict(), self.device, tt_cache_path=tt_cache_path)
 
+        transformer = MambaSsmBlockTransformer(self.device, self.args.d_inner, self.args.d_state)
+
         self.layers = [
-            TtResidualBlock(self.args, device, configs, loader.get_tensor_loader(i)) for i in range(self.num_layers)
+            TtResidualBlock(self.args, device, configs, loader.get_tensor_loader(i), transformer)
+            for i in range(self.num_layers)
         ]
 
         self.norm_f = reference_model.norm_f

--- a/models/experimental/mamba/tt_opt/mamba_block.py
+++ b/models/experimental/mamba/tt_opt/mamba_block.py
@@ -12,10 +12,10 @@ from models.utility_functions import torch2tt_tensor, tt2torch_tensor
 from models.helper_funcs import Linear
 from models.experimental.mamba.reference.args import ModelArgs
 from models.experimental.mamba.tt_opt.mamba_one_step_ssm import TtMambaSSM
-
+from models.experimental.mamba.tt_opt.transforms import MambaSsmBlockTransformer
 
 class TtMambaBlock(torch.nn.Module):
-    def __init__(self, args: ModelArgs, device, configs, load_fn: Callable):
+    def __init__(self, args: ModelArgs, device, configs, load_fn: Callable, transformer: MambaSsmBlockTransformer):
         super().__init__()
 
         self.device = device
@@ -77,7 +77,7 @@ class TtMambaBlock(torch.nn.Module):
                 )
             )
 
-        self.tt_ssm = TtMambaSSM(self.args, self.device, configs, load_fn)
+        self.tt_ssm = TtMambaSSM(self.args, self.device, configs, load_fn, transformer)
 
         self.compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
             math_fidelity=ttl.tensor.MathFidelity.HiFi3,

--- a/models/experimental/mamba/tt_opt/mamba_one_step_ssm.py
+++ b/models/experimental/mamba/tt_opt/mamba_one_step_ssm.py
@@ -3,20 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import torch.nn.functional as F
 
 import ttnn
 import tt_lib as ttl
 from typing import Callable
 
-from models.utility_functions import torch2tt_tensor
-from models.helper_funcs import Linear
 from models.experimental.mamba.reference.args import ModelArgs
+from models.experimental.mamba.tt_opt.transforms import MambaSsmBlockTransformer
 
 
 class TtMambaSSM(torch.nn.Module):
-    def __init__(self, args: ModelArgs, device, configs, load_fn: Callable):
+    def __init__(self, args: ModelArgs, device, configs, load_fn: Callable, transformer: MambaSsmBlockTransformer):
         super().__init__()
+
+        self.transformer = transformer
 
         self.device = device
         self.args = args
@@ -25,7 +25,7 @@ class TtMambaSSM(torch.nn.Module):
         self.num_users = args.batch_size
         self.hidden_size = args.d_inner
         self.configs = configs
-        self.n = 32
+        self.n = 16
         self.rank = self.args.dt_rank
 
         """
@@ -47,7 +47,7 @@ class TtMambaSSM(torch.nn.Module):
         def preprocess_B(x):
             x = x[self.args.dt_rank : (self.args.dt_rank + self.args.d_state), :]
             x = x.transpose(-1, -2)
-            x = F.pad(x, (0, 16), "constant", 0)
+            # x = F.pad(x, (0, 16), "constant", 0)
             return x
 
         self.B_proj_weights = load_fn(
@@ -59,7 +59,7 @@ class TtMambaSSM(torch.nn.Module):
         # C_proj_weights
         def preprocess_C(x):
             x = x[(self.args.dt_rank + self.args.d_state) :, :].transpose(-1, -2)
-            x = F.pad(x, (0, 16), "constant", 0)
+            # x = F.pad(x, (0, 16), "constant", 0)
             return x
 
         self.C_proj_weights = load_fn(x_proj_weight_name, preprocess_C, postfix="C_proj")
@@ -78,8 +78,8 @@ class TtMambaSSM(torch.nn.Module):
         def preprocess_A(x):
             x = -torch.exp(x.float())
             # padding with inf
-            x = F.pad(x, (0, 16), "constant", float("-inf"))
-            x = x.reshape(1, self.hidden_size * 32)  # (1, 2en)
+            # x = F.pad(x, (0, 16), "constant", float("-inf"))
+            x = x.reshape(1, self.hidden_size * self.n)  # (1, 2en)
             return x.repeat(self.num_users, 1)  # b, 2en
 
         self.A = load_fn(A_weight_name, tm_fn=preprocess_A, postfix=f"A_{self.args.batch_size}")
@@ -101,7 +101,12 @@ class TtMambaSSM(torch.nn.Module):
             math_approx_mode=False,
             fp32_dest_acc_en=True,
         )
-        self.core_grid_row = 4
+        self.compute_kernel_config_mask = ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+        )
+        self.core_grid_row = 5
         self.core_grid_col = 8
 
     def forward(self, x):
@@ -132,7 +137,13 @@ class TtMambaSSM(torch.nn.Module):
         ttnn.deallocate(delta_t1)
 
         # calculate abar
-        delta_t3 = ttnn.repeat_interleave(delta_t2, self.n, dim=3)
+        delta_t3 = self.transformer.repeat_interleave(
+            delta_t2,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_kernel_config_mask,
+            core_grid=ttnn.CoreGrid(y=7, x=8),
+        )  # b,n
+
         ttnn.deallocate(delta_t2)
 
         # shard delta and A
@@ -144,19 +155,18 @@ class TtMambaSSM(torch.nn.Module):
         ttnn.deallocate(delta_t4)
 
         abar2 = ttnn.to_memory_config(abar1, memory_config=ttnn.L1_MEMORY_CONFIG)
-        ttnn.deallocate(abar1)  # THIS CAUSES A CRASH
+        ttnn.deallocate(abar1)
         abar3 = ttnn.exp(abar2, memory_config=ttnn.L1_MEMORY_CONFIG)
         ttnn.deallocate(abar2)
 
         abar4 = ttnn.to_memory_config(abar3, memory_config=self.configs["sharded_dn"])
-        ttnn.deallocate(abar3)  # THIS CAUSES A CRASH
+        ttnn.deallocate(abar3)
 
         # multiply abar and hidden_state
         hidden_state0 = ttnn.to_memory_config(self.tt_hidden_state, memory_config=self.configs["sharded_dn"])
         amulh0 = ttnn.mul(abar4, hidden_state0, memory_config=self.configs["sharded_dn"])
 
         # deallocate abar and hidden_state
-
         ttnn.deallocate(abar4)
         ttnn.deallocate(hidden_state0)
 
@@ -170,10 +180,16 @@ class TtMambaSSM(torch.nn.Module):
             core_grid=ttnn.CoreGrid(y=self.core_grid_row, x=self.core_grid_col),
         )
 
-        B1 = ttnn.repeat(B0, ttnn.Shape([1, 1, 1, self.hidden_size], [1, 1, 32, self.hidden_size]))
+        # repeat using mask+matmul instead of ttnn.repeat to avoid fallback
+        B1 = self.transformer.repeat(
+            B0,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_kernel_config_mask,
+            core_grid=ttnn.CoreGrid(y=7, x=8),
+        )
         ttnn.deallocate(B0)
 
-        # Shard B
+        # shard B
         B2 = ttnn.to_memory_config(B1, memory_config=self.configs["sharded_dn"])
         ttnn.deallocate(B1)
 
@@ -186,8 +202,14 @@ class TtMambaSSM(torch.nn.Module):
         ttnn.deallocate(delta_t4)
         ttnn.deallocate(B2)
 
-        # multiply bbar and x
-        x0 = ttnn.repeat_interleave(x, self.n, dim=3)
+        # multiply bbar and x with mask instead of ttnn.repeat_interleave(x, self.n, dim=3)
+        x0 = self.transformer.repeat_interleave(
+            x,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_kernel_config_mask,
+            core_grid=ttnn.CoreGrid(y=7, x=8),
+        )  # b,n
+
         x1 = ttnn.to_memory_config(x0, memory_config=self.configs["sharded_dn"])
         ttnn.deallocate(x0)
         bmulx0 = ttnn.mul(bbar0, x1, memory_config=self.configs["sharded_dn"])
@@ -214,26 +236,38 @@ class TtMambaSSM(torch.nn.Module):
             use_1d_systolic_array=True,
             core_grid=ttnn.CoreGrid(y=self.core_grid_row, x=self.core_grid_col),
         )  # b,n
-        # ttnn.deallocate(C_proj)
-        C1 = ttnn.permute(C0, (0, 2, 3, 1))  # b,n,1
+
+        # repeat using mask+matmul instead of ttnn.repeat to avoid fallback
+        C1 = self.transformer.repeat(
+            C0,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_kernel_config_mask,
+            core_grid=ttnn.CoreGrid(y=7, x=8),
+        )
         ttnn.deallocate(C0)
 
-        # hidden state @ C
-        hidden_state1 = ttnn.to_memory_config(hidden_state1, memory_config=ttnn.L1_MEMORY_CONFIG)
-        hidden_state1 = ttnn.reshape(hidden_state1, (1, self.num_users, self.hidden_size, self.n))  # b, d, 32
-
-        C2 = ttnn.matmul(hidden_state1, C1, memory_config=ttnn.L1_MEMORY_CONFIG)  # b, d, 1
+        # shard c
+        C2 = ttnn.to_memory_config(C1, memory_config=self.configs["sharded_dn"])
         ttnn.deallocate(C1)
-        ttnn.deallocate(hidden_state1)
 
-        C3 = ttnn.permute(C2, (0, 3, 1, 2))  # b, d
+        C3 = ttnn.mul(hidden_state1, C2, memory_config=self.configs["sharded_dn"])
+        ttnn.deallocate(hidden_state1)
         ttnn.deallocate(C2)
 
-        # shard x
-        # shard C
-        x = ttnn.to_memory_config(x, memory_config=self.configs["sharded_d"])
-        C4 = ttnn.to_memory_config(C3, memory_config=self.configs["sharded_d"])
+        # Reduction matmul
+        C3 = ttnn.to_memory_config(C3, memory_config=ttnn.L1_MEMORY_CONFIG)
+        C4 = self.transformer.reduce(
+            C3,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_kernel_config_mask,
+            core_grid=ttnn.CoreGrid(y=7, x=8),
+        )  # b,n
         ttnn.deallocate(C3)
+
+        # shard x, C
+        x = ttnn.to_memory_config(x, memory_config=self.configs["sharded_d"])
+        C5 = ttnn.to_memory_config(C4, memory_config=self.configs["sharded_d"])
+        ttnn.deallocate(C4)
 
         # shard D
         D = ttnn.to_memory_config(self.D, memory_config=self.configs["sharded_d"])
@@ -243,8 +277,8 @@ class TtMambaSSM(torch.nn.Module):
         ttnn.deallocate(x)
 
         # add xD and x
-        output = ttnn.add(xD, C4, memory_config=self.configs["sharded_d"])
+        output = ttnn.add(xD, C5, memory_config=self.configs["sharded_d"])
         ttnn.deallocate(xD)
-        ttnn.deallocate(C4)
+        ttnn.deallocate(C5)
 
         return output

--- a/models/experimental/mamba/tt_opt/model_config.py
+++ b/models/experimental/mamba/tt_opt/model_config.py
@@ -7,9 +7,9 @@ import ttnn
 
 def create_model_config(batch_size, hidden_size):
     configs = {}
-    row = 4
+    row = 5
     col = 8
-    latent = 32
+    latent = 16
     configs["sharded_d"] = ttnn.create_sharded_memory_config(
         shape=(1, 1, batch_size, hidden_size * 2),
         core_grid=ttnn.CoreGrid(y=row, x=col),

--- a/models/experimental/mamba/tt_opt/residual_block.py
+++ b/models/experimental/mamba/tt_opt/residual_block.py
@@ -10,10 +10,11 @@ from typing import Callable
 
 from models.experimental.mamba.reference.args import ModelArgs
 from models.experimental.mamba.tt_opt.mamba_block import TtMambaBlock
+from models.experimental.mamba.tt_opt.transforms import MambaSsmBlockTransformer
 
 
 class TtResidualBlock(torch.nn.Module):
-    def __init__(self, args: ModelArgs, device, configs, load_fn: Callable):
+    def __init__(self, args: ModelArgs, device, configs, load_fn: Callable, transformer: MambaSsmBlockTransformer):
         super().__init__()
 
         self.device = device
@@ -22,7 +23,7 @@ class TtResidualBlock(torch.nn.Module):
         rms_norm_weight_name = "norm.weight"
         self.rms_norm_weights = load_fn(rms_norm_weight_name)
 
-        self.tt_mamba_block = TtMambaBlock(self.args, self.device, configs, load_fn)
+        self.tt_mamba_block = TtMambaBlock(self.args, self.device, configs, load_fn, transformer)
 
     def forward(self, x):
         assert len(x.shape) == 4, "Mamba residual block expects inputs to be rank 4"

--- a/models/experimental/mamba/tt_opt/transforms.py
+++ b/models/experimental/mamba/tt_opt/transforms.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+
+
+class MambaSsmBlockTransformer:
+    def __init__(self, device, hidden_size, latent_size, dtype=ttnn.bfloat4_b):
+        permute_mask = torch.repeat_interleave(torch.eye(hidden_size), latent_size, dim=0)
+        self.reduce_mask = ttnn.from_torch(
+            permute_mask,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=dtype,
+        )
+
+        repeat_interleave_mask = torch.repeat_interleave(torch.eye(hidden_size), latent_size, dim=1)
+        self.repeat_interleave_mask = ttnn.from_torch(
+            repeat_interleave_mask,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=dtype,
+        )
+
+        repeat_mask = torch.eye(latent_size).repeat(1, hidden_size).unsqueeze(0).unsqueeze(0)
+        self.repeat_mask = ttnn.from_torch(
+            repeat_mask,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=dtype,
+        )
+
+    def repeat_interleave(self, x, memory_config, compute_kernel_config, core_grid):
+        return ttnn.linear(
+            x,
+            self.repeat_interleave_mask,
+            memory_config=memory_config,
+            compute_kernel_config=compute_kernel_config,
+            core_grid=core_grid,
+        )
+
+    def repeat(self, x, memory_config, compute_kernel_config, core_grid):
+        return ttnn.linear(
+            x,
+            self.repeat_mask,
+            memory_config=memory_config,
+            compute_kernel_config=compute_kernel_config,
+            core_grid=core_grid,
+        )
+
+    def reduce(self, x, memory_config, compute_kernel_config, core_grid):
+        return ttnn.linear(
+            x,
+            self.reduce_mask,
+            memory_config=memory_config,
+            compute_kernel_config=compute_kernel_config,
+            core_grid=core_grid,
+        )


### PR DESCRIPTION
This change removes repeat/repeat_interleave/permute in the Mamba SSM block due to them falling back and causing slow inference times. We have improved overall performance by using a mask+matmul to avoid falling back at the cost of some accuracy (0.995 vs. 0.988).