### PR TITLE
#7188: Add backward support for cplx2 ops

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -1070,6 +1070,10 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.polar_bw
 
+.. autofunction:: tt_lib.tensor.complex_add_bw
+
+.. autofunction:: tt_lib.tensor.complex_sub_bw
+
 .. autofunction:: tt_lib.tensor.multigammaln_bw
 
 .. autofunction:: tt_lib.tensor.repeat_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_abs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_abs.py
@@ -39,11 +39,11 @@ def test_bw_abs_cplx1(input_shapes, device):
         tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
 
-    tt_output_tensor_on_device = tt_lib.tensor.angle_bw(grad_tensor, input_tensor, True)
+    tt_output_tensor_on_device = tt_lib.tensor.complex_abs_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
-    pyt_y = torch.angle(in_data)
+    pyt_y = torch.abs(in_data)
 
     pyt_y.backward(gradient=grad_data)
 
@@ -75,11 +75,11 @@ def test_bw_complex_abs_zero_inp(input_shapes, device):
         tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
 
-    tt_output_tensor_on_device = tt_lib.tensor.angle_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = tt_lib.tensor.complex_abs_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
-    pyt_y = torch.angle(in_data)
+    pyt_y = torch.abs(in_data)
 
     pyt_y.backward(gradient=grad_data)
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_backward_complex_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_backward_complex_ops.py
@@ -1,0 +1,850 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from pathlib import Path
+import sys
+
+import torch
+
+import tt_lib as ttl
+from models.utility_functions import print_diff_argmax
+import pytest
+from loguru import logger
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal, comp_allclose
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    data_gen_with_range,
+)
+from models.utility_functions import (
+    skip_for_wormhole_b0,
+)
+from models.utility_functions import is_wormhole_b0
+from functools import partial
+from math import pi
+
+
+class Complex:
+    def __init__(self, input_shape: torch.Size = None, re=None, im=None):
+        if input_shape:
+            val = 1.0 + torch.arange(0, input_shape.numel()).reshape(input_shape).bfloat16()
+            self._cplx = val[:, :, :, : input_shape[-1] // 2] + val[:, :, :, input_shape[-1] // 2 :] * 1j
+        else:
+            self._cplx = re + im * 1j
+
+    def reset(self, val: torch.Tensor):
+        self._cplx = val
+
+    def is_imag(self):
+        return self.real == 0.0
+
+    def is_real(self):
+        return self.imag == 0.0
+
+    @property
+    def angle(self):
+        return torch.angle(self._cplx)
+
+    @property
+    def real(self):
+        return self._cplx.real
+
+    @property
+    def imag(self):
+        return self._cplx.imag
+
+    @property
+    def metal(self):
+        return torch.cat([self.real, self.imag], -1)
+
+    ## operations
+    def abs(self):
+        return (self.real**2 + self.imag**2).sqrt()
+
+    def conj(self) -> "Complex":
+        self._cplx = self._cplx.conj()
+        return self
+
+    def recip(self):
+        self._cplx = 1.0 / self._cplx
+        return self
+
+    def add(self, that: "Complex"):
+        self._cplx += that._cplx
+        return self
+
+    def sub(self, that: "Complex"):
+        self._cplx -= that._cplx
+        return self
+
+    def __mul__(self, scale):
+        self._cplx *= scale
+        return self
+
+    def mul(self, that: "Complex"):
+        self._cplx *= that._cplx
+        return self
+
+    def div(self, that: "Complex"):
+        self._cplx /= that._cplx
+        return self
+
+
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
+def convert_to_torch_tensor(tt_dev):
+    for i in range(len(tt_dev)):
+        tt_dev_r = tt_dev[i].real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        tt_dev_i = tt_dev[i].imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        tt_dev[i] = Complex(re=tt_dev_r, im=tt_dev_i).metal
+    return tt_dev
+
+
+# backward tests for type 2 complex tensor
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_conj_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.conj_bw(grad_tensor, input_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.conj(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+
+    tt_cpu = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_imag_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_data = grad_data.imag
+    grad_tensor = ttl.tensor.Tensor(
+        ttl.tensor.Tensor(grad_data, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.imag_bw(grad_tensor, input_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.imag(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+
+    tt_cpu = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_real_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_data = grad_data.real
+    grad_tensor = ttl.tensor.Tensor(
+        ttl.tensor.Tensor(grad_data, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.real_bw(grad_tensor, input_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.real(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+
+    tt_cpu = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+@pytest.mark.parametrize("alpha", [0.0, -5.0, 3.5])
+def test_level2_complex_add_bw(bs, hw, alpha, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shape, (-20, 90), (-30, 100))
+    other_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    other_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_add_bw(grad_tensor, input_tensor, other_tensor, alpha, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.add(in_data, other_data, alpha=alpha)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_in_real = torch.real(in_data.grad)
+    grad_in_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+
+    tt_cpu = [torch.cat((grad_in_real, grad_in_imag), dim=-1), torch.cat((grad_other_real, grad_other_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+@pytest.mark.parametrize("alpha", [-5.0, 1.0, 3.5])
+def test_level2_complex_sub_bw(bs, hw, alpha, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shape, (-20, 90), (-30, 100))
+    other_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    other_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_sub_bw(grad_tensor, input_tensor, other_tensor, alpha, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.sub(in_data, other_data, alpha=alpha)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_in_real = torch.real(in_data.grad)
+    grad_in_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+
+    tt_cpu = [torch.cat((grad_in_real, grad_in_imag), dim=-1), torch.cat((grad_other_real, grad_other_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_complex_mul_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shape, (-20, 90), (-30, 100))
+    other_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    other_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_mul_bw(grad_tensor, input_tensor, other_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.mul(in_data, other_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_in_real = torch.real(in_data.grad)
+    grad_in_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+
+    tt_cpu = [torch.cat((grad_in_real, grad_in_imag), dim=-1), torch.cat((grad_other_real, grad_other_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_complex_div_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shape, (-20, 90), (-30, 100))
+    other_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    other_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_div_bw(grad_tensor, input_tensor, other_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.div(in_data, other_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_in_real = torch.real(in_data.grad)
+    grad_in_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+
+    tt_cpu = [torch.cat((grad_in_real, grad_in_imag), dim=-1), torch.cat((grad_other_real, grad_other_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+@skip_for_wormhole_b0()
+def test_level2_complex_div_bw_other_zero(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shape, (0, 0), (0, 0))
+    other_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    other_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_div_bw(grad_tensor, input_tensor, other_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.div(in_data, other_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_in_real = torch.real(in_data.grad)
+    grad_in_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+
+    tt_cpu = [torch.cat((grad_in_real, grad_in_imag), dim=-1), torch.cat((grad_other_real, grad_other_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_abs_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data, grad_tensor = data_gen_with_range(input_shape, -50, 40, device)
+
+    tt_dev = ttl.tensor.complex_abs_bw(grad_tensor, input_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.abs(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+
+    tt_cpu = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_abs_bw_inp_zero(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (0, 0), (0, 0))
+    in_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data, grad_tensor = data_gen_with_range(input_shape, -50, 80, device)
+
+    tt_dev = ttl.tensor.complex_abs_bw(grad_tensor, input_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.abs(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+
+    tt_cpu = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_recip_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_recip_bw(grad_tensor, input_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.reciprocal(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+
+    tt_cpu = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+@skip_for_wormhole_b0()
+def test_level2_recip_bw_inp_zero(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (0, 0), (0, 0))
+    in_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.complex_recip_bw(grad_tensor, input_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.reciprocal(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+
+    tt_cpu = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_angle_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+    in_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data, grad_tensor = data_gen_with_range(input_shape, -50, 40, device)
+
+    tt_dev = ttl.tensor.angle_bw(grad_tensor, input_tensor, True, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.angle(in_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+
+    tt_cpu = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
+@pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
+def test_level2_polar_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    # polar_bw use polar fwd op, which uses sin and cos ops with range (0, 2*pi).
+    in_data = random_complex_tensor(input_shape, (-90, 90), (0, 2 * pi))
+    in_data.requires_grad = True
+
+    input_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+
+    grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
+    grad_tensor = ttl.tensor.complex_tensor(
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+    )
+    tt_dev = ttl.tensor.polar_bw(grad_tensor, input_tensor, memcfg)
+    in_data.retain_grad()
+
+    tt_dev = convert_to_torch_tensor(tt_dev)
+
+    pyt_y = torch.polar(in_data.real, in_data.imag)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+
+    tt_cpu = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    for i in range(len(tt_dev)):
+        if is_wormhole_b0():
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        else:
+            passing, output = comp_pcc(tt_cpu[i], tt_dev[i])
+        logger.info(output)
+        assert passing

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1773,7 +1773,8 @@ std::vector<Tensor> unary_remainder_bw(const Tensor& grad, const Tensor& input, 
   /* TT_ASSERT( input.shape()[0] == 1, "tensor should have batch size 1"); */ \
   } while(0);
 
-//complex conj
+// complex conj
+// self: grad.conj()
 std::vector<Tensor> _conj_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     CHECK_FOR_COMPLEX(input);
     CHECK_FOR_COMPLEX(grad);
@@ -1800,7 +1801,7 @@ std::vector<Tensor> _complex_recip_bw(const Tensor& grad, const Tensor& input, c
     input_i.deallocate();
     Tensor nan_flag = mk_complex(condition_nan, condition_nan, output_mem_config);
     condition_nan.deallocate();
-    Tensor grad_result = where(nan_flag, full_like(input, std::nanf(""), output_mem_config), complex_mul(neg(grad, output_mem_config), conj(complex_mul(complex_recip(input, output_mem_config), complex_recip(input, output_mem_config), output_mem_config), output_mem_config), output_mem_config)) ;
+    Tensor grad_result = where(nan_flag, full_like(input, std::nanf(""), output_mem_config), complex_mul(neg(grad, output_mem_config), conj(complex_mul(complex_recip(input, output_mem_config), complex_recip(input, output_mem_config), output_mem_config), output_mem_config), output_mem_config), output_mem_config) ;
     nan_flag.deallocate();
     grad_tensor.emplace_back(grad_result);
     return grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -10,7 +10,6 @@
 #include "tensor/tensor.hpp"
 #include "tensor/tensor_utils.hpp"
 #include "tensor/owned_buffer_functions.hpp"
-#include "tt_dnn/op_library/complex/complex_ops.hpp"
 
 
 

--- a/tt_eager/tt_dnn/op_library/complex/complex_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/complex/complex_ops.cpp
@@ -233,6 +233,186 @@ ComplexTensor polar(const ComplexTensor& input, const MemoryConfig& output_mem_c
     return ComplexTensor({r,i});
 }
 
+// backward ops for type2 complex tensor
+// complex conj
+// self: grad.conj()
+std::vector<ComplexTensor> conj_bw(const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    ComplexTensor grad_result = conj(grad, output_mem_config);
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+
+// complex imag
+// imag: at::imag(grad)
+std::vector<ComplexTensor> imag_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    Tensor r = zeros_like(real(input, output_mem_config), output_mem_config);
+    ComplexTensor grad_result = ComplexTensor({r,grad});
+    r.deallocate();
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+
+// complex real
+// real: at::real(grad)
+std::vector<ComplexTensor> real_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    Tensor i = zeros_like(real(input, output_mem_config), output_mem_config);
+    ComplexTensor grad_result = ComplexTensor({grad, i});
+    i.deallocate();
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+
+// complex add
+// self: grad, other: grad * alpha
+std::vector<ComplexTensor> complex_add_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, float alpha, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    ComplexTensor grad_a = grad;
+    grad_tensor.emplace_back(grad_a);
+    const Tensor& grad_r = grad.real();
+    const Tensor& grad_i = grad.imag();
+    ComplexTensor grad_b = ComplexTensor({mul_unary(grad_r, alpha, output_mem_config), mul_unary(grad_i, alpha, output_mem_config)});
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+
+// complex sub
+// self: grad, other: -grad * alpha
+std::vector<ComplexTensor> complex_sub_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, float alpha, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    ComplexTensor grad_a = grad;
+    grad_tensor.emplace_back(grad);
+    const Tensor& grad_r = grad.real();
+    const Tensor& grad_i = grad.imag();
+    UnaryWithParam op1 {UnaryOpType::NEG};
+    UnaryWithParam op2 {UnaryOpType::MUL_UNARY_SFPU, alpha};
+    ComplexTensor grad_b = ComplexTensor({unary_chain( grad_r, {op1, op2}, output_mem_config), unary_chain( grad_i, {op1, op2}, output_mem_config)});
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+
+// complex mul
+// grad_input = grad * other.conj()
+// grad_other = grad * input.conj()
+std::vector<ComplexTensor> complex_mul_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    ComplexTensor grad_a = complex_mul(grad, conj(other,output_mem_config), output_mem_config);
+    grad_tensor.emplace_back(grad_a);
+    ComplexTensor grad_b = complex_mul(grad, conj(input,output_mem_config), output_mem_config);
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+
+//  complex div
+//  self: grad / other.conj();
+//  other: -grad * ((self / other) / other).conj();
+std::vector<ComplexTensor> complex_div_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    Tensor condition_nan = logical_and(eqz(other.real(),output_mem_config), eqz(other.imag(),output_mem_config), std::nullopt, output_mem_config);
+    ComplexTensor grad_a = complex_div(grad, conj(other,output_mem_config), output_mem_config);
+    Tensor grad_a_r = where(condition_nan, full_like(grad.real(), std::nanf(""), output_mem_config), real(grad_a,output_mem_config),  output_mem_config);
+    Tensor grad_a_i = where(condition_nan, full_like(grad.imag(), std::nanf(""), output_mem_config), imag(grad_a,output_mem_config),  output_mem_config);
+    grad_a = ComplexTensor({grad_a_r, grad_a_i});
+    grad_a_r.deallocate();
+    grad_a_i.deallocate();
+    grad_tensor.emplace_back(grad_a);
+    ComplexTensor neg_grad = ComplexTensor({neg(grad.real(),output_mem_config), neg(grad.imag(),output_mem_config)});
+    ComplexTensor grad_b = complex_mul(neg_grad, conj(complex_div(complex_div(input, other, output_mem_config), other, output_mem_config ),output_mem_config), output_mem_config);
+    neg_grad.deallocate();
+    Tensor grad_b_r = where(condition_nan, full_like(grad.real(), std::nanf(""), output_mem_config), real(grad_b,output_mem_config),  output_mem_config);
+    Tensor grad_b_i = where(condition_nan, full_like(grad.imag(), std::nanf(""), output_mem_config), imag(grad_b,output_mem_config),  output_mem_config);
+    grad_b = ComplexTensor({grad_b_r, grad_b_i});
+    grad_b_r.deallocate();
+    grad_b_i.deallocate();
+    condition_nan.deallocate();
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+
+// complex abs
+// self: grad * self.sgn()
+std::vector<ComplexTensor> complex_abs_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    Tensor result = complex_abs(input, output_mem_config);
+    Tensor grad_inp_r = where(eqz(result, output_mem_config), zeros_like(result, output_mem_config), mul(grad, mul(input.real(), recip(result, output_mem_config), std::nullopt, output_mem_config),std::nullopt, output_mem_config), output_mem_config );
+    Tensor grad_inp_i = where(eqz(result, output_mem_config), zeros_like(result, output_mem_config), mul(grad, mul(input.imag(), recip(result, output_mem_config), std::nullopt, output_mem_config),std::nullopt, output_mem_config), output_mem_config );
+    ComplexTensor grad_inp = ComplexTensor({ grad_inp_r, grad_inp_i});
+    result.deallocate();
+    grad_inp_r.deallocate();
+    grad_inp_i.deallocate();
+    grad_tensor.emplace_back(grad_inp);
+    return grad_tensor;
+}
+
+// complex reciprocal
+// self: -grad * (result * result).conj()
+std::vector<ComplexTensor> complex_recip_bw(const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    Tensor condition_nan = logical_and(eqz(input.real(),output_mem_config), eqz(input.imag(),output_mem_config), std::nullopt, output_mem_config);
+    ComplexTensor neg_grad = ComplexTensor({neg(grad.real(),output_mem_config), neg(grad.imag(),output_mem_config)});
+    ComplexTensor inp_recip = complex_recip(input, output_mem_config);
+    ComplexTensor grad_inp = complex_mul(neg_grad, conj(complex_mul(inp_recip, inp_recip, output_mem_config), output_mem_config), output_mem_config) ;
+    neg_grad.deallocate();
+    inp_recip.deallocate();
+    Tensor grad_inp_r = where(condition_nan, full_like(input.real(), std::nanf(""), output_mem_config), grad_inp.real(), output_mem_config);
+    Tensor grad_inp_i = where(condition_nan, full_like(input.imag(), std::nanf(""), output_mem_config), grad_inp.imag(), output_mem_config);
+    condition_nan.deallocate();
+    grad_inp = ComplexTensor({ grad_inp_r, grad_inp_i});
+    grad_inp_r.deallocate();
+    grad_inp_i.deallocate();
+    grad_tensor.emplace_back(grad_inp);
+    return grad_tensor;
+}
+
+// angle at::where(self == 0.0, at::zeros({}, self.options()), grad * self / self.abs().pow(2)
+std::vector<ComplexTensor> angle_bw(const Tensor& grad, const ComplexTensor& input, bool is_complextensor, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    const Tensor &inp_r = input.real();
+    const Tensor &inp_i = input.imag();
+    Tensor condition_zero = logical_and(eqz(input.real(),output_mem_config), eqz(input.imag(),output_mem_config), std::nullopt, output_mem_config);
+    Tensor abs_squared = recip(add(square(inp_r, output_mem_config), square(inp_i, output_mem_config), std::nullopt, output_mem_config), output_mem_config);
+    Tensor res_real = where(condition_zero, zeros_like(inp_r, output_mem_config), mul(grad, mul(neg(inp_i, output_mem_config), abs_squared, std::nullopt, output_mem_config), std::nullopt, output_mem_config), output_mem_config);
+    Tensor res_imag = where(condition_zero, zeros_like(inp_i, output_mem_config), mul(grad, mul(inp_r, abs_squared, std::nullopt, output_mem_config), std::nullopt, output_mem_config), output_mem_config);
+    condition_zero.deallocate();
+    abs_squared.deallocate();
+    ComplexTensor grad_result = ComplexTensor({res_real, res_imag});
+    res_real.deallocate();
+    res_imag.deallocate();
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+
+
+// polar
+// grad_abs = torch.real(grad_conj * torch.sgn(result))
+// result_mul_1_j = result * torch.tensor(0.0 + 1.0j)
+// grad_angle = torch.real(grad_conj * result_mul_1_j)
+// polar fwd op uses sin and cos hence input_b range is (0, 2*pi)
+std::vector<ComplexTensor> polar_bw(const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<ComplexTensor> grad_tensor;
+    ComplexTensor result = polar(input, output_mem_config);
+    Tensor abs_result = complex_abs(result, output_mem_config);
+    Tensor sgn_result_r = where(eqz(abs_result, output_mem_config), zeros_like(result.real(), output_mem_config), mul(result.real(), recip(abs_result, output_mem_config), std::nullopt, output_mem_config), output_mem_config );
+    Tensor sgn_result_i = where(eqz(abs_result, output_mem_config), zeros_like(result.imag(), output_mem_config), mul(result.imag(), recip(abs_result, output_mem_config), std::nullopt, output_mem_config), output_mem_config );
+    abs_result.deallocate();
+    ComplexTensor sgn_result = ComplexTensor({ sgn_result_r, sgn_result_i });
+    sgn_result_r.deallocate();
+    sgn_result_i.deallocate();
+    Tensor grad_abs = real(complex_mul(conj(grad, output_mem_config), sgn_result, output_mem_config), output_mem_config);
+    sgn_result.deallocate();
+    ComplexTensor flip_tensor = ComplexTensor({zeros_like(input.real(), output_mem_config), full_like(input.imag(), 1.0, output_mem_config) });
+    Tensor grad_angle = real(complex_mul(conj(grad, output_mem_config), complex_mul(result, flip_tensor, output_mem_config), output_mem_config), output_mem_config);
+    result.deallocate();
+    flip_tensor.deallocate();
+    ComplexTensor grad_result = ComplexTensor({grad_abs, grad_angle});
+    grad_abs.deallocate();
+    grad_angle.deallocate();
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+
 }//namespace tt_metal
 
 }//namespace tt

--- a/tt_eager/tt_dnn/op_library/complex/complex_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/complex/complex_ops.hpp
@@ -92,6 +92,19 @@ ComplexTensor complex_recip(const ComplexTensor& input, const MemoryConfig& outp
 Tensor polar(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 ComplexTensor polar(const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+//backward
+std::vector<ComplexTensor> conj_bw(const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> imag_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> real_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> complex_add_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, float alpha = 1.0, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> complex_sub_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, float alpha = 1.0, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> complex_mul_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> complex_div_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> complex_abs_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> complex_recip_bw(const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> angle_bw(const Tensor& grad, const ComplexTensor& input, bool is_complextensor = true, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<ComplexTensor> polar_bw(const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 } //namespace tt_metal
 
 } //namespace tt

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -27,7 +27,7 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("conj_bw", &tt::tt_metal::conj_bw,
+    m_tensor.def("conj_bw", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&conj_bw),
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for conjugate for complex tensor ``input`` with given ``grad``
 
@@ -1961,7 +1961,7 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("imag_bw", &tt::tt_metal::imag_bw,
+    m_tensor.def("imag_bw", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&imag_bw),
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for imaginary part of complex tensor ``input`` with given ``grad``
 
@@ -1977,7 +1977,7 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("real_bw", &tt::tt_metal::real_bw,
+    m_tensor.def("real_bw", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&real_bw),
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for real part of complex tensor ``input`` with given ``grad``
 
@@ -2005,8 +2005,8 @@ namespace tt::tt_metal::detail{
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
                 "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
-                "input_a", "absolute value of the complex tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
-                "input_b", "angle of the complex tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input_a", "absolute value of the complex tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input_b", "angle of the complex tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -1040,6 +1040,189 @@ namespace tt::tt_metal::detail{
 	        R"doc(Returns addition of a complex division of ``{0}`` by ``{1}``.)doc"
         );
 
+        // complex type2 - backward
+        m_tensor.def("imag_bw", py::overload_cast<const Tensor&, const ComplexTensor&, const MemoryConfig&>(&imag_bw),
+                py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+                Performs backward operations for imaginary part of complex tensor ``input`` with given ``grad``
+
+                Input tensors must have BFLOAT16 data type.
+
+                Output tensor will have BFLOAT16 data type.
+
+                .. csv-table::
+                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                    "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                    "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+            )doc");
+
+        m_tensor.def("real_bw", py::overload_cast<const Tensor&, const ComplexTensor&, const MemoryConfig&>(&real_bw),
+                py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+                Performs backward operations for real part of complex tensor ``input`` with given ``grad``
+
+                Input tensors must have BFLOAT16 data type.
+
+                Output tensor will have BFLOAT16 data type.
+
+                .. csv-table::
+                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                    "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                    "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+            )doc");
+
+        m_tensor.def("conj_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&conj_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = std::nullopt, R"doc(
+            Performs backward operations for conjugate for complex tensor ``input`` with given ``grad``
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("complex_add_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, float, const MemoryConfig&>(&complex_add_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for addition of  complex tensors``input`` and ``other`` with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "First input tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "other", "Second input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "alpha", "Alpha value", "float", "default to 1.0f", "No"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("complex_sub_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, float, const MemoryConfig&>(&complex_sub_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for subtraction of  complex tensors``input`` and ``other`` with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "First input tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "other", "Second input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "alpha", "Alpha value", "float", "default to 1.0f", "No"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("complex_mul_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&complex_mul_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for multiplication of complex tensors``input`` and ``other`` with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "First input tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "other", "Second input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("complex_div_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&complex_div_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for division of complex tensors``input`` and ``other`` with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "First input tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "other", "Second input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("complex_abs_bw", py::overload_cast<const Tensor&, const ComplexTensor&, const MemoryConfig&>(&complex_abs_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for abs of complex ``input`` tensor with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor add is applied to", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("complex_recip_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&complex_recip_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for reciprocal of complex tensor ``input`` with given ``grad``
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("angle_bw", py::overload_cast<const Tensor&, const ComplexTensor&, bool, const MemoryConfig&>(&angle_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("is_complextensor").noconvert() = true, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+                Performs backward operations for angle for the ``input`` with given ``grad``
+
+                Input tensors must have BFLOAT16 data type.
+
+                Output tensor will have BFLOAT16 data type.
+
+                .. csv-table::
+                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                    "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                    "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                    "is_complextensor", "True(default) if input is complex tensor", "bool", "True/False", "No"
+                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+            )doc");
+
+    m_tensor.def("polar_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&polar_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(),  py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for polar ``input`` with given ``grad``
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "Input complex tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
         //loss functions
         m_tensor.def("mseloss",
 		    py::overload_cast<const Tensor&,const Tensor&,const LossReductionMode,const MemoryConfig&>(tt::tt_metal::mseloss),


### PR DESCRIPTION
Add backward support for complex type-2 tensor. 
CI test : https://github.com/tenstorrent-metal/tt-metal/actions/runs/8629637019
https://github.com/tenstorrent/tt-metal/actions/runs/8793323704
https://github.com/tenstorrent/tt-metal/actions/runs/8795902148