### PR TITLE
#7309: Use both reader and writer kernels to read tiled data for Inte…

### DIFF
--- a/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
@@ -81,10 +81,17 @@ void kernel_main() {
         } else {
             cb_wait_front(cb_id_sync, 2);
             cb_pop_front(cb_id_sync, 2);
-            // push back per row to avoid issues with odd heights not dividing the CB size evenly
-            for (uint32_t h = 0; h < block_height_tiles; h++) {
-                cb_push_back(cb_id_in0, block_width_tiles);
-            }
+        }
+    }
+    // Push back in0 when
+    // - need to convert data format and
+    //     - the only reader kernel because two kernels are only for L1 or
+    //     - the second  kernel, which is the non-reserving one.
+    constexpr bool push_back_in0 = convert_df && (src_is_dram || !reserving_kernel);
+    if constexpr (push_back_in0) {
+        // push back per row to avoid issues with odd heights not dividing the CB size evenly
+        for (uint32_t h = 0; h < block_height_tiles; h++) {
+            cb_push_back(cb_id_in0, block_width_tiles);
         }
     }
 }

--- a/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
@@ -47,7 +47,7 @@ void kernel_main() {
     uint32_t barrier_count = 0;
     uint32_t curr_tile_id = start_id;
     uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-    if (reserving_kernel) {
+    if constexpr (reserving_kernel) {
         cb_reserve_back(cb_id_in0, all_block_num_tiles);
         cb_reserve_back(cb_id_sync, 1);
         cb_push_back(cb_id_sync, 1);

--- a/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
@@ -25,10 +25,14 @@ void kernel_main() {
     const uint32_t start_id_offset = get_arg_val<uint32_t>(6);
     const uint32_t start_id_base = get_arg_val<uint32_t>(7);
     const uint32_t start_id = start_id_base + start_id_offset;
+    const uint32_t all_block_num_tiles = get_arg_val<uint32_t>(8); // what to reserve for all cores
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr uint32_t num_readers = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_id_sync = get_compile_time_arg_val(3);
+    constexpr bool reserving_kernel = get_compile_time_arg_val(4) == 1;
+    constexpr bool convert_df = get_compile_time_arg_val(5) == 1;
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
     constexpr DataFormat data_format = get_dataformat(cb_id_in0);
@@ -42,8 +46,15 @@ void kernel_main() {
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<tile_bytes, num_readers>();
     uint32_t barrier_count = 0;
     uint32_t curr_tile_id = start_id;
-    cb_reserve_back(cb_id_in0, block_num_tiles);
     uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+    if (reserving_kernel) {
+        cb_reserve_back(cb_id_in0, all_block_num_tiles);
+        cb_reserve_back(cb_id_sync, 1);
+        cb_push_back(cb_id_sync, 1);
+    } else {
+        l1_write_addr += tile_bytes * (all_block_num_tiles - block_num_tiles);  // write address starts after other kernel's writes
+        cb_wait_front(cb_id_sync, 1);
+    }
     for (uint32_t h = 0; h < block_height_tiles; h++) {
         uint32_t tile_id = curr_tile_id;
         for (uint32_t w = 0; w < block_width_tiles; w++) {
@@ -59,5 +70,14 @@ void kernel_main() {
         curr_tile_id += input_width_offset_tiles;
     }
     noc_async_read_barrier();
-    cb_push_back(cb_id_in0, block_num_tiles);
+    if (convert_df) {
+        if (reserving_kernel) {
+            cb_reserve_back(cb_id_sync, 1);
+            cb_push_back(cb_id_sync, 1);
+        } else {
+            cb_wait_front(cb_id_sync, 2);
+            cb_pop_front(cb_id_sync, 2);
+            cb_push_back(cb_id_in0, all_block_num_tiles);
+        }
+    }
 }


### PR DESCRIPTION
…rleavedToSharded

Divide the tiles to be read by each core by height across both reader and writer kernels.

Use an extra intermediate CB to communicate between the two kernels when to start and complete writing.

Also, if not converting the data format will skip the cb_write_back for extra performance improvement.

Testing:
- Verified that output is correct
- Verified that performance improved by about 2x (with changes for Issue #6729 )
