### PR TITLE
Uneven Shards for Block Sharding in Direct Read and Write

### DIFF
--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -288,7 +288,7 @@ struct Tensor {
 
 Tensor create_device_tensor(const Shape& shape, DataType dtype, Layout layout, Device *device, const MemoryConfig& memory_config = {.memory_layout=tt::tt_metal::TensorMemoryLayout::INTERLEAVED});
 
-Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layout layout, Device *device, const MemoryConfig& memory_config, bool pad_to_same_shard_size=false);
+Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layout layout, Device *device, const MemoryConfig& memory_config);
 
 // template<typename Buffer>
 // void *get_host_buffer(const Tensor &tensor);

--- a/tt_eager/tt_dnn/op_library/fold/fold_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fold/fold_op.cpp
@@ -65,8 +65,8 @@ std::vector<Tensor> Fold::create_output_tensors(const std::vector<Tensor> &input
             output_dtype,
             input_tensor.get_layout(),
             input_tensor.device(),
-            mem_config,
-            true)};
+            mem_config
+            )};
     } else {
         return operation::generic_create_output_tensors(
             *this, input_tensors, output_dtype, Layout::ROW_MAJOR, input_tensor.memory_config());

--- a/tt_eager/tt_dnn/op_library/sharded/sharded_op.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/sharded_op.cpp
@@ -58,8 +58,7 @@ std::vector<Tensor> Sharded::create_output_tensors(const std::vector<Tensor>& in
             this->output_dtype,
             input_tensor.get_layout(),
             input_tensor.device(),
-            mem_config,
-            true
+            mem_config
             )};
     } else {
         return operation::generic_create_output_tensors(
@@ -126,8 +125,7 @@ std::vector<Tensor> Reshard::create_output_tensors(const std::vector<Tensor>& in
         input_tensor.get_dtype(),
         input_tensor.get_layout(),
         input_tensor.device(),
-        mem_config,
-        true
+        mem_config
         )};
 }
 
@@ -138,7 +136,6 @@ const operation::Hash Reshard::compute_program_hash(
         this->output_mem_config,
         this->input_shape);
 }
-
 
 
 

--- a/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.cpp
@@ -78,8 +78,7 @@ std::vector<Tensor> ShardedPartial::create_output_tensors(const std::vector<Tens
             this->output_dtype,
             input_tensor.get_layout(),
             input_tensor.device(),
-            mem_config,
-            true
+            mem_config
             )};
     } else {
         // Don't create anything, we already passed in output tensor

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -233,9 +233,7 @@ class Buffer {
         if(!is_sharded(this->buffer_layout_))
             return 1;
         else{
-            auto num_pages = this->size()/this->page_size();
-            auto shards_for_compute = div_up(num_pages, this->shard_spec().size());
-            return shards_for_compute;
+            return this->shard_spec().tensor_shard_spec.grid.num_cores();
         }
     }
 


### PR DESCRIPTION
CC: @TT-BrianLiu @AleksKnezevic 
This should address the matmul pcc issue. Or at least one of the possible reasons for it.


TLDR: there are two bugs, one when doing a direct read back, and a separate PCC issue for certain shapes when doing interleaved_to_sharded. 
This PR addresses the former, we can see if this is sufficient for SD.