### PR TITLE
#7294: Improve perf of mcast in matmuls

### DIFF
--- a/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -127,14 +127,14 @@ void kernel_main() {
             uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 
             // num_dests must not include source, since we are NOT really doing a local copy!
-            noc_async_write_multicast(in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true);
+            noc_async_write_multicast(in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, false, false);
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
             // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
             // We should also multicast the flag to destinations
             // num_dests must not include source, since we are NOT really doing a local copy!
-            noc_semaphore_set_multicast(in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores, false);
+            noc_semaphore_set_multicast(in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores, false, false);
             #endif
 
             #ifndef IN0_SHARDED

--- a/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding_block_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding_block_sharded.cpp
@@ -131,14 +131,14 @@ void kernel_main() {
             uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 
             // num_dests must not include source, since we are NOT really doing a local copy!
-            noc_async_write_multicast(in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true);
+            noc_async_write_multicast(in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, false, false);
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
             // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
             // We should also multicast the flag to destinations
             // num_dests must not include source, since we are NOT really doing a local copy!
-            noc_semaphore_set_multicast(in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores,false);
+            noc_semaphore_set_multicast(in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores,false, false);
             #endif
 
             cb_push_back(cb_id_in0, in0_block_num_tiles);

--- a/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -82,8 +82,8 @@ void kernel_main() {
     constexpr uint32_t in3_tensor_stride_w                = get_compile_time_arg_val(25);
 
     constexpr uint32_t cb_id_in3 = 3;
-    const uint32_t bias_single_tile_size_bytes = get_tile_size(cb_id_in3);
-    const DataFormat bias_data_format = get_dataformat(cb_id_in3);
+    constexpr uint32_t bias_single_tile_size_bytes = get_tile_size(cb_id_in3);
+    constexpr DataFormat bias_data_format = get_dataformat(cb_id_in3);
 
     uint32_t l1_write_addr_in3;
 
@@ -188,14 +188,14 @@ void kernel_main() {
             uint64_t in1_multicast_data_addr = in1_multicast_data_noc | in1_start_address;
 
             // num_dests must not include source, since we are NOT really doing a local copy!
-            noc_async_write_multicast(in1_start_address, in1_multicast_data_addr, in1_block_size_bytes, in1_mcast_num_cores, true);
+            noc_async_write_multicast(in1_start_address, in1_multicast_data_addr, in1_block_size_bytes, in1_mcast_num_cores, false, false);
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
             // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
             // We should also multicast the flag to destinations
             // num_dests must not include source, since we are NOT really doing a local copy!
-            noc_semaphore_set_multicast(in1_mcast_receiver_semaphore_addr, in1_mcast_receiver_semaphore_noc_addr, in1_mcast_num_cores, false);
+            noc_semaphore_set_multicast(in1_mcast_receiver_semaphore_addr, in1_mcast_receiver_semaphore_noc_addr, in1_mcast_num_cores, false, false);
 
             #endif
 
@@ -237,13 +237,13 @@ void kernel_main() {
                 uint64_t in3_multicast_data_addr = in1_multicast_data_noc | in3_start_address;
 
                 // num_dests must not include source, since we are NOT really doing a local copy!
-                noc_async_write_multicast(in3_start_address, in3_multicast_data_addr, in3_block_size_bytes, in1_mcast_num_cores, true);
+                noc_async_write_multicast(in3_start_address, in3_multicast_data_addr, in3_block_size_bytes, in1_mcast_num_cores, false, false);
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                 // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
                 // We should also multicast the flag to destinations
                 // num_dests must not include source, since we are NOT really doing a local copy!
-                noc_semaphore_set_multicast(in1_mcast_receiver_semaphore_addr, in1_mcast_receiver_semaphore_noc_addr, in1_mcast_num_cores, false);
+                noc_semaphore_set_multicast(in1_mcast_receiver_semaphore_addr, in1_mcast_receiver_semaphore_noc_addr, in1_mcast_num_cores, false, false);
 
                 #endif
 

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -359,6 +359,12 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
             .set_page_size(src2_cb_index, in0_single_tile_size).set_globally_allocated_address(*in0_buffer);
         cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
         log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", src2_cb_index, in0_single_tile_size, in2_CB_size / in0_single_tile_size, in2_CB_size);
+
+        // Local L1 to store temp vars
+        uint32_t l1_cb_index = 5;
+        CircularBufferConfig cb_for_l1_array_config = CircularBufferConfig(32 * 2, {{l1_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(l1_cb_index, 32 * 2);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
     }
 
     uint32_t output_cb_index = 16; // output operands start at index 16

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -480,6 +480,12 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             .set_page_size(src2_cb_index, in0_single_tile_size).set_globally_allocated_address(*in0_buffer);
         cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
         log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", src2_cb_index, in0_single_tile_size, in2_CB_size / in0_single_tile_size, in2_CB_size);
+
+        // Local L1 to store temp vars
+        uint32_t l1_cb_index = 5;
+        CircularBufferConfig cb_for_l1_array_config = CircularBufferConfig(32 * 2, {{l1_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(l1_cb_index, 32 * 2);
+        tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
     }
 
     uint32_t output_cb_index = 16; // output operands start at index 16


### PR DESCRIPTION
Based on learnings from conv perf improvments,
replicate same changes to matmuls with mcast.

* Disable mcast reserve path for mcast senders.
* Disable 'linked' for mcast senders.
* Avoid noc_async_write_barrier by mcasting valid semaphore signal to the sender as well.