### PR TITLE
#7443: optimize serialization/deserialization of multi-device tensors

### DIFF
--- a/tt_eager/tensor/owned_buffer.hpp
+++ b/tt_eager/tensor/owned_buffer.hpp
@@ -20,6 +20,10 @@ struct Buffer {
         shared_vector_(shared_vector),
         pointer_for_faster_access_(shared_vector->data()),
         size_(shared_vector->size()) {}
+    explicit Buffer(const std::shared_ptr<std::vector<T>>& shared_vector) :
+        shared_vector_(shared_vector),
+        pointer_for_faster_access_(shared_vector->data()),
+        size_(shared_vector->size()) {}
 
     const std::size_t size() const { return this->size_; }
 

--- a/tt_eager/tensor/serialization.hpp
+++ b/tt_eager/tensor/serialization.hpp
@@ -13,7 +13,9 @@ namespace tt {
 namespace tt_metal {
 
 void dump_tensor(const std::string& file_name, const Tensor& tensor);
-Tensor load_tensor(const std::string& file_name, Device* device = nullptr);
+
+template <typename T>
+Tensor load_tensor(const std::string& file_name, T device = nullptr);
 
 }  // namespace tt_metalls
 

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -338,7 +338,7 @@ Tensor Tensor::to(Device *target_device, const MemoryConfig &mem_config) const {
 Tensor Tensor::to(DeviceMesh *device_mesh, const MemoryConfig &mem_config) const {
     ZoneScoped;
     auto all_workers = device_mesh->get_devices();
-    auto workers = std::vector<Device*>(all_workers.begin(), all_workers.begin() + num_buffers_in_tensor(*this));
+    auto workers = std::vector<Device*>(all_workers.begin(), all_workers.end());
     TT_FATAL(validate_worker_modes(workers), "All device threads/workers must be running in the same mode (ASYNC or SYNC)");
     Tensor multi_device_tensor = Tensor(workers);
     uint32_t device_tensor_ref_count = multi_device_tensor.tensor_attributes->record_main_thread_ref_count();

--- a/tt_eager/tensor/tensor_impl.cpp
+++ b/tt_eager/tensor/tensor_impl.cpp
@@ -204,7 +204,7 @@ Tensor to_layout_bfloat8_b(const Tensor &tensor, Layout target_layout) {
                     output_buffers.push_back(output_uint32_buffer);
                 }
                 return Tensor(
-                    std::move(MultiDeviceHostStorage{output_buffers, storage.shapes}),
+                    std::move(MultiDeviceHostStorage{storage.strategy, output_buffers, storage.shapes}),
                     tensor.get_legacy_shape(),
                     DataType::BFLOAT8_B,
                     target_layout

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -502,7 +502,7 @@ inline Tensor to_layout(const Tensor& tensor, Layout target_layout) {
                     output_buffers.push_back(output_buffer);
                     output_shapes.push_back(storage.shapes[i]);
                 }
-                return MultiDeviceHostStorage{output_buffers, output_shapes};
+                return MultiDeviceHostStorage{storage.strategy, output_buffers, output_shapes};
             } else if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
                 TT_THROW("Device storage isn't supported");
             } else if constexpr (std::is_same_v<StorageType, MultiDeviceStorage>) {

--- a/tt_eager/tensor/tensor_utils.hpp
+++ b/tt_eager/tensor/tensor_utils.hpp
@@ -132,6 +132,8 @@ inline bool any_tensor_on_multi_device(const std::vector<ttnn::Tensor>& tensors)
     return false;
 }
 
+DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
+
 } // namespace tt_metal
 
 } // namespace tt

--- a/tt_eager/tensor/types.cpp
+++ b/tt_eager/tensor/types.cpp
@@ -12,6 +12,26 @@ namespace tt {
 
 namespace tt_metal {
 
+static DistributedTensorConfig create_shard_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata) {
+    return ShardTensor(std::stoi(metadata.at("shard_dim")));
+}
+static DistributedTensorConfig create_replicate_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata) {
+    return ReplicateTensor{};
+}
+
+DistributedTensorConfig get_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata) {
+    if (auto it = metadata.find("strategy"); it != metadata.end()) {
+        const std::string& strategy = it->second;
+        if (strategy == "shard") {
+            return create_shard_distributed_tensor_config(metadata);
+
+        } else if (strategy == "replicate") {
+            return create_replicate_distributed_tensor_config(metadata);
+        }
+    }
+    TT_THROW("Unsupported DistributedTensorConfig strategy:");
+}
+
 
 tt::DataFormat datatype_to_dataformat_converter(tt::tt_metal::DataType datatype) {
     switch (datatype) {
@@ -131,6 +151,16 @@ const uint32_t Shape::get_normalized_index(std::int64_t index) const {
             rank - 1,
             normalized_index));
     return normalized_index;
+}
+
+bool operator==(const ReplicateTensor&, const ReplicateTensor&) {
+    return true; // All instances are considered equal because there are no data members.
+}
+bool operator==(const AllGatherTensor&, const AllGatherTensor&) {
+    return true; // All instances are considered equal because there are no data members.
+}
+bool operator==(const ShardTensor& lhs, const ShardTensor& rhs) {
+    return lhs.shard_dimension == rhs.shard_dimension; // Equal if they have the same shard_dimension.
 }
 
 bool operator==(const Shape& shape_a, const Shape& shape_b) {

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -313,7 +313,7 @@ OutputTensors run_multi_device_operation(
         if constexpr(std::is_same_v<Tensors, std::remove_const_t<OutputTensors>>){
             multi_device_output_tensors.push_back(
                 Tensor{
-                    MultiDeviceStorage{buffers, shapes},
+                    MultiDeviceStorage{get_distributed_tensor_config_from_tensor(input_tensors[0]), buffers, shapes},
                     per_device_output_tensors[devices[0]][i].get_legacy_shape(),
                     per_device_output_tensors[devices[0]][i].get_dtype(),
                     per_device_output_tensors[devices[0]][i].get_layout()
@@ -323,7 +323,7 @@ OutputTensors run_multi_device_operation(
         else if constexpr(std::is_same_v<OptionalTensors, std::remove_const_t<OutputTensors>>){
             multi_device_output_tensors.push_back(
                 Tensor{
-                    MultiDeviceStorage{buffers, shapes},
+                    MultiDeviceStorage{get_distributed_tensor_config_from_tensor(input_tensors[0]), buffers, shapes},
                     per_device_output_tensors[devices[0]][i].value().get_legacy_shape(),
                     per_device_output_tensors[devices[0]][i].value().get_dtype(),
                     per_device_output_tensors[devices[0]][i].value().get_layout()

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -772,14 +772,12 @@ void TensorModule(py::module &m_tensor) {
         )doc"
     );
 
-    m_tensor.def(
-        "load_tensor",
-        &load_tensor,
-        py::arg("file_name"),
-        py::arg("device") = nullptr,
-        R"doc(
-            Load tensor to file
-        )doc");
+    m_tensor.def("load_tensor",
+          static_cast<Tensor (*)(const std::string&, Device*)>(&load_tensor<Device*>),
+          py::arg("file_name"), py::arg("device") = nullptr, R"doc(Load tensor to file)doc");
+    m_tensor.def("load_tensor",
+          static_cast<Tensor (*)(const std::string&, DeviceMesh*)>(&load_tensor<DeviceMesh*>),
+          py::arg("file_name"), py::arg("device") = nullptr, R"doc(Load tensor to file)doc");
 
     m_tensor.def(
         "num_cores_to_corerange_set",

--- a/ttnn/cpp/ttnn/multi_device.hpp
+++ b/ttnn/cpp/ttnn/multi_device.hpp
@@ -73,7 +73,7 @@ Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards)
             host_owned_buffers.push_back(std::get<OwnedStorage>(shard.get_storage()).buffer);
             shapes.push_back(shard.get_legacy_shape());
         }
-        auto storage = MultiDeviceHostStorage{std::move(host_owned_buffers), shapes};
+        auto storage = MultiDeviceHostStorage{AllGatherTensor(), std::move(host_owned_buffers), shapes};
         return Tensor(std::move(storage), tensor_shards.at(0).get_legacy_shape(), tensor_shards.at(0).get_dtype(),  tensor_shards.at(0).get_layout());
     } else {
         std::unordered_map<int, tt::tt_metal::Shape> shapes;
@@ -83,7 +83,7 @@ Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards)
             device_buffers.insert({device->id(), std::get<DeviceStorage>(shard.get_storage()).buffer});
             shapes.insert({device->id(), shard.get_legacy_shape()});
         }
-        auto storage = MultiDeviceStorage{std::move(device_buffers), shapes};
+        auto storage = MultiDeviceStorage{AllGatherTensor(), std::move(device_buffers), shapes};
         return Tensor(std::move(storage), tensor_shards.at(0).get_legacy_shape(), tensor_shards.at(0).get_dtype(),  tensor_shards.at(0).get_layout());
     }
 }

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -79,6 +79,9 @@ class TensorToMesh:
     def map(self, tensor: torch.tensor):
         raise NotImplementedError("Subclasses must implement this method")
 
+    def config(self):
+        raise NotImplementedError("Subclasses must implement this method")
+
 
 class MeshToTensor:
     """
@@ -103,6 +106,12 @@ class ShardTensorToMesh(TensorToMesh):
         self.device_id_to_tensor = {i: input_tensor for i, input_tensor in enumerate(sliced_tensors)}
         return self.device_id_to_tensor
 
+    def config(self):
+        return {
+            "strategy": "shard",
+            "shard_dim": f"{self.shard_dim}",
+        }
+
 
 class ReplicateTensorToMesh(TensorToMesh):
     def __init__(self, device_mesh: DeviceMesh):
@@ -111,6 +120,11 @@ class ReplicateTensorToMesh(TensorToMesh):
     def map(self, tensor: torch.tensor):
         self.device_id_to_tensor = {i: tensor for i in range(self.device_mesh.get_num_devices())}
         return self.device_id_to_tensor
+
+    def config(self):
+        return {
+            "strategy": "replicate",
+        }
 
 
 class ConcatMeshToTensor(MeshToTensor):


### PR DESCRIPTION
Previously when using native ttnn multi-chip APIs, the weight tensors that were assigned to be replicated across multi-device required serializing/deserializing tensor replicas. Now only a single tensor should ever be serialized/deserialized. The same serialized tensor on disk should work across different number of multi-devices.

To enable this, part of these changes include migrating how we distribute tensor to multi-device into C++. This also allows MultiDeviceHostStorage to alias a single C++ Buffer data via shared_ptr.