### PR TITLE
#7401: moved where page mappings are made to outside buffer constructor

### DIFF
--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -406,9 +406,8 @@ Tensor Tensor::cpu_sharded() const {
 
 
 Tensor Tensor::extract_shard(const CoreCoord & core) const{
-
-    auto buffer= this->buffer();
-    uint32_t core_id = buffer->core_to_core_id().at(core);
+    auto buffer_page_mapping = generate_buffer_page_mapping(*this->buffer());
+    auto core_id = buffer_page_mapping.core_to_core_id_.at(core);
     return this->extract_shard(core_id);
 }
 
@@ -542,14 +541,15 @@ bool Tensor::is_allocated() const {
 }
 
 std::vector<uint32_t> Tensor::host_page_ordering(){
-    auto cores = buffer()->all_cores();
+    auto buffer_page_mapping = generate_buffer_page_mapping(*this->buffer());
+    auto cores = buffer_page_mapping.all_cores_;
     auto shard_size = buffer()->shard_spec().size();
     auto num_pages = cores.size() * shard_size;
 
     std::vector<uint32_t> ret_vec;
     ret_vec.reserve(num_pages);
     for(int page_id = 0; page_id <num_pages ; page_id++){
-        ret_vec.push_back(buffer()->get_dev_to_host_mapped_page_id(page_id));
+        ret_vec.push_back(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id]);
     }
     return ret_vec;
 }

--- a/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp
@@ -367,7 +367,8 @@ struct InputTensorShardAddrGenArgGenerator final : public ShardAddrGenArgGenerat
             std::min(sharded_tensor_num_cores % num_workers, worker_index) :
             worker_index;
 
-        std::vector<CoreCoord> const& all_shard_cores = input_tensor.buffer()->all_cores();
+        auto buffer_page_mapping = generate_buffer_page_mapping(*input_tensor.buffer());
+        std::vector<CoreCoord> const& all_shard_cores = buffer_page_mapping.all_cores_;
         for (uint32_t c = worker_cores_start; c < worker_cores_start + this->args_struct.num_dest_cores; ++c) {
             CoreCoord const& worker_core = all_shard_cores.at(c);
             ccl::WorkerXY worker_xy(

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -135,6 +135,17 @@ struct ShardedBufferConfig {
 
 bool is_sharded(const TensorMemoryLayout & layout);
 
+struct BufferPageMapping {
+    std::vector< CoreCoord> all_cores_;
+    std::vector< uint32_t> core_bank_indices_;
+    std::vector< std::vector<uint32_t> > core_host_page_indices_;
+    std::vector<uint32_t> dev_page_to_core_mapping_;
+    std::vector<uint32_t> dev_page_to_host_page_mapping_;
+    std::vector<uint32_t> host_page_to_dev_page_mapping_;
+    std::unordered_map<CoreCoord, uint32_t> core_to_core_id_;
+    std::vector< uint32_t> host_page_to_local_shard_page_mapping_;
+};
+
 class Buffer {
    public:
     Buffer() :
@@ -182,8 +193,10 @@ class Buffer {
 
     uint64_t page_address(uint32_t bank_id, uint32_t page_index) const;
 
+
     // SHARDED API STARTS HERE
     // TODO: WILL SEPARATE INTO SHARDED BUFFER CLASS
+
     uint64_t sharded_page_address(uint32_t bank_id, uint32_t page_index) const;
 
     ShardSpecBuffer shard_spec() const {
@@ -192,92 +205,12 @@ class Buffer {
         return this->shard_parameters_.value();
     }
 
-    std::vector<uint32_t> get_dev_page_to_host_page_mapping() const {
-        return dev_page_to_host_page_mapping_;
-    }
-
-    std::vector<uint32_t> get_host_page_to_dev_page_mapping() const {
-        return host_page_to_dev_page_mapping_;
-    }
-
-    CoreCoord get_core_from_dev_page_id(uint32_t dev_page_id) const {
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        TT_ASSERT(dev_page_id < dev_page_to_core_mapping_.size());
-        return all_cores_[dev_page_to_core_mapping_[dev_page_id]];
-    }
-
-    uint32_t get_host_to_dev_mapped_page_id(uint32_t input_id) const {
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        TT_ASSERT(input_id < host_page_to_dev_page_mapping_.size());
-        return host_page_to_dev_page_mapping_[input_id];
-    }
-
-    uint32_t get_dev_to_host_mapped_page_id(uint32_t input_id) const {
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        TT_ASSERT(input_id < dev_page_to_core_mapping_.size());
-        return dev_page_to_host_page_mapping_[input_id];
-    }
-
-
-    std::vector<CoreCoord> all_cores() const{
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        return all_cores_;
-    }
-
-    std::vector< std::vector<uint32_t> > core_host_page_indices() const{
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        return core_host_page_indices_;
-    }
-
     uint32_t num_cores() const{
         if(!is_sharded(this->buffer_layout_))
             return 1;
         else{
             return this->shard_spec().tensor_shard_spec.grid.num_cores();
         }
-    }
-
-    std::unordered_map<CoreCoord, uint32_t> core_to_core_id() const{
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        return core_to_core_id_;
-    }
-
-    std::vector<uint32_t> host_pages_in_shard(uint32_t core_id) const
-    {
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        return core_host_page_indices_[core_id];
-    }
-
-    std::vector<uint32_t> host_pages_in_shard(CoreCoord core) const
-    {
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        auto core_id = core_to_core_id_.at(core);
-        return core_host_page_indices_[core_id];
-    }
-
-    std::vector<uint32_t> dev_pages_in_shard(const uint32_t & core_id) const
-    {
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        std::vector<uint32_t> ret_vec;
-        for(uint32_t i=0; i<this->dev_page_to_core_mapping_.size() ; i++) {
-           if(this->dev_page_to_core_mapping_[i] == core_id) {
-             ret_vec.push_back(i);
-           }
-        }
-        return ret_vec;
-    }
-
-    std::vector<uint32_t> dev_pages_in_shard(const CoreCoord & core) const
-    {
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        auto core_id = core_to_core_id_.at(core);
-        return dev_pages_in_shard(core_id);
-    }
-
-    std::vector<uint32_t> get_host_page_to_local_shard_page_mapping() const
-    {
-        TT_ASSERT(is_sharded(this->buffer_layout_) , "Buffer not sharded");
-        return host_page_to_local_shard_page_mapping_;
     }
 
 
@@ -294,15 +227,10 @@ class Buffer {
     BufferType buffer_type_;
     TensorMemoryLayout buffer_layout_;
     std::optional<ShardSpecBuffer> shard_parameters_;
-    std::vector< CoreCoord> all_cores_;
-    std::vector< uint32_t> core_bank_indices_;
-    std::vector< std::vector<uint32_t> > core_host_page_indices_;
-    std::vector<uint32_t> dev_page_to_core_mapping_;
-    std::vector<uint32_t> dev_page_to_host_page_mapping_;
-    std::vector<uint32_t> host_page_to_dev_page_mapping_;
-    std::unordered_map<CoreCoord, uint32_t> core_to_core_id_;
-    std::vector< uint32_t> host_page_to_local_shard_page_mapping_;
 };
+
+
+BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer);
 
 namespace detail {
 using PageAddress = uint32_t;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -380,7 +380,8 @@ struct IssuedReadData {
         this->page_size = buffer.page_size();
         this->padded_page_size = padded_page_size;
         if (this->buffer_layout == TensorMemoryLayout::WIDTH_SHARDED or this->buffer_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-            this->dev_page_to_host_page_mapping = buffer.get_dev_page_to_host_page_mapping();
+            auto buffer_page_mapping = generate_buffer_page_mapping(buffer);
+            this->dev_page_to_host_page_mapping = buffer_page_mapping.dev_page_to_host_page_mapping_;
         }
         this->dst = dst;
         this->dst_offset = dst_offset;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -194,10 +194,12 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
 
         TT_ASSERT(buffer.buffer_type() == BufferType::L1 && "Only L1 Buffers support sharding");
 
+
+        auto buffer_page_mapping = generate_buffer_page_mapping(buffer);
         auto total_pages = buffer.num_pages();
         for(int host_page_id=0; host_page_id<total_pages; host_page_id++){
-            auto dev_page_id = buffer.get_host_to_dev_mapped_page_id(host_page_id);
-            auto core = buffer.get_core_from_dev_page_id(dev_page_id);
+            auto dev_page_id = buffer_page_mapping.host_page_to_dev_page_mapping_[host_page_id];
+            auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_id]];
             auto bank_id = device->bank_ids_from_logical_core(core)[0];
             auto absolute_address = buffer.sharded_page_address(bank_id, dev_page_id);
             auto data_index = host_page_id * num_entries_per_page;
@@ -362,10 +364,11 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
 
         host_buffer = std::vector<uint32_t>(total_pages * num_entries_per_page);
 
+        auto buffer_page_mapping = generate_buffer_page_mapping(buffer);
         for(int dev_page_id=0; dev_page_id<total_pages; dev_page_id++){
-            auto core = buffer.get_core_from_dev_page_id(dev_page_id);
+            auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_id]];
             auto bank_id = device->bank_ids_from_logical_core(core)[0];
-            auto host_page_id = buffer.get_dev_to_host_mapped_page_id(dev_page_id);
+            auto host_page_id = buffer_page_mapping.dev_page_to_host_page_mapping_[dev_page_id];
             if(!shard_order){
                 read_pages_to_host_helper(
                     device,
@@ -443,11 +446,19 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
         uint32_t num_entries_per_shard = num_entries_per_page * buffer.shard_spec().size();
         host_buffer = std::vector<uint32_t>(num_entries_per_shard);
 
-        auto page_ids = buffer.dev_pages_in_shard(core_id);
+
+        std::vector<uint32_t> page_ids;
+        auto buffer_page_mapping = generate_buffer_page_mapping(buffer);
+        for(uint32_t i=0; i<buffer_page_mapping.dev_page_to_core_mapping_.size() ; i++) {
+           if(buffer_page_mapping.dev_page_to_core_mapping_[i] == core_id) {
+             page_ids.push_back(i);
+           }
+        }
+
 
         uint32_t host_page_id = 0;
         for(auto dev_page_id: page_ids){
-            auto core = buffer.get_core_from_dev_page_id(dev_page_id);
+            auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_id]];
             auto bank_id = device->bank_ids_from_logical_core(core)[0];
             read_pages_to_host_helper(
                 device,

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -86,9 +86,10 @@ std::vector<BufferInfo> get_buffers() {
                 bank_id = (bank_id + 1) % num_banks;
             }
         } else {
+            auto buffer_page_mapping = generate_buffer_page_mapping(*buffer);
             for (int page_index = 0; page_index < num_pages; page_index++) {
-                auto dev_page_index = buffer->get_host_to_dev_mapped_page_id(page_index);
-                auto core = buffer->get_core_from_dev_page_id(dev_page_index);
+                auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
+                auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];
                 auto bank_id = device->bank_ids_from_logical_core(core)[0];
 
                 if (bank_to_num_pages.find(bank_id) == bank_to_num_pages.end()) {
@@ -160,9 +161,10 @@ std::vector<BufferPageInfo> get_buffer_pages() {
                 bank_id = (bank_id + 1) % num_banks;
             }
         } else {
+            auto buffer_page_mapping = generate_buffer_page_mapping(*buffer);
             for (int page_index = 0; page_index < num_pages; page_index++) {
-                auto dev_page_index = buffer->get_host_to_dev_mapped_page_id(page_index);
-                auto core = buffer->get_core_from_dev_page_id(dev_page_index);
+                auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
+                auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];
                 auto bank_id = device->bank_ids_from_logical_core(core)[0];
                 auto page_address = buffer->sharded_page_address(bank_id, dev_page_index);
 


### PR DESCRIPTION
Currently the page mappings are being formed in the constructor of device buffer. This is sub-optimal because 1) this is done at runtime 2) not all buffers even need the mappings.

This recently came up with a regression in Bert and ViT perf (which is why I'm labelling this as a p0. @jliangTT )

We only need the mappings when writing directly to a sharded buffer, reading back directly from a sharded buffer and the creation of the program in reshard. For most on device ops we can bypass this.

CC: @davorchap @mo-tenstorrent 