### PR TITLE
Implement device capture mode for metal trace

### DIFF
--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -169,6 +169,15 @@ void DeviceModule(py::module &m_device) {
     m_device.def("DeallocateBuffers", &detail::DeallocateBuffers, R"doc(
         Deallocate all buffers associated with Device handle
     )doc");
+    m_device.def("BeginTraceCapture", &detail::BeginTraceCapture, R"doc(
+        Begin trace capture on Device handle
+    )doc");
+    m_device.def("EndTraceCapture", &detail::EndTraceCapture, R"doc(
+        End trace capture on Device handle
+    )doc");
+    m_device.def("ExecuteLastTrace", &detail::ExecuteLastTrace, R"doc(
+        Execute last captured trace on Device handle
+    )doc");
 }
 
 void ProfilerModule(py::module &m_profiler) {

--- a/tt_metal/common/env_lib.hpp
+++ b/tt_metal/common/env_lib.hpp
@@ -35,6 +35,13 @@ T parse_env(const char *env_name, const T &default_value) {
     }
 }
 
+template <typename T>
+T parse_trigger(const char *env_name, const T &default_value) {
+    T retval = parse_env<T>(env_name, default_value);
+    unsetenv(env_name);
+    return retval;
+}
+
 }  // namespace tt
 
 // Explicit specializations

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -38,6 +38,14 @@ namespace tt::tt_metal{
 
         void CloseDevices(std::map<chip_id_t, Device *> devices);
 
+        void BeginTraceCapture(Device *device);
+        void EndTraceCapture(Device *device);
+        void ExecuteLastTrace(Device *device, bool blocking);
+
+        void BeginTraceCaptures(std::map<chip_id_t, Device *> devices);
+        void EndTraceCaptures(std::map<chip_id_t, Device *> devices);
+        void ExecuteLastTraces(std::map<chip_id_t, Device *> devices, bool blocking);
+
         /**
         * Copies data from a host buffer into the specified buffer
         *

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <string>
 #include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/trace/trace.hpp"
 #include "tt_metal/common/core_descriptor.hpp"
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
@@ -11,7 +13,7 @@
 #include "impl/debug/watcher_server.hpp"
 #include "tt_metal/third_party/umd/device/util.hpp"
 
-
+#include "common/env_lib.hpp"
 #include "common/utils.hpp"
 #include "llrt/llrt.hpp"
 #include "dev_msgs.h"
@@ -867,7 +869,7 @@ HWCommandQueue& Device::hw_command_queue(size_t cq_id) {
     return *hw_command_queues_[cq_id];
 }
 
-CommandQueue& Device::command_queue(size_t cq_id) {
+CommandQueue &Device::command_queue(size_t cq_id) {
     detail::DispatchStateCheck(using_fast_dispatch);
     TT_ASSERT( cq_id < sw_command_queues_.size(), "cq_id {} is out of range", cq_id );
     TT_FATAL(this->is_initialized(), "Device has not been initialized, did you forget to call InitializeDevice?");
@@ -894,6 +896,53 @@ void Device::enable_async(bool enable) {
 bool Device::using_slow_dispatch() const {
     return not (this->using_fast_dispatch);
 }
+
+void Device::begin_trace() {
+    this->trace_contexts_.clear();
+    for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
+        trace_contexts_.push_back(std::make_shared<detail::TraceDescriptor>());
+        hw_command_queues_[cq_id]->record_begin(trace_contexts_.at(cq_id));
+    }
+}
+
+void Device::end_trace() {
+    this->trace_insts_.clear();
+    this->release_last_trace();
+    for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
+        hw_command_queues_[cq_id]->record_end();
+        uint32_t tid = Trace::instantiate(
+            this->command_queue(cq_id), trace_contexts_.at(cq_id), std::move(this->sysmem_manager().get_bypass_data()));
+        trace_insts_.push_back(tid);
+    }
+}
+
+void Device::execute_last_trace(bool blocking) {
+    for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
+        if (this->trace_insts_.at(cq_id).has_value()) {
+            uint32_t tid = this->trace_insts_.at(cq_id).value();
+            TT_FATAL(Trace::has_instance(tid), "Trace instance " + std::to_string(tid) + " must exist on device");
+            this->command_queue(cq_id).run_command(CommandInterface{
+                .type = EnqueueCommandType::ENQUEUE_TRACE,
+                .blocking = blocking,
+                .trace_id = tid
+            });
+        }
+    }
+}
+
+void Device::release_last_trace() {
+    for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
+        if (this->trace_insts_.size() > cq_id) {
+            if (this->trace_insts_.at(cq_id).has_value()) {
+                uint32_t tid = this->trace_insts_.at(cq_id).value();
+                if (Trace::has_instance(tid)) {
+                    Trace::remove_instance(tid);
+                }
+            }
+        }
+    }
+}
+
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -11,6 +11,7 @@
 #include "impl/dispatch/work_executor.hpp"
 #include "tt_metal/impl/allocator/basic_allocator.hpp"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
+// #include "tt_metal/impl/trace/trace.hpp"
 #include "tt_metal/jit_build/build.hpp"
 #include "llrt/tt_cluster.hpp"
 #include "dev_msgs.h"
@@ -37,6 +38,7 @@ struct ProgramDeleter {
     void operator()(Program* p);
 };
 
+class TraceDescriptor;
 
 }
 
@@ -177,6 +179,13 @@ class Device {
     SystemMemoryManager& sysmem_manager() { return *sysmem_manager_; }
     HWCommandQueue& hw_command_queue(size_t cq_id = 0);
     CommandQueue& command_queue(size_t cq_id = 0);
+
+    // Metal trace device capture mode
+    void begin_trace();
+    void end_trace();
+    void execute_last_trace(bool blocking);
+    void release_last_trace();
+
     bool using_slow_dispatch() const;
     void check_allocator_is_initialized() const;
 
@@ -263,6 +272,10 @@ class Device {
         return (std::hash<std::thread::id>{}(std::this_thread::get_id()) == this->work_executor.get_parent_thread_id())
                 or get_worker_mode() == WorkExecutorMode::SYNCHRONOUS;
     }
+
+   private:
+    std::vector<std::optional<uint32_t>> trace_insts_;
+    std::vector<std::shared_ptr<tt::tt_metal::detail::TraceDescriptor>> trace_contexts_;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1536,15 +1536,6 @@ volatile bool HWCommandQueue::is_noc_hung() {
     return illegal_noc_txn_hang;
 }
 
-void EnqueueAddBufferToProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program>> program, bool blocking) {
-    cq.run_command(CommandInterface{
-        .type = EnqueueCommandType::ADD_BUFFER_TO_PROGRAM,
-        .blocking = blocking,
-        .buffer = buffer,
-        .program = program,
-    });
-}
-
 void EnqueueAddBufferToProgramImpl(const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program>> program) {
     std::visit([program] (auto&& b) {
         using buffer_type = std::decay_t<decltype(b)>;
@@ -1562,18 +1553,14 @@ void EnqueueAddBufferToProgramImpl(const std::variant<std::reference_wrapper<Buf
     }, buffer);
 }
 
-void EnqueueUpdateRuntimeArgs(CommandQueue& cq, const std::shared_ptr<Kernel> kernel, const CoreCoord &core_coord, std::vector<uint32_t> &update_idx, std::shared_ptr<RuntimeArgs> runtime_args_ptr, bool blocking) {
-    auto runtime_args_md = RuntimeArgsMetadata {
-            .core_coord = core_coord,
-            .runtime_args_ptr = runtime_args_ptr,
-            .kernel = kernel,
-            .update_idx = update_idx,
-    };
-    cq.run_command( CommandInterface {
-        .type = EnqueueCommandType::UPDATE_RUNTIME_ARGS,
-        .blocking = blocking,
-        .runtime_args_md = runtime_args_md,
-    });
+void EnqueueAddBufferToProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program>> program, bool blocking) {
+    EnqueueAddBufferToProgramImpl(buffer, program);
+    // cq.run_command(CommandInterface{
+    //     .type = EnqueueCommandType::ADD_BUFFER_TO_PROGRAM,
+    //     .blocking = blocking,
+    //     .buffer = buffer,
+    //     .program = program,
+    // });
 }
 
 void EnqueueUpdateRuntimeArgsImpl (const RuntimeArgsMetadata& runtime_args_md) {
@@ -1596,17 +1583,19 @@ void EnqueueUpdateRuntimeArgsImpl (const RuntimeArgsMetadata& runtime_args_md) {
     }
 }
 
-void EnqueueSetRuntimeArgs(CommandQueue& cq, const std::shared_ptr<Kernel> kernel, const CoreCoord &core_coord, std::shared_ptr<RuntimeArgs> runtime_args_ptr, bool blocking) {
+void EnqueueUpdateRuntimeArgs(CommandQueue& cq, const std::shared_ptr<Kernel> kernel, const CoreCoord &core_coord, std::vector<uint32_t> &update_idx, std::shared_ptr<RuntimeArgs> runtime_args_ptr, bool blocking) {
     auto runtime_args_md = RuntimeArgsMetadata {
             .core_coord = core_coord,
             .runtime_args_ptr = runtime_args_ptr,
             .kernel = kernel,
+            .update_idx = update_idx,
     };
-    cq.run_command( CommandInterface {
-        .type = EnqueueCommandType::SET_RUNTIME_ARGS,
-        .blocking = blocking,
-        .runtime_args_md = runtime_args_md,
-    });
+    EnqueueUpdateRuntimeArgsImpl(runtime_args_md);
+    // cq.run_command( CommandInterface {
+    //     .type = EnqueueCommandType::UPDATE_RUNTIME_ARGS,
+    //     .blocking = blocking,
+    //     .runtime_args_md = runtime_args_md,
+    // });
 }
 
 void EnqueueSetRuntimeArgsImpl(const RuntimeArgsMetadata& runtime_args_md) {
@@ -1626,29 +1615,32 @@ void EnqueueSetRuntimeArgsImpl(const RuntimeArgsMetadata& runtime_args_md) {
     runtime_args_md.kernel -> set_runtime_args(runtime_args_md.core_coord, resolved_runtime_args);
 }
 
-void EnqueueGetBufferAddr(CommandQueue& cq, uint32_t* dst_buf_addr, const Buffer* buffer, bool blocking) {
-    cq.run_command( CommandInterface {
-        .type = EnqueueCommandType::GET_BUF_ADDR,
-        .blocking = blocking,
-        .shadow_buffer = buffer,
-        .dst = dst_buf_addr
-    });
+void EnqueueSetRuntimeArgs(CommandQueue& cq, const std::shared_ptr<Kernel> kernel, const CoreCoord &core_coord, std::shared_ptr<RuntimeArgs> runtime_args_ptr, bool blocking) {
+    auto runtime_args_md = RuntimeArgsMetadata {
+            .core_coord = core_coord,
+            .runtime_args_ptr = runtime_args_ptr,
+            .kernel = kernel,
+    };
+    EnqueueSetRuntimeArgsImpl(runtime_args_md);
+    // cq.run_command( CommandInterface {
+    //     .type = EnqueueCommandType::SET_RUNTIME_ARGS,
+    //     .blocking = blocking,
+    //     .runtime_args_md = runtime_args_md,
+    // });
 }
 
 void EnqueueGetBufferAddrImpl(void* dst_buf_addr, const Buffer* buffer) {
-    *(static_cast<uint32_t*>(dst_buf_addr)) = buffer -> address();
+    *(static_cast<uint32_t*>(dst_buf_addr)) = buffer->address();
 }
-void EnqueueAllocateBuffer(CommandQueue& cq, Buffer* buffer, bool bottom_up, bool blocking) {
-    auto alloc_md = AllocBufferMetadata {
-        .buffer = buffer,
-        .allocator = *(buffer->device()->allocator_),
-        .bottom_up = bottom_up,
-    };
-    cq.run_command(CommandInterface {
-        .type = EnqueueCommandType::ALLOCATE_BUFFER,
-        .blocking = blocking,
-        .alloc_md = alloc_md,
-    });
+
+void EnqueueGetBufferAddr(CommandQueue& cq, uint32_t* dst_buf_addr, const Buffer* buffer, bool blocking) {
+    EnqueueGetBufferAddrImpl(dst_buf_addr, buffer);
+    // cq.run_command( CommandInterface {
+    //     .type = EnqueueCommandType::GET_BUF_ADDR,
+    //     .blocking = blocking,
+    //     .shadow_buffer = buffer,
+    //     .dst = dst_buf_addr
+    // });
 }
 
 void EnqueueAllocateBufferImpl(AllocBufferMetadata alloc_md) {
@@ -1663,6 +1655,24 @@ void EnqueueAllocateBufferImpl(AllocBufferMetadata alloc_md) {
     buffer->set_address(static_cast<uint64_t>(allocated_addr));
 }
 
+void EnqueueAllocateBuffer(CommandQueue& cq, Buffer* buffer, bool bottom_up, bool blocking) {
+    auto alloc_md = AllocBufferMetadata{
+        .buffer = buffer,
+        .allocator = *(buffer->device()->allocator_),
+        .bottom_up = bottom_up,
+    };
+    EnqueueAllocateBufferImpl(alloc_md);
+    // cq.run_command(CommandInterface {
+    //     .type = EnqueueCommandType::ALLOCATE_BUFFER,
+    //     .blocking = blocking,
+    //     .alloc_md = alloc_md,
+    // });
+}
+
+void EnqueueDeallocateBufferImpl(AllocBufferMetadata alloc_md) {
+    allocator::deallocate_buffer(alloc_md.allocator, alloc_md.device_address, alloc_md.buffer_type);
+}
+
 void EnqueueDeallocateBuffer(CommandQueue& cq, Allocator& allocator, uint32_t device_address, BufferType buffer_type, bool blocking) {
     // Need to explictly pass in relevant buffer attributes here, since the Buffer* ptr can be deallocated a this point
     auto alloc_md = AllocBufferMetadata {
@@ -1670,15 +1680,12 @@ void EnqueueDeallocateBuffer(CommandQueue& cq, Allocator& allocator, uint32_t de
         .buffer_type = buffer_type,
         .device_address = device_address,
     };
-    cq.run_command(CommandInterface{
-        .type = EnqueueCommandType::DEALLOCATE_BUFFER,
-        .blocking = blocking,
-        .alloc_md = alloc_md,
-    });
-}
-
-void EnqueueDeallocateBufferImpl(AllocBufferMetadata alloc_md) {
-    allocator::deallocate_buffer(alloc_md.allocator, alloc_md.device_address, alloc_md.buffer_type);
+    EnqueueDeallocateBufferImpl(alloc_md);
+    // cq.run_command(CommandInterface{
+    //     .type = EnqueueCommandType::DEALLOCATE_BUFFER,
+    //     .blocking = blocking,
+    //     .alloc_md = alloc_md,
+    // });
 }
 
 void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, vector<uint32_t>& dst, bool blocking){

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -360,6 +360,7 @@ class EnqueueTraceCommand : public Command {
 };
 
 namespace detail {
+class TraceDescriptor;
 inline bool LAZY_COMMAND_QUEUE_MODE = false;
 
 /*
@@ -430,17 +431,25 @@ class HWCommandQueue {
     volatile bool is_dprint_server_hung();
     volatile bool is_noc_hung();
 
-    // Record all commands and metadata from run_commands function
-    template <typename Func>
-    inline std::vector<uint32_t> record_commands(std::shared_ptr<detail::TraceDescriptor> ctx, Func run_commands) {
+    void record_begin(std::shared_ptr<detail::TraceDescriptor> ctx) {
         // Issue event as a barrier and a counter reset
         std::shared_ptr<Event> event = std::make_shared<Event>();
         this->enqueue_record_event(event, true);
         // Record commands using bypass mode
         this->trace_ctx = ctx;
         this->manager.set_bypass_mode(true, true);  // start
-        run_commands();
+    }
+
+    void record_end() {
         this->manager.set_bypass_mode(false, false);  // stop
+    }
+
+    // Record all commands and metadata from run_commands function
+    template <typename Func>
+    inline std::vector<uint32_t> record_commands(std::shared_ptr<detail::TraceDescriptor> ctx, Func run_commands) {
+        this->record_begin(ctx);
+        run_commands();
+        this->record_end();
         return std::move(this->manager.get_bypass_data());
     }
 

--- a/tt_metal/impl/trace/trace.hpp
+++ b/tt_metal/impl/trace/trace.hpp
@@ -106,12 +106,13 @@ class Trace {
     CommandQueue& queue() const { return *tq; };
 
     // Stages a trace buffer into device DRAM via the CQ passed in and returns a unique trace id
-    uint32_t instantiate(CommandQueue& tq);
+    uint32_t instantiate(CommandQueue& cq);
 
     // Trace capture, validation, and query methods
     void begin_capture();
     void end_capture();
     void validate();
+    void reset();
 
     // Thread-safe accessors to manage trace instances
     static bool has_instance(const uint32_t tid);
@@ -119,6 +120,7 @@ class Trace {
     static void remove_instance(const uint32_t tid);
     static void release_all();  // note all instances across all devices are released
     static TraceBuffer get_instance(const uint32_t tid);
+    static uint32_t instantiate(CommandQueue& cq, shared_ptr<detail::TraceDescriptor> desc, const vector<uint32_t>& cmds);
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -664,6 +664,34 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
         EnqueueGetBufferAddr(buffer->device()->command_queue(), address_on_host, buffer, false);
     }
 
+    void BeginTraceCapture(Device *device) {
+        device->begin_trace();
+    }
+
+    void EndTraceCapture(Device *device) {
+        device->end_trace();
+    }
+
+    void ExecuteLastTrace(Device *device, bool blocking) {
+        device->execute_last_trace(blocking);
+    }
+
+    void BeginTraceCaptures(std::map<chip_id_t, Device *> devices) {
+        for (const auto &[device_id, dev] : devices) {
+            dev->begin_trace();
+        }
+    }
+    void EndTraceCaptures(std::map<chip_id_t, Device *> devices) {
+        for (const auto &[device_id, dev] : devices) {
+            dev->end_trace();
+        }
+    }
+    void ExecuteLastTraces(std::map<chip_id_t, Device *> devices, bool blocking) {
+        for (const auto &[device_id, dev] : devices) {
+            dev->execute_last_trace(blocking);
+        }
+    }
+
 }   // namespace detail
 
 size_t GetNumAvailableDevices() {


### PR DESCRIPTION
Device capture respective allocation/deallocation order of the non-traced run, and it also provides a more seamless way to capture an existing workload.