### PR TITLE
Add Line Allgather Support

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
@@ -290,6 +290,111 @@ def test_all_gather_on_t3000_post_commit(
     )
 
 
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, input_shape, dim, layout",
+    [
+        (4, 1, [4, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR),
+        (8, 1, [8, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR),
+        # (8, 1, [8, 1, 256, 32], 0, ttl.tensor.Layout.TILE),
+        (8, 1, [8, 8, 256, 384], 1, ttl.tensor.Layout.ROW_MAJOR),
+        (4, 2, [8, 8, 256, 384], 1, ttl.tensor.Layout.TILE),
+        (8, 1, [8, 8, 256, 384], 1, ttl.tensor.Layout.TILE),
+        (4, 1, [8, 5, 13, 384], 3, ttl.tensor.Layout.ROW_MAJOR),
+        (8, 1, [8, 5, 13, 512], 3, ttl.tensor.Layout.ROW_MAJOR),
+        (4, 1, [8, 5, 32, 384], 3, ttl.tensor.Layout.TILE),
+        (8, 1, [8, 5, 32, 512], 3, ttl.tensor.Layout.TILE),
+        (4, 1, [1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.DataType.BFLOAT8_B,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+    ],
+)
+def test_line_all_gather_on_t3000_post_commit(
+    all_devices,
+    num_devices,
+    input_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    num_iters=1,
+):
+    if len(all_devices) != 8:
+        pytest.skip("Not T3000!")
+
+    logger.info(f"Input shape: {input_shape}")
+    logger.info(f"dim: {dim}")
+
+    (is_known_failure, message) = is_unsupported_case(
+        input_shape, dim, mem_config, num_devices, num_links, input_dtype, layout
+    )
+    if is_known_failure:
+        pytest.skip(f"Skipping unsupported case {message}.")
+
+    devices = get_devices_for_t3000(all_devices, num_devices)
+    # for device in devices:
+    #    device.disable_and_clear_program_cache()
+
+    logger.info(f"Input shape: {input_shape}")
+    logger.info(f"dim: {dim}")
+
+    input_tensor = torch.zeros(input_shape).bfloat16()
+
+    id = 0
+    if layout == ttl.tensor.Layout.TILE:
+        for w in range(input_shape[0]):
+            for z in range(input_shape[1]):
+                for i in range(0, input_shape[2], 32):
+                    for j in range(0, input_shape[3], 32):
+                        input_tensor[w][z][i : i + 32][j : j + 32] = id
+                        id += 1
+    else:
+        for w in range(input_shape[0]):
+            for z in range(input_shape[1]):
+                for i in range(input_shape[2]):
+                    for j in range(0, input_shape[3], 32):
+                        input_tensor[w][z][i][j : j + 32] = id
+                        id += 1
+
+    input_tensors = torch.chunk(input_tensor, num_devices, dim)
+    tt_input_tensors = []
+    for i, t in enumerate(input_tensors):
+        tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
+
+    for i in range(num_iters):
+        tt_out_tensors = ttl.tensor.line_all_gather(tt_input_tensors, dim, num_links, output_mem_config=mem_config)
+
+        for d in devices:
+            ttl.device.Synchronize(d)
+        logger.info(f"Done iteration {i}")
+
+    for i, t in enumerate(tt_out_tensors):
+        tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        if input_dtype == ttl.tensor.DataType.BFLOAT16:
+            eq, output = comp_equal(tt_output_tensor, input_tensor)
+        else:
+            eq, output = comp_pcc(tt_output_tensor, input_tensor)
+        if not eq:
+            logger.error(f"output mismatch for tensor {i}")
+        assert eq, f"{i} FAILED: {output}"
+
+
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "num_devices, num_links",
@@ -639,28 +744,12 @@ def test_all_gather_post_commit_sharded(
     reported_mismatch = False
     for i, t in enumerate(tt_out_tensors):
         tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-        # print(tt_output_tensor[...,:2048])
-        # print(tt_output_tensor[...,6144:])
-        # breakpoint()
         if input_dtype == ttl.tensor.DataType.BFLOAT16:
             eq, output = comp_equal(tt_output_tensor, unchunked_input_tensor)
         else:
             eq, output = comp_pcc(tt_output_tensor, unchunked_input_tensor)
         if not eq:
-            print(f"output mismatch for tensor {i}")
-            if not reported_mismatch:
-                reported_mismatch = True
-                for w in range(unchunked_input_shape[0]):
-                    for z in range(unchunked_input_shape[1]):
-                        for y in range(unchunked_input_shape[2]):
-                            for x in range(unchunked_input_shape[3]):
-                                if tt_output_tensor[w, z, y, x] != unchunked_input_tensor[w, z, y, x]:
-                                    print(
-                                        f"mismatch at {w} {z} {y} {x} {unchunked_input_tensor[w, z, y, x]} != {tt_output_tensor[w, z, y, x]}"
-                                    )
-            all_eq = False
-            print(f"")
-            print(f"")
+            logger.error(f"output mismatch for tensor {i}")
     assert all_eq, f"{i} FAILED: {output}"
 
 

--- a/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
@@ -11,38 +11,69 @@
 
 #include "tt_dnn/op_library/run_operation.hpp"
 
+#include <optional>
+#include <vector>
+#include <algorithm>
+
 namespace tt {
 
 namespace tt_metal {
 
+enum AllGatherMode {
+    RING_INTERLEAVED,
+    FULL_WORKER_GRID_SHARDED,
+    SINGLE_TILE_HIGH_WIDTH_SHARDED
+};
+
+namespace all_gather_op {
+enum Topology {
+    Ring = 0,
+    Linear = 1,
+    Meash = 2
+};
+}; // namespace all_gather_op
 
 class AllGatherConfig {
    public:
-    AllGatherConfig(Tensor const& input_tensor, Tensor const& output_tensor, uint32_t dim, uint32_t ring_size, uint32_t num_links) :
+    AllGatherConfig(Tensor const& input_tensor, Tensor const& output_tensor, uint32_t dim, uint32_t ring_size, uint32_t num_links, all_gather_op::Topology topology) :
         num_links(num_links),
         semaphore_size(32),
         ring_size(ring_size),
 
-        // enable_bidirectional - currently doesn't support batch dim and multi-link (some tests are flaky with those configs)
         erisc_handshake_address(eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE),
+        topology(topology),
         enable_bidirectional(false),
 
         input_is_dram(input_tensor.buffer()->buffer_type() == BufferType::DRAM),
         output_is_dram(output_tensor.buffer()->buffer_type() == BufferType::DRAM)
     {
+        // "duplicate" directions are a short hand to enable linear/mesh all-gather topologies with
+        // less code-changes. Ideally a new concept is added amongst "num_eth_buffers", "num_workers_per_link", etc.
+        uint32_t num_duplicate_directions = topology == all_gather_op::Topology::Ring ? 1 : 2;
+
         constexpr uint32_t total_l1_buffer_space = eth_l1_mem::address_map::MAX_L1_LOADING_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
 
         this->is_sharded = input_tensor.is_sharded();
-        this->num_buffers = input_tensor.is_sharded() ? 1 : (this->enable_bidirectional ? 8 : 4);
+        this->num_eth_buffers = (this->enable_bidirectional ? 8 : (this->is_sharded && topology != all_gather_op::Topology::Linear? 8 : 4));
+        if (this->is_sharded) {
+            this->num_eth_buffers = std::min(this->num_eth_buffers, input_tensor.shard_spec()->num_cores());
+            if ((input_tensor.shard_spec()->num_cores() / this->num_eth_buffers) % (ring_size) != 0 &&
+                (ring_size % (input_tensor.shard_spec()->num_cores() / this->num_eth_buffers) != 0)) {
+                // Currently don't support misalignment here
+                this->num_eth_buffers = 1;
+            }
+            log_trace(tt::LogOp, "this->num_buffers: {}", this->num_eth_buffers);
+        }
+        this->num_workers_per_link = this->num_eth_buffers;
         this->eth_sems_l1_base_byte_address = this->erisc_handshake_address + 16;
-        this->semaphore_offset = this->semaphore_size * this->num_buffers; // TODO: Remove this once dedicated semaphore space for user kernels are added
+        this->semaphore_offset = this->semaphore_size * this->num_eth_buffers * num_duplicate_directions; // TODO: Remove this once dedicated semaphore space for user kernels are added
         this->eth_buffers_l1_base_byte_address = this->eth_sems_l1_base_byte_address + this->semaphore_offset;
 
         uint32_t const page_size = input_tensor.buffer()->page_size();
-        this->eth_buffer_size = round_down((total_l1_buffer_space - this->semaphore_offset) / this->num_buffers, page_size);
+        this->eth_buffer_size = round_down((total_l1_buffer_space - this->semaphore_offset) / (this->num_eth_buffers * num_duplicate_directions), page_size);
 
-        TT_FATAL(eth_buffer_size == 0 or num_buffers <= eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS);
-        TT_FATAL(this->eth_buffer_size * this->num_buffers + this->semaphore_offset <= total_l1_buffer_space);
+        TT_FATAL(eth_buffer_size == 0 or (this->num_eth_buffers * num_duplicate_directions) <= eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS);
+        TT_FATAL(this->eth_buffer_size * (this->num_eth_buffers * num_duplicate_directions) + this->semaphore_offset <= total_l1_buffer_space);
 
         // FIXME: dynamically select the number and size of each buffer based on tensor attributes, link count, ring size, etc.
         // Erisc is able to keep up with workers up to around 17-20 GBps bidirectional (numbers still being locked down)
@@ -58,8 +89,9 @@ class AllGatherConfig {
     uint32_t get_erisc_handshake_address() const { return this->erisc_handshake_address; }
 
     uint32_t get_semaphores_offset() const { return this->semaphore_offset; }
-    uint32_t get_num_buffers_per_link() const { return this->num_buffers; }
-    uint32_t get_num_buffers() const { return this->num_buffers * this->num_links; }
+    uint32_t get_num_eth_buffers_per_edm() const { return this->num_eth_buffers; }
+    uint32_t get_num_workers_per_link() const { return this->num_workers_per_link; }
+    uint32_t get_num_workers() const { return this->num_workers_per_link * this->num_links; }
 
     uint32_t get_eth_buffer_size() const { return this->eth_buffer_size; }
 
@@ -69,13 +101,10 @@ class AllGatherConfig {
 
     uint32_t get_semaphore_size() const { return this->semaphore_size; }
 
-    uint32_t get_num_buffers_in_clockwise_direction() const {
-        if (this->is_sharded) {
-            return 0; // Currently only support in CCW direction to make tile ordering work out.
-        }
+    uint32_t get_num_edm_channels_in_clockwise_direction() const {
         return this->enable_bidirectional ?
-            this->num_buffers / 2 :
-            this->num_buffers;
+            this->num_workers_per_link / 2 :
+            this->num_workers_per_link;
     }
     uint32_t get_ring_size() const { return this->ring_size; }
     bool is_buffer_in_clockwise_ring(const uint32_t buffer_index) const {
@@ -83,41 +112,48 @@ class AllGatherConfig {
         // This is slightly suboptimal since the non-full-chunks go to the upper half.
         // A more optimal split would be round robin
         return this->enable_bidirectional ?
-            buffer_index < get_num_buffers_in_clockwise_direction() :
+            buffer_index < get_num_edm_channels_in_clockwise_direction() :
             true;
     }
-    uint32_t get_num_buffers_in_counter_clockwise_direction() const {
+    uint32_t get_num_edm_channels_in_counter_clockwise_direction() const {
         // return all_gather_buffer_params::enable_bidirectional ? all_gather_buffer_params::num_buffers - all_gather_buffer_params::num_buffers / 2 : 0;
         // Force all through counter-clockwise direction
-        return this->num_buffers - this->get_num_buffers_in_clockwise_direction();
+        return this->num_workers_per_link - this->get_num_edm_channels_in_clockwise_direction();
     }
 
     bool is_input_dram() const { return input_is_dram; }
     bool is_output_dram() const { return output_is_dram; }
 
+    AllGatherMode get_mode() const { return mode; }
+
     void print() const {
-        log_trace(tt::LogOp, "AllGatherConfig: {");
+        log_trace(tt::LogOp, "AllGatherConfig: (");
+        log_trace(tt::LogOp, "\tis_sharded: {}", is_sharded);
         log_trace(tt::LogOp, "\terisc_handshake_address: {}", erisc_handshake_address);
-        log_trace(tt::LogOp, "\tnum_buffers: {}", num_buffers);
+        log_trace(tt::LogOp, "\tnum_buffers: {}", num_eth_buffers);
+        log_trace(tt::LogOp, "\tnum_workers_per_link: {}", num_workers_per_link);
         log_trace(tt::LogOp, "\teth_buffer_size: {}", eth_buffer_size);
         log_trace(tt::LogOp, "\tsemaphore_size: {}", semaphore_size);
         log_trace(tt::LogOp, "\tsemaphore_offset: {}", semaphore_offset);
         log_trace(tt::LogOp, "\teth_buffers_l1_base_byte_address: {}", eth_buffers_l1_base_byte_address);
         log_trace(tt::LogOp, "\teth_sems_l1_base_byte_address: {}", eth_sems_l1_base_byte_address);
         log_trace(tt::LogOp, "\tenable_bidirectional: {}", enable_bidirectional);
-        log_trace(tt::LogOp, "}");
+        log_trace(tt::LogOp, ")");
     }
 
    private:
     const uint32_t erisc_handshake_address;
     uint32_t ring_size;
     uint32_t num_links;
-    uint32_t num_buffers;
+    uint32_t num_eth_buffers;
+    uint32_t num_workers_per_link;
     uint32_t eth_buffer_size;
     uint32_t semaphore_size;
     uint32_t semaphore_offset;
     uint32_t eth_buffers_l1_base_byte_address;
     uint32_t eth_sems_l1_base_byte_address;
+    const all_gather_op::Topology topology;
+    AllGatherMode mode;
     bool is_sharded;
     const bool enable_bidirectional;
     const bool input_is_dram;
@@ -129,9 +165,10 @@ struct AllGather {
     const uint32_t num_links;
     const uint32_t ring_size;
     const uint32_t ring_index;
-    const chip_id_t receiver_device_id;
-    const chip_id_t sender_device_id;
+    const std::optional<chip_id_t> receiver_device_id;
+    const std::optional<chip_id_t> sender_device_id;
     const MemoryConfig output_mem_config;
+    const all_gather_op::Topology topology;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -140,9 +177,45 @@ struct AllGather {
     tt::stl::reflection::Attributes attributes() const;
 };
 
-operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor& input_tensor, Tensor& output_tensor, const uint32_t dim, const uint32_t num_links, const uint32_t ring_size, const uint32_t ring_index, const chip_id_t receiver_device_id, const chip_id_t sender_device_id);
+// All Gather Variants
+operation::ProgramWithCallbacks all_gather_full_shard_grid(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    const std::optional<chip_id_t> receiver_device_id,
+    const std::optional<chip_id_t> sender_device_id,
+    all_gather_op::Topology topology);
+operation::ProgramWithCallbacks all_gather_multi_core_with_workers(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    const std::optional<chip_id_t> receiver_device_id,
+    const std::optional<chip_id_t> sender_device_id,
+    all_gather_op::Topology topology);
 
-std::vector<Tensor> all_gather(const std::vector<Tensor> &input_tensors, const uint32_t dim, const uint32_t num_links = 1, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> all_gather_impl(
+    const std::vector<Tensor>& input_tensors,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const MemoryConfig& output_mem_config,
+    const all_gather_op::Topology topology);
+std::vector<Tensor> all_gather(
+    const std::vector<Tensor> &input_tensors,
+    const uint32_t dim,
+    const uint32_t num_links = 1,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<Tensor> line_all_gather(
+    const std::vector<Tensor> &input_tensors,
+    const uint32_t dim,
+    const uint32_t num_links = 1,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 
 struct ShardedAllGatherConfig {
@@ -433,7 +506,7 @@ struct OutputTensorShardAddrGenArgGenerator final : ShardAddrGenArgGenerator {
         // TODO: update to support block sharding
         // TODO: update if input grid != output grid
         return get_first_output_shard_starting_location(
-            all_gather_config.get_num_buffers(),
+            all_gather_config.get_num_eth_buffers_per_edm(),
             input_tensor.shard_spec()->grid.num_cores(),
             ring_index,
             all_gather_config.get_ring_size(),
@@ -509,6 +582,166 @@ struct OutputTensorShardAddrGenArgGenerator final : ShardAddrGenArgGenerator {
 
 };
 
+
+class EriscDatamoverBuilder {
+   public:
+    struct ChannelBufferInterface {
+        uint32_t eth_buffer_l1_address;
+        uint32_t eth_semaphore_l1_address;
+    };
+
+    EriscDatamoverBuilder(AllGatherConfig const& all_gather_config, std::vector<uint32_t> const& local_semaphore_addresses, std::vector<uint32_t> const& local_buffer_addresses) :
+        local_semaphore_addresses(local_semaphore_addresses),
+        local_buffer_addresses(local_buffer_addresses),
+        eth_buffer_size_bytes(all_gather_config.get_eth_buffer_size()),
+        handshake_addr(all_gather_config.get_erisc_handshake_address()),
+        num_channel_buffers(all_gather_config.get_num_eth_buffers_per_edm()),
+        enable_sender(false),
+        enable_receiver(false),
+        num_senders(0),
+        num_receivers(0)
+        {
+            active_channels.reserve(num_channel_buffers);
+            TT_ASSERT(eth_buffer_size_bytes < 163000);
+            log_trace(tt::LogOp, "EriscDatamoverBuilder:");
+            for (auto const& addr : local_semaphore_addresses) {
+                log_trace(tt::LogOp, "\tsemaphore_address: {}", addr);
+            }
+            for (auto const& addr : local_buffer_addresses) {
+                log_trace(tt::LogOp, "\tbuffer_address: {}", addr);
+            }
+        }
+
+    [[nodiscard]]
+    ChannelBufferInterface add_sender_channel(uint32_t worker_semaphore_address, uint32_t num_eth_messages_to_forward, std::vector<ccl::WorkerXY> const& worker_coords) {
+        this->enable_sender = true;
+        this->num_senders++;
+        auto channel = active_channels.size();
+        active_channels.emplace_back(true, worker_semaphore_address, num_eth_messages_to_forward, channel, worker_coords);
+        log_trace(tt::LogOp, "Adding sender channel:");
+        log_trace(tt::LogOp, "\tworker_semaphore_address: {}", active_channels.back().worker_semaphore_address);
+        log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
+        log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
+        log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
+        log_trace(tt::LogOp, "\tbuffer_address: {}", local_buffer_addresses.at(channel));
+        log_trace(tt::LogOp, "\tsemaphore_address: {}", local_semaphore_addresses.at(channel));
+
+        return ChannelBufferInterface{local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
+    }
+    [[nodiscard]]
+    ChannelBufferInterface add_receiver_channel(uint32_t worker_semaphore_address, uint32_t num_eth_messages_to_forward, std::vector<ccl::WorkerXY> const& worker_coords) {
+        this->enable_receiver = true;
+        this->num_receivers++;
+        auto channel = active_channels.size();
+        active_channels.emplace_back(false, worker_semaphore_address, num_eth_messages_to_forward, channel, worker_coords);
+        log_trace(tt::LogOp, "Adding receiver channel:");
+        log_trace(tt::LogOp, "\tworker_semaphore_address: {}", active_channels.back().worker_semaphore_address);
+        log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
+        log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
+        log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
+        return ChannelBufferInterface{local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
+    }
+
+    [[nodiscard]]
+    std::vector<uint32_t> emit_compile_time_args() const {
+        return std::vector<uint32_t>{
+            static_cast<uint32_t>(this->enable_sender ? 1 : 0),
+            static_cast<uint32_t>(this->enable_receiver ? 1 : 0),
+            this->num_senders,
+            this->num_receivers};
+    }
+
+    [[nodiscard]]
+    std::vector<uint32_t> emit_runtime_args() const {
+        std::vector<uint32_t> args;
+        uint32_t size = 3 + active_channels.size() * 6;
+        for (auto const& channel : active_channels) {
+            size += channel.worker_coords.size();
+        }
+        args.reserve(size);
+
+        // Handshake address
+        args.push_back(handshake_addr);
+
+        bool senders_below_receivers = active_channels.size() == 0 || this->active_channels.front().is_sender;
+
+        // Sender channel args
+        uint32_t sender_channels_offset = senders_below_receivers ? 0 : this->num_receivers;
+        args.push_back(sender_channels_offset);
+        for (auto const& channel : this->active_channels) {
+            if (!channel.is_sender) {
+                continue;
+            }
+            push_back_channel_args(args, channel);
+        }
+
+        // Receiver channel args
+        uint32_t receiver_channels_offset = senders_below_receivers ? this->num_senders : 0;
+        args.push_back(receiver_channels_offset);
+        for (auto const& channel : this->active_channels) {
+            if (channel.is_sender) {
+                continue;
+            }
+            push_back_channel_args(args, channel);
+        }
+
+        return args;
+    }
+
+    void dump_to_log() const {
+        auto const& rt_args = this->emit_runtime_args();
+        log_trace(tt::LogOp, "EDM RT Args:");
+        for (auto const& arg : rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+    };
+
+   private:
+    struct ChannelBufferSpec {
+        ChannelBufferSpec(
+            bool is_sender,
+            uint32_t worker_semaphore_address,
+            uint32_t num_eth_messages_to_forward,
+            uint32_t channel,
+            std::vector<ccl::WorkerXY> const& worker_coords
+        ) :
+            worker_coords(worker_coords),
+            worker_semaphore_address(worker_semaphore_address),
+            num_eth_messages_to_forward(num_eth_messages_to_forward),
+            channel(channel),
+            is_sender(is_sender) {}
+
+        std::vector<ccl::WorkerXY> const worker_coords;
+        uint32_t worker_semaphore_address;
+        uint32_t num_eth_messages_to_forward;
+        uint32_t channel;
+        bool is_sender;
+    };
+
+    void push_back_channel_args (std::vector<uint32_t> &args, ChannelBufferSpec const& channel) const {
+        args.push_back(this->local_buffer_addresses.at(channel.channel));
+        args.push_back(channel.num_eth_messages_to_forward);
+        args.push_back(this->eth_buffer_size_bytes);
+        args.push_back(this->local_semaphore_addresses.at(channel.channel));
+        args.push_back(channel.worker_semaphore_address);
+        args.push_back(channel.worker_coords.size());
+        for (auto const& worker_coord : channel.worker_coords) {
+            args.push_back(worker_coord.to_uint32());
+        }
+    }
+
+    std::vector<ChannelBufferSpec> active_channels;
+    std::vector<uint32_t> const local_semaphore_addresses;
+    std::vector<uint32_t> const local_buffer_addresses;
+    uint32_t eth_buffer_size_bytes;
+    uint32_t handshake_addr;
+    uint32_t const num_channel_buffers;
+    uint32_t num_senders;
+    uint32_t num_receivers;
+
+    bool enable_sender;
+    bool enable_receiver;
+};
 
 }  // namespace tt_metal
 

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include "dataflow_api.h"
-#include "debug/dprint.h"
 #include "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp"
 
 void kernel_main() {

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
@@ -35,6 +35,7 @@ void kernel_main() {
     constexpr uint32_t sem_addr = get_compile_time_arg_val(22);
     constexpr bool is_clockwise_direction = get_compile_time_arg_val(23) == 1;
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(24);
+    constexpr uint32_t ring_size = get_compile_time_arg_val(25);
     static_assert(half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than or equal to rem_num_pages");
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
@@ -86,7 +87,7 @@ void kernel_main() {
     for (uint32_t i = 1; i < num_transfers; ++i) {
         if (is_clockwise_direction) {
             if (input_ring_idx == 0) {
-                input_ring_idx = num_transfers;
+                input_ring_idx = ring_size - 1;
                 if constexpr(output_addr_offset != 0) {
                     d.bank_base_address += last_output_addr_offset;
                 }
@@ -103,7 +104,7 @@ void kernel_main() {
                 }
             }
         } else {
-            if (input_ring_idx == num_transfers) {//0) {
+            if (input_ring_idx == ring_size - 1) {//0) {
                 input_ring_idx = 0;
                 if constexpr(output_addr_offset != 0) {
                     d.bank_base_address -= last_output_addr_offset;
@@ -142,5 +143,4 @@ void kernel_main() {
             push_filler_pages_to_cb(cb_id_in0, half_cb_n_pages - rem_num_pages);
         }
     }
-
 }

--- a/tt_eager/tt_dnn/op_library/all_gather/multi_core/all_gather_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/multi_core/all_gather_op_multi_core.cpp
@@ -25,15 +25,16 @@ namespace tt {
 namespace tt_metal {
 
 
-std::tuple<CoreRangeSet,CoreRangeSet> select_worker_cores(AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t link) {
+std::tuple<CoreRangeSet,CoreRangeSet> select_worker_cores(AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t link, uint32_t full_send_direction) {
     constexpr uint32_t worker_grid_width = 8;
-    const bool fit_sender_and_receiver_workers_on_same_row = (worker_grid_width / 2) >= all_gather_config.get_num_buffers_per_link();
+    const bool fit_sender_and_receiver_workers_on_same_row = (worker_grid_width / 2) >= all_gather_config.get_num_eth_buffers_per_edm();
     std::set<CoreRange> receiver_worker_cores = {};
     std::set<CoreRange> sender_worker_cores = {};
     uint32_t max_cols = 8;
-    uint32_t curr_row = link * (((all_gather_config.get_num_buffers_per_link() * 2 - 1) / max_cols) + 1);
+    uint32_t curr_row = link * (((all_gather_config.get_num_eth_buffers_per_edm() * 2 - 1) / max_cols) + 1) +
+        (full_send_direction * num_links * (((all_gather_config.get_num_eth_buffers_per_edm() * 2 - 1) / max_cols) + 1));
     uint32_t curr_col = 0;
-    for (uint32_t r = 0; r < all_gather_config.get_num_buffers_per_link(); r++) {
+    for (uint32_t r = 0; r < all_gather_config.get_num_eth_buffers_per_edm(); r++) {
         receiver_worker_cores.insert(CoreRange(CoreCoord(curr_col, curr_row)));
         curr_col ++;
         if (curr_col == max_cols) {
@@ -41,7 +42,7 @@ std::tuple<CoreRangeSet,CoreRangeSet> select_worker_cores(AllGatherConfig const&
             curr_row++;
         }
     }
-    for (uint32_t s = 0; s < all_gather_config.get_num_buffers_per_link(); s++) {
+    for (uint32_t s = 0; s < all_gather_config.get_num_eth_buffers_per_edm(); s++) {
         sender_worker_cores.insert(CoreRange(CoreCoord(curr_col, curr_row)));
         curr_col ++;
         if (curr_col == max_cols) {
@@ -101,10 +102,16 @@ class AllGatherOpShardedTensorConfig final : public AllGatherOpTensorConfig {
     ShardSpec const shard_spec;
 };
 
-operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor& input_tensor, Tensor& output_tensor, const uint32_t dim, const uint32_t num_links, const uint32_t ring_size, const uint32_t ring_index, const chip_id_t receiver_device_id, const chip_id_t sender_device_id) {
+// For ring all-gather, we can send sub-sections of input tensor in opposite directions
+// For linear all-gather though, we must ensure we send full tensors in BOTH directions
+//   (in other words, disable the "bidirectional" send flag)
+operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor& input_tensor, Tensor& output_tensor, const uint32_t dim, const uint32_t num_links, const uint32_t ring_size, const uint32_t ring_index, const std::optional<chip_id_t> receiver_device_id, const std::optional<chip_id_t> sender_device_id, all_gather_op::Topology topology) {
+    TT_FATAL(!(receiver_device_id == std::nullopt && sender_device_id == std::nullopt), "At least one of receiver_device_id or sender_device_id must be specified");
+
+    bool is_linear = topology == all_gather_op::Topology::Linear;
 
     tt_metal::Program program{};
-    auto const& all_gather_config = AllGatherConfig(input_tensor, output_tensor, dim, ring_size, num_links);
+    auto const& all_gather_config = AllGatherConfig(input_tensor, output_tensor, dim, ring_size, num_links, topology);
 
     auto const& sharding_info = ShardedAllGatherConfig(input_tensor, output_tensor, dim);
     bool enable_print = false; // ring_index == 0
@@ -123,6 +130,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
         (input_buffer->shard_spec().page_shape[0] * input_buffer->shard_spec().page_shape[1] * input_buffer->shard_spec().tensor2d_shape[0] * input_buffer->shard_spec().tensor2d_shape[1] * input_tensor.element_size()) / input_tensor.shard_spec()->num_cores() :
         -1;
     uint32_t input_page_size = is_sharded ? shard_size_in_bytes : input_buffer->page_size();
+    uint32_t output_page_size = is_sharded ? shard_size_in_bytes : output_buffer->page_size();
     if (is_sharded) {
         log_trace(tt::LogOp, "input_buffer->shard_spec().page_shape[0]: {}", input_buffer->shard_spec().page_shape[0]);
         log_trace(tt::LogOp, "input_buffer->shard_spec().page_shape[1]: {}", input_buffer->shard_spec().page_shape[1]);
@@ -141,29 +149,11 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     log_trace(tt::LogOp, "max_buffer_per_chunk: {}", max_buffer_per_chunk);
     log_trace(tt::LogOp, "max_pages_per_chunk: {}", max_pages_per_chunk);
     const auto& device = input_tensor.device();
-    uint32_t sender_socket_idx = 0;
-    uint32_t receiver_socket_idx = 0;
-    if (receiver_device_id == sender_device_id) {
-        if (ring_index == 0) {
-            receiver_socket_idx = 1;
-        } else {
-            sender_socket_idx = 1;
-        }
-    }
-
-    const uint32_t num_transfers = ring_size - 1;
 
     bool rm = input_tensor.get_layout() == Layout::ROW_MAJOR;
     bool width = input_tensor.get_legacy_shape().rank() - 1 == dim;
     DataFormat df = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
 
-    uint32_t global_num_workers = all_gather_config.get_num_buffers_per_link() * num_links;
-    uint32_t shard_width = 0;
-    uint32_t shard_height = 0;
-    if (is_sharded) {
-        shard_width =  input_tensor.buffer()->shard_spec().page_shape.back();
-        shard_height = input_tensor.buffer()->shard_spec().page_shape.front();
-    }
 
     std::map<string, string> worker_defines;
     if (rm) {
@@ -173,25 +163,17 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     }
 
     // number of worker cores is 2x this since there is 1 worker for the sender buffer and 1 worker for the receiver buffer
-    uint32_t total_worker_core_pairs_used = num_links * all_gather_config.get_num_buffers_per_link();
-    std::vector<CoreCoord> eth_sender_cores;
-    eth_sender_cores.reserve(num_links);
-    std::vector<CoreCoord> eth_receiver_cores;
-    eth_receiver_cores.reserve(num_links);
+    uint32_t total_worker_core_pairs_used = num_links * all_gather_config.get_num_eth_buffers_per_edm();
     std::vector<KernelHandle> eth_sender_kernels;
     eth_sender_kernels.reserve(num_links);
     std::vector<KernelHandle> eth_receiver_kernels;
     eth_receiver_kernels.reserve(num_links);
 
-    std::vector<CoreRange> worker_sender_cores;
-    worker_sender_cores.reserve(num_links);
     std::vector<KernelHandle> worker_reader_sender_kernels;
     worker_reader_sender_kernels.reserve(total_worker_core_pairs_used);
     std::vector<KernelHandle> worker_writer_sender_kernels;
     worker_writer_sender_kernels.reserve(total_worker_core_pairs_used);
 
-    std::vector<CoreRange> worker_receiver_cores;
-    worker_receiver_cores.reserve(num_links);
     std::vector<KernelHandle> worker_reader_receiver_kernels;
     worker_reader_receiver_kernels.reserve(total_worker_core_pairs_used);
     std::vector<KernelHandle> worker_writer_receiver_kernels;
@@ -202,972 +184,1144 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     std::vector<CoreCoord> all_worker_receiver_cores;
     all_worker_receiver_cores.reserve(total_worker_core_pairs_used);
 
-    for (uint32_t l = 0; l < num_links; ++l) {
-        // Get the cores for the sender and receiver worker cores
-        auto eth_sender_core = device->get_ethernet_sockets(receiver_device_id).at(sender_socket_idx + l);
-        eth_sender_cores.push_back(eth_sender_core);
-        auto eth_receiver_core = device->get_ethernet_sockets(sender_device_id).at(receiver_socket_idx + l);
-        eth_receiver_cores.push_back(eth_receiver_core);
-    }
 
     uint32_t num_input_pages = input_tensor.buffer()->size() / input_page_size;
     uint32_t min_pages_per_link = num_input_pages / num_links;
 
-    std::vector<uint32_t> pages_per_link(num_links, min_pages_per_link);
-    for (uint32_t i = 0; i < num_input_pages % min_pages_per_link; ++i) {
-        pages_per_link.at(i)++;
-    }
 
-    uint32_t num_rows = 0, num_cols = 0, row_offset = 0, col_offset = 0, num_tiles = 0;
+    auto sender_noc = detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch());
+    auto receiver_noc = detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch());
 
-    if (rm) {
-        num_cols = input_tensor.get_legacy_shape()[-1];
-        auto input_shape = input_tensor.get_legacy_shape();
-        auto output_shape = output_tensor.get_legacy_shape();
-        num_rows = std::accumulate(input_shape.begin()+dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>());
-        row_offset = std::accumulate(output_shape.begin()+dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) - num_rows;
-    } else {
-        num_cols = input_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
-        auto input_shape = input_tensor.get_legacy_shape();
-        auto output_shape = output_tensor.get_legacy_shape();
-        uint32_t num_output_cols = output_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
-        num_rows = std::accumulate(input_shape.begin()+dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>()) / TILE_HEIGHT;
-        row_offset = (std::accumulate(output_shape.begin()+dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) / TILE_HEIGHT - num_rows) * num_output_cols;
-        col_offset = num_output_cols - num_cols;
-        num_tiles = num_rows * num_cols;
-    }
+    const uint32_t num_full_send_directions = topology == all_gather_op::Topology::Linear ? 2 : 1;
+    constexpr uint32_t max_num_full_send_directions = 2;
 
+    std::vector<EriscDatamoverBuilder> clockwise_edm_builders;
+    std::vector<EriscDatamoverBuilder> counter_clockwise_edm_builders;
+    TT_ASSERT(num_full_send_directions > 0);
 
-    uint32_t output_page_size = output_buffer->page_size();
+    // TODO: move to all-gather config
+    auto edm_sem_addrs_per_link = std::vector<std::vector<uint32_t>>(num_links);
+    auto edm_buffer_addrs_per_link = std::vector<std::vector<uint32_t>>(num_links);
+    for (uint32_t link = 0; link < num_links; link++) {
+        edm_sem_addrs_per_link.at(link).reserve(all_gather_config.get_num_eth_buffers_per_edm());
+        edm_buffer_addrs_per_link.at(link).reserve(all_gather_config.get_num_eth_buffers_per_edm());
 
-    uint32_t total_output_pages = output_buffer->size() / output_page_size;
-
-    uint32_t input_start_page_idx = 0;
-    uint32_t output_addr_offset = 0;
-    uint32_t col_idx = 0;
-    uint32_t row_idx = 0;
-    uint32_t output_page_offset = 0;
-
-    if (rm) {
-        if (width) {
-            output_addr_offset = input_page_size;
-        } else {
-            output_page_offset = num_rows;
-        }
-    } else {
-        if (width) {
-            output_page_offset = num_cols;
-        } else {
-            output_page_offset = num_tiles;
-        }
-    }
-    uint32_t output_start_page_idx = ring_index * output_page_offset;
-    uint32_t output_start_addr_offset = ring_index * output_addr_offset;
-
-    ///
-    /// (counter clockwise sender) < ----- (this chip) < ----- (counter-clockwise receiver)
-    ///
-    /// (clockwise receiver)       ------> (this chip) ------> (clockwise sender)
-    /// So clockwise sender and counter-clockwise receiver are on the same core
-    //  and counter-clockwise sender and clockwise receiver are on the same corwe
-
-    // Clockwise Direction
-    std::vector<uint32_t> link_clockwise_sender_channels_offsets =
-        std::vector<uint32_t>(num_links, 0);
-    std::vector<uint32_t> link_clockwise_sender_num_channels =
-        std::vector<uint32_t>(num_links, all_gather_config.get_num_buffers_in_clockwise_direction());
-    std::vector<uint32_t> link_clockwise_receiver_num_channels = link_clockwise_sender_num_channels;
-    // The clockwise direction's erisc's receiver offsets (i.e. for transfers coming INTO this chip)
-    std::vector<uint32_t> link_clockwise_receiver_channels_offsets = link_clockwise_sender_channels_offsets;
-
-    // Counter Clockwise Direction
-    std::vector<uint32_t> link_counter_clockwise_sender_channels_offsets =
-        std::vector<uint32_t>(num_links, all_gather_config.get_num_buffers_in_clockwise_direction());
-    // Counter clock-wise buffers start after clockwise buffers in L1
-    std::vector<uint32_t> link_counter_clockwise_sender_num_channels =
-        std::vector<uint32_t>(num_links, all_gather_config.get_num_buffers_in_counter_clockwise_direction());
-    std::vector<uint32_t> link_counter_clockwise_receiver_channels_offsets = link_counter_clockwise_sender_channels_offsets;
-    std::vector<uint32_t> link_counter_clockwise_receiver_num_channels = link_counter_clockwise_sender_num_channels;
-
-    std::vector<uint32_t> eth_sem_addrs;
-    std::vector<uint32_t> eth_buffer_addrs;
-    eth_sem_addrs.reserve(all_gather_config.get_num_buffers_per_link());
-    eth_buffer_addrs.reserve(all_gather_config.get_num_buffers_per_link());
-
-    for (uint32_t b = 0, eth_sem_addr = all_gather_config.get_eth_sems_l1_base_byte_address(), eth_buffer_addr = all_gather_config.get_eth_buffers_l1_base_byte_address(); b < all_gather_config.get_num_buffers_per_link(); ++b) {
-        eth_sem_addrs.push_back(eth_sem_addr);
-        eth_sem_addr += all_gather_config.get_semaphore_size();
-        eth_buffer_addrs.push_back(eth_buffer_addr);
-        eth_buffer_addr += all_gather_config.get_eth_buffer_size();
-    }
-
-    for (uint32_t i = 0; i < num_links; ++i) {
-        // We can't have overlap between the mcast grid for worker cores for different links since mcasting the semaphore in receiver would corrupt other link semaphores
-        // We can have overlap between a link's sender and receiver worker grids if we have the semaphores at different addresses
-        auto const& [receiver_workers, sender_workers] = select_worker_cores(all_gather_config, num_links, i);
-
-        // Circular Buffer Setup
-        uint32_t cb_page_size = is_sharded ? shard_size_in_bytes : input_page_size;
-        log_trace(tt::LogOp, "input_page_size: {}", input_page_size);
-        uint32_t cb_num_pages = 2 * max_pages_per_chunk;
-        log_trace(tt::LogOp, "cb_num_pages: {}", cb_num_pages);
-        uint32_t src0_cb_index = CB::c_in0;
-        tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(cb_num_pages * cb_page_size, {{src0_cb_index, df}})
-		.set_page_size(src0_cb_index, cb_page_size);
-        CBHandle cb_src0_sender_workers = CreateCircularBuffer(program, sender_workers, cb_src0_config);
-        CBHandle cb_src0_receiver_workers = CreateCircularBuffer(program, receiver_workers, cb_src0_config);
-
-        // This semaphore is used by the receiver core to tell workers that data is available to read
-        auto receiver_worker_semaphore_addr = tt_metal::CreateSemaphore(program, receiver_workers, 0);
-        // This semaphore is used by the receiver core to tell the worker sender writer that sender buffer is available to write to
-        auto sender_worker_writer_semaphore_addr = tt_metal::CreateSemaphore(program, sender_workers, 0);
-        // This semaphore is used by the worker receiver writer to tell the worker sender reader that data has been committed to memory
-        // This is currently a running counter of how many chunks were committed since the sender worker never decrements this buffer
-        // Potentially avoid overflow by having it actually decrement (using noc atomic inc with value of -1)
-        auto sender_worker_reader_semaphore_addr = tt_metal::CreateSemaphore(program, sender_workers, 0);
-
-        auto sender_noc = detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch());
-        auto receiver_noc = detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch());
-
-        auto eth_sender_core = device->get_ethernet_sockets(receiver_device_id).at(sender_socket_idx);
-        eth_sender_cores.push_back(eth_sender_core);
-        auto eth_receiver_core = device->get_ethernet_sockets(sender_device_id).at(receiver_socket_idx);
-        eth_receiver_cores.push_back(eth_receiver_core);
-
-        // Rename this the _channel
-        std::vector<uint32_t> pages_per_buffer;
-
-        // number of pages that can fit in a single ethernet L1 buffer (not the number of pages sent to this channel)
-        std::vector<uint32_t> pages_per_eth_l1_buffer;
-        pages_per_buffer.reserve(all_gather_config.get_num_buffers_per_link());
-        // std::cout << "all_gather_config.get_eth_buffer_size()=" << all_gather_config.get_eth_buffer_size() << std::endl;
-        // std::cout << "input_tensor.buffer()->page_size()=" << input_tensor.buffer()->page_size() << std::endl;
-        uint32_t max_pages_per_eth_l1_sender_buffer = all_gather_config.get_eth_buffer_size() / input_page_size;
-        for(uint32_t b = 0; b < all_gather_config.get_num_buffers_per_link(); ++b) {
-            pages_per_buffer.push_back((pages_per_link.at(i) / all_gather_config.get_num_buffers_per_link()));
-            pages_per_eth_l1_buffer.push_back(
-                is_sharded ? std::min(pages_per_buffer.back(), max_pages_per_eth_l1_sender_buffer)
-                           : max_pages_per_eth_l1_sender_buffer);
-            if (b < pages_per_link.at(i) % all_gather_config.get_num_buffers_per_link()) {
-                pages_per_buffer.back()++;
-            }
-
-            log_trace(tt::LogOp, "pages_per_link[{}]: {}", i, pages_per_link.at(i));
-            log_trace(tt::LogOp, "pages_per_buffer[{}]: {}", b, pages_per_buffer.at(b));
-            log_trace(tt::LogOp, "max_pages_per_eth_l1_sender_buffer: {}",max_pages_per_eth_l1_sender_buffer);
-        }
-        TT_ASSERT(std::accumulate(pages_per_buffer.begin(), pages_per_buffer.end(), 0) == pages_per_link.at(i));
-
-
-        uint32_t bytes_per_chunk = 0, pages_per_chunk = 0, num_full_chunks = 0, rem_bytes = 0, rem_pages = 0;
-        uint32_t link_size_bytes = pages_per_link.at(i) * input_page_size;
-        if (pages_per_link.at(i) >= max_pages_per_chunk) {
-            bytes_per_chunk = max_buffer_per_chunk;
-            pages_per_chunk = max_pages_per_chunk;
-            TT_ASSERT(max_buffer_per_chunk == max_pages_per_chunk * input_page_size);
-            num_full_chunks = link_size_bytes / bytes_per_chunk;
-            rem_bytes = link_size_bytes % bytes_per_chunk;
-            rem_pages = pages_per_link.at(i) % max_pages_per_chunk;
-        } else {
-            rem_bytes = link_size_bytes;
-            rem_pages = pages_per_link.at(i);
-        }
-
-        auto sender_worker_cores = corerange_to_cores(sender_workers, std::nullopt, true);
-        auto receiver_worker_cores = corerange_to_cores(receiver_workers, std::nullopt, true);
-        all_worker_sender_cores.insert(all_worker_sender_cores.end(), sender_worker_cores.begin(), sender_worker_cores.end());
-        all_worker_receiver_cores.insert(all_worker_receiver_cores.end(), receiver_worker_cores.begin(), receiver_worker_cores.end());
-
-        TT_ASSERT(rem_pages < pages_per_chunk || num_full_chunks == 0);
-        TT_ASSERT(rem_pages <= max_pages_per_chunk);
-        std::vector<uint32_t> num_full_chunks_per_worker(all_gather_config.get_num_buffers_per_link(), num_full_chunks / all_gather_config.get_num_buffers_per_link());
-        std::vector<uint32_t> rem_pages_per_worker(all_gather_config.get_num_buffers_per_link(), 0);
-        {
-            uint32_t worker_idx = 0;
-            for (worker_idx = 0; worker_idx < num_full_chunks % all_gather_config.get_num_buffers_per_link(); ++worker_idx) {
-                num_full_chunks_per_worker.at(worker_idx)++;
-            }
-            if (rem_pages != 0) {
-                rem_pages_per_worker.at(worker_idx % all_gather_config.get_num_buffers_per_link()) = rem_pages;
-                TT_ASSERT(rem_pages_per_worker.at(worker_idx % all_gather_config.get_num_buffers_per_link()) * 2 <= cb_num_pages);
+        uint32_t edm_sem_addr = all_gather_config.get_eth_sems_l1_base_byte_address();
+        uint32_t edm_buffer_addr = all_gather_config.get_eth_buffers_l1_base_byte_address();
+        for (uint32_t direction = 0; direction < num_full_send_directions; direction++) {
+            for (uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+                edm_sem_addrs_per_link.at(link).push_back(edm_sem_addr);
+                edm_sem_addr += all_gather_config.get_semaphore_size();
+                edm_buffer_addrs_per_link.at(link).push_back(edm_buffer_addr);
+                edm_buffer_addr += all_gather_config.get_eth_buffer_size();
+                TT_ASSERT((direction == 0 && b == 0) || (edm_buffer_addrs_per_link.at(link).back() != edm_buffer_addrs_per_link.at(link).front()));
+                TT_ASSERT((direction == 0 && b == 0) || (edm_sem_addrs_per_link.at(link).back() != edm_sem_addrs_per_link.at(link).front()));
             }
         }
 
-        std::vector<uint32_t> link_buffer_num_messages_to_send;
-        std::vector<uint32_t> edm_semaphores_base_address;
-        std::vector<uint32_t> link_buffer_sender_addresses;
-        link_buffer_num_messages_to_send.reserve(all_gather_config.get_num_buffers_per_link());
-        edm_semaphores_base_address.reserve(all_gather_config.get_num_buffers_per_link());
-        link_buffer_sender_addresses.reserve(all_gather_config.get_num_buffers_per_link());
-        for(uint32_t b = 0; b < all_gather_config.get_num_buffers_per_link(); ++b) {
-            // link num messages
-            link_buffer_num_messages_to_send.push_back(
-                (num_full_chunks_per_worker.at(b) + (rem_pages_per_worker.at(b) > 0 ? 1 : 0)) *
-                num_transfers);
-            edm_semaphores_base_address.push_back(all_gather_config.get_eth_sems_l1_base_byte_address() + b * all_gather_config.get_semaphore_size());
-            link_buffer_sender_addresses.push_back(all_gather_config.get_eth_buffers_l1_base_byte_address() + b * all_gather_config.get_eth_buffer_size());
-        }
-        for(uint32_t b = 0; b < all_gather_config.get_num_buffers_per_link(); ++b) {
-            log_trace(tt::LogOp, "rem_pages_per_worker[{}]: {}", b, rem_pages_per_worker.at(b));
-            log_trace(tt::LogOp, "num_full_chunks_per_worker[{}]: {}", b, num_full_chunks_per_worker.at(b));
-            log_trace(tt::LogOp, "link_buffer_num_messages_to_send[{}]: {}", b, link_buffer_num_messages_to_send.at(b));
-        }
-
-        std::vector<uint32_t> link_buffer_receiver_num_messages_to_send;
-        std::vector<uint32_t> receiver_semaphores_base_address;
-        std::vector<uint32_t> link_buffer_receiver_addresses;
-        link_buffer_receiver_num_messages_to_send.reserve(all_gather_config.get_num_buffers_per_link());
-        receiver_semaphores_base_address.reserve(all_gather_config.get_num_buffers_per_link());
-        link_buffer_receiver_addresses.reserve(all_gather_config.get_num_buffers_per_link());
-        for(uint32_t b = 0; b < all_gather_config.get_num_buffers_per_link(); ++b) {
-            link_buffer_receiver_num_messages_to_send.push_back(
-                (num_full_chunks_per_worker.at(b) + (rem_pages_per_worker.at(b) > 0 ? 1 : 0)) *
-                num_transfers);
-            receiver_semaphores_base_address.push_back(all_gather_config.get_eth_sems_l1_base_byte_address() + b * all_gather_config.get_semaphore_size());
-            link_buffer_receiver_addresses.push_back(all_gather_config.get_eth_buffers_l1_base_byte_address() + b * all_gather_config.get_eth_buffer_size());
-        }
+        clockwise_edm_builders.emplace_back(
+            all_gather_config, edm_sem_addrs_per_link.at(link), edm_buffer_addrs_per_link.at(link));
+        counter_clockwise_edm_builders.emplace_back(
+            all_gather_config, edm_sem_addrs_per_link.at(link), edm_buffer_addrs_per_link.at(link));
+    }
 
 
-        std::vector<uint32_t> edm_clockwise_kernel_rt_args = {
-            static_cast<uint32_t>(all_gather_config.get_erisc_handshake_address()),
-            static_cast<uint32_t>(link_clockwise_sender_channels_offsets.at(i))
-        };
+    for (uint32_t direction = 0; direction < num_full_send_directions; direction++) {
+        uint32_t global_num_workers = all_gather_config.get_num_eth_buffers_per_edm() * num_links;
+        // if we're in ring topology, we'll always need to transfer all ring indices (except the last one)
+        // but if we are implementing a line topology, the number of transfers will depend on whether we
+        // are setting up the forward/clockwise direction or the backward/counter-clockwise direction and also
+        // how far we are from the first/last chip, depending on whether we are in forward or  direction
+        const uint32_t sender_num_transfers = topology == all_gather_op::Topology::Linear ?
+            (direction == 0 ? ring_index + 1: ring_size - ring_index):
+            ring_size - 1;
+        const uint32_t receiver_num_transfers = topology == all_gather_op::Topology::Linear ?
+            sender_num_transfers - 1:
+            ring_size - 1;
+        std::vector<CoreCoord> eth_sender_cores;
+        eth_sender_cores.reserve(num_links);
+        std::vector<CoreCoord> eth_receiver_cores;
+        eth_receiver_cores.reserve(num_links);
+        // If linear topology, the first chip in the chain will not have a "receiver" eth core (or more correctly,
+        // it doesn't have an input clockwise our output counter-clockwise connection)
+        bool is_first_chip_in_chain = direction == 0 ? ring_index == 0 : ring_index == ring_size - 1;
+        // If linear topology, the last chip in the chain will not have a "sender" eth core (or more correctly,
+        // it doesn't have an output clockwise our input counter-clockwise connection)
+        bool is_last_chip_in_chain = direction == 0 ? ring_index == ring_size - 1 : ring_index == 0;
 
-        std::vector<uint32_t> edm_counter_clockwise_kernel_rt_args = {
-            static_cast<uint32_t>(all_gather_config.get_erisc_handshake_address()),
-            static_cast<uint32_t>(link_counter_clockwise_sender_channels_offsets.at(i))
-        };
-
-        for (uint32_t b = 0; b < all_gather_config.get_num_buffers_per_link(); ++b) {
-            const uint32_t num_workers_per_channel = 1;
-            // Setup sender direction args
-            auto& edm_kernel_rt_args = all_gather_config.is_buffer_in_clockwise_ring(b) ? edm_clockwise_kernel_rt_args : edm_counter_clockwise_kernel_rt_args;
-            // eth sender args
-            // sender_buffer_address
-            edm_kernel_rt_args.push_back(link_buffer_sender_addresses.at(b));
-
-            // sender_num_messages_to_send
-            edm_kernel_rt_args.push_back(link_buffer_num_messages_to_send.at(b));
-
-            // sender_channel_size
-            edm_kernel_rt_args.push_back(all_gather_config.get_eth_buffer_size());
-
-            // edm_semaphores_base_address -> erisc L1 address
-            edm_kernel_rt_args.push_back(eth_sem_addrs.at(b));
-
-            // worker_semaphore_address
-            edm_kernel_rt_args.push_back(sender_worker_writer_semaphore_addr);
-
-            // sender_num_workers - only 1 per channel right now
-            edm_kernel_rt_args.push_back(num_workers_per_channel);
-
-            // for (uint32_t b = 0; b < sender_worker_cores.size(); ++b) {
-            edm_kernel_rt_args.push_back((uint32_t)(
-                (device->worker_core_from_logical_core(sender_worker_cores.at(b)).y << 16) |
-                (device->worker_core_from_logical_core(sender_worker_cores.at(b)).x)
-            ));
-            log_trace(tt::LogOp, "sender_worker_writer_semaphore_addr: {}", sender_worker_writer_semaphore_addr);
-            log_trace(tt::LogOp, "edm_kernel_rt_args worker.x: {}", device->worker_core_from_logical_core(sender_worker_cores.at(b)).y);
-            log_trace(tt::LogOp, "edm_kernel_rt_args worker.y: {}", device->worker_core_from_logical_core(sender_worker_cores.at(b)).x);
-        }
-
-        // Setup receiver direction args. Clockwise receiver is same offset as sender offset for clockwise direction
-        edm_clockwise_kernel_rt_args.push_back(static_cast<uint32_t>(link_counter_clockwise_receiver_channels_offsets.at(i)));
-
-        edm_counter_clockwise_kernel_rt_args.push_back(static_cast<uint32_t>(link_clockwise_receiver_channels_offsets.at(i)));
-
-        for (uint32_t b = 0; b < all_gather_config.get_num_buffers_per_link(); ++b) {
-
-            const uint32_t num_workers_per_channel = 1;
-            auto& edm_kernel_rt_args = all_gather_config.is_buffer_in_clockwise_ring(b) ? edm_counter_clockwise_kernel_rt_args : edm_clockwise_kernel_rt_args ;
-            // eth receiver args
-            // sender_buffer_address
-            edm_kernel_rt_args.push_back(link_buffer_receiver_addresses.at(b));
-
-            // sender_num_messages_to_send
-            edm_kernel_rt_args.push_back(link_buffer_receiver_num_messages_to_send.at(b));
-
-            // sender_channel_size
-            edm_kernel_rt_args.push_back(all_gather_config.get_eth_buffer_size());
-
-            // edm_semaphores_base_address -> erisc L1 address
-            edm_kernel_rt_args.push_back(eth_sem_addrs.at(b));
-
-            // worker_semaphore_address
-            edm_kernel_rt_args.push_back(receiver_worker_semaphore_addr);
-
-            // sender_num_workers - only 1 per channel right now
-            edm_kernel_rt_args.push_back(num_workers_per_channel);
-
-            edm_kernel_rt_args.push_back((uint32_t)(
-                (device->worker_core_from_logical_core(receiver_worker_cores.at(b)).y << 16) |
-                (device->worker_core_from_logical_core(receiver_worker_cores.at(b)).x)
-            ));
-        }
-
-        // 1 Worker per buffer
-        for (uint32_t b = 0; b < all_gather_config.get_num_buffers_per_link(); ++b) {
-            uint32_t global_worker_index = all_gather_config.get_num_buffers_per_link() * i + b;
-
-            bool is_clockwise_direction = all_gather_config.is_buffer_in_clockwise_ring(b);
-
-            // Not fully sure about these two
-            uint32_t last_output_page_offset = (num_transfers) * output_page_offset;
-            uint32_t last_output_addr_offset = (num_transfers) * output_addr_offset;
-            uint32_t receiver_ring_index = is_clockwise_direction ?
-                (ring_index == 0 ? ring_size - 1 : ring_index - 1):
-                (ring_index == ring_size - 1 ? 0 : ring_index + 1);
-
-            uint32_t receiver_output_start_addr_offset = receiver_ring_index * output_addr_offset;
-
-            uint32_t receiver_output_start_page_idx = output_start_page_idx;
-            if (is_clockwise_direction) {
-                bool is_wraparound_ring_index = ring_index == 0;
-                if (is_wraparound_ring_index) {
-                    receiver_output_start_page_idx += last_output_page_offset;
-                } else {
-                    receiver_output_start_page_idx -= output_page_offset;
-                }
+        uint32_t sender_socket_idx = 0;
+        uint32_t receiver_socket_idx = 0;
+        if (receiver_device_id == sender_device_id) {
+            if (ring_index == 0) {
+                receiver_socket_idx = 1;
             } else {
-                // counter clockwise direction
-                bool is_wraparound_ring_index = ring_index == ring_size - 1;
-                if (is_wraparound_ring_index) {
-                    receiver_output_start_page_idx -= last_output_page_offset;
-                } else {
-                    receiver_output_start_page_idx += output_page_offset;
+                sender_socket_idx = 1;
+            }
+        }
+        log_trace (tt::LogOp, "--------------------------------------------");
+        log_trace (tt::LogOp, "ring_index: {}, ring_size: {}, direction: {}", ring_index, ring_size, direction);
+        for (uint32_t l = 0; l < num_links; ++l) {
+            // Get the cores for the sender and receiver worker cores
+            if (!is_linear || ring_index != ring_size - 1) {
+                auto eth_sender_core = device->get_ethernet_sockets(receiver_device_id.value()).at(sender_socket_idx + l);
+                eth_sender_cores.push_back(eth_sender_core);
+                log_trace(tt::LogOp, "\teth_sender_core on link {}: (x={},y={})", l, eth_sender_core.x, eth_sender_core.y);
+            }
+            if (!is_linear || ring_index != 0) {
+                auto eth_receiver_core = device->get_ethernet_sockets(sender_device_id.value()).at(receiver_socket_idx + l);
+                eth_receiver_cores.push_back(eth_receiver_core);
+                log_trace(tt::LogOp, "\teth_receiver_core on link {}: (x={},y={})", l, eth_receiver_core.x, eth_receiver_core.y);
+            }
+        }
+
+
+
+        auto is_buffer_in_clockwise_direction = [&all_gather_config,&direction](uint32_t b) {
+            TT_ASSERT(direction < max_num_full_send_directions);
+            bool in_clockwise_direction = all_gather_config.is_buffer_in_clockwise_ring(b);
+            return (direction == 0) ? in_clockwise_direction : !in_clockwise_direction;
+        };
+
+        std::vector<uint32_t> pages_per_link(num_links, min_pages_per_link);
+        for (uint32_t i = 0; i < num_input_pages % min_pages_per_link; ++i) {
+            pages_per_link.at(i)++;
+        }
+
+        uint32_t num_rows = 0, num_cols = 0, row_offset = 0, col_offset = 0, num_tiles = 0;
+
+        if (rm) {
+            num_cols = input_tensor.get_legacy_shape()[-1];
+            auto input_shape = input_tensor.get_legacy_shape();
+            auto output_shape = output_tensor.get_legacy_shape();
+            num_rows = std::accumulate(input_shape.begin()+dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>());
+            row_offset = std::accumulate(output_shape.begin()+dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) - num_rows;
+        } else {
+            num_cols = input_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
+            auto input_shape = input_tensor.get_legacy_shape();
+            auto output_shape = output_tensor.get_legacy_shape();
+            uint32_t num_output_cols = output_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
+            num_rows = std::accumulate(input_shape.begin()+dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>()) / TILE_HEIGHT;
+            row_offset = (std::accumulate(output_shape.begin()+dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) / TILE_HEIGHT - num_rows) * num_output_cols;
+            col_offset = num_output_cols - num_cols;
+            num_tiles = num_rows * num_cols;
+        }
+
+        uint32_t input_start_page_idx = 0;
+        uint32_t output_addr_offset = 0;
+        uint32_t col_idx = 0;
+        uint32_t row_idx = 0;
+        uint32_t output_page_offset = 0;
+
+        if (rm) {
+            if (width) {
+                output_addr_offset = input_page_size;
+            } else {
+                output_page_offset = num_rows;
+            }
+        } else {
+            if (width) {
+                output_page_offset = num_cols;
+            } else {
+                output_page_offset = num_tiles;
+            }
+        }
+        uint32_t output_start_page_idx = ring_index * output_page_offset;
+        uint32_t output_start_addr_offset = ring_index * output_addr_offset;
+
+        ///
+        /// (counter clockwise sender) < ----- (this chip) < ----- (counter-clockwise receiver)
+        ///
+        /// (clockwise receiver)       ------> (this chip) ------> (clockwise sender)
+        /// So clockwise sender and counter-clockwise receiver are on the same core
+        //  and counter-clockwise sender and clockwise receiver are on the same corwe
+
+        for (uint32_t i = 0; i < num_links; ++i) {
+            // We can't have overlap between the mcast grid for worker cores for different links since mcasting the semaphore in receiver would corrupt other link semaphores
+            // We can have overlap between a link's sender and receiver worker grids if we have the semaphores at different addresses
+            auto const& [receiver_workers, sender_workers] = select_worker_cores(all_gather_config, num_links, i, direction);
+            uint32_t worker_index = 0;
+            uint32_t workers_per_link = all_gather_config.get_num_workers_per_link() / all_gather_config.get_num_eth_buffers_per_edm();
+
+            // Circular Buffer Setup
+            uint32_t cb_page_size = is_sharded ? shard_size_in_bytes : input_page_size;
+            log_trace(tt::LogOp, "input_page_size: {}", input_page_size);
+            uint32_t cb_num_pages = 2 * max_pages_per_chunk;
+            log_trace(tt::LogOp, "cb_num_pages: {}", cb_num_pages);
+            uint32_t src0_cb_index = CB::c_in0;
+            tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(cb_num_pages * cb_page_size, {{src0_cb_index, df}})
+            .set_page_size(src0_cb_index, cb_page_size);
+            CBHandle cb_src0_sender_workers = CreateCircularBuffer(program, sender_workers, cb_src0_config);
+            CBHandle cb_src0_receiver_workers = CreateCircularBuffer(program, receiver_workers, cb_src0_config);
+
+            // This semaphore is used by the receiver core to tell workers that data is available to read
+            auto receiver_worker_semaphore_addr = tt_metal::CreateSemaphore(program, receiver_workers, 0);
+            // This semaphore is used by the receiver core to tell the worker sender writer that sender buffer is available to write to
+            auto sender_worker_writer_semaphore_addr = tt_metal::CreateSemaphore(program, sender_workers, 0);
+            // This semaphore is used by the worker receiver writer to tell the worker sender reader that data has been committed to memory
+            // This is currently a running counter of how many chunks were committed since the sender worker never decrements this buffer
+            // Potentially avoid overflow by having it actually decrement (using noc atomic inc with value of -1)
+            auto sender_worker_reader_semaphore_addr = tt_metal::CreateSemaphore(program, sender_workers, 0);
+
+            // Rename this the _channel
+            std::vector<uint32_t> pages_per_buffer;
+
+            // number of pages that can fit in a single ethernet L1 buffer (not the number of pages sent to this channel)
+            std::vector<uint32_t> pages_per_eth_l1_buffer;
+            pages_per_buffer.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            uint32_t max_pages_per_eth_l1_sender_buffer = all_gather_config.get_eth_buffer_size() / input_page_size;
+            for(uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+                pages_per_buffer.push_back((pages_per_link.at(i) / all_gather_config.get_num_eth_buffers_per_edm()));
+                pages_per_eth_l1_buffer.push_back(
+                    is_sharded ? std::min(pages_per_buffer.back(), max_pages_per_eth_l1_sender_buffer)
+                            : max_pages_per_eth_l1_sender_buffer);
+                if (b < pages_per_link.at(i) % all_gather_config.get_num_eth_buffers_per_edm()) {
+                    pages_per_buffer.back()++;
+                }
+
+                log_trace(tt::LogOp, "pages_per_link[{}]: {}", i, pages_per_link.at(i));
+                log_trace(tt::LogOp, "pages_per_buffer[{}]: {}", b, pages_per_buffer.at(b));
+                log_trace(tt::LogOp, "max_pages_per_eth_l1_sender_buffer: {}",max_pages_per_eth_l1_sender_buffer);
+            }
+            TT_ASSERT(std::accumulate(pages_per_buffer.begin(), pages_per_buffer.end(), 0) == pages_per_link.at(i));
+
+            uint32_t bytes_per_chunk = 0, pages_per_chunk = 0, num_full_chunks = 0, rem_bytes = 0, rem_pages = 0;
+            uint32_t link_size_bytes = pages_per_link.at(i) * input_page_size;
+            if (pages_per_link.at(i) >= max_pages_per_chunk) {
+                bytes_per_chunk = max_buffer_per_chunk;
+                pages_per_chunk = max_pages_per_chunk;
+                TT_ASSERT(max_buffer_per_chunk == max_pages_per_chunk * input_page_size);
+                num_full_chunks = link_size_bytes / bytes_per_chunk;
+                rem_bytes = link_size_bytes % bytes_per_chunk;
+                rem_pages = pages_per_link.at(i) % max_pages_per_chunk;
+            } else {
+                rem_bytes = link_size_bytes;
+                rem_pages = pages_per_link.at(i);
+            }
+
+            auto sender_worker_cores = corerange_to_cores(sender_workers, std::nullopt, true);
+            auto receiver_worker_cores = corerange_to_cores(receiver_workers, std::nullopt, true);
+            all_worker_sender_cores.insert(all_worker_sender_cores.end(), sender_worker_cores.begin(), sender_worker_cores.end());
+            all_worker_receiver_cores.insert(all_worker_receiver_cores.end(), receiver_worker_cores.begin(), receiver_worker_cores.end());
+
+            TT_ASSERT(rem_pages < pages_per_chunk || num_full_chunks == 0);
+            TT_ASSERT(rem_pages <= max_pages_per_chunk);
+            std::vector<uint32_t> num_full_chunks_per_worker(all_gather_config.get_num_eth_buffers_per_edm(), num_full_chunks / all_gather_config.get_num_eth_buffers_per_edm());
+            std::vector<uint32_t> rem_pages_per_worker(all_gather_config.get_num_eth_buffers_per_edm(), 0);
+            {
+                uint32_t worker_idx = 0;
+                for (worker_idx = 0; worker_idx < num_full_chunks % all_gather_config.get_num_eth_buffers_per_edm(); ++worker_idx) {
+                    num_full_chunks_per_worker.at(worker_idx)++;
+                }
+                if (rem_pages != 0) {
+                    rem_pages_per_worker.at(worker_idx % all_gather_config.get_num_eth_buffers_per_edm()) = rem_pages;
+                    TT_ASSERT(rem_pages_per_worker.at(worker_idx % all_gather_config.get_num_eth_buffers_per_edm()) * 2 <= cb_num_pages);
                 }
             }
 
-            log_trace(tt::LogOp,"Counter Clock-wise");
-            log_trace(tt::LogOp,"\tlast_output_page_offset={}", last_output_page_offset);
-            log_trace(tt::LogOp,"\tlast_output_addr_offset={}", last_output_addr_offset);
-            log_trace(tt::LogOp,"\treceiver_ring_index={}", receiver_ring_index);
-            log_trace(tt::LogOp,"\treceiver_output_start_addr_offset={}", receiver_output_start_addr_offset);
-            log_trace(tt::LogOp,"\treceiver_output_start_page_idx={}", receiver_output_start_page_idx);
-
-            // Sender Worker Kernels
-            log_trace(tt::LogOp, "HOST RWS ARGS: ");
-            log_trace(tt::LogOp, "\tnum_transfers: {}", num_transfers);
-            log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
-            log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
-            log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
-            log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer.at(b): {}", pages_per_eth_l1_buffer.at(b));
-            log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
-
-            //// Send Reader
-            auto build_worker_send_reader_ct_args = [&]() {
-                if (is_sharded) {
-                    // # Send Reader (CT)
-                    // 1) Shard Type
-                    // 2) num_transfers
-                    std::vector<uint32_t> worker_reader_sender_ct_args = {
-                        static_cast<uint32_t>(sharding_info.get_shard_type()),
-                        static_cast<uint32_t>(num_transfers)
-                    };
-                    log_trace(tt::LogOp, "----worker_reader_sender_ct_args size={}", worker_reader_sender_ct_args.size());
-                    log_trace(tt::LogOp, "\tsharding_info.get_shard_type(): {}", sharding_info.get_shard_type());
-                    log_trace(tt::LogOp, "\tnum_transfers: {}", num_transfers);
-
-                    return worker_reader_sender_ct_args;
-                } else {
-                    std::vector<uint32_t> worker_reader_sender_ct_args = {
-                        static_cast<uint32_t>(all_gather_config.is_input_dram()),
-                        static_cast<uint32_t>(all_gather_config.is_output_dram()),
-                        static_cast<uint32_t>(num_transfers),
-                        static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
-                        static_cast<uint32_t>(input_page_size),
-                        static_cast<uint32_t>(output_page_size),
-                        static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
-                        static_cast<uint32_t>(rem_pages_per_worker.at(b)),
-                        static_cast<uint32_t>(input_start_page_idx),
-                        static_cast<uint32_t>(output_start_page_idx),
-                        static_cast<uint32_t>(output_start_addr_offset),
-                        static_cast<uint32_t>(row_idx),
-                        static_cast<uint32_t>(col_idx),
-                        static_cast<uint32_t>(row_offset),
-                        static_cast<uint32_t>(col_offset),
-                        static_cast<uint32_t>(num_rows),
-                        static_cast<uint32_t>(num_cols),
-                        static_cast<uint32_t>(last_output_page_offset),
-                        static_cast<uint32_t>(output_page_offset),
-                        static_cast<uint32_t>(last_output_addr_offset),
-                        static_cast<uint32_t>(output_addr_offset),
-                        static_cast<uint32_t>(ring_index),
-                        static_cast<uint32_t>(sender_worker_reader_semaphore_addr),
-                        static_cast<uint32_t>(is_clockwise_direction ? 1 : 0),
-                        static_cast<uint32_t>(cb_num_pages / 2)
-                    };
-                    return worker_reader_sender_ct_args;
-                }
-            };
-
-            std::vector<uint32_t> const& worker_send_reader_ct_args = build_worker_send_reader_ct_args();
-
-            auto build_worker_send_reader_rt_args = [&]() {
-                bool is_clockwise = all_gather_config.is_buffer_in_clockwise_ring(b);
-                if (is_sharded) {
-                    // # Send Reader (RT)
-                    // 1) local semaphore address (same as before)
-                    // 2) input tensor shard reader
-                    // 3) output tensor shard reader
-                    auto curr_link = i;
-
-                    TT_ASSERT(all_gather_config.get_num_buffers_per_link() == 1 || all_gather_config.get_num_buffers_per_link() == 2 || all_gather_config.get_num_buffers_per_link() == 4 || all_gather_config.get_num_buffers_per_link() == 8);
-                    TT_ASSERT(input_tensor.buffer() != nullptr);
-                    auto input_tensor_shard_arg_generator =
-                        InputTensorShardAddrGenArgGenerator(
-                            device,
-                            input_tensor,
-                            ring_index,
-                            ring_size,
-                            global_num_workers,
-                            global_worker_index,
-                            0,
-                            0,
-                            is_clockwise);
-                    auto const& [starting_dest_worker_index, starting_chunk_into_shard] = OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
-                        all_gather_config, input_tensor, output_tensor,
-                        is_clockwise ?
-                            (ring_index == 0 ? ring_size - 1 : ring_index - 1) :
-                            (ring_index == ring_size - 1 ? 0 : ring_index + 1),
-                        global_worker_index);
-
-                    log_trace(tt::LogOp, "SendReader {} ring_index: {}, start dest worker index: {}, starting chunk into shard: {}", global_worker_index, ring_index, starting_dest_worker_index, starting_chunk_into_shard);
-                    auto output_tensor_shard_arg_generator =
-                        OutputTensorShardAddrGenArgGenerator(
-                            all_gather_config,
-                            device,
-                            input_tensor,
-                            output_tensor,
-                            ring_index,
-                            ring_size,
-                            global_num_workers,
-                            global_worker_index,
-                            starting_dest_worker_index,
-                            starting_chunk_into_shard,
-                            is_clockwise);
-
-                    auto const& input_shard_addr_generator_args = input_tensor_shard_arg_generator.generate();
-                    auto const& output_shard_addr_generator_args = output_tensor_shard_arg_generator.generate();
-                    std::vector<uint32_t> worker_send_reader_rt_args;
-                    worker_send_reader_rt_args.reserve(1 + input_shard_addr_generator_args.size() + output_shard_addr_generator_args.size());
-                    worker_send_reader_rt_args.push_back(sender_worker_reader_semaphore_addr);
-                    std::copy(input_shard_addr_generator_args.begin(), input_shard_addr_generator_args.end(), std::back_inserter(worker_send_reader_rt_args));
-                    std::copy(output_shard_addr_generator_args.begin(), output_shard_addr_generator_args.end(), std::back_inserter(worker_send_reader_rt_args));
-
-                    log_trace(tt::LogOp, "---worker_send_reader_rt_args.size()={}-----", worker_send_reader_rt_args.size());
-                    log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_addr: {}", sender_worker_reader_semaphore_addr);
-                    log_trace(tt::LogOp, "\tinput_shard_addr_generator_args:");
-                    input_tensor_shard_arg_generator.dump_to_log();
-                    log_trace(tt::LogOp, "\toutput_tensor_shard_arg_generator:");
-                    output_tensor_shard_arg_generator.dump_to_log();
-
-                    return worker_send_reader_rt_args;
-                } else {
-                    std::vector<uint32_t> args = {
-                        static_cast<uint32_t>(input_buffer->address()),
-                        static_cast<uint32_t>(output_buffer->address())
-                    };
-                    return args;
-                }
-            };
-            std::vector<uint32_t> const& worker_send_reader_rt_args = build_worker_send_reader_rt_args();
-
-            std::string const& send_reader_kernel_path = is_sharded ?
-                "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_reader.cpp" :
-                "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp";
-            KernelHandle worker_reader_sender_kernel_id = tt_metal::CreateKernel(
-                program,
-                send_reader_kernel_path,
-                sender_worker_cores.at(b),
-                tt_metal::ReaderDataMovementConfig(worker_send_reader_ct_args, worker_defines));
-
-            worker_reader_sender_kernels.push_back(worker_reader_sender_kernel_id);
-
-            tt_metal::SetRuntimeArgs(
-                program,
-                worker_reader_sender_kernel_id,
-                sender_worker_cores.at(b),
-                worker_send_reader_rt_args);
-
-
-            //// Send Writer
-            auto build_worker_sender_writer_ct_args = [&]() {
-                if (is_sharded) {
-                    std::vector<uint32_t> worker_sender_writer_ct_args = {
-                        static_cast<uint32_t>(sharding_info.get_shard_type())
-                    };
-                    log_trace(tt::LogOp, "----worker_sender_writer_ct_args size={}", worker_sender_writer_ct_args.size());
-                    log_trace(tt::LogOp, "\tsharding_info.get_shard_type(): {}", sharding_info.get_shard_type());
-
-                    return worker_sender_writer_ct_args;
-                } else {
-                    CoreCoord const& worker_eth_sender_core = is_clockwise_direction ? eth_sender_cores.at(i) : eth_receiver_cores.at(i);
-                    std::vector<uint32_t> worker_writer_sender_ct_args = {
-                        static_cast<uint32_t>(all_gather_config.is_output_dram()),
-                        static_cast<uint32_t>(num_transfers),
-                        static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
-                        static_cast<uint32_t>(input_page_size),
-                        static_cast<uint32_t>(output_page_size),
-                        static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
-                        static_cast<uint32_t>(rem_pages_per_worker.at(b)),
-                        static_cast<uint32_t>(input_start_page_idx),
-                        static_cast<uint32_t>(output_start_page_idx),
-                        static_cast<uint32_t>(output_start_addr_offset),
-                        static_cast<uint32_t>(row_idx),
-                        static_cast<uint32_t>(col_idx),
-                        static_cast<uint32_t>(row_offset),
-                        static_cast<uint32_t>(col_offset),
-                        static_cast<uint32_t>(num_rows),
-                        static_cast<uint32_t>(num_cols),
-                        static_cast<uint32_t>(ring_index),
-
-                        // worker local L1 address of semaphore
-                        static_cast<uint32_t>(sender_worker_writer_semaphore_addr),
-                        static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).x),
-                        static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).y),
-                        static_cast<uint32_t>(cb_num_pages / 2),
-                    };
-
-                    log_trace(tt::LogOp, "HOST SWS ARGS:");
-                    log_trace(tt::LogOp, "\toutput_is_dram: {}", all_gather_config.is_output_dram());
-                    log_trace(tt::LogOp, "\tnum_transfers: {}", num_transfers);
-                    log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
-                    log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
-                    log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
-                    log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer.at(b): {}", pages_per_eth_l1_buffer.at(b));
-                    log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
-
-                    return worker_writer_sender_ct_args;
-                }
-            };
-
-            std::vector<uint32_t> const& worker_sender_writer_ct_args = build_worker_sender_writer_ct_args();
-
-            auto build_worker_sender_writer_rt_args = [&]() {
-                if (is_sharded) {
-                    // Send Writer Args (RT)
-                    // 1) eth_sender_l1_base_addr
-                    // 2) eth_sender_l1_sem_addr
-                    // 3) eth_sender_noc_x
-                    // 4) eth_sender_noc_y
-                    // 5) writer_send_sem_addr
-                    // 6) num_transfers
-                    // 7)
-
-                    bool is_clockwise = all_gather_config.is_buffer_in_clockwise_ring(b);
-                    auto const& [starting_dest_worker_index, starting_chunk_into_shard] = OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
-                        all_gather_config,
-                        input_tensor,
-                        output_tensor,
-                        // this writes the input tensor to the first output location
-                        ring_index,
-                        global_worker_index);
-                    auto output_tensor_shard_arg_generator =
-                        OutputTensorShardAddrGenArgGenerator(
-                            all_gather_config,
-                            device,
-                            input_tensor,
-                            output_tensor,
-                            ring_index,
-                            ring_size,
-                            global_num_workers,
-                            global_worker_index,
-                            starting_dest_worker_index,
-                            starting_chunk_into_shard,
-                            all_gather_config.is_buffer_in_clockwise_ring(b)
-                        );
-                    auto const& output_tensor_shard_addr_gen_args = output_tensor_shard_arg_generator.generate();
-
-                    CoreCoord const& worker_eth_sender_core = is_clockwise_direction ? eth_sender_cores.at(i) : eth_receiver_cores.at(i);
-                    std::vector<uint32_t> worker_writer_sender_rt_args = {
-                        static_cast<uint32_t>(eth_buffer_addrs.at(b)), // eth_sender_l1_base_addr
-                        static_cast<uint32_t>(eth_sem_addrs.at(b)), // eth_sender_l1_sem_addr
-                        static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).x), // eth_sender_noc_x
-                        static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).y), // eth_sender_noc_y
-                        static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)), //output_tensor_shard_arg_generator.args_struct.num_dest_cores),//pages_per_eth_l1_buffer.at(b)),
-                        static_cast<uint32_t>(sender_worker_writer_semaphore_addr), // writer_send_sem_addr
-                        static_cast<uint32_t>(num_transfers) // num_transfers
-                    };
-                    std::copy(output_tensor_shard_addr_gen_args.begin(), output_tensor_shard_addr_gen_args.end(), std::back_inserter(worker_writer_sender_rt_args));
-
-                    // Currently the kernel assumes we don't need to break up the initial local tensor send to EDM into multiple
-                    // chunks
-
-                    log_trace(tt::LogOp, "----worker_writer_sender_rt_args size={}", worker_writer_sender_rt_args.size());
-                    log_trace(tt::LogOp, "\teth_sender_l1_base_addr: {}", eth_buffer_addrs.at(b));
-                    log_trace(tt::LogOp, "\teth_sender_l1_sem_addr: {}", eth_sem_addrs.at(b));
-                    log_trace(tt::LogOp, "\teth_sender_noc_x: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).x);
-                    log_trace(tt::LogOp, "\teth_sender_noc_y: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).y);
-                    log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer: {}", pages_per_eth_l1_buffer.at(b));
-                    log_trace(tt::LogOp, "\twriter_send_sem_addr: {}", sender_worker_writer_semaphore_addr);
-                    log_trace(tt::LogOp, "\tnum_transfers: {}", num_transfers);
-                    output_tensor_shard_arg_generator.dump_to_log();
-
-                    return worker_writer_sender_rt_args;
-                } else {
-                    std::vector<uint32_t> worker_writer_sender_rt_args = {
-                        static_cast<uint32_t>(output_buffer->address()),
-                        static_cast<uint32_t>(eth_buffer_addrs.at(b)),
-                        static_cast<uint32_t>(eth_sem_addrs.at(b))
-                    };
-                    return worker_writer_sender_rt_args;
-                }
-            };
-            std::vector<uint32_t> const& worker_sender_writer_rt_args = build_worker_sender_writer_rt_args();
-
-            std::string const& sender_writer_kernel_path = is_sharded ?
-                "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_writer.cpp" :
-                "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp";
-            KernelHandle worker_sender_writer_kernel_id = tt_metal::CreateKernel(
-                program,
-                sender_writer_kernel_path,
-                sender_worker_cores.at(b),
-                tt_metal::WriterDataMovementConfig(worker_sender_writer_ct_args, worker_defines));
-
-            worker_writer_sender_kernels.push_back(worker_sender_writer_kernel_id);
-
-            tt_metal::SetRuntimeArgs(
-                program,
-                worker_sender_writer_kernel_id,
-                sender_worker_cores.at(b),
-                worker_sender_writer_rt_args);
-
-            log_trace(tt::LogOp, "HOST RWR ARGS:");
-            log_trace(tt::LogOp, "\tnum_transfers: {}", num_transfers);
-            log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
-            log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
-            log_trace(tt::LogOp, "\tpages_per_chunk: {}", pages_per_chunk);
-            log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
-
-            //// Receive Reader
-            auto build_worker_receiver_reader_ct_args = [&]() {
-                if (is_sharded) {
-                    // Receiver Reader Args (CT)
-                    std::vector<uint32_t> worker_receiver_reader_ct_args = {
-                        static_cast<uint32_t>(sharding_info.get_shard_type())
-                    };
-                    log_trace(tt::LogOp, "----worker_receiver_reader_ct_args size={}", worker_receiver_reader_ct_args.size());
-                    log_trace(tt::LogOp, "\tsharding_info.get_shard_type(): {}", sharding_info.get_shard_type());
-
-                    return worker_receiver_reader_ct_args;
-                } else {
-                    CoreCoord const& worker_eth_receiver_core = is_clockwise_direction ? eth_receiver_cores.at(i) : eth_sender_cores.at(i);
-                    std::vector<uint32_t> worker_receiver_reader_ct_args = {
-                        static_cast<uint32_t>(num_transfers),
-                        static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
-                        static_cast<uint32_t>(input_page_size),
-                        static_cast<uint32_t>(pages_per_chunk),
-                        static_cast<uint32_t>(rem_pages_per_worker.at(b)),
-                        static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).x),
-                        static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).y),
-                        static_cast<uint32_t>(eth_sem_addrs.at(b)),
-                        static_cast<uint32_t>(receiver_worker_semaphore_addr),
-                        static_cast<uint32_t>(cb_num_pages / 2)
-                    };
-                    return worker_receiver_reader_ct_args;
-                }
-            };
-            std::vector<uint32_t> const& worker_receiver_reader_ct_args = build_worker_receiver_reader_ct_args();
-
-            auto build_worker_receiver_reader_rt_args = [&]() {
-                if (is_sharded) {
-                    // Receiver Reader Args (RT)
-                    // 1) eth_receiver_noc_x
-                    // 2) eth_receiver_noc_y
-                    // 3) eth_receiver_l1_base_addr
-                    // 4) eth_receiver_l1_semaphore_addr
-                    // 5) (local) receiver_read_sem_addr
-                    // 6) output tensor shard addr gen
-                    auto curr_link = i;
-                    bool is_clockwise = all_gather_config.is_buffer_in_clockwise_ring(b);
-                    auto const& [starting_dest_worker_index, starting_chunk_into_shard] = OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
-                        all_gather_config,
-                        input_tensor,
-                        output_tensor,
-                        is_clockwise ?
-                            (ring_index == 0 ? ring_size - 1 : ring_index - 1) :
-                            (ring_index == ring_size - 1 ? 0 : ring_index + 1), // ring_index
-                        global_worker_index);
-                    CoreCoord const& worker_eth_receiver_core = is_clockwise_direction ? eth_receiver_cores.at(i) : eth_sender_cores.at(i);
-                    auto output_tensor_shard_arg_generator =
-                        OutputTensorShardAddrGenArgGenerator(
-                            all_gather_config,
-                            device,
-                            input_tensor,
-                            output_tensor,
-                            ring_index,
-                            ring_size,
-                            global_num_workers,
-                            global_worker_index,
-                            starting_dest_worker_index,
-                            starting_chunk_into_shard,
-                            all_gather_config.is_buffer_in_clockwise_ring(b));
-                    auto const& output_tensor_shard_addr_gen_args = output_tensor_shard_arg_generator.generate();
-                    std::vector<uint32_t> worker_reader_receiver_rt_args;
-                    worker_reader_receiver_rt_args.reserve(7 + output_tensor_shard_addr_gen_args.size());
-
-                    worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).x)); // eth_receiver_noc_x
-                    worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).y)); // eth_receiver_noc_y
-                    worker_reader_receiver_rt_args.push_back(eth_buffer_addrs.at(b)); // eth_receiver_l1_base_addr
-                    worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(eth_sem_addrs.at(b))); // eth_receiver_l1_semaphore_addr
-                    worker_reader_receiver_rt_args.push_back(receiver_worker_semaphore_addr); // local_receiver_read_sem_addr
-                    worker_reader_receiver_rt_args.push_back(pages_per_eth_l1_buffer.at(b)), //output_tensor_shard_arg_generator.args_struct.num_dest_cores), //pages_per_eth_l1_buffer.at(b)); // num_shards_per_eth_buf
-                    worker_reader_receiver_rt_args.push_back(num_transfers); // local_receiver_read_sem_addr
-                    std::copy(output_tensor_shard_addr_gen_args.begin(), output_tensor_shard_addr_gen_args.end(), std::back_inserter(worker_reader_receiver_rt_args));
-
-                    log_trace(tt::LogOp, "----worker_receiver_reader_ct_args size={}", worker_receiver_reader_ct_args.size());
-                    log_trace(tt::LogOp, "\teth_receiver_noc_x: {}", static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).x));
-                    log_trace(tt::LogOp, "\teth_receiver_noc_y: {}", static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).y));
-                    log_trace(tt::LogOp, "\teth_receiver_l1_base_addr: {}", eth_buffer_addrs.at(b));
-                    log_trace(tt::LogOp, "\teth_receiver_l1_semaphore_addr: {}", static_cast<uint32_t>(eth_sem_addrs.at(b)));
-                    log_trace(tt::LogOp, "\tlocal_receiver_read_sem_addr: {}", receiver_worker_semaphore_addr);
-                    log_trace(tt::LogOp, "\tnum_shards_per_eth_buf: {}", pages_per_eth_l1_buffer.at(b));
-
-                    output_tensor_shard_arg_generator.dump_to_log();
-
-                    return worker_reader_receiver_rt_args;
-                } else {
-                    std::vector<uint32_t> worker_reader_receiver_rt_args = {
-                        static_cast<uint32_t>(eth_buffer_addrs.at(b))
-                    };
-                    return worker_reader_receiver_rt_args;
-                }
-            };
-            std::vector<uint32_t> worker_receiver_reader_rt_args = build_worker_receiver_reader_rt_args();
-
-            std::string const& receiver_reader_kernel_path = is_sharded ?
-                "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_reader.cpp" :
-                "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp";
-            KernelHandle worker_receiver_reader_kernel_id = tt_metal::CreateKernel(
-                program,
-                receiver_reader_kernel_path,
-                receiver_worker_cores.at(b),
-                tt_metal::ReaderDataMovementConfig(worker_receiver_reader_ct_args, worker_defines));
-
-            worker_reader_receiver_kernels.push_back(worker_receiver_reader_kernel_id);
-
-            tt_metal::SetRuntimeArgs(
-                program,
-                worker_receiver_reader_kernel_id,
-                receiver_worker_cores.at(b),
-                worker_receiver_reader_rt_args);
-
-            log_trace(tt::LogOp, "HOST SWR ARGS: \n");
-            log_trace(tt::LogOp, "\toutput_is_dram: {}", all_gather_config.is_output_dram());
-            log_trace(tt::LogOp, "\tnum_transfers: {}", num_transfers);
-            log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
-            log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
-            log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
-            log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer.at(b): {}", pages_per_eth_l1_buffer.at(b));
-            log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
-            log_trace(tt::LogOp, "\treceiver_output_start_page_idx: {}", receiver_output_start_page_idx);
-            log_trace(tt::LogOp, "\treceiver_output_start_addr_offset: {}", receiver_output_start_addr_offset);
-
-            //// Receive Writer
-            auto build_worker_receive_writer_ct_args = [&]() {
-                if (is_sharded) {
-                    // # Receiver Writer (CT)
-                    // 1) Shard Type
-                    std::vector<uint32_t> worker_receive_writer_ct_args = {
-                        static_cast<uint32_t>(sharding_info.get_shard_type())
-                    };
-                    log_trace(tt::LogOp, "----worker_receive_writer_ct_args size={}", worker_receive_writer_ct_args.size());
-                    log_trace(tt::LogOp, "\tsharding_info.get_shard_type(): {}", sharding_info.get_shard_type());
-
-                    return worker_receive_writer_ct_args;
-                } else {
-                    std::vector<uint32_t> worker_writer_receiver_ct_args = {
-                        static_cast<uint32_t>(all_gather_config.is_output_dram()),
-                        static_cast<uint32_t>(num_transfers),
-                        static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
-                        static_cast<uint32_t>(input_page_size),
-                        static_cast<uint32_t>(output_page_size),
-                        static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
-                        static_cast<uint32_t>(rem_pages_per_worker.at(b)),
-                        static_cast<uint32_t>(receiver_output_start_page_idx),
-                        static_cast<uint32_t>(receiver_output_start_addr_offset),
-                        static_cast<uint32_t>(row_idx),
-                        static_cast<uint32_t>(col_idx),
-                        static_cast<uint32_t>(row_offset),
-                        static_cast<uint32_t>(col_offset),
-                        static_cast<uint32_t>(num_rows),
-                        static_cast<uint32_t>(num_cols),
-                        static_cast<uint32_t>(last_output_page_offset),
-                        static_cast<uint32_t>(output_page_offset),
-                        static_cast<uint32_t>(last_output_addr_offset),
-                        static_cast<uint32_t>(output_addr_offset),
-                        static_cast<uint32_t>(receiver_ring_index),
-                        static_cast<uint32_t>(sender_worker_reader_semaphore_addr),
-                        static_cast<uint32_t>(is_clockwise_direction ? 1 : 0),
-                        static_cast<uint32_t>(cb_num_pages / 2)
-                    };
-                    return worker_writer_receiver_ct_args;
-                }
-            };
-            std::vector<uint32_t> const& worker_receive_writer_ct_args = build_worker_receive_writer_ct_args();
-
-            auto build_worker_receive_writer_rt_args = [&]() {
-                auto worker_sender_reader = device->worker_core_from_logical_core(sender_worker_cores.at(b));
-                if (is_sharded) {
-                    // # Receiver Writer (RT)
-                    // 1) Remote sender reader semaphore address
-                    // 2) Output tensor Writer shard addr gen
-                    bool is_clockwise = all_gather_config.is_buffer_in_clockwise_ring(b);
-
-                    auto const& [starting_dest_worker_index, starting_chunk_into_shard] = OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
-                        all_gather_config,
-                        input_tensor,
-                        output_tensor,
-                        is_clockwise ?
-                            (ring_index == 0 ? ring_size - 1 : ring_index - 1) :
-                            (ring_index == ring_size - 1 ? 0 : ring_index + 1),
-                        global_worker_index);
-                    log_trace(tt::LogOp, "ReceiverWriter {} ring_index: {}, start dest worker index: {}, starting chunk into shard: {}", global_worker_index, ring_index, starting_dest_worker_index, starting_chunk_into_shard);
-                    OutputTensorShardAddrGenArgGenerator output_tensor_shard_arg_generator(
-                        all_gather_config,
-                        device,
-                        input_tensor,
-                        output_tensor,
-                        ring_index,
-                        ring_size,
-                        global_num_workers,
-                        all_gather_config.get_num_buffers_per_link() * i + b,
-                        starting_dest_worker_index,
-                        starting_chunk_into_shard,
-                        all_gather_config.is_buffer_in_clockwise_ring(b));
-                    auto const& output_shard_addr_generator_args = output_tensor_shard_arg_generator.generate();
-                    std::vector<uint32_t> worker_receive_writer_rt_args;
-                    worker_receive_writer_rt_args.reserve(5 + output_shard_addr_generator_args.size());
-                    worker_receive_writer_rt_args.push_back(static_cast<uint32_t>(worker_sender_reader.x));
-                    worker_receive_writer_rt_args.push_back(static_cast<uint32_t>(worker_sender_reader.y));
-                    worker_receive_writer_rt_args.push_back(sender_worker_reader_semaphore_addr);
-
-                    worker_receive_writer_rt_args.push_back(output_tensor_shard_arg_generator.args_struct.num_dest_cores), //pages_per_eth_l1_buffer.at(b));
-                    worker_receive_writer_rt_args.push_back(num_transfers);
-
-                    std::copy(output_shard_addr_generator_args.begin(), output_shard_addr_generator_args.end(), std::back_inserter(worker_receive_writer_rt_args));
-
-                    log_trace(tt::LogOp, "----worker_receive_writer_rt_args size={}", worker_receive_writer_rt_args.size());
-                    log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_addr: {}", sender_worker_reader_semaphore_addr);
-                    output_tensor_shard_arg_generator.dump_to_log();
-
-                    return worker_receive_writer_rt_args;
-                } else {
-                    std::vector<uint32_t> worker_writer_receiver_rt_args = {
-                        static_cast<uint32_t>(output_buffer->address()),
-                        static_cast<uint32_t>(worker_sender_reader.x),
-                        static_cast<uint32_t>(worker_sender_reader.y),
-                    };
-                    return worker_writer_receiver_rt_args;
-                }
-            };
-            std::vector<uint32_t> worker_receive_writer_rt_args = build_worker_receive_writer_rt_args();
-
-            std::string const& receiver_writer_kernel_path = is_sharded ?
-                "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_writer.cpp" :
-                "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_receive_writer.cpp";
-            KernelHandle worker_receive_writer_kernel_id = tt_metal::CreateKernel(
-                program,
-                receiver_writer_kernel_path,
-                receiver_worker_cores.at(b),
-                tt_metal::WriterDataMovementConfig(worker_receive_writer_ct_args, worker_defines));
-
-            worker_writer_receiver_kernels.push_back(worker_receive_writer_kernel_id);
-
-            tt_metal::SetRuntimeArgs(
-                program,
-                worker_receive_writer_kernel_id,
-                receiver_worker_cores.at(b),
-                worker_receive_writer_rt_args);
-
-            uint32_t pages_per_worker = num_full_chunks_per_worker.at(b) * pages_per_chunk + rem_pages_per_worker.at(b);
+            std::vector<uint32_t> clockwise_link_buffer_num_messages_to_send;
+            std::vector<uint32_t> counter_clockwise_link_buffer_num_messages_to_send;
+            std::vector<uint32_t> edm_semaphores_base_address;
+            std::vector<uint32_t> link_buffer_sender_addresses;
+            clockwise_link_buffer_num_messages_to_send.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            counter_clockwise_link_buffer_num_messages_to_send.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            edm_semaphores_base_address.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            link_buffer_sender_addresses.reserve(all_gather_config.get_num_eth_buffers_per_edm());
             if (is_sharded) {
-                // nothing to do here - is handled by
-            } else {
-                if (rm) {
-                    uint32_t num_rows_shifted = row_idx + pages_per_worker;
-                    uint32_t num_blocks_shifted = width ? 0 : num_rows_shifted / num_rows;
-                    output_start_page_idx += pages_per_worker + num_blocks_shifted * row_offset;
-                    row_idx = width ? 0 : num_rows_shifted % num_rows;
-                } else {
-                    uint32_t num_cols_shifted = col_idx + pages_per_worker;
-                    uint32_t num_rows_shifted = num_cols_shifted / num_cols;
-                    uint32_t num_blocks_shifted = width ? 0 : num_rows_shifted / num_rows;
-                    output_start_page_idx += pages_per_worker + num_rows_shifted * col_offset + num_blocks_shifted * row_offset;
-                    col_idx = num_cols_shifted % num_cols;
-                    row_idx = width ? 0 : num_rows_shifted % num_rows;
+                for(uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+                    auto input_tensor_shard_arg_generator = InputTensorShardAddrGenArgGenerator(
+                                    device,
+                                    input_tensor,
+                                    ring_index,
+                                    ring_size,
+                                    global_num_workers,
+                                    b + i * all_gather_config.get_num_workers_per_link(),
+                                    0,
+                                    0,
+                                    // We want the input tensor to always be read in forward shard order so we
+                                    // always tell it we are in counter-clockwise direction (forward read order)
+                                    false
+                                );
+                    uint32_t max_shards_per_eth_buffer = std::min<uint32_t>(all_gather_config.get_eth_buffer_size() / input_tensor_shard_arg_generator.args_struct.shard_size_in_bytes, input_tensor_shard_arg_generator.args_struct.num_dest_cores);
+                    TT_ASSERT(max_shards_per_eth_buffer > 0, "Codepath needs further generalization to support computing multiple sends per shard");
+                    num_full_chunks_per_worker.at(b) = input_tensor_shard_arg_generator.args_struct.num_dest_cores < max_shards_per_eth_buffer ? 1 : input_tensor_shard_arg_generator.args_struct.num_dest_cores / max_shards_per_eth_buffer;
+                    rem_pages_per_worker.at(b) = max_shards_per_eth_buffer > input_tensor_shard_arg_generator.args_struct.num_dest_cores ? 0 : input_tensor_shard_arg_generator.args_struct.num_dest_cores - (num_full_chunks_per_worker.at(b) * max_shards_per_eth_buffer);
+                    TT_ASSERT(rem_pages_per_worker.at(b) == 0 || input_tensor_shard_arg_generator.args_struct.num_dest_cores >= num_full_chunks_per_worker.at(b) * max_shards_per_eth_buffer);
+                    TT_ASSERT(input_tensor_shard_arg_generator.args_struct.num_dest_cores == rem_pages_per_worker.at(b) + num_full_chunks_per_worker.at(b) * max_shards_per_eth_buffer);
                 }
-                input_start_page_idx += pages_per_worker;
+            }
+            for(uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+                // link num messages
+                clockwise_link_buffer_num_messages_to_send.push_back(
+                    (num_full_chunks_per_worker.at(b) + (rem_pages_per_worker.at(b) > 0 ? 1 : 0)) *
+                    sender_num_transfers);
+                counter_clockwise_link_buffer_num_messages_to_send.push_back(
+                    (num_full_chunks_per_worker.at(b) + (rem_pages_per_worker.at(b) > 0 ? 1 : 0)) *
+                    receiver_num_transfers);
+            }
+            for(uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+                log_trace(tt::LogOp, "rem_pages_per_worker[{}]: {}", b, rem_pages_per_worker.at(b));
+                log_trace(tt::LogOp, "num_full_chunks_per_worker[{}]: {}", b, num_full_chunks_per_worker.at(b));
+                log_trace(tt::LogOp, "clockwise_link_buffer_num_messages_to_send[{}]: {}", b, clockwise_link_buffer_num_messages_to_send.at(b));
+                log_trace(tt::LogOp, "counter_clockwise_link_buffer_num_messages_to_send[{}]: {}", b, counter_clockwise_link_buffer_num_messages_to_send.at(b));
+            }
+
+            std::vector<uint32_t> receiver_semaphores_base_address;
+            std::vector<uint32_t> link_buffer_receiver_addresses;
+            receiver_semaphores_base_address.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            link_buffer_receiver_addresses.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            for(uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+                receiver_semaphores_base_address.push_back(all_gather_config.get_eth_sems_l1_base_byte_address() + b * all_gather_config.get_semaphore_size());
+                link_buffer_receiver_addresses.push_back(all_gather_config.get_eth_buffers_l1_base_byte_address() + b * all_gather_config.get_eth_buffer_size());
+            }
+
+            std::vector<uint32_t> sender_eth_sem_addrs; sender_eth_sem_addrs.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            std::vector<uint32_t> sender_eth_buffer_addrs; sender_eth_buffer_addrs.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            std::vector<uint32_t> receiver_eth_sem_addrs; receiver_eth_sem_addrs.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            std::vector<uint32_t> receiver_eth_buffer_addrs; receiver_eth_buffer_addrs.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+            for (uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+                uint32_t num_workers_per_eth_buffer = std::min(workers_per_link, all_gather_config.get_num_eth_buffers_per_edm() - worker_index);
+
+                std::vector<ccl::WorkerXY> sender_worker_coords;
+                std::vector<ccl::WorkerXY> receiver_worker_coords;
+                for (uint32_t w = b * num_workers_per_eth_buffer; w < (b + 1) * num_workers_per_eth_buffer; ++w) {
+                    sender_worker_coords.push_back(
+                        ccl::WorkerXY(
+                            device->worker_core_from_logical_core(sender_worker_cores.at(w)).x,
+                            device->worker_core_from_logical_core(sender_worker_cores.at(w)).y));
+                    receiver_worker_coords.push_back(
+                        ccl::WorkerXY(
+                            device->worker_core_from_logical_core(receiver_worker_cores.at(w)).x,
+                            device->worker_core_from_logical_core(receiver_worker_cores.at(w)).y));
+                }
+
+                bool sender_enabled = (!is_linear || !is_last_chip_in_chain);
+                if (sender_enabled) {
+                    auto &sender_edm_builder = is_buffer_in_clockwise_direction(b) ? clockwise_edm_builders.at(i) : counter_clockwise_edm_builders.at(i);
+                    log_trace(tt::LogOp, "Adding sender EDM channel");
+                    EriscDatamoverBuilder::ChannelBufferInterface const& sender_channel_buffer_info =
+                        sender_edm_builder.add_sender_channel(sender_worker_writer_semaphore_addr, clockwise_link_buffer_num_messages_to_send.at(b), sender_worker_coords);
+                    sender_eth_sem_addrs.push_back(sender_channel_buffer_info.eth_semaphore_l1_address);
+                    sender_eth_buffer_addrs.push_back(sender_channel_buffer_info.eth_buffer_l1_address);
+                }
+
+                bool receiver_enabled = (!is_linear || !is_first_chip_in_chain);
+                if (receiver_enabled) {
+                    auto &receiver_edm_builder = is_buffer_in_clockwise_direction(b) ? counter_clockwise_edm_builders.at(i) : clockwise_edm_builders.at(i);
+                    log_trace(tt::LogOp, "Adding receiver EDM channel");
+                    EriscDatamoverBuilder::ChannelBufferInterface const& receiver_channel_buffer_info =
+                        receiver_edm_builder.add_receiver_channel(receiver_worker_semaphore_addr, counter_clockwise_link_buffer_num_messages_to_send.at(b), receiver_worker_coords);
+                    receiver_eth_sem_addrs.push_back(receiver_channel_buffer_info.eth_semaphore_l1_address);
+                    receiver_eth_buffer_addrs.push_back(receiver_channel_buffer_info.eth_buffer_l1_address);
+                }
+            }
+
+
+            // 1 Worker per buffer
+            for (uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+                uint32_t global_worker_index = all_gather_config.get_num_eth_buffers_per_edm() * i + b;
+
+                bool is_clockwise_direction = is_buffer_in_clockwise_direction(b);
+
+                // Not fully sure about these two
+                uint32_t last_output_page_offset = (ring_size - 1) * output_page_offset;
+                uint32_t last_output_addr_offset = (ring_size - 1) * output_addr_offset;
+
+                log_trace(tt::LogOp,"\tlast_output_page_offset={}", last_output_page_offset);
+                log_trace(tt::LogOp,"\tlast_output_addr_offset={}", last_output_addr_offset);
+
+                if (!is_linear || !is_last_chip_in_chain) {
+                    //// Send Reader
+                    auto build_worker_send_reader_ct_args = [&]() {
+                        if (is_sharded) {
+                            // # Send Reader (CT)
+                            // 1) Shard Type
+                            // 2) num_transfers
+                            std::vector<uint32_t> worker_reader_sender_ct_args = {
+                                static_cast<uint32_t>(sharding_info.get_shard_type()),
+                                static_cast<uint32_t>(sender_num_transfers)
+                            };
+                            log_trace(tt::LogOp, "----worker_reader_sender_ct_args size={}", worker_reader_sender_ct_args.size());
+                            log_trace(tt::LogOp, "\tsharding_info.get_shard_type(): {}", sharding_info.get_shard_type());
+                            log_trace(tt::LogOp, "\tnum_transfers: {}", sender_num_transfers);
+
+                            return worker_reader_sender_ct_args;
+                        } else {
+                            std::vector<uint32_t> worker_reader_sender_ct_args = {
+                                static_cast<uint32_t>(all_gather_config.is_input_dram()),
+                                static_cast<uint32_t>(all_gather_config.is_output_dram()),
+                                static_cast<uint32_t>(sender_num_transfers),
+                                static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
+                                static_cast<uint32_t>(input_page_size),
+                                static_cast<uint32_t>(output_page_size),
+                                static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
+                                static_cast<uint32_t>(rem_pages_per_worker.at(b)),
+                                static_cast<uint32_t>(input_start_page_idx),
+                                static_cast<uint32_t>(output_start_page_idx),
+                                static_cast<uint32_t>(output_start_addr_offset),
+                                static_cast<uint32_t>(row_idx),
+                                static_cast<uint32_t>(col_idx),
+                                static_cast<uint32_t>(row_offset),
+                                static_cast<uint32_t>(col_offset),
+                                static_cast<uint32_t>(num_rows),
+                                static_cast<uint32_t>(num_cols),
+                                static_cast<uint32_t>(last_output_page_offset),
+                                static_cast<uint32_t>(output_page_offset),
+                                static_cast<uint32_t>(last_output_addr_offset),
+                                static_cast<uint32_t>(output_addr_offset),
+                                static_cast<uint32_t>(ring_index),
+                                static_cast<uint32_t>(sender_worker_reader_semaphore_addr),
+                                static_cast<uint32_t>(is_clockwise_direction ? 1 : 0),
+                                static_cast<uint32_t>(cb_num_pages / 2),
+                                static_cast<uint32_t>(ring_size)
+                            };
+
+                            log_trace(tt::LogOp, "Worker {} SR args", b);
+                            log_trace(tt::LogOp, "\tall_gather_config.is_input_dram(): {}", all_gather_config.is_input_dram());
+                            log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
+                            log_trace(tt::LogOp, "\tsender_num_transfers: {}", sender_num_transfers);
+                            log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
+                            log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
+                            log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
+                            log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer.at(b): {}", pages_per_eth_l1_buffer.at(b));
+                            log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
+                            log_trace(tt::LogOp, "\tinput_start_page_idx: {}", input_start_page_idx);
+                            log_trace(tt::LogOp, "\toutput_start_page_idx: {}", output_start_page_idx);
+                            log_trace(tt::LogOp, "\toutput_start_addr_offset: {}", output_start_addr_offset);
+                            log_trace(tt::LogOp, "\trow_idx: {}", row_idx);
+                            log_trace(tt::LogOp, "\tcol_idx: {}", col_idx);
+                            log_trace(tt::LogOp, "\trow_offset: {}", row_offset);
+                            log_trace(tt::LogOp, "\tcol_offset: {}", col_offset);
+                            log_trace(tt::LogOp, "\tnum_rows: {}", num_rows);
+                            log_trace(tt::LogOp, "\tnum_cols: {}", num_cols);
+                            log_trace(tt::LogOp, "\tlast_output_page_offset: {}", last_output_page_offset);
+                            log_trace(tt::LogOp, "\toutput_page_offset: {}", output_page_offset);
+                            log_trace(tt::LogOp, "\tlast_output_addr_offset: {}", last_output_addr_offset);
+                            log_trace(tt::LogOp, "\toutput_addr_offset: {}", output_addr_offset);
+                            log_trace(tt::LogOp, "\tring_index: {}", ring_index);
+                            log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_addr: {}", sender_worker_reader_semaphore_addr);
+                            log_trace(tt::LogOp, "\tis_clockwise_direction: {}", is_clockwise_direction ? 1 : 0);
+
+                            return worker_reader_sender_ct_args;
+                        }
+                    };
+
+                    std::vector<uint32_t> const& worker_send_reader_ct_args = build_worker_send_reader_ct_args();
+
+                    auto build_worker_send_reader_rt_args = [&]() {
+                        bool is_clockwise = is_buffer_in_clockwise_direction(b);
+                        if (is_sharded) {
+                            // # Send Reader (RT)
+                            // 1) local semaphore address (same as before)
+                            // 2) input tensor shard reader
+                            // 3) output tensor shard reader
+                            auto curr_link = i;
+
+                            TT_ASSERT(all_gather_config.get_num_eth_buffers_per_edm() == 1 || all_gather_config.get_num_eth_buffers_per_edm() == 2 || all_gather_config.get_num_eth_buffers_per_edm() == 4 || all_gather_config.get_num_eth_buffers_per_edm() == 8);
+                            TT_ASSERT(input_tensor.buffer() != nullptr);
+                            auto input_tensor_shard_arg_generator =
+                                InputTensorShardAddrGenArgGenerator(
+                                    device,
+                                    input_tensor,
+                                    ring_index,
+                                    ring_size,
+                                    global_num_workers,
+                                    global_worker_index,
+                                    0,
+                                    0,
+                                    // We want the input tensor to always be read in forward shard order so we
+                                    // always tell it we are in counter-clockwise direction (forward read order)
+                                    false
+                                    );
+                            auto const& [starting_dest_worker_index, starting_chunk_into_shard] = OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                                all_gather_config, input_tensor, output_tensor,
+                                is_clockwise ?
+                                    (ring_index == 0 ? ring_size - 1 : ring_index - 1) :
+                                    (ring_index == ring_size - 1 ? 0 : ring_index + 1),
+                                global_worker_index);
+
+                            log_trace(tt::LogOp, "SendReader {} ring_index: {}, start dest worker index: {}, starting chunk into shard: {}", global_worker_index, ring_index, starting_dest_worker_index, starting_chunk_into_shard);
+                            auto output_tensor_shard_arg_generator =
+                                OutputTensorShardAddrGenArgGenerator(
+                                    all_gather_config,
+                                    device,
+                                    input_tensor,
+                                    output_tensor,
+                                    ring_index,
+                                    ring_size,
+                                    global_num_workers,
+                                    global_worker_index,
+                                    starting_dest_worker_index,
+                                    starting_chunk_into_shard,
+                                    is_clockwise);
+
+                            auto const& input_shard_addr_generator_args = input_tensor_shard_arg_generator.generate();
+                            auto const& output_shard_addr_generator_args = output_tensor_shard_arg_generator.generate();
+                            std::vector<uint32_t> worker_send_reader_rt_args;
+                            worker_send_reader_rt_args.reserve(2 + input_shard_addr_generator_args.size() + output_shard_addr_generator_args.size());
+                            worker_send_reader_rt_args.push_back(sender_worker_reader_semaphore_addr);
+                            worker_send_reader_rt_args.push_back(pages_per_buffer.at(b));
+                            worker_send_reader_rt_args.push_back(pages_per_eth_l1_buffer.at(b));
+                            worker_send_reader_rt_args.push_back(cb_num_pages / 2);
+                            std::copy(input_shard_addr_generator_args.begin(), input_shard_addr_generator_args.end(), std::back_inserter(worker_send_reader_rt_args));
+                            std::copy(output_shard_addr_generator_args.begin(), output_shard_addr_generator_args.end(), std::back_inserter(worker_send_reader_rt_args));
+
+                            log_trace(tt::LogOp, "---worker_send_reader_rt_args.size()={}-----", worker_send_reader_rt_args.size());
+                            log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_addr: {}", sender_worker_reader_semaphore_addr);
+                            log_trace(tt::LogOp, "\tinput_shard_addr_generator_args:");
+                            input_tensor_shard_arg_generator.dump_to_log();
+                            log_trace(tt::LogOp, "\toutput_tensor_shard_arg_generator:");
+                            output_tensor_shard_arg_generator.dump_to_log();
+
+                            return worker_send_reader_rt_args;
+                        } else {
+                            std::vector<uint32_t> args = {
+                                static_cast<uint32_t>(input_buffer->address()),
+                                static_cast<uint32_t>(output_buffer->address())
+                            };
+                            return args;
+                        }
+                    };
+                    std::vector<uint32_t> const& worker_send_reader_rt_args = build_worker_send_reader_rt_args();
+
+                    std::string const& send_reader_kernel_path = is_sharded ?
+                        "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_reader.cpp" :
+                        "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp";
+                    KernelHandle worker_reader_sender_kernel_id = tt_metal::CreateKernel(
+                        program,
+                        send_reader_kernel_path,
+                        sender_worker_cores.at(b),
+                        tt_metal::ReaderDataMovementConfig(worker_send_reader_ct_args, worker_defines));
+
+                    worker_reader_sender_kernels.push_back(worker_reader_sender_kernel_id);
+
+                    tt_metal::SetRuntimeArgs(
+                        program,
+                        worker_reader_sender_kernel_id,
+                        sender_worker_cores.at(b),
+                        worker_send_reader_rt_args);
+
+
+                    //// Send Writer
+                    auto build_worker_sender_writer_ct_args = [&]() {
+                        if (is_sharded) {
+                            std::vector<uint32_t> worker_sender_writer_ct_args = {
+                                static_cast<uint32_t>(sharding_info.get_shard_type())
+                            };
+                            log_trace(tt::LogOp, "----worker_sender_writer_ct_args size={}", worker_sender_writer_ct_args.size());
+                            log_trace(tt::LogOp, "\tsharding_info.get_shard_type(): {}", sharding_info.get_shard_type());
+
+                            return worker_sender_writer_ct_args;
+                        } else {
+                            CoreCoord const& worker_eth_sender_core = is_clockwise_direction ? eth_sender_cores.at(i) : eth_receiver_cores.at(i);
+                            std::vector<uint32_t> worker_writer_sender_ct_args = {
+                                static_cast<uint32_t>(all_gather_config.is_output_dram()),
+                                static_cast<uint32_t>(sender_num_transfers),
+                                static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
+                                static_cast<uint32_t>(input_page_size),
+                                static_cast<uint32_t>(output_page_size),
+                                static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
+                                static_cast<uint32_t>(rem_pages_per_worker.at(b)),
+                                static_cast<uint32_t>(input_start_page_idx),
+                                static_cast<uint32_t>(output_start_page_idx),
+                                static_cast<uint32_t>(output_start_addr_offset),
+                                static_cast<uint32_t>(row_idx),
+                                static_cast<uint32_t>(col_idx),
+                                static_cast<uint32_t>(row_offset),
+                                static_cast<uint32_t>(col_offset),
+                                static_cast<uint32_t>(num_rows),
+                                static_cast<uint32_t>(num_cols),
+                                static_cast<uint32_t>(ring_index),
+
+                                // worker local L1 address of semaphore
+                                static_cast<uint32_t>(sender_worker_writer_semaphore_addr),
+                                static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).x),
+                                static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).y),
+                                static_cast<uint32_t>(cb_num_pages / 2),
+                            };
+                            log_trace(tt::LogOp, "Worker {} SW CT args", b);
+                            log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
+                            log_trace(tt::LogOp, "\tsender_num_transfers: {}", sender_num_transfers);
+                            log_trace(tt::LogOp, "\tnum_full_chunks_per_worker: {}", num_full_chunks_per_worker.at(b));
+                            log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
+                            log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
+                            log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer: {}", pages_per_eth_l1_buffer.at(b));
+                            log_trace(tt::LogOp, "\trem_pages_per_worker: {}", rem_pages_per_worker.at(b));
+                            log_trace(tt::LogOp, "\tinput_start_page_idx: {}", input_start_page_idx);
+                            log_trace(tt::LogOp, "\toutput_start_page_idx: {}", output_start_page_idx);
+                            log_trace(tt::LogOp, "\toutput_start_addr_offset: {}", output_start_addr_offset);
+                            log_trace(tt::LogOp, "\trow_idx: {}", row_idx);
+                            log_trace(tt::LogOp, "\tcol_idx: {}", col_idx);
+                            log_trace(tt::LogOp, "\trow_offset: {}", row_offset);
+                            log_trace(tt::LogOp, "\tcol_offset: {}", col_offset);
+                            log_trace(tt::LogOp, "\tnum_rows: {}", num_rows);
+                            log_trace(tt::LogOp, "\tnum_cols: {}", num_cols);
+                            log_trace(tt::LogOp, "\tring_index: {}", ring_index);
+                            log_trace(tt::LogOp, "\tsender_worker_writer_semaphore_addr: {}", sender_worker_writer_semaphore_addr);
+                            log_trace(tt::LogOp, "\tethernet_core_x: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).x);
+                            log_trace(tt::LogOp, "\tethernet_core_y: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).y);
+                            log_trace(tt::LogOp, "\thalf_cb_num_pages: {}", cb_num_pages / 2);
+
+                            return worker_writer_sender_ct_args;
+                        }
+                    };
+
+                    std::vector<uint32_t> const& worker_sender_writer_ct_args = build_worker_sender_writer_ct_args();
+
+                    auto build_worker_sender_writer_rt_args = [&]() {
+                        if (is_sharded) {
+                            // Send Writer Args (RT)
+                            // 1) eth_sender_l1_base_addr
+                            // 2) eth_sender_l1_sem_addr
+                            // 3) eth_sender_noc_x
+                            // 4) eth_sender_noc_y
+                            // 5) writer_send_sem_addr
+                            // 6) num_transfers
+                            // 7)
+
+                            bool is_clockwise = is_buffer_in_clockwise_direction(b);
+                            auto const& [starting_dest_worker_index, starting_chunk_into_shard] = OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                                all_gather_config,
+                                input_tensor,
+                                output_tensor,
+                                // this writes the input tensor to the first output location
+                                ring_index,
+                                global_worker_index);
+                            auto input_tensor_shard_arg_generator = InputTensorShardAddrGenArgGenerator(
+                                    device,
+                                    input_tensor,
+                                    ring_index,
+                                    ring_size,
+                                    global_num_workers,
+                                    global_worker_index,
+                                    0,
+                                    0,
+                                    // We want the input tensor to always be read in forward shard order so we
+                                    // always tell it we are in counter-clockwise direction (forward read order)
+                                    false
+                                );
+                            auto output_tensor_shard_arg_generator =
+                                OutputTensorShardAddrGenArgGenerator(
+                                    all_gather_config,
+                                    device,
+                                    input_tensor,
+                                    output_tensor,
+                                    ring_index,
+                                    ring_size,
+                                    global_num_workers,
+                                    global_worker_index,
+                                    starting_dest_worker_index,
+                                    starting_chunk_into_shard,
+                                    is_buffer_in_clockwise_direction(b)
+                                );
+                            auto const& output_tensor_shard_addr_gen_args = output_tensor_shard_arg_generator.generate();
+
+                            CoreCoord const& worker_eth_sender_core = is_clockwise_direction ? eth_sender_cores.at(i) : eth_receiver_cores.at(i);
+                            std::vector<uint32_t> worker_writer_sender_rt_args = {
+                                static_cast<uint32_t>(sender_eth_buffer_addrs.at(b)), // eth_sender_l1_base_addr
+                                static_cast<uint32_t>(sender_eth_sem_addrs.at(b)), // eth_sender_l1_sem_addr
+                                static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).x), // eth_sender_noc_x
+                                static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).y), // eth_sender_noc_y
+                                static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)), //output_tensor_shard_arg_generator.args_struct.num_dest_cores),//pages_per_eth_l1_buffer.at(b)),
+                                static_cast<uint32_t>(sender_worker_writer_semaphore_addr), // writer_send_sem_addr
+                                static_cast<uint32_t>(sender_num_transfers),
+                                static_cast<uint32_t>(input_tensor_shard_arg_generator.args_struct.num_dest_cores),
+                                static_cast<uint32_t>(cb_num_pages / 2),
+                            };
+                            std::copy(output_tensor_shard_addr_gen_args.begin(), output_tensor_shard_addr_gen_args.end(), std::back_inserter(worker_writer_sender_rt_args));
+
+                            // Currently the kernel assumes we don't need to break up the initial local tensor send to EDM into multiple
+                            // chunks
+
+                            log_trace(tt::LogOp, "----worker_writer_sender_rt_args size={}", worker_writer_sender_rt_args.size());
+                            log_trace(tt::LogOp, "\teth_sender_l1_base_addr: {}", sender_eth_buffer_addrs.at(b));
+                            log_trace(tt::LogOp, "\teth_sender_l1_sem_addr: {}", sender_eth_sem_addrs.at(b));
+                            log_trace(tt::LogOp, "\teth_sender_noc_x: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).x);
+                            log_trace(tt::LogOp, "\teth_sender_noc_y: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).y);
+                            log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer: {}", pages_per_eth_l1_buffer.at(b));
+                            log_trace(tt::LogOp, "\twriter_send_sem_addr: {}", sender_worker_writer_semaphore_addr);
+                            log_trace(tt::LogOp, "\tnum_transfers: {}", sender_num_transfers);
+                            output_tensor_shard_arg_generator.dump_to_log();
+
+                            return worker_writer_sender_rt_args;
+                        } else {
+                            std::vector<uint32_t> worker_writer_sender_rt_args = {
+                                static_cast<uint32_t>(output_buffer->address()),
+                                static_cast<uint32_t>(sender_eth_buffer_addrs.at(b)),
+                                static_cast<uint32_t>(sender_eth_sem_addrs.at(b))
+                            };
+                            log_trace(tt::LogOp, "Worker {} SW rt args", b);
+                            log_trace(tt::LogOp, "\toutput_buffer->address(): {}", output_buffer->address());
+                            log_trace(tt::LogOp, "\tsender_eth_buffer_addrs: {}", sender_eth_buffer_addrs.at(b));
+                            log_trace(tt::LogOp, "\tsender_eth_sem_addrs: {}", sender_eth_sem_addrs.at(b));
+                            return worker_writer_sender_rt_args;
+                        }
+                    };
+                    std::vector<uint32_t> const& worker_sender_writer_rt_args = build_worker_sender_writer_rt_args();
+
+                    std::string const& sender_writer_kernel_path = is_sharded ?
+                        "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_writer.cpp" :
+                        "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp";
+                    KernelHandle worker_sender_writer_kernel_id = tt_metal::CreateKernel(
+                        program,
+                        sender_writer_kernel_path,
+                        sender_worker_cores.at(b),
+                        tt_metal::WriterDataMovementConfig(worker_sender_writer_ct_args, worker_defines));
+
+                    worker_writer_sender_kernels.push_back(worker_sender_writer_kernel_id);
+
+                    tt_metal::SetRuntimeArgs(
+                        program,
+                        worker_sender_writer_kernel_id,
+                        sender_worker_cores.at(b),
+                        worker_sender_writer_rt_args);
+
+                } // (!is_linear || !is_last_chip_in_chain)
+                else {
+                    log_trace(tt::LogOp, "Skipping sender workers for linear chain");
+                }
+
+                // RECEIVER WORKERS
+                if (!is_linear || !is_first_chip_in_chain) {
+                    TT_ASSERT(!is_linear ||
+                        ((is_clockwise_direction && (ring_index != 0)) || (!is_clockwise_direction && ring_index != ring_size - 1))
+                    );
+                    // TODO(snijjar): squash before merge
+                    uint32_t receiver_ring_index = is_linear?
+                        (is_clockwise_direction ? ring_index - 1 : ring_index + 1):
+                        (is_clockwise_direction ?
+                            (ring_index == 0 ? ring_size - 1 : ring_index - 1):
+                            (ring_index == ring_size - 1 ? 0 : ring_index + 1));
+
+                    uint32_t receiver_output_start_addr_offset = receiver_ring_index * output_addr_offset;
+
+                    uint32_t receiver_output_start_page_idx = output_start_page_idx;
+                    if (topology == all_gather_op::Topology::Linear) {
+                        if (is_clockwise_direction) {
+                            receiver_output_start_page_idx -= output_page_offset;
+                        } else {
+                            receiver_output_start_page_idx += output_page_offset;
+                        }
+                    } else {
+                        if (is_clockwise_direction) {
+                            bool is_wraparound_ring_index = ring_index == 0;
+                            if (is_wraparound_ring_index) {
+                                receiver_output_start_page_idx += last_output_page_offset;
+                            } else {
+                                receiver_output_start_page_idx -= output_page_offset;
+                            }
+                        } else {
+                            // counter clockwise direction
+                            bool is_wraparound_ring_index = ring_index == ring_size - 1;
+                            if (is_wraparound_ring_index) {
+                                receiver_output_start_page_idx -= last_output_page_offset;
+                            } else {
+                                receiver_output_start_page_idx += output_page_offset;
+                            }
+                        }
+                    }
+                    log_trace(tt::LogOp,"\treceiver_output_start_addr_offset={}", receiver_output_start_addr_offset);
+                    log_trace(tt::LogOp,"\treceiver_output_start_page_idx={}", receiver_output_start_page_idx);
+                    log_trace(tt::LogOp,"\treceiver_ring_index={}", receiver_ring_index);
+
+                    //// Receive Reader
+                    auto build_worker_receiver_reader_ct_args = [&]() {
+                        if (is_sharded) {
+                            // Receiver Reader Args (CT)
+                            std::vector<uint32_t> worker_receiver_reader_ct_args = {
+                                static_cast<uint32_t>(sharding_info.get_shard_type())
+                            };
+                            log_trace(tt::LogOp, "----worker_receiver_reader_ct_args size={}", worker_receiver_reader_ct_args.size());
+                            log_trace(tt::LogOp, "\tsharding_info.get_shard_type(): {}", sharding_info.get_shard_type());
+
+                            return worker_receiver_reader_ct_args;
+                        } else {
+                            CoreCoord const& worker_eth_receiver_core = is_clockwise_direction ? eth_receiver_cores.at(i) : eth_sender_cores.at(i);
+                            std::vector<uint32_t> worker_receiver_reader_ct_args = {
+                                static_cast<uint32_t>(receiver_num_transfers),
+                                static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
+                                static_cast<uint32_t>(input_page_size),
+                                static_cast<uint32_t>(pages_per_chunk),
+                                static_cast<uint32_t>(rem_pages_per_worker.at(b)),
+                                static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).x),
+                                static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).y),
+                                static_cast<uint32_t>(receiver_eth_sem_addrs.at(b)),
+                                static_cast<uint32_t>(receiver_worker_semaphore_addr),
+                                static_cast<uint32_t>(cb_num_pages / 2)
+                            };
+
+                            log_trace(tt::LogOp, "Worker {} RR ct args", b);
+                            log_trace(tt::LogOp, "\treceiver_num_transfers: {}", receiver_num_transfers);
+                            log_trace(tt::LogOp, "\tnum_full_chunks_per_worker: {}", num_full_chunks_per_worker.at(b));
+                            log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
+                            log_trace(tt::LogOp, "\tpages_per_chunk: {}", pages_per_chunk);
+                            log_trace(tt::LogOp, "\trem_pages_per_worker: {}", rem_pages_per_worker.at(b));
+                            log_trace(tt::LogOp, "\tethernet_core_x: {}", device->ethernet_core_from_logical_core(worker_eth_receiver_core).x);
+                            log_trace(tt::LogOp, "\tethernet_core_y: {}", device->ethernet_core_from_logical_core(worker_eth_receiver_core).y);
+                            log_trace(tt::LogOp, "\treceiver_eth_sem_addrs: {}", receiver_eth_sem_addrs.at(b));
+                            log_trace(tt::LogOp, "\treceiver_worker_semaphore_addr: {}", receiver_worker_semaphore_addr);
+                            log_trace(tt::LogOp, "\thalf_cb_num_pages : {}", cb_num_pages / 2);
+                            return worker_receiver_reader_ct_args;
+                        }
+                    };
+                    std::vector<uint32_t> const& worker_receiver_reader_ct_args = build_worker_receiver_reader_ct_args();
+
+                    auto build_worker_receiver_reader_rt_args = [&]() {
+                        if (is_sharded) {
+                            // Receiver Reader Args (RT)
+                            // 1) eth_receiver_noc_x
+                            // 2) eth_receiver_noc_y
+                            // 3) eth_receiver_l1_base_addr
+                            // 4) eth_receiver_l1_semaphore_addr
+                            // 5) (local) receiver_read_sem_addr
+                            // 6) output tensor shard addr gen
+                            auto curr_link = i;
+                            bool is_clockwise = is_buffer_in_clockwise_direction(b);
+                            auto const& [starting_dest_worker_index, starting_chunk_into_shard] = OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                                all_gather_config,
+                                input_tensor,
+                                output_tensor,
+                                is_clockwise ?
+                                    (ring_index == 0 ? ring_size - 1 : ring_index - 1) :
+                                    (ring_index == ring_size - 1 ? 0 : ring_index + 1),
+                                global_worker_index);
+                            CoreCoord const& worker_eth_receiver_core = is_clockwise_direction ? eth_receiver_cores.at(i) : eth_sender_cores.at(i);
+                            auto input_tensor_shard_arg_generator = InputTensorShardAddrGenArgGenerator(
+                                    device,
+                                    input_tensor,
+                                    ring_index,
+                                    ring_size,
+                                    global_num_workers,
+                                    global_worker_index,
+                                    0,
+                                    0,
+                                    // We want the input tensor to always be read in forward shard order so we
+                                    // always tell it we are in counter-clockwise direction (forward read order)
+                                    false
+                                );
+                            auto const& output_tensor_shard_addr_gen_args = input_tensor_shard_arg_generator.generate();
+                            std::vector<uint32_t> worker_reader_receiver_rt_args;
+                            worker_reader_receiver_rt_args.reserve(7 + output_tensor_shard_addr_gen_args.size());
+
+                            worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).x)); // eth_receiver_noc_x
+                            worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).y)); // eth_receiver_noc_y
+                            worker_reader_receiver_rt_args.push_back(receiver_eth_buffer_addrs.at(b)); // eth_receiver_l1_base_addr
+                            worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(receiver_eth_sem_addrs.at(b))); // eth_receiver_l1_semaphore_addr
+                            worker_reader_receiver_rt_args.push_back(receiver_worker_semaphore_addr); // local_receiver_read_sem_addr
+                            worker_reader_receiver_rt_args.push_back(pages_per_eth_l1_buffer.at(b)), //output_tensor_shard_arg_generator.args_struct.num_dest_cores), //pages_per_eth_l1_buffer.at(b)); // num_shards_per_eth_buf
+                            worker_reader_receiver_rt_args.push_back(receiver_num_transfers); // local_receiver_read_sem_addr
+                            worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(cb_num_pages / 2)); // local_receiver_read_sem_addr
+                            std::copy(output_tensor_shard_addr_gen_args.begin(), output_tensor_shard_addr_gen_args.end(), std::back_inserter(worker_reader_receiver_rt_args));
+
+                            log_trace(tt::LogOp, "----worker_receiver_reader_ct_args size={}", worker_receiver_reader_ct_args.size());
+                            log_trace(tt::LogOp, "\teth_receiver_noc_x: {}", static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).x));
+                            log_trace(tt::LogOp, "\teth_receiver_noc_y: {}", static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).y));
+                            log_trace(tt::LogOp, "\teth_receiver_l1_base_addr: {}", receiver_eth_buffer_addrs.at(b));
+                            log_trace(tt::LogOp, "\teth_receiver_l1_semaphore_addr: {}", static_cast<uint32_t>(receiver_eth_sem_addrs.at(b)));
+                            log_trace(tt::LogOp, "\tlocal_receiver_read_sem_addr: {}", receiver_worker_semaphore_addr);
+                            log_trace(tt::LogOp, "\tnum_shards_per_eth_buf: {}", pages_per_eth_l1_buffer.at(b));
+
+                            input_tensor_shard_arg_generator.dump_to_log();
+
+                            return worker_reader_receiver_rt_args;
+                        } else {
+                            std::vector<uint32_t> worker_reader_receiver_rt_args = {
+                                static_cast<uint32_t>(receiver_eth_buffer_addrs.at(b))
+                            };
+
+                            log_trace(tt::LogOp, "Worker {} RR rt args", b);
+                            log_trace(tt::LogOp, "\treceiver_eth_buffer_addrs: {}", receiver_eth_buffer_addrs.at(b));
+                            return worker_reader_receiver_rt_args;
+                        }
+                    };
+                    std::vector<uint32_t> worker_receiver_reader_rt_args = build_worker_receiver_reader_rt_args();
+
+                    std::string const& receiver_reader_kernel_path = is_sharded ?
+                        "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_reader.cpp" :
+                        "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp";
+                    KernelHandle worker_receiver_reader_kernel_id = tt_metal::CreateKernel(
+                        program,
+                        receiver_reader_kernel_path,
+                        receiver_worker_cores.at(b),
+                        tt_metal::ReaderDataMovementConfig(worker_receiver_reader_ct_args, worker_defines));
+
+                    worker_reader_receiver_kernels.push_back(worker_receiver_reader_kernel_id);
+
+                    tt_metal::SetRuntimeArgs(
+                        program,
+                        worker_receiver_reader_kernel_id,
+                        receiver_worker_cores.at(b),
+                        worker_receiver_reader_rt_args);
+
+                    //// Receive Writer
+                    auto build_worker_receive_writer_ct_args = [&]() {
+                        if (is_sharded) {
+                            // # Receiver Writer (CT)
+                            // 1) Shard Type
+                            std::vector<uint32_t> worker_receive_writer_ct_args = {
+                                static_cast<uint32_t>(sharding_info.get_shard_type())
+                            };
+                            log_trace(tt::LogOp, "----worker_receive_writer_ct_args size={}", worker_receive_writer_ct_args.size());
+                            log_trace(tt::LogOp, "\tsharding_info.get_shard_type(): {}", sharding_info.get_shard_type());
+
+                            return worker_receive_writer_ct_args;
+                        } else {
+                            std::vector<uint32_t> worker_writer_receiver_ct_args = {
+                                static_cast<uint32_t>(all_gather_config.is_output_dram()),
+                                static_cast<uint32_t>(receiver_num_transfers),
+                                static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
+                                static_cast<uint32_t>(input_page_size),
+                                static_cast<uint32_t>(output_page_size),
+                                static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
+                                static_cast<uint32_t>(rem_pages_per_worker.at(b)),
+                                static_cast<uint32_t>(receiver_output_start_page_idx),
+                                static_cast<uint32_t>(receiver_output_start_addr_offset),
+                                static_cast<uint32_t>(row_idx),
+                                static_cast<uint32_t>(col_idx),
+                                static_cast<uint32_t>(row_offset),
+                                static_cast<uint32_t>(col_offset),
+                                static_cast<uint32_t>(num_rows),
+                                static_cast<uint32_t>(num_cols),
+                                static_cast<uint32_t>(last_output_page_offset),
+                                static_cast<uint32_t>(output_page_offset),
+                                static_cast<uint32_t>(last_output_addr_offset),
+                                static_cast<uint32_t>(output_addr_offset),
+                                static_cast<uint32_t>(receiver_ring_index),
+                                static_cast<uint32_t>(sender_worker_reader_semaphore_addr),
+                                static_cast<uint32_t>(is_clockwise_direction ? 1 : 0),
+                                static_cast<uint32_t>(cb_num_pages / 2),
+                                static_cast<uint32_t>(ring_size)
+                            };
+
+                            log_trace(tt::LogOp, "Worker {} RW ct args", b);
+                            log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
+                            log_trace(tt::LogOp, "\treceiver_num_transfers: {}", receiver_num_transfers);
+                            log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
+                            log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
+                            log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
+                            log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer.at(b): {}", pages_per_eth_l1_buffer.at(b));
+                            log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
+                            log_trace(tt::LogOp, "\treceiver_output_start_page_idx: {}", receiver_output_start_page_idx);
+                            log_trace(tt::LogOp, "\treceiver_output_start_addr_offset: {}", receiver_output_start_addr_offset);
+                            log_trace(tt::LogOp, "\trow_idx: {}", row_idx);
+                            log_trace(tt::LogOp, "\tcol_idx: {}", col_idx);
+                            log_trace(tt::LogOp, "\trow_offset: {}", row_offset);
+                            log_trace(tt::LogOp, "\tcol_offset: {}", col_offset);
+                            log_trace(tt::LogOp, "\tnum_rows: {}", num_rows);
+                            log_trace(tt::LogOp, "\tnum_cols: {}", num_cols);
+                            log_trace(tt::LogOp, "\tlast_output_page_offset: {}", last_output_page_offset);
+                            log_trace(tt::LogOp, "\toutput_page_offset: {}", output_page_offset);
+                            log_trace(tt::LogOp, "\tlast_output_addr_offset: {}", last_output_addr_offset);
+                            log_trace(tt::LogOp, "\toutput_addr_offset: {}", output_addr_offset);
+                            log_trace(tt::LogOp, "\treceiver_ring_index: {}", receiver_ring_index);
+                            log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_addr: {}", sender_worker_reader_semaphore_addr);
+                            log_trace(tt::LogOp, "\tis_clockwise_direction ? 1 : 0: {}", is_clockwise_direction ? 1 : 0);
+                            log_trace(tt::LogOp, "\thalf_cb_num_pages: {}", cb_num_pages / 2);
+                            log_trace(tt::LogOp, "\tring_size: {}", ring_size);
+                            return worker_writer_receiver_ct_args;
+                        }
+                    };
+                    std::vector<uint32_t> const& worker_receive_writer_ct_args = build_worker_receive_writer_ct_args();
+
+                    auto build_worker_receive_writer_rt_args = [&]() {
+                        auto worker_sender_reader = device->worker_core_from_logical_core(sender_worker_cores.at(b));
+                        if (is_sharded) {
+                            // # Receiver Writer (RT)
+                            // 1) Remote sender reader semaphore address
+                            // 2) Output tensor Writer shard addr gen
+                            bool is_clockwise = is_buffer_in_clockwise_direction(b);
+
+                            auto const& [starting_dest_worker_index, starting_chunk_into_shard] = OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                                all_gather_config,
+                                input_tensor,
+                                output_tensor,
+                                is_clockwise ?
+                                    (ring_index == 0 ? ring_size - 1 : ring_index - 1) :
+                                    (ring_index == ring_size - 1 ? 0 : ring_index + 1),
+                                global_worker_index);
+                            log_trace(tt::LogOp, "ReceiverWriter {} ring_index: {}, start dest worker index: {}, starting chunk into shard: {}", global_worker_index, ring_index, starting_dest_worker_index, starting_chunk_into_shard);
+                            OutputTensorShardAddrGenArgGenerator output_tensor_shard_arg_generator(
+                                all_gather_config,
+                                device,
+                                input_tensor,
+                                output_tensor,
+                                ring_index,
+                                ring_size,
+                                global_num_workers,
+                                all_gather_config.get_num_eth_buffers_per_edm() * i + b,
+                                starting_dest_worker_index,
+                                starting_chunk_into_shard,
+                                is_buffer_in_clockwise_direction(b));
+                            auto const& output_shard_addr_generator_args = output_tensor_shard_arg_generator.generate();
+                            std::vector<uint32_t> worker_receive_writer_rt_args;
+                            worker_receive_writer_rt_args.reserve(5 + output_shard_addr_generator_args.size());
+                            worker_receive_writer_rt_args.push_back(static_cast<uint32_t>(worker_sender_reader.x));
+                            worker_receive_writer_rt_args.push_back(static_cast<uint32_t>(worker_sender_reader.y));
+                            worker_receive_writer_rt_args.push_back(sender_worker_reader_semaphore_addr);
+
+                            worker_receive_writer_rt_args.push_back(output_tensor_shard_arg_generator.args_struct.num_dest_cores), //pages_per_eth_l1_buffer.at(b));
+                            worker_receive_writer_rt_args.push_back(receiver_num_transfers);
+                            worker_receive_writer_rt_args.push_back(pages_per_buffer.at(b));
+                            worker_receive_writer_rt_args.push_back(static_cast<uint32_t>(cb_num_pages / 2));
+
+
+                            std::copy(output_shard_addr_generator_args.begin(), output_shard_addr_generator_args.end(), std::back_inserter(worker_receive_writer_rt_args));
+
+                            log_trace(tt::LogOp, "----worker_receive_writer_rt_args size={}", worker_receive_writer_rt_args.size());
+                            log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_addr: {}", sender_worker_reader_semaphore_addr);
+                            output_tensor_shard_arg_generator.dump_to_log();
+
+                            return worker_receive_writer_rt_args;
+                        } else {
+                            std::vector<uint32_t> worker_writer_receiver_rt_args = {
+                                static_cast<uint32_t>(output_buffer->address()),
+                                static_cast<uint32_t>(worker_sender_reader.x),
+                                static_cast<uint32_t>(worker_sender_reader.y),
+                            };
+
+                            log_trace(tt::LogOp, "Worker {} RW rt args", b);
+                            log_trace(tt::LogOp, "\toutput_buffer->address(): {}", output_buffer->address());
+                            log_trace(tt::LogOp, "\tworker_sender_reader.x: {}", worker_sender_reader.x);
+                            log_trace(tt::LogOp, "\tworker_sender_reader.y: {}", worker_sender_reader.y);
+                            return worker_writer_receiver_rt_args;
+                        }
+                    };
+                    std::vector<uint32_t> worker_receive_writer_rt_args = build_worker_receive_writer_rt_args();
+
+                    std::string const& receiver_writer_kernel_path = is_sharded ?
+                        "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_writer.cpp" :
+                        "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_interleaved_ring_gather_receive_writer.cpp";
+                    KernelHandle worker_receive_writer_kernel_id = tt_metal::CreateKernel(
+                        program,
+                        receiver_writer_kernel_path,
+                        receiver_worker_cores.at(b),
+                        tt_metal::WriterDataMovementConfig(worker_receive_writer_ct_args, worker_defines));
+
+                    worker_writer_receiver_kernels.push_back(worker_receive_writer_kernel_id);
+
+                    tt_metal::SetRuntimeArgs(
+                        program,
+                        worker_receive_writer_kernel_id,
+                        receiver_worker_cores.at(b),
+                        worker_receive_writer_rt_args);
+                } // (!is_linear || !is_first_chip_in_chain)
+                else {
+                    log_trace(tt::LogOp, "Skipping receiver workers for linear chain");
+                }
+
+                uint32_t pages_per_worker = num_full_chunks_per_worker.at(b) * pages_per_chunk + rem_pages_per_worker.at(b);
+                if (is_sharded) {
+                    // nothing to do here - is handled by
+                } else {
+                    // Only for interleaved
+                    if (pages_per_worker > 0) {
+                        if (rm) {
+                            uint32_t num_rows_shifted = row_idx + pages_per_worker;
+                            uint32_t num_blocks_shifted = width ? 0 : num_rows_shifted / num_rows;
+                            output_start_page_idx += pages_per_worker + num_blocks_shifted * row_offset;
+                            row_idx = width ? 0 : num_rows_shifted % num_rows;
+                        } else {
+                            uint32_t num_cols_shifted = col_idx + pages_per_worker;
+                            uint32_t num_rows_shifted = num_cols_shifted / num_cols;
+                            uint32_t num_blocks_shifted = width ? 0 : num_rows_shifted / num_rows;
+                            output_start_page_idx += pages_per_worker + num_rows_shifted * col_offset + num_blocks_shifted * row_offset;
+                            col_idx = num_cols_shifted % num_cols;
+                            row_idx = width ? 0 : num_rows_shifted % num_rows;
+                        }
+                    }
+                    input_start_page_idx += pages_per_worker;
+                }
+            }
+
+
+            if (receiver_device_id == sender_device_id) {
+                receiver_socket_idx += 2;
+                sender_socket_idx += 2;
+            } else {
+                receiver_socket_idx += 1;
+                sender_socket_idx += 1;
             }
         }
-
-        // Ethernet Kernels
-        std::vector<uint32_t> eth_sender_ct_args = {
-            static_cast<uint32_t>(all_gather_config.get_num_buffers_in_clockwise_direction() ? 1 : 0),
-            static_cast<uint32_t>(all_gather_config.get_num_buffers_in_counter_clockwise_direction() ? 1 : 0),
-            static_cast<uint32_t>(link_clockwise_sender_num_channels.at(i)),
-            static_cast<uint32_t>(link_counter_clockwise_receiver_num_channels.at(i))
-        };
-
-        log_trace(tt::LogOp, "EDM sender side link_clockwise_sender_num_channels.at(i) {}", link_clockwise_sender_num_channels.at(i));
-        log_trace(tt::LogOp, "EDM sender side link_counter_clockwise_receiver_num_channels.at(i) {}", link_counter_clockwise_receiver_num_channels.at(i));
-
-        auto eth_sender_kernel = tt_metal::CreateKernel(
-            program,
-            "tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp",
-            eth_sender_cores.at(i),
-            tt_metal::EthernetConfig{.noc=sender_noc, .compile_args=eth_sender_ct_args});
+    } // num_full_send_directions
 
 
-        tt_metal::SetRuntimeArgs(
-            program,
-            eth_sender_kernel,
-            eth_sender_cores.at(i),
-            edm_clockwise_kernel_rt_args);
+    {  // emit EDM kernel configs
+    uint32_t sender_socket_idx = 0;
+    uint32_t receiver_socket_idx = 0;
+    if (receiver_device_id == sender_device_id) {
+        if (ring_index == 0) {
+            receiver_socket_idx = 1;
+        } else {
+            sender_socket_idx = 1;
+        }
+    }
+    for (uint32_t i = 0; i < num_links; ++i) {
+        bool is_clockwise_direction_edm_enabled = !is_linear || ring_index != ring_size - 1;
+        if (is_clockwise_direction_edm_enabled) {
+            log_trace(tt::LogOp, "EDM CLOCKWISE KERNEL RT ARGS: ");
+            clockwise_edm_builders.at(i).dump_to_log();
 
-        eth_sender_kernels.push_back(eth_sender_kernel);
+            auto eth_sender_core = device->get_ethernet_sockets(receiver_device_id.value()).at(sender_socket_idx);
 
-        std::vector<uint32_t> eth_receiver_ct_args = {
-            static_cast<uint32_t>(all_gather_config.get_num_buffers_in_counter_clockwise_direction() ? 1 : 0),
-            static_cast<uint32_t>(all_gather_config.get_num_buffers_in_clockwise_direction() ? 1 : 0),
-            static_cast<uint32_t>(link_counter_clockwise_sender_num_channels.at(i)),
-            static_cast<uint32_t>(link_clockwise_receiver_num_channels.at(i))
-        };
+            std::vector<uint32_t> const& edm_clockwise_kernel_rt_args = clockwise_edm_builders.at(i).emit_runtime_args();
+            // Ethernet Kernels
+            std::vector<uint32_t> eth_sender_ct_args = clockwise_edm_builders.at(i).emit_compile_time_args();
 
-        auto eth_receiver_kernel = tt_metal::CreateKernel(
-            program,
-            "tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp",
-            eth_receiver_cores.at(i),
-            tt_metal::EthernetConfig{.noc=receiver_noc, .compile_args=eth_receiver_ct_args});
+            auto eth_sender_kernel = tt_metal::CreateKernel(
+                program,
+                "tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp",
+                eth_sender_core,
+                tt_metal::EthernetConfig{.noc=sender_noc, .compile_args=eth_sender_ct_args});
 
-        eth_receiver_kernels.push_back(eth_receiver_kernel);
 
-        log_trace(tt::LogOp, "RingIndex: {}. Link {}. Clockwise EDM Core (x={},y={}), Counter-clockwise EDM Core (x={},y={})", ring_index, i, eth_sender_cores.at(i).x, eth_sender_cores.at(i).y, eth_receiver_cores.at(i).x, eth_receiver_cores.at(i).y);
+            tt_metal::SetRuntimeArgs(
+                program,
+                eth_sender_kernel,
+                eth_sender_core,
+                edm_clockwise_kernel_rt_args);
 
-        if (enable_print) {
+            eth_sender_kernels.push_back(eth_sender_kernel);
+            log_trace(tt::LogOp, "RingIndex: {}. Link {}. Clockwise EDM Core (x={},y={})", ring_index, i, eth_sender_core.x, eth_sender_core.y);
+
             std::stringstream ss;
             ss << "HOST SENDER EDM ARGS:\n";
             for (auto const& s : edm_clockwise_kernel_rt_args) {
                 ss << "\t" << s << "\n";
             }
-            std::cout << ss.str() << std::endl;
+            log_trace(tt::LogOp, "{}", ss.str());
         }
-        if (enable_print) {
-            std::stringstream ss;
-            ss << "HOST RECEIVER EDM ARGS:\n";
+
+        bool is_counter_clockwise_direction_edm_enabled = !is_linear || ring_index != 0;
+        if (is_counter_clockwise_direction_edm_enabled) {
+            log_trace(tt::LogOp, "EDM COUNTER CLOCKWISE KERNEL RT ARGS: ");
+            counter_clockwise_edm_builders.at(i).dump_to_log();
+            std::vector<uint32_t> const& edm_counter_clockwise_kernel_rt_args = counter_clockwise_edm_builders.at(i).emit_runtime_args();
+
+            auto eth_receiver_core = device->get_ethernet_sockets(sender_device_id.value()).at(receiver_socket_idx);
+            std::vector<uint32_t> eth_receiver_ct_args = counter_clockwise_edm_builders.at(i).emit_compile_time_args();
+
+            auto eth_receiver_kernel = tt_metal::CreateKernel(
+                program,
+                "tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp",
+                eth_receiver_core,
+                tt_metal::EthernetConfig{.noc=receiver_noc, .compile_args=eth_receiver_ct_args});
+
+            eth_receiver_kernels.push_back(eth_receiver_kernel);
+
+            log_trace(tt::LogOp, "RingIndex: {}. Link {}. Counter-clockwise EDM Core (x={},y={})", ring_index, i, eth_receiver_core.x, eth_receiver_core.y);
+
+            std::stringstream ss2;
+            ss2 << "HOST RECEIVER EDM ARGS:\n";
             for (auto const& s : edm_counter_clockwise_kernel_rt_args) {
-                ss << "\t" << s << "\n";
+                ss2 << "\t" << s << "\n";
             }
-            std::cout << ss.str() << std::endl;
+            log_trace(tt::LogOp, "{}", ss2.str());
+
+            tt_metal::SetRuntimeArgs(
+                program,
+                eth_receiver_kernel,
+                eth_receiver_core,
+                edm_counter_clockwise_kernel_rt_args);
         }
-
-
-        tt_metal::SetRuntimeArgs(
-            program,
-            eth_receiver_kernel,
-            eth_receiver_cores.at(i),
-            edm_counter_clockwise_kernel_rt_args);
 
         if (receiver_device_id == sender_device_id) {
             receiver_socket_idx += 2;
@@ -1176,6 +1330,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
             receiver_socket_idx += 1;
             sender_socket_idx += 1;
         }
+    }
     }
 
     auto override_runtime_arguments_callback = [num_links, total_worker_core_pairs_used, worker_reader_sender_kernels, worker_writer_sender_kernels, worker_reader_receiver_kernels, worker_writer_receiver_kernels, all_worker_sender_cores, all_worker_receiver_cores] (

--- a/tt_eager/tt_dnn/op_library/ccl/edm/erisc_async_datamover.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/edm/erisc_async_datamover.hpp
@@ -110,9 +110,6 @@ class ChannelBuffer final {
             uint64_t worker_semaphore_address =
                 get_noc_addr((uint32_t)worker_xy.x, (uint32_t)worker_xy.y, this->worker_semaphore_l1_address);
 
-            // TODO: Check for (!noc_cmd_buf_ready(noc, cmd_buf)) and exit early if not ready. Try to do other processing if
-            //       possible and come back to this at the next opportunity
-            //       So far no solid use case as it's always single worker per channel
             noc_semaphore_inc(worker_semaphore_address, 1);
         }
     }

--- a/tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -13,6 +13,13 @@
 
 namespace ccl {
 
+enum EriscDataMoverBufferSharingMode: uint32_t {
+    NOT_SHARED = 0,
+    ROUND_ROBIN = 1,
+    SHARED = 2,
+    ROUND_ROBIN_AND_SHARED = 3
+};
+
 // TODO: let the kernel runtime args
 
 enum ShardType : uint8_t { Width = 0, Height = 1, Block = 2 };
@@ -37,6 +44,9 @@ struct WorkerXY {
         return !(*this == rhs);
     }
 };
+
+static constexpr uint32_t UNINITIALIZED_VALUE_U32 = std::numeric_limits<uint32_t>::max();
+static constexpr uint16_t UNINITIALIZED_VALUE_U16 = std::numeric_limits<uint16_t>::max();
 
 template <bool T>
 struct ArchDependentTypes;

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
@@ -526,6 +526,10 @@ namespace tt::tt_metal::detail{
             py::arg("input_tensors"), py::arg("dim"), py::arg("num_links") = 1, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
             R"doc(Performs all gather on a list of tensors that form one tensor that is distributed across devices. The output is a list of a tensor which has been duplciated across the input devices.)doc"
         );
+        m_tensor.def("line_all_gather", &line_all_gather,
+            py::arg("input_tensors"), py::arg("dim"), py::arg("num_links") = 1, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            R"doc(Performs all gather on a list of tensors that form one tensor that is distributed across devices. The output is a list of a tensor which has been duplciated across the input devices.)doc"
+        );
     }
 
 }


### PR DESCRIPTION
Line all-gather support is required to enable model bringup on t7000 galaxy systems. 

This part's mainly relevant to @tt-aho 
This change looks pretty invasive to `all_gather_op_multi_core.cpp` but it's mostly indentation with select changes made to enable linear. At a high-level, I reused most of the ring-all-gather host code and "tricked" it into disabling bidirectional so it would send the full tensor in the clockwise direction. I then run the host code again (in a direction loop), with bidirectional disabled, but with ring direction set to counter-clockwise to force the full tensor to also be sent in the counter-clockwise direction.

Future work to add new ops (reduce-scatter), cut down this large function into constituent parts and more reusable components (across ops), although you can start to see the beginnings of that in this PR (like in the addition of the EDM builder component). This should hopefully cut down the size of future PRs.