### PR TITLE
#3019: Fix mean_hw

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -486,7 +486,7 @@ def mean_hw(x, *args, device, dtype, layout, input_mem_config, output_mem_config
     t1 = ttl.tensor.mean_hw(t0, output_mem_config=output_mem_config)
 
     output = tt2torch_tensor(t1)
-    output = output.max(2, True)[0].max(3, True)[0]
+    output = output[:, :, 0, 0]
 
     return output
 


### PR DESCRIPTION
Fix issue #3019 and #3606 

Broken unit test : `pytest tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_stats_mean_hw.py`

![Screenshot 2024-04-17 at 4 53 55 PM](https://github.com/tenstorrent/tt-metal/assets/156493059/576cac71-2722-463a-b961-1ed9fec98dad)


Broken sweep test : `python tests/tt_eager/python_api_testing/sweep_tests/run_pytorch_test.py -i tests/tt_eager/python_api_testing/sweep_tests/test_configs/ci_sweep_tests/broken_grayskull/pytorch_stats_mean_hw_test.yaml -o ./result-sweeps`

[stats_mean_hw_sweep.csv](https://github.com/tenstorrent/tt-metal/files/15021028/stats_mean_hw_sweep.csv)


All post commit test : https://github.com/tenstorrent/tt-metal/actions/runs/8733687863