### PR TITLE
#0: add SD unet e2e test to post-commit pipeline

### DIFF
--- a/tests/ttnn/unit_tests/test_sd_e2e.py
+++ b/tests/ttnn/unit_tests/test_sd_e2e.py
@@ -1,0 +1,1 @@
+../integration_tests/stable_diffusion/test_unet_2d_condition_model.py


### PR DESCRIPTION
It adds SD unet e2e test to [ttnn post-commit](https://github.com/tenstorrent-metal/tt-metal/actions/runs/8666818947/job/23769222837) pipeline. 

fyi @AleksKnezevic 