### PR TITLE
Nsmith/unet perf

### DIFF
--- a/models/experimental/functional_unet/tt/ttnn_shallow_unet.py
+++ b/models/experimental/functional_unet/tt/ttnn_shallow_unet.py
@@ -114,7 +114,7 @@ class UNet:
         output_tensor = self.c1(input_tensor)
         output_tensor = self.c1_2(output_tensor)
         if perf_mode:
-            save_c1_2_out = output_tensor
+            save_c1_2_out = ttnn.to_layout(output_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
         else:
             save_c1_2_out = ttl.tensor.sharded_to_interleaved(
                 output_tensor, ttnn.DRAM_MEMORY_CONFIG, output_dtype=ttl.tensor.DataType.BFLOAT16
@@ -253,7 +253,6 @@ class UNet:
         output_tensor = ttnn.reshape(output_tensor, (1, 1, nhw, output_tensor.shape[-1]))
 
         profiler.tracy_message("concat4")
-        save_c1_2_out = ttnn.to_layout(save_c1_2_out, layout=ttnn.ROW_MAJOR_LAYOUT)
         output_tensor = unet_concat([output_tensor, save_c1_2_out], dim=-1, perf_mode=perf_mode)
 
         profiler.tracy_message("c8")

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_multi_core.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_multi_core.py
@@ -165,7 +165,7 @@ def test_run_optimized_conv(
             ttl.tensor.MathFidelity.HiFi4,
             ttl.tensor.OptimizedConvParallelizationConfig(
                 grid_size=(num_cores_x, num_cores_y),
-                num_cores_nhw=num_cores_x,
+                num_cores_nhw=num_cores_y,
                 per_core_out_matrix_height_ntiles=per_core_out_matrix_h_ntiles,
                 per_core_out_matrix_width_ntiles=per_core_weight_matrix_w_ntiles,
             ),

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_v2.py
@@ -259,8 +259,8 @@ def test_simple(
     batch_size = 1
     output_channels = 128
     input_channels = 128
-    input_height = 16
-    input_width = 16
+    input_height = 17
+    input_width = 17
     filter_height = 3
     filter_width = 3
     stride_h = 2
@@ -270,8 +270,8 @@ def test_simple(
     is_1d_systolic = False
     untilize_out = False
     bias = False
-    config = None  # {"act_reshard_num_cores_nhw": 2}
-    debug = True
+    config = {"num_cores_nhw": 2}
+    debug = False
     fuse_relu = False
 
     assert output_channels % 32 == 0
@@ -370,7 +370,7 @@ def test_simple(
     )
 
     # Remove the else block when resolved (https://github.com/tenstorrent-metal/tt-metal/issues/6310):
-    if is_1d_systolic:
+    if False and is_1d_systolic:
         conv_input = conv_input.to(device, conv.input_sharded_memory_config)
     else:
         interleaved_mem_config = tt_lib.tensor.MemoryConfig(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_first_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_first_conv.py
@@ -53,6 +53,7 @@ def test_resnet50_first_conv(
     fuse_relu,
     sharded_out,
 ):
+    pytest.skip("This conv path is deprecated and will be removed during conv refactor efforts")
     compute_grid_size = device.compute_with_storage_grid_size()
     is_e75_grid_size = (compute_grid_size.x * compute_grid_size.y) == 88
     if N == 8 and is_e75_grid_size:

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv_v2.py
@@ -16,6 +16,7 @@ from models.demos.resnet.tt.metalResnetBlock50 import (
     _nearest_y,
     format_tensor,
 )
+from models.utility_functions import skip_for_grayskull
 
 from tt_eager.tt_dnn.op_library.sliding_window_op_infra.tt_py_composite_conv import (
     TTPyCompositeConv,
@@ -411,6 +412,7 @@ hardcoded_conv_blocking_and_parallelization_config = {
 }
 
 
+@skip_for_grayskull()
 @pytest.mark.parametrize("N", (8, 16, 20), ids=["batch_8", "batch_16", "batch_20"])
 @pytest.mark.parametrize(
     "K, C, H, W, R, S, stride_h, stride_w, pad_h, pad_w",

--- a/tests/ttnn/integration_tests/unet/test_ttnn_shallow_unet.py
+++ b/tests/ttnn/integration_tests/unet/test_ttnn_shallow_unet.py
@@ -511,7 +511,7 @@ class UNet(nn.Module):
 
 
 @pytest.mark.parametrize("loop", [0])
-@pytest.mark.parametrize("perf_mode, groups", [(False, 1)])  # , (True, 1), (True, 2)])
+@pytest.mark.parametrize("perf_mode, groups", [(False, 1), (True, 1)])  # , (True, 2)])
 def test_unet(device, loop, perf_mode, groups):
     with torch.no_grad():
         torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_conv2d.py
@@ -1178,3 +1178,60 @@ def test_halo_reshard_conv(
         use_1d_systolic_array,
         config_override,
     )
+
+
+@pytest.mark.parametrize(
+    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, config_override, xfail",
+    (
+        (1, 128, 128, 17, 17, 3, 3, 1, 1, 1, 1, {"num_cores_nhw": 4}, False),
+        (1, 128, 128, 17, 17, 3, 3, 2, 2, 1, 1, {"num_cores_nhw": 2}, False),
+        (2, 64, 64, 16, 16, 3, 3, 1, 1, 1, 1, {"num_cores_nhw": 3}, False),
+        (2, 64, 64, 23, 23, 3, 3, 2, 2, 1, 1, {"num_cores_nhw": 3}, False),
+        (1, 64, 64, 23, 23, 3, 3, 1, 1, 1, 1, {"num_cores_nhw": 10}, True),
+    ),
+)
+@pytest.mark.parametrize("use_1d_systolic_array", [False, True])
+def test_conv_core_nondivis(
+    device,
+    use_program_cache,
+    use_1d_systolic_array,
+    batch_size,
+    output_channels,
+    input_channels,
+    input_height,
+    input_width,
+    filter_height,
+    filter_width,
+    stride_h,
+    stride_w,
+    pad_h,
+    pad_w,
+    config_override,
+    xfail,
+):
+    if xfail:
+        pytest.xfail()
+
+    math_fidelity = ttnn.MathFidelity.HiFi4
+    activations_dtype = ttnn.bfloat16
+    weights_dtype = ttnn.bfloat8_b
+
+    run_conv(
+        device,
+        math_fidelity,
+        activations_dtype,
+        weights_dtype,
+        batch_size,
+        output_channels,
+        input_channels,
+        input_height,
+        input_width,
+        filter_height,
+        filter_width,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        use_1d_systolic_array,
+        config_override,
+    )

--- a/tests/ttnn/unit_tests/operations/test_max_pool2d.py
+++ b/tests/ttnn/unit_tests/operations/test_max_pool2d.py
@@ -179,7 +179,6 @@ def test_run_max_pool(
 
     out_pytorch_padded = ttnn.to_torch(out_padded)
     out_pytorch = out_pytorch_padded[:, :, :, :in_c]
-    out_pytorch = torch.permute(out_pytorch, (0, 3, 1, 2))  ## N, C, 1, HW
 
     ## reference
     golden_pytorch = torch.nn.MaxPool2d(
@@ -192,7 +191,9 @@ def test_run_max_pool(
     )(act)
 
     ## test for equivalance
-    out_pytorch = out_pytorch.reshape(golden_pytorch.shape)
+    golden_shape = golden_pytorch.shape
+    out_pytorch = out_pytorch.reshape(golden_shape[0], golden_shape[2], golden_shape[3], golden_shape[1])
+    out_pytorch = torch.permute(out_pytorch, (0, 3, 1, 2))  ## N, C, H, W
     assert_with_pcc(out_pytorch, golden_pytorch)
 
     ## do more rigorous comparision for each element
@@ -208,3 +209,81 @@ def test_run_max_pool(
     assert isclose
     if dtype == ttnn.bfloat16:
         assert isequal
+
+
+@pytest.mark.parametrize(
+    "batch_size, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, config_override, xfail",
+    (
+        (1, 32, 9, 9, 3, 3, 1, 1, 1, 1, {"num_cores_nhw": 2, "snap_to_tile": True}, False),
+        (1, 32, 17, 17, 3, 3, 1, 1, 1, 1, {"num_cores_nhw": 4, "snap_to_tile": True}, False),
+        (1, 32, 17, 17, 3, 3, 2, 2, 1, 1, {"num_cores_nhw": 2, "snap_to_tile": True}, False),
+        (2, 32, 16, 16, 3, 3, 1, 1, 1, 1, {"num_cores_nhw": 3, "snap_to_tile": True}, False),
+        (2, 32, 23, 23, 3, 3, 2, 2, 1, 1, {"num_cores_nhw": 3, "snap_to_tile": True}, False),
+        (1, 32, 23, 23, 3, 3, 1, 1, 1, 1, {"num_cores_nhw": 10, "snap_to_tile": True}, True),
+    ),
+)
+def test_pool_core_nondivis(
+    device,
+    use_program_cache,
+    batch_size,
+    input_channels,
+    input_height,
+    input_width,
+    filter_height,
+    filter_width,
+    stride_h,
+    stride_w,
+    pad_h,
+    pad_w,
+    config_override,
+    xfail,
+):
+    if xfail:
+        pytest.xfail()
+
+    torch.manual_seed(0)
+
+    if True:
+        v = batch_size * input_height * input_width
+        act = (
+            torch.arange(v, dtype=torch.bfloat16)
+            .repeat(input_channels)
+            .reshape(input_channels, batch_size, input_height, input_width)
+            .permute(1, 0, 2, 3)
+        )
+    else:
+        act = torch.randn((batch_size, input_channels, input_height, input_width), dtype=torch.bfloat16)
+    golden = torch.nn.functional.max_pool2d(
+        act, (filter_height, filter_width), stride=(stride_h, stride_w), padding=(pad_h, pad_w)
+    )
+
+    act_permuted = torch.permute(act, (0, 2, 3, 1))
+    act_reshaped = act_permuted.reshape(batch_size, 1, input_height * input_width, input_channels)
+
+    reader_patterns_cache = {}
+    max_pool = ttnn.MaxPool2d(
+        kernel_size=(filter_height, filter_width),
+        stride=(stride_h, stride_w),
+        padding=(pad_h, pad_w),
+        dtype=ttnn.bfloat16,
+        device=device,
+        batch_size=batch_size,
+        input_height=input_height,
+        input_width=input_width,
+        reader_patterns_cache=reader_patterns_cache,
+        parallel_config_override=config_override,
+    )
+
+    ttact = ttnn.from_torch(act_reshaped, ttnn.bfloat16)
+    ttact_d = max_pool.copy_input_to_device(ttact)
+    out_d = max_pool(ttact_d)
+    out_padded = max_pool.copy_output_from_device(out_d)
+    out_pytorch_padded = ttnn.to_torch(out_padded)
+    out_pytorch = out_pytorch_padded[:, :, :, :input_channels]
+    out_pytorch = out_pytorch.reshape(golden.shape[0], golden.shape[2], golden.shape[3], golden.shape[1])
+    out_pytorch = torch.permute(out_pytorch, (0, 3, 1, 2))  ## N, C, H, W
+
+    ## test for equivalance
+    out_pytorch = out_pytorch.reshape(golden.shape)
+    assert_with_pcc(out_pytorch, golden)
+    assert torch.allclose(out_pytorch, golden)

--- a/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
@@ -136,7 +136,8 @@ std::vector<Shape> OptimizedConv::compute_output_shapes(const std::vector<Tensor
     // Tiled output shape is padded shape. Padded to tile shape.
     auto shape_w = batch_size * conv_output_h * conv_output_w;
     auto shape_c = output_channels;
-    auto padded_shape_w = round_up(shape_w, TILE_HEIGHT);
+    auto padded_shape_w =
+        parallelization_config.num_cores_nhw * parallelization_config.per_core_out_matrix_height_ntiles * TILE_WIDTH;
     auto padded_shape_c = round_up(this->output_channels, TILE_WIDTH);
     auto output_padding = Padding(
         {{0, 0}, {0, 0}, {0, (padded_shape_w - shape_w)}, {0, (padded_shape_c - shape_c)}}, Padding::PadValue::Zero);

--- a/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
@@ -137,7 +137,7 @@ std::vector<Shape> OptimizedConv::compute_output_shapes(const std::vector<Tensor
     auto shape_w = batch_size * conv_output_h * conv_output_w;
     auto shape_c = output_channels;
     auto padded_shape_w =
-        parallelization_config.num_cores_nhw * parallelization_config.per_core_out_matrix_height_ntiles * TILE_WIDTH;
+        parallelization_config.num_cores_nhw * parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT;
     auto padded_shape_c = round_up(this->output_channels, TILE_WIDTH);
     auto output_padding = Padding(
         {{0, 0}, {0, 0}, {0, (padded_shape_w - shape_w)}, {0, (padded_shape_c - shape_c)}}, Padding::PadValue::Zero);

--- a/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_max_pool.py
+++ b/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_max_pool.py
@@ -56,6 +56,8 @@ class TTPyMaxPool(TTPyOp):
                 key == "max_pool" or key == "halo" or key == "conv"
             ), f"reader_patterns_cache should have 1 of the following keys - 'conv', 'max_pool' or 'halo'. Found key - {key}"
 
+        snap_to_tile = parallel_config_override.get("snap_to_tile", False)
+        df_needs_tiled = act_dtype is not None and act_dtype == ttl.tensor.DataType.BFLOAT8_B
         conv_parallel_config = determine_parallel_config(
             True,
             0,
@@ -63,7 +65,7 @@ class TTPyMaxPool(TTPyOp):
             sliding_window_op_params,
             device,
             config_override=parallel_config_override,
-            is_out_tiled=True if act_dtype is not None and act_dtype == ttl.tensor.DataType.BFLOAT8_B else False,
+            is_out_tiled=snap_to_tile or df_needs_tiled,
         )
         self.grid_size = (conv_parallel_config.grid_size.x, conv_parallel_config.grid_size.y)
         self.ncores_nhw = conv_parallel_config.num_cores_nhw
@@ -94,6 +96,25 @@ class TTPyMaxPool(TTPyOp):
 
         self.device = device
 
+        self.input_sharded_memory_config = calculate_memory_config(
+            self.sliding_window_op_params,
+            True,
+            0 if channels is None else channels,
+            calc_input=True,
+            tile_size=32 if snap_to_tile else 1,
+        )
+        self.output_sharded_memory_config = (
+            calculate_memory_config(
+                self.sliding_window_op_params,
+                True,
+                0 if channels is None else channels,
+                calc_input=False,
+                tile_size=32 if snap_to_tile else 1,
+            )
+            if output_mem_config is None
+            else output_mem_config
+        )
+
         self.set_op_configs(
             sliding_window_op_params_hash,
             reader_patterns_cache["max_pool"],
@@ -103,7 +124,6 @@ class TTPyMaxPool(TTPyOp):
 
         self.set_op_weights_biases(
             self.sliding_window_op_params,
-            output_mem_config,
             reader_indices,
         )
 
@@ -113,22 +133,10 @@ class TTPyMaxPool(TTPyOp):
             self.sliding_window_op_params,
             reader_patterns_cache["halo"],
             pad_val=self.pad_val,
-            is_out_tiled=False,
+            is_out_tiled=snap_to_tile,
         )
 
         self.deallocate_activation = deallocate_activation
-        self.input_sharded_memory_config = calculate_memory_config(
-            self.sliding_window_op_params,
-            True,
-            0 if channels is None else channels,
-            calc_input=True,
-        )
-        self.output_sharded_memory_config = calculate_memory_config(
-            self.sliding_window_op_params,
-            True,
-            0 if channels is None else channels,
-            calc_input=False,
-        )
 
     # override abstract methods from base class TTPyOp
     def set_op_configs(self, sliding_window_op_params_hash, reader_patterns_cache):
@@ -142,25 +150,13 @@ class TTPyMaxPool(TTPyOp):
             batch_size = self.sliding_window_op_params.batch_size
             input_h = self.sliding_window_op_params.input_h
             input_w = self.sliding_window_op_params.input_w
-
             ncores_h = self.sliding_window_op_params.num_cores_h
             ncores_w = self.sliding_window_op_params.num_cores_w
             ncores_nhw = self.sliding_window_op_params.num_cores_nhw
 
             input_nchw_shape = [batch_size, 1, input_h, input_w]
-            input_volume = batch_size * input_h * input_w
-            output_h = ((int)((input_h + (2 * pad_h) - window_h) / stride_h)) + 1
-            output_w = ((int)((input_w + (2 * pad_w) - window_w) / stride_w)) + 1
-            output_volume = batch_size * output_h * output_w
-
-            # input_size_to_shard_evenly = _nearest_y(input_volume, ncores_nhw * 32)
-            assert input_volume % ncores_nhw == 0
-            input_shard_height = input_volume // ncores_nhw
-
-            # output_size_to_shard_evenly = _nearest_y(output_volume, ncores_nhw * 32)
-            assert output_volume % ncores_nhw == 0
-            output_shard_height = output_volume // ncores_nhw
-
+            input_shard_height = self.input_sharded_memory_config.shard_spec.shape[0]
+            output_shard_height = self.output_sharded_memory_config.shard_spec.shape[0]
             input_padded_width = input_w + 2 * pad_w
 
             pad_metadata, data_top_left_indices = trace_conv_to_generate_data_top_left_indices_and_pad_metadata(
@@ -207,7 +203,7 @@ class TTPyMaxPool(TTPyOp):
 
         return
 
-    def set_op_weights_biases(self, op_params, output_mem_config, reader_indices):
+    def set_op_weights_biases(self, op_params, reader_indices):
         stride_h = op_params.stride_h
         stride_w = op_params.stride_w
         pad_h = op_params.pad_h
@@ -236,7 +232,7 @@ class TTPyMaxPool(TTPyOp):
                 stride_w,
                 pad_h,
                 pad_w,
-                output_mem_config=act_mem_config if output_mem_config is None else output_mem_config,
+                output_mem_config=self.output_sharded_memory_config,
             )
             haloed_act.deallocate()
             return output
@@ -247,53 +243,38 @@ class TTPyMaxPool(TTPyOp):
         return self.max_pool(activation)
 
     def copy_input_to_device(self, input: ttl.tensor.Tensor):
-        interleaved_mem_config = ttl.tensor.MemoryConfig(
-            ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
-        )
         in_shape = input.get_legacy_shape()
         in_c = in_shape[-1]
         in_n = self.sliding_window_op_params.batch_size
         in_h = self.sliding_window_op_params.input_h
         in_w = self.sliding_window_op_params.input_w
-        assert in_c % 16 == 0, "Input channels should be multiple of 32. General case is TODO"
+        assert in_c % 16 == 0, "Input channels should be multiple of 16. General case is TODO"
+        act_shape = (1, 1, in_n * in_h * in_w, in_c)
+        act_reshaped = input.reshape(act_shape)
+        padded_nhw = self.input_sharded_memory_config.shard_spec.shape[0] * self.sliding_window_op_params.num_cores_nhw
+        if padded_nhw != act_shape[-2]:
+            padded_shape = ttl.tensor.Shape(act_shape, (1, 1, padded_nhw, in_c))
+            act_reshaped = ttl.tensor.format_input_tensor(
+                act_reshaped,
+                self.device,
+                padded_shape,
+                -float("inf"),
+                act_reshaped.layout,
+            )
 
-        ## this op expects input tensor as { N, 1, H * W, C } or { 1, 1, N * H * W, C }
-
-        in_hw = in_h * in_w
-        if input.get_dtype() == ttl.tensor.DataType.BFLOAT8_B:
-            ## currently the case when the input is bfp8_b and height is not divible by tile height is not supported. TODO.
-            assert in_hw % 32 == 0, "For BFP8_B datatype, input height * width should be multiple of 32"
-            ## last two dims are multiple of tile size (padded if needed)
-            in_hw_padded = _nearest_32(in_hw)
-            assert in_hw_padded == in_shape[1] * in_shape[2] or in_hw_padded == in_shape[0] * in_shape[1] * in_shape[2]
-            act_shape = (in_n, 1, in_hw_padded, in_c)
-        else:
-            act_shape = (in_n, 1, in_hw, in_c)
-
-        act_reshaped = input.reshape(act_shape).to(self.device, interleaved_mem_config)
-
-        # padded_shape = ttl.tensor.pad_to_tile_shape(act_reshaped.get_legacy_shape(), False, False, False, True)
-        # act_reshaped = ttl.tensor.format_input_tensor(
-        #             act_reshaped,
-        #             self.device,
-        #             padded_shape,
-        #             0.0,
-        #             ttl.tensor.Layout.ROW_MAJOR,
-        #             interleaved_mem_config,
-        #         )
-
-        shard_shape = [in_n * in_hw // self.sliding_window_op_params.num_cores_nhw, in_c]
-        act_sharded = ttl.tensor.interleaved_to_sharded(
-            act_reshaped,
-            self.grid_size,
-            shard_shape,
-            self.shard_layout,
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
+        interleaved_mem_config = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
         )
-
-        if self.deallocate_activation:
-            act_reshaped.deallocate()
-        return act_sharded
+        mem_config = self.input_sharded_memory_config
+        shard_shape = mem_config.shard_spec.shape
+        shard_shape[1] = in_c
+        mem_config.shard_spec.shape = shard_shape
+        act_reshaped = act_reshaped.to(self.device, interleaved_mem_config)
+        return ttl.tensor.interleaved_to_sharded(
+            act_reshaped,
+            mem_config,
+            input.get_dtype(),
+        )
 
     def copy_output_from_device(self, output_d: ttl.tensor.Tensor):
         interleaved_mem_config = ttl.tensor.MemoryConfig(


### PR DESCRIPTION
#0: conv support for non-divisible tensor nhw on core grid

Just a few minor fixes to some calculations that enables support for the
tensor shape, nhw, to be auto-padded to fit the desired core grid.  This
is especially useful to avoid costly reshards.

#0: Support nhw core override for maxpool with auto-pad support

This also changes the compute shape of maxpool from [n, 1, hw, c] to
match conv, [1, 1, nhw, c]