### PR TITLE
#6918: Update watcher noc alignment checks to be relative

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -138,22 +138,15 @@ void RunTestOnCore(WatcherFixture* fixture, Device* device, CoreCoord &core, boo
             );
             break;
         case SanitizeAlignmentL1:
-            expected = fmt::format(
-                "Device {}, {} Core {}[physical {}]: {} using noc0 accesses local L1[addr=0x{:08x},len=102400]",
-                device->id(),
-                (is_eth_core) ? "Ethnet" : "Worker",
-                core.str(), phys_core.str(),
-                (is_eth_core) ? "erisc" : "brisc", l1_buffer_addr
-            );
-            break;
         case SanitizeAlignmentDRAM:
             expected = fmt::format(
-                "Device {}, {} Core {}[physical {}]: {} using noc0 tried to access DRAM core w/ physical coords {} DRAM[addr=0x{:08x},len=102400]",
+                "Device {}, {} Core {}[physical {}]: {} using noc0 tried to access DRAM core w/ physical coords {} DRAM[addr=0x{:08x},len=102400], misaligned with local L1[addr=0x{:08x}]",
                 device->id(),
                 (is_eth_core) ? "Ethnet" : "Worker",
                 core.str(), phys_core.str(),
                 (is_eth_core) ? "erisc" : "brisc", input_dram_noc_xy.str(),
-                input_dram_buffer_addr
+                input_dram_buffer_addr,
+                l1_buffer_addr
             );
             break;
         default:

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -34,49 +34,52 @@ typedef bool debug_sanitize_noc_dir_t;
 #define DEBUG_SANITIZE_NOC_UNICAST false
 typedef bool debug_sanitize_noc_cast_t;
 
-#define DEBUG_VALID_L1_ADDR(a, l, extra_alignment_bytes) \
+// TODO(PGK): remove soft reset when fw is downloaded at init
+#define DEBUG_VALID_REG_ADDR(a, l) \
+    ( \
+        ( \
+            ( \
+                ((a) >= NOC_OVERLAY_START_ADDR) && \
+                ((a) < NOC_OVERLAY_START_ADDR + NOC_STREAM_REG_SPACE_SIZE * NOC_NUM_STREAMS) \
+            ) || \
+            ((a) == RISCV_DEBUG_REG_SOFT_RESET_0) \
+        ) \
+        && (l) == 4 \
+    )
+#define DEBUG_VALID_WORKER_ADDR(a, l) \
     ( \
         (a >= MEM_L1_BASE) && \
         (a + l <= MEM_L1_BASE + MEM_L1_SIZE) && \
-        ((a) + (l) > (a)) && \
-        ((a % NOC_L1_ALIGNMENT_BYTES) == 0) && \
-        ((a % extra_alignment_bytes) == 0) \
-    )
-
-// TODO(PGK): remove soft reset when fw is downloaded at init
-#define DEBUG_VALID_REG_ADDR(a)                                                        \
-    ((((a) >= NOC_OVERLAY_START_ADDR) &&                                               \
-      ((a) < NOC_OVERLAY_START_ADDR + NOC_STREAM_REG_SPACE_SIZE * NOC_NUM_STREAMS)) || \
-     ((a) == RISCV_DEBUG_REG_SOFT_RESET_0))
-#define DEBUG_VALID_WORKER_ADDR(a, l, extra_alignment_bytes) \
-    ( \
-        DEBUG_VALID_L1_ADDR(a, l, extra_alignment_bytes) || \
-        (DEBUG_VALID_REG_ADDR(a) && (l) == 4) \
+        ((a) + (l) > (a)) \
     )
 #define DEBUG_VALID_PCIE_ADDR(a, l) (((a) >= NOC_PCIE_ADDR_BASE) && \
                                      ((a) + (l) <= NOC_PCIE_ADDR_END) && \
-                                     ((a) + (l) > (a)) && \
-                                     ((a % NOC_PCIE_ALIGNMENT_BYTES) == 0))
+                                     ((a) + (l) > (a)))
 #define DEBUG_VALID_DRAM_ADDR(a, l) (((a) >= NOC_DRAM_ADDR_BASE) && \
                                      ((a) + (l) <= NOC_DRAM_ADDR_END) && \
-                                     ((a) + (l) > (a)) && \
-                                     ((a % NOC_DRAM_ALIGNMENT_BYTES) == 0))
+                                     ((a) + (l) > (a)))
 
 #define DEBUG_VALID_ETH_ADDR(a, l) (((a) >= MEM_ETH_BASE) && \
-                                    ((a) + (l) <= MEM_ETH_BASE + MEM_ETH_SIZE) && \
-                                    ((a % NOC_L1_ALIGNMENT_BYTES) == 0))
+                                    ((a) + (l) <= MEM_ETH_BASE + MEM_ETH_SIZE))
 
 // Note:
 //  - this isn't racy w/ the host so long as invalid is written last
 //  - this isn't racy between riscvs so long as each gets their own noc_index
-inline void debug_sanitize_post_noc_addr_and_hang(uint64_t a, uint32_t l, uint32_t invalid)
-{
+inline void debug_sanitize_post_noc_addr_and_hang(
+    uint64_t noc_addr,
+    uint32_t l1_addr,
+    uint32_t len,
+    debug_sanitize_noc_cast_t multicast,
+    uint16_t invalid
+) {
     debug_sanitize_noc_addr_msg_t tt_l1_ptr *v = *GET_MAILBOX_ADDRESS_DEV(sanitize_noc);
 
     if (v[noc_index].invalid == DebugSanitizeNocInvalidOK) {
-        v[noc_index].addr = a;
-        v[noc_index].len = l;
+        v[noc_index].noc_addr = noc_addr;
+        v[noc_index].l1_addr = l1_addr;
+        v[noc_index].len = len;
         v[noc_index].which = debug_get_which_riscv();
+        v[noc_index].multicast = multicast;
         v[noc_index].invalid = invalid;
     }
 
@@ -94,12 +97,13 @@ inline void debug_sanitize_post_noc_addr_and_hang(uint64_t a, uint32_t l, uint32
     }
 }
 
-// Return value is the alignment requirement (in bytes) for the type of core the noc address points
+// Return value is the alignment mask for the type of core the noc address points
 // to. Need to do this because L1 alignment needs to match the noc address alignment requirements,
 // even if it's different than the inherent L1 alignment requirements. Note that additional
 // alignment restrictions only apply for writes from L1, so need to specify direction as well.
 uint32_t debug_sanitize_noc_addr(
     uint64_t noc_addr,
+    uint32_t l1_addr,
     uint32_t noc_len,
     debug_sanitize_noc_cast_t multicast,
     debug_sanitize_noc_dir_t dir) {
@@ -122,47 +126,54 @@ uint32_t debug_sanitize_noc_addr(
         if (!NOC_WORKER_XY_P(x, y) ||
             !NOC_WORKER_XY_P(x_end, y_end) ||
             (x > x_end || y > y_end)) {
-            debug_sanitize_post_noc_addr_and_hang(noc_addr, noc_len, DebugSanitizeNocInvalidMulticast);
+            debug_sanitize_post_noc_addr_and_hang(
+                noc_addr, l1_addr, noc_len,
+                multicast, DebugSanitizeNocInvalidMulticast
+            );
         }
     }
 
     // Check noc addr, we save the alignment requirement from the noc src/dst because the L1 address
-    // needs to match alignment (even if it's different than the L1 alignment requirements).
-    uint32_t extra_alignment_req = NOC_L1_ALIGNMENT_BYTES;
+    // needs to match alignment.
+    uint32_t alignment_mask = NOC_L1_ALIGNMENT_BYTES-1; // Default alignment, only override in ceratin cases.
     uint32_t invalid = multicast? DebugSanitizeNocInvalidMulticast : DebugSanitizeNocInvalidUnicast;
     if (NOC_PCIE_XY_P(x, y)) {
         // Additional alignment restriction only applies to reads
         if (dir == DEBUG_SANITIZE_NOC_READ)
-            extra_alignment_req = NOC_PCIE_ALIGNMENT_BYTES;
+            alignment_mask = NOC_PCIE_ALIGNMENT_BYTES - 1;
         if (!DEBUG_VALID_PCIE_ADDR(noc_local_addr, noc_len)) {
-            debug_sanitize_post_noc_addr_and_hang(noc_addr, noc_len, invalid);
+            debug_sanitize_post_noc_addr_and_hang(noc_addr, l1_addr, noc_len, multicast, invalid);
         }
     } else if (NOC_DRAM_XY_P(x, y)) {
         // Additional alignment restriction only applies to reads
         if (dir == DEBUG_SANITIZE_NOC_READ)
-            extra_alignment_req = NOC_DRAM_ALIGNMENT_BYTES;
+            alignment_mask = NOC_DRAM_ALIGNMENT_BYTES - 1;
         if (!DEBUG_VALID_DRAM_ADDR(noc_local_addr, noc_len)) {
-            debug_sanitize_post_noc_addr_and_hang(noc_addr, noc_len, invalid);
+            debug_sanitize_post_noc_addr_and_hang(noc_addr, l1_addr, noc_len, multicast, invalid);
         }
     } else if (NOC_ETH_XY_P(x, y)) {
         if (!DEBUG_VALID_ETH_ADDR(noc_local_addr, noc_len)) {
-            debug_sanitize_post_noc_addr_and_hang(noc_addr, noc_len, invalid);
+            debug_sanitize_post_noc_addr_and_hang(noc_addr, l1_addr, noc_len, multicast, invalid);
         }
     } else if (NOC_WORKER_XY_P(x, y)) {
-        if (!DEBUG_VALID_WORKER_ADDR(noc_local_addr, noc_len, NOC_L1_ALIGNMENT_BYTES)) {
-            debug_sanitize_post_noc_addr_and_hang(noc_addr, noc_len, invalid);
+        if (!DEBUG_VALID_WORKER_ADDR(noc_local_addr, noc_len)) {
+            debug_sanitize_post_noc_addr_and_hang(noc_addr, l1_addr, noc_len, multicast, invalid);
         }
     } else {
         // Bad XY
-        debug_sanitize_post_noc_addr_and_hang(noc_addr, noc_len, invalid);
+        debug_sanitize_post_noc_addr_and_hang(noc_addr, l1_addr, noc_len, multicast, invalid);
     }
 
-    return extra_alignment_req;
+    return alignment_mask;
 }
 
-void debug_sanitize_worker_addr(uint32_t addr, uint32_t len, uint32_t extra_alignment_req) {
-    if (!DEBUG_VALID_WORKER_ADDR(addr, len, extra_alignment_req)) {
-        debug_sanitize_post_noc_addr_and_hang(addr, len, DebugSanitizeNocInvalidL1);
+void debug_sanitize_worker_addr(uint32_t addr, uint32_t len) {
+    // Regs are exempt from standard L1 validation
+    if (DEBUG_VALID_REG_ADDR(addr, len))
+        return;
+
+    if (!DEBUG_VALID_WORKER_ADDR(addr, len)) {
+        debug_sanitize_post_noc_addr_and_hang(addr, 0, len, false, DebugSanitizeNocInvalidL1);
     }
 }
 
@@ -174,19 +185,26 @@ void debug_sanitize_noc_and_worker_addr(
     debug_sanitize_noc_dir_t dir
 ) {
     // Check noc addr, get any extra alignment req for worker.
-    uint32_t extra_alignment_req = debug_sanitize_noc_addr(noc_addr, len, multicast, dir);
+    uint32_t alignment_mask = debug_sanitize_noc_addr(noc_addr, worker_addr, len, multicast, dir);
 
     // Check worker addr
-    debug_sanitize_worker_addr(worker_addr, len, extra_alignment_req);
+    debug_sanitize_worker_addr(worker_addr, len);
+
+    // Check alignment, but not for reg addresses.
+    if (!DEBUG_VALID_REG_ADDR(worker_addr, len)) {
+        if ((worker_addr & alignment_mask) != (noc_addr & alignment_mask)) {
+            debug_sanitize_post_noc_addr_and_hang(noc_addr, worker_addr, len, multicast, DebugSanitizeNocInvalidAlignment);
+        }
+    }
 }
 
 // TODO: should be able clean up uses of the first three macros and remove them.
 #define DEBUG_SANITIZE_WORKER_ADDR(a, l) \
-    debug_sanitize_worker_addr(a, l, NOC_L1_ALIGNMENT_BYTES)
+    debug_sanitize_worker_addr(a, l)
 #define DEBUG_SANITIZE_NOC_ADDR(a, l) \
-    debug_sanitize_noc_addr(a, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ)
+    debug_sanitize_noc_addr(a, 0, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ)
 #define DEBUG_SANITIZE_NOC_MULTI_ADDR(a, l) \
-    debug_sanitize_noc_addr(a, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_READ)
+    debug_sanitize_noc_addr(a, 0, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_READ)
 #define DEBUG_SANITIZE_NOC_TRANSACTION(noc_a, worker_a, l, multicast, dir) \
     debug_sanitize_noc_and_worker_addr(noc_a, worker_a, l, multicast, dir)
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_a, worker_a, l) \

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -82,11 +82,15 @@ struct debug_status_msg_t {
     volatile uint8_t status[num_status_bytes_per_riscv];
 };
 
+// TODO: Clean up this struct with #6738
 struct debug_sanitize_noc_addr_msg_t {
-    volatile uint64_t addr;
+    volatile uint64_t noc_addr;
+    volatile uint32_t l1_addr;
     volatile uint32_t len;
     volatile uint16_t which;
     volatile uint16_t invalid;
+    volatile uint16_t multicast;
+    volatile uint16_t pad;
 };
 
 enum debug_sanitize_noc_invalid_enum {
@@ -95,6 +99,7 @@ enum debug_sanitize_noc_invalid_enum {
     DebugSanitizeNocInvalidL1         = 3,
     DebugSanitizeNocInvalidUnicast    = 4,
     DebugSanitizeNocInvalidMulticast  = 5,
+    DebugSanitizeNocInvalidAlignment  = 6,
 };
 
 struct debug_assert_msg_t {


### PR DESCRIPTION
Noc sanitization via watcher should now match hw alignment restrictions. The noc sanitize mailbox is a little messier now, but it'll be cleaned up when I implement #6738 

Passing CI:
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8578329530
https://github.com/tenstorrent-metal/tt-metal/actions/runs/8577989872