### PR TITLE
#0: Migrate TTL version of Falcon7B to async mode

### DIFF
--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -7,7 +7,8 @@ from models.demos.falcon7b.demo.demo import run_falcon_demo_kv
 from models.utility_functions import is_wormhole_b0, get_devices_for_t3000
 
 
-@pytest.mark.parametrize("perf_mode", (False,))  # Option to measure perf using max seq length (with invalid outputs)
+@pytest.mark.parametrize("perf_mode", (True,))  # Option to measure perf using max seq length (with invalid outputs)
+@pytest.mark.parametrize("async_mode", (False,))  # Option to run Falcon in Async mode
 @pytest.mark.parametrize("num_devices", (1, 2, 3, 4, 5, 6, 7, 8))
 def test_demo_multichip(
     perf_mode,
@@ -17,10 +18,13 @@ def test_demo_multichip(
     get_tt_cache_path,
     all_devices,
     use_program_cache,
+    async_mode,
 ):
     assert is_wormhole_b0(), "Multi-chip is only supported for Wormhole B0"
     devices = get_devices_for_t3000(all_devices, num_devices)
 
+    for device in devices:
+        device.enable_async(async_mode)
     return run_falcon_demo_kv(
         user_input=user_input,
         batch_size=32,

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -82,18 +82,10 @@ Tensor::~Tensor() {
 }
 
 void Tensor::deallocate(bool force) {
-    ZoneScoped;
+    ZoneScopedN("TensorDeallocate");
     if (this->tensor_attributes.use_count()) {
         // Check if the attributes didn't get moved to another tensor.
         // If not, we can deallocate this tensor.
-        if (this->tensor_attributes->dynamic_storage) {
-            // Tensor was populated with autoformat. Storage type can change
-            // based on op behaviour. Wait for tensor metadata populated.
-            // This is a special case, where storage type cannot change for multi
-            // device tensors (see assert in launch_op). Hence, this only applies
-            // to the single device case, where metadata populated == tensor populated.
-            this->wait_for_tensor_metadata_populated();
-        }
         std::visit(
                 [force, this](auto& storage) {
                     using T = std::decay_t<decltype(storage)>;
@@ -107,6 +99,8 @@ void Tensor::deallocate(bool force) {
                             uint32_t ref_count_to_use = (this->workers.at(0)->get_worker_mode() == WorkExecutorMode::SYNCHRONOUS) ? this->tensor_attributes.use_count() : this->tensor_attributes->main_thread_ref_count;
                             if ((force or ref_count_to_use == 1) and not this->tensor_attributes->deallocated) {
                                 this->tensor_attributes->deallocated = true;
+                                // Record ref count before sending to worker
+                                uint32_t device_tensor_ref_count = this->tensor_attributes->record_main_thread_ref_count();
                                 this->workers.at(0)->push_work([force, *this] () mutable {
                                     std::visit([force, this] (auto&& s) {
                                         using type = std::decay_t<decltype(s)>;
@@ -118,9 +112,16 @@ void Tensor::deallocate(bool force) {
                                             // If any other tensor handles hold this buffer, it will not be deleted, until the last handle goes out of scope
                                             // or is deallocated.
                                             s.buffer.reset();
+                                        } else if  constexpr(std::is_same_v<type, OwnedStorage>) {
+                                            // Manage Dynamic Storage (due to autoformat in async mode): Main thread sees this tensor as a device tensor, since worker has not updated
+                                            // storage time. When the worker executes the dealloc request, the storage type has been appropriately updated to Owned.
+                                            TT_ASSERT(this->tensor_attributes->dynamic_storage, "Tensor storage type changed during runtime (device -> host), but dynamic storage was not marked.");
+                                            std::visit([] (auto&& buffer) { buffer.reset(); }, s.buffer);
                                         }
                                     }, this->tensor_attributes->storage);
                                 });
+                                // Update ref count after sending to worker
+                                this->tensor_attributes->update_main_thread_ref_count(this->workers.at(0), device_tensor_ref_count);
                             }
                         } else {
                             TT_FATAL(this->deallocate_through_destructor, "Device tensors cannot be explictly deallocated in worker threads.");
@@ -134,6 +135,8 @@ void Tensor::deallocate(bool force) {
                             uint32_t ref_count_to_use = (this->workers.at(0)->get_worker_mode() == WorkExecutorMode::SYNCHRONOUS) ? this->tensor_attributes.use_count() : this->tensor_attributes->main_thread_ref_count;
                             if ((force or ref_count_to_use == 1) and not this->tensor_attributes->deallocated) {
                                 this->tensor_attributes->deallocated = true;
+                                // Record ref count before sending to workers
+                                uint32_t device_tensor_ref_count = this->tensor_attributes->record_main_thread_ref_count();
                                 for (auto worker : this->workers) {
                                     worker->push_work([force, *this, worker] () mutable {
                                         std::visit([force, worker] (auto&& s) {
@@ -149,6 +152,8 @@ void Tensor::deallocate(bool force) {
                                         }, this->tensor_attributes->storage);
                                     });
                                 }
+                                // Update ref count after sending to workers
+                                this->tensor_attributes->update_main_thread_ref_count(this->workers.at(0), device_tensor_ref_count);
                             }
                         }
                     } else if constexpr (std::is_same_v<T, MultiDeviceHostStorage>) {
@@ -308,12 +313,32 @@ const Storage& Tensor::get_storage() const {
 
 Tensor Tensor::to(CommandQueue & queue, const MemoryConfig & mem_config) const {
     ZoneScoped;
-    if (storage_type() == StorageType::DEVICE) {
-        TT_ASSERT(this->device() == queue.device() && "Currently do not support moving between devices");
-        return *this;
-    }
-    tensor_impl::validate_on_device_dtype_and_layout(queue.device(), this->get_dtype(), this->get_layout());
-    return tensor_impl::to_device_wrapper(*this, queue.device(), mem_config, queue);
+    auto target_device = queue.device();
+    // Tensor can be using borrowed storage. If so, when running in async mode, copy this tensor to owned storage.
+    Tensor async_safe_tensor = copy_borrowed_tensor_in_async_mode(target_device, *this);
+    // Populate device storage outside of thread, so that downstream
+    // functions running in main can get storage type without blocking
+    Tensor device_tensor({target_device});
+    // Record main thread ref count for tensors before pushing to queue.
+    uint32_t device_tensor_ref_count = device_tensor.tensor_attributes->record_main_thread_ref_count();
+    uint32_t original_tensor_ref_count = async_safe_tensor.tensor_attributes->record_main_thread_ref_count();
+    queue.device()->push_work([async_safe_tensor, device_tensor, mem_config, target_device] () mutable {
+        if (async_safe_tensor.storage_type() == StorageType::DEVICE) {
+            TT_ASSERT(async_safe_tensor.device() == target_device && "Currently do not support moving between devices");
+            device_tensor.populate_buffers_and_metadata(async_safe_tensor);
+        }
+        else {
+            tensor_impl::validate_on_device_dtype_and_layout(target_device, async_safe_tensor.get_dtype(), async_safe_tensor.get_layout());
+            auto local_tensor = tensor_impl::to_device_wrapper(async_safe_tensor, target_device, mem_config);
+            // Populate device tensor
+            device_tensor.populate_buffers_and_metadata(local_tensor);
+        }
+    });
+    // Update main thread ref count for tensors after pushing to queue (update original tensor and returned tensor,
+    // since both can be on device).
+    device_tensor.tensor_attributes->update_main_thread_ref_count(device_tensor.workers.at(0), device_tensor_ref_count);
+    async_safe_tensor.tensor_attributes->update_main_thread_ref_count(device_tensor.workers.at(0), original_tensor_ref_count);
+    return device_tensor;
 }
 
 Tensor Tensor::to(Device *target_device, const MemoryConfig &mem_config) const {

--- a/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.hpp
+++ b/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.hpp
@@ -41,15 +41,21 @@ inline Tensor embeddings(
     std::optional<uint32_t> pad_token = std::nullopt,
     const MemoryConfig &mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<const DataType> output_dtype = std::nullopt) {
-    return operation::run_without_autoformat(
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor, weights}))};
+    operation::launch_op(
+        [tilized, embeddings_type, pad_token, mem_config, output_dtype] (std::vector<Tensor> input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+            auto& input_tensor = input_tensors.at(0);
+            auto& weights = input_tensors.at(1);
+            return operation::run_without_autoformat(
                Embeddings{
                    .output_mem_config = mem_config,
                    .tilized = tilized,
                    .embeddings_type = embeddings_type,
                    .pad_token = pad_token,
                    .output_dtype = output_dtype.value_or(weights.get_dtype())},
-               {input_tensor, weights})
-        .at(0);
+               {input_tensor, weights});
+        }, {input_tensor, weights}, output_tensors);
+    return output_tensors.at(0);
 }
 
 }  // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/transpose/transpose_op.cpp
+++ b/tt_eager/tt_dnn/op_library/transpose/transpose_op.cpp
@@ -195,41 +195,47 @@ inline Tensor transpose_(const Tensor &a, TransposeOpDim transpose_dim, const Me
 }
 
 Tensor transpose(const Tensor &a, std::int64_t dim1, std::int64_t dim2, const MemoryConfig& output_mem_config) {
-    uint32_t normalized_dim1 = a.get_legacy_shape().get_normalized_index(dim1);
-    uint32_t normalized_dim2 = a.get_legacy_shape().get_normalized_index(dim2);
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({a}))};
+    operation::launch_with_autoformat(
+        [dim1, dim2, output_mem_config] (std::vector<Tensor> input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+            auto& a = input_tensors.at(0);
+            uint32_t normalized_dim1 = a.get_legacy_shape().get_normalized_index(dim1);
+            uint32_t normalized_dim2 = a.get_legacy_shape().get_normalized_index(dim2);
 
-    TT_FATAL( normalized_dim1 <= 3, "dimension have to be 0-3 only corresponding to N,C,H,W");
-    TT_FATAL(normalized_dim2 <= 3, "dimension have to be 0-3 only corresponding to N,C,H,W");
+            TT_FATAL( normalized_dim1 <= 3, "dimension have to be 0-3 only corresponding to N,C,H,W");
+            TT_FATAL(normalized_dim2 <= 3, "dimension have to be 0-3 only corresponding to N,C,H,W");
 
-    if (
-        (normalized_dim1 == normalized_dim2) ||
-        (a.get_legacy_shape()[normalized_dim1] == 1 && a.get_legacy_shape()[normalized_dim2] == 1)
-    ) {
-        return AutoFormat::move_tensor_to_mem_config(a, output_mem_config);
-    }
+            if (
+                (normalized_dim1 == normalized_dim2) ||
+                (a.get_legacy_shape()[normalized_dim1] == 1 && a.get_legacy_shape()[normalized_dim2] == 1)
+            ) {
+                return {AutoFormat::move_tensor_to_mem_config(a, output_mem_config)};
+            }
 
-    if ( normalized_dim1 > normalized_dim2 ) {
-        std::swap(normalized_dim1, normalized_dim2);
-    }
+            if ( normalized_dim1 > normalized_dim2 ) {
+                std::swap(normalized_dim1, normalized_dim2);
+            }
 
-    TransposeOpDim transpose_dim = TransposeOpDim::NW;
+            TransposeOpDim transpose_dim = TransposeOpDim::NW;
 
-    if ( normalized_dim2 == 3 && normalized_dim1 == 0 ) {
-        transpose_dim = TransposeOpDim::NW;
-    } else if (normalized_dim2 == 3 && normalized_dim1 == 1) {
-       transpose_dim = TransposeOpDim::CW;
-    } else if (normalized_dim2 == 3 && normalized_dim1 == 2) {
-        transpose_dim = TransposeOpDim::WH;
-    } else if (normalized_dim2 == 2 && normalized_dim1 == 0) {
-        transpose_dim = TransposeOpDim::NH;
-    } else if (normalized_dim2 == 2 && normalized_dim1 == 1) {
-        transpose_dim = TransposeOpDim::HC;
-    } else if (normalized_dim2 == 1 && normalized_dim1 == 0) {
-        transpose_dim = TransposeOpDim::CN;
-    } else {
-        TT_ASSERT(false, "Unsupported transpose dims");
-    }
-    return transpose_(a, transpose_dim, output_mem_config);
+            if ( normalized_dim2 == 3 && normalized_dim1 == 0 ) {
+                transpose_dim = TransposeOpDim::NW;
+            } else if (normalized_dim2 == 3 && normalized_dim1 == 1) {
+            transpose_dim = TransposeOpDim::CW;
+            } else if (normalized_dim2 == 3 && normalized_dim1 == 2) {
+                transpose_dim = TransposeOpDim::WH;
+            } else if (normalized_dim2 == 2 && normalized_dim1 == 0) {
+                transpose_dim = TransposeOpDim::NH;
+            } else if (normalized_dim2 == 2 && normalized_dim1 == 1) {
+                transpose_dim = TransposeOpDim::HC;
+            } else if (normalized_dim2 == 1 && normalized_dim1 == 0) {
+                transpose_dim = TransposeOpDim::CN;
+            } else {
+                TT_ASSERT(false, "Unsupported transpose dims");
+            }
+            return {transpose_(a, transpose_dim, output_mem_config)};
+        }, {a}, output_tensors);
+    return output_tensors.at(0);
 }
 
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
@@ -864,6 +864,11 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
 
                     tt_tensor = tt_tensor.to(tt_device)
             )doc")
+            .def("track_ref_count",
+                [](Tensor &self) { return self.track_ref_count(); },
+                R"doc(
+                    Log the reference count (as seen by the main and worker threads) of a tensor as it evolves during runtime.
+                )doc")
             .def(
                 "to",
                 py::overload_cast<DeviceMesh *, const MemoryConfig &>(&Tensor::to, py::const_),

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -58,7 +58,7 @@ void ActiveDevices::deactivate_device(chip_id_t id) {
     this->active_devices_[id] = ActiveState::INACTIVE;
 }
 
-Device::Device(chip_id_t device_id, const uint8_t num_hw_cqs, const std::vector<uint32_t>& l1_bank_remap) : id_(device_id), num_hw_cqs_(num_hw_cqs)
+Device::Device(chip_id_t device_id, const uint8_t num_hw_cqs, const std::vector<uint32_t>& l1_bank_remap) : id_(device_id), num_hw_cqs_(num_hw_cqs), work_executor(device_id)
 {
     ZoneScoped;
     TT_ASSERT(num_hw_cqs > 0 and num_hw_cqs < 3, "num_hw_cqs can be between 1 and 2");

--- a/tt_metal/impl/dispatch/work_executor.hpp
+++ b/tt_metal/impl/dispatch/work_executor.hpp
@@ -5,10 +5,13 @@
 #pragma once
 
 #include <functional>
+#include <pthread.h>
+#include <sched.h>
 #include <thread>
 
 #include "common/env_lib.hpp"
 #include "lock_free_queue.hpp"
+#include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 
 namespace tt {
 
@@ -31,7 +34,7 @@ class WorkExecutor {
     public:
     LockFreeQueue<std::function<void()>> worker_queue;
 
-    WorkExecutor() {
+    WorkExecutor(int device_id) : managed_device_id(device_id) {
         if (this->worker_queue_mode == WorkExecutorMode::ASYNCHRONOUS) {
             this->start_worker();
         }
@@ -52,9 +55,10 @@ class WorkExecutor {
                 if (this->worker_state == WorkerState::TERMINATE) {
                     break;
                 }
-                std::this_thread::sleep_for(std::chrono::microseconds(10));
+                std::this_thread::sleep_for(std::chrono::microseconds(5));
             }
             else {
+                ZoneScopedN("PopWork");
                 auto func = this->worker_queue.pop();
                 (*func)();
             }
@@ -62,6 +66,7 @@ class WorkExecutor {
     }
 
     inline void push_work(const std::function<void()>& work_executor, bool blocking = false) {
+        ZoneScopedN("PushWork");
         if (this->worker_queue_mode == WorkExecutorMode::ASYNCHRONOUS) {
             if (std::hash<std::thread::id>{}(std::this_thread::get_id()) == worker_queue.parent_thread_id.load()) {
                 // Push function executor to worker queue
@@ -109,12 +114,19 @@ class WorkExecutor {
     private:
     std::thread worker_thread;
     WorkerState worker_state = WorkerState::IDLE;
+    int managed_device_id = 0;
 
     inline void start_worker() {
         this->worker_queue.parent_thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
         this->worker_state = WorkerState::RUNNING;
         this->worker_thread = std::thread(&WorkExecutor::run_worker, this);
         this->worker_queue.worker_thread_id = std::hash<std::thread::id>{}(this->worker_thread.get_id());
+        // Bind a worker tied to a device to a specific CPU core in round robin fashion. Thread affinity == Better Perf.
+        cpu_set_t cpuset;
+        CPU_ZERO(&cpuset);
+        CPU_SET(managed_device_id % std::thread::hardware_concurrency(), &cpuset);
+        int rc = pthread_setaffinity_np(worker_thread.native_handle(), sizeof(cpu_set_t), &cpuset);
+        TT_FATAL(rc == 0, "Unable to bind worker thread to CPU Core");
     }
 
     inline void stop_worker() {

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -5,8 +5,10 @@
 #pragma once
 #include <thread>
 #include <string>
+#include <future>
 
 #include "common/tt_backend_api_types.hpp"
+#include "common/executor.hpp"
 #include "common/utils.hpp"
 #include "common/core_coord.h"
 #include "jit_build/data_format.hpp"
@@ -155,6 +157,10 @@ class JitBuildSettings {
     virtual const string& get_full_kernel_name() const = 0;
     virtual void process_defines(const std::function<void (const string& define, const string &value)>) const = 0;
     virtual void process_compile_time_args(const std::function<void (int i, uint32_t value)>) const = 0;
+    void set_multithreaded_compile(bool mt_compile) { this->use_multi_threaded_compile = mt_compile; }
+    bool using_multithreaded_compile() const { return this->use_multi_threaded_compile; }
+  private:
+    bool use_multi_threaded_compile = true;
 };
 
 void jit_build(const JitBuildState& build, const JitBuildSettings *settings, const string& kernel_in_path);
@@ -168,4 +174,20 @@ inline const string jit_build_get_kernel_compile_outpath(int device_id) {
     return llrt::OptionsG.get_root_dir() + "/built/" + std::to_string(device_id) + "/kernels/";
 }
 
+inline void launch_build_step(bool multi_threaded, const std::function<void()> build_func, std::vector<std::shared_future<void>>& events) {
+    if (multi_threaded) {
+      events.emplace_back(detail::async(build_func));
+    }
+    else {
+      build_func();
+    }
+}
+
+inline void sync_build_step(bool multi_threaded, std::vector<std::shared_future<void>>& events) {
+  if (multi_threaded) {
+    for (auto & f : events) {
+      f.get();
+    }
+  }
+}
 } // namespace tt::tt_metal


### PR DESCRIPTION
  - Migrate all ops used for TTL Falcon to use async mode
  - Resolve bugs exposed on T3000 systems (mainly regarding a deadlock during compile exposed due to 8 worker threads 
     contenting on a single taskflow queue with 32 threads)
  - Compile in async mode is currently only parallelized across workers (workers no longer spawn TF threads)
  - Add tensor ref count tracker with API to enable tracking for specific tensors (helpful for debug)
  - Bind worker threads to CPU for better and more consistent perf

Tested using sequence length 128 and 1024.