### PR TITLE
FD2.0 SetCommonRuntimeArgs() support w/ Multicast

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
@@ -128,7 +128,7 @@ bool verify_results(
 
         // Verify common RT Args (same for all cores) if they exist.
         if (common_rt_args.size() > 0) {
-            const auto common_args_addr = rt_args_base_addr + common_rt_args_offset; // Common args are placed after unique args per core.
+            const auto common_args_addr = rt_args_base_addr + align(common_rt_args_offset, L1_ALIGNMENT); // Common args are placed after unique args per core. 16B aligned.
             for (auto &core_range : kernel->logical_coreranges()) {
                 for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
                     for (auto y = core_range.start.y; y <= core_range.end.y; y++) {

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -76,7 +76,7 @@ constexpr static uint32_t get_arg_addr(int arg_idx) {
  */
 constexpr static uint32_t get_common_arg_addr(int arg_idx) {
     // args are 4B in size
-    return TRISC_L1_ARG_BASE + COMMON_RT_ARGS_OFFSET + (arg_idx << 2);
+    return L1_ARG_BASE + COMMON_RT_ARGS_OFFSET + (arg_idx << 2);
 }
 
 /**

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -299,12 +299,15 @@ const DeviceCommand EnqueueProgramCommand::assemble_preamble_commands() {
     }
 }
 
+// Generate command sequence for unique (unicast) and common (multicast) runtime args
 const vector<DeviceCommand> EnqueueProgramCommand::assemble_runtime_args_commands() {
     program.update_runtime_args_transfer_info(this->device);
 
     vector<DeviceCommand> runtime_args_command_sequences;
-    // Unicast runtime args
-    for (const auto& [dst, transfer_info] : program.program_transfer_info.runtime_args) {
+
+    // Unicast unique runtime args per core.
+    for (const auto& [dst, transfer_info] : program.program_transfer_info.unicast_runtime_args) {
+
         uint32_t num_packed_cmds = transfer_info.size();
         uint32_t runtime_args_len = transfer_info[0].data.size();
 
@@ -337,6 +340,48 @@ const vector<DeviceCommand> EnqueueProgramCommand::assemble_runtime_args_command
             rt_payload_sizeB,
             unicast_sub_cmds,
             rt_data_and_sizes);
+        runtime_args_command_sequences.emplace_back(command_sequence);
+    }
+
+    // Muticast common runtime args (shared by all cores)
+    for (const auto& [dst, transfer_info_vec] : program.program_transfer_info.multicast_runtime_args) {
+        uint32_t num_packed_cmds = 0;
+        uint32_t runtime_args_len = transfer_info_vec[0].data.size();
+
+        for (const auto& transfer_info: transfer_info_vec) {
+            for (const auto& dst_noc_info: transfer_info.dst_noc_info) {
+                TT_ASSERT(transfer_info.data.size() == runtime_args_len, "Not all data vectors in write packed common rtargs cmd equal in len");
+                num_packed_cmds += 1;
+            }
+        }
+
+        uint32_t aligned_runtime_data_sizeB = align(runtime_args_len * sizeof(uint32_t), L1_ALIGNMENT) * num_packed_cmds;
+        uint32_t dispatch_cmd_sizeB = align(sizeof(CQDispatchCmd) + num_packed_cmds * sizeof(CQDispatchWritePackedMulticastSubCmd), L1_ALIGNMENT);
+        uint32_t mcast_payload_sizeB = dispatch_cmd_sizeB + aligned_runtime_data_sizeB;
+        uint32_t cmd_sequence_sizeB = align(sizeof(CQPrefetchCmd) +  mcast_payload_sizeB, PCIE_ALIGNMENT);
+
+        DeviceCommand command_sequence(cmd_sequence_sizeB);
+
+        std::vector<CQDispatchWritePackedMulticastSubCmd> multicast_sub_cmds;
+        std::vector<const void *> rtarg_data;
+
+        for (const auto& transfer_info: transfer_info_vec) {
+            for (const auto& dst_noc_info: transfer_info.dst_noc_info) {
+                multicast_sub_cmds.emplace_back(
+                    CQDispatchWritePackedMulticastSubCmd{.noc_xy_addr = dst_noc_info.first, .num_mcast_dests = dst_noc_info.second}
+                );
+                rtarg_data.emplace_back(transfer_info.data.data());
+            }
+        }
+
+        command_sequence.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
+            num_packed_cmds,
+            dst,
+            runtime_args_len * sizeof(uint32_t),
+            mcast_payload_sizeB,
+            multicast_sub_cmds,
+            rtarg_data
+        );
         runtime_args_command_sequences.emplace_back(command_sequence);
     }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -568,6 +568,24 @@ void Program::invalidate_compile() {
     }
 }
 
+
+template <typename CoreRangeContainer>
+vector<pair<uint32_t, uint32_t>> extract_dst_noc_multicast_info(Device* device, const CoreRangeContainer& ranges, const CoreType core_type) {
+    // This API extracts all the pairs of noc multicast encodings given a set of core ranges
+    vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info;
+    for (const CoreRange& core_range : ranges) {
+        CoreCoord physical_start = device->physical_core_from_logical_core(core_range.start, core_type);
+        CoreCoord physical_end = device->physical_core_from_logical_core(core_range.end, core_type);
+
+        uint32_t dst_noc_multicast_encoding =
+            NOC_MULTICAST_ENCODING(physical_start.x, physical_start.y, physical_end.x, physical_end.y);
+
+        uint32_t num_receivers = core_range.size();
+        dst_noc_multicast_info.push_back(std::make_pair(dst_noc_multicast_encoding, num_receivers));
+    }
+    return dst_noc_multicast_info;
+}
+
 void Program::populate_dispatch_data(Device* device) {
     static const map<RISCV, uint32_t> processor_to_local_mem_addr = {
         {RISCV::BRISC, MEM_BRISC_INIT_LOCAL_L1_BASE},
@@ -576,23 +594,6 @@ void Program::populate_dispatch_data(Device* device) {
         {RISCV::TRISC1, MEM_TRISC1_INIT_LOCAL_L1_BASE},
         {RISCV::TRISC2, MEM_TRISC2_INIT_LOCAL_L1_BASE},
         {RISCV::ERISC, eth_l1_mem::address_map::FIRMWARE_BASE}};
-
-    auto extract_dst_noc_multicast_info =
-        [&device](const set<CoreRange>& ranges, const CoreType core_type) -> vector<pair<uint32_t, uint32_t>> {
-        // This API extracts all the pairs of noc multicast encodings given a set of core ranges
-        vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info;
-        for (const CoreRange& core_range : ranges) {
-            CoreCoord physical_start = device->physical_core_from_logical_core(core_range.start, core_type);
-            CoreCoord physical_end = device->physical_core_from_logical_core(core_range.end, core_type);
-
-            uint32_t dst_noc_multicast_encoding =
-                NOC_MULTICAST_ENCODING(physical_start.x, physical_start.y, physical_end.x, physical_end.y);
-
-            uint32_t num_receivers = core_range.size();
-            dst_noc_multicast_info.push_back(std::make_pair(dst_noc_multicast_encoding, num_receivers));
-        }
-        return dst_noc_multicast_info;
-    };
 
     auto extract_dst_noc_unicast_info =
         [&device](const set<CoreRange>& ranges, const CoreType core_type) -> vector<pair<uint32_t, uint32_t>> {
@@ -622,7 +623,7 @@ void Program::populate_dispatch_data(Device* device) {
 
         // TODO: use semaphore.core_type from main
         if (semaphore.core_type() == CoreType::WORKER) {
-            vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info = extract_dst_noc_multicast_info(semaphore.core_range_set().ranges(), semaphore.core_type());
+            vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info = extract_dst_noc_multicast_info<std::set<CoreRange>>(device, semaphore.core_range_set().ranges(), semaphore.core_type());
             transfer_info_2 transfer_info = {
                 .dst_base_addr = semaphore.address(),
                 .dst_noc_info = dst_noc_multicast_info,
@@ -647,7 +648,7 @@ void Program::populate_dispatch_data(Device* device) {
     // TODO: cleanup put the WORKERS and ETH logic together..
     for (KernelGroup& kernel_group : this->get_kernel_groups(CoreType::WORKER)) {
         vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
-            extract_dst_noc_multicast_info(kernel_group.core_ranges.ranges(), kernel_group.get_core_type());
+            extract_dst_noc_multicast_info<std::set<CoreRange>>(device, kernel_group.core_ranges.ranges(), kernel_group.get_core_type());
 
         kernel_group.launch_msg.mode = DISPATCH_MODE_DEV;
         vector<uint32_t> go_signals_data(sizeof(launch_msg_t) / sizeof(uint32_t));
@@ -834,9 +835,9 @@ void Program::update_runtime_args_transfer_info(Device* device) {
         }
         return dst_noc_unicast_info;
     };
-    this->program_transfer_info.runtime_args.clear();
-    // Runtime Args
-    // TODO: add multicasting
+    this->program_transfer_info.unicast_runtime_args.clear();
+    this->program_transfer_info.multicast_runtime_args.clear();
+    // Unique Runtime Args (Unicast)
     for (size_t kernel_id = 0; kernel_id < this->num_kernels(); kernel_id++) {
         auto kernel = detail::GetKernel(*this, kernel_id);
 
@@ -852,7 +853,22 @@ void Program::update_runtime_args_transfer_info(Device* device) {
 
             transfer_info_2 transfer_info = {
                 .dst_base_addr = dst, .dst_noc_info = dst_noc_unicast_info, .linked = false, .data = runtime_args_data};
-            this->program_transfer_info.runtime_args[dst].push_back(transfer_info);
+            this->program_transfer_info.unicast_runtime_args[dst].push_back(transfer_info);
+        }
+
+        // Common Runtime Args (Multicast)
+        const auto &common_rt_args = kernel->common_runtime_args();
+
+        if (common_rt_args.size() > 0) {
+            uint32_t common_args_addr = dst + kernel->get_common_runtime_args_offset();
+            vector<pair<uint32_t, uint32_t>> dst_noc_multicast_info =
+                extract_dst_noc_multicast_info<std::vector<CoreRange>>(device, kernel->logical_coreranges(),kernel->get_kernel_core_type());
+            transfer_info_2 transfer_info = {
+                .dst_base_addr = common_args_addr,
+                .dst_noc_info = dst_noc_multicast_info,
+                .linked = false,
+                .data = common_rt_args};
+            this->program_transfer_info.multicast_runtime_args[common_args_addr].push_back(transfer_info);
         }
     }
 }

--- a/tt_metal/impl/program/program_device_map.hpp
+++ b/tt_metal/impl/program/program_device_map.hpp
@@ -35,7 +35,8 @@ enum class PageTransferType { MULTICAST, UNICAST };
 
 struct ProgramTransferInfo {
     std::uint32_t num_active_cores;
-    std::unordered_map<uint32_t, vector<transfer_info_2>> runtime_args;            // WritePacked, sorted by dst
+    std::unordered_map<uint32_t, vector<transfer_info_2>> unicast_runtime_args;    // WritePacked, sorted by dst
+    std::unordered_map<uint32_t, vector<transfer_info_2>> multicast_runtime_args;  // WritePacked, sorted by dst
     std::unordered_map<uint32_t, vector<transfer_info_2>> multicast_semaphores;    // WritePacked, sorted by dst
     std::unordered_map<uint32_t, vector<transfer_info_2>> unicast_semaphores;      // WritePacked, sorted by dst
     vector<transfer_info_2> go_signals;                                            // WriteLinear


### PR DESCRIPTION
    #4476: FD2.0 SetCommonRuntimeArgs() support w/ Multicast

     - Initial FD2 changes for SetCommonRuntimeArgs()
     - Allow FD2 to multicast common runtime args via SetCommonRuntimeArgs() instead of unicast
     - common_rt_args_offset must be 16B aligned for packed-write to work, so update
       validate_runtime_args_size() and get_common_runtime_args_offset() for this
     - BugFix in dataflow_api.h use L1_ARG_BASE instead of TRISC_L1_ARG_BASE in get_common_arg_addr()
     - Passes bunch of unit tests, with varying number of common runtime
       args across cores and processors.

     - Note: Tests not included here, WIP, will come in followup commit shortly.
     
     
     
     Edit: Updated to exclude tests for now, will include in follow up commit.