### PR TITLE
#5480: Fix prefetch queue corruption.

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_packet_path.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_packet_path.cpp
@@ -761,7 +761,7 @@ void gen_terminate_cmds(vector<uint32_t>& prefetch_cmds,
 void write_prefetcher_cmd(Device *device,
                           vector<uint32_t>& cmds,
                           uint32_t& cmd_offset,
-                          uint16_t cmd_size16b,
+                          uint32_t cmd_size16b,
                           uint32_t*& host_mem_ptr,
                           uint32_t& prefetch_q_dev_ptr,
                           uint32_t& prefetch_q_dev_fence,
@@ -788,7 +788,7 @@ void write_prefetcher_cmd(Device *device,
     }
 
     // wrap
-    if (prefetch_q_dev_ptr == prefetch_q_base + prefetch_q_entries_g * sizeof(uint16_t)) {
+    if (prefetch_q_dev_ptr == prefetch_q_base + prefetch_q_entries_g * sizeof(prefetch_q_entry_type)) {
         prefetch_q_dev_ptr = prefetch_q_base;
 
         while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
@@ -797,9 +797,9 @@ void write_prefetcher_cmd(Device *device,
         }
     }
 
-    tt::Cluster::instance().write_core((void *)&cmd_size16b, sizeof(uint16_t), tt_cxy_pair(device->id(), phys_prefetch_core), prefetch_q_dev_ptr, true);
+    tt::Cluster::instance().write_reg(&cmd_size16b, tt_cxy_pair(device->id(), phys_prefetch_core), prefetch_q_dev_ptr);
 
-    prefetch_q_dev_ptr += sizeof(uint16_t);
+    prefetch_q_dev_ptr += sizeof(prefetch_q_entry_type);
 }
 
 void write_prefetcher_cmds(uint32_t iterations,
@@ -820,13 +820,13 @@ void write_prefetcher_cmds(uint32_t iterations,
         vector<uint32_t> prefetch_q(DEFAULT_PREFETCH_Q_ENTRIES, 0);
         vector<uint32_t> prefetch_q_rd_ptr_addr_data;
 
-        prefetch_q_rd_ptr_addr_data.push_back(prefetch_q_base + prefetch_q_entries_g * sizeof(uint16_t));
+        prefetch_q_rd_ptr_addr_data.push_back(prefetch_q_base + prefetch_q_entries_g * sizeof(prefetch_q_entry_type));
         llrt::write_hex_vec_to_core(device->id(), phys_prefetch_core, prefetch_q_rd_ptr_addr_data, prefetch_q_rd_ptr_addr);
         llrt::write_hex_vec_to_core(device->id(), phys_prefetch_core, prefetch_q, prefetch_q_base);
 
         host_mem_ptr = (uint32_t *)host_hugepage_base;
         prefetch_q_dev_ptr = prefetch_q_base;
-        prefetch_q_dev_fence = prefetch_q_base + prefetch_q_entries_g * sizeof(uint16_t);
+        prefetch_q_dev_fence = prefetch_q_base + prefetch_q_entries_g * sizeof(prefetch_q_entry_type);
         initialize_device_g = false;
     }
 
@@ -1120,7 +1120,7 @@ int main(int argc, char **argv) {
         vector<uint32_t>zero_data(0);
         llrt::write_hex_vec_to_core(device->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
 
-        uint32_t prefetch_q_size = prefetch_q_entries_g * sizeof(uint16_t);
+        uint32_t prefetch_q_size = prefetch_q_entries_g * sizeof(prefetch_q_entry_type);
         uint32_t noc_read_alignment = 32;
         uint32_t cmddat_q_base = prefetch_q_base + ((prefetch_q_size + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
         uint32_t scratch_db_base = cmddat_q_base + ((cmddat_q_size_g + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
@@ -1194,7 +1194,7 @@ int main(int argc, char **argv) {
              dev_hugepage_base,
              hugepage_buffer_size_g,
              prefetch_q_base,
-             prefetch_q_entries_g * (uint32_t)sizeof(uint16_t),
+             prefetch_q_entries_g * (uint32_t)sizeof(prefetch_q_entry_type),
              prefetch_q_rd_ptr_addr,
              cmddat_q_base,
              cmddat_q_size_g,

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -248,7 +248,6 @@ void stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(
 
                 vector<uint32_t> res;
                 res.resize(buf_size / sizeof(uint32_t));
-
                 if (cq_read) {
                     EnqueueReadBuffer(cq, buf, res.data(), true);
                 } else {
@@ -355,9 +354,6 @@ TEST_F(CommandQueueSingleCardFixture, Sending131072Pages) {
 }
 
 TEST_F(CommandQueueSingleCardFixture, TestNon32BAlignedPageSizeForDram) {
-    if (this->arch_ == tt::ARCH::GRAYSKULL) {
-        GTEST_SKIP() << "Causes issues on Grayskull. See #7067";
-    }
     TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
     for (Device *device : devices_) {
@@ -366,9 +362,6 @@ TEST_F(CommandQueueSingleCardFixture, TestNon32BAlignedPageSizeForDram) {
 }
 
 TEST_F(CommandQueueSingleCardFixture, TestNon32BAlignedPageSizeForDram2) {
-    if (this->arch_ == tt::ARCH::GRAYSKULL) {
-        GTEST_SKIP() << "Causes issues on Grayskull. See #7067";
-    }
     // From stable diffusion read buffer
     TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
@@ -378,9 +371,6 @@ TEST_F(CommandQueueSingleCardFixture, TestNon32BAlignedPageSizeForDram2) {
 }
 
 TEST_F(CommandQueueFixture, TestPageSizeTooLarge) {
-    if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
-        GTEST_SKIP();  // This test hanging on wormhole b0
-    }
     // Should throw a host error due to the page size not fitting in the consumer CB
     TestBufferConfig config = {.num_pages = 1024, .page_size = 250880 * 2, .buftype = BufferType::DRAM};
 
@@ -610,9 +600,6 @@ TEST_F(CommandQueueSingleCardFixture, TestNonblockingReads) {
 namespace stress_tests {
 
 TEST_F(CommandQueueSingleCardFixture, WritesToRandomBufferTypeAndThenReadsBlocking) {
-    if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
-        GTEST_SKIP() << "ND fails on Wormhole.";
-    }
     BufferStressTestConfig config = {
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
 
@@ -623,9 +610,6 @@ TEST_F(CommandQueueSingleCardFixture, WritesToRandomBufferTypeAndThenReadsBlocki
 }
 
 TEST_F(CommandQueueSingleCardFixture, WritesToRandomBufferTypeAndThenReadsNonblocking) {
-    if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
-        GTEST_SKIP() << "ND fails on Wormhole.";
-    }
     BufferStressTestConfig config = {
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
 
@@ -639,9 +623,6 @@ TEST_F(CommandQueueSingleCardFixture, WritesToRandomBufferTypeAndThenReadsNonblo
 
 // TODO: Split this into separate tests
 TEST_F(CommandQueueSingleCardFixture, ShardedBufferReadWrites) {
-    if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
-        GTEST_SKIP() << "ND fails on Wormhole.";
-    }
     for (Device *device : devices_) {
         for (const std::array<uint32_t, 2> cores :
              {std::array<uint32_t, 2>{1, 1},

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -322,7 +322,7 @@ void Device::compile_command_queue_programs() {
     constexpr uint32_t dispatch_buffer_pages = DISPATCH_BUFFER_BLOCK_SIZE_PAGES * DISPATCH_BUFFER_SIZE_BLOCKS;
     uint32_t dispatch_buffer_base = get_dispatch_buffer_base();
     constexpr uint32_t prefetch_q_base = DISPATCH_L1_UNRESERVED_BASE;
-    constexpr uint32_t prefetch_q_size = PREFETCH_Q_ENTRIES * sizeof(uint16_t);
+    constexpr uint32_t prefetch_q_size = PREFETCH_Q_ENTRIES * sizeof(prefetch_q_entry_type);
     constexpr uint32_t noc_read_alignment = 32;
     constexpr uint32_t cmddat_q_base = prefetch_q_base + ((prefetch_q_size + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
     constexpr uint32_t scratch_db_base = cmddat_q_base + ((CMDDAT_Q_SIZE + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
@@ -388,7 +388,7 @@ void Device::compile_command_queue_programs() {
                     CQ_START,
                     issue_queue_size,
                     prefetch_q_base,
-                    PREFETCH_Q_ENTRIES * (uint32_t)sizeof(uint16_t),
+                    PREFETCH_Q_ENTRIES * (uint32_t)sizeof(prefetch_q_entry_type),
                     CQ_PREFETCH_Q_RD_PTR,
                     cmddat_q_base,
                     CMDDAT_Q_SIZE,
@@ -516,7 +516,7 @@ void Device::configure_command_queue_programs() {
                 // Initialize the FetchQ
                 std::vector<uint32_t> prefetch_q(PREFETCH_Q_ENTRIES, 0);
                 std::vector<uint32_t> prefetch_q_rd_ptr_addr_data = {
-                    (uint32_t)(prefetch_q_base + PREFETCH_Q_ENTRIES * sizeof(uint16_t))
+                    (uint32_t)(prefetch_q_base + PREFETCH_Q_ENTRIES * sizeof(prefetch_q_entry_type))
                 };
                 detail::WriteToDeviceL1(this, prefetch_location, CQ_PREFETCH_Q_RD_PTR, prefetch_q_rd_ptr_addr_data);
                 detail::WriteToDeviceL1(this, prefetch_location, prefetch_q_base, prefetch_q);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -108,7 +108,7 @@ void write_downstream(uint32_t& data_ptr,
 
 template<uint32_t preamble_size>
 FORCE_INLINE
-void read_from_pcie(volatile tt_l1_ptr uint16_t *& prefetch_q_rd_ptr,
+void read_from_pcie(volatile tt_l1_ptr uint32_t *& prefetch_q_rd_ptr,
                     uint32_t& pending_read_size,
                     uint32_t& fence,
                     uint32_t& pcie_read_ptr,
@@ -145,7 +145,7 @@ void read_from_pcie(volatile tt_l1_ptr uint16_t *& prefetch_q_rd_ptr,
 
     // Wrap prefetch_q
     if ((uint32_t)prefetch_q_rd_ptr == prefetch_q_end) {
-        prefetch_q_rd_ptr = (volatile tt_l1_ptr uint16_t*)prefetch_q_base;
+        prefetch_q_rd_ptr = (volatile tt_l1_ptr uint32_t*)prefetch_q_base;
     }
 }
 
@@ -173,7 +173,7 @@ template<uint32_t preamble_size>
 void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_ptr) {
 
     static uint32_t pending_read_size = 0;
-    static volatile tt_l1_ptr uint16_t* prefetch_q_rd_ptr = (volatile tt_l1_ptr uint16_t*)prefetch_q_base;
+    static volatile tt_l1_ptr uint32_t* prefetch_q_rd_ptr = (volatile tt_l1_ptr uint32_t*)prefetch_q_base;
 
     DPRINT << "fetch_q_get_cmds: " << cmd_ptr << " " << fence << ENDL();
     if (fence < cmd_ptr) {


### PR DESCRIPTION
Switch to u32 prefetch q entries
Use REG_TLB for writing prefetch q entries
Update umd submodule to support caching tlb configs to avoid reprogramming