### PR TITLE
#5544: Add output tensors parameter to moreh_nll_loss op

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
@@ -140,7 +140,9 @@ def get_tt_tensors_2d(torch_input, torch_target, torch_weight, torch_divisor, to
 )
 @pytest.mark.parametrize("ignore_index", [0, -1])
 @pytest.mark.parametrize("reduction_mean", [True, False])
-def test_moreh_nll_loss_4d(shape, ignore_index, reduction_mean, device):
+@pytest.mark.parametrize("has_output", [True, False])
+def test_moreh_nll_loss_4d(shape, ignore_index, reduction_mean, has_output, device):
+    # def test_moreh_nll_loss_4d(shape, ignore_index, reduction_mean, device):
     device.enable_program_cache()
 
     (torch_input, torch_target, torch_weight, torch_divisor, torch_output) = get_torch_tensors_4d(shape, device)
@@ -152,8 +154,9 @@ def test_moreh_nll_loss_4d(shape, ignore_index, reduction_mean, device):
     (tt_input, tt_target, tt_weight, tt_divisor, tt_output) = get_tt_tensors_4d(
         torch_input, torch_target, torch_weight, torch_divisor, torch_output, device
     )
+
     tt_loss = ttl.operations.primary.moreh_nll_loss(
-        tt_input, tt_target, tt_weight, tt_divisor, tt_output, ignore_index, reduction_mean
+        tt_input, tt_target, tt_weight, tt_divisor, tt_output if has_output else None, ignore_index, reduction_mean
     )
     tt_loss_to_cpu = tt_loss.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile([1, 1, 1, 1]).to_torch().reshape([1])
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
@@ -141,9 +141,8 @@ def get_tt_tensors_2d(torch_input, torch_target, torch_weight, torch_divisor, to
 @pytest.mark.parametrize("ignore_index", [0, -1])
 @pytest.mark.parametrize("reduction_mean", [True, False])
 @pytest.mark.parametrize("has_output", [True, False])
-def test_moreh_nll_loss_4d(shape, ignore_index, reduction_mean, has_output, device):
+def test_moreh_nll_loss_4d(shape, ignore_index, reduction_mean, has_output, device, use_program_cache):
     # def test_moreh_nll_loss_4d(shape, ignore_index, reduction_mean, device):
-    device.enable_program_cache()
 
     (torch_input, torch_target, torch_weight, torch_divisor, torch_output) = get_torch_tensors_4d(shape, device)
     nll_loss = torch.nn.NLLLoss(
@@ -171,9 +170,7 @@ def test_moreh_nll_loss_4d(shape, ignore_index, reduction_mean, has_output, devi
 @pytest.mark.parametrize("shape", ([1, 2], [3, 4], [12, 6]))
 @pytest.mark.parametrize("ignore_index", [0, -1])
 @pytest.mark.parametrize("reduction_mean", [True, False])
-def test_moreh_nll_loss_2d(shape, ignore_index, reduction_mean, device):
-    device.enable_program_cache()
-
+def test_moreh_nll_loss_2d(shape, ignore_index, reduction_mean, device, use_program_cache):
     (torch_input, torch_target, torch_weight, torch_divisor, torch_output) = get_torch_tensors_2d(shape, device)
     nll_loss = torch.nn.NLLLoss(
         weight=torch_weight, ignore_index=ignore_index, reduction="mean" if reduction_mean else "sum"
@@ -206,9 +203,8 @@ def test_moreh_nll_loss_2d(shape, ignore_index, reduction_mean, device):
 )
 @pytest.mark.parametrize("ignore_index", [0, -1])
 @pytest.mark.parametrize("reduction_mean", [True, False])
-def test_moreh_nll_loss_4d_backward(shape, ignore_index, reduction_mean, device):
-    device.enable_program_cache()
-
+@pytest.mark.parametrize("has_output", [True, False])
+def test_moreh_nll_loss_4d_backward(shape, ignore_index, reduction_mean, has_output, device, use_program_cache):
     (torch_input, torch_target, torch_weight, torch_divisor, torch_output) = get_torch_tensors_4d(shape, device)
     nll_loss = torch.nn.NLLLoss(
         weight=torch_weight, ignore_index=ignore_index, reduction="mean" if reduction_mean else "sum"
@@ -223,7 +219,7 @@ def test_moreh_nll_loss_4d_backward(shape, ignore_index, reduction_mean, device)
     tt_loss = ttl.operations.primary.moreh_nll_loss(
         tt_input, tt_target, tt_weight, tt_divisor, tt_output, ignore_index, reduction_mean
     )
-    tt_loss_to_cpu = tt_loss.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile([1, 1, 1, 1]).to_torch().reshape([1])
+    tt_loss.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile([1, 1, 1, 1]).to_torch().reshape([1])
 
     output_grad = torch.randn_like(torch_loss)
     torch_loss.backward(output_grad)
@@ -241,10 +237,17 @@ def test_moreh_nll_loss_4d_backward(shape, ignore_index, reduction_mean, device)
         .to(device)
     )
 
-    tt_input_grad_ = ttl.operations.primary.moreh_nll_loss_backward(
-        tt_input, tt_target, tt_weight, tt_divisor, tt_output_grad, tt_input_grad, ignore_index, reduction_mean
+    tt_input_grad = ttl.operations.primary.moreh_nll_loss_backward(
+        tt_input,
+        tt_target,
+        tt_weight,
+        tt_divisor,
+        tt_output_grad,
+        tt_input_grad if has_output else None,
+        ignore_index,
+        reduction_mean,
     )
-    tt_input_grad_to_cpu = tt_input_grad_.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape).to_torch()
+    tt_input_grad_to_cpu = tt_input_grad.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape).to_torch()
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_to_cpu, pcc=0.999, rtol=rtol, atol=atol)
@@ -258,9 +261,7 @@ def test_moreh_nll_loss_4d_backward(shape, ignore_index, reduction_mean, device)
 @pytest.mark.parametrize("shape", ([1, 2], [3, 4], [12, 6]))
 @pytest.mark.parametrize("ignore_index", [0, -1])
 @pytest.mark.parametrize("reduction_mean", [True, False])
-def test_moreh_nll_loss_2d_backward(shape, ignore_index, reduction_mean, device):
-    device.enable_program_cache()
-
+def test_moreh_nll_loss_2d_backward(shape, ignore_index, reduction_mean, device, use_program_cache):
     (torch_input, torch_target, torch_weight, torch_divisor, torch_output) = get_torch_tensors_2d(shape, device)
     nll_loss = torch.nn.NLLLoss(
         weight=torch_weight, ignore_index=ignore_index, reduction="mean" if reduction_mean else "sum"

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
@@ -179,7 +179,7 @@ Tensor moreh_nll_loss(
     const Tensor& target_tensor,
     const std::optional<const Tensor> weight_tensor,
     const std::optional<const Tensor> divisor_tensor,
-    const Tensor& output_tensor,
+    const std::optional<const Tensor> output_tensor,
     const int32_t ignore_index,
     const bool reduction_mean,
     const MemoryConfig& output_mem_config) {
@@ -194,14 +194,12 @@ Tensor moreh_nll_loss(
         const Tensor& step2_result = moreh_nll_loss_step2(input_tensor, target_tensor, weight_tensor, divisor_tensor, ignore_index, reduction_mean, output_mem_config);
         std::vector<int64_t> dims_step2;
 
-        moreh_sum(step2_result, dims_step2, output_tensor);
-        return output_tensor;
+        return moreh_sum(step2_result, dims_step2, output_tensor);
     } else {
         const Tensor& step2_result = moreh_nll_loss_step2(input_tensor, target_tensor, weight_tensor, std::nullopt, ignore_index, reduction_mean, output_mem_config);
 
         std::vector<int64_t> dims;
-        moreh_sum(step2_result, dims, output_tensor);
-        return output_tensor;
+        return moreh_sum(step2_result, dims, output_tensor);
     }
 }
 

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.hpp
@@ -86,7 +86,7 @@ Tensor moreh_nll_loss(
     const Tensor& target_tensor,
     const std::optional<const Tensor> weight_tensor,
     const std::optional<const Tensor> divisor_tensor,
-    const Tensor& output_tensor,
+    const std::optional<const Tensor> output_tensor,
     const int32_t ignore_index,
     const bool reduction_mean,
     const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward_op.hpp
@@ -22,20 +22,24 @@ struct MorehNllLossBackward {
     int32_t ignore_index;
     bool reduction_mean;
 
-    const MemoryConfig output_mem_config;
+    const MemoryConfig input_grad_mem_config;
     const CoreRange core_range;  // unused for now
 
-    void validate(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
+    void validate_with_output_tensors(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        const std::vector<std::optional<Tensor>> &output_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor> &output_tensors
     ) const;
-    static constexpr auto attribute_names = std::make_tuple("output_mem_config");
+    static constexpr auto attribute_names = std::make_tuple("input_grad_mem_config");
     const auto attribute_values() const {
-        return std::make_tuple(std::cref(this->output_mem_config));
+        return std::make_tuple(std::cref(this->input_grad_mem_config));
     }
 };
 
@@ -45,10 +49,10 @@ Tensor moreh_nll_loss_backward_(
     const std::optional<const Tensor> weight_tensor,
     const std::optional<const Tensor> divisor_tensor,
     const Tensor& output_grad_tensor,
-    const Tensor& input_grad_tensor,
+    const std::optional<const Tensor> input_grad_tensor,
     const int32_t ignore_index,
     const bool reduction_mean,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &input_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 Tensor moreh_nll_loss_backward(
     const Tensor& input_tensor,
@@ -56,10 +60,10 @@ Tensor moreh_nll_loss_backward(
     const std::optional<const Tensor> weight_tensor,
     const std::optional<const Tensor> divisor_tensor,
     const Tensor& output_grad_tensor,
-    const Tensor& input_grad_tensor,
+    const std::optional<const Tensor> input_grad_tensor,
     const int32_t ignore_index,
     const bool reduction_mean,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &input_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 }  // namespace primary
 }  // namespace operations

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -634,8 +634,8 @@ void py_module(py::module& m_primary) {
         py::arg("input_grad_tensor").noconvert(),
         py::arg("ignore_index").noconvert(),
         py::arg("reduction_mean").noconvert(),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        "Performs a nll_loss_backward operation. Returns an output tensor.");
+        py::arg("input_grad_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        "Performs a nll_loss_backward operation. Returns an input_grad tensor.");
 
     // moreh_norm
     m_primary.def(


### PR DESCRIPTION
I added output tensor parameters to these OPs below refer to issue https://github.com/tenstorrent-metal/tt-metal/issues/5044 .

- moreh_nll_loss
- moreh_nll_loss_backward

Passed the relevant test below.

- tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py