### PR TITLE
Update Falcon7b to use generic weight cache path and optimize multi-device caching

### DIFF
--- a/models/demos/falcon7b/tests/test_falcon_attention.py
+++ b/models/demos/falcon7b/tests/test_falcon_attention.py
@@ -13,7 +13,6 @@ from models.demos.falcon7b.reference.hf_modeling_falcon import (
 from models.demos.falcon7b.tt.falcon_attention import TtFalconAttention
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
-    get_tt_cache_path,
 )
 from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_outputs
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -172,12 +171,15 @@ def test_FalconAttention_inference(
     pcc,
     model_config_str,
     model_location_generator,
+    get_tt_cache_path,
     all_devices,
 ):
     devices = get_devices_for_t3000(all_devices, num_devices)
 
     model_config = get_model_config(model_config_str)
-    tt_cache_path = get_tt_cache_path(model_version)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
 
     run_test_FalconAttention_inference(
         devices,

--- a/models/demos/falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon7b/tests/test_falcon_causallm.py
@@ -14,7 +14,6 @@ from models.demos.falcon7b.tt.falcon_causallm import TtFalconCausalLM
 
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
-    get_tt_cache_path,
 )
 from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_out_layer_present
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -226,12 +225,15 @@ def test_FalconCausalLM_inference(
     request,
     model_config_str,
     model_location_generator,
+    get_tt_cache_path,
     all_devices,
 ):
     devices = get_devices_for_t3000(all_devices, num_devices)
 
     model_config = get_model_config(model_config_str)
-    tt_cache_path = get_tt_cache_path(model_version)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
 
     run_test_FalconCausalLM_inference(
         devices,

--- a/models/demos/falcon7b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon7b/tests/test_falcon_decoder.py
@@ -13,7 +13,6 @@ from models.demos.falcon7b.reference.hf_modeling_falcon import (
 from models.demos.falcon7b.tt.falcon_decoder import TtFalconDecoderLayer
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
-    get_tt_cache_path,
 )
 from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_outputs
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -170,12 +169,15 @@ def test_FalconDecoder_inference(
     pcc,
     model_config_str,
     model_location_generator,
+    get_tt_cache_path,
     all_devices,
 ):
     devices = get_devices_for_t3000(all_devices, num_devices)
 
     model_config = get_model_config(model_config_str)
-    tt_cache_path = get_tt_cache_path(model_version)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
 
     run_test_FalconDecoder_inference(
         devices,

--- a/models/demos/falcon7b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon7b/tests/test_falcon_end_to_end.py
@@ -21,7 +21,6 @@ from models.demos.falcon7b.tt.falcon_common import (
 
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
-    get_tt_cache_path,
 )
 from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_out_layer_present
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -336,12 +335,15 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     request,
     model_config_str,
     model_location_generator,
+    get_tt_cache_path,
 ):
     if is_e75(device) and batch == 32:
         pytest.skip("Falcon batch 32 is unsupported on E75")
 
     model_config = get_model_config(model_config_str)
-    tt_cache_path = get_tt_cache_path(model_version)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
 
     disable_persistent_kernel_cache()
     disable_compilation_reports()

--- a/models/demos/falcon7b/tests/test_falcon_mlp.py
+++ b/models/demos/falcon7b/tests/test_falcon_mlp.py
@@ -13,7 +13,6 @@ from models.demos.falcon7b.reference.hf_modeling_falcon import (
 from models.demos.falcon7b.tt.falcon_mlp import TtFalconMLP
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
-    get_tt_cache_path,
 )
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,
@@ -118,12 +117,15 @@ def test_FalconMLP_inference(
     pcc,
     model_config_str,
     model_location_generator,
+    get_tt_cache_path,
     all_devices,
 ):
     devices = get_devices_for_t3000(all_devices, num_devices)
 
     model_config = get_model_config(model_config_str)
-    tt_cache_path = get_tt_cache_path(model_version)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
 
     run_test_FalconMLP_inference(
         devices,

--- a/models/demos/falcon7b/tests/test_falcon_model.py
+++ b/models/demos/falcon7b/tests/test_falcon_model.py
@@ -12,7 +12,6 @@ from models.demos.falcon7b.reference.hf_modeling_falcon import (
 from models.demos.falcon7b.tt.falcon_model import TtFalconModel
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
-    get_tt_cache_path,
 )
 from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_out_layer_present
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -219,12 +218,15 @@ def test_FalconModel_inference(
     pcc,
     model_config_str,
     model_location_generator,
+    get_tt_cache_path,
     all_devices,
 ):
     devices = get_devices_for_t3000(all_devices, num_devices)
 
     model_config = get_model_config(model_config_str)
-    tt_cache_path = get_tt_cache_path(model_version)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
     run_test_FalconModel_inference(
         devices,
         model_version,

--- a/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
+++ b/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
@@ -14,7 +14,6 @@ from models.demos.falcon7b.tt.falcon_causallm import TtFalconCausalLM
 
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
-    get_tt_cache_path,
 )
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -206,10 +205,13 @@ def test_FalconCausalLM_inference(
     request,
     model_config_str,
     model_location_generator,
+    get_tt_cache_path,
     device,
 ):
     model_config = get_model_config(model_config_str)
-    tt_cache_path = get_tt_cache_path(model_version)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
 
     batch = 32
     seq_len = 128

--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -21,7 +21,6 @@ from models.demos.falcon7b.tt.falcon_common import (
 
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
-    get_tt_cache_path,
 )
 from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_out_layer_present
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -382,6 +381,7 @@ class TestParametrized:
         request,
         model_config_str,
         model_location_generator,
+        get_tt_cache_path,
         device,
         use_program_cache,
     ):
@@ -392,7 +392,9 @@ class TestParametrized:
             pytest.skip("Sharded config is not supported on GS")
 
         model_config = get_model_config(model_config_str)
-        tt_cache_path = get_tt_cache_path(model_version)
+        tt_cache_path = get_tt_cache_path(
+            model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+        )
 
         disable_persistent_kernel_cache()
         disable_compilation_reports()
@@ -446,6 +448,7 @@ class TestParametrized:
         request,
         model_config_str,
         model_location_generator,
+        get_tt_cache_path,
         all_devices,
     ):
         if num_devices > 1:
@@ -455,7 +458,9 @@ class TestParametrized:
         devices = get_devices_for_t3000(all_devices, num_devices)
 
         model_config = get_model_config(model_config_str)
-        tt_cache_path = get_tt_cache_path(model_version)
+        tt_cache_path = get_tt_cache_path(
+            model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+        )
 
         disable_persistent_kernel_cache()
         disable_compilation_reports()
@@ -503,7 +508,6 @@ class TestParametrized:
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-L1",))
 def test_perf_virtual_machine(
-    use_program_cache,
     model_version,
     llm_mode,
     batch,
@@ -515,13 +519,17 @@ def test_perf_virtual_machine(
     request,
     model_config_str,
     model_location_generator,
+    get_tt_cache_path,
     device,
+    use_program_cache,
 ):
     if is_e75(device) and batch == 32:
         pytest.skip("Falcon batch 32 is not supported on E75")
 
     model_config = get_model_config(model_config_str)
-    tt_cache_path = get_tt_cache_path(model_version)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 

--- a/models/demos/falcon7b/tt/model_config.py
+++ b/models/demos/falcon7b/tt/model_config.py
@@ -113,6 +113,7 @@ def get_model_config(model_config_str):
         "DEFAULT_DTYPE": dtype,
         "DEFAULT_MEMCFG": mem_config,
         "MOVE_DECODER_OUTPUT_BOOL": False,
+        "DEFAULT_CACHE_PATH": Path(f"models/demos/falcon7b/datasets/"),
     }  # DEFAULT_MEMCFG also used to determine banking for ttl.device.InitializeDevice
     model_config.update({f"{key}_MEMCFG": mem_config for key in OP_KEYS if key not in NO_MEMCFG})
     model_config.update({f"{key}_DTYPE": dtype for key in OP_KEYS if key not in NO_DTYPE})
@@ -185,16 +186,6 @@ def get_model_config(model_config_str):
     # logger.debug(f"Falcon model config: \n{pretty_print_model_config(model_config)}")
 
     return model_config
-
-
-# TODO: Generalize TT tensor caching
-def get_tt_cache_path(model_version):
-    tt_cache_path = Path("/mnt/MLPerf/tt_dnn-models/tt/Falcon") / model_version
-    if tt_cache_path.exists():
-        return tt_cache_path
-    else:
-        Path(f"models/demos/falcon7b/datasets/{model_version}").mkdir(parents=True, exist_ok=True)
-        return Path(f"models/demos/falcon7b/datasets/{model_version}")
 
 
 model_config_entries = {

--- a/models/demos/grayskull/falcon7b/demo_grayskull.py
+++ b/models/demos/grayskull/falcon7b/demo_grayskull.py
@@ -11,6 +11,7 @@ def test_demo(
     perf_mode,
     user_input,
     model_location_generator,
+    get_tt_cache_path,
     device,
     use_program_cache,
 ):
@@ -20,6 +21,7 @@ def test_demo(
         max_seq_len=1024,
         model_config_strs_prefill_decode=["BFLOAT16-DRAM", "BFLOAT16-DRAM"],
         model_location_generator=model_location_generator,
+        get_tt_cache_path=get_tt_cache_path,
         devices=[device],
         perf_mode=perf_mode,
     )

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -14,6 +14,7 @@ def test_demo_multichip(
     num_devices,
     user_input,
     model_location_generator,
+    get_tt_cache_path,
     all_devices,
     use_program_cache,
 ):
@@ -26,6 +27,7 @@ def test_demo_multichip(
         max_seq_len=1024,
         model_config_strs_prefill_decode=["BFLOAT16-DRAM", "BFLOAT16-L1_SHARDED"],
         model_location_generator=model_location_generator,
+        get_tt_cache_path=get_tt_cache_path,
         devices=devices,
         perf_mode=perf_mode,
     )

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -11,6 +11,7 @@ def test_demo(
     perf_mode,
     user_input,
     model_location_generator,
+    get_tt_cache_path,
     device,
     use_program_cache,
 ):
@@ -20,6 +21,7 @@ def test_demo(
         max_seq_len=1024,
         model_config_strs_prefill_decode=["BFLOAT16-DRAM", "BFLOAT16-L1_SHARDED"],
         model_location_generator=model_location_generator,
+        get_tt_cache_path=get_tt_cache_path,
         devices=[device],
         perf_mode=perf_mode,
     )


### PR DESCRIPTION
- Update Falcon7b tests to use get_tt_cache_path fixture 
- Fix bug with loading cached embeddings tensor (Issue #7465)
- Optimize multi-device weight caching (only convert to tt layout one time)