### PR TITLE
Fix mistral7b perf pipeline

### DIFF
--- a/.github/workflows/build-cmake.yaml
+++ b/.github/workflows/build-cmake.yaml
@@ -1,0 +1,38 @@
+name: "[internal] Build cmake"
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  build-cmake:
+    strategy:
+      matrix:
+        arch: [grayskull, wormhole_b0]
+    name: CMake Build
+    env:
+      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
+      ARCH_NAME: ${{ matrix.arch }}
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
+    runs-on: build
+    steps:
+      - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+        with:
+          ref: vtangTT/cmake_metal_eager
+      - name: Set up dynamic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - name: CMake CI Build - Generate build files
+        run: |
+          rm -rf build
+          cmake -DCMAKE_BUILD_TYPE=ci -DCONFIG=ci -B build
+      - name: CMake CI Build - Build metal + eager
+        timeout-minutes: 15
+        run: |
+          cmake --build build -- -j8
+      - name: CMake CI Build - Build tests
+        timeout-minutes: 10
+        run: |
+          cmake --build build --target tests -- -j8


### PR DESCRIPTION
Waiting on previous CI test hangs to confirm that this fix is passing CI.

Previous perf pipeline run here: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8647255656/job/23708301363 was segfaulting on test 
`models/demos/falcon7b/tests/test_perf_falcon.py::TestParametrized::test_perf_wh_bare_metal[prefill_seq128-1-BFLOAT16-DRAM-falcon_7b-layers_32]`