### PR TITLE
#6805: Add generic sharded implementation of create_qkv_heads

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_create_qkv_heads.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from loguru import logger
+
+import tt_lib as ttl
+from models.utility_functions import tt2torch_tensor, comp_pcc
+from models.utility_functions import is_grayskull
+import torch
+
+
+def run_create_qkv_heads_test(
+    batch,
+    seq_len,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    device,
+    transpose_k=False,
+    in_mem_config=None,
+    out_mem_config=None,
+):
+    torch.manual_seed(1234)
+
+    q_shape = [batch, 1, seq_len, num_kv_heads, num_q_heads // num_kv_heads * head_dim]
+    k_shape = [batch, 1, seq_len, num_kv_heads, head_dim]
+    v_shape = [batch, 1, seq_len, num_kv_heads, head_dim]
+
+    # torch reference vectors
+    if dtype == ttl.tensor.DataType.FLOAT32:
+        torch_dtype = torch.float32
+    else:
+        torch_dtype = torch.bfloat16
+
+    Q = torch.randn(q_shape, dtype=torch_dtype)
+    K = torch.randn(k_shape, dtype=torch_dtype)
+    V = torch.randn(v_shape, dtype=torch_dtype)
+    QKV = torch.concat([Q.flatten(-2, -1), K.flatten(-2, -1), V.flatten(-2, -1)], -1)
+    QKV_interleaved = torch.concat([Q, K, V], -1).flatten(-2, -1)
+
+    in0_shard_spec = ttl.tensor.ShardSpec(
+        ttl.tensor.CoreRangeSet(
+            {
+                ttl.tensor.CoreRange(
+                    ttl.tensor.CoreCoord(0, 0),
+                    ttl.tensor.CoreCoord(num_kv_heads - 1, batch - 1),
+                ),
+            }
+        ),
+        [
+            seq_len,
+            QKV.shape[-1] // num_kv_heads,
+        ],
+        ttl.tensor.ShardOrientation.ROW_MAJOR,
+        False,
+    )
+
+    in0_mem_config = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED, ttl.tensor.BufferType.L1, in0_shard_spec
+    )
+    in0_t = ttl.tensor.Tensor(QKV_interleaved, dtype).to(ttl.tensor.Layout.TILE).to(device, in0_mem_config)
+
+    out_shard_spec = in0_shard_spec
+    out_mem_config = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1, out_shard_spec
+    )
+    q, k, v = ttl.tensor.create_qkv_heads(
+        in0_t,
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        transpose_k_heads=False,
+        output_mem_config=out_mem_config,
+    )
+
+    assert list(q.get_legacy_shape()) == [batch, num_q_heads, seq_len, head_dim]
+    assert list(k.get_legacy_shape()) == [batch, num_kv_heads, seq_len, head_dim]
+    assert list(v.get_legacy_shape()) == [batch, num_kv_heads, seq_len, head_dim]
+
+    pyt_got_back_rm_q = tt2torch_tensor(q)
+    pyt_got_back_rm_k = tt2torch_tensor(k)
+    pyt_got_back_rm_v = tt2torch_tensor(v)
+
+    (ref_q, ref_k, ref_v) = torch.split(
+        QKV, [num_q_heads * head_dim, num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1
+    )
+    # Additional shuffling for Q, K, V heads
+    ref_q = torch.reshape(ref_q, [batch, seq_len, num_q_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+
+    if dtype == ttl.tensor.DataType.BFLOAT8_B:
+        pcc = 0.99
+    else:
+        pcc = 1.0
+
+    passing_pcc_q, output_pcc_q = comp_pcc(ref_q, pyt_got_back_rm_q, pcc)
+    logger.debug(f"Q passing={passing_pcc_q}")
+    logger.debug(f"Q output pcc={output_pcc_q}")
+
+    passing_pcc_k, output_pcc_k = comp_pcc(ref_k, pyt_got_back_rm_k, pcc)
+    logger.debug(f"K passing={passing_pcc_k}")
+    logger.debug(f"K output pcc={output_pcc_k}")
+
+    passing_pcc_v, output_pcc_v = comp_pcc(ref_v, pyt_got_back_rm_v, pcc)
+    logger.debug(f"V passing={passing_pcc_v}")
+    logger.debug(f"V output pcc={output_pcc_v}")
+
+    assert passing_pcc_q
+    assert passing_pcc_k
+    assert passing_pcc_v
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.FLOAT32),
+    ids=["BFLOAT8_B", "BFLOAT16", "FLOAT32"],
+)
+@pytest.mark.parametrize(
+    "batch, seq_len, num_q_heads, num_kv_heads, head_dim",
+    (
+        (7, 224, 8, 8, 64),
+        (7, 384, 8, 8, 64),
+    ),
+)
+def test_nlp_create_qkv_heads_test(
+    batch,
+    seq_len,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    device,
+):
+    if is_grayskull() and dtype == ttl.tensor.DataType.FLOAT32:
+        pytest.skip("Skipping float32 tests on Grayskull")
+
+    run_create_qkv_heads_test(batch, seq_len, num_q_heads, num_kv_heads, head_dim, dtype, device)

--- a/tests/ttnn/unit_tests/operations/test_transformer.py
+++ b/tests/ttnn/unit_tests/operations/test_transformer.py
@@ -295,7 +295,7 @@ def test_sharded_split_query_key_value_and_split_heads(
     torch.manual_seed(0)
 
     input_shape = (batch_size, sequence_size, num_heads * 3 * head_size)
-
+    # needs to be shuffled
     input_memory_config = ttnn.create_sharded_memory_config(
         input_shape, core_grid=ttnn.CoreGrid(y=8, x=12), strategy=ttnn.ShardStrategy.BLOCK
     )

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -176,6 +176,7 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_falcon7b.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads.cpp \
+	tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp \
 	tt_eager/tt_dnn/op_library/rotate_half/single_core/rotate_half_op_single_core.cpp \
 	tt_eager/tt_dnn/op_library/rotate_half/rotate_half_op.cpp \
 	tt_eager/tt_dnn/op_library/rotary_embedding/multi_core/rotary_embedding_op_multi_core.cpp \

--- a/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_create_qkv_heads_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_create_qkv_heads_sharded.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t q_heads_per_group               = get_compile_time_arg_val(0); // number of Q heads in the group, n
+    constexpr uint32_t k_heads_per_group               = get_compile_time_arg_val(1); // number of K heads in the group, expecting 1
+    constexpr uint32_t v_heads_per_group               = get_compile_time_arg_val(2); // number of V heads in the group, expecting 1
+
+
+    constexpr uint32_t q_out_block_wt_size_bytes       = get_compile_time_arg_val(3); // size of a Q head in bytes
+    constexpr uint32_t k_out_block_wt_size_bytes       = get_compile_time_arg_val(4); // size of a K head `` ``
+    constexpr uint32_t v_out_block_wt_size_bytes       = get_compile_time_arg_val(5); // size of a V head `` ``
+
+    constexpr uint32_t block_wt_size_bytes             = get_compile_time_arg_val(6); // size of each group, used for skipping each group
+    constexpr uint32_t block_ht                        = get_compile_time_arg_val(7); // number of tiles along the seq_len*batch dimension
+    constexpr uint32_t block_groups_wt                 = get_compile_time_arg_val(8); // number of tiles inside one nQ K V group
+
+    constexpr uint32_t q_num_tiles                     = get_compile_time_arg_val(9); // total number of Q pages, used for CB reservation
+    constexpr uint32_t k_num_tiles                     = get_compile_time_arg_val(10); // total number of K pages
+    constexpr uint32_t v_num_tiles                     = get_compile_time_arg_val(11); // total number of V pages
+
+    constexpr uint32_t q_size_per_group                = get_compile_time_arg_val(12); // total size of all n Q heads in a group, used to find start of first K head
+    constexpr uint32_t q_k_size_per_group              = get_compile_time_arg_val(13); // total size of all n Q heads and K heads (expecting 1) in a group
+
+    constexpr uint32_t cb_in0 = tt::CB::c_in0;
+    constexpr uint32_t cb_out0 = tt::CB::c_out0;
+    constexpr uint32_t cb_out1 = tt::CB::c_out1;
+    constexpr uint32_t cb_out2 = tt::CB::c_out2;
+
+
+    // copy one entire head_dim tile, then go to next sequence*batch tile and do another head_dim.
+    // after that, go to next head (head_dim > sequence * batch > head)
+    // since Q's heads are shuffled and n Q heads are interleaved with a KV, have to do 3 loops
+
+
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_in0);
+    const DataFormat data_format = get_dataformat(cb_in0);
+
+    /**
+     * Iterate over number of heads in each group (n Q, 1 K, 1 V) where total number of groups = total number of KV heads
+     * block_ht is the number of tiles along the batch * seq_len dimension shard
+    */
+    uint64_t src_noc_addr = get_noc_addr(get_read_ptr(cb_in0));
+
+    // re-order q
+    cb_reserve_back(cb_out0, q_num_tiles);
+    uint32_t l1_write_addr_out0 = get_write_ptr(cb_out0);
+    uint32_t src_noc_addr_offset_outer = 0;
+    for (uint32_t k = 0; k < block_groups_wt; k++) { // number of groups, divided into tiles
+        uint32_t l1_read_addr_offset = 0; // start at 0 since Q is always first
+        for (uint32_t j = 0; j < q_heads_per_group; j++) { // go to next Q heads in the group (0 to n-1 for the nQ per KV group)
+            for (uint32_t i = 0; i < block_ht; i++) { // iterate across seq_len dimension tiles
+                uint64_t q_src_noc_addr = src_noc_addr + l1_read_addr_offset + src_noc_addr_offset_outer;
+                noc_async_read(q_src_noc_addr, l1_write_addr_out0, q_out_block_wt_size_bytes); // read one head worth of tiles
+                l1_write_addr_out0 += q_out_block_wt_size_bytes; // read in one Q head
+                l1_read_addr_offset += block_wt_size_bytes; // go to next group along sequence
+            }
+            src_noc_addr_offset_outer += q_out_block_wt_size_bytes;
+        }
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_out0, q_num_tiles);
+
+    // re-order k
+    cb_reserve_back(cb_out1, k_num_tiles);
+    uint32_t l1_write_addr_out1 = get_write_ptr(cb_out1);
+    src_noc_addr_offset_outer = 0;
+    for (uint32_t k = 0; k < block_groups_wt; ++k) { // m kv head tiles
+        uint32_t l1_read_addr_offset = q_size_per_group; // skip the first n*Q since we're writing K
+        for (uint32_t j = 0; j < k_heads_per_group; j++) { // 1 k tile per kv head
+            for (uint32_t i = 0; i < block_ht; i++) { // seq_len
+                uint64_t k_src_noc_addr = src_noc_addr + l1_read_addr_offset + src_noc_addr_offset_outer;
+                noc_async_read(k_src_noc_addr, l1_write_addr_out1, k_out_block_wt_size_bytes);
+                l1_write_addr_out1 += k_out_block_wt_size_bytes;
+                l1_read_addr_offset += block_wt_size_bytes;
+            }
+            src_noc_addr_offset_outer += k_out_block_wt_size_bytes;
+        }
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_out1, k_num_tiles);
+
+
+    // re-order v
+    cb_reserve_back(cb_out2, v_num_tiles);
+    uint32_t l1_write_addr_out2 = get_write_ptr(cb_out2);
+    src_noc_addr_offset_outer = 0;
+    for (uint32_t k = 0; k < block_groups_wt; ++k) { // number of group-tiles
+        uint32_t l1_read_addr_offset = q_k_size_per_group;
+        for (uint32_t j = 0; j < v_heads_per_group; j++) { // 1 v tile per kv head
+            for (uint32_t i = 0; i < block_ht; i++) { // sequence length
+                uint64_t v_src_noc_addr = src_noc_addr + l1_read_addr_offset + src_noc_addr_offset_outer;
+                noc_async_read(v_src_noc_addr, l1_write_addr_out2, v_out_block_wt_size_bytes);
+                l1_write_addr_out2 += v_out_block_wt_size_bytes;
+                l1_read_addr_offset += block_wt_size_bytes;
+            }
+            src_noc_addr_offset_outer += v_out_block_wt_size_bytes;
+        }
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_out2, v_num_tiles);
+}

--- a/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/nlp_tms/nlp_tms.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+
+using namespace tt::constants;
+using namespace tt;
+
+
+static inline operation::ProgramWithCallbacks create_heads_combined_qkv_sharded(const Tensor &input_tensor, const vector<uint32_t> &&heads_per_group, const uint32_t head_dim, const uint32_t groups, std::vector<Tensor> &output) {
+    // groups = kv_heads usually
+    // heads_per_group = [x 1 1] if qkv since q_heads >= kv_heads and k=v heads but this should be generic
+    TT_FATAL(head_dim % TILE_WIDTH == 0, fmt::format("head dim {} needs to be a multiple of tile width {}", head_dim, TILE_WIDTH));
+    TT_FATAL(heads_per_group.size() == output.size() && output.size() == 3);
+
+    const uint32_t total_heads_per_group = std::accumulate(heads_per_group.begin(), heads_per_group.end(), 0); // num q heads + 2 * num_kv_heads
+    const uint32_t elements_per_group = head_dim * total_heads_per_group; // head_dim * (num q heads + 2 * num kv heads)
+    const uint32_t tiles_per_group = elements_per_group / TILE_WIDTH; // head_dim % TILE_WIDTH == 0 so guaranteed to fit evenly
+
+    const auto &input_shape = input_tensor.get_legacy_shape();
+
+    TT_FATAL(input_shape[3] % elements_per_group == 0, fmt::format("flattened inner tensor dimension {} does not divide evenly into head dim {}, heads per group, and groups {}", input_shape[3], head_dim, groups));
+    TT_FATAL(input_shape[2] % TILE_HEIGHT == 0, fmt::format("Sequence length {} must divide evenly into Tiles of Tile Height {}", input_shape[2], TILE_HEIGHT));
+    TT_FATAL(input_tensor.shard_spec().has_value() == true, "Unsharded input is invalid for create_qkv_heads");
+
+    auto shard_spec = input_tensor.shard_spec().value();
+    auto all_cores = shard_spec.grid;
+    auto bbox = all_cores.bounding_box();
+    ShardOrientation shard_orientation = shard_spec.orientation;
+    bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
+    uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+
+    TT_FATAL(input_shape[3] % (num_w_cores * TILE_WIDTH) == 0, fmt::format("Flattened hidden dimensions of QKV {} must be a multiple of width cores {} times tile width {}", input_shape[3], num_w_cores, TILE_WIDTH));
+    TT_FATAL(groups % num_w_cores == 0, fmt::format("number of groups {} must be a multiple of the number of width cores {}", groups, num_w_cores));
+
+    uint32_t groups_per_block = groups / num_w_cores;
+    uint32_t M = input_shape[2]*input_shape[0];
+    uint32_t K = input_shape[3];
+    uint32_t Mt = M / TILE_HEIGHT;
+    uint32_t Kt = K / TILE_WIDTH;
+    uint32_t block_wt = Kt / num_w_cores; // number of tiles in width dimension  - multiple tiles per head, multiple heads per group, multiple tensors in group, multiple groups per cores
+
+    TT_FATAL(Mt % num_h_cores == 0, fmt::format("Outer dimension of batch {} times sequence length {} must divide evenly across cores {}", input_shape[0], input_shape[2], num_h_cores));
+    uint32_t block_ht = Mt / num_h_cores; // number of tiles in each each batch*seq_len dimension
+    TT_FATAL(input_shape[2] % (block_ht * TILE_HEIGHT) == 0, fmt::format("Per core work load must be within a batch. The sequence length {} and elements in each height shard {} must divide evenly", input_shape[2], block_ht*TILE_HEIGHT));
+    uint32_t per_core_tiles = block_ht * block_wt;
+
+    auto data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    uint32_t single_tile_size = tile_size(data_format);
+    TT_FATAL(L1_SIZE >= 2 * per_core_tiles * single_tile_size, fmt::format("Workload of Tiles {} at Tile Size {} (times 2 for output) exceeds L1 capacity {}", per_core_tiles, single_tile_size, L1_SIZE));
+
+    std::vector<uint32_t> num_tiles_per_group;
+    num_tiles_per_group.reserve(output.size());
+    for (uint32_t heads : heads_per_group) {
+        num_tiles_per_group.push_back(heads * head_dim / TILE_WIDTH);
+    }
+
+    Program program = CreateProgram();
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t) heads_per_group[0], // q heads in group
+        (std::uint32_t) heads_per_group[1], // k heads in group
+        (std::uint32_t) heads_per_group[2], // v heads in group
+        (std::uint32_t) head_dim / TILE_WIDTH * single_tile_size, // size of a q head
+        (std::uint32_t) head_dim / TILE_WIDTH * single_tile_size, // size of a k head
+        (std::uint32_t) head_dim / TILE_WIDTH * single_tile_size, // size of a v head
+        (std::uint32_t) tiles_per_group * single_tile_size, // group size, used to skip past group to the rest of the three tensors
+        (std::uint32_t) block_ht, // how many tiles to read along sequence dimension
+        (std::uint32_t) groups_per_block, // groups per shard (kv heads per core)
+        (std::uint32_t) block_ht * num_tiles_per_group[0] * groups_per_block, // number of pages in q output tensor
+        (std::uint32_t) block_ht * num_tiles_per_group[1] * groups_per_block, // number of pages in k output tensor
+        (std::uint32_t) block_ht * num_tiles_per_group[2] * groups_per_block, // number of pages in v output tensor
+        (std::uint32_t) num_tiles_per_group[0] * single_tile_size, // size of n*Q tiles in bytes to get to K heads
+        (std::uint32_t) (num_tiles_per_group[0] * single_tile_size) + (num_tiles_per_group[1] * single_tile_size), // size of n*Q + K tiles in bytes to get to V heads
+    };
+
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_create_qkv_heads_sharded.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    uint32_t input_size = block_ht*block_wt*single_tile_size;
+    uint32_t q_size = block_ht*num_tiles_per_group[0]*single_tile_size*groups_per_block;
+    uint32_t k_size = block_ht*num_tiles_per_group[1]*single_tile_size*groups_per_block;
+    uint32_t v_size = block_ht*num_tiles_per_group[2]*single_tile_size*groups_per_block;
+
+    // qkv tensor
+    auto c_in0_config = CircularBufferConfig(input_size, {{CB::c_in0, data_format}}).set_page_size(CB::c_in0, single_tile_size).set_globally_allocated_address(*input_tensor.buffer());
+    auto cb_in0_id = CreateCircularBuffer(program, all_cores, c_in0_config);
+
+    // q sharded
+    auto c_out0_config = CircularBufferConfig(q_size, {{CB::c_out0, data_format}})
+        .set_page_size(CB::c_out0, single_tile_size).set_globally_allocated_address(*output[0].buffer());
+    auto cb_out0_id = CreateCircularBuffer( program, all_cores, c_out0_config );
+    // k sharded
+    auto c_out1_config = CircularBufferConfig(k_size, {{CB::c_out1, data_format}})
+        .set_page_size(CB::c_out1, single_tile_size).set_globally_allocated_address(*output[1].buffer());
+    auto cb_out1_id = CreateCircularBuffer( program, all_cores, c_out1_config );
+    // v sharded
+    auto c_out2_config = CircularBufferConfig(v_size, {{CB::c_out2, data_format}})
+        .set_page_size(CB::c_out2, single_tile_size).set_globally_allocated_address(*output[2].buffer());
+    auto cb_out2_id = CreateCircularBuffer( program, all_cores, c_out2_config );
+
+    auto override_runtime_args_callback = [
+        cb_in0_id,
+        cb_out0_id,
+        cb_out1_id,
+        cb_out2_id
+        ]
+    (
+        const void* operation,
+        Program& program,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        const std::vector<Tensor>& output_tensors
+    ) {
+        auto in0_buffer = input_tensors.at(0).buffer();
+        auto out0_buffer = output_tensors.at(0).buffer();
+        auto out1_buffer = output_tensors.at(1).buffer();
+        auto out2_buffer = output_tensors.at(2).buffer();
+
+        UpdateDynamicCircularBufferAddress(program, cb_in0_id, *in0_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_out0_id, *out0_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_out1_id, *out1_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_out2_id, *out2_buffer);
+    };
+
+    return {std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
+
+namespace tt {
+namespace tt_metal {
+
+/**
+ * Combined QKV
+ *
+ * m = num_KV_heads
+ * p = num_Q_heads
+ * n = p/m
+ * i = head index for K/V, corresponding Q group for K/V
+ *
+ * input: [nQi Ki Vi for i in [0, m)] repeated for the sequence length
+ * dims: [B, 1, S, H] Hi = [nQi Ki Vi] for all i kv heads = ((n + 2)*head_dim)
+ *
+ * output: 3 separate tensors organized by heads
+ * [Qs,j for j in [0, p] and s in [0,S)]
+ * dims: [B, p, S, head_dim] (all nQi in the KVi group are stacked together, p = n*m)
+ *
+ * [Ks,i for i in [0, m) and s in [0,S)]
+ * dims: [B, m, S, head_dim]
+ *
+ * [Vs,i for i in [0, m) and s in [0,S)]
+ * dims: [B, m, S, head_dim]
+ *
+ * Tiles stay the same Vi,s[x:x+32] to Vi+32,s[x:x+32] stays in one tile, but now instead of nQi,s and Ki,s tiles there is Vi,s-1 and Vi,s+1
+ *
+ * Shard across each i kv head group (width sharding) and then shard across each token s (height sharding)
+ * Each block: B x [nQi Ki Vi]s (shard across flattened heads and sequence length)
+ *
+ * Combined batch/sequence sharding is possible too...that may best be left as an extension
+*/
+operation::ProgramWithCallbacks multi_core_create_qkv_heads_sharded(const Tensor &input_tensor_qkv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
+    TT_FATAL(num_q_heads % num_kv_heads == 0, fmt::format("num q heads {} / num kv heads {} needs to be a whole number", num_q_heads, num_kv_heads));
+    return create_heads_combined_qkv_sharded(input_tensor_qkv, {num_q_heads/num_kv_heads, 1, 1}, head_dim, num_kv_heads, output);
+}
+
+} // namespace tt_metal
+
+} // namespace tt
+
+// batch*seq_len  (num_q_heads/num_kv_heads*Qi Ki Vi)

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -261,6 +261,107 @@ tt::stl::reflection::Attributes NlpConcatHeads::attributes() const {
     };
 }
 
+void CreateQKVHeads::validate(const std::vector<Tensor> &input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
+    TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(input_tensor.is_sharded(), "Operands to TM must be sharded");
+    const auto input_shape = input_tensor.get_legacy_shape();
+    TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
+
+    auto bbox = input_tensor.shard_spec().value().grid.bounding_box();
+    TT_FATAL((bbox.end.x < input_tensor.device()->compute_with_storage_grid_size().x && bbox.end.y < input_tensor.device()->compute_with_storage_grid_size().y));
+    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
+    ShardOrientation shard_orientation = input_tensor.shard_spec().value().orientation;
+    bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
+    uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+
+    TT_FATAL(this->num_q_heads % this->num_kv_heads == 0, "Number of q heads {} must fit evenly into number of kv heads {}", this->num_q_heads, this->num_kv_heads);
+    TT_FATAL(input_shape[3] % (num_w_cores * TILE_WIDTH) == 0, fmt::format("Flattened hidden dimension {} must be a multiple of width cores {} * tile width {} to ensure that each core gets an even amount of tiles", input_shape[3], num_w_cores, TILE_WIDTH));
+
+    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+}
+
+std::vector<Shape> CreateQKVHeads::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    std::vector<Shape> output_shape_vec;
+    const auto& input_tensor = input_tensors.at(0);
+    const auto input_shape = input_tensor.get_legacy_shape();
+
+    const Shape q_output_shape = {input_shape[0], this->num_q_heads, input_shape[2], this->head_dim};
+    const Shape v_output_shape = {input_shape[0], this->num_kv_heads, input_shape[2], this->head_dim};
+    const Shape k_output_shape = this->transpose_k_heads
+                                     ? (Shape){input_shape[0], this->num_kv_heads, head_dim, input_shape[2]}
+                                     : v_output_shape;
+    output_shape_vec = {q_output_shape, k_output_shape, v_output_shape};
+
+    return output_shape_vec;
+}
+
+operation::ProgramWithCallbacks CreateQKVHeads::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+
+    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    return  multi_core_create_qkv_heads_sharded(input_tensor, this->num_q_heads, this->num_kv_heads, this->head_dim, this->transpose_k_heads, output_tensors, compute_with_storage_grid_size);
+}
+
+std::vector<Tensor> CreateQKVHeads::create_output_tensors(const std::vector<Tensor>& input_tensors) const  {
+    // no create_output_tensors variant that takes in optional input tensors?
+    const auto& input_tensor = input_tensors.at(0);
+
+    CoreRangeSet all_cores = input_tensor.shard_spec().value().grid;
+    ShardOrientation shard_orientation = input_tensor.shard_spec().value().orientation;
+    auto bbox = all_cores.bounding_box();
+    // TODO: Do we need to know cores along row and col?
+    //bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
+    //uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
+    //uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+    uint32_t num_cores = bbox.size();
+
+    const auto &input_shape = input_tensor.get_legacy_shape();
+    auto shapes = compute_output_shapes(input_tensors);
+    auto q_shape = shapes.at(0);
+    auto k_shape = shapes.at(1);
+    auto v_shape = shapes.at(2);
+
+    // TODO: Do we need?
+    //uint32_t num_kv_heads_per_shard = k_shape[1] / num_w_cores;
+    //uint32_t num_q_heads_per_shard = q_shape[1] / num_w_cores;
+
+    uint32_t q_shard_h = q_shape[0] * q_shape[1] * q_shape[2] / num_cores; // want the API to work for different sequence lengths
+    uint32_t kv_shard_h = k_shape[0] * k_shape[1] * k_shape[2] / num_cores; // want the API to work for different sequence lengths
+    auto q_spec = ShardSpec(all_cores, {q_shard_h, head_dim}, shard_orientation);
+    auto kv_spec = ShardSpec(all_cores, {kv_shard_h, head_dim}, shard_orientation);
+
+    // create sharded tensors
+    auto mem_config_q = this->output_mem_config;
+    mem_config_q.shard_spec = q_spec;
+
+    auto mem_config_k = this->output_mem_config;
+    mem_config_k.shard_spec = kv_spec;
+
+    auto mem_config_v = this->output_mem_config;
+    mem_config_v.shard_spec = kv_spec;
+
+    auto out_tensor_q = create_sharded_device_tensor(q_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_q);
+    auto out_tensor_k = create_sharded_device_tensor(k_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_k);
+    auto out_tensor_v = create_sharded_device_tensor(v_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_v);
+    return {out_tensor_q, out_tensor_k, out_tensor_v};
+
+    return {};
+}
+
+tt::stl::reflection::Attributes CreateQKVHeads::attributes() const {
+    return {
+        {"num_q_heads", this->num_q_heads},
+        {"num_kv_heads", this->num_kv_heads},
+        {"transpose_k_heads", this->transpose_k_heads},
+        {"output_mem_config", this->output_mem_config},
+    };
+}
+
 } // namespace tt_metal
 
 } // namespace tt

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.hpp
@@ -12,6 +12,33 @@ namespace tt {
 
 namespace tt_metal {
 
+// input_tensor - qkv tensor if kv_tensor is nullopt, q tensor if kv_tensor is populated
+// expectation for both interleaved and sharded implementation is that each q, k and v vector are concatenated across the last dimension (|q_i k_i v_i| is each row of the tensor)
+
+// operation::ProgramWithCallbacks multi_core_create_qkv_heads_interleaved(const Tensor &input_tensor_qkv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_create_qkv_heads_sharded(const Tensor &input_tensor_qkv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
+
+struct CreateQKVHeads {
+    uint32_t num_q_heads;
+    uint32_t num_kv_heads;
+    uint32_t head_dim;
+    bool transpose_k_heads;
+    MemoryConfig output_mem_config;
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
+    tt::stl::reflection::Attributes attributes() const;
+};
+
+inline std::tuple<Tensor, Tensor, Tensor> create_qkv_heads(const Tensor &input_tensor, const uint32_t num_q_heads, const std::optional<uint32_t> num_kv_heads, const bool transpose_k_heads, const MemoryConfig& output_mem_config) {
+    const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_q_heads);
+    TT_FATAL(input_tensor.get_legacy_shape()[3] % (num_q_heads + (2 * num_kv_heads_val)) == 0, "Flattened hidden dimension {} must be a multiple of the combined Q {}, K {} and V {} heads", input_tensor.get_legacy_shape()[3], num_q_heads, num_kv_heads_val, num_kv_heads_val);
+    const uint32_t head_dim = input_tensor.get_legacy_shape()[3] / (num_q_heads + (2 * num_kv_heads_val));
+    auto output_tensors = operation::run(CreateQKVHeads{num_q_heads, num_kv_heads_val, head_dim, transpose_k_heads, output_mem_config}, {input_tensor});
+    return {output_tensors.at(0), output_tensors.at(1), output_tensors.at(2)};
+}
+
 operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_falcon7b(const Tensor &input_tensor_a, std::vector<Tensor> &output, CoreCoord compute_with_storage_grid_size);
 operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_sharded(const Tensor &input_tensor, std::optional<const Tensor> input_tensor_kv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
 operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads(const Tensor &input_tensor, std::optional<const Tensor> input_tensor_kv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor> &output, CoreCoord compute_with_storage_grid_size);

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -148,6 +148,16 @@ namespace tt::tt_metal::detail
             py::arg().noconvert(), py::arg().noconvert(), py::arg("bias").noconvert() = std::nullopt, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, py::arg("math_fidelity").noconvert() = MathFidelity::LoFi, R"doc(
             Perform a resnet_matmul with fused bias.
         )doc");
+
+        m_tensor.def("create_qkv_heads", &create_qkv_heads,
+        py::arg("input").noconvert(),
+        py::arg("num_q_heads").noconvert(),
+        py::arg("num_kv_heads").noconvert() = std::nullopt,
+        py::arg("transpose_k_heads").noconvert() = false, // change this to true when the transposed impl is done
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
+        Splits a [B, 1, Seq_len, H] fused qkv matrix (where H is num_kv_heads * (num_q_heads/num_kv_heads + 2) * head_dim) into a Q tensor [B, num_q_heads, Seq_len, head_dim], K tensor [B, num_kv_heads, Seq_len, head_dim] (with the last two dims transposed if applicable) and V tensor [B, num_kv_heads, Seq_len, head_dim].
+        )doc");
     }
 
 }


### PR DESCRIPTION
- This also addresses issue #6712
- TODO: Add support for grouped heads (ie. multiple q heads per kv heads)
- TODO: Add support for groups of sequences per core (enables larger number of kv heads per core)
- TODO: Add optional transpose for k heads