### PR TITLE
Test fixes for fd2 packetized path

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -57,8 +57,11 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre" # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre -sdis" # Smoke Test
 
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -spre -sdis -packetized_en" # TrueSmoke Test with packetized path
-run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -spre -sdis -packetized_en" # Smoke Test with packetized path
+if [[ $ARCH_NAME == "wormhole_b0" ]]; then
+    # packetized path used only on multi-chip WH
+    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -spre -sdis -packetized_en" # TrueSmoke Test with packetized path
+    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -spre -sdis -packetized_en" # Smoke Test with packetized path
+fi
 
 
 # Testcase: Paged Write Cmd to DRAM. 256 pages, 224b size.
@@ -99,13 +102,14 @@ echo "Running test_dispatcher tests now...";
 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_dispatcher -i 3 -w 5 -t 4 -min 1024 -max 1024
 
 
-# TODO - re-enable these when regression hangs are resolved
-# #############################################
-# # PACKETIZED PATH TESTS                     #
-# #############################################
-# echo "Running packetized path tests now...";
-# # 4 TX -> 4:1 Mux -> 1:4 Demux -> 4 RX
-# ./build/test/tt_metal/perf_microbenchmark/routing/test_mux_demux
+if [[ $ARCH_NAME == "wormhole_b0" ]]; then
+    #############################################
+    # PACKETIZED PATH TESTS - WH only           #
+    #############################################
+    echo "Running packetized path tests now...";
+    # 4 TX -> 4:1 Mux -> 1:4 Demux -> 4 RX
+    ./build/test/tt_metal/perf_microbenchmark/routing/test_mux_demux
 
-# # 16 TX -> 4 x 4:1 Mux -> 4:1 Mux -> 1:4 Demux -> 4 x 1:4 Demux -> 16 RX
-# ./build/test/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level
+    # 16 TX -> 4 x 4:1 Mux -> 4:1 Mux -> 1:4 Demux -> 4 x 1:4 Demux -> 16 RX
+    ./build/test/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level
+fi

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
@@ -15,7 +15,7 @@ using namespace tt;
 int main(int argc, char **argv) {
 
     constexpr uint32_t default_prng_seed = 0x100;
-    constexpr uint32_t default_data_kb_per_tx = 256*1024;
+    constexpr uint32_t default_data_kb_per_tx = 64*1024;
     constexpr uint32_t default_max_packet_size_words = 0x100;
 
     constexpr uint32_t default_tx_queue_start_addr = 0x80000;
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         }
 
         constexpr uint32_t rx_x = 0;
-        constexpr uint32_t rx_y = 6;
+        constexpr uint32_t rx_y = 4;
         std::vector<CoreCoord> rx_core;
         std::vector<CoreCoord> rx_phys_core;
         for (uint32_t i = 0; i < num_dest_endpoints; i++) {
@@ -120,18 +120,18 @@ int main(int argc, char **argv) {
             mux_l1_phys_core.push_back(device->worker_core_from_logical_core(core));
         }
 
-        constexpr uint32_t mux_l2_x = 0;
-        constexpr uint32_t mux_l2_y = 3;
+        constexpr uint32_t mux_l2_x = 4;
+        constexpr uint32_t mux_l2_y = 2;
         CoreCoord mux_l2_core = {mux_l2_x, mux_l2_y};
         CoreCoord mux_l2_phys_core = device->worker_core_from_logical_core(mux_l2_core);
 
         constexpr uint32_t demux_l1_x = 0;
-        constexpr uint32_t demux_l1_y = 4;
+        constexpr uint32_t demux_l1_y = 3;
         CoreCoord demux_l1_core = {demux_l1_x, demux_l1_y};
         CoreCoord demux_l1_phys_core = device->worker_core_from_logical_core(demux_l1_core);
 
-        constexpr uint32_t demux_l2_x = 0;
-        constexpr uint32_t demux_l2_y = 5;
+        constexpr uint32_t demux_l2_x = 1;
+        constexpr uint32_t demux_l2_y = 3;
         std::vector<CoreCoord> demux_l2_core;
         std::vector<CoreCoord> demux_l2_phys_core;
         for (uint32_t i = 0; i < num_demux_l2; i++) {


### PR DESCRIPTION
Changes for fd2 packetized path tests:
 - Run these only for WH (no use case for GS). 
 - Change the 16-way TX/RX test to use a smaller subset of the grid 

These changes resolve the recent failures. 