### PR TITLE
#7078: This is a refactor to better handle optional output tensors

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -95,8 +95,8 @@ and create_output_tensors with the additional parameter for the output_tensors.
     struct <NewOperation> {
         void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
         std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
-        std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-        operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
+        std::vector<std::optional<Tensor>> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+        operation::ProgramWithOptionalOutputTensors create_program(const std::vector<Tensor>& input_tensors, std::vector<std::optional<Tensor>> &output_tensors) const;
 
         static constexpr auto attribute_names = std::make_tuple();
         const auto attribute_values() const {

--- a/docs/source/ttnn/ttnn/usage.rst
+++ b/docs/source/ttnn/ttnn/usage.rst
@@ -309,7 +309,7 @@ Open the visualizer by running the following command:
 
 .. code-block:: bash
 
-    flask --app ttnn/visualizer run
+    python ttnn/visualizer/app.py
 
 
 

--- a/tt_eager/queue/queue.cpp
+++ b/tt_eager/queue/queue.cpp
@@ -22,12 +22,13 @@ void EnqueueDeviceToHostTransfer(
 
 void QueueSynchronize(CommandQueue& q) { Finish(q); }
 
-std::vector<Tensor> EnqueueOperation(
+template<class OutputTensors=tt_metal::operation::Tensors>
+OutputTensors EnqueueOperation(
     CommandQueue& queue,
-    operation::DeviceOperation& devop,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    const std::vector<std::optional<Tensor>>& optional_output_tensors) {
+    operation::DeviceOperation<OutputTensors>& devop,
+    const tt_metal::operation::Tensors& input_tensors,
+    const tt_metal::operation::OptionalConstTensors& optional_input_tensors,
+    const tt_metal::operation::OptionalTensors& optional_output_tensors) {
     return operation::run(queue, devop, input_tensors, optional_input_tensors, optional_output_tensors);
 }
 }

--- a/tt_eager/queue/queue.hpp
+++ b/tt_eager/queue/queue.hpp
@@ -8,13 +8,11 @@
 #include <vector>
 #include "tt_eager/tensor/tensor.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
+#include "tt_dnn/op_library/operation.hpp"
 
 namespace tt::tt_metal {
 
 class Event;
-namespace operation{
-   class DeviceOperation;
-}
 
 void EnqueueHostToDeviceTransfer(
     CommandQueue&, Tensor& dst, const void* src, const std::optional<std::size_t> transfer_size = std::nullopt);
@@ -31,12 +29,13 @@ void EnqueueWaitForEvent(CommandQueue&, std::shared_ptr<Event>);
 void EventSynchronize(std::shared_ptr<Event>);
 void QueueSynchronize(CommandQueue&);
 
-std::vector<Tensor> EnqueueOperation(
+template<class OutputTensors=tt_metal::operation::Tensors>
+OutputTensors EnqueueOperation(
     CommandQueue&,
-    operation::DeviceOperation&,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {});
+    operation::DeviceOperation<OutputTensors>&,
+    const tt_metal::operation::Tensors& input_tensors,
+    const tt_metal::operation::OptionalConstTensors& optional_input_tensors = {},
+    const tt_metal::operation::Tensors& optional_output_tensors = {});
 }
 
 // Future APIs to be added later

--- a/tt_eager/tt_dnn/op_library/operation.hpp
+++ b/tt_eager/tt_dnn/op_library/operation.hpp
@@ -30,22 +30,86 @@ static Hash hash_operation(const Types&... objects) {
 using OverrideAddressesCallback =
     std::function<void(const Program&, const std::vector<Buffer*>&, const std::vector<Buffer*>&)>;
 
+using Tensors = std::vector<Tensor>;
+using OptionalTensors = std::vector<std::optional<Tensor>>;
+using OptionalConstTensors = std::vector<std::optional<const Tensor>>;
+
+template<typename OutputTensors = Tensors>
 using OverrideRuntimeArgumentsCallback = std::function<void(
     const void* operation,
     Program&,
-    const std::vector<Tensor>&,
-    const std::vector<std::optional<const Tensor>>&,
-    const std::vector<Tensor>&)>;
+    const Tensors&,
+    const OptionalConstTensors&,
+    const OutputTensors&)>;
 
-struct ProgramWithCallbacks {
+template<typename OutputTensors = Tensors>
+struct CacheableProgram {
     Program program{};
     std::optional<OverrideAddressesCallback> override_addresses_callback = std::nullopt;
-    std::optional<OverrideRuntimeArgumentsCallback> override_runtime_arguments_callback = std::nullopt;
+    std::optional<OverrideRuntimeArgumentsCallback<OutputTensors>> override_runtime_arguments_callback = std::nullopt;
 
     bool supports_program_cache() const {
         return this->override_addresses_callback.has_value() or this->override_runtime_arguments_callback.has_value();
     }
 };
+
+template <typename... Args>
+struct last_type;
+
+template <typename T>
+struct last_type<T> {
+    using type = T;
+};
+
+template <typename First, typename... Rest>
+struct last_type<First, Rest...> : last_type<Rest...> {};
+
+// An alias template to map to a function
+template <class TReturn, class... TArgs>
+using fn = TReturn(TArgs...) const;
+
+template <class FnPtr>
+struct function_traits;
+
+// "T::" means member of
+// * means pointer
+// fn<TReturn, TArgs...> represents the function member type
+// conceptually it is TReturn (T::*)(TArgs...) but fn<TReturn, TArgs...>
+// allows us to then get to TReturn
+template <class T, class TReturn, class... TArgs>
+struct function_traits<fn<TReturn, TArgs...> T::*> {
+  using return_t = TReturn;
+  using last_arg_t = typename last_type<TArgs...>::type;
+};
+
+//Just grab the last arg from the function_traits
+template <class FnPtr>
+using last_arg_of_function_t = typename function_traits<FnPtr>::last_arg_t;
+
+template<typename, typename = std::void_t<>>
+struct has_create_program : std::false_type {};
+
+template<typename ConcreteOperation>
+struct has_create_program<ConcreteOperation, std::void_t<decltype(&ConcreteOperation::create_program)>> : std::true_type {};
+
+template <typename ConcreteOperation, bool HasCreateProgram = has_create_program<ConcreteOperation>::value>
+struct program_output_helper;
+
+// If we have create_program, then we need to use the last argument for the OutputTensors
+template <typename ConcreteOperation>
+struct program_output_helper<ConcreteOperation, true> {
+    using type = std::remove_const_t<std::remove_reference_t<last_arg_of_function_t<decltype(&std::remove_reference<ConcreteOperation>::type::create_program)>>>;
+};
+
+// If create_program does not exist on the ConcreteOperation this specialization will fallback to Tensors
+template <typename ProgramType>
+struct program_output_helper<ProgramType, false> {
+    using type = Tensors;
+};
+
+template <typename ProgramType>
+using ProgramOutputTensors = typename program_output_helper<ProgramType>::type;
+
 
 struct OpPerformanceModel {
     int ideal_compute_cycles = 1;
@@ -55,7 +119,7 @@ struct OpPerformanceModel {
     std::vector<int> inputs_bytes = {};
     std::vector<int> outputs_bytes = {};
 
-    OpPerformanceModel(std::vector<Tensor> input_tensors, std::vector<Tensor> output_tensors, int ideal_compute_cycles) {
+    OpPerformanceModel(Tensors input_tensors, Tensors output_tensors, int ideal_compute_cycles) {
 
         const auto& t = input_tensors.at(0);
         const auto arch = t.storage_type() == StorageType::DEVICE ? t.device()->arch() : ARCH::WORMHOLE_B0;
@@ -186,7 +250,7 @@ using has_validate_t = decltype(std::declval<T>().validate(std::declval<Args>().
 
 template <class T>
 constexpr bool implements_validate() {
-    return std::experimental::is_detected_v<has_validate_t, T, const std::vector<Tensor>&>;
+    return std::experimental::is_detected_v<has_validate_t, T, const Tensors&>;
 }
 
 
@@ -195,7 +259,7 @@ constexpr bool implements_validate_with_optional_input_tensors() {
     return std::experimental::is_detected_v<
         has_validate_t,
         T,
-        const std::vector<Tensor>&,
+        const Tensors&,
         const std::vector<std::optional<const Tensor>>&>;
 }
 
@@ -207,8 +271,8 @@ constexpr bool implements_validate_with_output_tensors() {
     return std::experimental::is_detected_v<
         has_validate_with_output_tensors_t,
         T,
-        const std::vector<Tensor>&, // input_tensors
-        const std::vector<std::optional<Tensor>>&>; // optional output_tensors
+        const Tensors&, // input_tensors
+        const OptionalTensors&>; // optional output_tensors
 }
 
 template <class T>
@@ -216,9 +280,9 @@ constexpr bool implements_validate_with_output_tensors_and_optional_input_tensor
     return std::experimental::is_detected_v<
         has_validate_with_output_tensors_t,
         T,
-        const std::vector<Tensor>&, // input_tensors
+        const Tensors&, // input_tensors
         const std::vector<std::optional<const Tensor>>&, // optional input_tensors
-        const std::vector<std::optional<Tensor>>&>; // optional output_tensors
+        const OptionalTensors&>; // optional output_tensors
 }
 
 
@@ -227,7 +291,7 @@ using has_create_output_tensors_t = decltype(std::declval<T>().create_output_ten
 
 template <class T>
 constexpr bool implements_create_output_tensors() {
-    return std::experimental::is_detected_v<has_create_output_tensors_t, T, const std::vector<Tensor>&>;
+    return std::experimental::is_detected_v<has_create_output_tensors_t, T, const Tensors&>;
 }
 
 template <class T>
@@ -235,8 +299,8 @@ constexpr bool implements_create_output_tensors_with_optional_output_tensors() {
     return std::experimental::is_detected_v<
         has_create_output_tensors_t,
         T,
-        const std::vector<Tensor>&,
-        const std::vector<std::optional<Tensor>>&>;
+        const Tensors&,
+        const OptionalTensors&>;
 }
 
 
@@ -245,7 +309,8 @@ using has_create_program_t = decltype(std::declval<T>().create_program(std::decl
 
 template <class T>
 constexpr bool implements_create_program() {
-    return std::experimental::is_detected_v<has_create_program_t, T, const std::vector<Tensor>&, std::vector<Tensor>&>;
+    return std::experimental::is_detected_v<has_create_program_t, T, const Tensors&, Tensors&>
+     || std::experimental::is_detected_v<has_create_program_t, T, const Tensors&, OptionalTensors&>;
 }
 
 template <class T, class... Args>
@@ -257,9 +322,16 @@ constexpr bool implements_create_program_with_optional_input_tensors() {
     return std::experimental::is_detected_v<
         has_create_program_with_optional_input_tensors_t,
         T,
-        const std::vector<Tensor>&,
+        const Tensors&,
         const std::vector<std::optional<const Tensor>>&,
-        std::vector<Tensor>&>;
+        Tensors&>
+        ||
+        std::experimental::is_detected_v<
+        has_create_program_with_optional_input_tensors_t,
+        T,
+        const Tensors&,
+        const std::vector<std::optional<const Tensor>>&,
+        OptionalTensors&>;
 }
 
 template <class T, class... Args>
@@ -271,9 +343,9 @@ constexpr bool implements_create_op_performance_model() {
     return std::experimental::is_detected_v<
         has_create_op_performance_model_t,
         T,
-        const std::vector<Tensor>&,
+        const Tensors&,
         const std::vector<std::optional<const Tensor>>&,
-        std::vector<Tensor>&>;
+        Tensors&>;
 }
 
 template <class T, class... Args>
@@ -281,7 +353,7 @@ using has_compute_program_hash_t = decltype(std::declval<T>().compute_program_ha
 
 template <class T>
 constexpr bool implements_compute_program_hash() {
-    return std::experimental::is_detected_v<has_compute_program_hash_t, T, const std::vector<Tensor>&>;
+    return std::experimental::is_detected_v<has_compute_program_hash_t, T, const Tensors&>;
 }
 
 template <class T, class... Args>
@@ -293,7 +365,7 @@ constexpr bool implements_compute_program_hash_with_optional_input_tensors() {
     return std::experimental::is_detected_v<
         has_compute_program_hash_with_optional_input_tensors_t,
         T,
-        const std::vector<Tensor>&,
+        const Tensors&,
         const std::vector<std::optional<const Tensor>>&>;
 }
 
@@ -313,20 +385,22 @@ using has_get_parallelization_strategy_t =
 
 template <class T>
 constexpr bool implements_get_parallelization_strategy() {
-    return std::experimental::is_detected_v<has_get_parallelization_strategy_t, T, const std::vector<Tensor>&>;
+    return std::experimental::is_detected_v<has_get_parallelization_strategy_t, T, const Tensors&>;
 }
 
 }  // namespace detail
 
+template<class OutputTensorsT=Tensors>
 struct HostOperation final {
     using storage_t = std::array<std::byte, 512>;
+    using OutputTensors = OutputTensorsT;
 
     // Methods
     const std::function<const std::string()> get_type_name;
-    const std::function<void(const std::vector<Tensor>&)> validate;
-    const std::function<const std::vector<Shape>(const std::vector<Tensor>&)> compute_output_shapes;
-    const std::function<const std::vector<Tensor>(const std::vector<Tensor>&)> compute_output_tensors;
-    const std::function<const ProfilerInfo(const std::vector<Tensor> &input_tensors)> create_profiler_info;
+    const std::function<void(const Tensors&)> validate;
+    const std::function<const std::vector<Shape>(const Tensors&)> compute_output_shapes;
+    const std::function<const OutputTensors(const Tensors&)> compute_output_tensors;
+    const std::function<const ProfilerInfo(const Tensors &input_tensors)> create_profiler_info;
     const std::function<const tt::stl::reflection::Attributes()> attributes;
 
     template <typename T>
@@ -341,19 +415,19 @@ struct HostOperation final {
 
         // Initialize methods
         get_type_name{[]() -> const std::string { return boost::core::demangle(typeid(T).name()); }},
-        validate{[this](const std::vector<Tensor>& input_tensors) {
+        validate{[this](const Tensors& input_tensors) {
             const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&this->type_erased_storage);
             operation.validate(input_tensors);
         }},
-        compute_output_shapes{[this](const std::vector<Tensor>& input_tensors) {
+        compute_output_shapes{[this](const Tensors& input_tensors) {
             const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&this->type_erased_storage);
             return operation.compute_output_shapes(input_tensors);
         }},
-        compute_output_tensors{[this](const std::vector<Tensor>& input_tensors) {
+        compute_output_tensors{[this](const Tensors& input_tensors) {
             const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&this->type_erased_storage);
             return operation.compute_output_tensors(input_tensors);
         }},
-        create_profiler_info{[this](const std::vector<Tensor>& input_tensors) -> ProfilerInfo {
+        create_profiler_info{[this](const Tensors& input_tensors) -> ProfilerInfo {
             std::optional<std::string> preferred_name = this->get_type_name();
             std::optional<std::string> parallelization_strategy = std::nullopt;
             return {.preferred_name = preferred_name, .parallelization_strategy = parallelization_strategy};
@@ -378,48 +452,50 @@ struct HostOperation final {
     void (*delete_storage)(storage_t&) = nullptr;
 };
 
+template<class OutputTensorsT=Tensors>
 struct DeviceOperation final {
     using storage_t = std::array<std::byte, 1152>;
+    using OutputTensors = OutputTensorsT;
 
     inline const std::string get_type_name() const { return this->get_type_name_impl_(this->type_erased_storage); }
 
     inline const void validate(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        const std::vector<std::optional<Tensor>>& optional_output_tensors) const {
+        const Tensors& input_tensors,
+        const OptionalConstTensors& optional_input_tensors,
+        const OptionalTensors& optional_output_tensors) const {
         return this->validate_impl_(this->type_erased_storage, input_tensors, optional_input_tensors, optional_output_tensors);
     }
 
-    inline const std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    inline const std::vector<Shape> compute_output_shapes(const Tensors& input_tensors) const {
         return this->compute_output_shapes_impl_(this->type_erased_storage, input_tensors);
     }
 
-    inline const std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    inline const OutputTensors create_output_tensors(const Tensors& input_tensors, const OptionalTensors& output_tensors) const {
         return this->create_output_tensors_impl_(this->type_erased_storage, input_tensors, output_tensors);
     }
 
-    inline ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor>& output_tensors) const {
+    inline CacheableProgram<OutputTensors> create_program(
+        const Tensors& input_tensors,
+        const OptionalConstTensors& optional_input_tensors,
+        OutputTensors& output_tensors) const {
         return this->create_program_impl_(
             this->type_erased_storage, input_tensors, optional_input_tensors, output_tensors);
     }
 
     inline OpPerformanceModel create_op_performance_model(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor>& output_tensors) const {
+        const Tensors& input_tensors,
+        const OptionalConstTensors& optional_input_tensors,
+        OutputTensors& output_tensors) const {
         return this->create_op_performance_model_impl_(
             this->type_erased_storage, input_tensors, optional_input_tensors, output_tensors);
     }
 
     inline void override_runtime_arguments(
-        OverrideRuntimeArgumentsCallback& override_runtime_arguments_callback,
+        OverrideRuntimeArgumentsCallback<OutputTensors>& override_runtime_arguments_callback,
         Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor>& output_tensors) const {
+        const Tensors& input_tensors,
+        const OptionalConstTensors& optional_input_tensors,
+        OutputTensors& output_tensors) const {
         return this->override_runtime_arguments_impl_(
             this->type_erased_storage,
             override_runtime_arguments_callback,
@@ -430,12 +506,12 @@ struct DeviceOperation final {
     }
 
     inline const Hash compute_program_hash(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
+        const Tensors& input_tensors,
+        const OptionalConstTensors& optional_input_tensors) const {
         return this->compute_program_hash_impl_(this->type_erased_storage, input_tensors, optional_input_tensors);
     }
 
-    inline const ProfilerInfo create_profiler_info(const std::vector<Tensor>& input_tensors) const {
+    inline const ProfilerInfo create_profiler_info(const Tensors& input_tensors) const {
         return this->create_profiler_info_impl_(this->type_erased_storage, input_tensors);
     }
 
@@ -464,9 +540,9 @@ struct DeviceOperation final {
         }},
         validate_impl_{
             [](const storage_t& storage,
-               const std::vector<Tensor>& input_tensors,
-               const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-               const std::vector<std::optional<Tensor>>& optional_output_tensors) -> void {
+               const Tensors& input_tensors,
+               const OptionalConstTensors& optional_input_tensors,
+               const OptionalTensors& optional_output_tensors) -> void {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
                 if constexpr ((detail::implements_validate<T>() || detail::implements_validate_with_optional_input_tensors<T>()) &&
                         (detail::implements_validate_with_output_tensors<T>() || detail::implements_validate_with_output_tensors_and_optional_input_tensors<T>())){
@@ -505,12 +581,12 @@ struct DeviceOperation final {
 
             }},
         compute_output_shapes_impl_{
-            [](const storage_t& storage, const std::vector<Tensor>& input_tensors) -> const std::vector<Shape> {
+            [](const storage_t& storage, const Tensors& input_tensors) -> const std::vector<Shape> {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
                 return operation.compute_output_shapes(input_tensors);
             }},
         create_output_tensors_impl_{
-            [](const storage_t& storage, const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) -> const std::vector<Tensor> {
+            [](const storage_t& storage, const Tensors& input_tensors, const OptionalTensors& output_tensors) -> const Tensors {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
                 if constexpr (detail::implements_create_output_tensors_with_optional_output_tensors<T>()) {
                     return operation.create_output_tensors(input_tensors, output_tensors);
@@ -521,9 +597,9 @@ struct DeviceOperation final {
             }},
         create_program_impl_{
             [](const storage_t& storage,
-               const std::vector<Tensor>& input_tensors,
-               const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-               std::vector<Tensor>& output_tensors) -> ProgramWithCallbacks {
+               const Tensors& input_tensors,
+               const OptionalConstTensors& optional_input_tensors,
+               OutputTensors& output_tensors) -> CacheableProgram<OutputTensors> {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
                 if constexpr (detail::implements_create_program<T>()) {
                     TT_ASSERT(optional_input_tensors.empty());
@@ -537,9 +613,9 @@ struct DeviceOperation final {
             }},
         create_op_performance_model_impl_{
             [](const storage_t& storage,
-               const std::vector<Tensor>& input_tensors,
-               const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-               std::vector<Tensor>& output_tensors) -> OpPerformanceModel {
+               const Tensors& input_tensors,
+               const OptionalConstTensors& optional_input_tensors,
+               OutputTensors& output_tensors) -> OpPerformanceModel {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
                 if constexpr (detail::implements_create_op_performance_model<T>()) {
                     return operation.create_op_performance_model(input_tensors, optional_input_tensors, output_tensors);
@@ -549,19 +625,19 @@ struct DeviceOperation final {
             }},
         override_runtime_arguments_impl_{
             [](const storage_t& storage,
-               OverrideRuntimeArgumentsCallback& override_runtime_arguments_callback,
+               OverrideRuntimeArgumentsCallback<OutputTensors>& override_runtime_arguments_callback,
                Program& program,
-               const std::vector<Tensor>& input_tensors,
-               const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-               std::vector<Tensor>& output_tensors) -> void {
+               const Tensors& input_tensors,
+               const OptionalConstTensors& optional_input_tensors,
+               OutputTensors& output_tensors) -> void {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
                 override_runtime_arguments_callback(
                     &operation, program, input_tensors, optional_input_tensors, output_tensors);
             }},
         compute_program_hash_impl_{
             [](const storage_t& storage,
-               const std::vector<Tensor>& input_tensors,
-               const std::vector<std::optional<const Tensor>>& optional_input_tensors) -> const Hash {
+               const Tensors& input_tensors,
+               const OptionalConstTensors& optional_input_tensors) -> const Hash {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
 
                 if constexpr (detail::implements_compute_program_hash<T>()) {
@@ -583,7 +659,7 @@ struct DeviceOperation final {
                 }
             }},
         create_profiler_info_impl_{
-            [](const storage_t& storage, const std::vector<Tensor>& input_tensors) -> const ProfilerInfo {
+            [](const storage_t& storage, const Tensors& input_tensors) -> const ProfilerInfo {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
                 std::optional<std::string> preferred_name = boost::core::demangle(typeid(T).name());
 
@@ -619,35 +695,35 @@ struct DeviceOperation final {
 
     const std::string (*get_type_name_impl_)(const storage_t& value);
     void (*validate_impl_)(
-        const storage_t& value, const std::vector<Tensor>&, const std::vector<std::optional<const Tensor>>&, const std::vector<std::optional<Tensor>>&);
-    void (*validate_with_output_tensors_impl_)(
-        const storage_t& value, const std::vector<Tensor>&, const std::vector<std::optional<const Tensor>>&, const std::vector<std::optional<Tensor>>&);
-    const std::vector<Shape> (*compute_output_shapes_impl_)(const storage_t& value, const std::vector<Tensor>&);
-    const std::vector<Tensor> (*create_output_tensors_impl_)(const storage_t& value, const std::vector<Tensor>&, const std::vector<std::optional<Tensor>>&);
-    ProgramWithCallbacks (*create_program_impl_)(
+        const storage_t& value, const Tensors&, const std::vector<std::optional<const Tensor>>&, const OptionalTensors&);
+    const std::vector<Shape> (*compute_output_shapes_impl_)(const storage_t& value, const Tensors&);
+    const OutputTensors (*create_output_tensors_impl_)(const storage_t& value, const Tensors&, const OptionalTensors&);
+
+    CacheableProgram<OutputTensors> (*create_program_impl_)(
         const storage_t& value,
-        const std::vector<Tensor>&,
+        const Tensors&,
         const std::vector<std::optional<const Tensor>>&,
-        std::vector<Tensor>&);
+        OutputTensors&);
     OpPerformanceModel (*create_op_performance_model_impl_)(
         const storage_t& value,
-        const std::vector<Tensor>&,
+        const Tensors&,
         const std::vector<std::optional<const Tensor>>&,
-        std::vector<Tensor>&);
+        OutputTensors&);
     void (*override_runtime_arguments_impl_)(
         const storage_t& value,
-        OverrideRuntimeArgumentsCallback&,
+        OverrideRuntimeArgumentsCallback<OutputTensors>&,
         Program&,
-        const std::vector<Tensor>&,
+        const Tensors&,
         const std::vector<std::optional<const Tensor>>&,
-        std::vector<Tensor>&);
+        OutputTensors&);
     const Hash (*compute_program_hash_impl_)(
-        const storage_t& value, const std::vector<Tensor>&, const std::vector<std::optional<const Tensor>>&);
-    const ProfilerInfo (*create_profiler_info_impl_)(const storage_t& value, const std::vector<Tensor>& input_tensors);
+        const storage_t& value, const Tensors&, const std::vector<std::optional<const Tensor>>&);
+    const ProfilerInfo (*create_profiler_info_impl_)(const storage_t& value, const Tensors& input_tensors);
     const tt::stl::reflection::Attributes (*attributes_impl_)(const storage_t& value);
 };
 
 struct ExternalOperation {
+    using OutputTensors = Tensors;
     const std::string function_name_;
     const tt::stl::reflection::Attributes attributes_;
 
@@ -655,7 +731,12 @@ struct ExternalOperation {
     const tt::stl::reflection::Attributes attributes() const { return this->attributes_; }
 };
 
-using Operation = std::variant<HostOperation, DeviceOperation, ExternalOperation>;
+
+using ProgramWithCallbacks = CacheableProgram<Tensors>;
+using ProgramWithOptionalOutputTensors = CacheableProgram<OptionalTensors>;
+
+
+using Operation = std::variant<HostOperation<Tensors>, HostOperation<OptionalTensors>, DeviceOperation<Tensors>, DeviceOperation<OptionalTensors>, ExternalOperation>;
 
 }  // namespace operation
 }  // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -21,11 +21,11 @@ namespace tt::tt_metal::operation {
 
 namespace detail {
 
-inline bool any_tensor_on_multi_device(const std::vector<Tensor>& tensors) {
+inline bool any_tensor_on_multi_device(const Tensors& tensors) {
     return std::any_of(tensors.begin(), tensors.end(), [](const Tensor& tensor) { return tensor.storage_type() == StorageType::MULTI_DEVICE; });
 }
 
-static Device* get_device(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors = {}) {
+static Device* get_device(const Tensors& input_tensors, const OptionalConstTensors& optional_input_tensors = {}) {
     for (auto& input_tensor : input_tensors) {
         if (input_tensor.storage_type() == StorageType::DEVICE) {
             TT_FATAL(input_tensor.buffer() != nullptr, "Operands need to be allocated in buffers on device");
@@ -48,12 +48,13 @@ void validate_op_launch(Device* worker) {
     }
 }
 
+template<class OutputTensors=Tensors>
 void override_addresses(
     const OverrideAddressesCallback& override_addresses_callback,
     const Program &program,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    const std::vector<Tensor>& output_tensors
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OutputTensors& output_tensors
 ) {
     std::vector<Buffer*> input_buffers;
     for (auto& tensor : input_tensors) {
@@ -66,11 +67,32 @@ void override_addresses(
 
     std::vector<Buffer*> output_buffers;
     for (auto& tensor : output_tensors) {
-        output_buffers.push_back(tensor.buffer());
+        if constexpr(std::is_same_v<OptionalTensors, OutputTensors>){
+            auto buffer = tensor.has_value() ? tensor.value().buffer() : nullptr;
+            output_buffers.push_back(buffer);
+        }
+        else{
+            output_buffers.push_back(tensor.buffer());
+        }
     }
 
     override_addresses_callback(program, input_buffers, output_buffers);
 }
+
+template void override_addresses<Tensors>(
+    const OverrideAddressesCallback& override_addresses_callback,
+    const Program &program,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const Tensors& output_tensors);
+
+template void override_addresses<OptionalTensors>(
+    const OverrideAddressesCallback& override_addresses_callback,
+    const Program &program,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& output_tensors);
+
 
 template <typename Function>
 constexpr auto decorate_host_operation(const Function& function) {
@@ -93,7 +115,8 @@ constexpr auto decorate_device_operation(const Function& function) {
     };
 }
 
-std::vector<Tensor> run_host_operation(const HostOperation& operation, const std::vector<Tensor>& input_tensors) {
+template<typename OutputTensors = Tensors>
+OutputTensors run_host_operation(const HostOperation<OutputTensors>& operation, const Tensors& input_tensors) {
     ZoneScopedN("TT_DNN_HOST_OP");
     uint32_t op_id = assign_id();
 
@@ -105,45 +128,50 @@ std::vector<Tensor> run_host_operation(const HostOperation& operation, const std
     return output_tensors;
 }
 
+template Tensors run_host_operation(const HostOperation<Tensors>& operation, const Tensors& input_tensors);
+template OptionalTensors run_host_operation(const HostOperation<OptionalTensors>& operation, const Tensors& input_tensors);
+
 inline const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
 
-std::vector<Tensor> run_device_operation(
+template<typename OutputTensors = Tensors>
+OutputTensors run_device_operation(
     std::optional<std::reference_wrapper<CommandQueue>> queue,
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    const std::vector<std::optional<Tensor>>& optional_output_tensors) {
+    const DeviceOperation<OutputTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors) {
     ZoneScopedN("TT_DNN_DEVICE_OP");
     uint32_t op_id = assign_id();
 
     std::function<std::variant<std::shared_ptr<Program>, std::reference_wrapper<Program>>(
-        const DeviceOperation&,
-        const std::vector<Tensor>&,
-        const std::vector<std::optional<const Tensor>>&,
-        std::vector<Tensor>&)>
+        const DeviceOperation<OutputTensors>&,
+        const Tensors&,
+        const OptionalConstTensors&,
+        OutputTensors&)>
         get_or_create_program;
     auto& program_cache = input_tensors[0].device()->program_cache;
     if (program_cache.is_enabled()) {
-        get_or_create_program = [&program_cache](const DeviceOperation& operation,
-                                   const std::vector<Tensor>& input_tensors,
-                                   const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-                                   std::vector<Tensor>& output_tensors) -> std::reference_wrapper<Program> {
+        get_or_create_program = [&program_cache](const DeviceOperation<OutputTensors>& operation,
+                                   const Tensors& input_tensors,
+                                   const OptionalConstTensors& optional_input_tensors,
+                                   OutputTensors& output_tensors) -> std::reference_wrapper<Program> {
 
             auto program_hash = operation.compute_program_hash(input_tensors, optional_input_tensors);
             auto program_ptr = program_cache.find(program_hash);
 
             bool cache_hit = program_ptr.has_value();
             if (not cache_hit) {
-                program_ptr = std::make_shared<operation::ProgramWithCallbacks>(operation.create_program(input_tensors, optional_input_tensors, output_tensors));
+                program_ptr = std::make_shared<operation::CacheableProgram<OutputTensors>>(operation.create_program(input_tensors, optional_input_tensors, output_tensors));
                 program_cache.insert(program_hash, program_ptr.value());
             }
-            auto& program_with_callbacks = *(reinterpret_cast<operation::ProgramWithCallbacks*>(program_ptr.value().get()));
+            auto& program_with_callbacks = *(reinterpret_cast<operation::CacheableProgram<OutputTensors>*>(program_ptr.value().get()));
             TT_ASSERT(program_with_callbacks.supports_program_cache());
 
             if (cache_hit) {
                 ZoneScopedN("Cache_hit_set_runtime_args");
                 if (program_with_callbacks.override_addresses_callback.has_value()) {
                     auto override_addresses_callback = program_with_callbacks.override_addresses_callback.value();
+                    // Deprecated
                     override_addresses(
                         override_addresses_callback, program_with_callbacks.program, input_tensors, optional_input_tensors, output_tensors);
                 }
@@ -162,10 +190,10 @@ std::vector<Tensor> run_device_operation(
             return program_with_callbacks.program;
         };
     } else {
-        get_or_create_program = [](const DeviceOperation& operation,
-                                   const std::vector<Tensor>& input_tensors,
-                                   const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-                                   std::vector<Tensor>& output_tensors) -> std::shared_ptr<Program> {
+        get_or_create_program = [](const DeviceOperation<OutputTensors>& operation,
+                                   const Tensors& input_tensors,
+                                   const OptionalConstTensors& optional_input_tensors,
+                                   OutputTensors& output_tensors) -> std::shared_ptr<Program> {
             auto program_with_callbacks =
                 operation.create_program(input_tensors, optional_input_tensors, output_tensors);
             return std::make_shared<Program>(std::move(program_with_callbacks.program));
@@ -210,22 +238,37 @@ std::vector<Tensor> run_device_operation(
 
     return output_tensors;
 }
-
-std::vector<Tensor> run_multi_device_operation(
+template Tensors run_device_operation(
     std::optional<std::reference_wrapper<CommandQueue>> queue,
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    const std::vector<std::optional<Tensor>>& optional_output_tensors)
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors);
+
+template OptionalTensors run_device_operation(
+    std::optional<std::reference_wrapper<CommandQueue>> queue,
+    const DeviceOperation<OptionalTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors);
+
+template<typename OutputTensors = Tensors>
+OutputTensors run_multi_device_operation(
+    std::optional<std::reference_wrapper<CommandQueue>> queue,
+    const DeviceOperation<OutputTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors)
 {
     // TODO: Assumes each input/output tensor is mapped to the same set of devices; relax this later
     std::vector<Device*> devices = get_devices(input_tensors[0]);
     detail::validate_op_launch(devices.at(0));
-    std::map<Device*, std::vector<Tensor>> per_device_output_tensors;
+
+    std::map<Device*, OutputTensors> per_device_output_tensors;
     std::optional<std::size_t> num_output_tensors_per_device;
     for (Device *device : devices)
     {
-        auto device_output_tensors = run_device_operation(
+        auto device_output_tensors = run_device_operation<OutputTensors>(
             device->command_queue(),
             operation,
             get_device_tensors(device, input_tensors),
@@ -242,72 +285,163 @@ std::vector<Tensor> run_multi_device_operation(
         }
     }
 
-    std::vector<Tensor> multi_device_output_tensors;
+    OutputTensors multi_device_output_tensors;
     for (int i = 0; i < num_output_tensors_per_device; ++i)
     {
         std::unordered_map<int, DeviceBuffer> buffers;
         std::unordered_map<int, Shape> shapes;
-        for (Device* device : devices) {
-            buffers.insert({device->id(), per_device_output_tensors[device][i].device_buffer()});
-            shapes.insert({device->id(), per_device_output_tensors[device][i].get_legacy_shape()});
+        for (Device *device : devices) {
+            if constexpr(std::is_same_v<Tensors, std::remove_const_t<OutputTensors>>){
+                buffers.insert({device->id(), per_device_output_tensors[device][i].device_buffer()});
+                shapes.insert({device->id(),per_device_output_tensors[device][i].get_legacy_shape()});
+            }
+            else if constexpr(std::is_same_v<OptionalTensors, std::remove_const_t<OutputTensors>>){
+                if(per_device_output_tensors[device][i].has_value()){
+                    buffers.insert({device->id(),per_device_output_tensors[device][i].value().device_buffer()});
+                    shapes.insert({device->id(),per_device_output_tensors[device][i].value().get_legacy_shape()});
+                }
+            }
+            else{
+                static_assert(false_type_t<OutputTensors>, "OutputTensors must be either Tensors or OptionalTensors.");
+            }
         }
 
-        multi_device_output_tensors.push_back(
-            Tensor{
-                MultiDeviceStorage{buffers, shapes},
-                per_device_output_tensors[devices[0]][i].get_legacy_shape(),
-                per_device_output_tensors[devices[0]][i].get_dtype(),
-                per_device_output_tensors[devices[0]][i].get_layout()
-            }
-        );
+        if constexpr(std::is_same_v<Tensors, std::remove_const_t<OutputTensors>>){
+            multi_device_output_tensors.push_back(
+                Tensor{
+                    MultiDeviceStorage{buffers, shapes},
+                    per_device_output_tensors[devices[0]][i].get_legacy_shape(),
+                    per_device_output_tensors[devices[0]][i].get_dtype(),
+                    per_device_output_tensors[devices[0]][i].get_layout()
+                }
+            );
+        }
+        else if constexpr(std::is_same_v<OptionalTensors, std::remove_const_t<OutputTensors>>){
+            multi_device_output_tensors.push_back(
+                Tensor{
+                    MultiDeviceStorage{buffers, shapes},
+                    per_device_output_tensors[devices[0]][i].value().get_legacy_shape(),
+                    per_device_output_tensors[devices[0]][i].value().get_dtype(),
+                    per_device_output_tensors[devices[0]][i].value().get_layout()
+                }
+            );
+        }
+        else {
+            static_assert(false_type_t<OutputTensors>, "OutputTensors must be either Tensors or OptionalTensors.");
+        }
     }
     return multi_device_output_tensors;
 }
 
+template OptionalTensors run_multi_device_operation(
+    std::optional<std::reference_wrapper<CommandQueue>> queue,
+    const DeviceOperation<OptionalTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors);
+
+template Tensors run_multi_device_operation(
+    std::optional<std::reference_wrapper<CommandQueue>> queue,
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors);
+
 }  // namespace detail
 
-std::vector<Tensor> run(const HostOperation& operation, const std::vector<Tensor>& input_tensors) {
-    return detail::decorate_host_operation(detail::run_host_operation)(operation, input_tensors);
+template<class OutputTensors=Tensors>
+OutputTensors run(const HostOperation<OutputTensors>& operation, const Tensors& input_tensors) {
+    return detail::decorate_host_operation(detail::run_host_operation<OutputTensors>)(operation, input_tensors);
 }
+template Tensors run(const HostOperation<Tensors>& operation, const Tensors& input_tensors);
+template OptionalTensors run(const HostOperation<OptionalTensors>& operation, const Tensors& input_tensors);
 
-std::vector<Tensor> run(
+template<class OutputTensors=Tensors>
+OutputTensors run(
     CommandQueue& queue,
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    const std::vector<std::optional<Tensor>>& optional_output_tensors) {
+    const DeviceOperation<OutputTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors) {
+    // Async Mode: Asserts to ensure that tensors are populated before running op
+    // TODO : Joseph/Eyon, this was deleted in a prior PR, is that correct?
+    // for (const Tensor& tensor : input_tensors) {
+    //     TT_ASSERT(tensor.metadata_populated(), "Input tensors must be populated before running op.");
+    // }
+    // for (auto& tensor : optional_input_tensors) {
+    //     if (tensor.has_value()) {
+    //         TT_ASSERT(tensor.value().metadata_populated(), "Input tensors must be populated before running op.");
+    //     }
+    // }
     if (detail::any_tensor_on_multi_device(input_tensors)) {
-        return detail::decorate_device_operation(detail::run_multi_device_operation)(
+        return detail::decorate_device_operation(detail::run_multi_device_operation<OutputTensors>)(
             std::make_optional(std::ref(queue)), operation, input_tensors, optional_input_tensors, optional_output_tensors);
     }
-    return detail::decorate_device_operation(detail::run_device_operation)(
+    return detail::decorate_device_operation(detail::run_device_operation<OutputTensors>)(
         queue, operation, input_tensors, optional_input_tensors, optional_output_tensors);
 }
 
-std::vector<Tensor> run(
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    const std::vector<std::optional<Tensor>>& optional_output_tensors) {
+template Tensors run(
+    CommandQueue& queue,
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors);
+
+template OptionalTensors run(
+    CommandQueue& queue,
+    const DeviceOperation<OptionalTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors);
+
+template<class OutputTensors=Tensors>
+OutputTensors run(
+    const DeviceOperation<OutputTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors) {
+    // Async Mode: Asserts to ensure that tensors are populated before running op
+    // for (const Tensor& tensor : input_tensors) {
+    //     TT_ASSERT(tensor.metadata_populated(), "Input tensors must be populated before running op.");
+    // }
+    // for (auto& tensor : optional_input_tensors) {
+    //     if (tensor.has_value()) {
+    //         TT_ASSERT(tensor.value().metadata_populated(), "Input tensors must be populated before running op.");
+    //     }
+    // }
     if (detail::any_tensor_on_multi_device(input_tensors)) {
-        return detail::decorate_device_operation(detail::run_multi_device_operation)(
+        return detail::decorate_device_operation(detail::run_multi_device_operation<OutputTensors>)(
             std::nullopt, operation, input_tensors, optional_input_tensors, optional_output_tensors);
     }
     auto device = detail::get_device(input_tensors, optional_input_tensors);
     detail::validate_op_launch(device);
-    return detail::decorate_device_operation(detail::run_device_operation)(
+    return detail::decorate_device_operation(detail::run_device_operation<OutputTensors>)(
         detail::USE_FAST_DISPATCH ? std::make_optional(std::ref(device->command_queue())) : std::nullopt, operation, input_tensors, optional_input_tensors, optional_output_tensors);
 }
 
-std::vector<Tensor> run_without_autoformat(
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors
+template Tensors run(
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors);
+
+template OptionalTensors run(
+    const DeviceOperation<OptionalTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors);
+
+template<class OutputTensors=Tensors>
+OutputTensors run_without_autoformat(
+    const DeviceOperation<OutputTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors
 ) {
     ZoneScoped;
     Device* device = detail::get_device(input_tensors, optional_input_tensors);
     detail::validate_op_launch(device);
-    std::vector<Tensor> input_tensors_on_dev;
+    Tensors input_tensors_on_dev;
     input_tensors_on_dev.reserve(input_tensors.size());
     for (auto& input_tensor : input_tensors) {
         if (input_tensor.storage_type() != StorageType::DEVICE) {
@@ -316,7 +450,7 @@ std::vector<Tensor> run_without_autoformat(
             input_tensors_on_dev.push_back(input_tensor);
         }
     }
-    std::vector<std::optional<const Tensor>> optional_input_tensors_on_dev;
+    OptionalConstTensors optional_input_tensors_on_dev;
     optional_input_tensors_on_dev.reserve(optional_input_tensors.size());
     for (auto& optional_input_tensor : optional_input_tensors) {
         if (optional_input_tensor.has_value() and optional_input_tensor.value().storage_type() != StorageType::DEVICE) {
@@ -325,19 +459,32 @@ std::vector<Tensor> run_without_autoformat(
             optional_input_tensors_on_dev.push_back(optional_input_tensor);
         }
     }
-    return run(operation, input_tensors_on_dev, optional_input_tensors_on_dev, {});
+    return run<OutputTensors>(operation, input_tensors_on_dev, optional_input_tensors_on_dev, {});
 }
 
-std::vector<Tensor> run_without_autoformat(
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    const std::vector<std::optional<Tensor>>& optional_output_tensors
+template Tensors run_without_autoformat<Tensors>(
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors
+);
+
+template OptionalTensors run_without_autoformat<OptionalTensors>(
+    const DeviceOperation<OptionalTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors
+);
+
+template<class OutputTensors=Tensors>
+OutputTensors run_without_autoformat(
+    const DeviceOperation<OutputTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors
 ) {
     ZoneScoped;
     Device* device = detail::get_device(input_tensors, optional_input_tensors);
     detail::validate_op_launch(device);
-    std::vector<Tensor> input_tensors_on_dev;
+    Tensors input_tensors_on_dev;
     input_tensors_on_dev.reserve(input_tensors.size());
     for (auto& input_tensor : input_tensors) {
         if (input_tensor.storage_type() != StorageType::DEVICE) {
@@ -346,7 +493,7 @@ std::vector<Tensor> run_without_autoformat(
             input_tensors_on_dev.push_back(input_tensor);
         }
     }
-    std::vector<std::optional<const Tensor>> optional_input_tensors_on_dev;
+    OptionalConstTensors optional_input_tensors_on_dev;
     optional_input_tensors_on_dev.reserve(optional_input_tensors.size());
     for (auto& optional_input_tensor : optional_input_tensors) {
         if (optional_input_tensor.has_value() and optional_input_tensor.value().storage_type() != StorageType::DEVICE) {
@@ -355,26 +502,40 @@ std::vector<Tensor> run_without_autoformat(
             optional_input_tensors_on_dev.push_back(optional_input_tensor);
         }
     }
-    return run(operation, input_tensors_on_dev, optional_input_tensors_on_dev, optional_output_tensors);
+    return run<OutputTensors>(operation, input_tensors_on_dev, optional_input_tensors_on_dev, optional_output_tensors);
 }
+
+template Tensors run_without_autoformat<Tensors>(
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors
+);
+
+template OptionalTensors run_without_autoformat<OptionalTensors>(
+    const DeviceOperation<OptionalTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors
+);
 
 // To be deprecated/removed in favor of new implementation where ops specifically request how to format inputs/outputss
-std::vector<Tensor> run_with_autoformat(
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+Tensors run_with_autoformat(
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
     const float pad_value,
     const bool pad_c
 ) {
     ZoneScoped;
     if (detail::any_tensor_on_multi_device(input_tensors)) {
-        return run(operation, input_tensors, optional_input_tensors);
+        return run<Tensors>(operation, input_tensors, optional_input_tensors);
     }
     Device* device = detail::get_device(input_tensors, optional_input_tensors);
     detail::validate_op_launch(device);
     auto output_shapes = operation.compute_output_shapes(input_tensors);
 
-    std::vector<Tensor> formatted_input_tensors;
+    Tensors formatted_input_tensors;
     formatted_input_tensors.reserve(input_tensors.size());
     for (auto& input_tensor : input_tensors) {
         auto padded_input_shape = AutoFormat::pad_to_tile_shape(input_tensor.get_legacy_shape(), pad_c);
@@ -386,7 +547,7 @@ std::vector<Tensor> run_with_autoformat(
         }
     }
 
-    std::vector<std::optional<const Tensor>> formatted_optional_input_tensors;
+    OptionalConstTensors formatted_optional_input_tensors;
     formatted_optional_input_tensors.reserve(optional_input_tensors.size());
     for (auto& optional_input_tensor : optional_input_tensors) {
         if (optional_input_tensor.has_value()) {
@@ -403,7 +564,7 @@ std::vector<Tensor> run_with_autoformat(
         }
     }
 
-    auto output_tensors = run(operation, formatted_input_tensors, formatted_optional_input_tensors);
+    auto output_tensors = run<Tensors>(operation, formatted_input_tensors, formatted_optional_input_tensors);
 
     TT_ASSERT(output_tensors.size() == output_shapes.size());
 
@@ -416,17 +577,17 @@ std::vector<Tensor> run_with_autoformat(
     return output_tensors;
 }
 
-std::vector<Tensor> run_with_autoformat(
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
+Tensors run_with_autoformat(
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
     const std::vector<FormatParams>& input_formatting,
     const std::vector<Layout>& output_layouts,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+    const OptionalConstTensors& optional_input_tensors,
     const std::vector<std::optional<FormatParams>>& optional_input_formatting
 ) {
     ZoneScoped;
     if (detail::any_tensor_on_multi_device(input_tensors)) {
-        return run(operation, input_tensors, optional_input_tensors);
+        return run<Tensors>(operation, input_tensors, optional_input_tensors);
     }
     Device* device = detail::get_device(input_tensors, optional_input_tensors);
     detail::validate_op_launch(device);
@@ -435,13 +596,13 @@ std::vector<Tensor> run_with_autoformat(
     TT_ASSERT(input_tensors.size() == input_formatting.size());
     TT_ASSERT(optional_input_tensors.size() == optional_input_formatting.size());
 
-    std::vector<Tensor> formatted_input_tensors;
+    Tensors formatted_input_tensors;
     formatted_input_tensors.reserve(input_tensors.size());
     for (uint32_t i = 0; i < input_tensors.size(); ++i) {
         formatted_input_tensors.push_back(AutoFormat::format_input_tensor(input_tensors[i], device, input_formatting[i].pad_shape, input_formatting[i].pad_value, input_formatting[i].target_layout));
     }
 
-    std::vector<std::optional<const Tensor>> formatted_optional_input_tensors;
+    OptionalConstTensors formatted_optional_input_tensors;
     formatted_optional_input_tensors.reserve(optional_input_tensors.size());
     for (uint32_t i = 0; i < optional_input_tensors.size(); ++i) {
         if (optional_input_tensors[i].has_value()) {
@@ -454,7 +615,7 @@ std::vector<Tensor> run_with_autoformat(
         }
     }
 
-    auto output_tensors = run(operation, formatted_input_tensors, formatted_optional_input_tensors);
+    auto output_tensors = run<Tensors>(operation, formatted_input_tensors, formatted_optional_input_tensors);
 
     TT_ASSERT(output_tensors.size() == output_shapes.size());
     TT_ASSERT(output_tensors.size() == output_layouts.size());

--- a/tt_eager/tt_dnn/op_library/run_operation.hpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.hpp
@@ -18,19 +18,20 @@ namespace tt::tt_metal {
 namespace operation {
 
 template<typename ConcreteOperation>
-std::vector<Tensor> generic_create_output_tensors(
+auto generic_create_output_tensors(
     const ConcreteOperation& operation,
-    const std::vector<Tensor>& input_tensors,
+    const Tensors& input_tensors,
     const DataType output_dtype,
     const Layout output_layout,
     const MemoryConfig& output_mem_config
-) {
+) -> ProgramOutputTensors<ConcreteOperation> {
     const auto& input_tensor = input_tensors.at(0);
     const auto& output_shapes = operation.compute_output_shapes(input_tensors);
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE);
 
-    std::vector<Tensor> output_tensors;
+    using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
+    OutputTensors output_tensors;
     output_tensors.reserve(output_shapes.size());
     for (const auto& output_shape : output_shapes) {
         output_tensors.emplace_back(
@@ -122,10 +123,14 @@ namespace detail {
 
 template <typename OperationType>
 std::string operation_type_to_string() {
-    if constexpr (std::is_same_v<OperationType, HostOperation>) {
-        return "host";
-    } else if constexpr (std::is_same_v<OperationType, DeviceOperation>) {
-        return "device";
+    if constexpr (std::is_same_v<OperationType, HostOperation<Tensors>>) {
+        return "host<Tensors>";
+    } else if constexpr (std::is_same_v<OperationType, DeviceOperation<Tensors>>) {
+        return "device<Tensors>";
+    } else if constexpr (std::is_same_v<OperationType, HostOperation<OptionalTensors>>) {
+        return "host<OptionalTensors>";
+    } else if constexpr (std::is_same_v<OperationType, DeviceOperation<OptionalTensors>>) {
+        return "device<OptionalTensors>";
     } else if constexpr (std::is_same_v<OperationType, ExternalOperation>) {
         return "external";
     } else {
@@ -171,8 +176,9 @@ template <typename OperationType>
 static void append_operation_to_operation_history(
     const std::size_t ttnn_operation_id,
     const OperationType& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors) {
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors) {
+
     std::vector<operation_history::TensorRecord> input_tensor_records;
     input_tensor_records.reserve(input_tensors.size() + optional_input_tensors.size());
 
@@ -187,7 +193,7 @@ static void append_operation_to_operation_history(
 
     std::optional<bool> program_cache_hit = std::nullopt;
     std::optional<tt::stl::hash::hash_t> program_hash = std::nullopt;
-    if constexpr (std::is_same_v<OperationType, DeviceOperation>) {
+    if constexpr (std::is_same_v<OperationType, DeviceOperation<typename OperationType::OutputTensors>>) {
         auto& program_cache = input_tensors[0].device()->program_cache;
         if (program_cache.is_enabled()) {
             program_hash = operation.compute_program_hash(input_tensors, optional_input_tensors);
@@ -213,16 +219,16 @@ static void append_operation_to_operation_history(
 template<typename OperationType>
 inline void log_operation(
     const OperationType& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {}) {
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors = {},
+    const OptionalTensors& optional_output_tensors = {}) {
     tt::log_debug(
         tt::LogOp,
         "Launching Operation: \"{}\" ({})",
         operation.get_type_name(),
         detail::operation_type_to_string<OperationType>());
 
-    if constexpr (std::is_same_v<OperationType, DeviceOperation>) {
+    if constexpr (std::is_same_v<OperationType, DeviceOperation<typename OperationType::OutputTensors>>) {
         auto& program_cache = input_tensors[0].device()->program_cache;
         if (program_cache.is_enabled()) {
             auto program_hash = operation.compute_program_hash(input_tensors, optional_input_tensors);
@@ -268,9 +274,9 @@ inline void log_operation(
 template <typename OperationType>
 inline void log_operation(
     const OperationType& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {}) {}
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors = {},
+    const OptionalTensors& optional_output_tensors = {}) {}
 #endif
 
 inline uint32_t assign_id()
@@ -279,101 +285,111 @@ inline uint32_t assign_id()
     return atomic_count.fetch_add(1);
 }
 
-std::vector<Tensor> run(
-    const HostOperation& operation,
-    const std::vector<Tensor>& input_tensors
+template<class OutputTensors=Tensors>
+OutputTensors run(
+    const HostOperation<OutputTensors>& operation,
+    const Tensors& input_tensors
 );
 
-std::vector<Tensor> run(
+template<class OutputTensors=Tensors>
+OutputTensors run(
     CommandQueue& queue,
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {});
+    const DeviceOperation<OutputTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors = {},
+    const OptionalTensors& optional_output_tensors = {});
 
-std::vector<Tensor> run(
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {});
+template<class OutputTensors=Tensors>
+OutputTensors run(
+    const DeviceOperation<OutputTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors = {},
+    const OptionalTensors& optional_output_tensors = {});
 
 template<typename ConcreteOperation>
-inline std::vector<Tensor> run(
+inline auto run(
     ConcreteOperation&& concrete_op,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {}
-) {
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors={},
+    const OptionalTensors& optional_output_tensors={}
+) -> ProgramOutputTensors<ConcreteOperation> {
+    using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     if constexpr (detail::is_host_operation<ConcreteOperation>()) {
         TT_ASSERT(optional_input_tensors.empty());
         const auto operation = HostOperation(concrete_op);
-        return run(operation, input_tensors);
+        return run<OutputTensors>(operation, input_tensors);
     } else if constexpr (detail::is_device_operation<ConcreteOperation>()) {
         const auto operation = DeviceOperation(concrete_op);
-        return run(operation, input_tensors, optional_input_tensors, optional_output_tensors);
+        return run<OutputTensors>(operation, input_tensors, optional_input_tensors, optional_output_tensors);
     } else {
         static_assert(tt::stl::concepts::always_false_v<ConcreteOperation>, "Unsupported Operation");
     }
 }
 
-std::vector<Tensor> run_without_autoformat(
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {}
+template<class OutputTensors=Tensors>
+OutputTensors run_without_autoformat(
+    const DeviceOperation<OutputTensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors = {},
+    const OptionalTensors& optional_output_tensors = {}
 );
 template <typename ConcreteOperation>
-inline std::vector<Tensor> run_without_autoformat(
+inline auto run_without_autoformat(
     ConcreteOperation&& concrete_op,
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {}) {
-    const auto operation = DeviceOperation(concrete_op);
-    return run_without_autoformat(operation, input_tensors, optional_input_tensors, optional_output_tensors);
+    const std::vector<std::optional<Tensor>>& optional_output_tensors = {})
+    -> ProgramOutputTensors<ConcreteOperation>{
+    using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
+    const auto operation = DeviceOperation<OutputTensors>(concrete_op);
+    return run_without_autoformat<OutputTensors>(operation, input_tensors, optional_input_tensors, optional_output_tensors);
 }
 
-std::vector<Tensor> run_with_autoformat(
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
+Tensors run_with_autoformat(
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
+    const OptionalConstTensors& optional_input_tensors = {},
     const float pad_value = 0,
     const bool pad_c = false
 );
+
 template<typename ConcreteOperation>
-inline std::vector<Tensor> run_with_autoformat(
+inline auto run_with_autoformat(
     ConcreteOperation&& concrete_op,
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
     const float pad_value = 0,
     const bool pad_c = false
-) {
-    const auto operation = DeviceOperation(concrete_op);
+)-> Tensors {
+    using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
+    const auto operation = DeviceOperation<Tensors>(concrete_op);
     return run_with_autoformat(operation, input_tensors, optional_input_tensors, pad_value, pad_c);
 }
 
-std::vector<Tensor> run_with_autoformat(
-    const DeviceOperation& operation,
-    const std::vector<Tensor>& input_tensors,
+Tensors run_with_autoformat(
+    const DeviceOperation<Tensors>& operation,
+    const Tensors& input_tensors,
     const std::vector<FormatParams>& input_formatting,
     const std::vector<Layout>& output_layouts,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
+    const OptionalConstTensors& optional_input_tensors = {},
     const std::vector<std::optional<FormatParams>>& optional_input_formatting = {}
 );
 template<typename ConcreteOperation>
-inline std::vector<Tensor> run_with_autoformat(
+inline auto run_with_autoformat(
     ConcreteOperation&& concrete_op,
     const std::vector<Tensor>& input_tensors,
     const std::vector<FormatParams>& input_formatting,
     const std::vector<Layout>& output_layouts,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
     const std::vector<std::optional<FormatParams>>& optional_input_formatting = {}
-) {
-    const auto operation = DeviceOperation(concrete_op);
+)-> ProgramOutputTensors<ConcreteOperation> {
+    using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
+    const auto operation = DeviceOperation<OutputTensors>(concrete_op);
     return run_with_autoformat(operation, input_tensors, input_formatting, output_layouts, optional_input_tensors, optional_input_formatting);
 }
 
 void launch_op(
-    std::function<std::vector<Tensor>(const std::vector<Tensor>&, const std::vector<std::optional<const Tensor>>&)>&& op_func,
+    std::function<std::vector<Tensor>(const Tensors&, const OptionalConstTensors&)>&& op_func,
     const std::vector<Tensor> input_tensors,
     std::vector<Tensor>& output_tensors,
     const std::vector<std::optional<const Tensor>> optional_input_tensors = {}

--- a/tt_metal/tools/profiler/profile_this.py
+++ b/tt_metal/tools/profiler/profile_this.py
@@ -26,7 +26,7 @@ def profile_command(test_command, output_folder, name_append):
         options += f"-o {output_folder}"
     if name_append:
         options += f" -n {name_append}"
-    opProfilerTestCommand = f"python -m tracy -r -p {options} -m {test_command}"
+    opProfilerTestCommand = f"python -m tracy -v -r -p {options} -m {test_command}"
     subprocess.run([opProfilerTestCommand], shell=True, check=False, env=currentEnvs)
 
 

--- a/ttnn/visualizer/app.py
+++ b/ttnn/visualizer/app.py
@@ -716,4 +716,4 @@ def operation_stack_trace(operation_id):
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=True, port=8000)


### PR DESCRIPTION
A request to support optional tensors in create_program was originally made on https://github.com/tenstorrent-metal/tt-metal/issues/5163 . It became clear that support should be provided for cases were optional tensors could be ignored.

The approach taken here was to allow for std::vector<std::optional<Tensor>> to be provided for the output tensors in create_program which are always the last argument.   The expectation is that the return type of create_output_tensors would also match the output_tensors of create_program.