### PR TITLE
FD2: Fix incorrect data and remove redundant buffers/cmds when program binaries have multiple spans

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -486,10 +486,21 @@ const DeviceCommand EnqueueProgramCommand::assemble_device_commands() {
                     align(kg_transfer_info.lengths[kernel_idx], DeviceCommand::PROGRAM_PAGE_SIZE)
                 );
 
+                uint32_t base_address, page_offset;
+                if (kg_transfer_info.page_offsets[kernel_idx] > CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK) {
+                    const uint32_t num_banks = this->device->num_banks(this->program.kg_buffers[buffer_idx]->buffer_type());
+                    page_offset = kg_transfer_info.page_offsets[kernel_idx] % num_banks;
+                    uint32_t num_full_pages_written_per_bank = kg_transfer_info.page_offsets[kernel_idx] / num_banks;
+                    base_address = this->program.kg_buffers[buffer_idx]->address() + num_full_pages_written_per_bank * this->program.kg_buffers[buffer_idx]->page_size();
+                } else {
+                    base_address = this->program.kg_buffers[buffer_idx]->address();
+                    page_offset = kg_transfer_info.page_offsets[kernel_idx];
+                }
+
                 command_sequence.add_prefetch_relay_paged(
                     true, // is_dram
-                    kg_transfer_info.page_offsets[kernel_idx],
-                    this->program.kg_buffers[buffer_idx]->address(),
+                    page_offset,
+                    base_address,
                     this->program.kg_buffers[buffer_idx]->page_size(),
                     align(kg_transfer_info.lengths[kernel_idx], DeviceCommand::PROGRAM_PAGE_SIZE) / this->program.kg_buffers[buffer_idx]->page_size()
                 );

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -695,24 +695,22 @@ void Program::populate_dispatch_data(Device* device) {
                     std::copy(mem_ptr, mem_ptr + len, binaries_data.end() - len);
                     binaries_data.resize(
                         align(binaries_data.size(), DeviceCommand::PROGRAM_PAGE_SIZE / sizeof(uint32_t)), 0);
-
-                    kernel_bins_transfer_info kernel_bins_transfer_info = {
-                        .dst_base_addrs = dst_base_addrs,
-                        .page_offsets = page_offsets,
-                        .lengths = lengths,
-                        .dst_noc_info = dst_noc_multicast_info,
-                        .linked = false,
-                        .data = binaries_data};
-                    this->program_transfer_info.kernel_bins.push_back(kernel_bins_transfer_info);
-
-                    this->kg_buffers.push_back(std::make_unique<Buffer>(
-                        device,
-                        binaries_data.size() * sizeof(uint32_t),
-                        DeviceCommand::PROGRAM_PAGE_SIZE,
-                        BufferType::DRAM));
-
                     k++;
                 });
+                kernel_bins_transfer_info kernel_bins_transfer_info = {
+                    .dst_base_addrs = dst_base_addrs,
+                    .page_offsets = page_offsets,
+                    .lengths = lengths,
+                    .dst_noc_info = dst_noc_multicast_info,
+                    .linked = false,
+                    .data = binaries_data};
+                this->program_transfer_info.kernel_bins.push_back(kernel_bins_transfer_info);
+
+                this->kg_buffers.push_back(std::make_unique<Buffer>(
+                    device,
+                    binaries_data.size() * sizeof(uint32_t),
+                    DeviceCommand::PROGRAM_PAGE_SIZE,
+                    BufferType::DRAM));
                 sub_kernel_index++;
             }
         }
@@ -770,24 +768,22 @@ void Program::populate_dispatch_data(Device* device) {
                     std::copy(mem_ptr, mem_ptr + len, binaries_data.end() - len);
                     binaries_data.resize(
                         align(binaries_data.size(), DeviceCommand::PROGRAM_PAGE_SIZE / sizeof(uint32_t)), 0);
-
-                    kernel_bins_transfer_info kernel_bins_transfer_info = {
-                        .dst_base_addrs = dst_base_addrs,
-                        .page_offsets = page_offsets,
-                        .lengths = lengths,
-                        .dst_noc_info = dst_noc_unicast_info,
-                        .linked = false,
-                        .data = binaries_data};
-                    this->program_transfer_info.kernel_bins.push_back(kernel_bins_transfer_info);
-
-                    this->kg_buffers.push_back(std::make_unique<Buffer>(
-                        device,
-                        binaries_data.size() * sizeof(uint32_t),
-                        DeviceCommand::PROGRAM_PAGE_SIZE,
-                        BufferType::DRAM));
-
                     k++;
                 });
+                kernel_bins_transfer_info kernel_bins_transfer_info = {
+                    .dst_base_addrs = dst_base_addrs,
+                    .page_offsets = page_offsets,
+                    .lengths = lengths,
+                    .dst_noc_info = dst_noc_unicast_info,
+                    .linked = false,
+                    .data = binaries_data};
+                this->program_transfer_info.kernel_bins.push_back(kernel_bins_transfer_info);
+
+                this->kg_buffers.push_back(std::make_unique<Buffer>(
+                    device,
+                    binaries_data.size() * sizeof(uint32_t),
+                    DeviceCommand::PROGRAM_PAGE_SIZE,
+                    BufferType::DRAM));
                 sub_kernel_index++;
             }
         }


### PR DESCRIPTION
@pgkeller I wasn't sure why for the `packed_page_flags` of the `CQPrefetchRelayPagedCmd` we only give 4 bits to the page offset value since the is_dram flag is only 1 bit, we could use 7 bits for the page offset value unless we plan to put other flags in here. Let me know if I should revert this as this change isn't required to fix functionality.