### PR TITLE
Adding Multichip Microbenchmarks

### DIFF
--- a/tests/scripts/run_frequent_regressions_multi_device.sh
+++ b/tests/scripts/run_frequent_regressions_multi_device.sh
@@ -16,6 +16,9 @@ cd $TT_METAL_HOME
 export PYTHONPATH=$TT_METAL_HOME
 
 pytest tests/ttnn/unit_tests/test_multi_device.py
+
+pytest tests/tt_metal/microbenchmarks/ethernet/test_ethernet_bidirectional_bandwidth_microbenchmark.py
+
 pytest models/demos/ttnn_falcon7b/tests/multi_chip -k test_falcon_mlp
 pytest models/demos/ttnn_falcon7b/tests/multi_chip -k test_falcon_attention
 pytest models/demos/ttnn_falcon7b/tests/multi_chip -k test_falcon_decoder

--- a/tests/scripts/run_frequent_regressions_multi_device.sh
+++ b/tests/scripts/run_frequent_regressions_multi_device.sh
@@ -18,6 +18,7 @@ export PYTHONPATH=$TT_METAL_HOME
 pytest tests/ttnn/unit_tests/test_multi_device.py
 
 pytest tests/tt_metal/microbenchmarks/ethernet/test_ethernet_bidirectional_bandwidth_microbenchmark.py
+pytest tests/tt_metal/microbenchmarks/ethernet/test_ethernet_ring_latency_microbenchmark.py
 
 pytest models/demos/ttnn_falcon7b/tests/multi_chip -k test_falcon_mlp
 pytest models/demos/ttnn_falcon7b/tests/multi_chip -k test_falcon_attention

--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_bidirectional_bandwidth_microbenchmark.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_bidirectional_bandwidth_microbenchmark.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from loguru import logger
+import pytest
+from tt_metal.tools.profiler.process_device_log import import_log_run_stats
+import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
+
+
+@pytest.mark.parametrize("sample_counts", [(1, 1024)])  # , 8, 16, 64, 256],
+@pytest.mark.parametrize(
+    "sample_sizes",
+    [
+        (
+            512,
+            1024,
+        )
+    ],
+)  # , 1024, 2048, 4096],
+@pytest.mark.parametrize(
+    "channel_counts",
+    [
+        (
+            1,
+            2,
+        )
+    ],
+)  # , 2, 3, 4])
+def test_bidirectional_erisc_bandwidth(sample_counts, sample_sizes, channel_counts):
+    test_string_name = f"test_ethernet_send_data_microbenchmark - \
+            sample_counts: {sample_counts}, \
+                sample_sizes: {sample_sizes}, \
+                    channel_counts: {channel_counts}"
+    print(f"{test_string_name}")
+    os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
+
+    sample_counts_str = " ".join([str(s) for s in sample_counts])
+    sample_sizes_str = " ".join([str(s) for s in sample_sizes])
+    channel_counts_str = " ".join([str(s) for s in channel_counts])
+
+    rc = os.system(
+        f"TT_METAL_DEVICE_PROFILER=1 \
+            {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm \
+                {len(sample_counts)} {sample_counts_str} \
+                    {len(sample_sizes)} {sample_sizes_str} \
+                        {len(channel_counts)} {channel_counts_str} \
+            "
+    )
+    if rc != 0:
+        print("Error in running the test")
+        assert False
+
+    return True

--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_ring_latency_microbenchmark.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_ring_latency_microbenchmark.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from loguru import logger
+import pytest
+from tt_metal.tools.profiler.process_device_log import import_log_run_stats
+import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
+
+
+@pytest.mark.parametrize("sample_counts", [(64,)])
+@pytest.mark.parametrize("page_sizes", [(16,)])
+@pytest.mark.parametrize("channel_counts", [(1,)])
+@pytest.mark.parametrize("hop_counts", [(4, 8, 12)])
+def test_multichip_hop_latency(sample_counts, page_sizes, channel_counts, hop_counts):
+    test_string_name = f"test_ethernet_send_data_microbenchmark - \
+            sample_counts: {sample_counts}, \
+                page_sizes: {page_sizes}, \
+                    channel_counts: {channel_counts}, \
+                        hop_counts: {hop_counts}"
+    print(f"{test_string_name}")
+    os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
+
+    sample_counts_str = " ".join([str(s) for s in sample_counts])
+    page_sizes_str = " ".join([str(s) for s in page_sizes])
+    channel_counts_str = " ".join([str(s) for s in channel_counts])
+    hop_counts_str = " ".join([str(s) for s in hop_counts])
+
+    rc = os.system(
+        f"TT_METAL_DEVICE_PROFILER=1 \
+            ./build/test/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm \
+                {len(sample_counts)} {sample_counts_str} \
+                    {len(page_sizes)} {page_sizes_str} \
+                        {len(channel_counts)} {channel_counts_str} \
+                            {len(hop_counts)} {hop_counts_str}"
+    )
+    if rc != 0:
+        print("Error in running the test")
+        assert False
+
+    return True

--- a/tests/tt_metal/tt_metal/module.mk
+++ b/tests/tt_metal/tt_metal/module.mk
@@ -17,6 +17,7 @@ TT_METAL_TESTS += \
 		 tests/tt_metal/perf_microbenchmark/dispatch/test_prefetcher \
 		 tests/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data \
 		 tests/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional \
+ 		 tests/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm \
 		 tests/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1 \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1 \

--- a/tests/tt_metal/tt_metal/module.mk
+++ b/tests/tt_metal/tt_metal/module.mk
@@ -18,6 +18,7 @@ TT_METAL_TESTS += \
 		 tests/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data \
 		 tests/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional \
  		 tests/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm \
+		 tests/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm \
 		 tests/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1 \
 		 tests/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1 \

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -1,0 +1,340 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <random>
+#include <tuple>
+
+#include "device/tt_arch_types.h"
+#include "impl/device/device.hpp"
+#include "impl/kernels/kernel_types.hpp"
+#include "tt_backend_api_types.hpp"
+#include "tt_metal/common/core_coord.h"
+#include "tt_metal/common/math.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/kernels/kernel.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/df/df.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+#include "tt_metal/detail/persistent_kernel_cache.hpp"
+
+using namespace tt;
+using namespace tt::test_utils;
+using namespace tt::test_utils::df;
+
+
+class N300TestDevice {
+   public:
+    N300TestDevice() : device_open(false) {
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+
+        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() >= 2 and
+            tt::tt_metal::GetNumPCIeDevices() >= 1) {
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                auto* device = tt::tt_metal::CreateDevice(id);
+                devices_.push_back(device);
+            }
+            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+
+        } else {
+            TT_THROW("This suite can only be run on N300 Wormhole devices");
+        }
+        device_open = true;
+    }
+    ~N300TestDevice() {
+        if (device_open) {
+            TearDown();
+        }
+    }
+
+    void TearDown() {
+        device_open = false;
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+        for (unsigned int id = 0; id < devices_.size(); id++) {
+            tt::tt_metal::CloseDevice(devices_.at(id));
+        }
+    }
+
+    std::vector<tt::tt_metal::Device*> devices_;
+    tt::ARCH arch_;
+    size_t num_devices_;
+
+   private:
+    bool device_open;
+};
+
+struct ChipSenderReceiverEthCore {
+    CoreCoord sender_core;
+    CoreCoord receiver_core;
+};
+
+std::tuple<Program,Program> build(
+    Device *device0,
+    Device *device1,
+    CoreCoord eth_sender_core,
+    CoreCoord eth_receiver_core,
+    std::size_t num_samples,
+    std::size_t sample_page_size,
+    std::size_t max_channels_per_direction,
+    KernelHandle &local_kernel,
+    KernelHandle &remote_kernel
+) {
+    Program program0;
+    Program program1;
+
+    std::vector<uint32_t> const& ct_args = {};
+    constexpr std::size_t num_links = 0;
+
+    // Kernel Setup
+
+    auto rt_args = [&](bool send_channels_at_offset_0) -> std::vector<uint32_t> {
+        return std::vector<uint32_t> {
+            eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE,
+            static_cast<uint32_t>(num_samples),
+            static_cast<uint32_t>(sample_page_size),
+            static_cast<uint32_t>(max_channels_per_direction),
+            static_cast<uint32_t>(send_channels_at_offset_0)};
+    };
+
+    local_kernel = tt_metal::CreateKernel(
+        program0,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_bidirectional_ubench.cpp",
+        eth_sender_core,
+        tt_metal::EthernetConfig {
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = ct_args});
+    tt_metal::SetRuntimeArgs(program0, local_kernel, eth_sender_core, rt_args(true));
+
+    remote_kernel = tt_metal::CreateKernel(
+        program1,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_bidirectional_ubench.cpp",
+        eth_receiver_core,
+        tt_metal::EthernetConfig {
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = ct_args});
+    tt_metal::SetRuntimeArgs(program1, remote_kernel, eth_receiver_core, rt_args(false));
+
+    // Launch
+    try {
+        tt::tt_metal::detail::CompileProgram(device0, program0);
+        tt::tt_metal::detail::CompileProgram(device1, program1);
+    } catch (std::exception& e) {
+        log_error(tt::LogTest, "Failed compile: {}", e.what());
+        throw e;
+    }
+
+    return std::tuple<Program,Program>{std::move(program0),std::move(program1)};
+}
+
+void run(
+    Device *device0,
+    Device *device1,
+    Program &program0,
+    Program &program1,
+    KernelHandle local_kernel,
+    KernelHandle remote_kernel,
+
+    CoreCoord eth_sender_core,
+    CoreCoord eth_receiver_core,
+    std::size_t num_samples,
+    std::size_t sample_page_size,
+    std::size_t max_channels_per_direction
+) {
+    auto rt_args = [&](bool send_channels_at_offset_0) -> std::vector<uint32_t> {
+        return std::vector<uint32_t> {
+            eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE,
+            static_cast<uint32_t>(num_samples),
+            static_cast<uint32_t>(sample_page_size),
+            static_cast<uint32_t>(max_channels_per_direction),
+            static_cast<uint32_t>(send_channels_at_offset_0)};
+    };
+    log_trace(tt::LogTest, "Running...");
+
+    tt_metal::SetRuntimeArgs(program0, local_kernel, eth_sender_core, rt_args(true));
+    tt_metal::SetRuntimeArgs(program1, remote_kernel, eth_receiver_core, rt_args(false));
+
+    tt_metal::EnqueueProgram(device0->command_queue(), program0, false);
+    tt_metal::EnqueueProgram(device1->command_queue(), program1, false);
+    tt::tt_metal::detail::DumpDeviceProfileResults(device0);
+    tt::tt_metal::detail::DumpDeviceProfileResults(device1);
+}
+
+bool MeasureBidirectionalBandwidth(
+    Device *device0,
+    Device *device1,
+    CoreCoord eth_sender_core,
+    CoreCoord eth_receiver_core,
+    std::size_t num_samples,
+    std::size_t sample_page_size,
+    std::size_t max_channels_per_direction
+) {
+    Program program0;
+    Program program1;
+
+    std::vector<uint32_t> const& ct_args = {};
+    constexpr std::size_t num_links = 0;
+
+    // Kernel Setup
+    auto rt_args = [&](bool send_channels_at_offset_0) -> std::vector<uint32_t> {
+        return std::vector<uint32_t> {
+            eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE,
+            static_cast<uint32_t>(num_samples),
+            static_cast<uint32_t>(sample_page_size),
+            static_cast<uint32_t>(max_channels_per_direction),
+            static_cast<uint32_t>(send_channels_at_offset_0)};
+    };
+
+    auto local_kernel = tt_metal::CreateKernel(
+        program0,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_bidirectional_ubench.cpp",
+        eth_sender_core,
+        tt_metal::EthernetConfig {
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = ct_args});
+    tt_metal::SetRuntimeArgs(program0, local_kernel, eth_sender_core, rt_args(true));
+
+    auto remote_kernel = tt_metal::CreateKernel(
+        program1,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_bidirectional_ubench.cpp",
+        eth_receiver_core,
+        tt_metal::EthernetConfig {
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = ct_args});
+    tt_metal::SetRuntimeArgs(program1, remote_kernel, eth_receiver_core, rt_args(false));
+
+    // Launch
+    try {
+        tt::tt_metal::detail::CompileProgram(device0, program0);
+        tt::tt_metal::detail::CompileProgram(device1, program1);
+    } catch (std::exception& e) {
+        log_trace(tt::LogTest, "Failed compile: {}", e.what());
+        throw e;
+    }
+
+    log_trace(tt::LogTest, "Running...");
+
+    std::thread th2 = std::thread([&] { tt_metal::detail::LaunchProgram(device0, program0); });
+    std::thread th1 = std::thread([&] { tt_metal::detail::LaunchProgram(device1, program1); });
+
+    th2.join();
+    th1.join();
+
+    tt::tt_metal::detail::DumpDeviceProfileResults(device0);
+    tt::tt_metal::detail::DumpDeviceProfileResults(device1);
+
+    return true;
+}
+
+int main(int argc, char** argv) {
+    // argv[0]: program
+    // argv[1]: num_samples
+    // argv[2]: sample_page_size
+    // argv[3]: max_channels_per_direction
+    assert(argc >= 4);
+    std::size_t arg_idx = 1;
+    std::size_t num_sample_counts = std::stoi(argv[arg_idx++]);
+    log_trace(tt::LogTest, "num_sample_counts: {}", std::stoi(argv[arg_idx]));
+    std::vector<std::size_t> sample_counts;
+    for (std::size_t i = 0; i < num_sample_counts; i++) {
+        sample_counts.push_back(std::stoi(argv[arg_idx++]));
+        log_trace(tt::LogTest, "sample_counts[{}]: {}", i, sample_counts.back());
+    }
+
+    std::size_t num_sample_sizes = std::stoi(argv[arg_idx++]);
+    std::vector<std::size_t> sample_sizes;
+    log_trace(tt::LogTest, "num_sample_sizes: {}", num_sample_sizes);
+    for (std::size_t i = 0; i < num_sample_sizes; i++) {
+        sample_sizes.push_back(std::stoi(argv[arg_idx++]));
+        log_trace(tt::LogTest, "sample_sizes[{}]: {}", i, sample_sizes.back());
+    }
+
+    std::size_t num_channel_counts = std::stoi(argv[arg_idx++]);
+    std::vector<std::size_t> channel_counts;
+    log_trace(tt::LogTest, "num_channel_counts: {}", num_channel_counts);
+    for (std::size_t i = 0; i < num_channel_counts; i++) {
+        channel_counts.push_back(std::stoi(argv[arg_idx++]));
+        log_trace(tt::LogTest, "channel_counts[{}]: {}", i, channel_counts.back());
+    }
+
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    if (num_devices < 2) {
+        log_info(tt::LogTest, "Need at least 2 devices to run this test");
+        return 0;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        log_info(tt::LogTest, "Test must be run on WH");
+        return 0;
+    }
+
+    N300TestDevice test_fixture;
+
+    const auto& device_0 = test_fixture.devices_.at(0);
+    auto const& active_eth_cores = device_0->get_active_ethernet_cores(true);
+    auto eth_sender_core_iter = active_eth_cores.begin();
+    auto eth_sender_core = *eth_sender_core_iter;
+    eth_sender_core_iter++;
+    if (eth_sender_core_iter != active_eth_cores.end())
+        eth_sender_core = *eth_sender_core_iter;
+
+    auto [device_id, eth_receiver_core] = device_0->get_connected_ethernet_core(eth_sender_core);
+    const auto& device_1 = test_fixture.devices_.at(device_id);
+    tt_metal::detail::EnablePersistentKernelCache();
+    // Add more configurations here until proper argc parsing added
+    bool success = false;
+    success = true;
+    for (auto num_samples : sample_counts) {
+        for (auto sample_page_size : sample_sizes) {
+            for (auto max_channels_per_direction : channel_counts) {
+                log_trace(tt::LogTest, "num_samples: {}, sample_page_size: {}, num_channels_per_direction: {}", num_samples, sample_page_size, max_channels_per_direction);
+                KernelHandle local_kernel;
+                KernelHandle remote_kernel;
+                try {
+                    auto [program0,program1] = build(
+                        device_0,
+                        device_1,
+                        eth_sender_core,
+                        eth_receiver_core,
+                        num_samples,
+                        sample_page_size,
+                        max_channels_per_direction,
+                        local_kernel,
+                        remote_kernel
+                    );
+                    run(
+                        device_0,
+                        device_1,
+                        program0,
+                        program1,
+                        local_kernel,
+                        remote_kernel,
+
+                        eth_sender_core,
+                        eth_receiver_core,
+                        num_samples,
+                        sample_page_size,
+                        max_channels_per_direction
+                    );
+                } catch (std::exception& e) {
+                    log_error(tt::LogTest, "Caught exception: {}", e.what());
+                    test_fixture.TearDown();
+                    return -1;
+                }
+            }
+        }
+    }
+
+    tt_metal::detail::DisablePersistentKernelCache();
+    test_fixture.TearDown();
+
+    return success ? 0 : -1;
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -1,0 +1,485 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <random>
+#include <tuple>
+
+#include "common/logger.hpp"
+#include "device/tt_arch_types.h"
+#include "impl/device/device.hpp"
+#include "impl/kernels/data_types.hpp"
+#include "impl/kernels/kernel_types.hpp"
+#include "tt_backend_api_types.hpp"
+#include "tt_metal/common/core_coord.h"
+#include "tt_metal/common/math.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/kernels/kernel.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/df/df.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+#include "tt_metal/detail/persistent_kernel_cache.hpp"
+
+using tt::tt_metal::Device;
+
+class T3000TestDevice {
+   public:
+    T3000TestDevice() : device_open(false) {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            TT_THROW("This suite can only be run without TT_METAL_SLOW_DISPATCH_MODE set");
+        }
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+
+        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() == 8 and
+            tt::tt_metal::GetNumPCIeDevices() == 4) {
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                auto* device = tt::tt_metal::CreateDevice(id);
+                devices_.push_back(device);
+            }
+            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+
+        } else {
+            TT_THROW("This suite can only be run on T3000 Wormhole devices");
+        }
+        device_open = true;
+    }
+    ~T3000TestDevice() {
+        if (device_open) {
+            TearDown();
+        }
+    }
+
+    void TearDown() {
+        device_open = false;
+        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+        for (unsigned int id = 0; id < devices_.size(); id++) {
+            tt::tt_metal::CloseDevice(devices_.at(id));
+        }
+    }
+
+    std::vector<tt::tt_metal::Device*> devices_;
+    tt::ARCH arch_;
+    size_t num_devices_;
+
+   private:
+    bool device_open;
+};
+
+namespace tt {
+
+namespace tt_metal {
+
+
+std::vector<uint32_t> get_eth_receiver_rt_args(
+    Device *device,
+    bool is_starting_core,
+    uint32_t num_samples,
+    uint32_t max_concurrent_samples,
+    uint32_t sample_page_size,
+    CoreCoord const& eth_sender_core,
+    uint32_t start_semaphore,
+    uint32_t init_handshake_core_x,
+    uint32_t init_handshake_core_y,
+    uint32_t init_handshake_addr
+    ) {
+    constexpr std::size_t semaphore_size = 16;
+    std::vector<uint32_t> erisc_semaphore_addresses(max_concurrent_samples, eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 16 + 16);
+    std::vector<uint32_t> erisc_buffer_addresses(max_concurrent_samples, eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 16 + 16 + round_up(semaphore_size * max_concurrent_samples, 16));
+    for (std::size_t i = 0; i < max_concurrent_samples; i++) {
+        erisc_semaphore_addresses.at(i) += i * semaphore_size;
+        erisc_buffer_addresses.at(i) += i * sample_page_size;
+    }
+
+    std::vector<uint32_t> rt_args = {
+        static_cast<uint32_t>(is_starting_core ? 1 : 0),
+        eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE,
+        num_samples,
+        max_concurrent_samples,
+        sample_page_size,
+        static_cast<uint32_t>(device->ethernet_core_from_logical_core(eth_sender_core).x),
+        static_cast<uint32_t>(device->ethernet_core_from_logical_core(eth_sender_core).y),
+        start_semaphore,
+        init_handshake_core_x,
+        init_handshake_core_y,
+        init_handshake_addr};
+    for (std::size_t i = 0; i < max_concurrent_samples; i++) {
+        rt_args.push_back(erisc_semaphore_addresses.at(i));
+        rt_args.push_back(erisc_buffer_addresses.at(i));
+    }
+
+    return rt_args;
+}
+
+
+std::vector<uint32_t> get_eth_sender_rt_args(
+    Device *device,
+    bool is_starting_core,
+    uint32_t num_samples,
+    uint32_t max_concurrent_samples,
+    uint32_t sample_page_size,
+    uint32_t receiver_x,
+    uint32_t receiver_y,
+    uint32_t receiver_start_semaphore) {
+    constexpr std::size_t semaphore_size = 16;
+    std::vector<uint32_t> erisc_semaphore_addresses(max_concurrent_samples, eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 16 + 16);
+    std::vector<uint32_t> erisc_buffer_addresses(max_concurrent_samples, eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 16 + 16 + round_up(semaphore_size * max_concurrent_samples, 16));
+    for (std::size_t i = 0; i < max_concurrent_samples; i++) {
+        erisc_semaphore_addresses.at(i) += i * semaphore_size;
+        erisc_buffer_addresses.at(i) += i * sample_page_size;
+    }
+
+    std::vector<uint32_t> rt_args = {
+        static_cast<uint32_t>(is_starting_core ? 1 : 0),
+        eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE,
+        num_samples,
+        max_concurrent_samples,
+        sample_page_size,
+        receiver_x,
+        receiver_y,
+        receiver_start_semaphore};
+    for (std::size_t i = 0; i < max_concurrent_samples; i++) {
+        rt_args.push_back(erisc_semaphore_addresses.at(i));
+        rt_args.push_back(erisc_buffer_addresses.at(i));
+    }
+
+    return rt_args;
+}
+
+struct hop_eth_sockets {
+    chip_id_t receiver_device_id;
+    CoreCoord receiver_core;
+    chip_id_t sender_device_id;
+    CoreCoord sender_core;
+};
+
+
+void build_and_run_roundtrip_latency_test(
+    std::vector<Device*> devices,
+    std::vector<hop_eth_sockets> hop_eth_sockets,
+    std::size_t num_samples,
+    std::size_t sample_page_size,
+    std::size_t max_concurrent_samples,
+    std::size_t n_hops,
+
+    std::vector<Program> &programs,
+    std::vector<KernelHandle> &receiver_kernel_ids,
+    std::vector<KernelHandle> &sender_kernel_ids
+) {
+    TT_ASSERT(hop_eth_sockets.size() == devices.size());
+    TT_ASSERT(n_hops == devices.size());
+    TT_ASSERT(programs.size() == 0);
+    TT_ASSERT(receiver_kernel_ids.size() == 0);
+    TT_ASSERT(sender_kernel_ids.size() == 0);
+    programs.reserve(n_hops);
+    receiver_kernel_ids.reserve(n_hops);
+    sender_kernel_ids.reserve(n_hops);
+
+    std::unordered_map<Device*,Program*> device_program_map;
+    for (std::size_t i = 0; i < n_hops; i++) {
+        if (device_program_map.find(devices.at(i)) == device_program_map.end()) {
+            programs.emplace_back();
+            device_program_map[devices.at(i)] = &programs.back();
+        }
+    }
+
+    std::unordered_map<Device*, uint32_t> device_visits;
+
+    for (std::size_t i = 0; i < n_hops; i++) {
+        auto previous_hop = i == 0 ? n_hops - 1 : i - 1;
+        Device *device = devices.at(i);
+        auto &program = *device_program_map.at(device);
+        auto const& eth_sender_core = hop_eth_sockets.at(i).sender_core;
+        auto const& eth_receiver_core = hop_eth_sockets.at(previous_hop).receiver_core;
+
+        CoreCoord init_worker_core = CoreCoord{0, device_visits[device]++};
+
+        uint32_t worker_sem0 = CreateSemaphore(program, init_worker_core, 0, CoreType::WORKER);
+        uint32_t worker_sem1 = CreateSemaphore(program, init_worker_core, 0, CoreType::WORKER);
+
+        std::vector<uint32_t> const& receiver_eth_ct_args = {};
+        std::vector<uint32_t> const& sender_eth_ct_args = {};
+        bool is_starting_core = i == 0;
+        uint32_t receiver_start_semaphore = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 16;//CreateSemaphore(program, eth_receiver_core, 0, CoreType::ETH);
+        log_trace(tt::LogTest, "is_starting_core: {}", (is_starting_core ? 1 : 0));
+        std::vector<uint32_t> const& receiver_eth_rt_args = get_eth_receiver_rt_args(
+            device,
+            is_starting_core,
+            num_samples,
+            max_concurrent_samples,
+            sample_page_size,
+            eth_sender_core,
+            receiver_start_semaphore,
+            device->physical_core_from_logical_core(init_worker_core, CoreType::WORKER).x,
+            device->physical_core_from_logical_core(init_worker_core, CoreType::WORKER).y,
+            worker_sem0);
+        std::vector<uint32_t> const& sender_eth_rt_args = get_eth_sender_rt_args(
+            device,
+            is_starting_core,
+            num_samples,
+            max_concurrent_samples,
+            sample_page_size,
+            // device->physical_core_from_logical_core(eth_receiver_core, CoreType::ETH).x,
+            // device->physical_core_from_logical_core(eth_receiver_core, CoreType::ETH).y,
+            // receiver_start_semaphore
+            device->physical_core_from_logical_core(init_worker_core, CoreType::WORKER).x,
+            device->physical_core_from_logical_core(init_worker_core, CoreType::WORKER).y,
+            worker_sem1);
+
+        std::vector<uint32_t> worker_init_rt_args = {
+            worker_sem0,
+            worker_sem1,
+            static_cast<uint32_t>(device->physical_core_from_logical_core(eth_receiver_core, CoreType::ETH).x),
+            static_cast<uint32_t>(device->physical_core_from_logical_core(eth_receiver_core, CoreType::ETH).y),
+            receiver_start_semaphore
+        };
+
+        auto receiver_kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_receiver.cpp",
+            eth_receiver_core,
+            tt_metal::EthernetConfig {
+                .noc = tt_metal::NOC::RISCV_0_default,
+                .compile_args = receiver_eth_ct_args});
+        receiver_kernel_ids.push_back(receiver_kernel);
+
+        auto sender_kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_sender.cpp",
+            eth_sender_core,
+            tt_metal::EthernetConfig {
+                .noc = tt_metal::NOC::RISCV_1_default,
+                .compile_args = sender_eth_ct_args});
+        sender_kernel_ids.push_back(sender_kernel);
+
+        // This guy is only used until fast dispatch 2 is available
+        // it coordinates eth core ready states so the receiver and sender only
+        // communicate after they are initialized
+        auto worker_kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_init_coordination_worker.cpp",
+            init_worker_core,
+            tt_metal::DataMovementConfig {
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt_metal::NOC::RISCV_1_default,
+                .compile_args = {}});
+
+
+        log_trace(tt::LogOp, "-------------Hop: {}, Device: {}:", i, device->id());
+        log_trace(tt::LogOp, "Receiver Kernel Info: Receives from {} on core[logical]: (x={},y={}), [noc]: (x={},y={}):", devices.at(previous_hop)->id(), eth_receiver_core.x, eth_receiver_core.y, device->ethernet_core_from_logical_core(eth_receiver_core).x, device->ethernet_core_from_logical_core(eth_receiver_core).y);
+        log_trace(tt::LogOp, "- RT Args ({})", receiver_eth_rt_args.size());
+        for (std::size_t i = 0; i < receiver_eth_rt_args.size(); i++) {
+            log_trace(tt::LogOp, "  - {}: {}", i, receiver_eth_rt_args.at(i));
+        }
+        log_trace(tt::LogOp, "Sender Kernel Info: on core[logical]: (x={},y={}), [noc]: (x={},y={}):", eth_sender_core.x, eth_sender_core.y, device->ethernet_core_from_logical_core(eth_sender_core).x, device->ethernet_core_from_logical_core(eth_sender_core).y);
+        for (std::size_t i = 0; i < sender_eth_rt_args.size(); i++) {
+            log_trace(tt::LogOp, "  - {}: {}", i, sender_eth_rt_args.at(i));
+        }
+        log_trace(tt::LogOp, "Worker Kernel Info: on core[logical]: (x={},y={})", init_worker_core.x, init_worker_core.y);
+        for (std::size_t i = 0; i < worker_init_rt_args.size(); i++) {
+            log_trace(tt::LogOp, "  - {}: {}", i, worker_init_rt_args.at(i));
+        }
+
+        tt_metal::SetRuntimeArgs(program, receiver_kernel, eth_receiver_core, receiver_eth_rt_args);
+        tt_metal::SetRuntimeArgs(program, sender_kernel, eth_sender_core, sender_eth_rt_args);
+        log_trace(tt::LogOp, "Setting RT args for receiver. kernel_id: {}, core: (x={},y={})", receiver_kernel, eth_receiver_core.x, eth_receiver_core.y);
+        log_trace(tt::LogOp, "Setting RT args for sender. kernel_id: {}, core: (x={},y={})", sender_kernel, eth_sender_core.x, eth_sender_core.y);
+        tt_metal::SetRuntimeArgs(program, worker_kernel, init_worker_core, worker_init_rt_args);
+        log_trace(tt::LogOp, "Setting RT args for worker. kernel_id: {}, core: (x={},y={})", worker_kernel, init_worker_core.x, init_worker_core.y);
+
+        tt::tt_metal::detail::CompileProgram(device, program);
+    }
+
+    for (auto [device_ptr, program_ptr] : device_program_map) {
+        tt_metal::EnqueueProgram(device_ptr->command_queue(), *program_ptr, false);
+    }
+
+    for (auto [device_ptr, program_ptr] : device_program_map) {
+        tt_metal::Finish(device_ptr->command_queue());
+    }
+
+    for (auto [device_ptr, program_ptr] : device_program_map) {
+        tt::tt_metal::detail::DumpDeviceProfileResults(device_ptr);
+    }
+
+}
+
+}  // namespace tt_metal
+
+}  // namespace tt
+
+
+auto is_device_pcie_connected(chip_id_t device_id) {
+    return device_id < 4;
+}
+
+
+std::vector<hop_eth_sockets> build_eth_sockets_list(std::vector<Device*> const& devices) {
+    std::vector<hop_eth_sockets> sockets;
+    std::unordered_map<uint64_t, std::size_t> n_edge_visits;
+    for (std::size_t i = 0; i < devices.size(); i++) {
+        Device *curr_device = devices.at(i);
+        Device *next_device = i == devices.size() - 1 ? devices.at(0) : devices.at(i + 1);
+        uint64_t edge = (static_cast<uint64_t>(curr_device->id()) << 32) | static_cast<uint64_t>(next_device->id());
+        bool edge_needs_tunneling = !is_device_pcie_connected(curr_device->id()) || !is_device_pcie_connected(next_device->id());
+
+
+        std::size_t conn = (edge_needs_tunneling ? 0 : 0) + n_edge_visits[edge];
+        std::size_t link = 0;
+        std::unordered_map<uint64_t, int> edge_link_idx;
+        auto const& active_eth_cores = curr_device->get_active_ethernet_cores(true);
+        auto eth_sender_core_iter = active_eth_cores.begin();
+        bool found = false;
+        for (; !found && eth_sender_core_iter != active_eth_cores.end(); eth_sender_core_iter++) {
+
+            auto [device_id, receiver_core] = curr_device->get_connected_ethernet_core(*eth_sender_core_iter);
+            if (device_id == next_device->id()) {
+                uint64_t pair_edge = (static_cast<uint64_t>(curr_device->id()) << 32) | static_cast<uint64_t>(device_id);
+                if (edge_link_idx[pair_edge] == conn) {
+                    CoreCoord eth_sender_core = *eth_sender_core_iter;
+                    CoreCoord eth_receiver_core = receiver_core;
+                    chip_id_t receiver_device_id = device_id;
+                    sockets.push_back({receiver_device_id,eth_receiver_core,curr_device->id(),eth_sender_core});
+                    TT_ASSERT(receiver_device_id == next_device->id());
+                    found = true;
+                    break;
+                }
+                edge_link_idx[pair_edge]++;
+            }
+        }
+        TT_ASSERT(eth_sender_core_iter != active_eth_cores.end());
+        TT_ASSERT(found);
+
+        n_edge_visits[edge] += 1;
+    }
+
+    return sockets;
+}
+
+
+
+int main (int argc, char** argv) {
+    // num samples
+    // page sizes
+    // concurrent samples
+    // hop counts
+    // Early exit if invalid test setup
+    auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    if (num_devices != 8) {
+        log_info(tt::LogTest, "Need at least 2 devices to run this test");
+        return 0;
+    }
+    if (arch == tt::ARCH::GRAYSKULL) {
+        log_info(tt::LogTest,"Test must be run on WH");
+        return 0;
+    }
+
+    // Arg setup
+    assert(argc >= 4);
+    std::size_t arg_idx = 1;
+    std::size_t num_sample_counts = std::stoi(argv[arg_idx++]);
+    log_trace(tt::LogTest, "num_sample_counts: {}", num_sample_counts);
+    std::vector<std::size_t> sample_counts;
+    for (std::size_t i = 0; i < num_sample_counts; i++) {
+        sample_counts.push_back(std::stoi(argv[arg_idx++]));
+        log_trace(tt::LogTest, "sample_counts[{}]: {}", i, sample_counts.back());
+    }
+
+    std::size_t num_page_sizes = std::stoi(argv[arg_idx++]);
+    std::vector<std::size_t> page_sizes;
+    log_trace(tt::LogTest, "num_page_sizes: {}", num_page_sizes);
+    for (std::size_t i = 0; i < num_page_sizes; i++) {
+        page_sizes.push_back(std::stoi(argv[arg_idx++]));
+        log_trace(tt::LogTest, "page_sizes[{}]: {}", i, page_sizes.back());
+    }
+
+    std::size_t num_max_concurrent_samples = std::stoi(argv[arg_idx++]);
+    std::vector<std::size_t> max_concurrent_samples;
+    log_trace(tt::LogTest, "num_max_concurrent_samples: {}", num_max_concurrent_samples);
+    for (std::size_t i = 0; i < num_max_concurrent_samples; i++) {
+        max_concurrent_samples.push_back(std::stoi(argv[arg_idx++]));
+        log_trace(tt::LogTest, "max_concurrent_samples[{}]: {}", i, max_concurrent_samples.back());
+    }
+
+    std::size_t num_hop_counts = std::stoi(argv[arg_idx++]);
+    std::vector<uint32_t> hop_counts;
+    log_trace(tt::LogTest, "num_hop_counts: {}", num_hop_counts);
+    for (std::size_t i = 0; i < num_hop_counts; i++) {
+        hop_counts.push_back(std::stoi(argv[arg_idx++]));
+        log_trace(tt::LogTest, "hop_counts[{}]: {}", i, hop_counts.back());
+    }
+    TT_ASSERT(argc == arg_idx);
+
+    // Arg Validation
+    TT_ASSERT(std::all_of(sample_counts.begin(), sample_counts.end(), [](std::size_t n) { return n > 0; }));
+    TT_ASSERT(std::all_of(page_sizes.begin(), page_sizes.end(), [](std::size_t n) { return n > 0; }));
+    TT_ASSERT(std::all_of(page_sizes.begin(), page_sizes.end(), [](std::size_t n) { return n % 16 == 0; }));
+    TT_ASSERT(std::all_of(max_concurrent_samples.begin(), max_concurrent_samples.end(), [](std::size_t n) { return n > 0; }));
+
+    T3000TestDevice test_fixture;
+
+    // Device setup
+    std::vector<chip_id_t> device_ids = std::vector<chip_id_t>{0, 1, 2, 3, 4, 5, 6, 7};
+
+    auto get_device_list = [](std::vector<Device*> const& all_devices, std::size_t n_hops) {
+        switch (n_hops) {
+            case 2:
+                return std::vector<Device*>{all_devices[0], all_devices[1]};
+
+            case 4:
+                return std::vector<Device*>{all_devices[0], all_devices[1], all_devices[2], all_devices[3]};
+
+            case 8:
+                return std::vector<Device*>{all_devices[0], all_devices[7], all_devices[6], all_devices[1], all_devices[2], all_devices[5], all_devices[4], all_devices[3]};
+
+            case 12: // Does an extra loop through the inner ring
+                return std::vector<Device*>{all_devices[0], all_devices[7], all_devices[6], all_devices[1], all_devices[2], all_devices[3], all_devices[0], all_devices[1], all_devices[2], all_devices[5], all_devices[4], all_devices[3]};
+
+            default:
+                TT_ASSERT("Unsupported hop_count");
+                return std::vector<Device*>{};
+        };
+    };
+
+    constexpr std::size_t placeholder_arg_value = 1;
+    for (auto n_hops : hop_counts) {
+
+        auto devices = get_device_list(test_fixture.devices_, n_hops);
+        std::vector<hop_eth_sockets> hop_eth_sockets = build_eth_sockets_list(devices);
+
+        for (auto max_concurrent_samples : max_concurrent_samples) {
+            for (auto num_samples : sample_counts) {
+                for (auto sample_page_size : page_sizes) {
+                    log_trace(tt::LogTest, "Running test with num_devices={}, num_samples={}, sample_page_size={}, max_concurrent_samples={}, n_hops={}",
+                        n_hops, num_samples, sample_page_size, max_concurrent_samples, n_hops);
+                    std::vector<Program> programs = {};
+                    std::vector<KernelHandle> receiver_kernel_ids;
+                    std::vector<KernelHandle> sender_kernel_ids;
+                    tt::tt_metal::build_and_run_roundtrip_latency_test(
+                        devices,
+                        hop_eth_sockets,
+                        num_samples,
+                        sample_page_size,
+                        max_concurrent_samples,
+                        n_hops,
+
+                        programs,
+                        receiver_kernel_ids,
+                        sender_kernel_ids
+                    );
+                }
+            }
+        }
+    }
+
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_receiver.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/assert.h"
+#include "ethernet/dataflow_api.h"
+#include <array>
+
+
+struct addr_sem_pair {
+    uint32_t addr;
+    uint32_t sem_addr;
+};
+
+static constexpr bool DISABLE_CONTEXT_SWITCHING = true;
+
+template <bool measure>
+FORCE_INLINE void roundtrip_ping(
+    std::array<uint32_t, 8> channels_addrs,
+    std::array<uint32_t, 8> channels_sem_addrs,
+    uint32_t max_concurrent_samples,
+    uint32_t page_size,
+    uint32_t eth_noc_x,
+    uint32_t eth_noc_y,
+    bool is_ring_start) {
+
+    if (is_ring_start) {
+        if constexpr (measure) {
+            DeviceZoneScopedN("ROUNDTRIP-PING");
+            for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+                uint32_t sender_sem = channels_sem_addrs[i];
+                uint32_t buffer_addr = channels_addrs[i];
+                uint64_t send_buffer_noc_addr = get_noc_addr(eth_noc_x, eth_noc_y, buffer_addr);
+                uint64_t send_sem_noc_addr = get_noc_addr(eth_noc_x, eth_noc_y, sender_sem);
+
+                noc_async_write(buffer_addr, send_buffer_noc_addr, page_size);
+                noc_semaphore_inc(send_sem_noc_addr, 1);
+                eth_receiver_channel_ack(i);
+            }
+
+            eth_noc_async_write_barrier();
+
+            for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+                if constexpr(DISABLE_CONTEXT_SWITCHING) {
+                    while(!eth_bytes_are_available_on_channel(i)) {
+                        asm volatile ("");
+                    }
+                } else {
+                    eth_wait_for_bytes_on_channel(page_size, i);
+                }
+                eth_receiver_channel_done(i);
+            }
+        } else {
+            for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+                uint32_t sender_sem = channels_sem_addrs[i];
+                uint32_t buffer_addr = channels_addrs[i];
+                uint64_t send_buffer_noc_addr = get_noc_addr(eth_noc_x, eth_noc_y, buffer_addr);
+                uint64_t send_sem_noc_addr = get_noc_addr(eth_noc_x, eth_noc_y, sender_sem);
+
+                noc_async_write(buffer_addr, send_buffer_noc_addr, page_size);
+                noc_semaphore_inc(send_sem_noc_addr, 1);
+                eth_receiver_channel_ack(i);
+            }
+
+            eth_noc_async_write_barrier();
+
+            for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+                if constexpr(DISABLE_CONTEXT_SWITCHING) {
+                    while(!eth_bytes_are_available_on_channel(i)) {
+                        asm volatile ("");
+                    }
+                } else {
+                    eth_wait_for_bytes_on_channel(page_size, i);
+                }
+                eth_receiver_channel_done(i);
+            }
+
+        }
+    } else {
+        for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+            if constexpr (DISABLE_CONTEXT_SWITCHING) {
+                while(!eth_bytes_are_available_on_channel(i)) {
+                    asm volatile ("");
+                }
+            } else {
+                eth_wait_for_bytes_on_channel(page_size, i);
+            }
+            uint32_t sender_sem = channels_sem_addrs[i];
+            uint32_t buffer_addr = channels_addrs[i];
+            uint64_t send_buffer_noc_addr = get_noc_addr(eth_noc_x, eth_noc_y, buffer_addr);
+            uint64_t send_sem_noc_addr = get_noc_addr(eth_noc_x, eth_noc_y, sender_sem);
+            noc_async_write(buffer_addr, send_buffer_noc_addr, page_size);
+            noc_semaphore_inc(send_sem_noc_addr, 1);
+            eth_receiver_channel_ack(i);
+        }
+
+        eth_noc_async_write_barrier();
+
+        for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+            eth_receiver_channel_done(i);
+        }
+    }
+}
+
+FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        eth_wait_for_receiver_done();
+    } else {
+        eth_wait_for_bytes(16);
+        eth_receiver_channel_done(0);
+    }
+}
+
+void kernel_main() {
+    std::array<uint32_t, 8> channels_addrs;
+    std::array<uint32_t, 8> channels_sem_addrs;
+    uint32_t arg_idx = 0;
+    const bool is_ring_start = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_samples = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t max_concurrent_samples = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t transfer_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t eth_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t eth_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    volatile uint32_t* start_semaphore = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t init_handshake_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t init_handshake_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t init_handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    ASSERT(max_concurrent_samples <= 8);
+    for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+        channels_addrs[i] = get_arg_val<uint32_t>(arg_idx++);
+        channels_sem_addrs[i] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    eth_setup_handshake(handshake_addr, false);
+    // Delete me when migrating to FD2 - for now we require a worker core to act as intermediary between local chip eriscs
+    // because CreateSemaphore doesn't reliably worker on ethernet cores prior to FD2
+    *start_semaphore = 0;
+    // Delete me when migrating to FD2
+    uint64_t init_handshake_noc_addr = get_noc_addr(init_handshake_noc_x, init_handshake_noc_y, init_handshake_addr);
+    // Delete me when migrating to FD2
+    noc_semaphore_inc(init_handshake_noc_addr, 1);
+
+    eth_noc_semaphore_wait(start_semaphore, 1);
+
+    // Clear the ring
+    roundtrip_ping<false>(channels_addrs, channels_sem_addrs, max_concurrent_samples, 16, eth_noc_x, eth_noc_y, is_ring_start);
+
+    {
+        for (uint32_t i = 0; i < num_samples; i++) {
+            roundtrip_ping<true>(channels_addrs, channels_sem_addrs, max_concurrent_samples, transfer_size, eth_noc_x, eth_noc_y, is_ring_start);
+        }
+    }
+
+    if (is_ring_start) {
+        for (uint i = 0; i < 10000; i++) {
+            DeviceZoneScopedN("ZONE-SCOPE_OVERHEAD");
+        }
+    }
+
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_sender.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "dataflow_api.h"
+#include "debug/assert.h"
+#include <array>
+#include "ethernet/dataflow_api.h"
+
+
+struct addr_sem_pair {
+    uint32_t addr;
+    uint32_t sem_addr;
+};
+
+static constexpr bool DISABLE_CONTEXT_SWITCHING = true;
+
+FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        eth_wait_for_receiver_done();
+    } else {
+        eth_wait_for_bytes(16);
+        eth_receiver_channel_done(0);
+    }
+}
+
+template <bool measure>
+FORCE_INLINE void forward_ping(std::array<uint32_t, 8> const& channels_addrs, std::array<uint32_t, 8> const& channels_sem_addrs, uint32_t max_concurrent_samples, uint32_t page_size) {
+
+    for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+        volatile uint32_t *sem_addr = reinterpret_cast<volatile uint32_t*>(channels_sem_addrs[i]);
+        uint32_t buffer_addr = channels_addrs[i];
+        if constexpr (DISABLE_CONTEXT_SWITCHING) {
+            noc_semaphore_wait(sem_addr, 1);
+        } else {
+            eth_noc_semaphore_wait(sem_addr, 1);
+        }
+        *sem_addr = 0;
+        eth_send_bytes_over_channel(buffer_addr, buffer_addr, page_size, i);
+    }
+    for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+        if constexpr (DISABLE_CONTEXT_SWITCHING) {
+            while (!eth_is_receiver_channel_send_done(i)) {
+                asm volatile ("");
+            }
+        } else {
+            eth_wait_for_receiver_channel_done(i);
+        }
+    }
+}
+
+
+void kernel_main() {
+    std::array<uint32_t, 8> channels_addrs;
+    std::array<uint32_t, 8> channels_sem_addrs;
+    uint32_t arg_idx = 0;
+    const bool is_ring_start = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_samples = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t max_concurrent_samples = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t transfer_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t local_receiver_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t local_receiver_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t receiver_start_semaphore = get_arg_val<uint32_t>(arg_idx++);
+
+    ASSERT(max_concurrent_samples <= 8);
+    for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+        channels_addrs[i] = get_arg_val<uint32_t>(arg_idx++);
+        channels_sem_addrs[i] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    for (uint32_t i = 0; i < max_concurrent_samples; i++) {
+        *(volatile uint32_t*)channels_sem_addrs[i] = 0;
+    }
+
+    {
+    eth_setup_handshake(handshake_addr, true);
+    }
+
+    uint64_t receiver_start_semaphore_noc_addr = get_noc_addr(local_receiver_noc_x, local_receiver_noc_y, receiver_start_semaphore);
+    noc_semaphore_inc(receiver_start_semaphore_noc_addr, 1);
+
+    // Clear the ring
+    forward_ping<false>(channels_addrs, channels_sem_addrs, max_concurrent_samples, 16);
+
+    for (uint32_t i = 0; i < num_samples; i++) {
+        forward_ping<true>(channels_addrs, channels_sem_addrs, max_concurrent_samples, transfer_size);
+    }
+
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_init_coordination_worker.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_init_coordination_worker.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/assert.h"
+#include "debug/dprint.h"
+#include "dataflow_api.h"
+#include <array>
+
+
+void kernel_main() {
+    std::array<uint32_t, 8> channels_addrs;
+    std::array<uint32_t, 8> channels_sem_addrs;
+    uint32_t arg_idx = 0;
+    volatile uint32_t* sem0 = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
+    volatile uint32_t* sem1 = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t core0_x = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t core0_y = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t core0_start_sem = get_arg_val<uint32_t>(arg_idx++);
+
+    noc_semaphore_wait(sem0, 1);
+    noc_semaphore_wait(sem1, 1);
+
+    uint64_t core0_start_sem_noc_addr = get_noc_addr(core0_x, core0_y, core0_start_sem);
+
+    noc_semaphore_inc(core0_start_sem_noc_addr, 1);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_bidirectional_ubench.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_bidirectional_ubench.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <array>
+#include "eth_l1_address_map.h"
+#include "ethernet/dataflow_api.h"
+#include "debug/assert.h"
+
+FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
+    if (is_sender) {
+        eth_send_bytes(handshake_register_address, handshake_register_address, 16);
+        eth_wait_for_receiver_done();
+    } else {
+        eth_wait_for_bytes(16);
+        eth_receiver_channel_done(0);
+    }
+}
+
+static constexpr uint32_t MAX_CHANNELS = 8;
+void kernel_main() {
+    uint32_t arg_idx = 0;
+    const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_messages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t message_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_channels = get_arg_val<uint32_t>(arg_idx++);
+    bool is_sender_offset_0 = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const uint32_t message_size_eth_words = message_size >> 4;
+
+    ASSERT(num_channels * 2 <= 8);
+
+    std::array<uint32_t, MAX_CHANNELS> messages_complete;
+    std::array<uint32_t, MAX_CHANNELS> channel_addrs;
+    {
+        uint32_t channel_addr = handshake_addr + sizeof(eth_channel_sync_t);
+        for (uint8_t i = 0; i < num_channels*2; i++) {
+            messages_complete[i] = 0;
+            channel_addrs[i] = channel_addr;
+            channel_addr += message_size;
+        }
+    }
+
+    const uint32_t last_channel = num_channels - 1;
+    uint32_t channels_complete = 0;
+    uint8_t senders_start = is_sender_offset_0 ? 0 : num_channels;
+    uint8_t receivers_start = is_sender_offset_0 ? num_channels : 0;
+    uint8_t senders_end = senders_start + num_channels;
+    uint8_t receivers_end = receivers_start + num_channels;
+
+    eth_setup_handshake(handshake_addr, is_sender_offset_0);
+
+    uint32_t ready_to_send_payload = (1 << num_channels) - 1;
+    uint32_t ready_to_send_payload_available = 0;
+    uint32_t wait_ack = 0;
+
+    uint32_t idle_count = 0;
+    uint32_t idle_max = 1000000000;
+    {
+        DeviceZoneScopedN("MAIN-TEST-BODY");
+        uint32_t i = 0;
+        while (channels_complete < num_channels*2) {
+            uint32_t sender_channel = senders_start + i;
+
+            // Sender
+            const bool try_send_payload = (ready_to_send_payload >> i) & 0x1;
+            if (try_send_payload && !eth_txq_is_busy()) {
+                eth_send_bytes_over_channel_payload_only(
+                    channel_addrs[sender_channel],
+                    channel_addrs[sender_channel],
+                    message_size,
+                    sender_channel,
+                    message_size,
+                    message_size_eth_words);
+                ready_to_send_payload &= ~(1 << i);
+                ready_to_send_payload_available |= (1 << i);
+                idle_count = 0;
+            }
+
+            const bool try_send_payload_available = (ready_to_send_payload_available >> i) & 0x1;
+            if (try_send_payload_available && !eth_txq_is_busy()) {
+                eth_send_payload_complete_signal_over_channel(
+                    sender_channel, message_size);
+                ready_to_send_payload_available &= ~(1 << i);
+                wait_ack |= (1 << i);
+                idle_count = 0;
+            }
+
+            const bool sender_check_ack = (wait_ack >> i) & 0x1;
+            if (sender_check_ack) {
+                bool acked = eth_is_receiver_channel_send_done(sender_channel);
+                if (acked) {
+                    messages_complete[sender_channel]++;
+                    wait_ack &= ~(1 << i);
+                    if (messages_complete[sender_channel] == num_messages) {
+                        channels_complete++;
+                    } else {
+                        ready_to_send_payload |= 1 << i;
+                    }
+                    idle_count = 0;
+                }
+            }
+
+            // Receiver
+            uint8_t receiver_channel = receivers_start + i;
+            if (eth_bytes_are_available_on_channel(receiver_channel)) {
+                if (!eth_txq_is_busy()) {
+                    eth_receiver_channel_done(receiver_channel);
+                    messages_complete[receiver_channel]++;
+                    if (messages_complete[receiver_channel] == num_messages) {
+                        channels_complete++;
+                    }
+                    idle_count = 0;
+                }
+            }
+
+            i = i == last_channel ? 0 : i + 1;
+
+            idle_count++;
+            if (idle_count > idle_max) {
+                run_routing();
+                idle_count = 0;
+            }
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
- Bidirectional bandwidth microbenchmarks
   - This benchmark replays buffers from local erisc over the ethernet link. No data integrity check (since we don't have overheads of receiving data from noc)
   - Peak acheived was ~21.3GBps for best configuration
   - No IRAM support enabled yet

```
TT_METAL_DEVICE_PROFILER=1 {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm {num_samples}  {sample_size}  {num_channels}
```  

Latency benchmark:
```
TT_METAL_DEVICE_PROFILER=1  ./build/test/tt_metal/perf_microbenchmark/test_ethernet_hop_latencies_no_edm  {len(sample_counts)} {sample_counts_str}    {len(page_sizes)} {page_sizes_str}   {len(channel_counts)} 
 {channel_counts_str}   {len(hop_counts)} {hop_counts_str}
```


Initial Latency Results:
https://docs.google.com/spreadsheets/d/16gRDxhMGRUYQbLZeGcjvmWUY5onnmWM-b3Zfa4jJCX8/edit?usp=sharing
<img width="877" alt="image" src="https://github.com/tenstorrent/tt-metal/assets/1865303/77196c1e-a5b4-4377-a954-32cb79a9bf34">

<img width="877" alt="image" src="https://github.com/tenstorrent/tt-metal/assets/1865303/55cf3875-b0ed-45df-b0cf-5042840c83db">

<img width="660" alt="image" src="https://github.com/tenstorrent/tt-metal/assets/1865303/95720556-1ae6-456b-9aed-507e9207cbd7">

<img width="605" alt="image" src="https://github.com/tenstorrent/tt-metal/assets/1865303/0bc7a908-47df-416e-bfd0-508bbc8a6184">


