### PR TITLE
[Falcon7b] Fix pytest fixture bug resulting in use_program_cache being ignored

### DIFF
--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -79,9 +79,6 @@ def run_test_FalconCausalLM_end_to_end(
     # Clear global profiler state before starting measurements
     profiler.clear()
 
-    for device in devices:
-        device.enable_program_cache()
-
     num_devices = len(devices)
     global_batch = batch * num_devices
     model_name = model_location_generator(model_version, model_subdir="Falcon")
@@ -373,7 +370,7 @@ class TestParametrized:
     )
     @skip_for_wormhole_b0()
     def test_perf_gs_bare_metal(
-        use_program_cache,
+        self,
         model_version,
         llm_mode,
         batch,
@@ -386,6 +383,7 @@ class TestParametrized:
         model_config_str,
         model_location_generator,
         device,
+        use_program_cache,
     ):
         if is_e75(device) and batch == 32:
             pytest.skip("Falcon batch 32 is not supported on E75")
@@ -434,6 +432,7 @@ class TestParametrized:
     )
     @skip_for_grayskull()
     def test_perf_wh_bare_metal(
+        self,
         use_program_cache,
         model_version,
         num_devices,


### PR DESCRIPTION
- Fix bug introduced in [0505ba7](https://github.com/tenstorrent-metal/tt-metal/commit/0505ba7da635571cd47aeda81886ed093a6cfcda) causing use_program_cache fixture to be ignored in Falcon7b GS/WH tests