### PR TITLE
Update complex ops - type1

### DIFF
--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_complex_pcc.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_complex_pcc.py
@@ -127,6 +127,30 @@ test_sweep_args = [
         ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
         38346,
     ),
+    (
+        (2, 3, 192, 448),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.TILE,
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        38346,
+    ),
+    (
+        (4, 4, 256, 448),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.TILE,
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        38346,
+    ),
+    (
+        (1, 1, 192, 512),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.TILE,
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        38346,
+    ),
 ]
 
 


### PR DESCRIPTION
Update complex type1 ops to use unpad instead of using split last dim as discussed in this issue https://github.com/tenstorrent-metal/tt-metal/issues/4518 


CI runs - https://github.com/tenstorrent-metal/tt-metal/actions/runs/8598577116