### PR TITLE
#6874: Manually-specify program configs for mistral for now

### DIFF
--- a/models/demos/mistral7b/tt/mistral_model.py
+++ b/models/demos/mistral7b/tt/mistral_model.py
@@ -64,6 +64,12 @@ class TtTransformer(nn.Module):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             cache_file_name=weight_cache_path / "output.weight",
         )
+        self.output_program_config = ttnn.operations.matmul.create_matmul_1d_systolic_array_program_config(
+            input_shape_a=ttnn.Shape([1, 1, args.max_batch_size, args.dim]),
+            input_shape_b=self.output_weight.shape,
+            core_grid=args.max_grid_size,
+            fp32_dst=args.get_compute_kernel_config().fp32_dest_acc_en,
+        )
 
     def forward(
         self,
@@ -75,5 +81,10 @@ class TtTransformer(nn.Module):
             x = layer(x, current_pos, attn_masks)
 
         x = self.norm(x)
-        output = ttnn.linear(x, self.output_weight, core_grid=self.args.max_grid_size)
+        output = ttnn.linear(
+            x,
+            self.output_weight,
+            program_config=self.output_program_config,
+            compute_kernel_config=self.args.get_compute_kernel_config(),
+        )
         return output

--- a/models/demos/mistral7b/tt/model_config.py
+++ b/models/demos/mistral7b/tt/model_config.py
@@ -23,7 +23,7 @@ class TtModelArgs:
     # Parameters for our use
     max_batch_size = 32
     max_seq_len = 4096
-    kv_seq_len = 512  # TODO Update the initial cache size when scaling up (Should be window_size == 4096)
+    kv_seq_len = 1024  # TODO Update the initial cache size when scaling up (Should be window_size == 4096)
 
     OP_KEYS = (
         # Embedding


### PR DESCRIPTION
With this change the python model forward method completes in 50ms, faster than the total device time of ~80ms, moving the bottleneck clearly away from ttnn. Can consider revert this commit when 6874 adds memoization for the creation of these configs.

Overall host perf with this up to 8 tok/s/user.