### PR TITLE
#7386: Add better validation for sharded buffers

### DIFF
--- a/models/demos/bert/tt/ttnn_optimized_sharded_bert.py
+++ b/models/demos/bert/tt/ttnn_optimized_sharded_bert.py
@@ -120,7 +120,7 @@ def bert_attention(
         value,
     ) = ttnn.transformer.split_query_key_value_and_split_heads(
         query_key_value,
-        memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
         num_heads=num_heads,
     )
     ttnn.deallocate(query_key_value)
@@ -128,7 +128,7 @@ def bert_attention(
     attention_scores = ttnn.matmul(
         query,
         key,
-        memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
         dtype=ttnn.bfloat8_b,
         program_config=config.program_configs["query_by_key_matmul_program_config"],
     )
@@ -145,7 +145,7 @@ def bert_attention(
     context_layer = ttnn.matmul(
         attention_probabilities,
         value,
-        memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
         dtype=ttnn.bfloat8_b,
         program_config=config.program_configs["attention_probabilities_by_value_matmul_program_config"],
     )

--- a/models/demos/metal_BERT_large_11/tt/model_config.py
+++ b/models/demos/metal_BERT_large_11/tt/model_config.py
@@ -111,8 +111,11 @@ def get_model_config(batch, device_grid_size, model_config_str):
         tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
     )
     L1_MEMCFG = tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1)
-    SHARDED_MEMCFG = tt_lib.tensor.MemoryConfig(
+    BLOCK_SHARDED_MEMCFG = tt_lib.tensor.MemoryConfig(
         tt_lib.tensor.TensorMemoryLayout.BLOCK_SHARDED, tt_lib.tensor.BufferType.L1
+    )
+    HEIGHT_SHARDED_MEMCFG = tt_lib.tensor.MemoryConfig(
+        tt_lib.tensor.TensorMemoryLayout.HEIGHT_SHARDED, tt_lib.tensor.BufferType.L1
     )
 
     # Set default dtype and mem_config based on model_config_str
@@ -131,7 +134,7 @@ def get_model_config(batch, device_grid_size, model_config_str):
         mem_config = L1_MEMCFG
     elif model_config_str in ("BFLOAT8_B-SHARDED"):
         dtype = tt_lib.tensor.DataType.BFLOAT8_B
-        mem_config = SHARDED_MEMCFG
+        mem_config = BLOCK_SHARDED_MEMCFG
     else:
         raise NotImplementedError(f"Model config {model_config_str} is not supported!")
 
@@ -302,9 +305,12 @@ def get_model_config(batch, device_grid_size, model_config_str):
             "SHARD_ORIENTATION": shard_orientation,
             "QKV_INTERLEAVED": activation_grid_dim,
             "OP4_SOFTMAX_ATTENTION_MASK_DTYPE": tt_lib.tensor.DataType.BFLOAT16,
-            "OP1_FUSED_QKV_MM_INPUT_SHARDED_MEMCFG": SHARDED_MEMCFG,
+            "OP1_FUSED_QKV_MM_INPUT_SHARDED_MEMCFG": BLOCK_SHARDED_MEMCFG,
             "OP1_FUSED_QKV_MM_INPUT_MEMCFG": L1_MEMCFG,
+            "OP2_SPLIT_QKV_HEADS_OUTPUT_MEMCFG": HEIGHT_SHARDED_MEMCFG,
+            "OP3_PRE_SOFTMAX_BMM_OUTPUT_MEMCFG": HEIGHT_SHARDED_MEMCFG,
             "OP4_SOFTMAX_ATTENTION_MASK_MEMCFG": L1_MEMCFG,
+            "OP5_POST_SOFTMAX_BMM_OUTPUT_MEMCFG": HEIGHT_SHARDED_MEMCFG,
             "INPUT_EMBEDDINGS_MEMCFG": L1_MEMCFG,
             "OUTPUT_EMBEDDINGS_MEMCFG": L1_MEMCFG,
             "QA_LINEAR_OUTPUT_MEMCFG": L1_MEMCFG,

--- a/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads_sharded.py
+++ b/models/experimental/bert_large_performant/unit_tests/test_bert_large_split_query_key_value_and_split_heads_sharded.py
@@ -40,7 +40,7 @@ def test_split_query_key_value_and_split_heads_with_program_cache(device, dtype,
     torch.manual_seed(1234)
 
     sharded_mem_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
         buffer_type=ttl.tensor.BufferType.L1,
     )
 

--- a/models/experimental/functional_vit/tt/ttnn_optimized_sharded_vit.py
+++ b/models/experimental/functional_vit/tt/ttnn_optimized_sharded_vit.py
@@ -306,7 +306,7 @@ def vit_attention(
         value,
     ) = ttnn.transformer.split_query_key_value_and_split_heads(
         query_key_value,
-        memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
         num_heads=num_heads,
     )
     ttnn.deallocate(query_key_value)
@@ -314,7 +314,7 @@ def vit_attention(
     attention_scores = ttnn.matmul(
         query,
         key,
-        memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
         dtype=ttnn.bfloat8_b,
         program_config=config.program_configs["query_by_key_matmul_program_config"],
     )
@@ -331,7 +331,7 @@ def vit_attention(
     context_layer = ttnn.matmul(
         attention_probs,
         value,
-        memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
         dtype=ttnn.bfloat8_b,
         program_config=config.program_configs["attention_probabilities_by_value_matmul_program_config"],
     )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded_tensor.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded_tensor.py
@@ -234,7 +234,7 @@ def get_tensor(shape, dtype):
         (
             ttl.tensor.ShardOrientation.ROW_MAJOR,
             [1, 1, 8192, 1536],
-            ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+            ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
             (1024, 320),
             ttl.tensor.CoreRangeSet(
                 {

--- a/tests/ttnn/unit_tests/operations/test_transformer.py
+++ b/tests/ttnn/unit_tests/operations/test_transformer.py
@@ -332,7 +332,7 @@ def test_sharded_split_query_key_value_and_split_heads(
     )
 
     query_tensor, key_tensor, value_tensor = ttnn.transformer.split_query_key_value_and_split_heads(
-        input_tensor, num_heads=num_heads, memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
+        input_tensor, num_heads=num_heads, memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
     )
     query_tensor = ttnn.to_torch(query_tensor)
     key_tensor = ttnn.to_torch(key_tensor)

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -631,34 +631,9 @@ Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layo
     TT_ASSERT(memory_config.is_sharded());
     TT_ASSERT(memory_config.shard_spec.has_value());
     TT_ASSERT(memory_config.buffer_type == BufferType::L1);
+
     auto shard_spec = memory_config.shard_spec.value();
     auto& shard_shape = shard_spec.shape;
-
-    uint32_t num_cores = shard_spec.num_cores();
-
-    uint32_t num_shards;
-    uint32_t total_height = tt_metal::compute_volume(shape) / shape[-1];
-    uint32_t total_width = shape[-1];
-    if (memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        TT_ASSERT(total_width == shard_shape[1], "Shard shape {} does not divide tensor shape {} correctly according to sharding scheme", shard_shape[1], total_width);
-        num_shards = div_up(total_height, shard_shape[0]);
-    } else if (memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        TT_ASSERT(total_height == shard_shape[0], "Shard shape does not divide tensor shape correctly according to sharding scheme");
-        num_shards = div_up(total_width, shard_shape[1]);
-    } else if (memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        num_shards = div_up(total_height, shard_shape[0]) * div_up(total_width, shard_shape[1]);
-    } else {
-        TT_FATAL(false, "Unsupported sharding scheme");
-    }
-
-    TT_ASSERT(num_shards == num_cores, fmt::format("Number of shards {} must match number of cores {}", num_shards, num_cores));
-
-    if (layout == Layout::TILE) {
-        TT_ASSERT((shard_shape[0] % TILE_HEIGHT == 0 && shard_shape[1] % TILE_WIDTH == 0), "Shard shape must be tile sized");
-    } else if (layout == Layout::ROW_MAJOR) {
-        // Require alignment for now
-        // TT_ASSERT(shard_shape[1] * tensor_impl::element_size_bytes_wrapper(data_type) % ADDRESS_ALIGNMENT == 0);
-    }
 
     auto width = shape[-1];
     auto other_dims = 1;
@@ -671,7 +646,6 @@ Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layo
     std::array<uint32_t,2> tensor2d_size = {other_dims/page_shape[0], width/page_shape[1]};
     ShardSpecBuffer shard_spec_buffer(shard_spec, page_shape, tensor2d_size);
     uint32_t packed_size_in_bytes;
-
 
     packed_size_in_bytes = tensor_impl::packed_buffer_size_bytes_wrapper(data_type, compute_buffer_size(shape, data_type));
     auto device_buffer = tensor_impl::allocate_buffer_on_device(packed_size_in_bytes, device, shape,

--- a/tt_eager/tensor/tensor_impl.cpp
+++ b/tt_eager/tensor/tensor_impl.cpp
@@ -118,6 +118,51 @@ DeviceBuffer allocate_sharded_buffer_on_device(uint32_t buffer_size_bytes, Devic
                                             std::optional<ShardSpecBuffer> shard_params,
                                             const MemoryConfig& memory_config) {
     TT_ASSERT(shard_params.has_value(), "Shard params are required for sharded buffer and they were not initialized");
+
+    auto shard_spec = memory_config.shard_spec.value();
+    auto& shard_shape = shard_spec.shape;
+
+    uint32_t num_cores = shard_spec.num_cores();
+
+    uint32_t total_height = tt_metal::compute_volume(shape) / shape[-1];
+    uint32_t total_width = shape[-1];
+    if (memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        TT_ASSERT(total_width == shard_shape[1], fmt::format("Shard shape {} does not divide tensor shape {} correctly according to sharding scheme", shard_shape[1], total_width));
+        uint32_t num_shards = div_up(total_height, shard_shape[0]);
+        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} must match number of cores {}", num_shards, num_cores));
+    } else if (memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        TT_ASSERT(total_height == shard_shape[0], "Shard shape does not divide tensor shape correctly according to sharding scheme");
+        uint32_t num_shards = div_up(total_width, shard_shape[1]);
+        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} must match number of cores {}", num_shards, num_cores));
+    } else if (memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        // TODO (#7386): Uncomment once we fix ops that violate this
+        // TT_ASSERT(shard_spec.grid.ranges().size() == 1, "Shard grid must be one full rectangular grid for block sharded!");
+        uint32_t num_shards_along_height = div_up(total_height, shard_shape[0]);
+        uint32_t num_shards_along_width = div_up(total_width, shard_shape[1]);
+        uint32_t num_shards = num_shards_along_height * num_shards_along_width;
+        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} must match number of cores {}", num_shards, num_cores));
+
+        // TODO (#7386): Uncomment once we fix ops that violate this
+        // Additionally check that number of cores along height and width matches shard grid
+        // const CoreCoord shard_grid = shard_spec.grid.bounding_box().grid_size();
+        // if (shard_spec.orientation == ShardOrientation::ROW_MAJOR) {
+        //     TT_ASSERT(num_shards_along_height <= shard_grid.y, fmt::format("Number of shards along height {} must match number of rows {} for row major orientation!", num_shards_along_height, shard_grid.y));
+        //     TT_ASSERT(num_shards_along_width <= shard_grid.x, fmt::format("Number of shards along width {} must match number of columns {} for row major orientation!", num_shards_along_width, shard_grid.x));
+        // } else {
+        //     TT_ASSERT(num_shards_along_height <= shard_grid.x, fmt::format("Number of shards along height {} must match number of columns {} for column major orientation!", num_shards_along_height, shard_grid.x));
+        //     TT_ASSERT(num_shards_along_width <= shard_grid.y, fmt::format("Number of shards along width {} must match number of rows {} for column major orientation!", num_shards_along_width, shard_grid.y));
+        // }
+    } else {
+        TT_FATAL(false, "Unsupported sharding scheme");
+    }
+
+    if (layout == Layout::TILE) {
+        TT_ASSERT((shard_shape[0] % constants::TILE_HEIGHT == 0 && shard_shape[1] % constants::TILE_WIDTH == 0), "Shard shape must be tile sized");
+    } else if (layout == Layout::ROW_MAJOR) {
+        // Require alignment for now
+        // TT_ASSERT(shard_shape[1] * tensor_impl::element_size_bytes_wrapper(data_type) % ADDRESS_ALIGNMENT == 0);
+    }
+
     auto page_shape = shard_params.value().page_shape;
     uint32_t size_of_element = element_size_bytes_wrapper(data_type);
     uint32_t page_size = page_shape[0] * page_shape[1] * size_of_element;

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -282,8 +282,7 @@ void CreateQKVHeads::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(this->num_q_heads % this->num_kv_heads == 0, "Number of q heads {} must fit evenly into number of kv heads {}", this->num_q_heads, this->num_kv_heads);
     TT_FATAL(input_shape[3] % (num_w_cores * TILE_WIDTH) == 0, fmt::format("Flattened hidden dimension {} must be a multiple of width cores {} * tile width {} to ensure that each core gets an even amount of tiles", input_shape[3], num_w_cores, TILE_WIDTH));
 
-    // TODO: Add this back when output is HEIGHT sharded only!
-    // TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
     TT_FATAL(input_shape[0] == num_h_cores, fmt::format("Batch size  {} must be equal to num cores {}", input_shape[0], num_h_cores));
 }
 

--- a/ttnn/ttnn/operations/transformer.py
+++ b/ttnn/ttnn/operations/transformer.py
@@ -217,9 +217,8 @@ def split_query_key_value_and_split_heads(
         ):
             raise RuntimeError("input_tensor memory config must be BLOCK sharded when input_tensor is sharded!")
 
-        # TODO: Add this back when output is HEIGHT sharded only!
-        # if memory_config != ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG:
-        #     raise RuntimeError("Output memory config must be HEIGHT sharded when input_tensor is sharded!")
+        if memory_config != ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG:
+            raise RuntimeError("Output memory config must be HEIGHT sharded when input_tensor is sharded!")
 
         input_tensor = ttnn.reshape(
             input_tensor,


### PR DESCRIPTION
- Lower validations into allocate_sharded_buffer_on_device so all paths get checked
~~- Add more stringent checks for row/col for BLOCK sharding~~ (Doing this one in a separate PR since it involves other ops)