### PR TITLE
#5249: Resolve nd output and hangs with 2048 seq len Falcon40 prefill

### DIFF
--- a/models/demos/falcon40b/tests/test_falcon_prefill_determinism.py
+++ b/models/demos/falcon40b/tests/test_falcon_prefill_determinism.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+
+import tt_lib
+from models.demos.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM, FalconConfig
+from models.demos.falcon40b.tt.falcon_causallm import TtFalconCausalLM
+from models.demos.falcon40b.tt.model_config import get_model_config, model_config_entries
+from models.utility_functions import (
+    torch2tt_tensor,
+    tt2torch_tensor,
+    skip_for_grayskull,
+    get_devices_for_t3000,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_pcc,
+)
+
+
+def run_test_falcon_prefill_end_to_end_determinism(
+    devices,
+    model_version,
+    generate_weights,
+    batch,
+    seq_len,
+    kv_cache_len,
+    iterations,
+    num_layers,
+    model_config,
+    tt_cache_path,
+    model_location_generator,
+):
+    if generate_weights:
+        logger.info("Loading PyTorch Falcon model...")
+        model_name = model_location_generator(model_version, model_subdir="Falcon")
+        hugging_face_reference_model = FalconForCausalLM.from_pretrained(
+            model_name, low_cpu_mem_usage=True, num_hidden_layers=num_layers
+        )
+        hugging_face_reference_model.eval()
+        configuration = hugging_face_reference_model.config
+        state_dict = hugging_face_reference_model.state_dict()
+        logger.info("Done loading PyTorch Falcon model")
+    else:
+        configuration = FalconConfig(**model_config_entries)
+        state_dict = None
+
+    torch.manual_seed(0)
+    base_url = ""
+    max_position_embeddings = 2048
+    head_dim = configuration.hidden_size // configuration.num_attention_heads
+    num_kv_heads = configuration.num_kv_heads
+    use_cache = True
+    use_global_cos_sin_cache = True
+
+    # Generate dummy kv_cache --------------------------------------------------------------
+    q_len = seq_len
+    assert q_len % 32 == 0, "For prefill, seq_len must be multiple of 32!"
+    assert kv_cache_len == 0, "For prefill, no kv_cache is passed in!"
+
+    tt_layer_past = ()
+    tt_k_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
+    tt_v_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
+    tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
+    tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
+
+    for _ in range(num_layers):
+        tt_k_cache = []
+        tt_v_cache = []
+        for j in range(len(devices)):
+            tt_k_cache.append(
+                torch2tt_tensor(
+                    tt_k_cache_host[j],
+                    devices[j],
+                    tt_lib.tensor.Layout.TILE,
+                    model_config["KV_CACHE_MEMCFG"],
+                    model_config["KV_CACHE_DTYPE"],
+                )
+            )
+            tt_v_cache.append(
+                torch2tt_tensor(
+                    tt_v_cache_host[j],
+                    devices[j],
+                    tt_lib.tensor.Layout.TILE,
+                    model_config["KV_CACHE_MEMCFG"],
+                    model_config["KV_CACHE_DTYPE"],
+                )
+            )
+        tt_layer_past += ((tt_k_cache, tt_v_cache),)
+
+    logger.info("Loading TT Falcon Model...")
+    # NOTE: Passing in pytorch tensor here instead of tt tensor
+    # since we don't yet have embedding support on device
+    tt_FalconCausalLM = TtFalconCausalLM(
+        devices,
+        state_dict,
+        base_url,
+        num_layers,
+        configuration,
+        max_position_embeddings,
+        model_config,
+        tt_cache_path,
+        use_global_cos_sin_cache,
+    )
+    for device in devices:
+        tt_lib.device.Synchronize(device)
+    logger.info("Done loading TT Falcon Model")
+
+    # Prepare inputs -----------------------------------------------------------------------
+    model_input = torch.arange(seq_len * batch).reshape(batch, seq_len)
+    model_inputs = torch.split(model_input, 1)
+
+    # First run to get reference output ----------------------------------------------------
+    tt_embeddings, tt_attention_mask = zip(
+        *[
+            tt_FalconCausalLM.model_preprocessing("prefill", m_i, kv_cache_len, num_input_tokens=seq_len)
+            for m_i in model_inputs
+        ]
+    )
+
+    logger.info("Running TT Falcon model once to get reference output...")
+
+    tt_outs = []
+    for user_id in range(batch):
+        tt_out, tt_layer_present = tt_FalconCausalLM(
+            input_embeddings=tt_embeddings[user_id],
+            llm_mode="prefill",
+            attention_mask=tt_attention_mask[user_id],
+            user_id=user_id,
+            layer_past=tt_layer_past,
+            layer_past_len=kv_cache_len,
+            use_cache=use_cache,
+        )
+        tt_outs.append(tt_out)
+    tt_outs = [[tt_o.cpu() for tt_o in tt_out] for tt_out in tt_outs]
+    tt_out = tt_outs
+
+    logger.info("Done running TT Falcon model")
+
+    for device in devices:
+        tt_lib.device.Synchronize(device)
+
+    reference_out = torch.vstack(
+        [torch.cat([tt2torch_tensor(tt_o).squeeze(1) for tt_o in tt_out], -1) for tt_out in tt_outs]
+    )
+    reference_kv_cache = []
+    for i in range(num_layers):
+        tt_layer_pres = (
+            torch.cat([tt2torch_tensor(tt_layer_p) for tt_layer_p in tt_layer_present[i][0]], 1),
+            torch.cat([tt2torch_tensor(tt_layer_p) for tt_layer_p in tt_layer_present[i][1]], 1),
+        )
+        reference_kv_cache.append(tt_layer_pres)
+
+    del tt_out
+    del tt_layer_present
+    del tt_embeddings
+    del tt_attention_mask
+
+    # Determinism runs ---------------------------------------------------------------------
+    does_pass = True
+    expected_pcc = 1
+    logger.info(f"Running {iterations} iterations...")
+    for i in range(iterations):
+        logger.info(f"Iteration {i}")
+        tt_embeddings, tt_attention_mask = zip(
+            *[
+                tt_FalconCausalLM.model_preprocessing("prefill", m_i, kv_cache_len, num_input_tokens=seq_len)
+                for m_i in model_inputs
+            ]
+        )
+
+        tt_outs = []
+        for user_id in range(batch):
+            tt_out, tt_layer_present = tt_FalconCausalLM(
+                input_embeddings=tt_embeddings[user_id],
+                llm_mode="prefill",
+                attention_mask=tt_attention_mask[user_id],
+                user_id=user_id,
+                layer_past=tt_layer_past,
+                layer_past_len=kv_cache_len,
+                use_cache=use_cache,
+            )
+            tt_outs.append(tt_out)
+        tt_outs = [[tt_o.cpu() for tt_o in tt_out] for tt_out in tt_outs]
+        tt_out = tt_outs
+
+        # Check outputs --------------------------------------------------------------------
+        pt_tt_out = torch.vstack(
+            [torch.cat([tt2torch_tensor(tt_o).squeeze(1) for tt_o in tt_out], -1) for tt_out in tt_outs]
+        )
+        output_passes, output_pcc = comp_pcc(reference_out, pt_tt_out, expected_pcc)
+        logger.info(f"Output: {output_pcc}")
+
+        does_pass = does_pass and output_passes
+
+        for i in range(num_layers):
+            pytorch_layer_pres = reference_kv_cache[i]
+            tt_layer_pres = (
+                torch.cat([tt2torch_tensor(tt_layer_p) for tt_layer_p in tt_layer_present[i][0]], 1),
+                torch.cat([tt2torch_tensor(tt_layer_p) for tt_layer_p in tt_layer_present[i][1]], 1),
+            )
+
+            k_cache_passes, output_pcc = comp_pcc(pytorch_layer_pres[0], tt_layer_pres[0], expected_pcc)
+            logger.info(f"K Cache Layer {i}: {output_pcc}")
+
+            does_pass = does_pass and k_cache_passes
+
+            v_cache_passes, output_pcc = comp_pcc(pytorch_layer_pres[1], tt_layer_pres[1], expected_pcc)
+            logger.info(f"V Cache Layer {i}: {output_pcc}")
+
+            does_pass = does_pass and v_cache_passes
+
+        del tt_out
+        del tt_layer_present
+        del tt_embeddings
+        del tt_attention_mask
+
+    assert does_pass, "Determinism test failed"
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "generate_weights", (True, False), ids=["generate_weights_if_not_cached", "load_cached_weights"]
+)
+@pytest.mark.parametrize("enable_program_cache", (True, False), ids=["enable_program_cache", "disable_program_cache"])
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
+@pytest.mark.parametrize(
+    "batch, seq_len, kv_cache_len, iterations",
+    (
+        (1, 32, 0, 30),
+        (1, 128, 0, 30),
+        (1, 2048, 0, 30),
+    ),
+    ids=[
+        "prefill_seq32",
+        "prefill_seq128",
+        "prefill_seq2048",
+    ],
+)
+@pytest.mark.parametrize(
+    "num_layers",
+    (1, 60),
+    ids=["layers_1", "layers_60"],
+)
+@pytest.mark.parametrize(
+    "model_version",
+    ("tiiuae/falcon-40b-instruct",),
+    ids=["falcon_40b"],
+)
+@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-DRAM",))
+def test_falcon_prefill_end_to_end_determinism(
+    generate_weights,
+    enable_program_cache,
+    num_devices,
+    model_version,
+    batch,
+    seq_len,
+    kv_cache_len,
+    iterations,
+    num_layers,
+    model_config_str,
+    model_location_generator,
+    get_tt_cache_path,
+    all_devices,
+):
+    num_devices = 8
+    if model_config_str not in ["BFLOAT8_B-DRAM"]:
+        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config!")
+
+    input_shape = [batch, seq_len]
+    model_config = get_model_config(model_config_str, "prefill", input_shape, num_devices)
+    devices = get_devices_for_t3000(all_devices, num_devices)
+    compute_grid_size = devices[0].compute_with_storage_grid_size()
+    if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
+        pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
+
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
+
+    if enable_program_cache:
+        for device in devices:
+            device.enable_program_cache()
+
+    run_test_falcon_prefill_end_to_end_determinism(
+        devices,
+        model_version,
+        generate_weights,
+        batch,
+        seq_len,
+        kv_cache_len,
+        iterations,
+        num_layers,
+        model_config,
+        tt_cache_path,
+        model_location_generator,
+    )
+
+    if enable_program_cache:
+        for device in devices:
+            device.disable_and_clear_program_cache()

--- a/models/demos/falcon40b/tt/falcon_attention.py
+++ b/models/demos/falcon40b/tt/falcon_attention.py
@@ -335,6 +335,8 @@ class TtFalconAttention:
                     output_dtype=self.model_config["FUSED_QKV_MM_OUTPUT_DTYPE"],
                     grid=ttnn.CoreGrid(x=8, y=4) if q_len >= 512 else ttnn.CoreGrid(x=8, y=1),
                     transpose_mcast=True,
+                    overwrite_subblock_w=1,  # Workaround for non deterministic output/hang; issue: 7066
+                    overwrite_subblock_h=1,
                 )
             )
 

--- a/models/demos/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/falcon40b/tt/falcon_mlp.py
@@ -185,6 +185,8 @@ class TtFalconMLP:
                 self.model_config["COMPUTE_KERNEL_CONFIG"],
                 output_mem_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
                 output_dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
+                overwrite_subblock_w=1,  # Workaround for non deterministic output/hang; issue: 7066
+                overwrite_subblock_h=1,
             )
 
         # return TT Tensor


### PR DESCRIPTION
We observed nd behavior and hangs with 1d/2d matmuls (issue #7066), so I added the workaround until the bug is resolved. I also added a determinism test used to debug the issue. 

I haven't added the new test to CI since they take a while (especially 2k one), and I am not sure about the capacity we have with T3000 machines currently.

CI:
- [post commit tests](https://github.com/tenstorrent-metal/tt-metal/actions/runs/8684813910)
- [multi device unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/8701967810)