### PR TITLE
Add support for dispatching out of eth cores 

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -41,7 +41,7 @@ jobs:
         run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: ${{ matrix.test-group.name }} tests
-        timeout-minutes: 15
+        timeout-minutes: 30
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME

--- a/tests/scripts/run_cpp_unit_tests.sh
+++ b/tests/scripts/run_cpp_unit_tests.sh
@@ -13,6 +13,9 @@ if [[ ! -z "$TT_METAL_SLOW_DISPATCH_MODE" ]]; then
     env python tests/scripts/run_tt_eager.py --dispatch-mode slow
 else
     ./build/test/tt_metal/unit_tests_fast_dispatch
+    if [[ "$ARCH_NAME" == "wormhole_b0" ]]; then
+        WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="-*WatcherFixture.*:*DPrintFixture.*:*DPrintErrorChecking.*:*DPrintFixtureDisableDevices.*"
+    fi
     # env python tests/scripts/run_tt_eager.py --dispatch-mode fast
     # env python tests/scripts/run_tt_metal.py --dispatch-mode fast
 fi

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_multichip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_multichip.cpp
@@ -66,7 +66,7 @@ bool warmup_g = false;
 bool debug_g;
 uint32_t max_prefetch_command_size_g;
 
-uint32_t dispatch_buffer_page_size_g = 1 << DISPATCH_BUFFER_LOG_PAGE_SIZE;
+uint32_t dispatch_buffer_page_size_g = 1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE;
 uint32_t prefetch_q_entries_g;
 uint32_t hugepage_issue_buffer_size_g;
 void * host_hugepage_completion_buffer_base_g;
@@ -122,7 +122,7 @@ void init(int argc, char **argv) {
         log_info(LogTest, "  -hp: host huge page issue buffer size (default {})", DEFAULT_HUGEPAGE_ISSUE_BUFFER_SIZE);
         log_info(LogTest, "  -pq: prefetch queue entries (default {})", DEFAULT_PREFETCH_Q_ENTRIES);
         log_info(LogTest, "  -cs: cmddat q size (default {})", DEFAULT_CMDDAT_Q_SIZE);
-        log_info(LogTest, "-pdcs: prefetch_d cmddat cb size (default {})", PREFETCH_D_BUFFER_SIZE);
+        log_info(LogTest, "-pdcs: prefetch_d cmddat cb size (default {})", dispatch_constants::PREFETCH_D_BUFFER_SIZE);
         log_info(LogTest, "  -ss: scratch cb size (default {})", DEFAULT_SCRATCH_DB_SIZE);
         log_info(LogTest, "  -mc: max command size (default {})", DEFAULT_MAX_PREFETCH_COMMAND_SIZE);
         log_info(LogTest, " -pcies: size of data to transfer in pcie bw test type (default: {})", PCIE_TRANSFER_SIZE_DEFAULT);
@@ -151,7 +151,7 @@ void init(int argc, char **argv) {
     pcie_transfer_size_g = test_args::get_command_option_uint32(input_args, "-pcies", PCIE_TRANSFER_SIZE_DEFAULT);
     dram_page_size_g = test_args::get_command_option_uint32(input_args, "-dpgs", DRAM_PAGE_SIZE_DEFAULT);
     dram_pages_to_read_g = test_args::get_command_option_uint32(input_args, "-dpgr", DRAM_PAGES_TO_READ_DEFAULT);
-    prefetch_d_buffer_size_g = test_args::get_command_option_uint32(input_args, "-pdcs", PREFETCH_D_BUFFER_SIZE);
+    prefetch_d_buffer_size_g = test_args::get_command_option_uint32(input_args, "-pdcs", dispatch_constants::PREFETCH_D_BUFFER_SIZE);
 
     test_type_g = test_args::get_command_option_uint32(input_args, "-t", DEFAULT_TEST_TYPE);
     all_workers_g.end.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end.x);
@@ -354,8 +354,8 @@ void add_prefetcher_cmd_to_hostq(vector<uint32_t>& cmds,
     }
     uint32_t new_size = (cmds.size() - prior_end) * sizeof(uint32_t);
     TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((new_size >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
-    sizes.push_back(new_size >> PREFETCH_Q_LOG_MINSIZE);
+    TT_ASSERT((new_size >> dispatch_constants::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
+    sizes.push_back(new_size >> dispatch_constants::PREFETCH_Q_LOG_MINSIZE);
 }
 
 void add_prefetcher_cmd(vector<uint32_t>& cmds,
@@ -535,8 +535,8 @@ void gen_dram_read_cmd(Device *device,
 
     uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
     TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((new_size >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
-    cmd_sizes.push_back(new_size >> PREFETCH_Q_LOG_MINSIZE);
+    TT_ASSERT((new_size >> dispatch_constants::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
+    cmd_sizes.push_back(new_size >> dispatch_constants::PREFETCH_Q_LOG_MINSIZE);
 
     // Model the paged read in this function by updating worker data with interleaved/paged DRAM data, for validation later.
     add_paged_dram_data_to_worker_data(dram_data_map, worker_core, worker_data, start_page, base_addr, page_size, pages, length_adjust);
@@ -590,8 +590,8 @@ void gen_linear_read_cmd(Device *device,
 
     uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
     TT_ASSERT(new_size <= max_prefetch_command_size_g, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((new_size >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
-    cmd_sizes.push_back(new_size >> PREFETCH_Q_LOG_MINSIZE);
+    TT_ASSERT((new_size >> dispatch_constants::PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "HostQ command too large to represent");
+    cmd_sizes.push_back(new_size >> dispatch_constants::PREFETCH_Q_LOG_MINSIZE);
 
     // Add linear data to worker data:
     uint32_t length_words = length / sizeof(uint32_t);
@@ -1096,7 +1096,7 @@ void write_prefetcher_cmd(Device *device,
 
     static vector<uint32_t> read_vec;  // static to avoid realloc
 
-    uint32_t cmd_size_bytes = (uint32_t)cmd_size16b << PREFETCH_Q_LOG_MINSIZE;
+    uint32_t cmd_size_bytes = (uint32_t)cmd_size16b << dispatch_constants::PREFETCH_Q_LOG_MINSIZE;
     uint32_t cmd_size_words = cmd_size_bytes / sizeof(uint32_t);
 
     for (uint32_t i = 0; i < cmd_size_words; i++) {
@@ -1114,7 +1114,7 @@ void write_prefetcher_cmd(Device *device,
     }
 
     // wrap
-    if (prefetch_q_dev_ptr == prefetch_q_base + prefetch_q_entries_g * sizeof(prefetch_q_entry_type)) {
+    if (prefetch_q_dev_ptr == prefetch_q_base + prefetch_q_entries_g * sizeof(dispatch_constants::prefetch_q_entry_type)) {
         prefetch_q_dev_ptr = prefetch_q_base;
 
         while (prefetch_q_dev_ptr == prefetch_q_dev_fence) {
@@ -1125,7 +1125,7 @@ void write_prefetcher_cmd(Device *device,
 
     tt::Cluster::instance().write_reg(&cmd_size16b, tt_cxy_pair(device->id(), phys_prefetch_core), prefetch_q_dev_ptr);
 
-    prefetch_q_dev_ptr += sizeof(prefetch_q_entry_type);
+    prefetch_q_dev_ptr += sizeof(dispatch_constants::prefetch_q_entry_type);
 }
 
 void write_prefetcher_cmds(uint32_t iterations,
@@ -1155,20 +1155,20 @@ void write_prefetcher_cmds(uint32_t iterations,
         vector<uint32_t> prefetch_q(DEFAULT_PREFETCH_Q_ENTRIES, 0);
         vector<uint32_t> prefetch_q_rd_ptr_addr_data;
 
-        prefetch_q_rd_ptr_addr_data.push_back(prefetch_q_base + prefetch_q_entries_g * sizeof(prefetch_q_entry_type));
+        prefetch_q_rd_ptr_addr_data.push_back(prefetch_q_base + prefetch_q_entries_g * sizeof(dispatch_constants::prefetch_q_entry_type));
         llrt::write_hex_vec_to_core(device->id(), phys_prefetch_core, prefetch_q_rd_ptr_addr_data, prefetch_q_rd_ptr_addr);
         llrt::write_hex_vec_to_core(device->id(), phys_prefetch_core, prefetch_q, prefetch_q_base);
 
         host_mem_ptr = (uint32_t *)host_hugepage_base;
         prefetch_q_dev_ptr = prefetch_q_base;
-        prefetch_q_dev_fence = prefetch_q_base + prefetch_q_entries_g * sizeof(prefetch_q_entry_type);
+        prefetch_q_dev_fence = prefetch_q_base + prefetch_q_entries_g * sizeof(dispatch_constants::prefetch_q_entry_type);
         initialize_device_g = false;
     }
 
     for (uint32_t i = 0; i < iterations; i++) {
         uint32_t cmd_ptr = 0;
         for (uint32_t j = 0; j < cmd_sizes.size(); j++) {
-            uint32_t cmd_size_words = ((uint32_t)cmd_sizes[j] << PREFETCH_Q_LOG_MINSIZE) / sizeof(uint32_t);
+            uint32_t cmd_size_words = ((uint32_t)cmd_sizes[j] << dispatch_constants::PREFETCH_Q_LOG_MINSIZE) / sizeof(uint32_t);
             uint32_t space_at_end_for_wrap_words = CQ_PREFETCH_CMD_BARE_MIN_SIZE / sizeof(uint32_t);
             if ((void *)(host_mem_ptr + cmd_size_words) > (void *)((uint8_t *)host_hugepage_base + hugepage_issue_buffer_size_g)) {
                 // Wrap huge page
@@ -1267,7 +1267,8 @@ int main(int argc, char **argv) {
 
     init(argc, argv);
 
-    uint32_t dispatch_buffer_pages = DISPATCH_BUFFER_BLOCK_SIZE_PAGES * DISPATCH_BUFFER_SIZE_BLOCKS;
+    const CoreType dispatch_core_type = CoreType::WORKER;
+    uint32_t dispatch_buffer_pages = dispatch_constants::get(dispatch_core_type).dispatch_buffer_block_size_pages() * dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS;
 
     bool pass = true;
     try {
@@ -1340,20 +1341,20 @@ int main(int argc, char **argv) {
         uint32_t tunneler_test_results_size = 0x8000;
 
         // Want different buffers on each core, instead use big buffer and self-manage it
-        uint32_t l1_unreserved_base_aligned = align(DISPATCH_L1_UNRESERVED_BASE, (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE)); // Was not aligned, lately.
-        uint32_t l1_buf_base = l1_unreserved_base_aligned + (1 << DISPATCH_BUFFER_LOG_PAGE_SIZE); // Reserve a page.
-        TT_ASSERT((l1_buf_base & ((1 << DISPATCH_BUFFER_LOG_PAGE_SIZE) - 1)) == 0);
+        uint32_t l1_unreserved_base_aligned = align(DISPATCH_L1_UNRESERVED_BASE, (1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE)); // Was not aligned, lately.
+        uint32_t l1_buf_base = l1_unreserved_base_aligned + (1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE); // Reserve a page.
+        TT_ASSERT((l1_buf_base & ((1 << dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE) - 1)) == 0);
 
         uint32_t dispatch_buffer_base = l1_buf_base;
         uint32_t prefetch_d_buffer_base = l1_buf_base;
-        uint32_t prefetch_d_buffer_pages = prefetch_d_buffer_size_g >> PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+        uint32_t prefetch_d_buffer_pages = prefetch_d_buffer_size_g >> dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
         uint32_t prefetch_q_base = l1_buf_base;
         uint32_t prefetch_q_rd_ptr_addr = l1_unreserved_base_aligned;
         dispatch_wait_addr_g = l1_unreserved_base_aligned + 16;
         vector<uint32_t>zero_data(0);
         llrt::write_hex_vec_to_core(device->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
 
-        uint32_t prefetch_q_size = prefetch_q_entries_g * sizeof(prefetch_q_entry_type);
+        uint32_t prefetch_q_size = prefetch_q_entries_g * sizeof(dispatch_constants::prefetch_q_entry_type);
         uint32_t noc_read_alignment = 32;
         uint32_t cmddat_q_base = prefetch_q_base + ((prefetch_q_size + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
 
@@ -1440,14 +1441,14 @@ int main(int argc, char **argv) {
 
         std::vector<uint32_t> prefetch_compile_args = {
             dispatch_buffer_base, // overridden below for prefetch_h
-            DISPATCH_BUFFER_LOG_PAGE_SIZE, // overridden below for prefetch_h
+            dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE, // overridden below for prefetch_h
             dispatch_buffer_pages, // overridden below for prefetch_h
             prefetch_downstream_cb_sem, // overridden below for prefetch_d
             dispatch_cb_sem, // overridden below for prefetch_h
             dev_hugepage_base_g,
             hugepage_issue_buffer_size_g,
             prefetch_q_base,
-            prefetch_q_entries_g * (uint32_t)sizeof(prefetch_q_entry_type),
+            prefetch_q_entries_g * (uint32_t)sizeof(dispatch_constants::prefetch_q_entry_type),
             prefetch_q_rd_ptr_addr,
             cmddat_q_base, // overridden for split below
             cmddat_q_size_g, // overridden for split below
@@ -1457,8 +1458,8 @@ int main(int argc, char **argv) {
             prefetch_d_buffer_pages, // prefetch_d only
             prefetch_d_upstream_cb_sem, // prefetch_d only
             prefetch_downstream_cb_sem, // prefetch_d only
-            PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
-            PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
+            dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
+            dispatch_constants::PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
         };
 
         if (split_prefetcher_g) {
@@ -1466,13 +1467,13 @@ int main(int argc, char **argv) {
             log_info(LogTest, "split prefetcher test, packetized_path_en={}", packetized_path_en_g);
 
             // prefetch_d
-            uint32_t scratch_db_base = prefetch_d_buffer_base + (((prefetch_d_buffer_pages << PREFETCH_D_BUFFER_LOG_PAGE_SIZE) +
+            uint32_t scratch_db_base = prefetch_d_buffer_base + (((prefetch_d_buffer_pages << dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE) +
                                                                   noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
             TT_ASSERT(scratch_db_base < 1024 * 1024); // L1 size
 
             prefetch_compile_args[3] = prefetch_d_downstream_cb_sem;
             prefetch_compile_args[10] = prefetch_d_buffer_base;
-            prefetch_compile_args[11] = prefetch_d_buffer_pages * (1 << PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
+            prefetch_compile_args[11] = prefetch_d_buffer_pages * (1 << dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
             prefetch_compile_args[12] = scratch_db_base;
 
             CoreCoord phys_prefetch_d_upstream_core =
@@ -1487,7 +1488,7 @@ int main(int argc, char **argv) {
 
             // prefetch_h
             prefetch_compile_args[0] = prefetch_d_buffer_base;
-            prefetch_compile_args[1] = PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+            prefetch_compile_args[1] = dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
             prefetch_compile_args[2] = prefetch_d_buffer_pages;
             prefetch_compile_args[3] = prefetch_downstream_cb_sem;
             prefetch_compile_args[4] = prefetch_d_upstream_cb_sem;
@@ -1570,7 +1571,7 @@ int main(int argc, char **argv) {
                     0x0,// 18: output_depacketize info
                     // 19: input 0 packetize info:
                     packet_switch_4B_pack(0x1,
-                                        DISPATCH_BUFFER_LOG_PAGE_SIZE,
+                                        dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE,
                                         prefetch_d_upstream_cb_sem, // local sem
                                         prefetch_downstream_cb_sem), // upstream sem
                     packet_switch_4B_pack(0, 0, 0, 0), // 20: input 1 packetize info
@@ -1722,7 +1723,7 @@ int main(int argc, char **argv) {
                         timeout_mcycles * 1000 * 1000, // 24: timeout_cycles
                         0x1, // 25: output_depacketize_mask
                         // 26: output 0 packetize info:
-                        packet_switch_4B_pack(DISPATCH_BUFFER_LOG_PAGE_SIZE,
+                        packet_switch_4B_pack(dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE,
                                             prefetch_downstream_cb_sem, // local sem
                                             prefetch_d_upstream_cb_sem, // downstream sem
                                             0),
@@ -1762,17 +1763,17 @@ int main(int argc, char **argv) {
 
         std::vector<uint32_t> dispatch_compile_args = {
              dispatch_buffer_base,
-             DISPATCH_BUFFER_LOG_PAGE_SIZE,
-             DISPATCH_BUFFER_SIZE_BLOCKS * DISPATCH_BUFFER_BLOCK_SIZE_PAGES,
+             dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE,
+             dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS * dispatch_constants::get(dispatch_core_type).dispatch_buffer_block_size_pages(),
              dispatch_cb_sem, // overridden below for h
              split_prefetcher_g ? prefetch_d_downstream_cb_sem : prefetch_downstream_cb_sem,
-             DISPATCH_BUFFER_SIZE_BLOCKS,
+             dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS,
              prefetch_sync_sem,
              dev_hugepage_base_g,
              dev_hugepage_completion_buffer_base,
              DEFAULT_HUGEPAGE_COMPLETION_BUFFER_SIZE,
              dispatch_buffer_base,
-             DISPATCH_BUFFER_LOG_PAGE_SIZE * dispatch_buffer_pages,
+             dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE * dispatch_buffer_pages,
              0, // unused on hd, filled in below for h and d
              0, // unused on hd, filled in below for h and d
              0, // unused unless tunneler is between h and d

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -358,7 +358,7 @@ TEST_F(CommandQueueSingleCardFixture, TestPageLargerThanAndUnalignedToTransferPa
     for (Device *device : devices_) {
         TestBufferConfig config = {
             .num_pages = num_round_robins * (device->num_banks(BufferType::DRAM)),
-            .page_size = TRANSFER_PAGE_SIZE + 32,
+            .page_size = dispatch_constants::TRANSFER_PAGE_SIZE + 32,
             .buftype = BufferType::DRAM
         };
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(device, device->command_queue(), config);
@@ -368,9 +368,11 @@ TEST_F(CommandQueueSingleCardFixture, TestPageLargerThanAndUnalignedToTransferPa
 TEST_F(CommandQueueSingleCardFixture, TestPageLargerThanMaxPrefetchCommandSize) {
     constexpr uint32_t num_round_robins = 1;
     for (Device *device : devices_) {
+        CoreType dispatch_core_type = dispatch_core_manager::get(device->num_hw_cqs()).get_dispatch_core_type(device->id());
+        const uint32_t max_prefetch_command_size = dispatch_constants::get(dispatch_core_type).max_prefetch_command_size();
         TestBufferConfig config = {
             .num_pages = 1,
-            .page_size = MAX_PREFETCH_COMMAND_SIZE + 2048,
+            .page_size = max_prefetch_command_size + 2048,
             .buftype = BufferType::DRAM
         };
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(device, device->command_queue(), config);
@@ -379,8 +381,10 @@ TEST_F(CommandQueueSingleCardFixture, TestPageLargerThanMaxPrefetchCommandSize) 
 
 TEST_F(CommandQueueSingleCardFixture, TestUnalignedPageLargerThanMaxPrefetchCommandSize) {
     constexpr uint32_t num_round_robins = 1;
-    uint32_t unaligned_page_size = MAX_PREFETCH_COMMAND_SIZE + 4;
     for (Device *device : devices_) {
+        CoreType dispatch_core_type = dispatch_core_manager::get(device->num_hw_cqs()).get_dispatch_core_type(device->id());
+        const uint32_t max_prefetch_command_size = dispatch_constants::get(dispatch_core_type).max_prefetch_command_size();
+        uint32_t unaligned_page_size = max_prefetch_command_size + 4;
         TestBufferConfig config = {
             .num_pages = 1,
             .page_size = unaligned_page_size,

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
@@ -18,7 +18,7 @@ enum class DataMovementMode: uint8_t {
 };
 
 constexpr uint32_t completion_queue_event_offset = sizeof(CQDispatchCmd);
-constexpr uint32_t completion_queue_page_size = TRANSFER_PAGE_SIZE;
+constexpr uint32_t completion_queue_page_size = dispatch_constants::TRANSFER_PAGE_SIZE;
 
 TEST_F(CommandQueueFixture, TestEventsDataMovementWrittenToCompletionQueueInOrder) {
     size_t num_buffers = 100;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWaitForEvent.cpp
@@ -145,7 +145,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueWaitForEventCrossC
 
     for (uint cq_id = 0; cq_id < cqs.size(); cq_id++) {
         for (size_t i = 0; i < num_cmds_per_cq * cqs.size() * num_events_per_cq; i++) {
-            uint32_t host_addr = completion_queue_base[cq_id] + i * TRANSFER_PAGE_SIZE + sizeof(CQDispatchCmd);
+            uint32_t host_addr = completion_queue_base[cq_id] + i * dispatch_constants::TRANSFER_PAGE_SIZE + sizeof(CQDispatchCmd);
             tt::Cluster::instance().read_sysmem(&event, 4, host_addr, mmio_device_id, channel);
             log_debug(tt::LogTest, "Checking completion queue. cq_id: {} i: {} host_addr: {}. Got event_id: {}", cq_id, i, host_addr, event);
             EXPECT_EQ(event, expected_event_id[cq_id]++);

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -126,6 +126,10 @@ int main() {
                 uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(DISPATCH_CORE_X), NOC_Y(DISPATCH_CORE_Y), DISPATCH_MESSAGE_ADDR);
                 noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
             }
+
+            while (1) {
+                RISC_POST_HEARTBEAT(heartbeat);
+            }
         }
     }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -321,18 +321,6 @@ void Device::compile_command_queue_programs() {
     ZoneScoped;
     unique_ptr<Program, detail::ProgramDeleter> command_queue_program_ptr(new Program);
 
-    constexpr uint32_t dispatch_buffer_pages = DISPATCH_BUFFER_BLOCK_SIZE_PAGES * DISPATCH_BUFFER_SIZE_BLOCKS;
-    uint32_t dispatch_buffer_base = get_dispatch_buffer_base();
-
-    std::cout << "DISPATCH_L1_UNRESERVED_BASE " << DISPATCH_L1_UNRESERVED_BASE
-              << " prefetch q base " << PREFETCH_Q_BASE << " size " << PREFETCH_Q_SIZE
-              << " cmdat q base " << CMDDAT_Q_BASE << " size " << CMDDAT_Q_SIZE
-              << " scratch db base " << SCRATCH_DB_BASE << " size " << SCRATCH_DB_SIZE << std::endl;
-
-    static_assert(SCRATCH_DB_BASE + SCRATCH_DB_SIZE < MEM_ETH_SIZE);
-
-    constexpr uint32_t prefetch_d_buffer_pages = PREFETCH_D_BUFFER_SIZE >> PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-
     std::string prefetch_kernel_path = "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp";
     std::string dispatch_kernel_path = "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp";
 
@@ -370,13 +358,9 @@ void Device::compile_command_queue_programs() {
                 CoreCoord completion_q_physical_core = get_physical_core_coordinate(completion_q_writer_location, dispatch_core_type);
                 CoreCoord dispatch_physical_core = get_physical_core_coordinate(dispatch_location, dispatch_core_type);
 
-                if (dispatch_core_type == CoreType::WORKER) {
-                    std::cout << "Dispatching on tenix:\t";
-                } else {
-                    std::cout << "Dispatching on ethernet:\t";
-                }
-                std::cout << "Prefetch " << prefetch_location.str() << " physical " << prefetch_physical_core.str()
-                          << " Dispatch " << dispatch_location.str() << " physical " << dispatch_physical_core.str() << std::endl;
+                log_debug(LogDevice, "Dispatching out of {} cores",  magic_enum::enum_name(dispatch_core_type));
+                log_debug(LogDevice, "Prefetch HD logical location: {} physical core: {}", prefetch_location.str(), prefetch_physical_core.str());
+                log_debug(LogDevice, "Dispatch HD logical location: {} physical core {}", dispatch_location.str(), dispatch_physical_core.str());
 
                 uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id, cq_size);
                 uint32_t issue_queue_start_addr = command_queue_start_addr + CQ_START;
@@ -398,26 +382,26 @@ void Device::compile_command_queue_programs() {
                 };
 
                 std::vector<uint32_t> prefetch_compile_args = {
-                    dispatch_buffer_base,
-                    DISPATCH_BUFFER_LOG_PAGE_SIZE,
-                    dispatch_buffer_pages,
+                    dispatch_constants::DISPATCH_BUFFER_BASE,
+                    dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE,
+                    dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages(),
                     prefetch_downstream_cb_sem,
                     dispatch_cb_sem,
                     issue_queue_start_addr,
                     issue_queue_size,
-                    PREFETCH_Q_BASE,
-                    PREFETCH_Q_ENTRIES * (uint32_t)sizeof(prefetch_q_entry_type),
+                    dispatch_constants::PREFETCH_Q_BASE,
+                    dispatch_constants::PREFETCH_Q_SIZE,
                     CQ_PREFETCH_Q_RD_PTR,
-                    CMDDAT_Q_BASE,
-                    CMDDAT_Q_SIZE,
-                    SCRATCH_DB_BASE,
-                    SCRATCH_DB_SIZE,
+                    dispatch_constants::CMDDAT_Q_BASE,
+                    dispatch_constants::get(dispatch_core_type).cmddat_q_size(),
+                    dispatch_constants::get(dispatch_core_type).scratch_db_base(),
+                    dispatch_constants::get(dispatch_core_type).scratch_db_size(),
                     prefetch_sync_sem,
-                    prefetch_d_buffer_pages, // prefetch_d only
+                    dispatch_constants::PREFETCH_D_BUFFER_PAGES, // prefetch_d only
                     prefetch_d_upstream_cb_sem, // prefetch_d only
                     prefetch_downstream_cb_sem, // prefetch_d only
-                    PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
-                    PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
+                    dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
+                    dispatch_constants::PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
                     prefetch_h_exec_buf_sem,
                     true,   // is_dram_variant
                     true    // is_host_variant
@@ -442,7 +426,7 @@ void Device::compile_command_queue_programs() {
                 }
 
                 tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, 0, dispatch_core_type);
-                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, dispatch_buffer_pages, dispatch_core_type);
+                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages(), dispatch_core_type);
                 tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, 0, dispatch_core_type);
 
                 if (device_id == this->id()) {
@@ -456,18 +440,18 @@ void Device::compile_command_queue_programs() {
                         {"DOWNSTREAM_NOC_Y", std::to_string(0)},
                     };
                     std::vector<uint32_t> dispatch_compile_args = {
-                        dispatch_buffer_base,
-                        DISPATCH_BUFFER_LOG_PAGE_SIZE,
-                        DISPATCH_BUFFER_SIZE_BLOCKS * DISPATCH_BUFFER_BLOCK_SIZE_PAGES,
+                        dispatch_constants::DISPATCH_BUFFER_BASE,
+                        dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE,
+                        dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages(),
                         dispatch_cb_sem,
                         prefetch_downstream_cb_sem,
-                        DISPATCH_BUFFER_SIZE_BLOCKS,
+                        dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS,
                         prefetch_sync_sem,
                         command_queue_start_addr,
                         completion_queue_start_addr,
                         completion_queue_size,
-                        dispatch_buffer_base,
-                        DISPATCH_BUFFER_LOG_PAGE_SIZE * dispatch_buffer_pages,
+                        dispatch_constants::DISPATCH_BUFFER_BASE,
+                        dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE * dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages(),
                         0, // unused on hd, filled in below for h and d
                         0, // unused on hd, filled in below for h and d
                         0, // unused unless tunneler is between h and d
@@ -495,7 +479,7 @@ void Device::compile_command_queue_programs() {
 
                     tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, 0, dispatch_core_type);
                     tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, 0, dispatch_core_type);
-                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, dispatch_buffer_pages, dispatch_core_type);
+                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages(), dispatch_core_type);
 
                 } else {
                     TT_THROW("FD2.0 does not support R chip yet");
@@ -551,12 +535,12 @@ void Device::configure_command_queue_programs() {
                     "Issue queue interface is on device {} and completion queue interface is on device {} but they are expected to be on device {}", prefetch_location.chip, completion_q_writer_location.chip, this->id());
 
                 // Initialize the FetchQ
-                std::vector<uint32_t> prefetch_q(PREFETCH_Q_ENTRIES, 0);
+                std::vector<uint32_t> prefetch_q(dispatch_constants::PREFETCH_Q_ENTRIES, 0);
                 std::vector<uint32_t> prefetch_q_rd_ptr_addr_data = {
-                    (uint32_t)(PREFETCH_Q_BASE + PREFETCH_Q_SIZE)
+                    (uint32_t)(dispatch_constants::PREFETCH_Q_BASE + dispatch_constants::PREFETCH_Q_SIZE)
                 };
                 detail::WriteToDeviceL1(this, prefetch_location, CQ_PREFETCH_Q_RD_PTR, prefetch_q_rd_ptr_addr_data, dispatch_core_type);
-                detail::WriteToDeviceL1(this, prefetch_location, PREFETCH_Q_BASE, prefetch_q, dispatch_core_type);
+                detail::WriteToDeviceL1(this, prefetch_location, dispatch_constants::PREFETCH_Q_BASE, prefetch_q, dispatch_core_type);
 
                 // Initialize completion queue write pointer and read pointer copy
                 uint32_t issue_queue_size = this->sysmem_manager_->get_issue_queue_size(cq_id);
@@ -678,9 +662,9 @@ bool Device::close() {
 
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
 
-    // if (llrt::OptionsG.get_clear_l1()) {
-    //     this->clear_l1_state();
-    // }
+    if (llrt::OptionsG.get_clear_l1()) {
+        this->clear_l1_state();
+    }
     tt::Cluster::instance().l1_barrier(id_);
     allocator::clear(*this->allocator_);
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -323,14 +323,18 @@ void Device::compile_command_queue_programs() {
 
     constexpr uint32_t dispatch_buffer_pages = DISPATCH_BUFFER_BLOCK_SIZE_PAGES * DISPATCH_BUFFER_SIZE_BLOCKS;
     uint32_t dispatch_buffer_base = get_dispatch_buffer_base();
-    constexpr uint32_t prefetch_q_base = DISPATCH_L1_UNRESERVED_BASE;
-    constexpr uint32_t prefetch_q_size = PREFETCH_Q_ENTRIES * sizeof(prefetch_q_entry_type);
-    constexpr uint32_t noc_read_alignment = 32;
-    constexpr uint32_t cmddat_q_base = prefetch_q_base + ((prefetch_q_size + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
-    constexpr uint32_t scratch_db_base = cmddat_q_base + ((CMDDAT_Q_SIZE + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
-    static_assert(scratch_db_base < MEM_L1_SIZE);
+
+    std::cout << "DISPATCH_L1_UNRESERVED_BASE " << DISPATCH_L1_UNRESERVED_BASE
+              << " prefetch q base " << PREFETCH_Q_BASE << " size " << PREFETCH_Q_SIZE
+              << " cmdat q base " << CMDDAT_Q_BASE << " size " << CMDDAT_Q_SIZE
+              << " scratch db base " << SCRATCH_DB_BASE << " size " << SCRATCH_DB_SIZE << std::endl;
+
+    static_assert(SCRATCH_DB_BASE + SCRATCH_DB_SIZE < MEM_ETH_SIZE);
 
     constexpr uint32_t prefetch_d_buffer_pages = PREFETCH_D_BUFFER_SIZE >> PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+
+    std::string prefetch_kernel_path = "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp";
+    std::string dispatch_kernel_path = "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp";
 
     // TODO: These are semaphore IDs, remove these when CreateSemaphore returns ID rather than address
     constexpr uint32_t prefetch_sync_sem = 0;
@@ -366,6 +370,14 @@ void Device::compile_command_queue_programs() {
                 CoreCoord completion_q_physical_core = get_physical_core_coordinate(completion_q_writer_location, dispatch_core_type);
                 CoreCoord dispatch_physical_core = get_physical_core_coordinate(dispatch_location, dispatch_core_type);
 
+                if (dispatch_core_type == CoreType::WORKER) {
+                    std::cout << "Dispatching on tenix:\t";
+                } else {
+                    std::cout << "Dispatching on ethernet:\t";
+                }
+                std::cout << "Prefetch " << prefetch_location.str() << " physical " << prefetch_physical_core.str()
+                          << " Dispatch " << dispatch_location.str() << " physical " << dispatch_physical_core.str() << std::endl;
+
                 uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id, cq_size);
                 uint32_t issue_queue_start_addr = command_queue_start_addr + CQ_START;
                 uint32_t issue_queue_size = this->sysmem_manager_->get_issue_queue_size(cq_id);
@@ -393,12 +405,12 @@ void Device::compile_command_queue_programs() {
                     dispatch_cb_sem,
                     issue_queue_start_addr,
                     issue_queue_size,
-                    prefetch_q_base,
+                    PREFETCH_Q_BASE,
                     PREFETCH_Q_ENTRIES * (uint32_t)sizeof(prefetch_q_entry_type),
                     CQ_PREFETCH_Q_RD_PTR,
-                    cmddat_q_base,
+                    CMDDAT_Q_BASE,
                     CMDDAT_Q_SIZE,
-                    scratch_db_base,
+                    SCRATCH_DB_BASE,
                     SCRATCH_DB_SIZE,
                     prefetch_sync_sem,
                     prefetch_d_buffer_pages, // prefetch_d only
@@ -411,19 +423,27 @@ void Device::compile_command_queue_programs() {
                     true    // is_host_variant
                 };
 
-                tt::tt_metal::CreateKernel(
-                    *command_queue_program_ptr,
-                    "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp", // update this for remote device
-                    prefetch_location,
-                    tt::tt_metal::DataMovementConfig {
-                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                        .noc = tt::tt_metal::NOC::RISCV_0_default,
-                        .compile_args = prefetch_compile_args,
-                        .defines = prefetch_defines});
+                if (dispatch_core_type == CoreType::WORKER) {
+                    tt::tt_metal::CreateKernel(
+                        *command_queue_program_ptr, prefetch_kernel_path, prefetch_location,
+                        DataMovementConfig{
+                            .processor = DataMovementProcessor::RISCV_1,
+                            .noc = NOC::NOC_0,
+                            .compile_args = prefetch_compile_args,
+                            .defines = prefetch_defines});
+                } else {
+                    tt::tt_metal::CreateKernel(
+                        *command_queue_program_ptr, prefetch_kernel_path, prefetch_location,
+                        EthernetConfig{
+                            .eth_mode = Eth::IDLE,
+                            .noc = NOC::NOC_0,
+                            .compile_args = prefetch_compile_args,
+                            .defines = prefetch_defines});
+                }
 
-                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, 0);
-                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, dispatch_buffer_pages);
-                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, 0);
+                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, 0, dispatch_core_type);
+                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, dispatch_buffer_pages, dispatch_core_type);
+                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_location, 0, dispatch_core_type);
 
                 if (device_id == this->id()) {
                     std::map<string, string> dispatch_defines = {
@@ -455,19 +475,27 @@ void Device::compile_command_queue_programs() {
                         true    // is_host_variant
                     };
 
-                    tt::tt_metal::CreateKernel(
-                        *command_queue_program_ptr,
-                        "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
-                        dispatch_location,
-                        tt::tt_metal::DataMovementConfig {
-                            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                            .noc = tt::tt_metal::NOC::RISCV_0_default,
-                            .compile_args = dispatch_compile_args,
-                            .defines = dispatch_defines});
+                    if (dispatch_core_type == CoreType::WORKER) {
+                        tt::tt_metal::CreateKernel(
+                            *command_queue_program_ptr, dispatch_kernel_path, dispatch_location,
+                            DataMovementConfig{
+                                .processor = DataMovementProcessor::RISCV_1,
+                                .noc = NOC::NOC_0,
+                                .compile_args = dispatch_compile_args,
+                                .defines = dispatch_defines});
+                    } else {
+                        tt::tt_metal::CreateKernel(
+                            *command_queue_program_ptr, dispatch_kernel_path, dispatch_location,
+                            EthernetConfig{
+                                .eth_mode = Eth::IDLE,
+                                .noc = NOC::NOC_0,
+                                .compile_args = dispatch_compile_args,
+                                .defines = dispatch_defines});
+                    }
 
-                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, 0);
-                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, 0);
-                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, dispatch_buffer_pages);
+                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, 0, dispatch_core_type);
+                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, 0, dispatch_core_type);
+                    tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_location, dispatch_buffer_pages, dispatch_core_type);
 
                 } else {
                     TT_THROW("FD2.0 does not support R chip yet");
@@ -492,8 +520,6 @@ void Device::configure_command_queue_programs() {
 
     TT_ASSERT(this->command_queue_programs.size() == 1);
     Program& command_queue_program = *this->command_queue_programs[0];
-
-    uint32_t prefetch_q_base = DISPATCH_L1_UNRESERVED_BASE;
 
     for (uint8_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
         // Reset the host manager's pointer for this command queue
@@ -527,24 +553,24 @@ void Device::configure_command_queue_programs() {
                 // Initialize the FetchQ
                 std::vector<uint32_t> prefetch_q(PREFETCH_Q_ENTRIES, 0);
                 std::vector<uint32_t> prefetch_q_rd_ptr_addr_data = {
-                    (uint32_t)(prefetch_q_base + PREFETCH_Q_ENTRIES * sizeof(prefetch_q_entry_type))
+                    (uint32_t)(PREFETCH_Q_BASE + PREFETCH_Q_SIZE)
                 };
-                detail::WriteToDeviceL1(this, prefetch_location, CQ_PREFETCH_Q_RD_PTR, prefetch_q_rd_ptr_addr_data);
-                detail::WriteToDeviceL1(this, prefetch_location, prefetch_q_base, prefetch_q);
+                detail::WriteToDeviceL1(this, prefetch_location, CQ_PREFETCH_Q_RD_PTR, prefetch_q_rd_ptr_addr_data, dispatch_core_type);
+                detail::WriteToDeviceL1(this, prefetch_location, PREFETCH_Q_BASE, prefetch_q, dispatch_core_type);
 
                 // Initialize completion queue write pointer and read pointer copy
                 uint32_t issue_queue_size = this->sysmem_manager_->get_issue_queue_size(cq_id);
                 uint32_t completion_queue_start_addr = CQ_START + issue_queue_size + get_absolute_cq_offset(curr_channel, cq_id, curr_cq_size);
                 uint32_t completion_queue_start_addr_16B = completion_queue_start_addr >> 4;
                 vector<uint32_t> completion_queue_wr_ptr = {completion_queue_start_addr_16B};
-                detail::WriteToDeviceL1(this, completion_q_writer_location, CQ_COMPLETION_READ_PTR, completion_queue_wr_ptr);
-                detail::WriteToDeviceL1(this, completion_q_writer_location, CQ_COMPLETION_WRITE_PTR, completion_queue_wr_ptr);
-                detail::WriteToDeviceL1(this, completion_q_writer_location, CQ0_COMPLETION_LAST_EVENT, zero);
-                detail::WriteToDeviceL1(this, completion_q_writer_location, CQ1_COMPLETION_LAST_EVENT, zero);
+                detail::WriteToDeviceL1(this, completion_q_writer_location, CQ_COMPLETION_READ_PTR, completion_queue_wr_ptr, dispatch_core_type);
+                detail::WriteToDeviceL1(this, completion_q_writer_location, CQ_COMPLETION_WRITE_PTR, completion_queue_wr_ptr, dispatch_core_type);
+                detail::WriteToDeviceL1(this, completion_q_writer_location, CQ0_COMPLETION_LAST_EVENT, zero, dispatch_core_type);
+                detail::WriteToDeviceL1(this, completion_q_writer_location, CQ1_COMPLETION_LAST_EVENT, zero, dispatch_core_type);
 
                 // Initialize address where workers signal to completion to dispatch core
                 // This value is always increasing
-                detail::WriteToDeviceL1(this, dispatch_location, DISPATCH_MESSAGE_ADDR, zero);
+                detail::WriteToDeviceL1(this, dispatch_location, DISPATCH_MESSAGE_ADDR, zero, dispatch_core_type);
             }
         }
     }
@@ -633,6 +659,10 @@ bool Device::close() {
     watcher_detach(this);
     DprintServerDetach(this);
 
+    for (const std::unique_ptr<HWCommandQueue> &hw_command_queue : hw_command_queues_) {
+        hw_command_queue->terminate();
+    }
+
     // Assert worker cores
     CoreCoord grid_size = this->logical_grid_size();
     for (uint32_t y = 0; y < grid_size.y; y++) {
@@ -648,9 +678,9 @@ bool Device::close() {
 
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
 
-    if (llrt::OptionsG.get_clear_l1()) {
-        this->clear_l1_state();
-    }
+    // if (llrt::OptionsG.get_clear_l1()) {
+    //     this->clear_l1_state();
+    // }
     tt::Cluster::instance().l1_barrier(id_);
     allocator::clear(*this->allocator_);
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -920,6 +920,42 @@ void EnqueueTraceCommand::process() {
     // log_trace(LogDispatch, "EnqueueTraceCommand issued write_ptr={}, fetch_size={}, commands={}", write_ptr, fetch_size_bytes, this->commands);
 }
 
+EnqueueTerminateCommand::EnqueueTerminateCommand(
+    uint32_t command_queue_id,
+    Device* device,
+    SystemMemoryManager& manager) :
+    command_queue_id(command_queue_id), device(device), manager(manager) {}
+
+const DeviceCommand EnqueueTerminateCommand::assemble_device_commands() {
+    uint32_t cmd_sequence_sizeB =
+        CQ_PREFETCH_CMD_BARE_MIN_SIZE + // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_TERMINATE
+        CQ_PREFETCH_CMD_BARE_MIN_SIZE;  // CQ_PREFETCH_CMD_TERMINATE
+
+    DeviceCommand command_sequence(cmd_sequence_sizeB);
+    command_sequence.add_dispatch_terminate();
+    command_sequence.add_prefetch_terminate();
+
+    return command_sequence;
+}
+
+void EnqueueTerminateCommand::process() {
+    DeviceCommand command_sequence = this->assemble_device_commands();
+
+    uint32_t fetch_size_bytes = command_sequence.size_bytes();
+
+    // move this into the command queue interface
+    TT_ASSERT(fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE, "Generated prefetcher command exceeds max command size");
+    TT_ASSERT((fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
+
+    this->manager.fetch_queue_reserve_back(this->command_queue_id);
+
+    uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_id);
+    this->manager.cq_write(command_sequence.data(), fetch_size_bytes, write_ptr);
+    this->manager.issue_queue_push_back(fetch_size_bytes, this->command_queue_id);
+    this->manager.fetch_queue_write(fetch_size_bytes, this->command_queue_id);
+}
+
+
 // HWCommandQueue section
 HWCommandQueue::HWCommandQueue(Device* device, uint32_t id) :
     manager(device->sysmem_manager()), completion_queue_thread{} {
@@ -1599,6 +1635,14 @@ volatile bool HWCommandQueue::is_dprint_server_hung() {
 
 volatile bool HWCommandQueue::is_noc_hung() {
     return illegal_noc_txn_hang;
+}
+
+void HWCommandQueue::terminate() {
+    ZoneScopedN("HWCommandQueue_terminate");
+    tt::log_debug(tt::LogDispatch, "Terminating dispatch kernels for command queue {}", this->id);
+    std::cout << "Sent terminate command!" << std::endl;
+    auto command = EnqueueTerminateCommand(this->id, this->device, this->manager);
+    this->enqueue_command(command, false);
 }
 
 void EnqueueAddBufferToProgramImpl(const std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program>> program) {

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -111,10 +111,6 @@ void EnqueueReadBufferCommand::process() {
 
     uint32_t fetch_size_bytes = command_sequence.size_bytes();
 
-    // move this into the command queue interface
-    TT_ASSERT(fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
-
     this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
     uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_id);
@@ -241,10 +237,6 @@ void EnqueueWriteBufferCommand::process() {
     DeviceCommand command_sequence = this->assemble_device_commands();
 
     uint32_t fetch_size_bytes = command_sequence.size_bytes();
-
-    // TODO: move this into the command queue interface
-    TT_ASSERT(fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
 
     this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
@@ -641,13 +633,8 @@ void EnqueueProgramCommand::process() {
     uint32_t total_fetch_size_bytes =
         preamble_fetch_size_bytes + runtime_args_fetch_size_bytes + program_fetch_size_bytes;
 
-    if (total_fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE) {
-        // move this into the command queue interface
-        TT_ASSERT(
-            total_fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE,
-            "Generated prefetcher command exceeds max command size");
-        TT_ASSERT((total_fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
-
+    CoreType dispatch_core_type = dispatch_core_manager::get(this->device->num_hw_cqs()).get_dispatch_core_type(this->device->id());
+    if (total_fetch_size_bytes <= dispatch_constants::get(dispatch_core_type).max_prefetch_command_size()) {
         this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
         uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_id);
@@ -673,13 +660,6 @@ void EnqueueProgramCommand::process() {
         // One fetch queue entry for entire program
         this->manager.fetch_queue_write(total_fetch_size_bytes, this->command_queue_id);
     } else {
-        // move this into the command queue interface
-        TT_ASSERT(
-            preamble_fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE,
-            "Generated prefetcher command exceeds max command size");
-        TT_ASSERT(
-            (preamble_fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
-
         this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
         uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_id);
@@ -697,10 +677,6 @@ void EnqueueProgramCommand::process() {
 
         for (const auto& cmds : runtime_args_command_sequences) {
             uint32_t fetch_size_bytes = cmds.size_bytes();
-            // move this into the command queue interface
-            TT_ASSERT(
-                fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE, "Generated prefetcher command exceeds max command size");
-            TT_ASSERT((fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
 
             this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
@@ -717,14 +693,6 @@ void EnqueueProgramCommand::process() {
             // One fetch queue entry for each runtime args write location, e.g. BRISC/NCRISC/TRISC/ERISC
             this->manager.fetch_queue_write(fetch_size_bytes, this->command_queue_id);
         }
-
-        // move this into the command queue interface
-        TT_ASSERT(
-            program_fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE,
-            "Generated prefetcher command exceeds max command size");
-        TT_ASSERT(
-            (program_fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
-
         this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
         write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_id);
@@ -757,17 +725,17 @@ EnqueueRecordEventCommand::EnqueueRecordEventCommand(
     clear_count(clear_count) {}
 
 const DeviceCommand EnqueueRecordEventCommand::assemble_device_commands() {
-    std::vector<uint32_t> event_payload(EVENT_PADDED_SIZE / sizeof(uint32_t), 0);
+    std::vector<uint32_t> event_payload(dispatch_constants::EVENT_PADDED_SIZE / sizeof(uint32_t), 0);
     event_payload[0] = this->event_id;
 
     uint8_t num_hw_cqs = this->device->num_hw_cqs(); // Device initialize asserts that there can only be a maximum of 2 HW CQs
     uint32_t packed_event_payload_sizeB = align(sizeof(CQDispatchCmd) + num_hw_cqs * sizeof(CQDispatchWritePackedUnicastSubCmd), L1_ALIGNMENT)
-        + (align(EVENT_PADDED_SIZE, L1_ALIGNMENT) * num_hw_cqs);
+        + (align(dispatch_constants::EVENT_PADDED_SIZE, L1_ALIGNMENT) * num_hw_cqs);
     uint32_t packed_write_sizeB = align(sizeof(CQPrefetchCmd) + packed_event_payload_sizeB, PCIE_ALIGNMENT);
 
     uint32_t cmd_sequence_sizeB = CQ_PREFETCH_CMD_BARE_MIN_SIZE + // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
         packed_write_sizeB + // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PACKED + unicast subcmds + event payload
-        align(CQ_PREFETCH_CMD_BARE_MIN_SIZE + EVENT_PADDED_SIZE, PCIE_ALIGNMENT); // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_LINEAR_HOST + event ID
+        align(CQ_PREFETCH_CMD_BARE_MIN_SIZE + dispatch_constants::EVENT_PADDED_SIZE, PCIE_ALIGNMENT); // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_LINEAR_HOST + event ID
 
     DeviceCommand command_sequence(cmd_sequence_sizeB);
 
@@ -790,14 +758,14 @@ const DeviceCommand EnqueueRecordEventCommand::assemble_device_commands() {
     command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
         num_hw_cqs,
         address,
-        EVENT_PADDED_SIZE,
+        dispatch_constants::EVENT_PADDED_SIZE,
         packed_event_payload_sizeB,
         unicast_sub_cmds,
         event_payloads
     );
 
     bool flush_prefetch = true;
-    command_sequence.add_dispatch_write_host(flush_prefetch, EVENT_PADDED_SIZE, event_payload.data());
+    command_sequence.add_dispatch_write_host(flush_prefetch, dispatch_constants::EVENT_PADDED_SIZE, event_payload.data());
 
     return command_sequence;
 }
@@ -806,10 +774,6 @@ void EnqueueRecordEventCommand::process() {
     DeviceCommand command_sequence = this->assemble_device_commands();
 
     uint32_t fetch_size_bytes = command_sequence.size_bytes();
-
-    // move this into the command queue interface
-    TT_ASSERT(fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
 
     this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
@@ -853,10 +817,6 @@ void EnqueueWaitForEventCommand::process() {
     DeviceCommand command_sequence = this->assemble_device_commands();
 
     uint32_t fetch_size_bytes = command_sequence.size_bytes();
-
-    // move this into the command queue interface
-    TT_ASSERT(fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
 
     this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
@@ -907,10 +867,6 @@ void EnqueueTraceCommand::process() {
 
     uint32_t fetch_size_bytes = command_sequence.size_bytes();
 
-    // move this into the command queue interface
-    TT_ASSERT(fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
-
     this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
     uint32_t write_ptr = this->manager.get_issue_queue_write_ptr(this->command_queue_id);
@@ -942,10 +898,6 @@ void EnqueueTerminateCommand::process() {
     DeviceCommand command_sequence = this->assemble_device_commands();
 
     uint32_t fetch_size_bytes = command_sequence.size_bytes();
-
-    // move this into the command queue interface
-    TT_ASSERT(fetch_size_bytes <= MAX_PREFETCH_COMMAND_SIZE, "Generated prefetcher command exceeds max command size");
-    TT_ASSERT((fetch_size_bytes >> PREFETCH_Q_LOG_MINSIZE) < 0xFFFF, "FetchQ command too large to represent");
 
     this->manager.fetch_queue_reserve_back(this->command_queue_id);
 
@@ -1039,6 +991,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
 
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device->id());
+    CoreType dispatch_core_type = dispatch_core_manager::get(this->device->num_hw_cqs()).get_dispatch_core_type(this->device->id());
 
     uint32_t padded_page_size = align(buffer.page_size(), 32);
     uint32_t pages_to_read = buffer.num_pages();
@@ -1046,7 +999,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
     uint32_t src_page_index = 0;
 
     if (is_sharded(buffer.buffer_layout())) {
-        constexpr uint32_t half_scratch_space = SCRATCH_DB_SIZE / 2;
+        const uint32_t half_scratch_space = dispatch_constants::get(dispatch_core_type).scratch_db_size() / 2;
         auto buffer_page_mapping = generate_buffer_page_mapping(buffer);
         // Note that the src_page_index is the device page idx, not the host page idx
         // Since we read core by core we are reading the device pages sequentially
@@ -1139,7 +1092,9 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
     uint32_t padded_page_size = align(buffer.page_size(), 32);
 
     const uint32_t command_issue_limit = this->manager.get_issue_queue_limit(this->id);
-    uint32_t max_data_sizeB = MAX_PREFETCH_COMMAND_SIZE - ((sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd)) * 2); // * 2 to account for issue
+    CoreType dispatch_core_type = dispatch_core_manager::get(this->device->num_hw_cqs()).get_dispatch_core_type(this->device->id());
+    const uint32_t max_prefetch_command_size = dispatch_constants::get(dispatch_core_type).max_prefetch_command_size();
+    uint32_t max_data_sizeB = max_prefetch_command_size - ((sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd)) * 2); // * 2 to account for issue
 
     uint32_t dst_page_index = 0;
 
@@ -1168,7 +1123,7 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
                 if (issue_wait) {
                     data_offset_bytes *= 2; // commands prefixed with CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
                 }
-                uint32_t space_available_bytes = std::min(command_issue_limit - this->manager.get_issue_queue_write_ptr(this->id), MAX_PREFETCH_COMMAND_SIZE);
+                uint32_t space_available_bytes = std::min(command_issue_limit - this->manager.get_issue_queue_write_ptr(this->id), max_prefetch_command_size);
                 int32_t num_pages_available =
                     (int32_t(space_available_bytes) - int32_t(data_offset_bytes)) / int32_t(padded_page_size);
 
@@ -1202,7 +1157,7 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
         uint32_t padded_buffer_size = buffer.num_pages() * padded_page_size;
         if (write_partial_pages) {
             TT_ASSERT(buffer.num_pages() == 1, "TODO: add support for multi-paged buffer with page size > 64KB");
-            uint32_t partial_size = BASE_PARTIAL_PAGE_SIZE;
+            uint32_t partial_size = dispatch_constants::BASE_PARTIAL_PAGE_SIZE;
             while (padded_buffer_size % partial_size != 0) {
                 partial_size += PCIE_ALIGNMENT;
             }
@@ -1229,7 +1184,7 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
                 data_offsetB *= 2; // commands prefixed with CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
             }
 
-            uint32_t space_availableB = std::min(command_issue_limit - this->manager.get_issue_queue_write_ptr(this->id), MAX_PREFETCH_COMMAND_SIZE);
+            uint32_t space_availableB = std::min(command_issue_limit - this->manager.get_issue_queue_write_ptr(this->id), max_prefetch_command_size);
             int32_t num_pages_available = (int32_t(space_availableB) - int32_t(data_offsetB)) / int32_t(page_size_to_write);
 
             if (num_pages_available <= 0) {
@@ -1419,7 +1374,7 @@ void HWCommandQueue::copy_into_user_space(const detail::ReadBufferDescriptor &re
 
         // completion queue write ptr on device could have wrapped but our read ptr is lagging behind
         uint32_t bytes_xfered = std::min(remaining_bytes_to_read, bytes_avail_in_completion_queue);
-        uint32_t num_pages_xfered = (bytes_xfered + TRANSFER_PAGE_SIZE - 1) / TRANSFER_PAGE_SIZE;
+        uint32_t num_pages_xfered = (bytes_xfered + dispatch_constants::TRANSFER_PAGE_SIZE - 1) / dispatch_constants::TRANSFER_PAGE_SIZE;
 
         completion_q_data.resize(bytes_xfered / sizeof(uint32_t));
 
@@ -1583,9 +1538,9 @@ void HWCommandQueue::read_completion_queue() {
                             this->copy_into_user_space(read_descriptor, read_ptr, mmio_device_id, channel);
                         }
                         else if constexpr (std::is_same_v<T, detail::ReadEventDescriptor>) {
-                            static std::vector<uint32_t> dispatch_cmd_and_event((sizeof(CQDispatchCmd) + EVENT_PADDED_SIZE) / sizeof(uint32_t));
+                            static std::vector<uint32_t> dispatch_cmd_and_event((sizeof(CQDispatchCmd) + dispatch_constants::EVENT_PADDED_SIZE) / sizeof(uint32_t));
                             tt::Cluster::instance().read_sysmem(
-                                dispatch_cmd_and_event.data(), sizeof(CQDispatchCmd) + EVENT_PADDED_SIZE, read_ptr, mmio_device_id, channel);
+                                dispatch_cmd_and_event.data(), sizeof(CQDispatchCmd) + dispatch_constants::EVENT_PADDED_SIZE, read_ptr, mmio_device_id, channel);
                             uint32_t event_completed = dispatch_cmd_and_event.at(sizeof(CQDispatchCmd) / sizeof(uint32_t));
                             TT_ASSERT(event_completed == read_descriptor.event_id, "Event Order Issue: expected to read back completion signal for event {} but got {}!", read_descriptor.event_id, event_completed);
                             this->manager.completion_queue_pop_front(1, this->id);
@@ -1640,7 +1595,6 @@ volatile bool HWCommandQueue::is_noc_hung() {
 void HWCommandQueue::terminate() {
     ZoneScopedN("HWCommandQueue_terminate");
     tt::log_debug(tt::LogDispatch, "Terminating dispatch kernels for command queue {}", this->id);
-    std::cout << "Sent terminate command!" << std::endl;
     auto command = EnqueueTerminateCommand(this->id, this->device, this->manager);
     this->enqueue_command(command, false);
 }

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -14,15 +14,23 @@
 
 using namespace tt::tt_metal;
 
+// todo consider moving these to dispatch_addr_map
+static constexpr uint32_t PCIE_ALIGNMENT = 32;
+static constexpr uint32_t MAX_HUGEPAGE_SIZE = 1 << 30; // 1GB;
+
 typedef uint32_t prefetch_q_entry_type;
 static constexpr uint32_t PREFETCH_Q_LOG_MINSIZE = 4;
 static constexpr uint32_t PREFETCH_Q_ENTRIES = 128;
+static constexpr uint32_t PREFETCH_Q_SIZE = PREFETCH_Q_ENTRIES * sizeof(prefetch_q_entry_type);
 static constexpr uint32_t MAX_PREFETCH_COMMAND_SIZE = 64 * 1024;
-static constexpr uint32_t CMDDAT_Q_SIZE = 128 * 1024;
-static constexpr uint32_t SCRATCH_DB_SIZE = 128 * 1024;
+static constexpr uint32_t PREFETCH_Q_BASE = DISPATCH_L1_UNRESERVED_BASE;
 
-static constexpr uint32_t PCIE_ALIGNMENT = 32;
-static constexpr uint32_t MAX_HUGEPAGE_SIZE = 1 << 30; // 1GB;
+static constexpr uint32_t CMDDAT_Q_BASE = PREFETCH_Q_BASE + ((PREFETCH_Q_SIZE + PCIE_ALIGNMENT - 1) / PCIE_ALIGNMENT * PCIE_ALIGNMENT);
+
+// TODO: three below should be diff for tensix/eth and be configurable
+static constexpr uint32_t CMDDAT_Q_SIZE = 64 * 1024;
+static constexpr uint32_t SCRATCH_DB_BASE = CMDDAT_Q_BASE + ((CMDDAT_Q_SIZE + PCIE_ALIGNMENT - 1) / PCIE_ALIGNMENT * PCIE_ALIGNMENT);
+static constexpr uint32_t SCRATCH_DB_SIZE = 64 * 1024;
 
 static constexpr uint32_t LOG_TRANSFER_PAGE_SIZE = 12;
 static constexpr uint32_t TRANSFER_PAGE_SIZE = 1 << LOG_TRANSFER_PAGE_SIZE;

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -140,7 +140,7 @@ struct CQDispatchWritePagedCmd {
 
 struct CQDispatchWritePackedCmd {
     uint8_t is_multicast;
-    uint16_t count;           // number of sub-cmds (max 1020 unicast, 510 mcast). Max num sub-cmds = (TRANSFER_PAGE_SIZE - sizeof(CQDispatchCmd)) / sizeof(CQDispatchWritePacked*castSubCmd)
+    uint16_t count;           // number of sub-cmds (max 1020 unicast, 510 mcast). Max num sub-cmds = (dispatch_constants::TRANSFER_PAGE_SIZE - sizeof(CQDispatchCmd)) / sizeof(CQDispatchWritePacked*castSubCmd)
     uint32_t addr;            // common memory address across all packed SubCmds
     uint16_t size;            // size of each packet, stride is padded to L1 alignment and less than dispatch_cb_page_size
 } __attribute__((packed));

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -140,3 +140,17 @@ void DeviceCommand::add_prefetch_exec_buf(uint32_t base_addr, uint32_t log_page_
 
     this->write_to_cmd_sequence(&exec_buf_cmd, sizeof(CQPrefetchCmd), PCIE_ALIGNMENT);
 }
+
+void DeviceCommand::add_dispatch_terminate() {
+    this->add_prefetch_relay_inline(true, sizeof(CQDispatchCmd));
+    CQDispatchCmd terminate_cmd;
+    terminate_cmd.base.cmd_id = CQ_DISPATCH_CMD_TERMINATE;
+    this->write_to_cmd_sequence(&terminate_cmd, sizeof(CQDispatchCmd));
+}
+
+void DeviceCommand::add_prefetch_terminate() {
+    CQPrefetchCmd terminate_cmd;
+    terminate_cmd.base.cmd_id = CQ_PREFETCH_CMD_TERMINATE;
+
+    this->write_to_cmd_sequence(&terminate_cmd, sizeof(CQPrefetchCmd), PCIE_ALIGNMENT);
+}

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -60,7 +60,7 @@ class DeviceCommand {
         static_assert(std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value or std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value);
         bool multicast = std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value;
 
-        static constexpr uint32_t max_num_packed_sub_cmds = (TRANSFER_PAGE_SIZE - sizeof(CQDispatchCmd)) / sizeof(PackedSubCmd);
+        static constexpr uint32_t max_num_packed_sub_cmds = (dispatch_constants::TRANSFER_PAGE_SIZE - sizeof(CQDispatchCmd)) / sizeof(PackedSubCmd);
         TT_ASSERT(num_sub_cmds <= max_num_packed_sub_cmds, "Max number of packed sub commands are {} but requesting {}", max_num_packed_sub_cmds, num_sub_cmds);
 
         bool flush_prefetch = true;

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -41,6 +41,10 @@ class DeviceCommand {
 
     void add_prefetch_exec_buf(uint32_t base_addr, uint32_t log_page_size, uint32_t pages);
 
+    void add_dispatch_terminate();
+
+    void add_prefetch_terminate();
+
     void update_cmd_sequence(uint32_t cmd_idx, const void *new_data, uint32_t data_sizeB) {
         memcpy(this->cmd_sequence.data() + cmd_idx, new_data, data_sizeB);
     }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -779,6 +779,8 @@ static inline bool process_cmd_h(uint32_t& cmd_ptr) {
 }
 
 void kernel_main() {
+
+
     DPRINT << "dispatch_" << is_d_variant << is_h_variant << ": start" << ENDL();
 
     static_assert(is_d_variant || split_dispatch_page_preamble_size == 0);
@@ -845,6 +847,11 @@ void kernel_main() {
         // components use.
         noc_semaphore_inc(get_noc_addr_helper(upstream_noc_xy, get_semaphore(upstream_dispatch_cb_sem_id)), 0x80000000);
     }
+
+#if defined(COMPILE_FOR_IDLE_ERISC)
+    uint32_t heartbeat = 0;
+    RISC_POST_HEARTBEAT(heartbeat);
+#endif
 
     DPRINT << "dispatch_" << is_d_variant << is_h_variant << ": out" << ENDL();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -625,7 +625,14 @@ static void process_wait() {
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr);
     DPRINT << " DISPATCH WAIT " << HEX() << addr << " count " << count << ENDL();
-    while (*sem_addr < count); // XXXXX use a wrapping compare
+#if defined(COMPILE_FOR_IDLE_ERISC)
+    uint32_t heartbeat = 0;
+#endif
+    while (*sem_addr < count) { // XXXXX use a wrapping compare
+#if defined(COMPILE_FOR_IDLE_ERISC)
+        RISC_POST_HEARTBEAT(heartbeat);
+#endif
+    }
     DEBUG_STATUS('P', 'W', 'D');
 
     if (clear_count) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1067,8 +1067,6 @@ void kernel_main_hd() {
 
 void kernel_main() {
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
-
-
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();
     } else if (is_h_variant) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -632,7 +632,14 @@ uint32_t process_stall(uint32_t cmd_ptr) {
     DEBUG_STATUS('P', 'S', 'W');
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(downstream_sync_sem_id));
-    while (*sem_addr != count);
+#if defined(COMPILE_FOR_IDLE_ERISC)
+    uint32_t heartbeat = 0;
+#endif
+    while (*sem_addr != count) {
+#if defined(COMPILE_FOR_IDLE_ERISC)
+        RISC_POST_HEARTBEAT(heartbeat);
+#endif
+    }
     DEBUG_STATUS('P', 'S', 'D');
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -980,6 +980,10 @@ void kernel_main_h() {
             DPRINT << "terminating\n";
             done = true;
         }
+#if defined(COMPILE_FOR_IDLE_ERISC)
+        uint32_t heartbeat = 0;
+        RISC_POST_HEARTBEAT(heartbeat);
+#endif
     }
 }
 
@@ -1025,6 +1029,10 @@ void kernel_main_d() {
 
         // Move to next page
         cmd_ptr = round_up_pow2(cmd_ptr, cmddat_q_page_size);
+#if defined(COMPILE_FOR_IDLE_ERISC)
+        uint32_t heartbeat = 0;
+        RISC_POST_HEARTBEAT(heartbeat);
+#endif
     }
 
     // Set upstream semaphore MSB to signal completion and path teardown
@@ -1050,11 +1058,17 @@ void kernel_main_hd() {
         uint32_t stride;
         done = process_cmd<false, false>(cmd_ptr, downstream_data_ptr, stride);
         cmd_ptr += stride;
+#if defined(COMPILE_FOR_IDLE_ERISC)
+        uint32_t heartbeat = 0;
+        RISC_POST_HEARTBEAT(heartbeat);
+#endif
     }
 }
 
 void kernel_main() {
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
+
+
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();
     } else if (is_h_variant) {


### PR DESCRIPTION
- same mechanism as switching to FD out of eth as main (via `WH_ARCH_YAML` env flag)
- added terminate command called on device close 

https://github.com/tenstorrent/tt-metal/actions/runs/8723569411