### PR TITLE
#5480: FD2 exec_buf split prefetcher support

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -54,6 +54,9 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 5 -i 5 -x" # Paged DRAM Write + Read Test
 #run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -x"  # Host Test not supported w/ exec_buf
 
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre" # Smoke Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre -sdis" # Smoke Test
+
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -spre -packetized_en" # TrueSmoke Test with packetized path
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -spre -packetized_en" # Smoke Test with packetized path
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -554,7 +554,7 @@ inline void gen_dispatcher_host_write_cmd(vector<uint32_t>& cmds, uint32_t lengt
     CQDispatchCmd cmd;
     memset(&cmd, 0, sizeof(CQDispatchCmd));
 
-    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_HOST;
+    cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST;
     // Include cmd in transfer
     cmd.write_linear_host.length = length + sizeof(CQDispatchCmd);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1518,7 +1518,7 @@ int main(int argc, char **argv) {
                 prefetch_compile_args,
                 prefetch_core,
                 phys_prefetch_core_g,
-                {0, 0}, // upstream core unused
+                {0xffffffff, 0xffffffff}, // upstream core unused
                 phys_prefetch_h_downstream_core);
 
             if (packetized_path_en_g) {
@@ -1680,7 +1680,7 @@ int main(int argc, char **argv) {
                 prefetch_compile_args,
                 prefetch_core,
                 phys_prefetch_core_g,
-                {0, 0}, // upstream core unused
+                {0xffffffff, 0xffffffff}, // upstream core unused
                 phys_dispatch_core);
         }
 
@@ -1724,7 +1724,7 @@ int main(int argc, char **argv) {
                 dispatch_h_core,
                 phys_dispatch_h_core,
                 phys_dispatch_core,
-                {0,0});
+                {0xffffffff,0xffffffff});
         } else {
             configure_kernel_variant<true, true>(program,
                 "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
@@ -1732,7 +1732,7 @@ int main(int argc, char **argv) {
                 dispatch_core,
                 phys_dispatch_core,
                 phys_upstream_from_dispatch_core,
-                {0,0});
+                {0xffffffff,0xffffffff});
         }
 
         log_info(LogTest, "Hugepage buffer size {}", std::to_string(hugepage_issue_buffer_size_g));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_multichip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_multichip.cpp
@@ -216,7 +216,7 @@ bool validate_host_results(
         CQDispatchCmd *cmd = (CQDispatchCmd *)&cmds[cmd_index];
 
         // Validate only works for packed write linear host commands
-        TT_ASSERT(cmd->base.cmd_id == CQ_DISPATCH_CMD_WRITE_LINEAR_HOST);
+        TT_ASSERT(cmd->base.cmd_id == CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST);
 
         uint32_t length = cmd->write_linear_host.length;
         for (int i = 0; i < length / sizeof(uint32_t); i++) {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -338,6 +338,7 @@ void Device::compile_command_queue_programs() {
 
     constexpr uint32_t prefetch_d_upstream_cb_sem = 1;
     constexpr uint32_t prefetch_d_downstream_cb_sem = 2;
+    constexpr uint32_t prefetch_h_exec_buf_sem = 2;
 
     if (this->is_mmio_capable()) {
         for (const chip_id_t &device_id : tt::Cluster::instance().get_devices_controlled_by_mmio_device(this->id())) {
@@ -403,6 +404,7 @@ void Device::compile_command_queue_programs() {
                     prefetch_downstream_cb_sem, // prefetch_d only
                     PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
                     PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
+                    prefetch_h_exec_buf_sem,
                     true,   // is_dram_variant
                     true    // is_host_variant
                 };
@@ -419,6 +421,7 @@ void Device::compile_command_queue_programs() {
 
                 tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, 0);
                 tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, dispatch_buffer_pages);
+                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, 0);
 
                 if (device_id == this->id()) {
                     std::map<string, string> dispatch_defines = {

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -31,15 +31,16 @@ enum CQPrefetchCmdId : uint8_t {
 enum CQDispatchCmdId : uint8_t {
     CQ_DISPATCH_CMD_ILLEGAL = 0,            // common error value
     CQ_DISPATCH_CMD_WRITE_LINEAR = 1,       // write data from dispatcher to dst_noc
-    CQ_DISPATCH_CMD_WRITE_LINEAR_HOST = 2,  // like write, dedicated to writing to host
-    CQ_DISPATCH_CMD_WRITE_PAGED = 3,        // write banked/paged data from dispatcher to dst_noc
-    CQ_DISPATCH_CMD_WRITE_PACKED = 4,       // write to multiple noc addresses with packed data
-    CQ_DISPATCH_CMD_WAIT = 5,               // wait until workers are done
-    CQ_DISPATCH_CMD_GO = 6,                 // send go message
-    CQ_DISPATCH_CMD_SINK = 7,               // act as a data sink (for testing)
-    CQ_DISPATCH_CMD_DEBUG = 8,              // log waypoint data to watcher, checksum
-    CQ_DISPATCH_CMD_DELAY = 9,              // insert delay (for testing)
-    CQ_DISPATCH_CMD_TERMINATE = 10,         // quit
+    CQ_DISPATCH_CMD_WRITE_LINEAR_H = 2,     // write data from dispatcher to dst_noc on dispatch_h chip
+    CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST = 3,// like write, dedicated to writing to host
+    CQ_DISPATCH_CMD_WRITE_PAGED = 4,        // write banked/paged data from dispatcher to dst_noc
+    CQ_DISPATCH_CMD_WRITE_PACKED = 5,       // write to multiple noc addresses with packed data
+    CQ_DISPATCH_CMD_WAIT = 6,               // wait until workers are done
+    CQ_DISPATCH_CMD_GO = 7,                 // send go message
+    CQ_DISPATCH_CMD_SINK = 8,               // act as a data sink (for testing)
+    CQ_DISPATCH_CMD_DEBUG = 9,              // log waypoint data to watcher, checksum
+    CQ_DISPATCH_CMD_DELAY = 10,             // insert delay (for testing)
+    CQ_DISPATCH_CMD_TERMINATE = 11,         // quit
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -121,7 +121,7 @@ void DeviceCommand::add_dispatch_write_host(bool flush_prefetch, uint32_t data_s
     this->add_prefetch_relay_inline(flush_prefetch, payload_sizeB);
 
     CQDispatchCmd write_cmd;
-    write_cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_HOST;
+    write_cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST;
     write_cmd.write_linear_host.length = payload_sizeB; // CQ_DISPATCH_CMD_WRITE_LINEAR_HOST writes dispatch cmd back to completion queue
 
     this->write_to_cmd_sequence(&write_cmd, sizeof(CQDispatchCmd));


### PR DESCRIPTION
Support for exec_buf + split dispatcher requires a new semaphore on prefetch_h.  This will need more plumbing to work w/ the runtime (getting the address into the exec buf).

Heads up Tony/Umair