### PR TITLE
#7192: Add backward support for complex abs and angle

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -894,6 +894,8 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.abs_bw
 
+.. autofunction:: tt_lib.tensor.complex_abs_bw
+
 .. autofunction:: tt_lib.tensor.rsqrt_bw
 
 .. autofunction:: tt_lib.tensor.neg_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_abs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_abs.py
@@ -7,38 +7,8 @@ import pytest
 import tt_lib
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
     data_gen_with_range,
-    compare_pcc,
     compare_results,
 )
-from models.utility_functions import (
-    skip_for_wormhole_b0,
-)
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
-def test_bw_angle(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-
-    pyt_y = torch.angle(in_data)
-
-    tt_output_tensor_on_device = tt_lib.tensor.angle_bw(grad_tensor, input_tensor, False)
-
-    in_data.retain_grad()
-
-    pyt_y.backward(gradient=grad_data)
-
-    golden_tensor = [in_data.grad]
-
-    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
-    assert comp_pass
 
 
 def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
@@ -57,7 +27,7 @@ def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100))
     ),
 )
 # testing for Type 1 complex tensor
-def test_bw_angle_cplx1(input_shapes, device):
+def test_bw_abs_cplx1(input_shapes, device):
     in_data = random_complex_tensor(input_shapes, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
@@ -94,7 +64,7 @@ def test_bw_angle_cplx1(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_bw_complex_angle_zero_inp(input_shapes, device):
+def test_bw_complex_abs_zero_inp(input_shapes, device):
     in_data = random_complex_tensor(input_shapes, (0, 0), (0, 0))
     in_data.requires_grad = True
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -80,6 +80,8 @@ std::vector<Tensor> binary_le_bw(const Tensor& grad, const Tensor& input, const 
 
 std::vector<Tensor> abs_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> complex_abs_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 std::vector<Tensor> rsqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> neg_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
@@ -168,7 +170,7 @@ std::vector<Tensor> elu_bw(const Tensor& grad, const Tensor& input, float alpha,
 
 std::vector<Tensor> hardtanh_bw(const Tensor& grad, const Tensor& input, float min, float max, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> angle_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+std::vector<Tensor> angle_bw(const Tensor& grad, const Tensor& input, bool is_complextensor = true, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> sin_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -649,6 +649,22 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+    m_tensor.def("complex_abs_bw", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&complex_abs_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for abs of complex ``input`` tensor with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor add is applied to", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
     m_tensor.def("rsqrt_bw", &tt::tt_metal::rsqrt_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for rsqrt of ``input`` tensors with given ``grad``.
@@ -1225,8 +1241,8 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("angle_bw", &tt::tt_metal::angle_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def("angle_bw", py::overload_cast<const Tensor&, const Tensor&, bool, const MemoryConfig&>(&angle_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("is_complextensor").noconvert() = true, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for angle for the ``input`` with given ``grad``
 
                 Input tensors must have BFLOAT16 data type.
@@ -1238,6 +1254,7 @@ namespace tt::tt_metal::detail{
 
                     "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                     "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                    "is_complextensor", "True(default) if input is complex tensor", "bool", "True/False", "No"
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 


### PR DESCRIPTION
Add backward support for complex abs and angle for type 1 complex tensor
CI test: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8629614632
https://github.com/tenstorrent/tt-metal/actions/runs/8764636178 (passed)