### PR TITLE
#0: Use wormhole_b0 tag for runners for multi-device pipelines instead of arch-wormhole_b0 per note

### DIFF
--- a/.github/workflows/multi-device-build-and-unit-tests-frequent.yaml
+++ b/.github/workflows/multi-device-build-and-unit-tests-frequent.yaml
@@ -14,9 +14,7 @@ jobs:
       matrix:
         runner-info: [
           # N300 2x4
-          # NOTE: Never use arch-wormhole_b0 tags, however we're using it here because this machine is used by devs during the day
-          # We don't want other CI runs to interrupt dev flows. However, we need to fix this once we have more 2x4 machines dedicated to CI
-          {name: "n300-2x4", arch: wormhole_b0, runs-on: ["arch-wormhole_b0", "multi-chip-num-pcie-4", "multi-chip-num-chips-8"]},
+          {name: "n300-2x4", arch: wormhole_b0, runs-on: ["wormhole_b0", "multi-chip-num-pcie-4", "multi-chip-num-chips-8"]},
         ]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}

--- a/.github/workflows/multi-device-build-and-unit-tests.yaml
+++ b/.github/workflows/multi-device-build-and-unit-tests.yaml
@@ -14,9 +14,7 @@ jobs:
       matrix:
         runner-info: [
           # N300 2x4
-          # NOTE: Never use arch-wormhole_b0 tags, however we're using it here because this machine is used by devs during the day
-          # We don't want other CI runs to interrupt dev flows. However, we need to fix this once we have more 2x4 machines dedicated to CI
-          {name: "n300-2x4", arch: wormhole_b0, runs-on: ["arch-wormhole_b0", "multi-chip-num-pcie-4", "multi-chip-num-chips-8"]},
+          {name: "n300-2x4", arch: wormhole_b0, runs-on: ["wormhole_b0", "multi-chip-num-pcie-4", "multi-chip-num-chips-8"]},
         ]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}


### PR DESCRIPTION
…. Details: We only arch-wormhole_b0 for bookkeeping and should NOT be using them in pipeline definitions. This is because arch-wormhole_b0 may grab a machine that's out of service. Only in service machines have the proper arch tag attached