### PR TITLE
#7237: Use bfloat8 MLP weights in Mamba SSM block

### DIFF
--- a/models/experimental/mamba/demo/demo.py
+++ b/models/experimental/mamba/demo/demo.py
@@ -8,6 +8,8 @@ from typing import List
 from loguru import logger
 import ttnn
 
+import pytest
+
 import torch
 
 from transformers import AutoTokenizer
@@ -36,6 +38,7 @@ def get_tt_metal_model(version: MambaPretrainedModelName, use_cache: bool, batch
         cache_path = ""
     model = MambaTT(reference_model, device, tt_cache_path=cache_path)
     return model, device
+
 
 def get_tt_opt_metal_model(version: MambaPretrainedModelName, use_cache: bool, batch_size: int):
     from models.experimental.mamba.tt_opt.full_model import MambaTT
@@ -155,6 +158,30 @@ def run_demo(
     if device is not None:
         ttnn.close_device(device)
     return all_decoded_sequences
+
+
+@pytest.mark.parametrize(
+    "prompt, model_type, model_version, batch, genlen",
+    (
+        (
+            "Hello",
+            "wh-opt",
+            "state-spaces/mamba-2.8b",
+            32,
+            50,
+        ),
+    ),
+)
+def test_demo(prompt: str, model_type: str, model_version: MambaPretrainedModelName, batch: int, genlen: int):
+    prompts = [prompt for _ in range(batch)]
+    run_demo(
+        prompts,
+        model_type,
+        generated_sequence_length=genlen,
+        model_version=model_version,
+        display=True,
+        use_cache=True,
+    )
 
 
 def main():

--- a/models/experimental/mamba/tt_opt/mamba_one_step_ssm.py
+++ b/models/experimental/mamba/tt_opt/mamba_one_step_ssm.py
@@ -22,7 +22,7 @@ class TtMambaSSM(torch.nn.Module):
         self.args = args
 
         # hidden state
-        self.num_users = args.batch_size
+        self.batch_size = args.batch_size
         self.hidden_size = args.d_inner
         self.configs = configs
         self.n = 16
@@ -84,7 +84,7 @@ class TtMambaSSM(torch.nn.Module):
             # padding with inf
             # x = F.pad(x, (0, 16), "constant", float("-inf"))
             x = x.reshape(1, self.hidden_size * self.n)  # (1, 2en)
-            return x.repeat(self.num_users, 1)  # b, 2en
+            return x.repeat(self.batch_size, 1)  # b, 2en
 
         self.A = load_fn(A_weight_name, tm_fn=preprocess_A, postfix=f"A_{self.args.batch_size}")
 
@@ -97,7 +97,7 @@ class TtMambaSSM(torch.nn.Module):
         )
 
         # hidden state
-        prev_hidden_states = torch.zeros((1, 1, self.num_users, self.hidden_size * self.n))
+        prev_hidden_states = torch.zeros((1, 1, self.batch_size, self.hidden_size * self.n))
         self.tt_hidden_state = load_fn(f"tt_hidden_state_{args.batch_size}", torch_tensor=prev_hidden_states)
 
         self.compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(


### PR DESCRIPTION
This change consists of two commits:
- Use bfloat8 MLP weights in Mamba SSM block to improve runtime performance. This doesn't appear affect overall model PCC.
- Rename all instances of `num_users` to `batch_size`. We are using the terms interchangeably around the codebase, this attempts to make things more consistent.