### PR TITLE
#5544:  Add output tensors parameter to moreh_sgd op

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sgd.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sgd.py
@@ -42,7 +42,8 @@ def create_tt_tensor(tensor, device):
 @pytest.mark.parametrize(
     "momentum_initialized", [True, False], ids=["MOMENTUM_INITIALIZED", "MOMENTUM_NOT_INITIALIZED"]
 )
-def test_moreh_sgd(shape, lr, momentum, dampening, weight_decay, nesterov, momentum_initialized, device):
+@pytest.mark.parametrize("has_param_out", [True, False], ids=["HAS_PARAM_OUT_TRUE", "HAS_PARAM_OUT_FALSE"])
+def test_moreh_sgd(shape, lr, momentum, dampening, weight_decay, nesterov, momentum_initialized, has_param_out, device):
     if nesterov and (momentum <= 0 or dampening != 0):
         pytest.skip()
 
@@ -110,11 +111,11 @@ def test_moreh_sgd(shape, lr, momentum, dampening, weight_decay, nesterov, momen
 
         dev_momentum_buffer_out = create_tt_tensor(cpu_param_in, device)
 
-    ttl.operations.primary.moreh_sgd(
+    dev_param_out, dev_momentum_buffer_out = ttl.operations.primary.moreh_sgd(
         dev_param_in,
         dev_grad,
         dev_momentum_buffer_in,
-        dev_param_out,
+        dev_param_out if has_param_out else None,
         dev_momentum_buffer_out,
         lr,
         momentum,

--- a/tt_eager/tt_dnn/op_library/moreh_sgd/moreh_sgd.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sgd/moreh_sgd.cpp
@@ -183,12 +183,12 @@ operation::ProgramWithCallbacks moreh_sgd_(
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         const std::vector<Tensor>& output_tensors
         ) {
-        TT_ASSERT(input_tensors.size() == 3);
-        TT_ASSERT(optional_input_tensors.size() == 0 || optional_input_tensors.size() == 2);
+        TT_ASSERT(input_tensors.size() == 2);
+        TT_ASSERT(optional_input_tensors.size() == 0 || optional_input_tensors.size() == 1);
 
         auto param_in_address = input_tensors.at(0).buffer()->address();
         auto grad_address = input_tensors.at(1).buffer()->address();
-        auto param_out_address = input_tensors.at(2).buffer()->address();
+        auto param_out_address = output_tensors.at(0).buffer()->address();
 
         for (uint32_t core_i = 0; core_i < num_cores; core_i++) {
             CoreCoord core = {core_i / core_h, core_i % core_h};
@@ -211,7 +211,7 @@ operation::ProgramWithCallbacks moreh_sgd_(
                 runtime_args[0] = param_out_address;
 
                 if (has_momentum_buffer) {
-                    auto momentum_buffer_out = optional_input_tensors.at(1).value().buffer();
+                    auto momentum_buffer_out = output_tensors.at(1).buffer();
                     TT_ASSERT(momentum_buffer_out != nullptr);
                     runtime_args[1] = momentum_buffer_out->address();
                 }

--- a/tt_eager/tt_dnn/op_library/moreh_sgd/moreh_sgd_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sgd/moreh_sgd_op.cpp
@@ -18,42 +18,66 @@ namespace tt {
 namespace operations {
 namespace primary {
 
-void MorehSGD::validate(
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
-    TT_ASSERT(input_tensors.size() == 3, "Must have 1 input tensors");
+void MorehSGD::validate_with_output_tensors(
+    const std::vector<Tensor> &input_tensors,
+    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+    const std::vector<std::optional<Tensor>> &output_tensors) const {
+    TT_ASSERT(input_tensors.size() == 2, "Must have 2 input tensors");
     TT_ASSERT(
-        optional_input_tensors.size() == 0 || optional_input_tensors.size() == 2, "Must have 0 or 2 optional tensors");
+        optional_input_tensors.size() == 0 || optional_input_tensors.size() == 1, "Must have 0 or 1 optional tensors");
 
     auto& param_in = input_tensors.at(0);
     auto& grad = input_tensors.at(1);
-    auto& param_out = input_tensors.at(2);
+    auto& param_out = output_tensors.at(0);
 
     TT_ASSERT(param_in.storage_type() == StorageType::DEVICE, "param_in to SGD need to be on device!");
-    TT_ASSERT(grad.storage_type() == StorageType::DEVICE, "grad to SGD need to be on device!");
-    TT_ASSERT(param_out.storage_type() == StorageType::DEVICE, "param_out to SGD need to be on device!");
-
     TT_ASSERT(param_in.buffer() != nullptr, "param_in to SGD need to be allocated in buffers on device!");
-    TT_ASSERT(grad.buffer() != nullptr, "grad to SGD need to be allocated in buffers on device!");
-    TT_ASSERT(param_out.buffer() != nullptr, "param_out to SGD need to be allocated in buffers on device!");
-
     TT_ASSERT((param_in.get_layout() == Layout::TILE), "param_in to SGD must be tilized");
-    TT_ASSERT((grad.get_layout() == Layout::TILE), "grad to SGD must be tilized");
-    TT_ASSERT((param_out.get_layout() == Layout::TILE), "param_out to SGD must be tilized");
-
     TT_ASSERT(param_in.get_dtype() == DataType::BFLOAT16 || param_in.get_dtype() == DataType::BFLOAT8_B);
+
+    TT_ASSERT(grad.storage_type() == StorageType::DEVICE, "grad to SGD need to be on device!");
+    TT_ASSERT(grad.buffer() != nullptr, "grad to SGD need to be allocated in buffers on device!");
+    TT_ASSERT((grad.get_layout() == Layout::TILE), "grad to SGD must be tilized");
     TT_ASSERT(grad.get_dtype() == DataType::BFLOAT16 || grad.get_dtype() == DataType::BFLOAT8_B);
-    TT_ASSERT(param_out.get_dtype() == DataType::BFLOAT16 || param_out.get_dtype() == DataType::BFLOAT8_B);
+
+    if (param_out.has_value()) {
+        TT_ASSERT(param_out.value().storage_type() == StorageType::DEVICE, "param_out to SGD need to be on device!");
+        TT_ASSERT(param_out.value().buffer() != nullptr, "param_out to SGD need to be allocated in buffers on device!");
+        TT_ASSERT((param_out.value().get_layout() == Layout::TILE), "param_out to SGD must be tilized");
+        TT_ASSERT(param_out.value().get_dtype() == DataType::BFLOAT16 || param_out.value().get_dtype() == DataType::BFLOAT8_B);
+    }
 }
 
 std::vector<Shape> MorehSGD::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    // Do nothing because it's an in-place operation
-    return {};
+    auto output_shape = input_tensors.at(0).get_legacy_shape();
+    return {output_shape, output_shape};
 }
 
-std::vector<Tensor> MorehSGD::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    // Do nothing because it's an in-place operation
-    return {};
+std::vector<Tensor> MorehSGD::create_output_tensors(
+    const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const {
+    const auto &output_shapes = this->compute_output_shapes(input_tensors);
+    auto dtype = input_tensors.at(0).get_dtype();
+    Layout layout{Layout::TILE};
+    auto device = input_tensors.at(0).device();
+
+    std::vector<Tensor> result;
+    result.reserve(2);
+
+    if (output_tensors.at(0).has_value()) {
+        result.push_back(output_tensors.at(0).value());
+    } else {
+        result.push_back(create_device_tensor(
+                  output_shapes.at(0), dtype, layout, device, this->param_out_mem_config));
+    }
+
+    if (output_tensors.at(1).has_value()) {
+        result.push_back(output_tensors.at(1).value());
+    } else if (this->momentum != 0.0f) {
+        result.push_back(create_device_tensor(
+                  output_shapes.at(1), dtype, layout, device, this->momentum_buffer_out_mem_config));
+    }
+
+    return std::move(result);
 }
 
 operation::ProgramWithCallbacks MorehSGD::create_program(
@@ -63,8 +87,9 @@ operation::ProgramWithCallbacks MorehSGD::create_program(
     auto& param_in = input_tensors.at(0);
     auto& grad = input_tensors.at(1);
     auto& momentum_buffer_in = optional_input_tensors.at(0);
-    auto& param_out = input_tensors.at(2);
-    auto& momentum_buffer_out = optional_input_tensors.at(1);
+    auto& param_out = output_tensors.at(0);
+    std::optional<Tensor> momentum_buffer_out =
+        (output_tensors.size() == 2) ? (std::make_optional<Tensor>(output_tensors.at(1))) : (std::nullopt);
 
     return {moreh_sgd_(
         param_in,
@@ -81,23 +106,25 @@ operation::ProgramWithCallbacks MorehSGD::create_program(
         this->core_range)};
 }
 
-void moreh_sgd(
+std::vector<std::optional<Tensor>> moreh_sgd(
     const Tensor& param_in,
     const Tensor& grad,
     std::optional<const Tensor> momentum_buffer_in,
-    const Tensor& param_out,
+    std::optional<const Tensor> param_out,
     std::optional<const Tensor> momentum_buffer_out,
     float lr,
     float momentum,
     float dampening,
     float weight_decay,
     bool nesterov,
-    bool momentum_initialized) {
+    bool momentum_initialized,
+    const MemoryConfig &param_out_mem_config,
+    const MemoryConfig &momentum_buffer_out_mem_config) {
     auto device = param_in.device();
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
-    operation::run(
+    auto output_tensors = operation::run(
         MorehSGD{
             .lr = lr,
             .momentum = momentum,
@@ -105,9 +132,22 @@ void moreh_sgd(
             .weight_decay = weight_decay,
             .nesterov = nesterov,
             .momentum_initialized = momentum_initialized,
-            .core_range = all_cores},
-        {param_in, grad, param_out},
-        {momentum_buffer_in, momentum_buffer_out});
+            .core_range = all_cores,
+            .param_out_mem_config = param_out_mem_config,
+            .momentum_buffer_out_mem_config = momentum_buffer_out_mem_config},
+        {param_in, grad},
+        {momentum_buffer_in},
+        {param_out, momentum_buffer_out});
+
+    std::vector<std::optional<Tensor>> result;
+    result.push_back(output_tensors.at(0));
+    if (output_tensors.size() == 2) {
+        result.push_back(output_tensors.at(1));
+    } else {
+        result.push_back(std::nullopt);
+    }
+
+    return std::move(result);
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_sgd/moreh_sgd_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sgd/moreh_sgd_op.hpp
@@ -38,18 +38,22 @@ struct MorehSGD {
     bool nesterov;
     bool momentum_initialized;
     const CoreRange core_range;  // unused for now
+    MemoryConfig param_out_mem_config;
+    MemoryConfig momentum_buffer_out_mem_config;
 
-    void validate(
+    void validate_with_output_tensors(
         const std::vector<Tensor> &input_tensors,
-        const std::vector<std::optional<const Tensor>> &optional_input_tensors) const;
+        const std::vector<std::optional<const Tensor>> &optional_input_tensors,
+        const std::vector<std::optional<Tensor>> &output_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors,
         std::vector<Tensor> &output_tensors) const;
     static constexpr auto attribute_names =
-        std::make_tuple("lr", "momentum", "dampening", "weight_decay", "nesterov", "momentum_initialized");
+        std::make_tuple("lr", "momentum", "dampening", "weight_decay", "nesterov", "momentum_initialized", "param_out_mem_config", "momentum_buffer_out_mem_config");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->lr),
@@ -57,22 +61,26 @@ struct MorehSGD {
             std::cref(this->dampening),
             std::cref(this->weight_decay),
             std::cref(this->nesterov),
-            std::cref(this->momentum_initialized));
+            std::cref(this->momentum_initialized),
+            std::cref(this->param_out_mem_config),
+            std::cref(this->momentum_buffer_out_mem_config));
     }
 };
 
-void moreh_sgd(
+std::vector<std::optional<Tensor>> moreh_sgd(
     const Tensor &param_in,
     const Tensor &grad,
     std::optional<const Tensor> momentum_buffer_in,
-    const Tensor &param_out,
+    std::optional<const Tensor> param_out,
     std::optional<const Tensor> momentum_buffer_out,
     float lr,
     float momentum,
     float dampening,
     float weight_decay,
     bool nesterov,
-    bool momentum_initialized);
+    bool momentum_initialized,
+    const MemoryConfig &param_out_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const MemoryConfig &momentum_buffer_out_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 }  // namespace primary
 }  // namespace operations

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -884,7 +884,7 @@ void py_module(py::module& m_primary) {
         py::arg("param_in").noconvert(),
         py::arg("grad").noconvert(),
         py::arg("momentum_buffer_in").noconvert() = std::nullopt,
-        py::arg("param_out").noconvert(),
+        py::arg("param_out").noconvert() = std::nullopt,
         py::arg("momentum_buffer_out").noconvert() = std::nullopt,
         py::arg("lr").noconvert(),
         py::arg("momentum").noconvert(),
@@ -892,6 +892,8 @@ void py_module(py::module& m_primary) {
         py::arg("weight_decay").noconvert(),
         py::arg("nesterov").noconvert(),
         py::arg("momentum_initialized").noconvert(),
+        py::arg("param_out_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("momentum_buffer_out_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         "Performs a SGD operation.");
 
     py::class_<GroupNormShardedMultiCoreProgramConfig>(m_primary, "GroupNormShardedMultiCoreProgramConfig")


### PR DESCRIPTION
I added output tensor parameters to these OPs below refer to issue https://github.com/tenstorrent-metal/tt-metal/issues/5044 .

- moreh_sgd

Passed the relevant test below.

- tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sgd.py