### PR TITLE
Move embedding computation in Falcon7b to device in model and tests

### DIFF
--- a/models/demos/falcon7b/demo/demo.py
+++ b/models/demos/falcon7b/demo/demo.py
@@ -181,7 +181,7 @@ def run_falcon_demo_kv(
     # State dict is needed for embeddings
     logger.info("Loading weights...")
     profiler.start(f"loading_weights")
-    if len(os.listdir(tt_cache_path)) < 260:
+    if len(os.listdir(tt_cache_path)) < 261:
         logger.info("Weights not found on machine; downloading weights...")
         model_name = model_location_generator(model_version, model_subdir="Falcon")
         hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
@@ -242,7 +242,7 @@ def run_falcon_demo_kv(
     for user_id in tqdm(range(N)):
         time_prefill_compile_start = time.time()
         (
-            tt_prefill_embeddings,
+            tt_prefill_input_ids,
             tt_prefill_attention_mask,
         ) = tt_FalconCausalLM_singlelayer.model_preprocessing(
             "prefill", prefill_ids[user_id::batch_size], 0, num_input_tokens=num_input_tokens
@@ -250,7 +250,7 @@ def run_falcon_demo_kv(
         assert tt_prefill_attention_mask is not None
 
         tt_logits, kv_cache_singlelayer = tt_FalconCausalLM_singlelayer(
-            input_embeddings=tt_prefill_embeddings,
+            input_ids=tt_prefill_input_ids,
             llm_mode="prefill",
             attention_mask=tt_prefill_attention_mask,
             user_id=user_id,
@@ -263,7 +263,7 @@ def run_falcon_demo_kv(
         time_prefill_compile += time_prefill_compile_end - time_prefill_compile_start
 
         for i in range(num_devices):
-            tt_prefill_embeddings[i].deallocate()
+            tt_prefill_input_ids[i].deallocate()
             if tt_prefill_attention_mask is not None:
                 tt_prefill_attention_mask[i].deallocate()
 
@@ -284,7 +284,7 @@ def run_falcon_demo_kv(
     for kv_cache_len in tqdm(range(num_input_tokens, max_seq_len, 32)):
         time_decode_compile_start = time.time()
         (
-            tt_decode_embeddings,
+            tt_decode_input_ids,
             tt_decode_attention_mask,
         ) = tt_FalconCausalLM_singlelayer.model_preprocessing(
             "decode", decode_ids, kv_cache_len, num_input_tokens=kv_cache_len + 1
@@ -292,7 +292,7 @@ def run_falcon_demo_kv(
         assert tt_decode_attention_mask is not None
 
         tt_logits, kv_cache_singlelayer = tt_FalconCausalLM_singlelayer(
-            input_embeddings=tt_decode_embeddings,
+            input_ids=tt_decode_input_ids,
             llm_mode="decode",
             attention_mask=tt_decode_attention_mask,
             layer_past=kv_cache_singlelayer,
@@ -304,7 +304,7 @@ def run_falcon_demo_kv(
         time_decode_compile += time_decode_compile_end - time_decode_compile_start
 
         for i in range(num_devices):
-            tt_decode_embeddings[i].deallocate()
+            tt_decode_input_ids[i].deallocate()
             if tt_decode_attention_mask is not None:
                 tt_decode_attention_mask[i].deallocate()
 
@@ -314,10 +314,10 @@ def run_falcon_demo_kv(
     synchronize_devices(devices)
 
     del tt_logits
-    del tt_prefill_embeddings
+    del tt_prefill_input_ids
     del tt_prefill_attention_mask
     del decode_ids
-    del tt_decode_embeddings
+    del tt_decode_input_ids
     del tt_FalconCausalLM_singlelayer
     del kv_cache_singlelayer
 
@@ -351,7 +351,7 @@ def run_falcon_demo_kv(
         user_id = i if not perf_mode else 0
         time_prefill_inference_start = time.time()
         (
-            tt_prefill_embeddings,
+            tt_prefill_input_ids,
             tt_prefill_attention_mask,
         ) = tt_FalconCausalLM.model_preprocessing(
             "prefill", prefill_ids[user_id::batch_size], 0, num_input_tokens=num_input_tokens
@@ -359,7 +359,7 @@ def run_falcon_demo_kv(
         assert tt_prefill_attention_mask is not None
 
         tt_logits, kv_cache = tt_FalconCausalLM(
-            input_embeddings=tt_prefill_embeddings,
+            input_ids=tt_prefill_input_ids,
             llm_mode="prefill",
             attention_mask=tt_prefill_attention_mask,
             user_id=user_id,
@@ -375,7 +375,7 @@ def run_falcon_demo_kv(
         logits = torch.concat([tt2torch_tensor(tt_logits[j]).squeeze(1) for j in range(num_devices)], dim=-2)
 
         for j in range(num_devices):
-            tt_prefill_embeddings[j].deallocate()
+            tt_prefill_input_ids[j].deallocate()
             if tt_prefill_attention_mask is not None:
                 tt_prefill_attention_mask[j].deallocate()
             tt_logits[j].deallocate()
@@ -413,13 +413,13 @@ def run_falcon_demo_kv(
     for output_token_index in range(N):
         time_decode_inference_start = time.time()
         (
-            tt_decode_embeddings,
+            tt_decode_input_ids,
             tt_decode_attention_mask,
         ) = tt_FalconCausalLM.model_preprocessing("decode", decode_ids, kv_cache_len, num_input_tokens=kv_cache_len + 1)
         assert tt_decode_attention_mask is not None
 
         tt_logits, kv_cache = tt_FalconCausalLM(
-            input_embeddings=tt_decode_embeddings,
+            input_ids=tt_decode_input_ids,
             llm_mode="decode",
             attention_mask=tt_decode_attention_mask,
             layer_past=kv_cache,
@@ -434,7 +434,7 @@ def run_falcon_demo_kv(
         logits = torch.concat([tt2torch_tensor(tt_logits[i]).squeeze(1) for i in range(num_devices)], dim=-2)
 
         for i in range(num_devices):
-            tt_decode_embeddings[i].deallocate()
+            tt_decode_input_ids[i].deallocate()
             if tt_decode_attention_mask is not None:
                 tt_decode_attention_mask[i].deallocate()
             tt_logits[i].deallocate()

--- a/models/demos/falcon7b/demo/demo.py
+++ b/models/demos/falcon7b/demo/demo.py
@@ -259,15 +259,14 @@ def run_falcon_demo_kv(
             use_cache=use_cache,
         )
         synchronize_devices(devices)
-        time_prefill_compile_end = time.time()
-        time_prefill_compile += time_prefill_compile_end - time_prefill_compile_start
 
         for i in range(num_devices):
             tt_prefill_input_ids[i].deallocate()
             if tt_prefill_attention_mask is not None:
                 tt_prefill_attention_mask[i].deallocate()
-
             tt_logits[i].deallocate()
+
+        time_prefill_compile += time.time() - time_prefill_compile_start
 
     synchronize_devices(devices)
     logger.info("Finished 1st run prefill stage with compile!")
@@ -300,15 +299,14 @@ def run_falcon_demo_kv(
             use_cache=use_cache,
         )
         synchronize_devices(devices)
-        time_decode_compile_end = time.time()
-        time_decode_compile += time_decode_compile_end - time_decode_compile_start
 
         for i in range(num_devices):
             tt_decode_input_ids[i].deallocate()
             if tt_decode_attention_mask is not None:
                 tt_decode_attention_mask[i].deallocate()
-
             tt_logits[i].deallocate()
+
+        time_decode_compile += time.time() - time_decode_compile_start
 
     logger.info("Finished 1st run decode stage with compile!")
     synchronize_devices(devices)
@@ -368,9 +366,6 @@ def run_falcon_demo_kv(
             use_cache=use_cache,
         )
         synchronize_devices(devices)
-        time_prefill_inference_end = time.time()
-        if i >= N_warmup:
-            time_prefill_inference += time_prefill_inference_end - time_prefill_inference_start
 
         logits = torch.concat([tt2torch_tensor(tt_logits[j]).squeeze(1) for j in range(num_devices)], dim=-2)
 
@@ -382,6 +377,9 @@ def run_falcon_demo_kv(
 
         user_output_ids = post_processor(logits=logits, index=num_input_tokens - 1)
         output_ids[user_id::batch_size] = user_output_ids
+
+        if i >= N_warmup:
+            time_prefill_inference += time.time() - time_prefill_inference_start
 
     logger.info("Finished inference prefill stage!")
     num_users_generated_prefill = num_users if not perf_mode else (N - N_warmup) * num_devices
@@ -427,9 +425,6 @@ def run_falcon_demo_kv(
             use_cache=use_cache,
         )
         synchronize_devices(devices)
-        time_decode_inference_end = time.time()
-        if output_token_index >= N_warmup:
-            time_decode_inference += time_decode_inference_end - time_decode_inference_start
 
         logits = torch.concat([tt2torch_tensor(tt_logits[i]).squeeze(1) for i in range(num_devices)], dim=-2)
 
@@ -439,12 +434,15 @@ def run_falcon_demo_kv(
                 tt_decode_attention_mask[i].deallocate()
             tt_logits[i].deallocate()
 
-        if not perf_mode:
-            if greedy_sampling:
-                decode_ids = post_processor(logits=logits, index=...).reshape(global_batch, 1)
-            else:
-                decode_ids = top_pk_logits_efficient(logits.reshape(global_batch, -1)).reshape(global_batch, 1)
+        if greedy_sampling:
+            decode_ids = post_processor(logits=logits, index=...).reshape(global_batch, 1)
+        else:
+            decode_ids = top_pk_logits_efficient(logits.reshape(global_batch, -1)).reshape(global_batch, 1)
 
+        if output_token_index >= N_warmup:
+            time_decode_inference += time.time() - time_decode_inference_start
+
+        if not perf_mode:
             for user_id, user_decode_id in enumerate(decode_ids[:num_users]):
                 if user_decode_id == END_OF_TEXT:
                     prompt_is_done[user_id] = True

--- a/models/demos/falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon7b/tests/test_falcon_causallm.py
@@ -104,9 +104,6 @@ def run_test_FalconCausalLM_inference(
         input_ids=model_input, past_key_values=past_key_values, use_cache=use_cache
     )
 
-    # NOTE: Passing in pytorch tensor here instead of ll buda tensor
-    # since we don't yet have embedding support on device
-    # device, state_dict, base_url, max_position_embeddings, config, num_decoders
     tt_FalconCausalLM = TtFalconCausalLM(
         devices,
         state_dict,
@@ -118,10 +115,10 @@ def run_test_FalconCausalLM_inference(
         tt_cache_path,
     )
 
-    # TODO: Generate embeddings and attention_mask on device
+    # TODO: Generate attention_mask on device
     if llm_mode == "prefill":
         tt_outs = torch.zeros(global_batch, seq_len, configuration.vocab_size)  # Output tensor to overwrite
-        tt_embeddings, tt_attention_mask = zip(
+        tt_input_ids, tt_attention_mask = zip(
             *[
                 tt_FalconCausalLM.model_preprocessing(
                     llm_mode, model_input[i::batch], kv_cache_len, num_input_tokens=seq_len
@@ -131,7 +128,7 @@ def run_test_FalconCausalLM_inference(
         )
         for user_id in range(batch):
             tt_out, tt_layer_present = tt_FalconCausalLM(
-                input_embeddings=tt_embeddings[user_id],
+                input_ids=tt_input_ids[user_id],
                 llm_mode=llm_mode,
                 attention_mask=tt_attention_mask[user_id],
                 user_id=user_id,
@@ -144,11 +141,11 @@ def run_test_FalconCausalLM_inference(
         tt_out = tt_outs
 
     elif llm_mode == "decode":
-        tt_embeddings, tt_attention_mask = tt_FalconCausalLM.model_preprocessing(
+        tt_input_ids, tt_attention_mask = tt_FalconCausalLM.model_preprocessing(
             llm_mode, model_input, kv_cache_len, num_input_tokens=kv_len
         )
         tt_out, tt_layer_present = tt_FalconCausalLM(
-            input_embeddings=tt_embeddings,
+            input_ids=tt_input_ids,
             llm_mode=llm_mode,
             attention_mask=tt_attention_mask,
             layer_past=tt_layer_past,

--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -43,9 +43,9 @@ from models.utility_functions import (
 from models.perf.perf_utils import prep_perf_report
 
 
-def generate_embeddings(llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len):
+def get_inputs_on_device(llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len):
     if llm_mode == "prefill":
-        tt_embeddings, tt_attention_mask = zip(
+        tt_input_ids, tt_attention_mask = zip(
             *[
                 tt_FalconCausalLM.model_preprocessing(
                     llm_mode, model_input[i::batch], kv_cache_len, num_input_tokens=seq_len
@@ -54,10 +54,10 @@ def generate_embeddings(llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, 
             ]
         )
     elif llm_mode == "decode":
-        tt_embeddings, tt_attention_mask = tt_FalconCausalLM.model_preprocessing(
+        tt_input_ids, tt_attention_mask = tt_FalconCausalLM.model_preprocessing(
             llm_mode, model_input, kv_cache_len, num_input_tokens=kv_len
         )
-    return tt_embeddings, tt_attention_mask
+    return tt_input_ids, tt_attention_mask
 
 
 # TODO: Replace this with actual Falcon application-level tests
@@ -122,10 +122,6 @@ def run_test_FalconCausalLM_end_to_end(
         generate_attention_inputs=False,
     )
 
-    # NOTE: Passing in pytorch tensor here instead of ll buda tensor
-    # since we don't yet have embedding support on device
-    # device, state_dict, base_url, max_position_embeddings, config, num_decoders
-
     profiler.start("TtFalcon_model_setup")
     tt_FalconCausalLM = TtFalconCausalLM(
         devices,
@@ -140,8 +136,8 @@ def run_test_FalconCausalLM_end_to_end(
     profiler.end("TtFalcon_model_setup")
 
     profiler.start("processing_of_input")
-    # TODO: Generate embeddings and attention_mask on device
-    tt_embeddings, tt_attention_mask = generate_embeddings(
+    # TODO: Generate attention_mask on device
+    tt_input_ids, tt_attention_mask = get_inputs_on_device(
         llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len
     )
     profiler.end("processing_of_input")
@@ -154,13 +150,13 @@ def run_test_FalconCausalLM_end_to_end(
     profiler.start("first_model_run_with_compile", force_enable=True)
     if llm_mode == "prefill":
         tt_outs = []
-        # Embedding time is included in model run time for prefill
-        tt_embeddings, tt_attention_mask = generate_embeddings(
+        # Device transfer time is included in model run time for prefill
+        tt_input_ids, tt_attention_mask = get_inputs_on_device(
             llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len
         )
         for user_id in range(batch):
             tt_out, tt_layer_present = tt_FalconCausalLM(
-                input_embeddings=tt_embeddings[user_id],
+                input_ids=tt_input_ids[user_id],
                 llm_mode=llm_mode,
                 attention_mask=tt_attention_mask[user_id],
                 user_id=user_id,
@@ -173,7 +169,7 @@ def run_test_FalconCausalLM_end_to_end(
 
     elif llm_mode == "decode":
         tt_out, tt_layer_present = tt_FalconCausalLM(
-            input_embeddings=tt_embeddings,
+            input_ids=tt_input_ids,
             llm_mode=llm_mode,
             attention_mask=tt_attention_mask,
             layer_past=tt_layer_past,
@@ -186,7 +182,7 @@ def run_test_FalconCausalLM_end_to_end(
     del tt_out
     del tt_layer_past
     del tt_layer_present
-    del tt_embeddings
+    del tt_input_ids
     del tt_attention_mask
 
     # Re-generate dummy kv_cache ------------------------------------------------------------
@@ -222,21 +218,21 @@ def run_test_FalconCausalLM_end_to_end(
     profiler.enable()
     enable_persistent_kernel_cache()
 
-    # Regenerate embeddings and attention_mask
-    tt_embeddings, tt_attention_mask = generate_embeddings(
+    # Regenerate input ids and attention_mask on device
+    tt_input_ids, tt_attention_mask = get_inputs_on_device(
         llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len
     )
 
     profiler.start(f"model_run_for_inference")
     if llm_mode == "prefill":
         tt_outs = []
-        # Embedding time is included in model run time for prefill
-        tt_embeddings, tt_attention_mask = generate_embeddings(
+        # Device transfer time is included in model run time for prefill
+        tt_input_ids, tt_attention_mask = get_inputs_on_device(
             llm_mode, tt_FalconCausalLM, model_input, kv_cache_len, seq_len, batch, kv_len
         )
         for user_id in range(batch):
             tt_out, tt_layer_present = tt_FalconCausalLM(
-                input_embeddings=tt_embeddings[user_id],
+                input_ids=tt_input_ids[user_id],
                 llm_mode=llm_mode,
                 attention_mask=tt_attention_mask[user_id],
                 user_id=user_id,
@@ -248,7 +244,7 @@ def run_test_FalconCausalLM_end_to_end(
 
     elif llm_mode == "decode":
         tt_out, tt_layer_present = tt_FalconCausalLM(
-            input_embeddings=tt_embeddings,
+            input_ids=tt_input_ids,
             llm_mode=llm_mode,
             attention_mask=tt_attention_mask,
             layer_past=tt_layer_past,
@@ -340,7 +336,7 @@ def run_test_FalconCausalLM_end_to_end(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "num_layers, pcc",
-    ((32, 0.88),),
+    ((32, 0.84),),
     ids=["layers_32"],
 )
 @pytest.mark.parametrize(

--- a/models/demos/falcon7b/tt/falcon_causallm.py
+++ b/models/demos/falcon7b/tt/falcon_causallm.py
@@ -53,7 +53,7 @@ class TtFalconCausalLM(TtFalconModelShared):
 
     def forward(
         self,
-        input_embeddings: tt_lib.tensor.Tensor,
+        input_ids: tt_lib.tensor.Tensor,
         llm_mode: str,
         attention_mask: tt_lib.tensor.Tensor = None,
         user_id: int = 0,
@@ -62,7 +62,7 @@ class TtFalconCausalLM(TtFalconModelShared):
         use_cache: bool = False,
     ) -> tt_lib.tensor.Tensor:
         hidden_states, presents = super().forward(
-            input_embeddings=input_embeddings,
+            input_ids=input_ids,
             attention_mask=attention_mask,
             llm_mode=llm_mode,
             user_id=user_id,

--- a/models/demos/falcon7b/tt/model_config.py
+++ b/models/demos/falcon7b/tt/model_config.py
@@ -118,6 +118,9 @@ def get_model_config(model_config_str):
     model_config.update({f"{key}_MEMCFG": mem_config for key in OP_KEYS if key not in NO_MEMCFG})
     model_config.update({f"{key}_DTYPE": dtype for key in OP_KEYS if key not in NO_DTYPE})
 
+    # Input ids are UINT32
+    model_config["INPUT_DTYPE"] = ttl.tensor.DataType.UINT32
+
     # Matmul Weights must always be BFP8_B
     # Override defaults for certain configs
     for key in model_config.keys():

--- a/models/demos/falcon7b/tt/model_utils.py
+++ b/models/demos/falcon7b/tt/model_utils.py
@@ -16,7 +16,11 @@ def get_weights_cached(
     weights_to_cache,
     overwrite=False,
     padzero=False,
+    tt_layout=tt_lib.tensor.Layout.TILE,
 ):
+    if padzero:
+        assert tt_layout == tt_lib.tensor.Layout.TILE, "padding by zero currently only uses TILE layout"
+
     """Load cached weights and duplicate per device. Store if not cached."""
     if (
         not overwrite
@@ -38,6 +42,7 @@ def get_weights_cached(
             weights_host = torch2tt_tensor(
                 weights_to_cache,
                 tt_device=None,
+                tt_layout=tt_layout,
                 tt_memory_config=model_config[f"{weight_config_str}_MEMCFG"],
                 tt_dtype=model_config[f"{weight_config_str}_DTYPE"],
             )


### PR DESCRIPTION
- Move embedding computation from cpu to device using ttnn.embedding() in Falcon7b model and tests
- Modify e2e time measurement in demo to include device to host transfer and token selection