### PR TITLE
#6729: Reduce number of bariers in i2s read kernel

### DIFF
--- a/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reader_unary_sharded_blocks_interleaved_start_id.cpp
@@ -3,9 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
+#include <cstdint>
 #include "dataflow_api.h"
+#include "tensix_types.h"
 
 //#include "debug/dprint.h"
+
+// Target 8KB of data before a single barrier for 8x8 grid of readers
+template <uint32_t tile_bytes, uint32_t num_readers>
+constexpr uint32_t get_barrier_read_threshold() {
+    return ((512 / num_readers) * (1024 + 128)) / tile_bytes;
+}
 
 void kernel_main() {
     const uint32_t src_addr  = get_arg_val<uint32_t>(0);
@@ -19,9 +27,10 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr bool src_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t num_readers = get_compile_time_arg_val(2);
 
-    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
+    constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
     const InterleavedAddrGenFast<src_is_dram> s = {
         .bank_base_address = src_addr,
@@ -29,6 +38,8 @@ void kernel_main() {
         .data_format = data_format
     };
 
+    constexpr uint32_t barrier_threshold = get_barrier_read_threshold<tile_bytes, num_readers>();
+    uint32_t barrier_count = 0;
     uint32_t curr_tile_id = start_id;
     cb_reserve_back(cb_id_in0, block_num_tiles);
     uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
@@ -38,9 +49,13 @@ void kernel_main() {
             noc_async_read_tile(tile_id, s, l1_write_addr);
             tile_id++;
             l1_write_addr += tile_bytes;
-            noc_async_read_barrier();
+            if (++barrier_count == barrier_threshold) {
+                noc_async_read_barrier();
+                barrier_count = 0;
+            }
         }
         curr_tile_id += input_width_offset_tiles;
     }
+    noc_async_read_barrier();
     cb_push_back(cb_id_in0, block_num_tiles);
 }

--- a/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
@@ -118,7 +118,7 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(const Tensor& 
 
     tt_metal::KernelHandle unary_reader_kernel_id;
     if (input.get_layout() == Layout::TILE) {
-        std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_cb_index, (std::uint32_t)src_is_dram};
+        std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_cb_index, (std::uint32_t)src_is_dram, all_cores.num_cores()};
 
         unary_reader_kernel_id = tt_metal::CreateKernel(
             program,


### PR DESCRIPTION
There seems to be a specific amount of data transferred on NOC to active optimal performance..
This depends on num tile reads, num cores which read interleaved data (DRAM/L1) and tile data format.

Improved dram reads bw:
Float16 - 10%
Bfp8 - 30%
Bfp4 - 50%

More detailed perf impact can be viewed here 
https://docs.google.com/spreadsheets/d/1uB3_AYX5PmID6DWW6WZaRN8D2FqTuTkp/edit#gid=1816091962