### PR TITLE
#0: Remove CODEOWNERS for models/experimental/ as we want it to be the wild west and approval is too slow for fast-moving models

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -126,6 +126,7 @@ models/metal_BERT_large_11 @tt-aho @TT-BrianLiu
 functional_*/ @eyonland @arakhmati @cfjchu @xanderchin
 models/demos @eyonland @arakhmati @cfjchu @xanderchin
 models/demos/grayskull @boris-drazic
+models/experimental/
 
 # docs
 docs/source/ttnn/dependencies/tt_lib.rst @eyonland @arakhmati @cfjchu @xanderchin


### PR DESCRIPTION
…