### PR TITLE
Initial SetCommonRuntimeArgs() API/Tests for slow-dispatch

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -12,3 +12,5 @@ Runtime Arguments
 .. doxygenfunction:: UpdateRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const CoreCoord &core_coord, std::vector<uint32_t> &update_idx, std::shared_ptr<RuntimeArgs> runtime_args)
 
 .. doxygenfunction:: GetRuntimeArgs
+
+.. doxygenfunction:: SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/kernel_args/get_common_arg_addr.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/kernel_args/get_common_arg_addr.rst
@@ -1,0 +1,4 @@
+get_common_arg_addr
+===================
+
+.. doxygenfunction:: get_common_arg_addr

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/kernel_args/get_common_arg_val.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/kernel_args/get_common_arg_val.rst
@@ -1,0 +1,4 @@
+get_common_arg_val
+==================
+
+.. doxygenfunction:: get_common_arg_val

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/kernel_args/kernel_args.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/kernel_args/kernel_args.rst
@@ -4,4 +4,6 @@ Kernel Argument APIs
 .. toctree::
   get_arg_addr
   get_arg_val
+  get_common_arg_addr
+  get_common_arg_val
   get_compile_time_arg_val

--- a/tests/tt_metal/tt_metal/test_kernels/compute/increment_runtime_arg.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/increment_runtime_arg.cpp
@@ -9,15 +9,25 @@ void MAIN {
     // Tests get_arg_val API
     uint32_t arg_a  = get_arg_val<uint32_t>(0);
     uint32_t arg_b = get_arg_val<uint32_t>(1);
-
+    uint32_t common_arg_a = get_common_arg_val<uint32_t>(0);
+    uint32_t common_arg_b = get_common_arg_val<uint32_t>(1);
+    uint32_t common_arg_c = get_common_arg_val<uint32_t>(2);
+    uint32_t common_arg_d = get_common_arg_val<uint32_t>(3);
 
     // Need pointer as well to modify arg address to test in host
     volatile tt_l1_ptr std::uint32_t* arg_a_ptr = (volatile tt_l1_ptr uint32_t*)(TRISC_L1_ARG_BASE);
     volatile tt_l1_ptr std::uint32_t* arg_b_ptr = (volatile tt_l1_ptr uint32_t*)(TRISC_L1_ARG_BASE + 4);
-
+    volatile tt_l1_ptr std::uint32_t* common_arg_a_ptr = (volatile tt_l1_ptr uint32_t*)(TRISC_L1_ARG_BASE + COMMON_RT_ARGS_OFFSET);
+    volatile tt_l1_ptr std::uint32_t* common_arg_b_ptr = (volatile tt_l1_ptr uint32_t*)(TRISC_L1_ARG_BASE + COMMON_RT_ARGS_OFFSET + 4);
+    volatile tt_l1_ptr std::uint32_t* common_arg_c_ptr = (volatile tt_l1_ptr uint32_t*)(TRISC_L1_ARG_BASE + COMMON_RT_ARGS_OFFSET + 8);
+    volatile tt_l1_ptr std::uint32_t* common_arg_d_ptr = (volatile tt_l1_ptr uint32_t*)(TRISC_L1_ARG_BASE + COMMON_RT_ARGS_OFFSET + 12);
 
     UNPACK(arg_a_ptr[0] = arg_a + 87);
     UNPACK(arg_b_ptr[0] = arg_b + 216);
+    UNPACK(common_arg_a_ptr[0] = common_arg_a + 123);
+    UNPACK(common_arg_b_ptr[0] = common_arg_b + 234);
+    UNPACK(common_arg_c_ptr[0] = common_arg_c + 345);
+    UNPACK(common_arg_d_ptr[0] = common_arg_d + 456);
 
 }
 }

--- a/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
@@ -25,7 +25,6 @@ enum class KernelType {
     COMPUTE = 1,
 };
 
-
 Program initialize_program_data_movement(Device *device, const CoreRangeSet &core_range_set) {
     Program program = tt_metal::CreateProgram();
 
@@ -39,8 +38,6 @@ Program initialize_program_data_movement(Device *device, const CoreRangeSet &cor
     detail::CompileProgram(device, program);
     return std::move(program);
 }
-
-
 
 Program initialize_program_compute(Device *device, const CoreRangeSet &core_range_set) {
     Program program = tt_metal::CreateProgram();
@@ -60,59 +57,103 @@ Program initialize_program_compute(Device *device, const CoreRangeSet &core_rang
     return std::move(program);
 }
 
+uint32_t get_runtime_arg_addr(std::shared_ptr<Kernel> kernel) {
+    uint32_t result_base = 0;
+    switch (kernel->processor()) {
+        case tt::RISCV::BRISC: {
+            result_base = BRISC_L1_ARG_BASE;
+        } break;
+        case tt::RISCV::NCRISC: {
+            result_base = NCRISC_L1_ARG_BASE;
+        } break;
+        case tt::RISCV::COMPUTE: {
+            result_base = TRISC_L1_ARG_BASE;
+        } break;
+        default: TT_THROW("Unknown processor");
+    }
+    return result_base;
+};
 
-bool verify_result_data_movement(
-    Device *device, const Program &program, const std::map<CoreCoord, std::vector<uint32_t>> &core_to_rt_args) {
+// Verify the runtime args for a single core (apply optional non-zero increment amounts to values written to match compute kernel)
+bool verify_core_rt_args(Device *device, bool is_common, CoreCoord core, uint32_t base_addr, const std::vector<uint32_t> &written_args, const std::vector<uint32_t> &incr_amts) {
     bool pass = true;
-    auto get_runtime_arg_addr = [](std::shared_ptr<Kernel> kernel) {
-        uint32_t arg_base = 0;
-        switch (kernel->processor()) {
-            case tt::RISCV::BRISC: {
-                arg_base = BRISC_L1_ARG_BASE;
-            } break;
-            case tt::RISCV::NCRISC: {
-                arg_base = NCRISC_L1_ARG_BASE;
-            } break;
-            default: TT_THROW("Only BRISC and NCRISC have runtime arg support");
-        }
-        return arg_base;
-    };
 
-    EXPECT_TRUE(
-        program.num_kernels() == 1);
-    auto kernel = tt_metal::detail::GetKernel(program, 0);
-    auto processor = kernel->processor();
-    auto rt_arg_addr = get_runtime_arg_addr(kernel);
+    std::vector<uint32_t> observed_args;
+    tt_metal::detail::ReadFromDeviceL1(device, core, base_addr, written_args.size() * sizeof(uint32_t), observed_args);
 
-    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
-        const auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
-        auto processor = kernel->processor();
-        for (const auto &logical_core : kernel->cores_with_runtime_args()) {
-            auto expected_rt_args = core_to_rt_args.at(logical_core);
-            auto rt_args = kernel->runtime_args(logical_core);
-            EXPECT_TRUE(rt_args == expected_rt_args);
-            std::vector<uint32_t> written_args;
-            tt_metal::detail::ReadFromDeviceL1(
-                device, logical_core, rt_arg_addr, rt_args.size() * sizeof(uint32_t), written_args);
-            bool got_expected_result = rt_args == written_args;
-            EXPECT_TRUE(got_expected_result);
-            pass &= got_expected_result;
-        }
+    for (size_t i = 0; i < written_args.size(); i++) {
+        uint32_t expected_result = written_args.at(i) + (i < incr_amts.size() ? incr_amts.at(i) : 0);
+        bool got_expected_result = observed_args.at(i) == expected_result;
+        log_debug(tt::LogTest, "Validating {} Args. Core: {} at addr: 0x{:x} idx: {} - Expected: {} Observed: {}",
+            is_common ? "Common" : "Unique", core.str(), base_addr, i, expected_result, observed_args[i]);
+        pass &= got_expected_result;
+        EXPECT_TRUE(got_expected_result);
     }
     return pass;
 }
 
+// Iterate over all cores unique and common runtime args, and verify they match expected values.
+bool verify_results(
+    bool is_compute_test, Device *device, const Program &program, const std::map<CoreCoord, std::vector<uint32_t>> &core_to_rt_args, const std::vector<uint32_t> &common_rt_args = {}) {
+
+    bool pass = true;
+    EXPECT_TRUE(program.num_kernels() == 1);
+
+    // These increment amounts model what is done by compute kernel in this test.
+    std::vector<uint32_t> unique_rt_arg_incr_amts, common_rt_arg_incr_amts;
+    if (is_compute_test) {
+        unique_rt_arg_incr_amts = {87, 216};
+        common_rt_arg_incr_amts = {123, 234, 345, 456};
+    } else {
+        unique_rt_arg_incr_amts = {0};
+        common_rt_arg_incr_amts = {0};
+    }
+
+    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
+        const auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
+        auto rt_args_base_addr = get_runtime_arg_addr(kernel);
+        auto processor = kernel->processor();
+        uint32_t common_rt_args_offset = 0; // Set to max required across all cores.
+
+        // Verify Unique RT Args (per core)
+        for (const auto &logical_core : kernel->cores_with_runtime_args()) {
+            auto expected_rt_args = core_to_rt_args.at(logical_core);
+            auto rt_args = kernel->runtime_args(logical_core);
+            EXPECT_EQ(rt_args, expected_rt_args);
+
+            pass &= verify_core_rt_args(device, false, logical_core, rt_args_base_addr, expected_rt_args, unique_rt_arg_incr_amts);
+            auto rt_args_size_bytes = rt_args.size() * sizeof(uint32_t);
+            common_rt_args_offset = rt_args_size_bytes > common_rt_args_offset ? rt_args_size_bytes : common_rt_args_offset;
+        }
+
+        // Verify common RT Args (same for all cores) if they exist.
+        if (common_rt_args.size() > 0) {
+            const auto common_args_addr = rt_args_base_addr + common_rt_args_offset; // Common args are placed after unique args per core.
+            for (auto &core_range : kernel->logical_coreranges()) {
+                for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
+                    for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                        CoreCoord logical_core({x, y});
+                        auto rt_args = kernel->common_runtime_args();
+                        EXPECT_EQ(rt_args, common_rt_args);
+                        pass &= verify_core_rt_args(device, true, logical_core, common_args_addr, common_rt_args, common_rt_arg_incr_amts);
+                    }
+                }
+            }
+        }
+    }
+
+    return pass;
+}
+
+// Write unique and common runtime args to device and readback to verify written correctly.
 TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         // First run the program with the initial runtime args
         CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
         CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(5, 5));
         CoreRangeSet core_range_set({first_core_range, second_core_range});
-        auto program =
-            unit_tests::runtime_args::initialize_program_data_movement(this->devices_.at(id), core_range_set);
-        ASSERT_TRUE(
-            program.num_kernels() ==
-            1);
+        auto program = unit_tests::runtime_args::initialize_program_data_movement(this->devices_.at(id), core_range_set);
+        ASSERT_TRUE(program.num_kernels() == 1);
         std::vector<uint32_t> initial_runtime_args = {101, 202};
         SetRuntimeArgs(program, 0, core_range_set, initial_runtime_args);
 
@@ -126,8 +167,7 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
             }
         }
         detail::WriteRuntimeArgsToDevice(this->devices_.at(id), program);
-        ASSERT_TRUE(
-            unit_tests::runtime_args::verify_result_data_movement(this->devices_.at(id), program, core_to_rt_args));
+        EXPECT_TRUE(unit_tests::runtime_args::verify_results(false, this->devices_.at(id), program, core_to_rt_args));
 
         std::vector<uint32_t> second_runtime_args = {303, 606};
         SetRuntimeArgs(program, 0, first_core_range, second_runtime_args);
@@ -138,64 +178,14 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
                 core_to_rt_args[logical_core] = second_runtime_args;
             }
         }
-        EXPECT_TRUE(
-            unit_tests::runtime_args::verify_result_data_movement(this->devices_.at(id), program, core_to_rt_args));
+        EXPECT_TRUE(unit_tests::runtime_args::verify_results(false, this->devices_.at(id), program, core_to_rt_args));
+
+        // Set common runtime args, automatically sent to all cores used by kernel.
+        std::vector<uint32_t> common_runtime_args = {303, 606, 999, 1234};
+        SetCommonRuntimeArgs(program, 0, common_runtime_args);
+        detail::WriteRuntimeArgsToDevice(this->devices_.at(id), program);
+        EXPECT_TRUE(unit_tests::runtime_args::verify_results(false, this->devices_.at(id), program, core_to_rt_args, common_runtime_args));
     }
-}
-
-bool verify_result_compute(
-    Device *device, const Program &program,
-        const std::map<CoreCoord, std::vector<uint32_t>> &core_to_rt_args,
-        KernelType kern_type = KernelType::DATA_MOVEMENT,
-        uint32_t buffer_addr = 0) {
-    bool pass = true;
-    auto get_runtime_arg_addr = [](std::shared_ptr<Kernel> kernel) {
-        uint32_t result_base = 0;
-        switch (kernel->processor()) {
-            case tt::RISCV::BRISC: {
-                result_base = BRISC_L1_ARG_BASE;
-            } break;
-            case tt::RISCV::NCRISC: {
-                result_base = NCRISC_L1_ARG_BASE;
-            } break;
-            case tt::RISCV::COMPUTE: {
-                result_base = TRISC_L1_ARG_BASE;
-            } break;
-            default: TT_THROW("Unknown processor");
-        }
-        return result_base;
-    };
-
-
-    EXPECT_TRUE(
-        program.num_kernels() == 1);
-    auto kernel = tt_metal::detail::GetKernel(program, 0);
-    auto processor = kernel->processor();
-    auto rt_arg_addr = get_runtime_arg_addr(kernel);
-    auto rt_result_addr = get_runtime_arg_addr(kernel);
-
-    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
-        const auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
-        auto processor = kernel->processor();
-        for (const auto &logical_core : kernel->cores_with_runtime_args()) {
-            auto expected_rt_args = core_to_rt_args.at(logical_core);
-            auto rt_args = kernel->runtime_args(logical_core);
-            EXPECT_TRUE(rt_args == expected_rt_args);
-            std::vector<uint32_t> written_args;
-            tt_metal::detail::ReadFromDeviceL1(
-                device, logical_core, rt_arg_addr, rt_args.size() * sizeof(uint32_t), written_args);
-
-            std::vector<uint32_t> increments = {87, 216};
-            for(int i=0; i<rt_args.size(); i++){
-                bool got_expected_result;
-                got_expected_result = written_args[i] == (rt_args[i] + increments[i]);
-                pass &= got_expected_result;
-                EXPECT_TRUE(got_expected_result);
-            }
-
-        }
-    }
-    return pass;
 }
 
 TEST_F(DeviceFixture, LegallyModifyRTArgsCompute) {
@@ -217,9 +207,132 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsCompute) {
                 }
             }
         }
+
+        // Set common runtime args, automatically sent to all cores used by kernel.
+        std::vector<uint32_t> common_runtime_args = {11, 22, 33, 44};
+        SetCommonRuntimeArgs(program, 0, common_runtime_args);
+
         tt_metal::detail::LaunchProgram(this->devices_.at(id), program);
-        EXPECT_TRUE(unit_tests::runtime_args::verify_result_compute(
-            this->devices_.at(id), program, core_to_rt_args, KernelType::COMPUTE));
+        EXPECT_TRUE(unit_tests::runtime_args::verify_results(true, this->devices_.at(id), program, core_to_rt_args, common_runtime_args));
+    }
+}
+
+// Don't cover all cores of kernel with SetRuntimeArgs. Verify that correct offset used to access common runtime args.
+TEST_F(DeviceFixture, SetRuntimeArgsSubsetOfCoresCompute) {
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        // First run the program with the initial runtime args
+        CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
+        CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(5, 5));
+        CoreRangeSet core_range_set({first_core_range, second_core_range});
+        auto program = unit_tests::runtime_args::initialize_program_compute(this->devices_.at(id), core_range_set);
+        std::vector<uint32_t> initial_runtime_args = {101, 202};
+        SetRuntimeArgs(program, 0, first_core_range, initial_runtime_args); // First core range only.
+
+        std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
+        for (auto x = first_core_range.start.x; x <= first_core_range.end.x; x++) {
+            for (auto y = first_core_range.start.y; y <= first_core_range.end.y; y++) {
+                CoreCoord logical_core(x, y);
+                core_to_rt_args[logical_core] = initial_runtime_args;
+            }
+        }
+
+        // Set common runtime args, automatically sent to all cores used by kernel.
+        std::vector<uint32_t> common_runtime_args = {11, 22, 33, 44};
+        SetCommonRuntimeArgs(program, 0, common_runtime_args);
+
+        tt_metal::detail::LaunchProgram(this->devices_.at(id), program);
+        EXPECT_TRUE(unit_tests::runtime_args::verify_results(true, this->devices_.at(id), program, core_to_rt_args, common_runtime_args));
+    }
+}
+
+// Different unique runtime args per core. Not overly special, but verify that it works.
+TEST_F(DeviceFixture, SetRuntimeArgsUniqueValuesCompute) {
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        // First run the program with the initial runtime args
+        CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
+        CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(5, 5));
+        CoreRangeSet core_range_set({first_core_range, second_core_range});
+        auto program = unit_tests::runtime_args::initialize_program_compute(this->devices_.at(id), core_range_set);
+
+        std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
+        for (auto core_range : core_range_set.ranges()) {
+            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
+                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                    CoreCoord logical_core(x, y);
+                    // Generate an rt arg val based on x and y.
+                    uint32_t val_offset = x * 100 + y * 10;
+                    std::vector<uint32_t> initial_runtime_args = {101 + val_offset, 202 + val_offset};
+                    SetRuntimeArgs(program, 0, logical_core, initial_runtime_args);
+                    core_to_rt_args[logical_core] = initial_runtime_args;
+                }
+            }
+        }
+
+        // Set common runtime args, automatically sent to all cores used by kernel.
+        std::vector<uint32_t> common_runtime_args = {11, 22, 33, 44};
+        SetCommonRuntimeArgs(program, 0, common_runtime_args);
+
+        tt_metal::detail::LaunchProgram(this->devices_.at(id), program);
+        EXPECT_TRUE(unit_tests::runtime_args::verify_results(true, this->devices_.at(id), program, core_to_rt_args, common_runtime_args));
+    }
+}
+
+// Some cores have more unique runtime args than others. Unused in kernel, but API supports it, so verify it works and that
+// common runtime args are appropriately offset by amount from core(s) with most unique runtime args.
+TEST_F(DeviceFixture, SetRuntimeArgsVaryingLengthPerCore) {
+
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        // First run the program with the initial runtime args
+        CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
+        CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(5, 5));
+        CoreRangeSet core_range_set({first_core_range, second_core_range});
+        auto program = unit_tests::runtime_args::initialize_program_compute(this->devices_.at(id), core_range_set);
+
+        std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
+        for (auto core_range : core_range_set.ranges()) {
+            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
+                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                    CoreCoord logical_core(x, y);
+                    // Generate rt args length and val based on x,y arbitrarily.
+                    uint32_t val_offset = x * 100 + y * 10;
+                    uint32_t num_rt_args = 2 + x + y;
+                    std::vector<uint32_t> initial_runtime_args;
+                    for (uint32_t i = 0; i < num_rt_args; i++) {
+                        initial_runtime_args.push_back(101 + val_offset + (i * 66));
+                    }
+                    SetRuntimeArgs(program, 0, logical_core, initial_runtime_args);
+                    core_to_rt_args[logical_core] = initial_runtime_args;
+                }
+            }
+        }
+
+        // Set common runtime args, automatically sent to all cores used by kernel.
+        std::vector<uint32_t> common_runtime_args = {11, 22, 33, 44};
+        SetCommonRuntimeArgs(program, 0, common_runtime_args);
+
+        tt_metal::detail::LaunchProgram(this->devices_.at(id), program);
+        EXPECT_TRUE(unit_tests::runtime_args::verify_results(true, this->devices_.at(id), program, core_to_rt_args, common_runtime_args));
+    }
+}
+
+// Too many unique and common runtime args, overflows allowed space and throws expected exception from both unique/common APIs.
+TEST_F(DeviceFixture, IllegalTooManyRuntimeArgs) {
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        CoreRange first_core_range(CoreCoord(1, 1), CoreCoord(2, 2));
+        CoreRangeSet core_range_set({first_core_range});
+        auto program = unit_tests::runtime_args::initialize_program_compute(this->devices_.at(id), core_range_set);
+
+        // Set 100 unique args, then try to set 300 common args and fail.
+        std::vector<uint32_t> initial_runtime_args(100);
+        SetRuntimeArgs(program, 0, core_range_set, initial_runtime_args);
+        std::vector<uint32_t> common_runtime_args(300);
+        EXPECT_ANY_THROW(SetCommonRuntimeArgs(program, 0, common_runtime_args));
+
+        // Set 100 common args, then try to set another 300 unique args and fail.
+        std::vector<uint32_t> more_common_runtime_args(100);
+        SetCommonRuntimeArgs(program, 0, more_common_runtime_args);
+        std::vector<uint32_t> more_unique_args(300);
+        EXPECT_ANY_THROW(SetRuntimeArgs(program, 0, core_range_set, more_unique_args));
     }
 }
 
@@ -229,11 +342,8 @@ TEST_F(DeviceFixture, IllegallyModifyRTArgs) {
         CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
         CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(5, 5));
         CoreRangeSet core_range_set({first_core_range, second_core_range});
-        auto program =
-            unit_tests::runtime_args::initialize_program_data_movement(this->devices_.at(id), core_range_set);
-        ASSERT_TRUE(
-            program.num_kernels() ==
-            1);
+        auto program = unit_tests::runtime_args::initialize_program_data_movement(this->devices_.at(id), core_range_set);
+        ASSERT_TRUE(program.num_kernels() == 1);
         std::vector<uint32_t> initial_runtime_args = {101, 202};
         SetRuntimeArgs(program, 0, core_range_set, initial_runtime_args);
 
@@ -247,10 +357,17 @@ TEST_F(DeviceFixture, IllegallyModifyRTArgs) {
             }
         }
         detail::WriteRuntimeArgsToDevice(this->devices_.at(id), program);
-        ASSERT_TRUE(
-            unit_tests::runtime_args::verify_result_data_movement(this->devices_.at(id), program, core_to_rt_args));
+        ASSERT_TRUE(unit_tests::runtime_args::verify_results(false, this->devices_.at(id), program, core_to_rt_args));
+
         std::vector<uint32_t> invalid_runtime_args = {303, 404, 505};
         EXPECT_ANY_THROW(SetRuntimeArgs(program, 0, first_core_range, invalid_runtime_args));
+
+        // Cannot modify number of common runtime args either.
+        std::vector<uint32_t> common_runtime_args = {11, 22, 33, 44};
+        SetCommonRuntimeArgs(program, 0, common_runtime_args);
+        std::vector<uint32_t> illegal_common_runtime_args = {0, 1, 2, 3, 4, 5};
+        EXPECT_ANY_THROW(SetCommonRuntimeArgs(program, 0, illegal_common_runtime_args));
+
     }
 }
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -243,6 +243,7 @@ void AssignGlobalBufferToProgram(std::shared_ptr<Buffer> buffer, std::variant<st
 using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;
 /**
  * Set runtime args for a kernel that are sent to the core during runtime. This API needs to be called to update the runtime args for the kernel.
+ * Maximum of 255 allowed runtime args per core (unique and common runtime args count toward same limit).
  *
  * Return value: void
  *
@@ -257,6 +258,7 @@ void SetRuntimeArgs(const Program &program, KernelHandle kernel, const std::vari
 
 /**
  * Set multiple runtime arguments of a kernel at once during runtime, each mapping to a specific core. The runtime args for each core may be unique.
+ * Maximum of 255 allowed runtime args per core (unique and common runtime args count toward same limit).
  *
  * Return value: void
  *
@@ -271,6 +273,7 @@ void SetRuntimeArgs(const Program &program, KernelHandle kernel, const std::vect
 
 /**
  * Set runtime args for a kernel that are sent to the specified cores using the command queue. This API must be used when Asynchronous Command Queue Mode is enabled.
+ * Maximum of 255 allowed runtime args per core (unique and common runtime args count toward same limit).
  *
  * Return value: void
  *
@@ -285,6 +288,7 @@ void SetRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const 
 
 /**
  * Set multiple runtime arguments of a kernel using the command queue. Each core can have distinct arguments. This API must be used when Asynchronous Command Queue Mode is enabled.
+ * Maximum of 255 allowed runtime args per core (unique and common runtime args count toward same limit).
  *
  * Return value: void
  * | Argument     | Description                                                            | Type                                                   | Valid Range                                                                | Required |
@@ -295,6 +299,21 @@ void SetRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const 
  * | runtime_args | The runtime args to be written                                         | const std::vector<std::shared_ptr<RuntimeArgs>>        | Outer vector size must be equal to size of core_spec vector                | Yes      |
  */
 void SetRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const std::vector< CoreCoord > & core_spec, const std::vector<std::shared_ptr<RuntimeArgs>> runtime_args);
+
+
+/**
+ * Set common (shared by all cores) runtime args for a kernel that are sent to all cores during runtime. This API needs to be called to update the common runtime args for the kernel.
+ * Maximum of 255 allowed runtime args per core (unique and common runtime args count toward same limit).
+ *
+ * Return value: void
+ *
+ * | Argument     | Description                                                            | Type                                                   | Valid Range                                                         | Required |
+ * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------|----------|
+ * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
+ * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)                                |                                                                     | Yes      |
+ * | runtime_args | The runtime args to be written                                         | const std::vector<uint32_t> &                          |                                                                     | Yes      |
+ */
+void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args);
 
 /**
  * Get the runtime args for a kernel.

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -50,6 +50,7 @@ class Kernel : public JitBuildSettings {
     void update_runtime_arg( const CoreCoord &logical_core, size_t idx, uint32_t value);
 
     std::vector<uint32_t> & runtime_args(const CoreCoord &logical_core);
+    std::vector<uint32_t> & common_runtime_args();
 
     std::map<std::string, std::string> defines() const { return defines_; }
 
@@ -65,9 +66,13 @@ class Kernel : public JitBuildSettings {
     inline uint16_t get_binary_size16() const { return binary_size16_; }
     void set_binary_path ( const std::string & binary_path) { binary_path_ = binary_path; }
     void set_binaries(chip_id_t device_id, std::vector<ll_api::memory> &&binaries);
+    uint32_t get_common_runtime_args_offset();
+    void set_common_runtime_args_offset();
     virtual void read_binaries(Device *device) = 0;
 
+    void validate_runtime_args_size(size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core);
     void set_runtime_args(const CoreCoord &logical_core, const std::vector<uint32_t> &runtime_args);
+    void set_common_runtime_args(const std::vector<uint32_t> &runtime_args);
 
     int get_watcher_kernel_id() { return watcher_kernel_id_; }
 
@@ -90,7 +95,10 @@ class Kernel : public JitBuildSettings {
     uint16_t binary_size16_;
     std::vector<uint32_t> compile_time_args_;
     std::vector< std::vector< std::vector<uint32_t>> > core_to_runtime_args_;
+    std::vector<uint32_t> common_runtime_args_;
     std::unordered_set<CoreCoord> core_with_runtime_args_;
+    std::size_t max_runtime_args_per_core_;             // For validation
+    CoreCoord core_with_max_runtime_args_;              // For validation
     std::map<std::string, std::string> defines_;        // preprocessor defines. this is to be able to generate generic instances.
     std::set<CoreCoord> logical_cores_;
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -871,6 +871,7 @@ void Program::compile( Device * device )
             events.emplace_back ( detail::async ( [kernel, device, this] {
 
                 JitBuildOptions build_options(device->build_env());
+                kernel->set_common_runtime_args_offset();
                 kernel->set_build_options(build_options);
                 this->set_cb_data_fmt(device, kernel->logical_coreranges(), build_options);
 

--- a/tt_metal/include/compute_kernel_api/common.h
+++ b/tt_metal/include/compute_kernel_api/common.h
@@ -10,33 +10,70 @@
 #include "compute_kernel_api/unpack.h"
 #include "compute_kernel_api/cb_api.h"
 
+
+// JIT Build flow will set this as needed.
+#ifndef COMMON_RT_ARGS_OFFSET
+    #define COMMON_RT_ARGS_OFFSET 0
+#endif
+
 /**
- * Returns the address in L1 for a given runtime argument index
+ * Returns the address in L1 for a given runtime argument index for unique (per core) runtime arguments set via SetRuntimeArgs() API.
  *
- * Return value: Associated L1 address of given runtime argument index
+ * Return value: Associated L1 address of given unique runtime argument index
  *
  * | Argument       | Description                                                             | Type     | Valid Range                                    | Required |
  * |----------------|-------------------------------------------------------------------------|----------|------------------------------------------------|----------|
- * | arg_idx        | Runtime argument index                                                  | uint32_t | 0 to 31                                        | True     |
+ * | arg_idx        | Unique Runtime argument index                                           | uint32_t | 0 to 255                                       | True     |
  */
 constexpr static uint32_t get_arg_addr(int arg_idx) {
     // args are 4B in size
     return TRISC_L1_ARG_BASE + (arg_idx << 2);
 }
 
-
 /**
- * Returns the value at a given runtime argument index
+ * Returns the address in L1 for a given runtime argument index for common (all cores) runtime arguments set via SetCommonRuntimeArgs() API.
  *
- * Return value: The value associated with the runtime argument index
+ * Return value: Associated L1 address of given common runtime argument index
  *
  * | Argument       | Description                                                             | Type     | Valid Range                                    | Required |
  * |----------------|-------------------------------------------------------------------------|----------|------------------------------------------------|----------|
- * | arg_idx        | Runtime argument index                                                  | uint32_t | 0 to 31                                        | True     |
+ * | arg_idx        | Common Runtime argument index                                           | uint32_t | 0 to 255                                       | True     |
+ */
+constexpr static uint32_t get_common_arg_addr(int arg_idx) {
+    // args are 4B in size
+    return TRISC_L1_ARG_BASE + COMMON_RT_ARGS_OFFSET + (arg_idx << 2);
+}
+
+/**
+ * Returns the value at a given runtime argument index for unique (per-core) runtime arguments set via SetRuntimeArgs() API.
+ *
+ * Return value: The value associated with the unique runtime argument index
+ *
+ * | Argument              | Description                                    | Type                  | Valid Range               | Required |
+ * |-----------------------|------------------------------------------------|-----------------------|---------------------------|----------|
+ * | arg_idx               | Unique Runtime argument index                  | uint32_t              | 0 to 255                  | True     |
+ * | T (template argument) | Data type of the returned argument             | Any 4-byte sized type | N/A                       | True     |
  */
 template <typename T>
 FORCE_INLINE T get_arg_val(int arg_idx) {
     // only 4B args are supported (eg int32, uint32)
     static_assert("Error: only 4B args are supported" && sizeof(T) == 4);
     return *((volatile tt_l1_ptr T*)(get_arg_addr(arg_idx)));
+}
+
+/**
+ * Returns the value at a given runtime argument index for common (all cores) runtime arguments set via SetCommonRuntimeArgs() API.
+ *
+ * Return value: The value associated with the common runtime argument index
+ *
+ * | Argument              | Description                                    | Type                  | Valid Range               | Required |
+ * |-----------------------|------------------------------------------------|-----------------------|---------------------------|----------|
+ * | arg_idx               | Common Runtime argument index                  | uint32_t              | 0 to 255                  | True     |
+ * | T (template argument) | Data type of the returned argument             | Any 4-byte sized type | N/A                       | True     |
+ */
+template <typename T>
+FORCE_INLINE T get_common_arg_val(int arg_idx) {
+    // only 4B args are supported (eg int32, uint32)
+    static_assert("Error: only 4B args are supported" && sizeof(T) == 4);
+    return *((volatile tt_l1_ptr T*)(get_common_arg_addr(arg_idx)));
 }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -584,7 +584,7 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
         auto device_id = device->id();
         detail::DispatchStateCheck( false );
 
-        auto get_l1_arg_base_addr = [](const RISCV &riscv) {
+        auto get_l1_arg_base_addr = [](const RISCV &riscv, std::shared_ptr<Kernel> kernel) {
             uint32_t l1_arg_base = 0;
             switch (riscv) {
                 case RISCV::BRISC: {
@@ -594,7 +594,12 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
                     l1_arg_base = NCRISC_L1_ARG_BASE;
                 } break;
                 case RISCV::ERISC: {
-                    l1_arg_base = eth_l1_mem::address_map::ERISC_L1_ARG_BASE;
+                    auto config = std::get<EthernetConfig>(kernel->config());
+                    if (config.eth_mode == Eth::IDLE) {
+                        l1_arg_base = IDLE_ERISC_L1_ARG_BASE;
+                    } else {
+                        l1_arg_base = eth_l1_mem::address_map::ERISC_L1_ARG_BASE;
+                    }
                 } break;
                 case RISCV::COMPUTE: {
                     l1_arg_base = TRISC_L1_ARG_BASE;
@@ -608,17 +613,33 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
         for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
             const auto kernel = detail::GetKernel(program, kernel_id);
             auto processor = kernel->processor();
+            auto args_base_addr = get_l1_arg_base_addr(processor, kernel);
+
             for (const auto &logical_core : kernel->cores_with_runtime_args()) {
                 auto physical_core = device->physical_core_from_logical_core(logical_core, kernel->get_kernel_core_type());
                 const auto & rt_args = kernel->runtime_args(logical_core);
-                auto arg_addr = get_l1_arg_base_addr(processor);
-                if (processor == RISCV::ERISC) {
-                    auto config = std::get<EthernetConfig>(kernel->config());
-                    if (config.eth_mode == Eth::IDLE) {
-                        arg_addr = IDLE_ERISC_L1_ARG_BASE;
+                log_trace(tt::LogMetal, "{} - Writing {} unique rtargs to core {} (physical: {}) addr 0x{:x} => args: {}",
+                    __FUNCTION__, rt_args.size(), logical_core.str(), physical_core.str(), args_base_addr, rt_args);
+                tt::llrt::write_hex_vec_to_core(device_id, physical_core, rt_args, args_base_addr);
+            }
+
+            // Unicast common runtime args to all cores for kernel. Fast-Dispatch will multicast as perf opt.
+            const auto &common_rt_args = kernel->common_runtime_args();
+            auto common_rt_args_offset = kernel->get_common_runtime_args_offset();
+
+            if (common_rt_args.size() > 0) {
+                for (auto &core_range : kernel->logical_coreranges()) {
+                    for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
+                        for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                            CoreCoord logical_core({x, y});
+                            auto physical_core = device->physical_core_from_logical_core(logical_core, kernel->get_kernel_core_type());
+                            const auto common_args_addr = args_base_addr + common_rt_args_offset;  // Common args are placed after unique args per core.
+                            log_trace(tt::LogMetal, "{} - Writing {} common rtargs to core {} (physical: {}) addr 0x{:x} => args: {}",
+                                __FUNCTION__, common_rt_args.size(), logical_core.str(), physical_core.str(), common_args_addr, common_rt_args);
+                            tt::llrt::write_hex_vec_to_core(device_id, physical_core, common_rt_args, common_args_addr);
+                        }
                     }
                 }
-                tt::llrt::write_hex_vec_to_core(device_id, physical_core, rt_args, arg_addr);
             }
         }
     }
@@ -830,6 +851,15 @@ void SetRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const 
     detail::DispatchStateCheck(not device->using_slow_dispatch());
     SetRuntimeArgs(device->command_queue(), kernel, core_spec, runtime_args, false);
 }
+
+
+void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args) {
+    ZoneScoped;
+    TT_FATAL( not CommandQueue::async_mode_set(), "This variant of SetCommonRuntimeArgs can only be called when Asyncrhonous SW Command Queues are disabled for Fast Dispatch.");
+    auto k = detail::GetKernel(program, kernel_id);
+    k->set_common_runtime_args(runtime_args);
+}
+
 
 std::vector<uint32_t> & GetRuntimeArgs(const Program &program, KernelHandle kernel_id, const CoreCoord &logical_core) {
     TT_FATAL( not CommandQueue::async_mode_set(), "GetRuntimeArgs can only be called when Asyncrhonous SW Command Queues are disabled for Fast Dispatch.");


### PR DESCRIPTION
    #4476: Initial SetCommonRuntimeArgs() API/Tests

     - Slow dispatch path covered for now, not FD2.0 yet
     - Update tests for data-movement, compute to cover SetCommonRuntimeArgs too
     - Cleanup test infra, a lot of it was able to be commonized (checking)
     - Add a test with unique rt arg vals per core, and a test that varies
       number of unique rt args per core, to show common offset used.
     - Add docs, and update words in dataflow_api.h / compute_kernel_api/common.h
       to be the same for existing APIs
     - Add note about combined max of 255 args between unique/combined in
       all flavors host APIs for runtime args.
     - Update validation to catch unique+common args exceeding 255 limit
     - Add default define COMMON_RT_ARGS_OFFSET in dataflow_api.h and
       common.h to prevent compile errors in unused kernels. When configured,
       the JIT Build flow will automatically populate this define.