### PR TITLE
#6805: Add generic sharded implementation of create_qkv_heads which t…

### DIFF
--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -632,7 +632,7 @@ Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layo
         TT_FATAL(false, "Unsupported sharding scheme");
     }
 
-    TT_ASSERT(num_shards == num_cores, "Number of shards {} must match number of cores {}", num_shards, num_cores);
+    TT_ASSERT(num_shards == num_cores, fmt::format("Number of shards {} must match number of cores {}", num_shards, num_cores));
 
     if (layout == Layout::TILE) {
         TT_ASSERT((shard_shape[0] % TILE_HEIGHT == 0 && shard_shape[1] % TILE_WIDTH == 0), "Shard shape must be tile sized");

--- a/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_create_qkv_heads_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_create_qkv_heads_sharded.cpp
@@ -6,80 +6,89 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    constexpr uint32_t q_heads_per_group               = get_compile_time_arg_val(0); // number of Q heads in the group, n
-    constexpr uint32_t k_heads_per_group               = get_compile_time_arg_val(1); // number of K heads in the group, expecting 1
-    constexpr uint32_t v_heads_per_group               = get_compile_time_arg_val(2); // number of V heads in the group, expecting 1
+    constexpr uint32_t q_heads_per_group                = get_compile_time_arg_val(0); // number of Q heads in the group, n
+    constexpr uint32_t k_heads_per_group                = get_compile_time_arg_val(1); // number of K heads in the group, expecting 1
+    constexpr uint32_t v_heads_per_group                = get_compile_time_arg_val(2); // number of V heads in the group, expecting 1
 
 
-    constexpr uint32_t q_out_block_wt_size_bytes       = get_compile_time_arg_val(3); // size of a Q head in bytes
-    constexpr uint32_t k_out_block_wt_size_bytes       = get_compile_time_arg_val(4); // size of a K head `` ``
-    constexpr uint32_t v_out_block_wt_size_bytes       = get_compile_time_arg_val(5); // size of a V head `` ``
+    constexpr uint32_t q_head_size_bytes                = get_compile_time_arg_val(3); // size of a Q head in bytes
+    constexpr uint32_t k_head_size_bytes                = get_compile_time_arg_val(4); // size of a K head `` ``
+    constexpr uint32_t v_head_size_bytes                = get_compile_time_arg_val(5); // size of a V head `` ``
 
-    constexpr uint32_t block_wt_size_bytes             = get_compile_time_arg_val(6); // size of each group, used for skipping each group
-    constexpr uint32_t block_ht                        = get_compile_time_arg_val(7); // number of tiles along the seq_len*batch dimension
-    constexpr uint32_t block_groups_wt                 = get_compile_time_arg_val(8); // number of tiles inside one nQ K V group
+    constexpr uint32_t group_t_size_bytes               = get_compile_time_arg_val(6); // size of each group
+    constexpr uint32_t block_ht                         = get_compile_time_arg_val(7); // number of tiles along the seq_len*batch dimension
+    constexpr uint32_t groups_per_block                 = get_compile_time_arg_val(8); // number of groups per shard
 
-    constexpr uint32_t q_num_tiles                     = get_compile_time_arg_val(9); // total number of Q pages, used for CB reservation
-    constexpr uint32_t k_num_tiles                     = get_compile_time_arg_val(10); // total number of K pages
-    constexpr uint32_t v_num_tiles                     = get_compile_time_arg_val(11); // total number of V pages
+    constexpr uint32_t q_num_tiles                      = get_compile_time_arg_val(9); // total number of Q pages, used for CB reservation
+    constexpr uint32_t k_num_tiles                      = get_compile_time_arg_val(10); // total number of K pages
+    constexpr uint32_t v_num_tiles                      = get_compile_time_arg_val(11); // total number of V pages
 
-    constexpr uint32_t q_size_per_group                = get_compile_time_arg_val(12); // total size of all n Q heads in a group, used to find start of first K head
-    constexpr uint32_t q_k_size_per_group              = get_compile_time_arg_val(13); // total size of all n Q heads and K heads (expecting 1) in a group
+    constexpr uint32_t q_size_per_group_t_bytes         = get_compile_time_arg_val(12); // total size of all n Q heads in a group
+    constexpr uint32_t k_size_per_group_t_bytes         = get_compile_time_arg_val(13); // total size of all K heads (expecting 1) in a group
+    constexpr uint32_t v_size_per_group_t_bytes         = get_compile_time_arg_val(14); // total size of all V heads (expecting 1) in a group
 
-    constexpr uint32_t cb_in0 = tt::CB::c_in0;
+    constexpr uint32_t cb_in0  = tt::CB::c_in0;
     constexpr uint32_t cb_out0 = tt::CB::c_out0;
     constexpr uint32_t cb_out1 = tt::CB::c_out1;
     constexpr uint32_t cb_out2 = tt::CB::c_out2;
 
 
-    // copy one entire head_dim tile, then go to next sequence*batch tile and do another head_dim.
+    // copy one entire head_dim tile, then go to next sequence tile and do another head_dim.
     // after that, go to next head (head_dim > sequence * batch > head)
-    // since Q's heads are shuffled and n Q heads are interleaved with a KV, have to do 3 loops
+    // since Q's heads are shuffled and n Q heads are paired with a KV, need to iterate through multiple Q heads before skipping to next sequence tile
 
 
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_in0);
+    constexpr uint32_t block_wt_size_bytes = groups_per_block * (group_t_size_bytes);
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_in0);
     const DataFormat data_format = get_dataformat(cb_in0);
 
     /**
      * Iterate over number of heads in each group (n Q, 1 K, 1 V) where total number of groups = total number of KV heads
      * block_ht is the number of tiles along the batch * seq_len dimension shard
     */
-    uint64_t src_noc_addr = get_noc_addr(get_read_ptr(cb_in0));
 
+    uint64_t src_noc_addr = get_noc_addr(get_read_ptr(cb_in0));
     // re-order q
     cb_reserve_back(cb_out0, q_num_tiles);
-    uint32_t l1_write_addr_out0 = get_write_ptr(cb_out0);
+
+    uint32_t q_write_addr = get_write_ptr(cb_out0);
     uint32_t src_noc_addr_offset_outer = 0;
-    for (uint32_t k = 0; k < block_groups_wt; k++) { // number of groups, divided into tiles
-        uint32_t l1_read_addr_offset = 0; // start at 0 since Q is always first
+
+    uint32_t group_addr_offset = 0;
+    for (uint32_t k = 0; k < groups_per_block; k++) { // number of kv heads inside the shard
+        uint32_t head_in_group_offset = 0;
         for (uint32_t j = 0; j < q_heads_per_group; j++) { // go to next Q heads in the group (0 to n-1 for the nQ per KV group)
+            uint32_t seq_tile_offset = 0;
             for (uint32_t i = 0; i < block_ht; i++) { // iterate across seq_len dimension tiles
-                uint64_t q_src_noc_addr = src_noc_addr + l1_read_addr_offset + src_noc_addr_offset_outer;
-                noc_async_read(q_src_noc_addr, l1_write_addr_out0, q_out_block_wt_size_bytes); // read one head worth of tiles
-                l1_write_addr_out0 += q_out_block_wt_size_bytes; // read in one Q head
-                l1_read_addr_offset += block_wt_size_bytes; // go to next group along sequence
+                uint64_t q_src_noc_addr = src_noc_addr + seq_tile_offset + head_in_group_offset + group_addr_offset;
+                noc_async_read(q_src_noc_addr, q_write_addr, q_head_size_bytes); // read one head worth of tiles
+                q_write_addr += q_head_size_bytes; // go to output address for next Q head
+                seq_tile_offset += block_wt_size_bytes; // go to next tile along seq_len
             }
-            src_noc_addr_offset_outer += q_out_block_wt_size_bytes;
+            head_in_group_offset += q_head_size_bytes;
         }
+        group_addr_offset += group_t_size_bytes;
     }
     noc_async_read_barrier();
     cb_push_back(cb_out0, q_num_tiles);
 
     // re-order k
     cb_reserve_back(cb_out1, k_num_tiles);
-    uint32_t l1_write_addr_out1 = get_write_ptr(cb_out1);
-    src_noc_addr_offset_outer = 0;
-    for (uint32_t k = 0; k < block_groups_wt; ++k) { // m kv head tiles
-        uint32_t l1_read_addr_offset = q_size_per_group; // skip the first n*Q since we're writing K
-        for (uint32_t j = 0; j < k_heads_per_group; j++) { // 1 k tile per kv head
-            for (uint32_t i = 0; i < block_ht; i++) { // seq_len
-                uint64_t k_src_noc_addr = src_noc_addr + l1_read_addr_offset + src_noc_addr_offset_outer;
-                noc_async_read(k_src_noc_addr, l1_write_addr_out1, k_out_block_wt_size_bytes);
-                l1_write_addr_out1 += k_out_block_wt_size_bytes;
-                l1_read_addr_offset += block_wt_size_bytes;
+    uint32_t k_write_addr = get_write_ptr(cb_out1);
+    group_addr_offset = q_size_per_group_t_bytes;
+    for (uint32_t k = 0; k < groups_per_block; k++) { // number of kv heads inside the shard
+        uint32_t head_in_group_offset = 0;
+        for (uint32_t j = 0; j < k_heads_per_group; j++) { // go to next K heads in the group (expecting only 1 for K)
+            uint32_t seq_tile_offset = 0;
+            for (uint32_t i = 0; i < block_ht; i++) { // iterate across seq_len dimension tiles
+                uint64_t k_src_noc_addr = src_noc_addr + seq_tile_offset + head_in_group_offset + group_addr_offset;
+                noc_async_read(k_src_noc_addr, k_write_addr, k_head_size_bytes); // read one head worth of tiles
+                k_write_addr += k_head_size_bytes; // output address of next K head
+                seq_tile_offset += block_wt_size_bytes; // go to next tile in seq_len
             }
-            src_noc_addr_offset_outer += k_out_block_wt_size_bytes;
+            head_in_group_offset += k_head_size_bytes;
         }
+        group_addr_offset += group_t_size_bytes;
     }
     noc_async_read_barrier();
     cb_push_back(cb_out1, k_num_tiles);
@@ -87,19 +96,21 @@ void kernel_main() {
 
     // re-order v
     cb_reserve_back(cb_out2, v_num_tiles);
-    uint32_t l1_write_addr_out2 = get_write_ptr(cb_out2);
-    src_noc_addr_offset_outer = 0;
-    for (uint32_t k = 0; k < block_groups_wt; ++k) { // number of group-tiles
-        uint32_t l1_read_addr_offset = q_k_size_per_group;
-        for (uint32_t j = 0; j < v_heads_per_group; j++) { // 1 v tile per kv head
-            for (uint32_t i = 0; i < block_ht; i++) { // sequence length
-                uint64_t v_src_noc_addr = src_noc_addr + l1_read_addr_offset + src_noc_addr_offset_outer;
-                noc_async_read(v_src_noc_addr, l1_write_addr_out2, v_out_block_wt_size_bytes);
-                l1_write_addr_out2 += v_out_block_wt_size_bytes;
-                l1_read_addr_offset += block_wt_size_bytes;
+    uint32_t v_write_addr = get_write_ptr(cb_out2);
+    group_addr_offset = q_size_per_group_t_bytes + k_size_per_group_t_bytes;
+    for (uint32_t k = 0; k < groups_per_block; k++) { // number of kv heads inide the hard
+        uint32_t head_in_group_offset = 0;
+        for (uint32_t j = 0; j < v_heads_per_group; j++) { // go to next V heads in the group (expecting only 1 for V)
+            uint32_t seq_tile_offset = 0;
+            for (uint32_t i = 0; i < block_ht; i++) { // iterate across seq_len dimension tiles
+                uint64_t k_src_noc_addr = src_noc_addr + seq_tile_offset + head_in_group_offset + group_addr_offset;
+                noc_async_read(k_src_noc_addr, v_write_addr, v_head_size_bytes); // read one head worth of tiles
+                v_write_addr += v_head_size_bytes; // output address of next V head
+                seq_tile_offset += block_wt_size_bytes; // go to next tile in seq_len
             }
-            src_noc_addr_offset_outer += v_out_block_wt_size_bytes;
+            head_in_group_offset += v_head_size_bytes;
         }
+        group_addr_offset += group_t_size_bytes;
     }
     noc_async_read_barrier();
     cb_push_back(cb_out2, v_num_tiles);

--- a/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
@@ -62,20 +62,26 @@ static inline operation::ProgramWithCallbacks create_heads_combined_qkv_sharded(
 
     Program program = CreateProgram();
     std::vector<uint32_t> reader_compile_time_args = {
+
         (std::uint32_t) heads_per_group[0], // q heads in group
         (std::uint32_t) heads_per_group[1], // k heads in group
         (std::uint32_t) heads_per_group[2], // v heads in group
+
         (std::uint32_t) head_dim / TILE_WIDTH * single_tile_size, // size of a q head
         (std::uint32_t) head_dim / TILE_WIDTH * single_tile_size, // size of a k head
         (std::uint32_t) head_dim / TILE_WIDTH * single_tile_size, // size of a v head
+
         (std::uint32_t) tiles_per_group * single_tile_size, // group size, used to skip past group to the rest of the three tensors
         (std::uint32_t) block_ht, // how many tiles to read along sequence dimension
         (std::uint32_t) groups_per_block, // groups per shard (kv heads per core)
+
         (std::uint32_t) block_ht * num_tiles_per_group[0] * groups_per_block, // number of pages in q output tensor
         (std::uint32_t) block_ht * num_tiles_per_group[1] * groups_per_block, // number of pages in k output tensor
         (std::uint32_t) block_ht * num_tiles_per_group[2] * groups_per_block, // number of pages in v output tensor
-        (std::uint32_t) num_tiles_per_group[0] * single_tile_size, // size of n*Q tiles in bytes to get to K heads
-        (std::uint32_t) (num_tiles_per_group[0] * single_tile_size) + (num_tiles_per_group[1] * single_tile_size), // size of n*Q + K tiles in bytes to get to V heads
+
+        (std::uint32_t) num_tiles_per_group[0] * single_tile_size, // size of n*Q tiles in each group, in bytes
+        (std::uint32_t) num_tiles_per_group[1] * single_tile_size, // size of K tiles in each group, in bytes
+        (std::uint32_t) num_tiles_per_group[2] * single_tile_size, // size of V tiles in each group, in bytes
     };
 
     auto reader_kernel_id = tt_metal::CreateKernel(

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -284,6 +284,7 @@ void CreateQKVHeads::validate(const std::vector<Tensor> &input_tensors) const {
 
     // TODO: Add this back when output is HEIGHT sharded only!
     // TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+    TT_FATAL(input_shape[0] == num_h_cores, fmt::format("Batch size  {} must be equal to num cores {}", input_shape[0], num_h_cores));
 }
 
 std::vector<Shape> CreateQKVHeads::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {


### PR DESCRIPTION
…urn a combined qkv tensor into 3 [batch, num_q_heads/num_kv_head, seq_len, head_dim] tensors

    - This also addresses issue #6712
    - TODO: clean up kernel/program creation and make sure the comments align with the most current code
    - TODO: implement support for batching > number of cores
    - TODO: parallelize work across NCRSIC and BRISC
    - TODO: support k transposing natively to the kernel rather than expecting a separate job
    - TODO: add an API for cross attention and when Q and KV are in separate tensors