### PR TITLE
TTNN sweep fixed and INT32, UINT16 sweeps support

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/run_pytorch_test.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/run_pytorch_test.py
@@ -33,6 +33,7 @@ DTYPES_TT_DICT = {
     "BFLOAT8_B": tt_lib.tensor.DataType.BFLOAT8_B,
     "UINT32": tt_lib.tensor.DataType.UINT32,
     "UINT16": tt_lib.tensor.DataType.UINT16,
+    "INT32": tt_lib.tensor.DataType.INT32,
 }
 
 LAYOUTS_TT_DICT = {

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_nextafter.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_nextafter.yaml
@@ -5,7 +5,7 @@ test-list:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
-        num-dims: [3]
+        num-dims: [4]
         num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_nextafter.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_nextafter.yaml
@@ -5,7 +5,7 @@ test-list:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
-        num-dims: [3]
+        num-dims: [4]
         num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_acos_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_acos_test.yaml
@@ -7,7 +7,7 @@ test-list:
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
         num-shapes: 1
-        num-samples: 128
+        num-samples: 64
         args-sampling-strategy: "all"
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -25,3 +25,28 @@ test-list:
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_acos_sweep.csv
+  - ttnn-acos:
+      shape:
+        start-shape: [1, 1, 1, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-dims: [2, 3, 4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -1
+          high: 1
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      output-file: eltwise_acos_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_cos_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_cos_test.yaml
@@ -7,7 +7,7 @@ test-list:
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
         num-shapes: 1
-        num-samples: 128
+        num-samples: 64
         args-sampling-strategy: "all"
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -25,3 +25,28 @@ test-list:
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cos_sweep.csv
+  - ttnn-cos:
+      shape:
+        start-shape: [1, 1, 1, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-dims: [2, 3, 4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: 0
+          high: 6.283185307179586
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      output-file: eltwise_cos_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_exp_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_exp_test.yaml
@@ -20,7 +20,7 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       args:
-        data-layout: ["TILE"]
+        data-layout: ["TILE", "ROW_MAJOR"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_exp_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_exp_test.yaml
@@ -7,7 +7,7 @@ test-list:
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
         num-shapes: 1
-        num-samples: 128
+        num-samples: 64
         args-sampling-strategy: "all"
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -20,8 +20,33 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       args:
-        data-layout: ["TILE", "ROW_MAJOR"]
+        data-layout: ["TILE"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_exp_sweep.csv
+  - ttnn-exp:
+      shape:
+        start-shape: [1, 1, 1, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-dims: [2, 3, 4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -10
+          high: 10
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      output-file: eltwise_exp_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_nextafter.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_nextafter.yaml
@@ -5,7 +5,7 @@ test-list:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
-        num-dims: [3]
+        num-dims: [4]
         num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_repeat_interleave_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_repeat_interleave_test.yaml
@@ -7,7 +7,7 @@ test-list:
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
         num-shapes: 1
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -21,7 +21,7 @@ test-list:
       args-gen: gen_ttnn_repeat_interleave_args
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        data-type: ["BFLOAT16", "BFLOAT8_B", "UINT32", "INT32", "UINT16"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
       output-file: repeat_interleave_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_acos_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_acos_test.yaml
@@ -7,7 +7,7 @@ test-list:
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
         num-shapes: 1
-        num-samples: 128
+        num-samples: 64
         args-sampling-strategy: "all"
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -25,3 +25,28 @@ test-list:
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_acos_sweep.csv
+  - ttnn-acos:
+      shape:
+        start-shape: [1, 1, 1, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-dims: [2, 3, 4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -1
+          high: 1
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      output-file: eltwise_acos_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_cos_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_cos_test.yaml
@@ -7,7 +7,7 @@ test-list:
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
         num-shapes: 1
-        num-samples: 128
+        num-samples: 64
         args-sampling-strategy: "all"
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -25,3 +25,28 @@ test-list:
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_cos_sweep.csv
+  - ttnn-cos:
+      shape:
+        start-shape: [1, 1, 1, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-dims: [2, 3, 4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: 0
+          high: 6.283185307179586
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      output-file: eltwise_cos_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_exp_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_exp_test.yaml
@@ -20,7 +20,7 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       args:
-        data-layout: ["TILE"]
+        data-layout: ["TILE", "ROW_MAJOR"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_exp_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_exp_test.yaml
@@ -7,7 +7,7 @@ test-list:
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
         num-shapes: 1
-        num-samples: 128
+        num-samples: 64
         args-sampling-strategy: "all"
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -20,8 +20,33 @@ test-list:
         function: comp_pcc
       args-gen: gen_dtype_layout_device
       args:
-        data-layout: ["TILE", "ROW_MAJOR"]
+        data-layout: ["TILE"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
       output-file: eltwise_exp_sweep.csv
+  - ttnn-exp:
+      shape:
+        start-shape: [1, 1, 1, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-dims: [2, 3, 4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -10
+          high: 10
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      output-file: eltwise_exp_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_nextafter.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_nextafter.yaml
@@ -5,7 +5,7 @@ test-list:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
-        num-dims: [3]
+        num-dims: [4]
         num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_repeat_interleave_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_repeat_interleave_test.yaml
@@ -7,7 +7,7 @@ test-list:
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
         num-shapes: 1
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -21,7 +21,7 @@ test-list:
       args-gen: gen_ttnn_repeat_interleave_args
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        data-type: ["BFLOAT16", "BFLOAT8_B", "UINT32", "INT32", "UINT16"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
       output-file: repeat_interleave_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -47,6 +47,9 @@ def dtype_to_ttnn(dtype):
     elif dtype == tt_lib.tensor.DataType.UINT16:
         return ttnn.uint16
 
+    elif dtype == tt_lib.tensor.DataType.INT32:
+        return ttnn.int32
+
     else:
         assert False, "Unknown dtype passed"
 


### PR DESCRIPTION
Fixed YAMLs for:
- nextfater
- repeat_interleave
- Added ROW_MAJOR support to exp, cos, acos op
- Added support for UINT16 and INT32 inside YAMLs
