### PR TITLE
Trace program bug fixes

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
@@ -297,7 +297,6 @@ TEST_F(CommandQueueFixture, EnqueueTraceProgramCommand) {
 }
 
 TEST_F(CommandQueueFixture, EnqueueTwoProgramTrace) {
-    GTEST_SKIP();
     // Get command queue from device for this test, since its running in async mode
     CommandQueue& command_queue = this->device_->command_queue();
 
@@ -377,7 +376,6 @@ TEST_F(CommandQueueFixture, EnqueueTwoProgramTrace) {
 }
 
 TEST_F(CommandQueueFixture, EnqueueMultiProgramTraceBenchmark) {
-    GTEST_SKIP();
     CommandQueue& command_queue = this->device_->command_queue();
 
     std::shared_ptr<Buffer> input = std::make_shared<Buffer>(this->device_, 2048, 2048, BufferType::DRAM);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -805,12 +805,13 @@ EnqueueTraceCommand::EnqueueTraceCommand(
     Device* device,
     SystemMemoryManager& manager,
     Buffer& buffer,
-    uint32_t expected_num_workers_completed) :
+    uint32_t& expected_num_workers_completed) :
     command_queue_id(command_queue_id),
     buffer(buffer),
     device(device),
     manager(manager),
-    expected_num_workers_completed(expected_num_workers_completed) {}
+    expected_num_workers_completed(expected_num_workers_completed),
+    clear_count(true) {}
 
 const DeviceCommand EnqueueTraceCommand::assemble_device_commands() {
     uint32_t cmd_sequence_sizeB =
@@ -820,7 +821,11 @@ const DeviceCommand EnqueueTraceCommand::assemble_device_commands() {
     DeviceCommand command_sequence(cmd_sequence_sizeB);
 
     command_sequence.add_dispatch_wait(
-        false, DISPATCH_MESSAGE_ADDR, this->expected_num_workers_completed, true);
+        false, DISPATCH_MESSAGE_ADDR, this->expected_num_workers_completed, this->clear_count);
+
+    if (this->clear_count) {
+        this->expected_num_workers_completed = 0;
+    }
 
     uint32_t page_size = buffer.page_size();
     uint32_t page_size_log2 = __builtin_ctz(page_size);
@@ -1209,13 +1214,13 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
             read_descriptor);
 
     }
+    this->enqueue_command(command, false);
+
     // Increment the global event counter due to trace emitting events in a batch
     this->manager.increment_event_id(this->id, num_events);
 
     // Increment the exepected worker cores counter due to trace programs completions
     this->expected_num_workers_completed += trace_inst.desc->num_completion_worker_cores;
-
-    this->enqueue_command(command, false);
 
     if (blocking) {
         this->finish();

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -339,7 +339,8 @@ class EnqueueTraceCommand : public Command {
     Buffer& buffer;
     Device* device;
     SystemMemoryManager& manager;
-    uint32_t expected_num_workers_completed;
+    uint32_t& expected_num_workers_completed;
+    bool clear_count;
 
    public:
     EnqueueTraceCommand(
@@ -347,7 +348,7 @@ class EnqueueTraceCommand : public Command {
         Device* device,
         SystemMemoryManager& manager,
         Buffer& buffer,
-        uint32_t expected_num_workers_completed);
+        uint32_t& expected_num_workers_completed);
 
     const DeviceCommand assemble_device_commands();
 


### PR DESCRIPTION
I implement the ability to clear wait count, for program tracing to work correct we need to insert a DISPATCHER_WAIT command with clear_count=true in InstantiateTrace and EnqueueTrace

Enabled all trace unit tests.