### PR TITLE
Fix mistral7b perf pipeline

### DIFF
--- a/models/demos/mistral7b/tests/test_mistral_attention.py
+++ b/models/demos/mistral7b/tests/test_mistral_attention.py
@@ -22,7 +22,6 @@ from models.utility_functions import skip_for_grayskull
 
 
 @skip_for_grayskull("Requires wormhole_b0 to run")
-@pytest.mark.skip(reason="Issue #7524: Failing")
 @pytest.mark.parametrize(
     "iterations",
     ((1),),

--- a/models/demos/mistral7b/tests/test_mistral_decoder.py
+++ b/models/demos/mistral7b/tests/test_mistral_decoder.py
@@ -20,7 +20,6 @@ from models.utility_functions import (
 from models.utility_functions import skip_for_grayskull
 
 
-@pytest.mark.skip(reason="Test failing, see issue #7524")
 @skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "iterations",

--- a/models/demos/mistral7b/tests/test_mistral_perf.py
+++ b/models/demos/mistral7b/tests/test_mistral_perf.py
@@ -32,6 +32,7 @@ class Emb(torch.nn.Module):
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.skip(reason="Issue #7540: Hanging")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, iterations, expected_compile_time, expected_inference_time",

--- a/tests/scripts/nightly/run_wh_b0_only.sh
+++ b/tests/scripts/nightly/run_wh_b0_only.sh
@@ -11,5 +11,5 @@ env pytest models/experimental/mamba/tests/test_demo.py             # -> failing
 env pytest models/demos/mistral7b/tests/test_mistral_embedding.py
 env pytest models/demos/mistral7b/tests/test_mistral_rms_norm.py
 env pytest models/demos/mistral7b/tests/test_mistral_mlp.py
-env pytest models/demos/mistral7b/tests/test_mistral_attention.py
-env pytest models/demos/mistral7b/tests/test_mistral_decoder.py     # -> failing: issue #7524
+env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/mistral7b/tests/test_mistral_attention.py
+env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/mistral7b/tests/test_mistral_decoder.py

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -61,9 +61,7 @@ run_perf_models_llm_javelin() {
 
     env pytest models/demos/falcon7b/tests -m $test_marker
 
-    if [ "$tt_arch" == "wormhole_b0" ]; then
-        env pytest models/demos/mistral7b/tests -m $test_marker
-    fi
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/mistral7b/tests -m $test_marker  # -> hanging: issue #7540
 
     ## Merge all the generated reports
     env python models/perf/merge_perf_results.py


### PR DESCRIPTION
Waiting on previous CI test hangs to confirm that this fix is passing CI.

Previous perf pipeline run here: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8647255656/job/23708301363 was segfaulting on test
`models/demos/falcon7b/tests/test_perf_falcon.py::TestParametrized::test_perf_wh_bare_metal[prefill_seq128-1-BFLOAT16-DRAM-falcon_7b-layers_32]`