### PR TITLE
#7229: Add backward support for complex div and polar

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -1062,6 +1062,10 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.real_bw
 
+.. autofunction:: tt_lib.tensor.complex_div_bw
+
+.. autofunction:: tt_lib.tensor.polar_bw
+
 .. autofunction:: tt_lib.tensor.multigammaln_bw
 
 .. autofunction:: tt_lib.tensor.repeat_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_cplx_div.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, compare_all_close
+from models.utility_functions import (
+    skip_for_wormhole_b0,
+)
+
+
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_cplx_div(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (-90, 100), (-70, 70))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shapes, (-110, 90), (-20, 80))
+    other_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-30, 30), (-40, 40))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=-1)
+    other_data_cplx = torch.cat((other_data.real, other_data.imag), dim=-1)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    other_tensor = (
+        tt_lib.tensor.Tensor(other_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    tt_output_tensor_on_device = tt_lib.tensor.complex_div_bw(grad_tensor, input_tensor, other_tensor)
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    pyt_y = torch.div(in_data, other_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_self_real = torch.real(in_data.grad)
+    grad_self_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+    golden_tensor = [
+        torch.cat((grad_self_real, grad_self_imag), dim=-1),
+        torch.cat((grad_other_real, grad_other_imag), dim=-1),
+    ]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@skip_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_cplx_div_other_zero(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (-90, 100), (-70, 70))
+    in_data.requires_grad = True
+
+    other_data = random_complex_tensor(input_shapes, (0, 0), (0, 0))
+    other_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-30, 30), (-40, 40))
+
+    in_data_cplx = torch.cat((in_data.real, in_data.imag), dim=-1)
+    other_data_cplx = torch.cat((other_data.real, other_data.imag), dim=-1)
+    input_tensor = (
+        tt_lib.tensor.Tensor(in_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    other_tensor = (
+        tt_lib.tensor.Tensor(other_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    tt_output_tensor_on_device = tt_lib.tensor.complex_div_bw(grad_tensor, input_tensor, other_tensor)
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    pyt_y = torch.div(in_data, other_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_self_real = torch.real(in_data.grad)
+    grad_self_imag = torch.imag(in_data.grad)
+    grad_other_real = torch.real(other_data.grad)
+    grad_other_imag = torch.imag(other_data.grad)
+    golden_tensor = [
+        torch.cat((grad_self_real, grad_self_imag), dim=-1),
+        torch.cat((grad_other_real, grad_other_imag), dim=-1),
+    ]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_polar.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_polar.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+from math import pi
+
+
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_polar(input_shapes, device):
+    in_data = random_complex_tensor(input_shapes, (-90, 110), (0, 2 * pi))
+    in_data.requires_grad = True
+
+    grad_data = random_complex_tensor(input_shapes, (-50, 50), (-60, 60))
+
+    input_tensor_a = (
+        tt_lib.tensor.Tensor(in_data.real, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    input_tensor_b = (
+        tt_lib.tensor.Tensor(in_data.imag, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    grad_data_cplx = torch.cat((grad_data.real, grad_data.imag), dim=-1)
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data_cplx, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+    tt_output_tensor_on_device = tt_lib.tensor.polar_bw(grad_tensor, input_tensor_a, input_tensor_b)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.polar(in_data.real, in_data.imag)
+
+    pyt_y.backward(gradient=grad_data)
+
+    grad_res_real = torch.real(in_data.grad)
+    grad_res_imag = torch.imag(in_data.grad)
+    golden_tensor = [torch.cat((grad_res_real, grad_res_imag), dim=-1)]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -256,6 +256,10 @@ std::vector<Tensor> imag_bw(const Tensor& grad, const Tensor& input, const Memor
 
 std::vector<Tensor> real_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> complex_div_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> polar_bw(const Tensor& grad, const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 std::vector<Tensor> multigammaln_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> repeat_bw(const Tensor& grad, const Tensor& input, const Shape& shape, const MemoryConfig& output_mem_config);

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -1977,6 +1977,40 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+    m_tensor.def("polar_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&polar_bw),
+            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for polar ``input_a`` and  ``input_b`` with given ``grad``
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input_a", "absolute value of the complex tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input_b", "angle of the complex tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def("complex_div_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&complex_div_bw),
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for division of complex tensors``input`` and ``other`` with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "input", "First input tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "other", "Second input Tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
     m_tensor.def("multigammaln_bw", &tt::tt_metal::multigammaln_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for multigammaln of ``input`` tensors with given ``grad`` and value of P is taken as 4.


### PR DESCRIPTION
Add backward support for complex div and polar for Type 1 complex tensor
CI test : https://github.com/tenstorrent/tt-metal/actions/runs/8754017218
https://github.com/tenstorrent/tt-metal/actions/runs/8765972648 (passed)