### PR TITLE
Merge changes for split dispatcher packetized path to fd-2/main

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -57,8 +57,8 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre" # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre -sdis" # Smoke Test
 
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -spre -packetized_en" # TrueSmoke Test with packetized path
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -spre -packetized_en" # Smoke Test with packetized path
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -spre -sdis -packetized_en" # TrueSmoke Test with packetized path
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -spre -sdis -packetized_en" # Smoke Test with packetized path
 
 
 # Testcase: Paged Write Cmd to DRAM. 256 pages, 224b size.
@@ -97,3 +97,14 @@ echo "Running test_dispatcher tests now...";
 # Packed Write
 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 3 -w 5 -t 4 -min 256 -max 256
 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 3 -w 5 -t 4 -min 1024 -max 1024
+
+
+#############################################
+# PACKETIZED PATH TESTS                     #
+#############################################
+echo "Running packetized path tests now...";
+# 4 TX -> 4:1 Mux -> 1:4 Demux -> 4 RX
+./build/test/tt_metal/perf_microbenchmark/routing/test_mux_demux
+
+# 16 TX -> 4 x 4:1 Mux -> 4:1 Mux -> 1:4 Demux -> 4 x 1:4 Demux -> 16 RX
+./build/test/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -440,12 +440,14 @@ int main(int argc, char **argv) {
              dispatch_buffer_size_blocks_g,
              prefetch_sync_sem,
              // Hugepage compile args aren't used in this test since WriteHost is not tested here
-             0,    // unused completion q
-             0,    // unused completion q
-             0,    // unused downstream_cb_base
-             0,    // unused downstream_cb_size
-             0,    // unused my_downstream_cb_sem_id
-             0,    // unused downstream_cb_sem_id
+             0,    // command_queue_base_addr
+             0,    // completion_queue_base_addr
+             0,    // completion_queue_size
+             0,    // downstream_cb_base
+             0,    // downstream_cb_size
+             0,    // my_downstream_cb_sem_id
+             0,    // downstream_cb_sem_id
+             0,    // split_dispatch_page_preamble_size
              true, // is_dram_variant
              true, // is_host_variant
             };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1699,6 +1699,7 @@ int main(int argc, char **argv) {
              DISPATCH_BUFFER_LOG_PAGE_SIZE * dispatch_buffer_pages,
              0, // unused on hd, filled in below for h and d
              0, // unused on hd, filled in below for h and d
+             0, // unused unless tunneler is between h and d
         };
 
         CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_multichip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_multichip.cpp
@@ -1775,6 +1775,7 @@ int main(int argc, char **argv) {
              DISPATCH_BUFFER_LOG_PAGE_SIZE * dispatch_buffer_pages,
              0, // unused on hd, filled in below for h and d
              0, // unused on hd, filled in below for h and d
+             0, // unused unless tunneler is between h and d
         };
 
         CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_test.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_test.hpp
@@ -11,7 +11,7 @@ inline const char *packet_queue_test_status_to_string(uint32_t status) {
     case PACKET_QUEUE_TEST_STARTED:
         return "STARTED";
     case PACKET_QUEUE_TEST_PASS:
-        return "PASS";
+        return "DONE/OK";
     case PACKET_QUEUE_TEST_TIMEOUT:
         return "TIMEOUT";
     case PACKET_QUEUE_TEST_DATA_MISMATCH:
@@ -19,4 +19,12 @@ inline const char *packet_queue_test_status_to_string(uint32_t status) {
     default:
         return "UNKNOWN";
     }
+}
+
+inline uint64_t get_64b_result(uint32_t* buf, uint32_t index) {
+    return (((uint64_t)buf[index]) << 32) | buf[index+1];
+}
+
+inline uint64_t get_64b_result(const std::vector<uint32_t>& vec, uint32_t index) {
+    return (((uint64_t)vec[index]) << 32) | vec[index+1];
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_demux_y = 2;
 
     constexpr uint32_t default_prng_seed = 0x100;
-    constexpr uint32_t default_data_kb_per_tx = 16*1024;
+    constexpr uint32_t default_data_kb_per_tx = 1024*1024;
     constexpr uint32_t default_max_packet_size_words = 0x100;
 
     constexpr uint32_t default_tx_queue_start_addr = 0x80000;
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_demux_queue_size_bytes = 0x20000;
 
     constexpr uint32_t default_test_results_addr = 0x100000;
-    constexpr uint32_t default_test_results_size = 0x40000;
+    constexpr uint32_t default_test_results_size = 0x1000;
 
     constexpr uint32_t default_timeout_mcycles = 1000;
     constexpr uint32_t default_rx_disable_data_check = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
@@ -5,7 +5,6 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
-#include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "kernels/traffic_gen_test.hpp"
@@ -16,7 +15,7 @@ using namespace tt;
 int main(int argc, char **argv) {
 
     constexpr uint32_t default_prng_seed = 0x100;
-    constexpr uint32_t default_data_kb_per_tx = 16*1024;
+    constexpr uint32_t default_data_kb_per_tx = 256*1024;
     constexpr uint32_t default_max_packet_size_words = 0x100;
 
     constexpr uint32_t default_tx_queue_start_addr = 0x80000;
@@ -29,7 +28,7 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_demux_queue_size_bytes = 0x20000;
 
     constexpr uint32_t default_test_results_addr = 0x100000;
-    constexpr uint32_t default_test_results_size = 0x40000;
+    constexpr uint32_t default_test_results_size = 0x1000;
 
     constexpr uint32_t default_timeout_mcycles = 1000;
     constexpr uint32_t default_rx_disable_data_check = 0;

--- a/tests/tt_metal/tt_metal/unit_tests/fast_dispatch_kernels/test_write_host.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/fast_dispatch_kernels/test_write_host.cpp
@@ -143,6 +143,7 @@ bool test_write_host(Device *device, uint32_t data_size, std::pair<uint32_t, uin
         0,    // unused downstream_cb_size
         0,    // unused my_downstream_cb_sem_id
         0,    // unused downstream_cb_sem_id
+        0,    // unused split_dispatch_page_preamble_size
         true,
         true};
     std::vector<uint32_t> spoof_prefetch_compile_args = {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -448,6 +448,7 @@ void Device::compile_command_queue_programs() {
                         DISPATCH_BUFFER_LOG_PAGE_SIZE * dispatch_buffer_pages,
                         0, // unused on hd, filled in below for h and d
                         0, // unused on hd, filled in below for h and d
+                        0, // unused unless tunneler is between h and d
                         true,   // is_dram_variant
                         true    // is_host_variant
                     };

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -34,8 +34,8 @@ constexpr uint32_t PREFETCH_D_BUFFER_SIZE = 256 * 1024;
 constexpr uint32_t PREFETCH_D_BUFFER_LOG_PAGE_SIZE = 12;
 constexpr uint32_t PREFETCH_D_BUFFER_BLOCKS = 4;
 
-// 764 to make this not divisible by 3 so we can test wrapping of dispatch buffer
-constexpr uint32_t DISPATCH_BUFFER_BLOCK_SIZE_PAGES = 764 * 1024 / (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE) / DISPATCH_BUFFER_SIZE_BLOCKS;
+// make this 2^N as required by the packetized stages
+constexpr uint32_t DISPATCH_BUFFER_BLOCK_SIZE_PAGES = 512 * 1024 / (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE) / DISPATCH_BUFFER_SIZE_BLOCKS;
 
 static constexpr uint32_t EVENT_PADDED_SIZE = 16;
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1029,8 +1029,8 @@ void kernel_main_d() {
 
     // Set upstream semaphore MSB to signal completion and path teardown
     // in case prefetch_d is connected to a depacketizing stage.
-    // This should be replaced with a signal similar to what packetized components
-    // use.
+    // TODO: This should be replaced with a signal similar to what packetized
+    // components use.
     DPRINT << "prefetch_d done" << ENDL();
     noc_semaphore_inc(get_noc_addr_helper(upstream_noc_xy, get_semaphore(upstream_cb_sem_id)), 0x80000000);
 }

--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -172,6 +172,14 @@ constexpr uint32_t output_depacketize_local_sem[MAX_SWITCH_FAN_OUT] =
         (get_compile_time_arg_val(29) >> 16) & 0xFF
     };
 
+constexpr uint32_t output_depacketize_remove_header[MAX_SWITCH_FAN_OUT] =
+    {
+        (get_compile_time_arg_val(26) >> 24) & 0x1,
+        (get_compile_time_arg_val(27) >> 24) & 0x1,
+        (get_compile_time_arg_val(28) >> 24) & 0x1,
+        (get_compile_time_arg_val(29) >> 24) & 0x1
+    };
+
 
 
 inline uint8_t dest_output_queue_id(uint32_t dest_endpoint_id) {
@@ -192,10 +200,11 @@ void kernel_main() {
 
     for (uint32_t i = 0; i < demux_fan_out; i++) {
         output_queues[i].init(i, remote_tx_queue_start_addr_words[i], remote_tx_queue_size_words[i],
-                             remote_tx_x[i], remote_tx_y[i], remote_tx_queue_id[i], remote_tx_network_type[i],
-                             &input_queue, 1,
-                             output_depacketize[i], output_depacketize_log_page_size[i],
-                             output_depacketize_downstream_sem[i], output_depacketize_local_sem[i]);
+                              remote_tx_x[i], remote_tx_y[i], remote_tx_queue_id[i], remote_tx_network_type[i],
+                              &input_queue, 1,
+                              output_depacketize[i], output_depacketize_log_page_size[i],
+                              output_depacketize_local_sem[i], output_depacketize_downstream_sem[i],
+                              output_depacketize_remove_header[i]);
     }
     input_queue.init(demux_fan_out, rx_queue_start_addr_words, rx_queue_size_words,
                      remote_rx_x, remote_rx_y, remote_rx_queue_id, remote_rx_network_type);

--- a/tt_metal/impl/dispatch/kernels/packet_mux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_mux.cpp
@@ -85,6 +85,7 @@ constexpr uint32_t output_depacketize_info = get_compile_time_arg_val(18);
 constexpr uint32_t output_depacketize_log_page_size = output_depacketize_info & 0xFF;
 constexpr uint32_t output_depacketize_downstream_sem = (output_depacketize_info >> 8) & 0xFF;
 constexpr uint32_t output_depacketize_local_sem = (output_depacketize_info >> 16) & 0xFF;
+constexpr bool output_depacketize_remove_header = (output_depacketize_info >> 24) & 0x1;
 
 constexpr uint32_t input_packetize[MAX_SWITCH_FAN_IN] =
     {
@@ -155,7 +156,8 @@ void kernel_main() {
                       remote_tx_x, remote_tx_y, remote_tx_queue_id, tx_network_type,
                       input_queues, mux_fan_in,
                       output_depacketize, output_depacketize_log_page_size,
-                      output_depacketize_downstream_sem, output_depacketize_local_sem);
+                      output_depacketize_downstream_sem, output_depacketize_local_sem,
+                      output_depacketize_remove_header);
 
     if (!wait_all_src_dest_ready(input_queues, mux_fan_in, &output_queue, 1, timeout_cycles)) {
         test_results[PQ_TEST_STATUS_INDEX] = PACKET_QUEUE_TEST_TIMEOUT;

--- a/tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp
@@ -32,18 +32,6 @@ constexpr uint32_t PQ_TEST_CYCLES_INDEX = 4;
 constexpr uint32_t PQ_TEST_ITER_INDEX = 6;
 constexpr uint32_t PQ_TEST_MISC_INDEX = 16;
 
-inline uint64_t get_64b_result(uint32_t* buf, uint32_t index) {
-    return (((uint64_t)buf[index]) << 32) | buf[index+1];
-}
-
-inline uint64_t get_64b_result(const std::vector<uint32_t>& vec, uint32_t index) {
-    return (((uint64_t)vec[index]) << 32) | vec[index+1];
-}
-
-inline void set_64b_result(uint32_t* buf, uint64_t val, uint32_t index = 0) {
-    buf[index] = val >> 32;
-    buf[index+1] = val & 0xFFFFFFFF;
-}
 
 enum DispatchPacketFlag : uint32_t {
     PACKET_CMD_START = (0x1 << 1),
@@ -89,6 +77,11 @@ struct dispatch_packet_header_t {
 
 inline uint32_t packet_switch_4B_pack(uint32_t b0, uint32_t b1, uint32_t b2, uint32_t b3) {
     return (b3 << 24) | (b2 << 16) | (b1 << 8) | b0;
+}
+
+inline void set_64b_result(uint32_t* buf, uint64_t val, uint32_t index = 0) {
+    buf[index] = val >> 32;
+    buf[index+1] = val & 0xFFFFFFFF;
 }
 
 static_assert(MAX_DEST_ENDPOINTS <= 32,


### PR DESCRIPTION
This branch includes the changes from `pkeller/fd2-pad-dis`, as well as:

- Additional dispatcher changes to add length to the preamble when sending the first page in a command, and to signal test completion. 
- `test_prefetcher` enhanced to add packetized path for the split dispatcher as well when the `-packetized_en` option is enabled. 
- Fixes for dispatcher compile-time argument vector (due to the new preamble field) in misc. other places where the dispatcher is instantiated. 
- Added more tests to `run_cpp_fd2_tests.sh`. 

All tests from `run_cpp_fd2_tests.sh` are passing on the branch. 

