### PR TITLE
#7363: L1 small region allocator support

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -256,7 +256,7 @@ def reset_tensix(request, silicon_arch_name):
 
 
 @pytest.fixture(scope="function")
-def device_init_destroy(request):
+def device_l1_small_size(request):
     import tt_lib as ttl
 
     device_id = request.config.getoption("device_id")
@@ -264,7 +264,11 @@ def device_init_destroy(request):
     num_devices = ttl.device.GetNumPCIeDevices()
     assert device_id < num_devices, "CreateDevice not supported for non-mmio device"
 
-    device = ttl.device.CreateDevice(device_id)
+    if hasattr(request, "param"):
+        l1_small_size = request.param
+        device = ttl.device.CreateDevice(device_id, l1_small_size)
+    else:
+        device = ttl.device.CreateDevice(device_id)
     ttl.device.SetDefaultDevice(device)
 
     yield device
@@ -274,7 +278,7 @@ def device_init_destroy(request):
 
 
 @pytest.fixture(scope="function")
-def device(device_init_destroy):
+def device(device_l1_small_size):
     import tt_lib as ttl
 
     device = ttl.device.GetDefaultDevice()

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_create_qkv_heads.py
@@ -126,6 +126,7 @@ def run_create_qkv_heads_test(
     assert passing_pcc_v
 
 
+@pytest.mark.parametrize("device_l1_small_size", [8192], indirect=True)
 @pytest.mark.parametrize(
     "dtype",
     (ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.FLOAT32),

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_downsample.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_downsample.py
@@ -25,6 +25,7 @@ from tests.tt_eager.python_api_testing.conv.conv_unit_test_utils import (
 import torch
 
 
+@pytest.mark.parametrize("device_l1_small_size", [8192], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, stride_h, stride_w, num_cores, grid_size, height_sharded",
     (

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_conv.py
@@ -16,6 +16,7 @@ from tests.ttnn.unit_tests.operations.test_conv2d import run_conv
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, bias, use_1d_systolic_array, config_override",
     (

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_optimized_conv_v2.py
@@ -24,6 +24,7 @@ from tt_eager.tt_dnn.op_library.sliding_window_op_infra.tt_py_composite_conv imp
 )
 
 
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, is_1d_systolic, bias, untilize_out, fuse_relu",
     (
@@ -249,6 +250,7 @@ def test_optimized_conv_v2(
     assert passing_pcc
 
 
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 def test_simple(
     device,
     use_program_cache,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv_v2.py
@@ -413,6 +413,7 @@ hardcoded_conv_blocking_and_parallelization_config = {
 
 
 @skip_for_grayskull()
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize("N", (8, 16, 20), ids=["batch_8", "batch_16", "batch_20"])
 @pytest.mark.parametrize(
     "K, C, H, W, R, S, stride_h, stride_w, pad_h, pad_w",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_softmax_sharded.py
@@ -19,6 +19,7 @@ from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_ze
 from models.utility_functions import is_grayskull
 
 
+@pytest.mark.parametrize("device_l1_small_size", [8192], indirect=True)
 @pytest.mark.parametrize(
     "in0_mem_config",
     (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),),
@@ -99,6 +100,7 @@ def test_softmax_causal_mask(device, in_dtype, in0_mem_config):
     assert allclose, f"FAILED: {output}"
 
 
+@pytest.mark.parametrize("device_l1_small_size", [8192], indirect=True)
 @pytest.mark.parametrize(
     "causal_mask",
     [True, False],
@@ -209,6 +211,7 @@ def test_softmax(device, in_dtype, in0_mem_config, causal_mask):
     assert allclose, f"FAILED: {output}"
 
 
+@pytest.mark.parametrize("device_l1_small_size", [8192], indirect=True)
 @pytest.mark.parametrize(
     "causal_mask",
     [True, False],
@@ -316,6 +319,7 @@ def test_scale_mask_softmax_rm(device, in_dtype, in0_mem_config, causal_mask):
     assert allclose, f"FAILED: {output}"
 
 
+@pytest.mark.parametrize("device_l1_small_size", [8192], indirect=True)
 @pytest.mark.parametrize(
     "shard_orient",
     [ttl.tensor.ShardOrientation.COL_MAJOR, ttl.tensor.ShardOrientation.ROW_MAJOR],

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_and_max_pool_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_and_max_pool_v2.py
@@ -33,6 +33,7 @@ def volume(shape):
 ## pad_h, pad_w
 ## dilation_h, dilation_w
 @skip_for_grayskull()
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize(
     "act_shape",  ## NCHW
     (

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_v2.py
@@ -45,6 +45,7 @@ def plot_diff(vals, fid, nsticks, stick_len):
 
 
 # conv params - output_channels, input_channels, filter_h, filter_w, stride_h, stride_w, pad_h, pad_w, dilation, groups
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize(
     "conv_params, batch_size, input_chw_shape, num_cores_nhw, grid_size, test_max_pool",
     (

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -96,10 +96,11 @@ inline std::vector<CoreCoord> get_cores_per_bank_id(Device *device, bool is_dram
 inline uint32_t get_min_required_buffer_addr(Device *device, bool is_dram){
 
     int32_t smallest_offset = std::numeric_limits<int32_t>::max();
-    uint32_t num_banks = device->num_banks(is_dram ? BufferType::DRAM : BufferType::L1);
+    BufferType buffer_type = is_dram ? BufferType::DRAM : BufferType::L1;
+    uint32_t num_banks = device->num_banks(buffer_type);
 
     for (int bank_id = 0; bank_id < num_banks; bank_id++) {
-        int32_t offset = is_dram ? device->dram_bank_offset_from_bank_id(bank_id) : device->l1_bank_offset_from_bank_id(bank_id);
+        int32_t offset = device->bank_offset(buffer_type, bank_id);
         smallest_offset = offset < smallest_offset ? offset : smallest_offset;
     }
 
@@ -539,10 +540,10 @@ inline bool validate_core_data(std::unordered_set<CoreCoord> &validated_cores, D
         if (is_dram) {
             auto channel = device->dram_channel_from_bank_id(bank_id);
             phys_core = device->core_from_dram_channel(channel);
-            bank_offset = device->dram_bank_offset_from_bank_id(bank_id);
+            bank_offset = device->bank_offset(BufferType::DRAM, bank_id);
         } else {
             phys_core = device->physical_core_from_logical_core(core, core_type);
-            bank_offset = device->l1_bank_offset_from_bank_id(bank_id);
+            bank_offset = device->bank_offset(BufferType::L1, bank_id);
         }
 
         log_debug(tt::LogTest, "Paged-{} for bank_id: {} has base_addr: (0x{:x}) and DRAM bank offset: {:x})",

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -315,17 +315,26 @@ void gen_cmds(Device *device,
 // Clear DRAM (helpful for paged write to DRAM debug to have a fresh slate)
 void initialize_dram_banks(Device *device)
 {
-
     auto num_banks = device->num_banks(BufferType::DRAM);
     auto bank_size = device->bank_size(BufferType::DRAM); // Or can hardcode to subset like 16MB.
     auto fill = std::vector<uint32_t>(bank_size / sizeof(uint32_t), 0xBADDF00D);
 
     for (int bank_id = 0; bank_id < num_banks; bank_id++) {
-        auto offset = device->dram_bank_offset_from_bank_id(bank_id);
-        auto dram_channel = device->dram_channel_from_bank_id(bank_id);
-        auto bank_core = device->core_from_dram_channel(dram_channel);
-        log_info(tt::LogTest, "Initializing DRAM {} bytes for bank_id: {} core: {} at addr: 0x{:x}", bank_size, bank_id, bank_core, offset);
-        tt::Cluster::instance().write_core(static_cast<const void*>(fill.data()), fill.size() * sizeof(uint32_t), tt_cxy_pair(device->id(), bank_core), offset);
+    auto offset = device->bank_offset(BufferType::DRAM, bank_id);
+    auto dram_channel = device->dram_channel_from_bank_id(bank_id);
+    auto bank_core = device->core_from_dram_channel(dram_channel);
+    log_info(
+        tt::LogTest,
+        "Initializing DRAM {} bytes for bank_id: {} core: {} at addr: 0x{:x}",
+        bank_size,
+        bank_id,
+        bank_core,
+        offset);
+    tt::Cluster::instance().write_core(
+        static_cast<const void*>(fill.data()),
+        fill.size() * sizeof(uint32_t),
+        tt_cxy_pair(device->id(), bank_core),
+        offset);
     }
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -950,7 +950,7 @@ void populate_interleaved_dram(Device *device, unordered_map<uint32_t, vector<ui
     num_dram_banks_g = device->num_banks(BufferType::DRAM);;
 
     for (int bank_id = 0; bank_id < num_dram_banks_g; bank_id++) {
-        auto offset = device->dram_bank_offset_from_bank_id(bank_id);
+        auto offset = device->bank_offset(BufferType::DRAM, bank_id);
         auto dram_channel = device->dram_channel_from_bank_id(bank_id);
         auto bank_core = device->core_from_dram_channel(dram_channel);
 
@@ -979,7 +979,7 @@ void initialize_dram_banks(Device *device)
     auto fill = std::vector<uint32_t>(bank_size / sizeof(uint32_t), 0xBADDF00D);
 
     for (int bank_id = 0; bank_id < num_banks; bank_id++) {
-        auto offset = device->dram_bank_offset_from_bank_id(bank_id);
+        auto offset = device->bank_offset(BufferType::DRAM, bank_id);
         auto dram_channel = device->dram_channel_from_bank_id(bank_id);
         auto bank_core = device->core_from_dram_channel(dram_channel);
 

--- a/tests/tt_metal/tt_metal/unit_tests/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/allocator/test_l1_banking_allocator.cpp
@@ -12,7 +12,7 @@
 
 // TODO: Uplift to DeviceFixture once it does not skip GS
 TEST_F(BasicFixture, TestL1BuffersAllocatedTopDown) {
-    tt::tt_metal::Device *device = tt::tt_metal::CreateDevice(0);
+    tt::tt_metal::Device *device = tt::tt_metal::CreateDevice(0, 1, 0);
 
     std::vector<uint32_t> alloc_sizes = {32 * 1024, 64 * 1024, 128 * 1024};
     size_t total_size_bytes = 0;
@@ -42,7 +42,7 @@ TEST_F(BasicFixture, TestL1BuffersAllocatedTopDown) {
 
 // TODO: Uplift to DeviceFixture once it does not skip GS
 TEST_F(BasicFixture, TestL1BuffersDoNotGrowBeyondBankSize) {
-    tt::tt_metal::Device *device = tt::tt_metal::CreateDevice(0);
+    tt::tt_metal::Device *device = tt::tt_metal::CreateDevice(0, 1, 0);
 
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(device->id());
     const uint32_t interleaved_l1_bank_size = tt::get_storage_core_bank_size(device->id(), device->num_hw_cqs());

--- a/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/device.cpp
@@ -224,7 +224,7 @@ TEST_F(DeviceFixture, ValidateKernelDoesNotTargetHarvestedCores) {
             host_input[0] = bank_id + 1;
             bank_id_to_value[bank_id] = host_input.at(0);
             CoreCoord logical_core = this->devices_.at(id)->logical_core_from_bank_id(bank_id);
-            uint32_t write_address = l1_address + this->devices_.at(id)->l1_bank_offset_from_bank_id(bank_id);
+            uint32_t write_address = l1_address + this->devices_.at(id)->bank_offset(BufferType::L1, bank_id);
             tt_metal::detail::WriteToDeviceL1(this->devices_.at(id), logical_core, write_address, host_input);
         }
 
@@ -247,7 +247,7 @@ TEST_F(DeviceFixture, ValidateKernelDoesNotTargetHarvestedCores) {
         std::vector<uint32_t> output;
         for (uint32_t bank_id = 0; bank_id < num_l1_banks; bank_id++) {
             CoreCoord logical_core = this->devices_.at(id)->logical_core_from_bank_id(bank_id);
-            uint32_t read_address = l1_address + this->devices_.at(id)->l1_bank_offset_from_bank_id(bank_id);
+            uint32_t read_address = l1_address + this->devices_.at(id)->bank_offset(BufferType::L1, bank_id);
             tt_metal::detail::ReadFromDeviceL1(this->devices_.at(id), logical_core, read_address, size_bytes, output);
             ASSERT_TRUE(output.size() == host_input.size());
             uint32_t expected_value =

--- a/tests/ttnn/integration_tests/resnet/test_performance.py
+++ b/tests/ttnn/integration_tests/resnet/test_performance.py
@@ -52,6 +52,7 @@ def test_perf_device_bare_metal(batch_size, test, expected_perf):
 @skip_for_wormhole_b0("This will be enabled after WH testing")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize(
     "model_name,batch_size,act_dtype,weight_dtype,math_fidelity,expected_compile_time,expected_inference_time",
     [("ResNet50", 20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, 23, 0.04)],  ## pass

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
@@ -265,6 +265,7 @@ def create_test_infra(device, batch_size, act_dtype, weight_dtype, math_fidelity
     return ResNet50TestInfra(device, batch_size, act_dtype, weight_dtype, math_fidelity)
 
 
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     (

--- a/tests/ttnn/unit_tests/operations/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_conv2d.py
@@ -305,6 +305,7 @@ def run_conv_with_split(
 @skip_for_wormhole_b0(
     "Issue #6992: Statically allocated circular buffers in program clash with L1 buffers on core range"
 )
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array",
     (
@@ -397,6 +398,7 @@ def test_resnet50_conv_gs(
 
 @skip_for_wormhole_b0()
 @skip_for_grayskull()
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
     (
@@ -511,6 +513,7 @@ def test_resnet50_conv_wh(
 
 @skip_for_wormhole_b0("WH ND hangs")
 @skip_for_grayskull()
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
     (
@@ -630,6 +633,7 @@ def test_resnet50_conv_wh_fp32(
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
     (
@@ -763,6 +767,7 @@ def test_sd_conv(
 
 @skip_for_wormhole_b0("Issue #7179: non-deterministically fails on N150 regression")
 @skip_for_grayskull()
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
     (
@@ -921,6 +926,7 @@ def test_sd_conv_wh(
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override, use_shallow_conv_variant",
     (
@@ -1021,6 +1027,7 @@ def test_unet_conv(
 
 
 @skip_for_grayskull()
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override, use_shallow_conv_variant",
     (
@@ -1122,6 +1129,7 @@ def test_unet_conv_wh(
     )
 
 
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, config_override",
     (
@@ -1180,6 +1188,7 @@ def test_halo_reshard_conv(
     )
 
 
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, config_override, xfail",
     (

--- a/tests/ttnn/unit_tests/operations/test_group_norm_v2.py
+++ b/tests/ttnn/unit_tests/operations/test_group_norm_v2.py
@@ -35,6 +35,7 @@ def manual_group_norm(input_tensor, num_groups, eps=1e-2):
     return input_tensor
 
 
+@pytest.mark.parametrize("device_l1_small_size", [0], indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups",
     [
@@ -130,6 +131,7 @@ def test_group_norm_with_block_sharded_v2_8x4_grid(device, N, C, H, W, num_group
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9997)
 
 
+@pytest.mark.parametrize("device_l1_small_size", [0], indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups",
     [

--- a/tests/ttnn/unit_tests/operations/test_max_pool2d.py
+++ b/tests/ttnn/unit_tests/operations/test_max_pool2d.py
@@ -18,6 +18,7 @@ import ttnn
 ## stride_h, stride_w
 ## pad_h, pad_w
 ## dilation_h, dilation_w
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize(
     "act_shape",  ## NCHW
     (
@@ -211,6 +212,7 @@ def test_run_max_pool(
         assert isequal
 
 
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, config_override, xfail",
     (

--- a/tests/ttnn/unit_tests/test_model_preprocessing.py
+++ b/tests/ttnn/unit_tests/test_model_preprocessing.py
@@ -60,6 +60,7 @@ def test_linear(device, model_name, batch_size, m_size, k_size, n_size):
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.parametrize("device_l1_small_size", [16384], indirect=True)
 @pytest.mark.parametrize("model_name", [None, "conv"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("num_input_channels", [128])
@@ -108,6 +109,7 @@ def test_conv(
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize("model_name", [None, "conv_relu_conv"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("num_input_channels", [128])
@@ -180,6 +182,7 @@ def test_conv_relu_conv(
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize("model_name", [None, "nested_conv_relu_conv"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("num_input_channels", [128])
@@ -261,6 +264,7 @@ def test_nested_conv_relu_conv(
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize("model_name", [None, "conv_relu_linear"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("num_input_channels", [128])
@@ -378,6 +382,7 @@ def test_module_with_childen_and_parameters(device, batch_size, m_size, k_size, 
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize("use_conv_bias", [True, False])
 def test_conv2d_with_batch_norm2d(device, use_conv_bias):
     torch.manual_seed(0)
@@ -470,6 +475,7 @@ def test_conv2d_with_batch_norm2d(device, use_conv_bias):
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 def test_resnet_with_module_cache(device):
     torch.manual_seed(0)
 

--- a/tests/ttnn/unit_tests/test_tracer.py
+++ b/tests/ttnn/unit_tests/test_tracer.py
@@ -77,6 +77,7 @@ def test_bloom(show_modules):
 @skip_for_wormhole_b0()
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
+@pytest.mark.parametrize("device_l1_small_size", [0], indirect=True)
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [384])

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -682,7 +682,7 @@ Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layo
     ZoneScoped;
     TT_ASSERT(memory_config.is_sharded());
     TT_ASSERT(memory_config.shard_spec.has_value());
-    TT_ASSERT(memory_config.buffer_type == BufferType::L1);
+    TT_ASSERT(memory_config.is_l1());
 
     auto shard_spec = memory_config.shard_spec.value();
     auto& shard_shape = shard_spec.shape;

--- a/tt_eager/tensor/types.cpp
+++ b/tt_eager/tensor/types.cpp
@@ -185,6 +185,10 @@ bool MemoryConfig::is_sharded() const {
     }
 }
 
+bool MemoryConfig::is_l1() const { return buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL; }
+
+bool MemoryConfig::is_dram() const { return buffer_type == BufferType::DRAM; }
+
 bool operator==(const MemoryConfig& config_a, const MemoryConfig& config_b) {
     return config_a.buffer_type == config_b.buffer_type && config_a.memory_layout == config_b.memory_layout && config_a.shard_spec == config_b.shard_spec;
 }

--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -214,6 +214,8 @@ struct MemoryConfig {
     BufferType buffer_type = BufferType::DRAM;                           // Can be either DRAM or L1
     std::optional<ShardSpec> shard_spec = std::nullopt;
     bool is_sharded() const;
+    bool is_l1() const;
+    bool is_dram() const;
 
     static constexpr auto attribute_names = std::make_tuple("memory_layout", "buffer_type", "shard_spec");
     const auto attribute_values() const {

--- a/tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/move/multi_core/move_op_multi_core.cpp
@@ -19,7 +19,7 @@ namespace tt {
 namespace tt_metal {
 
 operation::ProgramWithCallbacks move_multi_core(const Tensor &input, Tensor &output) {
-    bool src_and_dst_in_l1 = input.memory_config().buffer_type == BufferType::L1 && output.memory_config().buffer_type == BufferType::L1;
+    bool src_and_dst_in_l1 = input.memory_config().is_l1() && output.memory_config().is_l1();
     return copy_multi_core(input, output, src_and_dst_in_l1);
 }
 

--- a/tt_eager/tt_dnn/op_library/move/single_core/move_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/move/single_core/move_op_single_core.cpp
@@ -16,7 +16,7 @@ namespace tt {
 namespace tt_metal {
 
 operation::ProgramWithCallbacks move_single_core(const Tensor &input, Tensor &output) {
-    bool src_and_dst_in_l1 = input.memory_config().buffer_type == BufferType::L1 && output.memory_config().buffer_type == BufferType::L1;
+    bool src_and_dst_in_l1 = input.memory_config().is_l1() && output.memory_config().is_l1();
     return copy_single_core(input, output, src_and_dst_in_l1);
 }
 

--- a/tt_eager/tt_dnn/op_library/operation.hpp
+++ b/tt_eager/tt_dnn/op_library/operation.hpp
@@ -146,10 +146,9 @@ struct OpPerformanceModel {
 
         auto tensor_ns = [peak_dram_bw, noc_l1_bisection_bw](const Tensor& t) {
             int size_bytes = t.volume() * t.element_size();
-            if(t.memory_config().buffer_type == BufferType::DRAM) {
+            if (t.memory_config().is_dram()) {
                 return size_bytes / peak_dram_bw / 1024 / 1024 / 1024 * 1000 * 1000 * 1000;
-            }
-            else if(t.memory_config().buffer_type == BufferType::L1) {
+            } else if (t.memory_config().is_l1()) {
                 return 1.0f; // TODO: figure out better modelling scheme for L1->L1 Transfers
                 //return size_bytes / noc_l1_bisection_bw / 1024 / 1024 / 1024 * 1000 * 1000 * 1000;
             }

--- a/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_composite_conv.py
+++ b/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_composite_conv.py
@@ -651,7 +651,7 @@ class TTPyCompositeConv(TTPyOp):
             shard_halo = False
             shard_spec = ttl.tensor.ShardSpec(shard_grid, [1, conv_output_shard_height], shard_orientation, shard_halo)
             mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1, shard_spec
+                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1_SMALL, shard_spec
             )
             conv_reader_indices_sharded_tensor = (
                 conv_reader_indices_tt_tensor.to(device, mem_config)

--- a/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_max_pool.py
+++ b/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_max_pool.py
@@ -196,7 +196,7 @@ class TTPyMaxPool(TTPyOp):
             shard_spec = ttl.tensor.ShardSpec(
                 self.shard_grid, [1, reader_indices_tt_tensor.get_legacy_shape()[-1]], shard_orientation, shard_halo
             )
-            mem_config = ttl.tensor.MemoryConfig(self.shard_layout, ttl.tensor.BufferType.L1, shard_spec)
+            mem_config = ttl.tensor.MemoryConfig(self.shard_layout, ttl.tensor.BufferType.L1_SMALL, shard_spec)
             reader_indices_sharded_tensor = reader_indices_tt_tensor.to(self.device, mem_config)
 
             reader_patterns_cache[sliding_window_op_params_hash] = reader_indices_sharded_tensor

--- a/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_untilize_with_halo.py
+++ b/tt_eager/tt_dnn/op_library/sliding_window_op_infra/tt_py_untilize_with_halo.py
@@ -124,7 +124,7 @@ class TTPyUntilizeWithHalo(TTPyOp):
             shard_grid, shard_layout = calculate_shard_grid((num_cores_w, num_cores_h), num_cores_nhw)
             block_sharding = shard_layout == ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED
 
-            def get_memory_config(shard_shape):
+            def get_memory_config(shard_shape, buffer_type=ttl.tensor.BufferType.L1_SMALL):
                 shard_orientation = (
                     ttl.tensor.ShardOrientation.COL_MAJOR if block_sharding else ttl.tensor.ShardOrientation.ROW_MAJOR
                 )
@@ -135,7 +135,7 @@ class TTPyUntilizeWithHalo(TTPyOp):
                     if block_sharding
                     else ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED
                 )
-                mem_config = ttl.tensor.MemoryConfig(mem_layout, ttl.tensor.BufferType.L1, shard_spec)
+                mem_config = ttl.tensor.MemoryConfig(mem_layout, buffer_type, shard_spec)
                 return mem_config
 
             def gen_per_core_gather_data_uint16_tensor(config: list):
@@ -193,7 +193,7 @@ class TTPyUntilizeWithHalo(TTPyOp):
                 "padding_config": padding_config_tensor,
                 "local_config": local_config_tensor,
                 "remote_config": remote_config_tensor,
-                "out_mem_config": get_memory_config(out_shard_shape),
+                "out_mem_config": get_memory_config(out_shard_shape, buffer_type=ttl.tensor.BufferType.L1),
                 "remote_read": remote_read,
             }
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -108,7 +108,8 @@ void TensorModule(py::module &m_tensor) {
 
     py::enum_<BufferType>(m_tensor, "BufferType")
         .value("DRAM", BufferType::DRAM)
-        .value("L1", BufferType::L1);
+        .value("L1", BufferType::L1)
+        .value("L1_SMALL", BufferType::L1_SMALL);
 
     // Fusible Activations
     detail::export_enum<UnaryOpType>(m_tensor, "FusibleActivation");

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -34,6 +34,7 @@ namespace tt::tt_metal{
         std::map<chip_id_t, Device *> CreateDevices(
             std::vector<chip_id_t> device_ids,
             const uint8_t num_hw_cqs = 1,
+            const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
             const std::vector<uint32_t> &l1_bank_remap = {});
 
         void CloseDevices(std::map<chip_id_t, Device *> devices);
@@ -337,7 +338,7 @@ namespace tt::tt_metal{
             std::vector<int32_t> dram_offsets_per_bank(num_dram_banks);
             for (unsigned bank_id = 0; bank_id < num_dram_banks; bank_id++) {
                 dram_noc_coord_per_bank[bank_id] = device->core_from_dram_channel(device->dram_channel_from_bank_id(bank_id));
-                dram_offsets_per_bank[bank_id] = device->dram_bank_offset_from_bank_id(bank_id);
+                dram_offsets_per_bank[bank_id] = device->bank_offset(BufferType::DRAM, bank_id);
             }
             const size_t num_l1_banks = device->num_banks(BufferType::L1); // 128
             const size_t num_l1_banks_pow2 = std::pow(2, std::ceil(std::log2(num_l1_banks)));
@@ -345,7 +346,7 @@ namespace tt::tt_metal{
             std::vector<int32_t> l1_offset_per_bank(num_l1_banks);
             for (unsigned bank_id = 0; bank_id < num_l1_banks; bank_id++) {
                 l1_noc_coord_per_bank[bank_id] = device->worker_core_from_logical_core(device->logical_core_from_bank_id(bank_id));
-                l1_offset_per_bank[bank_id] = device->l1_bank_offset_from_bank_id(bank_id);
+                l1_offset_per_bank[bank_id] = device->bank_offset(BufferType::L1, bank_id);
             }
 
             const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device->id());

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -63,7 +63,11 @@ size_t GetNumPCIeDevices();
  * |------------|----------------------------|-----------------|-----------------------------------|----------|
  * | device_id  | ID of the device to target| chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
  * */
-Device *CreateDevice(chip_id_t device_id, const uint8_t num_hw_cqs = 1, const std::vector<uint32_t>& l1_bank_remap = {});
+Device *CreateDevice(
+    chip_id_t device_id,
+    const uint8_t num_hw_cqs = 1,
+    const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+    const std::vector<uint32_t> &l1_bank_remap = {});
 
 /**
  * Resets device and closes device

--- a/tt_metal/hostdevcommon/common_values.hpp
+++ b/tt_metal/hostdevcommon/common_values.hpp
@@ -16,6 +16,7 @@ constexpr static std::uint32_t NOTIFY_HOST_KERNEL_COMPLETE_VALUE = 512;
 // DRAM_buffer_addr % 32 == L1_buffer_addr % 32, or
 // DRAM_buffer_addr % 32 == L1_buffer_addr % 32 == 0
 constexpr static std::uint32_t ADDRESS_ALIGNMENT = 32;
+constexpr static std::size_t DEFAULT_L1_SMALL_SIZE = 0;  //(1 << 15);  // 32KB
 
 // Number of entries for each core/shard in dispatch command
 constexpr static std::uint32_t NUM_ENTRIES_PER_SHARD = 3;    //per shard/core 3 entries (uint32_t each)

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1466,10 +1466,11 @@ inline void RISC_POST_HEARTBEAT(uint32_t &heartbeat) {
   ptr[0] = 0xAABB0000 | (heartbeat & 0xFFFF);
 }
 
-enum class BufferType: uint8_t {
+enum class BufferType : uint8_t {
     DRAM = 0,
     L1 = 1,
-    SYSTEM_MEMORY = 2
+    SYSTEM_MEMORY = 2,
+    L1_SMALL = 3,
 };
 
 FORCE_INLINE
@@ -1565,6 +1566,10 @@ class Buffer {
             case BufferType::DRAM:          this->get_noc_addr_helper = get_dram_noc_addr; break;
             case BufferType::L1:            this->get_noc_addr_helper = get_l1_noc_addr; break;
             case BufferType::SYSTEM_MEMORY: this->get_noc_addr_helper = get_system_memory_noc_addr; break;
+            case BufferType::L1_SMALL:
+                // L1 small region is not supported here
+                this->get_noc_addr_helper = (decltype(get_noc_addr_helper))0xFFFFFFFF;
+                break;
         }
     }
     uint64_t get_noc_addr_(const uint32_t id, const uint32_t offset = 0) {

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -82,9 +82,7 @@ uint32_t dram_channel_from_bank_id(const Allocator &allocator, uint32_t bank_id)
 
 CoreCoord logical_core_from_bank_id(const Allocator &allocator, uint32_t bank_id);
 
-int32_t l1_bank_offset_from_bank_id(const Allocator &allocator, uint32_t bank_id);
-
-int32_t dram_bank_offset_from_bank_id(const Allocator &allocator, uint32_t bank_id);
+int32_t bank_offset(const Allocator &allocator, BufferType buffer_type, uint32_t bank_id);
 
 const std::vector<uint32_t> &bank_ids_from_dram_channel(const Allocator &allocator, uint32_t dram_channel);
 
@@ -112,6 +110,7 @@ struct Allocator {
 
     allocator::BankManager dram_manager;
     allocator::BankManager l1_manager;
+    allocator::BankManager l1_small_manager;
 
     // TODO: Track lowest l1 addresses!
 

--- a/tt_metal/impl/allocator/allocator_types.hpp
+++ b/tt_metal/impl/allocator/allocator_types.hpp
@@ -40,6 +40,7 @@ struct AllocatorConfig {
     CoreCoord worker_grid_size = {};
     size_t worker_l1_size = 0;
     size_t l1_bank_size = 0;
+    size_t l1_small_size = 0;
     std::unordered_map<CoreCoord, AllocCoreType> core_type_from_noc_coord_table = {};
     std::unordered_map<int, int> worker_log_to_physical_routing_x = {};
     std::unordered_map<int, int> worker_log_to_physical_routing_y = {};

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -3,20 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <random>
+
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/impl/buffers/buffer.hpp"
-
-#include <cmath>
-#include <algorithm>
-#include <random>
-#include <chrono>
 namespace tt {
 
 namespace tt_metal {
 
 namespace allocator {
 
-struct num_banks_t {  uint32_t total;  uint32_t per_storage_core; };
+struct num_banks_t {
+    uint32_t total;
+    uint32_t num_l1_banks;
+    uint32_t num_l1_small_banks;
+    uint32_t per_storage_core;
+};
 
 num_banks_t compute_total_and_storage_only_num_l1_banks(const AllocatorConfig &alloc_config) {
     auto num_in_category = [](const std::unordered_map<CoreCoord, AllocCoreType> &core_allocation_types, const AllocCoreType &alloc_type){
@@ -30,58 +37,79 @@ num_banks_t compute_total_and_storage_only_num_l1_banks(const AllocatorConfig &a
     };
 
     auto num_compute_and_storage_cores = num_in_category(alloc_config.core_type_from_noc_coord_table, AllocCoreType::ComputeAndStore);
-    auto num_storage_only_cores = num_in_category(alloc_config.core_type_from_noc_coord_table, AllocCoreType::StorageOnly);
+    auto num_storage_only_cores =
+        num_in_category(alloc_config.core_type_from_noc_coord_table, AllocCoreType::StorageOnly);
     uint32_t num_banks_per_storage_core = 0;
     if (num_storage_only_cores > 0) {
         TT_ASSERT(alloc_config.worker_l1_size % alloc_config.l1_bank_size == 0);
         num_banks_per_storage_core = alloc_config.worker_l1_size / alloc_config.l1_bank_size;
     }
-    uint32_t num_l1_banks = num_compute_and_storage_cores + (num_banks_per_storage_core * num_storage_only_cores);
-    return num_banks_t{.total = num_l1_banks, .per_storage_core = num_banks_per_storage_core};
+    // L1 small region carve out is only for compute cores
+    uint32_t num_l1_small_banks = (alloc_config.l1_small_size > 0) ? num_compute_and_storage_cores : 0;
+    uint32_t num_l1_banks =
+        num_compute_and_storage_cores + (num_banks_per_storage_core * num_storage_only_cores);
+    return num_banks_t{
+        .total = num_l1_banks + num_l1_small_banks,
+        .num_l1_banks = num_l1_banks,
+        .num_l1_small_banks = num_l1_small_banks,
+        .per_storage_core = num_banks_per_storage_core,
+    };
 }
 
 void init_compute_and_storage_l1_bank_manager(Allocator &allocator, const AllocatorConfig &alloc_config) {
-    std::unordered_map<uint32_t, int64_t> bank_id_to_bank_offset;
-
     num_banks_t num_banks = compute_total_and_storage_only_num_l1_banks(alloc_config);
 
+    auto logical_to_noc_coord = [&alloc_config](CoreCoord logical_core) {
+        TT_ASSERT(
+            alloc_config.worker_log_to_physical_routing_x.find(logical_core.x) !=
+                    alloc_config.worker_log_to_physical_routing_x.end() and
+                alloc_config.worker_log_to_physical_routing_y.find(logical_core.y) !=
+                    alloc_config.worker_log_to_physical_routing_y.end(),
+            "Cannot find log_coord=[.y={}, .x={}] in logical to routing coord lookup tables... invalid AllocatorConfig "
+            "setup",
+            logical_core.y,
+            logical_core.x);
+        CoreCoord noc_core({
+            static_cast<size_t>(alloc_config.worker_log_to_physical_routing_x.at(logical_core.x)),
+            static_cast<size_t>(alloc_config.worker_log_to_physical_routing_y.at(logical_core.y)),
+            });
+        TT_ASSERT (
+            alloc_config.core_type_from_noc_coord_table.find(noc_core) != alloc_config.core_type_from_noc_coord_table.end(),
+            "Cannot find noc-coord=[.y={}, .x={}] in core_type_from_noc_coord_table... invalid AllocatorConfig setup",
+            noc_core.y, noc_core.x
+            );
+        return noc_core;
+    };
+
     // Define the bank assignment here.
+    // Only l1_banks are shuffled, l1_small_banks are just contiguous and don't
+    // need remapping since they are only for compute cores
     std::vector<uint32_t> shuffled_bank_id = {};
     if (not alloc_config.l1_bank_remap.empty()) {
         TT_ASSERT(
-            num_banks.total == alloc_config.l1_bank_remap.size(),
-            "override l1_bank_remap.size()={} which is not equal to the expected expected_num_l1_banks={} from soc-desc",
-            alloc_config.l1_bank_remap.size(), num_banks.total
-        );
+            num_banks.num_l1_banks == alloc_config.l1_bank_remap.size(),
+            "override l1_bank_remap.size()={} which is not equal to the expected expected_num_l1_banks={} from "
+            "soc-desc",
+            alloc_config.l1_bank_remap.size(),
+            num_banks.num_l1_banks);
         std::copy(alloc_config.l1_bank_remap.begin(),alloc_config.l1_bank_remap.end(), std::back_inserter(shuffled_bank_id));
     } else {
         // randomize remap
-        for (uint32_t id = 0; id < num_banks.total; id++) {
+        for (uint32_t id = 0; id < num_banks.num_l1_banks; id++) {
             shuffled_bank_id.push_back(id);
         }
         auto rng = std::default_random_engine(0);
         std::shuffle(std::begin(shuffled_bank_id), std::end(shuffled_bank_id), rng);
     }
 
+    std::unordered_map<uint32_t, int64_t> bank_id_to_bank_offset;
+    // If l1_small_size exists, then it gets the top of L1 (offset 0)
+    // and the regular L1 region is offset just below it
     uint32_t bank_id = 0;
     for (uint32_t y = 0; y < alloc_config.worker_grid_size.y; y++) {
         for (uint32_t x = 0; x < alloc_config.worker_grid_size.x; x++) {
             CoreCoord logical_core = CoreCoord(x, y);
-            TT_ASSERT (
-                alloc_config.worker_log_to_physical_routing_x.find(logical_core.x) != alloc_config.worker_log_to_physical_routing_x.end() and
-                alloc_config.worker_log_to_physical_routing_y.find(logical_core.y) != alloc_config.worker_log_to_physical_routing_y.end(),
-                "Cannot find log_coord=[.y={}, .x={}] in logical to routing coord lookup tables... invalid AllocatorConfig setup",
-                logical_core.y, logical_core.x
-            );
-            CoreCoord noc_core({
-                static_cast<size_t>(alloc_config.worker_log_to_physical_routing_x.at(logical_core.x)),
-                static_cast<size_t>(alloc_config.worker_log_to_physical_routing_y.at(logical_core.y)),
-            });
-            TT_ASSERT (
-                alloc_config.core_type_from_noc_coord_table.find(noc_core) != alloc_config.core_type_from_noc_coord_table.end(),
-                "Cannot find noc-coord=[.y={}, .x={}] in core_type_from_noc_coord_table... invalid AllocatorConfig setup",
-                noc_core.y, noc_core.x
-            );
+            CoreCoord noc_core = logical_to_noc_coord(logical_core);
 
             if (alloc_config.core_type_from_noc_coord_table.at(noc_core) == AllocCoreType::ComputeAndStore) {
                 uint32_t remapped_bank_id = shuffled_bank_id[bank_id];
@@ -109,20 +137,59 @@ void init_compute_and_storage_l1_bank_manager(Allocator &allocator, const Alloca
             }
         }
     }
+    TT_ASSERT(bank_id == shuffled_bank_id.size());
 
+    std::unordered_map<uint32_t, int64_t> small_bank_id_to_bank_offset;
+    if (alloc_config.l1_small_size > 0) {
+        TT_ASSERT(num_banks.num_l1_small_banks > 0);
+        for (uint32_t y = 0; y < alloc_config.worker_grid_size.y; y++) {
+            for (uint32_t x = 0; x < alloc_config.worker_grid_size.x; x++) {
+                CoreCoord logical_core = CoreCoord(x, y);
+                CoreCoord noc_core = logical_to_noc_coord(logical_core);
+
+                if (alloc_config.core_type_from_noc_coord_table.at(noc_core) != AllocCoreType::ComputeAndStore) {
+                    continue;
+                }
+
+                allocator.logical_core_to_bank_ids.insert({logical_core, {bank_id}});
+                allocator.bank_id_to_logical_core.insert({bank_id, logical_core});
+                small_bank_id_to_bank_offset.insert({bank_id, 0});
+                bank_id++;
+            }
+        }
+    }
+
+    TT_ASSERT(bank_id_to_bank_offset.size() == num_banks.num_l1_banks);
+    TT_ASSERT(small_bank_id_to_bank_offset.size() == num_banks.num_l1_small_banks);
     TT_ASSERT(
-        bank_id_to_bank_offset.size() == num_banks.total,
-        "init_compute_and_storage_l1_bank_manager() -- banks setup={} must be equal to the number of bankes expected={}",
+        (bank_id_to_bank_offset.size() + small_bank_id_to_bank_offset.size()) == num_banks.total,
+        "init_compute_and_storage_l1_bank_manager() -- banks setup={} must be equal to the number of bankes "
+        "expected={}",
         bank_id_to_bank_offset.size(),
-        num_banks.total
-    );
+        small_bank_id_to_bank_offset.size(),
+        num_banks.total);
 
     // There is only alloc_config.l1_bank_size bytes available for L1 buffers to be allocated in
     uint64_t interleaved_address_limit = static_cast<uint64_t>(alloc_config.worker_l1_size - alloc_config.l1_bank_size) + STORAGE_ONLY_UNRESERVED_BASE;
-    uint64_t allocatable_l1_size = static_cast<uint64_t>(alloc_config.worker_l1_size) - L1_UNRESERVED_BASE;
+    uint64_t allocatable_l1_size =
+        static_cast<uint64_t>(alloc_config.worker_l1_size) - L1_UNRESERVED_BASE - alloc_config.l1_small_size;
     // Assuming top down allocation for L1 buffers so the allocatable memory space is the top alloc_config.l1_bank_size bytes of L1
     uint64_t alloc_offset = L1_UNRESERVED_BASE;
     allocator.l1_manager = BankManager(BufferType::L1, bank_id_to_bank_offset, allocatable_l1_size, interleaved_address_limit, alloc_offset);
+
+    uint64_t small_interleaved_address_limit = alloc_config.worker_l1_size - alloc_config.l1_small_size;
+    uint64_t small_alloc_offset = alloc_offset + allocatable_l1_size;
+    TT_ASSERT(
+        (alloc_offset + alloc_config.l1_small_size) <= alloc_config.worker_l1_size,
+        "L1 small region extends past L1 size");
+    if (alloc_config.l1_small_size > 0) {
+        allocator.l1_small_manager = BankManager(
+            BufferType::L1_SMALL,
+            small_bank_id_to_bank_offset,
+            alloc_config.l1_small_size,
+            small_interleaved_address_limit,
+            small_alloc_offset);
+    }
 }
 
 }   // namespace allocator

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -26,9 +26,9 @@ class Device;
 enum class BufferType {
     DRAM,
     L1,
-    SYSTEM_MEMORY
+    SYSTEM_MEMORY,
+    L1_SMALL,
 };
-
 
 enum class TensorMemoryLayout {
     INTERLEAVED,
@@ -198,6 +198,9 @@ class Buffer {
 
     BufferType buffer_type() const { return buffer_type_; }
 
+    bool is_l1() const { return buffer_type() == BufferType::L1 or buffer_type() == BufferType::L1_SMALL; }
+    bool is_dram() const { return buffer_type() == BufferType::DRAM; }
+
     TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
 
     uint32_t dram_channel_from_bank_id(uint32_t bank_id) const;
@@ -236,6 +239,8 @@ class Buffer {
 
     void deallocate();
     friend void DeallocateBuffer(Buffer &buffer);
+
+    uint64_t translate_page_address(uint64_t offset, uint32_t bank_id) const;
 
     Device *device_;
     uint64_t size_;                 // Size in bytes

--- a/tt_metal/impl/buffers/circular_buffer_types.hpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.hpp
@@ -33,7 +33,7 @@ class CircularBufferConfig {
         total_size_(total_size),
         dynamic_cb_(true),
         max_size_(buffer.size()) {
-        if (buffer.buffer_type() != BufferType::L1) {
+        if (not buffer.is_l1()) {
             TT_THROW("Only L1 buffers can have an associated circular buffer!");
         }
         if (total_size > buffer.size()) {
@@ -89,7 +89,7 @@ class CircularBufferConfig {
     }
 
     CircularBufferConfig set_globally_allocated_address(const Buffer &buffer) {
-        if (buffer.buffer_type() != BufferType::L1) {
+        if (not buffer.is_l1()) {
             TT_THROW("Only L1 buffers can have an associated circular buffer!");
         }
         this->globally_allocated_address_ = buffer.address();

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -68,7 +68,11 @@ class Device {
    public:
     // friend void tt_gdb(Device* device, int chip_id, const vector<CoreCoord> cores, vector<string> ops);
     Device () = delete;
-    Device(chip_id_t device_id, const uint8_t num_hw_cqs, const std::vector<uint32_t>& l1_bank_remap = {});
+    Device(
+        chip_id_t device_id,
+        const uint8_t num_hw_cqs,
+        std::size_t l1_small_size,
+        const std::vector<uint32_t> &l1_bank_remap = {});
 
     ~Device();
 
@@ -139,9 +143,7 @@ class Device {
 
     CoreCoord core_from_dram_channel(uint32_t dram_channel) const;
 
-    int32_t l1_bank_offset_from_bank_id(uint32_t bank_id) const;
-
-    int32_t dram_bank_offset_from_bank_id(uint32_t bank_id) const;
+    int32_t bank_offset(BufferType buffer_type, uint32_t bank_id) const;
 
     CoreCoord logical_core_from_bank_id(uint32_t bank_id) const;
 
@@ -150,6 +152,8 @@ class Device {
     const std::vector<uint32_t> &bank_ids_from_logical_core(const CoreCoord &logical_core) const;
 
     allocator::Statistics get_memory_allocation_statistics(const BufferType &buffer_type) const;
+
+    size_t get_l1_small_size() const;
 
     void dump_memory_blocks(const BufferType &buffer_type, std::ofstream &out) const;
 
@@ -182,9 +186,9 @@ class Device {
 
     // Checks that the given arch is on the given pci_slot and that it's responding
     // Puts device into reset
-    bool initialize(const std::vector<uint32_t>& l1_bank_remap = {});
+    bool initialize(size_t l1_small_size, const std::vector<uint32_t> &l1_bank_remap = {});
     void initialize_cluster();
-    void initialize_allocator(const std::vector<uint32_t>& l1_bank_remap = {});
+    void initialize_allocator(size_t l1_small_size, const std::vector<uint32_t> &l1_bank_remap = {});
     void initialize_build();
     void build_firmware();
     void initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg);

--- a/tt_metal/impl/device/multi_device.cpp
+++ b/tt_metal/impl/device/multi_device.cpp
@@ -13,7 +13,7 @@ namespace ttnn {
 namespace multi_device {
 
 
-DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids)
+DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids, size_t l1_small_size)
     : device_grid(device_grid)
 {
     auto [num_rows, num_cols] = device_grid;
@@ -23,7 +23,8 @@ DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_id
     TT_ASSERT(num_requested_devices <= device_ids.size(), "User provided insufficient number of device_ids for DeviceMesh");
 
     for (int i = 0; i < num_requested_devices; i++) {
-        managed_devices.emplace_back(device_ids[i], std::unique_ptr<Device>(CreateDevice(device_ids[i], 1)));
+        managed_devices.emplace_back(
+            device_ids[i], std::unique_ptr<Device>(CreateDevice(device_ids[i], 1, l1_small_size)));
     }
 }
 

--- a/tt_metal/impl/device/multi_device.hpp
+++ b/tt_metal/impl/device/multi_device.hpp
@@ -23,7 +23,7 @@ public:
     DeviceGrid device_grid;
     std::vector<std::pair<int, std::unique_ptr<Device>>> managed_devices;
 
-    DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids);
+    DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size);
     ~DeviceMesh() = default;
 
     DeviceMesh(const DeviceMesh &) = delete;

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -234,9 +234,7 @@ EnqueueWriteBufferCommand::EnqueueWriteBufferCommand(
     buffer(buffer),
     dst_page_index(dst_page_index),
     pages_to_write(pages_to_write.has_value() ? pages_to_write.value() : buffer.num_pages()) {
-    TT_ASSERT(
-        buffer.buffer_type() == BufferType::DRAM or buffer.buffer_type() == BufferType::L1,
-        "Trying to write to an invalid buffer");
+    TT_ASSERT(buffer.is_dram() or buffer.is_l1(), "Trying to write to an invalid buffer");
     this->device = device;
     this->event = event;
     this->dispatch_core_type = dispatch_core_manager::get(device->num_hw_cqs()).get_dispatch_core_type(device->id());

--- a/ttnn/cpp/pybind11/device.hpp
+++ b/ttnn/cpp/pybind11/device.hpp
@@ -15,7 +15,12 @@ namespace ttnn {
 namespace device {
 void py_module(py::module& module) {
     module.def(
-        "open_device", &ttnn::open_device, py::kw_only(), py::arg("device_id"), py::return_value_policy::reference);
+        "open_device",
+        &ttnn::open_device,
+        py::kw_only(),
+        py::arg("device_id"),
+        py::arg("l1_small_size"),
+        py::return_value_policy::reference);
 
     module.def("close_device", &ttnn::close_device, py::arg("device"), py::kw_only());
 

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -16,15 +16,24 @@ namespace ttnn {
 namespace multi_device {
 
 void py_module(py::module& module) {
-
     py::class_<DeviceMesh>(module, "DeviceMesh")
-        .def(py::init<DeviceGrid, std::vector<int>>(), py::kw_only(), py::arg("device_grid"), py::arg("device_ids"))
+        .def(
+            py::init<DeviceGrid, std::vector<int>, size_t>(),
+            py::kw_only(),
+            py::arg("device_grid"),
+            py::arg("device_ids"),
+            py::arg("l1_small_size"))
         .def("get_device", &ttnn::multi_device::DeviceMesh::get_device, py::return_value_policy::reference)
         .def("get_num_devices", &ttnn::multi_device::DeviceMesh::num_devices)
         .def("get_device_ids", &ttnn::multi_device::DeviceMesh::get_device_ids);
 
     module.def(
-        "open_device_mesh", &open_device_mesh, py::kw_only(), py::arg("device_grid"), py::arg("device_ids"));
+        "open_device_mesh",
+        &open_device_mesh,
+        py::kw_only(),
+        py::arg("device_grid"),
+        py::arg("device_ids"),
+        py::arg("l1_small_size"));
 
     module.def("close_device_mesh", &close_device_mesh, py::arg("device_mesh"), py::kw_only());
     module.def("get_device_tensors", &get_device_tensors, py::arg("tensor"), py::kw_only());

--- a/ttnn/cpp/ttnn/device.cpp
+++ b/ttnn/cpp/ttnn/device.cpp
@@ -15,13 +15,16 @@ std::vector<Device*> devices;
 
 } // device_pool
 
-Device &open_device(int device_id) {
+Device &open_device(int device_id, size_t l1_small_size) {
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     device_pool::devices.resize(num_devices, nullptr);
     TT_ASSERT(device_id < num_devices);
     if (device_pool::devices[device_id] == nullptr) {
-        device_pool::devices[device_id] = CreateDevice(device_id, 1);
+        device_pool::devices[device_id] = CreateDevice(device_id, 1, l1_small_size);
     }
+    TT_FATAL(
+        device_pool::devices[device_id]->get_l1_small_size() == l1_small_size,
+        "Device L1 small size mismatch, device already opened with different L1 small size.");
     return *device_pool::devices[device_id];
 }
 

--- a/ttnn/cpp/ttnn/device.hpp
+++ b/ttnn/cpp/ttnn/device.hpp
@@ -11,7 +11,7 @@ namespace ttnn {
 
 namespace device {
 
-Device &open_device(int device_id);
+Device &open_device(int device_id, size_t l1_small_size = DEFAULT_L1_SMALL_SIZE);
 void close_device(Device &device);
 void enable_program_cache(Device &device);
 void disable_and_clear_program_cache(Device &device);

--- a/ttnn/cpp/ttnn/multi_device.hpp
+++ b/ttnn/cpp/ttnn/multi_device.hpp
@@ -20,8 +20,8 @@ using DeviceGrid = std::pair<int, int>;
 using DeviceIds = std::vector<int>;
 
 
-inline DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids) {
-    return DeviceMesh(device_grid, device_ids);
+inline DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size) {
+    return DeviceMesh(device_grid, device_ids, l1_small_size);
 }
 
 inline void close_device_mesh(DeviceMesh &multi_device) {

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -64,7 +64,7 @@ struct BufferInfo {
 std::vector<BufferInfo> get_buffers() {
     std::vector<BufferInfo> buffer_infos;
     for (const auto &[key, buffer] : tt::tt_metal::detail::BUFFER_MAP.value()) {
-        if (buffer->buffer_type() != BufferType::L1) {
+        if (not buffer->is_l1()) {
             continue;
         }
 
@@ -129,7 +129,7 @@ struct BufferPageInfo {
 std::vector<BufferPageInfo> get_buffer_pages() {
     std::vector<BufferPageInfo> buffer_page_infos;
     for (const auto &[key, buffer] : tt::tt_metal::detail::BUFFER_MAP.value()) {
-        if (buffer->buffer_type() != BufferType::L1) {
+        if (not buffer->is_l1()) {
             continue;
         }
 

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -18,13 +18,13 @@ Device = ttl.device.Device
 Device.core_grid = property(get_device_core_grid)
 
 
-def open_device(device_id: int):
+def open_device(device_id: int, l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE):
     """
     open_device(device_id: int) -> ttnn.Device:
 
     Open a device with the given device_id. If the device is already open, return the existing device.
     """
-    return ttnn._ttnn.device.open_device(device_id=device_id)
+    return ttnn._ttnn.device.open_device(device_id=device_id, l1_small_size=l1_small_size)
 
 
 def close_device(device):

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -33,14 +33,18 @@ def get_device_ids() -> List[int]:
     return list(range(num_devices))
 
 
-def open_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: List[int]):
+def open_device_mesh(
+    device_grid: ttnn.DeviceGrid, device_ids: List[int], l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE
+):
     """
     open_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: int) -> ttnn.DeviceMesh:
 
     Open a device with the given device_id. If the device is already open, return the existing device.
     """
     assert len(device_ids) > 0
-    return ttnn._ttnn.multi_device.DeviceMesh(device_grid=device_grid.as_tuple(), device_ids=device_ids)
+    return ttnn._ttnn.multi_device.DeviceMesh(
+        device_grid=device_grid.as_tuple(), device_ids=device_ids, l1_small_size=l1_small_size
+    )
 
 
 def close_device_mesh(device_mesh):
@@ -53,13 +57,15 @@ def close_device_mesh(device_mesh):
 
 
 @contextlib.contextmanager
-def create_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: List[int]):
+def create_device_mesh(
+    device_grid: ttnn.DeviceGrid, device_ids: List[int], l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE
+):
     """
     create_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: List[int]) -> ttnn.DeviceMesh
 
     Context manager for opening and closing a device.
     """
-    device_mesh = open_device_mesh(device_grid=device_grid, device_ids=device_ids)
+    device_mesh = open_device_mesh(device_grid=device_grid, device_ids=device_ids, l1_small_size=l1_small_size)
     try:
         yield device_mesh
     finally:

--- a/ttnn/tutorials/003.ipynb
+++ b/ttnn/tutorials/003.ipynb
@@ -59,7 +59,7 @@
     "torch.manual_seed(0)\n",
     "\n",
     "device_id = 0\n",
-    "device = ttnn.open_device(device_id=device_id)"
+    "device = ttnn.open_device(device_id=device_id, l1_small_size=8192)"
    ]
   },
   {

--- a/ttnn/tutorials/004.ipynb
+++ b/ttnn/tutorials/004.ipynb
@@ -683,7 +683,7 @@
                 }
             ],
             "source": [
-                "device = ttnn.open_device(device_id=0)"
+                "device = ttnn.open_device(device_id=0, l1_small_size=8192)"
             ]
         },
         {


### PR DESCRIPTION
Reserve a special region of L1 at the top for config tensors / other sideband data for ops. Usually these are tiny allocations and are long lived, so as ops are created on the fly it can introduce bad fragmentation.

Code Changes:
- Inside of struct Allocator introduce a new BankManager, l1_small_manager
- During Device::initialize_allocator a reserved carve out size is passed in, by default it could be something like 32k, but could be overridden by the user at device creation, might have to bump it up for larger models. This size is subtracted from the l1_manager’s size and feeds the l1_small_manager size. L1 managers will need to program their respective alloc_offset accordingly
- Introduce a new BufferType called L1_SMALL, tensor/buffer creation calls in ttlib need to pass down a flag to denote that they want to allocate from the reserved region
- allocator::allocate_buffer and friends just handle a new case statement for dispatching to the l1_small_manager