### PR TITLE
#0: Don't pick up dprints from dispatch cores in gtesting

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -31,6 +31,17 @@ protected:
         tt::llrt::OptionsG.set_dprint_file_name(dprint_file_name);
         tt::llrt::OptionsG.set_test_mode_enabled(true);
 
+        // By default, exclude dispatch cores from printing
+        auto num_cqs_str = getenv("TT_METAL_NUM_HW_CQS");
+        int num_cqs = (num_cqs_str != nullptr)? std::stoi(num_cqs_str) : 1;
+        std::map<CoreType, std::unordered_set<CoreCoord>> disabled;
+        for (unsigned int id = 0; id < tt::tt_metal::GetNumAvailableDevices(); id++) {
+            for (auto core : tt::get_logical_dispatch_cores(id, num_cqs)) {
+                disabled[CoreType::WORKER].insert(core);
+            }
+        }
+        tt::llrt::OptionsG.set_dprint_disabled_cores(disabled);
+
         ExtraSetUp();
 
         // Parent class initializes devices and any necessary flags

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -14,8 +14,6 @@
 #include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
 #include "debug/dprint.h"
 
-#define ENABLE_PREFETCH_DPRINTS 0
-
 constexpr uint32_t downstream_cb_base = get_compile_time_arg_val(0);
 constexpr uint32_t downstream_cb_log_page_size = get_compile_time_arg_val(1);
 constexpr uint32_t downstream_cb_pages = get_compile_time_arg_val(2);
@@ -133,9 +131,7 @@ void read_from_pcie(volatile tt_l1_ptr uint32_t *& prefetch_q_rd_ptr,
     }
 
     uint64_t host_src_addr = get_noc_addr_helper(NOC_XY_ENCODING(PCIE_NOC_X, PCIE_NOC_Y), pcie_read_ptr);
-#if ENABLE_PREFETCH_DPRINTS
     DPRINT << "read_from_pcie: " << fence + preamble_size << " " << pcie_read_ptr << ENDL();
-#endif
     noc_async_read(host_src_addr, fence + preamble_size, size);
     pending_read_size = size + preamble_size;
     pcie_read_ptr += size;
@@ -179,13 +175,9 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
     static uint32_t pending_read_size = 0;
     static volatile tt_l1_ptr uint32_t* prefetch_q_rd_ptr = (volatile tt_l1_ptr uint32_t*)prefetch_q_base;
 
-#if ENABLE_PREFETCH_DPRINTS
     DPRINT << "fetch_q_get_cmds: " << cmd_ptr << " " << fence << ENDL();
-#endif
     if (fence < cmd_ptr) {
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "fetch_q_get_cmds wrap cmd" << ENDL();
-#endif
         cmd_ptr = fence;
     }
 
@@ -198,9 +190,7 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
     }
     if (!cmd_ready) {
         if (pending_read_size != 0) {
-#if ENABLE_PREFETCH_DPRINTS
             DPRINT << "fetch_q_get_cmds barrier" << ENDL();
-#endif
             noc_async_read_barrier();
 
             // wrap the cmddat_q
@@ -225,13 +215,9 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
             // By here, prefetch_q_ready must be false
             // Nothing to fetch, nothing pending, nothing available, stall on host
             DEBUG_STATUS('H', 'Q', 'W');
-#if ENABLE_PREFETCH_DPRINTS
             DPRINT << "prefetcher stall" << ENDL();
-#endif
             while ((fetch_size = *prefetch_q_rd_ptr) == 0);
-#if ENABLE_PREFETCH_DPRINTS
             DPRINT << "recurse" << ENDL();
-#endif
             fetch_q_get_cmds<preamble_size>(fence, cmd_ptr, pcie_read_ptr);
             DEBUG_STATUS('H', 'Q', 'D');
         }
@@ -629,9 +615,7 @@ uint32_t process_exec_buf_cmd(uint32_t cmd_ptr_outer,
     exec_buf_state.pages = cmd->exec_buf.pages;
     exec_buf_state.length = 0;
 
-#if ENABLE_PREFETCH_DPRINTS
     DPRINT << exec_buf_state.page_id << " " << exec_buf_state.base_addr << " " << " " << exec_buf_state.log_page_size << " " << exec_buf_state.pages << ENDL();
-#endif
 
     bool done = false;
     while (!done) {
@@ -667,16 +651,12 @@ bool process_cmd(uint32_t& cmd_ptr,
 
     switch (cmd->base.cmd_id) {
     case CQ_PREFETCH_CMD_RELAY_LINEAR:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "relay linear: " << cmd_ptr << ENDL();
-#endif
         stride = process_relay_linear_cmd(cmd_ptr, downstream_data_ptr);
         break;
 
     case CQ_PREFETCH_CMD_RELAY_PAGED:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "relay dram page: " << cmd_ptr << ENDL();
-#endif
         {
             uint32_t packed_page_flags = cmd->relay_paged.packed_page_flags;
             uint32_t is_dram = packed_page_flags & (1 << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT);
@@ -692,9 +672,7 @@ bool process_cmd(uint32_t& cmd_ptr,
         break;
 
     case CQ_PREFETCH_CMD_RELAY_INLINE:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "relay inline" << ENDL();
-#endif
         if (exec_buf) {
             stride = process_relay_inline_exec_buf_cmd(cmd_ptr, downstream_data_ptr);
         } else {
@@ -703,39 +681,29 @@ bool process_cmd(uint32_t& cmd_ptr,
         break;
 
     case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "inline no flush" << ENDL();
-#endif
         stride = process_relay_inline_noflush_cmd(cmd_ptr, downstream_data_ptr);
         break;
 
     case CQ_PREFETCH_CMD_EXEC_BUF:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "exec buf: " << cmd_ptr << ENDL();
-#endif
         ASSERT(!exec_buf);
         stride = process_exec_buf_cmd(cmd_ptr, downstream_data_ptr);
         break;
 
     case CQ_PREFETCH_CMD_EXEC_BUF_END:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "exec buf end: " << cmd_ptr << ENDL();
-#endif
         ASSERT(exec_buf);
         done = true;
         break;
 
     case CQ_PREFETCH_CMD_STALL:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "stall" << ENDL();
-#endif
         stride = process_stall(cmd_ptr);
         break;
 
     case CQ_PREFETCH_CMD_DEBUG:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "debug" << ENDL();
-#endif
         // Splitting debug cmds not implemented for exec_bufs (yet)
         if (exec_buf) {
             ASSERT(0);
@@ -744,22 +712,18 @@ bool process_cmd(uint32_t& cmd_ptr,
         break;
 
     case CQ_PREFETCH_CMD_TERMINATE:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "terminating\n";
-#endif
         ASSERT(!exec_buf);
         done = true;
         break;
 
     default:
-#if ENABLE_PREFETCH_DPRINTS
         DPRINT << "prefetch invalid command:" << (uint32_t)cmd->base.cmd_id << " " << cmd_ptr << " " << cmddat_q_base << ENDL();
         DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+1) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+2) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+3) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+4) << ENDL();
-#endif
         DEBUG_STATUS('!', 'C', 'M', 'D');
         ASSERT(0);
     }
@@ -813,9 +777,7 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence) {
 // This grabs whole (possibly sets of if multiple in a page) commands
 inline uint32_t relay_cb_get_cmds(uint32_t& fence, uint32_t& data_ptr) {
 
-#if ENABLE_PREFETCH_DPRINTS
     DPRINT << "get_commands: " << data_ptr << " " << fence << " " << cmddat_q_base << " " << cmddat_q_end << ENDL();
-#endif
     if (data_ptr == fence) {
         get_cb_page<
             cmddat_q_base,
@@ -856,9 +818,7 @@ inline uint32_t relay_cb_get_cmds(uint32_t& fence, uint32_t& data_ptr) {
     }
 
     data_ptr += sizeof(CQPrefetchHToPrefetchDHeader);
-#if ENABLE_PREFETCH_DPRINTS
     DPRINT << "done get cmds\n";
-#endif
 
     return length - sizeof(CQPrefetchHToPrefetchDHeader);
 }
@@ -878,9 +838,7 @@ void kernel_main_h() {
         volatile CQPrefetchCmd tt_l1_ptr *cmd = (volatile CQPrefetchCmd tt_l1_ptr *)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
         cmd_ptr = process_relay_inline_all(cmd_ptr, fence);
         if (cmd->base.cmd_id == CQ_PREFETCH_CMD_TERMINATE) {
-#if ENABLE_PREFETCH_DPRINTS
             DPRINT << "terminating\n";
-#endif
             done = true;
         }
     }
@@ -934,9 +892,7 @@ void kernel_main_d() {
     // in case prefetch_d is connected to a depacketizing stage.
     // This should be replaced with a signal similar to what packetized components
     // use.
-#if ENABLE_PREFETCH_DPRINTS
     DPRINT << "prefetch_d done" << ENDL();
-#endif
     noc_semaphore_inc(get_noc_addr_helper(upstream_noc_xy, get_semaphore(upstream_cb_sem_id)), 0x80000000);
 
 }
@@ -960,9 +916,7 @@ void kernel_main_hd() {
 }
 
 void kernel_main() {
-#if ENABLE_PREFETCH_DPRINTS
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
-#endif
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();
     } else if (is_h_variant) {
@@ -972,7 +926,5 @@ void kernel_main() {
     } else {
         ASSERT(0);
     }
-#if ENABLE_PREFETCH_DPRINTS
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": out" << ENDL();
-#endif
 }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <vector>
+#include <unordered_set>
 #include <cstdint>
 #include "tt_metal/common/core_coord.h"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // For CoreType
@@ -32,6 +33,7 @@ class RunTimeOptions {
 
     std::map<CoreType, std::vector<CoreCoord>> dprint_cores;
     std::map<CoreType, bool> dprint_all_cores;
+    std::map<CoreType, std::unordered_set<CoreCoord>> dprint_disabled_cores;
     bool dprint_enabled;
     std::vector<int> dprint_chip_ids;
     bool dprint_all_chips = false;
@@ -82,6 +84,12 @@ class RunTimeOptions {
     }
     inline void set_dprint_cores(std::map<CoreType, std::vector<CoreCoord>> cores) {
         dprint_cores = cores;
+    }
+    inline std::map<CoreType, std::unordered_set<CoreCoord>>& get_dprint_disabled_cores() {
+        return dprint_disabled_cores;
+    }
+    inline void set_dprint_disabled_cores(std::map<CoreType, std::unordered_set<CoreCoord>> disabled_cores) {
+        dprint_disabled_cores = disabled_cores;
     }
     // An alternative to setting cores by range, a flag to enable all.
     inline void set_dprint_all_cores(CoreType core_type, bool all_cores) {


### PR DESCRIPTION
Just add a quick way to disable specific dprint cores for gtests. Need to do it this way because dprint server is configured before devices are created in the gtests.

CI: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8654721221