### PR TITLE
#0: Disable ttlib resnet batch8

### DIFF
--- a/models/demos/resnet/tests/test_metal_resnet50.py
+++ b/models/demos/resnet/tests/test_metal_resnet50.py
@@ -118,7 +118,7 @@ golden_pcc = {
 
 
 @skip_for_wormhole_b0("This test is not supported on WHB0, please use the TTNN version.")
-@pytest.mark.parametrize("batch_size", [1, 2, 8, 16, 20], ids=["batch_1", "batch_2", "batch_8", "batch_16", "batch_20"])
+@pytest.mark.parametrize("batch_size", [1, 2, 16, 20], ids=["batch_1", "batch_2", "batch_16", "batch_20"])
 @pytest.mark.parametrize(
     "weights_dtype",
     [tt_lib.tensor.DataType.BFLOAT16, tt_lib.tensor.DataType.BFLOAT8_B],


### PR DESCRIPTION
This variant was failing, but we are transitioning to the ttnn version of this model.  For now we opted to just remove this config since this test is deprecated and will eventually be removed.