### PR TITLE
#5249: Perf optimizations for Falcon40b prefill

### DIFF
--- a/models/demos/falcon40b/scripts/perf_summary.py
+++ b/models/demos/falcon40b/scripts/perf_summary.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pandas as pd
+import argparse
+
+DRAM_INTERLEAVED = "{'buffer_type': 'DRAM'; 'memory_layout': 'INTERLEAVED'}"
+
+
+def assign_op_id_cross_device(df, num_chips):
+    df.loc[:, "OP ID CROSS DEVICE"] = df["GLOBAL CALL COUNT"].apply(lambda x: x // num_chips)
+
+    return df
+
+
+def group_by_op_all_devices(df):
+    # Split the DataFrame into AllGather and the rest
+    df1 = df[df["OP CODE"] != "tt::tt_metal::AllGather"]
+    df2 = df[df["OP CODE"] == "tt::tt_metal::AllGather"]
+
+    # Perform the groupby operation separately on each DataFrame
+    # We want to aggregate AllGather by the min and the rest by the max duration
+    grouped_df1 = df1.groupby("OP ID CROSS DEVICE").max()
+    grouped_df2 = df2.groupby("OP ID CROSS DEVICE").min()
+
+    # Concatenate the results
+    grouped_df = pd.concat([grouped_df1, grouped_df2])
+
+    # Sort by global call id again
+    grouped_df = grouped_df.sort_values(by="GLOBAL CALL COUNT", ascending=True)
+
+    grouped_df = grouped_df.reset_index()
+
+    return grouped_df
+
+
+def analyze_perf_csv(csv_file, layers, show_all, out_file=None, num_chips=1, seq=32, group=False):
+    df = pd.read_csv(csv_file)
+    df = df[df["DEVICE FW DURATION [ns]"] != "-"]
+    df["DEVICE FW DURATION [ns]"] = df["DEVICE FW DURATION [ns]"].astype(int)
+
+    df = assign_op_id_cross_device(df, num_chips)
+    sorted_df = df
+    sum_duration = df["DEVICE FW DURATION [ns]"].sum()
+
+    matmul_rows = sorted_df[sorted_df["OP CODE"].str.contains("Matmul")]
+
+    matmul_rows.loc[:, "bytes"] = (
+        matmul_rows["INPUT_1_W"] * matmul_rows["INPUT_1_Z"] * matmul_rows["INPUT_1_Y"] * matmul_rows["INPUT_1_X"]
+    )
+    matmul_rows.loc[:, "flops"] = 2 * matmul_rows["INPUT_0_Y"] * matmul_rows["INPUT_0_X"] * matmul_rows["OUTPUT_0_X"]
+    matmul_rows["GB/s"] = matmul_rows["bytes"] / matmul_rows["DEVICE FW DURATION [ns]"]
+    matmul_rows["TFLOP/s"] = matmul_rows["flops"] / matmul_rows["DEVICE FW DURATION [ns]"] / 1000
+    matmul_rows["% DRAM (240)"] = 100 * matmul_rows["GB/s"] / 240  # Peak expected WH bandwidth
+    matmul_rows["% FPU (82)"] = 100 * matmul_rows["TFLOP/s"] / 82  # Peak theoretical FP16 FPU performance
+    matmul_rows["% TIME"] = 100 * matmul_rows["DEVICE FW DURATION [ns]"] / sum_duration
+    # matmul_rows["% TIME SUM"] = matmul_rows["% TIME"].cumsum()
+    matmul_sum_duration = matmul_rows["DEVICE FW DURATION [ns]"].sum()
+
+    # shorten some column names
+    matmul_rows.rename(columns={"DEVICE FW DURATION [ns]": "DURATION [ns]"}, inplace=True)
+    sorted_df.rename(columns={"DEVICE FW DURATION [ns]": "DURATION [ns]"}, inplace=True)
+
+    data_type = {"BFLOAT16": 2, "BFLOAT8_B": 1}
+    sorted_df[["INPUT_0_DATATYPE", "INPUT_1_DATATYPE", "OUTPUT_0_DATATYPE"]] = (
+        sorted_df[["INPUT_0_DATATYPE", "INPUT_1_DATATYPE", "OUTPUT_0_DATATYPE"]]
+        .applymap(data_type.get)
+        .fillna(0)
+        .astype(int)
+    )
+
+    sorted_df.loc[:, "TOTAL_BYTES"] = (
+        (sorted_df["INPUT_0_MEMORY"].str.contains(DRAM_INTERLEAVED, na=False)).astype(int)
+        * (
+            sorted_df["INPUT_0_W"]
+            * sorted_df["INPUT_0_Z"]
+            * sorted_df["INPUT_0_Y"]
+            * sorted_df["INPUT_0_X"]
+            * sorted_df["INPUT_0_DATATYPE"]
+        )
+        + (sorted_df["INPUT_1_MEMORY"].str.contains(DRAM_INTERLEAVED, na=False)).astype(int)
+        * (
+            sorted_df["INPUT_1_W"]
+            * sorted_df["INPUT_1_Z"]
+            * sorted_df["INPUT_1_Y"]
+            * sorted_df["INPUT_1_X"]
+            * sorted_df["INPUT_1_DATATYPE"]
+        )
+        + (sorted_df["OUTPUT_0_MEMORY"].str.contains(DRAM_INTERLEAVED, na=False)).astype(int)
+        * (
+            sorted_df["OUTPUT_0_W"]
+            * sorted_df["OUTPUT_0_Z"]
+            * sorted_df["OUTPUT_0_Y"]
+            * sorted_df["OUTPUT_0_X"]
+            * sorted_df["OUTPUT_0_DATATYPE"]
+        )
+    )
+
+    sorted_df.loc[:, "flops"] = 2 * sorted_df["INPUT_0_Y"] * sorted_df["INPUT_0_X"] * sorted_df["OUTPUT_0_X"]
+    sorted_df["DRAM BW GB/s"] = sorted_df["TOTAL_BYTES"] * (1000**3) / (sorted_df["DURATION [ns]"] * (1024**3))
+    sorted_df["TFLOP/s"] = sorted_df["flops"] / sorted_df["DURATION [ns]"] / 1000
+    sorted_df["% DRAM (240)"] = 100 * sorted_df["DRAM BW GB/s"] / 240  # Peak expected WH bandwidth
+    sorted_df["% FPU (82)"] = 100 * sorted_df["TFLOP/s"] / 82  # Peak theoretical FP16 FPU performance
+    sorted_df["TOTAL MBs"] = sorted_df["TOTAL_BYTES"] / 1024 / 1024
+    selected_columns = [
+        "GLOBAL CALL COUNT",
+        "OP ID CROSS DEVICE",
+        "OP CODE",
+        "% TIME",
+        # "% TIME SUM",
+        "% DRAM (240)",
+        "% FPU (82)",
+        "DURATION [ns]",
+        "GB/s",
+        "TFLOP/s",
+        "CORE COUNT",
+        "INPUT_0_Y",
+        "INPUT_0_X",
+        "INPUT_1_Y",
+        "INPUT_1_X",
+        "OUTPUT_0_Y",
+        "OUTPUT_0_X",
+    ]
+
+    if show_all:
+        selected_columns = [
+            "GLOBAL CALL COUNT",
+            "OP ID CROSS DEVICE",
+            "OP CODE",
+            "% TIME",
+            # "% TIME SUM",
+            "DURATION [ns]",
+            "% DEV CB WAIT",
+            # "DURATION SUM [ns]",
+            "DRAM BW GB/s",
+            "% DRAM (240)",
+            "CORE COUNT",
+            "INPUT_0_Y",
+            "INPUT_0_X",
+            "INPUT_1_Y",
+            "INPUT_1_X",
+            "OUTPUT_0_Y",
+            "OUTPUT_0_X",
+            "TOTAL MBs",
+            "DEVICE COMPUTE CB WAIT FRONT [ns]",
+        ]
+        sorted_df["% TIME"] = 100 * sorted_df["DURATION [ns]"] / sum_duration
+        sorted_df["% DEV CB WAIT"] = (
+            100 * sorted_df["DEVICE COMPUTE CB WAIT FRONT [ns]"].astype(int) / sorted_df["DURATION [ns]"]
+        )
+
+        # trim all floats to 6 decimal places
+        sorted_df = sorted_df.round(6)
+        selected_df = sorted_df[selected_columns]
+
+        # save to file for further analysis
+        if out_file:
+            selected_df.to_csv(out_file, index=False, sep="\t")
+
+        if group:
+            grouped_df = group_by_op_all_devices(selected_df)
+
+            sum_duration = grouped_df["DURATION [ns]"].sum()
+            grouped_df["% TIME"] = 100 * grouped_df["DURATION [ns]"] / sum_duration
+            grouped_df["% DEV CB WAIT"] = (
+                100 * grouped_df["DEVICE COMPUTE CB WAIT FRONT [ns]"].astype(int) / grouped_df["DURATION [ns]"]
+            )
+
+            grouped_matmul_rows = group_by_op_all_devices(matmul_rows)
+            matmul_sum_duration = grouped_matmul_rows["DURATION [ns]"].sum()
+
+            if out_file:
+                grouped_df.to_csv(out_file.split(".")[0] + ".grouped.csv", index=False, sep="\t")
+
+    if layers:
+        tokens_per_sec_user = 1000000000 / sum_duration / layers
+        tokens_per_sec = seq * tokens_per_sec_user
+        print(f"Layer ms: {sum_duration / 1000000:.8f} ({matmul_sum_duration / sum_duration:.2%} matmul)")
+        print(f"Inferences/sec: {tokens_per_sec_user:.8f}")
+        print(f"Tokens/sec: {tokens_per_sec:.8f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze perf CSV file")
+    parser.add_argument(
+        "-a", "--all", action="store_true", help="List ops in the CSV file - by default only matmul ops are shown."
+    )
+    parser.add_argument("-l", "--layers", type=int, help="Number of layers to extrapolate perf results up to.")
+    parser.add_argument(
+        "csv_file", type=str, help="Path to the perf CSV file from tt-metal for a single decoder layer."
+    )
+    parser.add_argument(
+        "-o", "--out_file", required=False, type=str, help="Path to the output file for further analysis."
+    )
+
+    parser.add_argument(
+        "--num-chips", type=int, default=1, help="Number of chips running model in parallel mode. Default is 1."
+    )
+
+    parser.add_argument("--seq", type=int, default=32, help="Sequence length or number of users.")
+
+    parser.add_argument("-g", "--group", action="store_true", help="Group by ops running in parallel on all devices.")
+
+    args = parser.parse_args()
+
+    analyze_perf_csv(
+        args.csv_file,
+        layers=args.layers,
+        show_all=args.all,
+        out_file=args.out_file,
+        num_chips=args.num_chips,
+        seq=args.seq,
+        group=args.group,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/falcon40b/tt/falcon_attention.py
+++ b/models/demos/falcon40b/tt/falcon_attention.py
@@ -330,8 +330,6 @@ class TtFalconAttention:
                     output_dtype=self.model_config["FUSED_QKV_MM_OUTPUT_DTYPE"],
                     grid=ttnn.CoreGrid(x=8, y=4) if q_len >= 512 else ttnn.CoreGrid(x=8, y=1),
                     transpose_mcast=True,
-                    overwrite_subblock_w=1,  # Workaround for non deterministic output/hang; issue: 7066
-                    overwrite_subblock_h=1,
                 )
             )
 

--- a/models/demos/falcon40b/tt/falcon_attention.py
+++ b/models/demos/falcon40b/tt/falcon_attention.py
@@ -316,11 +316,6 @@ class TtFalconAttention:
         q_len = hidden_states[0].get_legacy_shape()[2]
         assert layer_past is not None
 
-        # Reshard
-        hidden_states = convert_to_layout(
-            hidden_states, self.model_config["ATTN_INPUT_MEMCFG"], self.model_config["FUSED_QKV_MM_INPUT_MEMCFG"]
-        )
-
         #################
         ### FUSED QKV ###
         #################
@@ -343,13 +338,6 @@ class TtFalconAttention:
         ###########
         ### TMs ###
         ###########
-        # TODO: Need to uplift nlp_create_qkv_heads to support HEIGHT > 32 for sharded; otherwise, need to spill to interleaved for prefill
-        fused_query_key_value = convert_to_layout(
-            fused_query_key_value,
-            self.model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
-            self.model_config["CREATE_QKV_HEADS_INPUT_MEMCFG"],
-        )
-
         query_layer = []
         key_layer = []
         value_layer = []
@@ -465,10 +453,6 @@ class TtFalconAttention:
                 output_mem_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
             )
 
-        attn_output = convert_to_layout(
-            attn_output, self.model_config["ATTN_ALL_GATHER_OUTPUT_MEMCFG"], self.model_config["DEFAULT_MEMCFG"]
-        )
-
         attn_output = tt_lib.tensor.all_gather(
             attn_output,
             dim=3,
@@ -476,9 +460,6 @@ class TtFalconAttention:
             output_mem_config=self.model_config["DEFAULT_MEMCFG"],
         )
 
-        attn_output = convert_to_layout(
-            attn_output, self.model_config["DEFAULT_MEMCFG"], self.model_config["ATTN_ALL_GATHER_OUTPUT_MEMCFG"]
-        )
         for i in range(len(attn_output)):
             attn_output[i] = falcon_prefill_matmul(
                 attn_output[i],

--- a/models/demos/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/falcon40b/tt/falcon_decoder.py
@@ -235,12 +235,6 @@ class TtFalconDecoderLayer:
             output_mem_config=self.model_config["DEFAULT_MEMCFG"],
         )
 
-        replicated_hidden_states = convert_to_layout(
-            replicated_hidden_states,
-            self.model_config["DEFAULT_MEMCFG"],
-            self.model_config["DECODER_ALL_GATHER_OUTPUT_MEMCFG"],
-        )
-
         attn_ln_output = partial_layernorm(
             replicated_hidden_states,
             self.ln_attn_gamma,
@@ -252,9 +246,6 @@ class TtFalconDecoderLayer:
             self.model_config["LN_MLP_OUTPUT_DTYPE"],
             self.hidden_size,
             self.devices,
-        )
-        attn_ln_output = convert_to_layout(
-            attn_ln_output, self.model_config["LN_ATTN_OUTPUT_MEMCFG"], self.model_config["ATTN_INPUT_MEMCFG"]
         )
 
         mlp_ln_output = partial_layernorm(
@@ -268,9 +259,6 @@ class TtFalconDecoderLayer:
             self.model_config["LN_MLP_OUTPUT_DTYPE"],
             self.hidden_size,
             self.devices,
-        )
-        mlp_ln_output = convert_to_layout(
-            mlp_ln_output, self.model_config["LN_MLP_OUTPUT_MEMCFG"], self.model_config["DEFAULT_MEMCFG"]
         )
 
         residual = hidden_states

--- a/models/demos/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/falcon40b/tt/falcon_mlp.py
@@ -162,22 +162,12 @@ class TtFalconMLP:
                 )
             )
             x[i].deallocate(True)
-        if self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"] != self.model_config["DEFAULT_MEMCFG"]:
-            for i in range(len(hidden_states)):
-                hidden_states[i] = tt_lib.tensor.sharded_to_interleaved(
-                    hidden_states[i], output_mem_config=self.model_config["DEFAULT_MEMCFG"]
-                )
         hidden_states = tt_lib.tensor.all_gather(
             hidden_states,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             output_mem_config=self.model_config["DEFAULT_MEMCFG"],
         )
-        if self.model_config["MLP_ALL_GATHER_OUTPUT_MEMCFG"] != self.model_config["DEFAULT_MEMCFG"]:
-            for i in range(len(hidden_states)):
-                hidden_states[i] = tt_lib.tensor.interleaved_to_sharded(
-                    hidden_states[i], sharded_mem_config=self.model_config["MLP_ALL_GATHER_OUTPUT_MEMCFG"]
-                )
         for i in range(len(hidden_states)):
             hidden_states[i] = falcon_prefill_matmul(
                 hidden_states[i],

--- a/models/demos/falcon40b/tt/falcon_model.py
+++ b/models/demos/falcon40b/tt/falcon_model.py
@@ -290,19 +290,12 @@ class TtFalconModelShared:
             presents += layer_output[1:]
             layer_output = layer_output[0]
 
-        layer_output = convert_to_layout(
-            layer_output, self.model_config["DROPOUT_ADD_OUTPUT_MEMCFG"], self.model_config["DEFAULT_MEMCFG"]
-        )
         layer_output = tt_lib.tensor.all_gather(
             layer_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             output_mem_config=self.model_config["DEFAULT_MEMCFG"],
         )
-        layer_output = convert_to_layout(
-            layer_output, self.model_config["DEFAULT_MEMCFG"], self.model_config["FINAL_ALL_GATHER_OUTPUT_MEMCFG"]
-        )
-
         # apply final norm layer
         layer_output = partial_layernorm(
             layer_output,
@@ -315,9 +308,6 @@ class TtFalconModelShared:
             self.model_config["LN_MLP_OUTPUT_DTYPE"],
             self.hidden_size,
             self.devices,
-        )
-        layer_output = convert_to_layout(
-            layer_output, self.model_config["LN_F_OUTPUT_MEMCFG"], self.model_config["DEFAULT_MEMCFG"]
         )
 
         return layer_output, presents

--- a/models/demos/falcon40b/tt/model_config.py
+++ b/models/demos/falcon40b/tt/model_config.py
@@ -835,7 +835,7 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
 
     # Layernorm is an exception that are sharded also here, because the interleaved OP does not fit in L1 for 40b hidden size
     layernorm_num_cores_x = 8
-    layernorm_max_num_cores_y = 7
+    layernorm_max_num_cores_y = 8
 
     layernorm_slice_size = 512
 
@@ -975,14 +975,14 @@ def get_sharded_layernorm_specs_for_seqlen(
     )
 
     layernorm_block_sharded_prg_config = ttl.operations.primary.LayerNormShardedMultiCoreProgramConfig(
-        compute_with_storage_grid_size=[layernorm_num_cores_x, layernorm_max_num_cores_y],
+        compute_with_storage_grid_size=[layernorm_num_cores_x, layernorm_num_cores_y],
         subblock_w=8,
         block_h=num_tiles_per_core_h,
         block_w=num_tiles_per_core_w,
         inplace=False,
     )
     layernorm_block_sharded_prg_config_inplace = ttl.operations.primary.LayerNormShardedMultiCoreProgramConfig(
-        compute_with_storage_grid_size=[layernorm_num_cores_x, layernorm_max_num_cores_y],
+        compute_with_storage_grid_size=[layernorm_num_cores_x, layernorm_num_cores_y],
         subblock_w=8,
         block_h=num_tiles_per_core_h,
         block_w=num_tiles_per_core_w,

--- a/models/demos/falcon40b/tt/model_utils.py
+++ b/models/demos/falcon40b/tt/model_utils.py
@@ -347,6 +347,7 @@ def partial_layernorm(
                     pgmconfig,
                 )
 
+            for i in range(num_devices):
                 ttl.tensor.sharded_to_interleaved_partial(
                     xs_slice[i],
                     xs_output_cat[i],


### PR DESCRIPTION
- Use 64 cores for partial layernorm
- Use larger subblock h/w with matmul 1d/2d where possible to improve 2k seq len performance
   - first attention matmul is actually not affected by #7066
   - lm head matmul can use subblock_w=4 for 2k seq len which improves performance; for 128 seq len we still need to use subblock_w=1 to avoid issue #7066
- Remove unnecessary layout conversions
- Add perf summary script to extract more meaningful information from the device profiler output

These optimizations are ported from `jrock/prefill-perf2` branch - attention optimizations are still being debugged, so they won't be added to main until the PCC is good.

cc @johanna-rock-tt 

Multi-chip CI: https://github.com/tenstorrent/tt-metal/actions/runs/8735592426