### PR TITLE
#7275: Fix tracy tools clean

### DIFF
--- a/module.mk
+++ b/module.mk
@@ -162,7 +162,7 @@ endif
 
 build: $(LIBS_TO_BUILD) $(TOOLS_TO_BUILD)
 
-clean: set_up_kernels/clean eager_package/clean
+clean: set_up_kernels/clean eager_package/clean tracy_tools_clean
 	test -d build && find build  -mindepth 1 -maxdepth 1 ! -path "build/python_env" -exec rm -rf {} + || true
 	rm -rf dist/
 

--- a/tt_metal/tracy.mk
+++ b/tt_metal/tracy.mk
@@ -30,3 +30,7 @@ tracy_tools:
 	cp $(TRACY_REPO)/csvexport/build/unix/csvexport-release $(TRACY_BUILD_DIR)
 	cd $(TRACY_REPO)/capture/build/unix && $(MAKE)
 	cp $(TRACY_REPO)/capture/build/unix/capture-release $(TRACY_BUILD_DIR)
+
+tracy_tools_clean:
+	cd $(TRACY_REPO)/csvexport/build/unix && $(MAKE) clean
+	cd $(TRACY_REPO)/capture/build/unix && $(MAKE) clean


### PR DESCRIPTION
make clean was not clearing tracy tools folders. This will clean those folders regardless of the build type.