### PR TITLE
#7328: Fix programming for eth cores with >1 span per binary

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
@@ -69,8 +69,6 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
 }
 
 TEST_F(DPrintFixture, TestPrintEthCores) {
-    // TODO: Re-enable with #7328
-    GTEST_SKIP();
     for (Device* device : this->devices_) {
         // Skip if no ethernet cores on this device
         if (device->get_active_ethernet_cores(true).size() == 0) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_all_harts.cpp
@@ -178,8 +178,6 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
 }
 
 TEST_F(DPrintFixture, TestPrintFromAllHarts) {
-    // TODO: Re-enable with #7328
-    GTEST_SKIP();
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -674,22 +674,23 @@ void Program::populate_dispatch_data(Device* device) {
             const auto& binaries = kernel->binaries(device->id());
 
             for (size_t j = 0; j < binaries.size(); j++) {
-                std::vector<uint32_t> dst_base_addrs;
-                std::vector<uint32_t> page_offsets;
-                std::vector<uint32_t> lengths;
-                vector<uint32_t> binaries_data;
                 const ll_api::memory& kernel_bin = binaries[j];
-
                 uint32_t k = 0;
                 uint32_t num_spans = kernel_bin.num_spans();
+
+                std::vector<uint32_t> dst_base_addrs(num_spans);
+                std::vector<uint32_t> page_offsets(num_spans);
+                std::vector<uint32_t> lengths(num_spans);
+                vector<uint32_t> binaries_data;
+
                 kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
                     linked &= (i != kernel_ids.size() - 1) or (j != binaries.size() - 1) or (k != num_spans - 1);
                     uint64_t relo_addr =
                         tt::llrt::relocate_dev_addr(dst, processor_to_local_mem_addr.at(sub_kernels[sub_kernel_index]));
 
-                    dst_base_addrs.push_back((uint32_t)relo_addr);
-                    page_offsets.push_back(binaries_data.size() * sizeof(uint32_t) / DeviceCommand::PROGRAM_PAGE_SIZE);
-                    lengths.push_back(len * sizeof(uint32_t));
+                    dst_base_addrs[k] = (uint32_t)relo_addr;
+                    page_offsets[k] = binaries_data.size() * sizeof(uint32_t) / DeviceCommand::PROGRAM_PAGE_SIZE;
+                    lengths[k] = len * sizeof(uint32_t);
 
                     binaries_data.resize(binaries_data.size() + len);
                     std::copy(mem_ptr, mem_ptr + len, binaries_data.end() - len);
@@ -748,21 +749,22 @@ void Program::populate_dispatch_data(Device* device) {
             uint32_t sub_kernel_index = 0;
             const auto& binaries = kernel->binaries(device->id());
             for (size_t j = 0; j < binaries.size(); j++) {
-                std::vector<uint32_t> dst_base_addrs(binaries.size());
-                std::vector<uint32_t> page_offsets(binaries.size());
-                std::vector<uint32_t> lengths(binaries.size());
-                vector<uint32_t> binaries_data;
                 const ll_api::memory& kernel_bin = binaries[j];
-
                 uint32_t k = 0;
                 uint32_t num_spans = kernel_bin.num_spans();
+
+                std::vector<uint32_t> dst_base_addrs(num_spans);
+                std::vector<uint32_t> page_offsets(num_spans);
+                std::vector<uint32_t> lengths(num_spans);
+                vector<uint32_t> binaries_data;
+
                 kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
                     uint64_t relo_addr =
                         tt::llrt::relocate_dev_addr(dst, processor_to_local_mem_addr.at(sub_kernels[sub_kernel_index]));
 
-                    dst_base_addrs[j] = (uint32_t)relo_addr;
-                    page_offsets[j] = binaries_data.size() * sizeof(uint32_t) / DeviceCommand::PROGRAM_PAGE_SIZE;
-                    lengths[j] = len * sizeof(uint32_t);
+                    dst_base_addrs[k] = (uint32_t)relo_addr;
+                    page_offsets[k] = binaries_data.size() * sizeof(uint32_t) / DeviceCommand::PROGRAM_PAGE_SIZE;
+                    lengths[k] = len * sizeof(uint32_t);
 
                     binaries_data.resize(binaries_data.size() + len);
                     std::copy(mem_ptr, mem_ptr + len, binaries_data.end() - len);


### PR DESCRIPTION
Issue here is that for eth cores where the binary has multiple spans, we were only writing the last span - causing incomplete binaries to be written.

CI passing: https://github.com/tenstorrent-metal/tt-metal/actions/runs/8669101156