### PR TITLE
#4860: FD2 fix split dispatcher preamble

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -736,6 +736,7 @@ void gen_host_test(Device *device,
                    uint32_t dst_addr) {
 
     std::vector<uint32_t> dispatch_cmds;
+
     gen_dispatcher_host_write_cmd(dispatch_cmds, 32);
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
     dispatch_cmds.resize(0);
@@ -743,6 +744,9 @@ void gen_host_test(Device *device,
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
     dispatch_cmds.resize(0);
     gen_dispatcher_host_write_cmd(dispatch_cmds, 1024);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+    dispatch_cmds.resize(0);
+    gen_dispatcher_host_write_cmd(dispatch_cmds, dispatch_buffer_page_size_g - sizeof(CQDispatchCmd));
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
     dispatch_cmds.resize(0);
     gen_dispatcher_host_write_cmd(dispatch_cmds, 16384);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -284,7 +284,8 @@ FORCE_INLINE
 void process_write_host_d() {
 
     volatile tt_l1_ptr CQDispatchCmd *cmd = (volatile tt_l1_ptr CQDispatchCmd *)cmd_ptr;
-    uint32_t length = sizeof(CQDispatchCmd) + cmd->write_linear_host.length;
+    // Remember: host transfer command includes the command in the payload, don't add it here
+    uint32_t length = cmd->write_linear_host.length;
     uint32_t data_ptr = cmd_ptr;
 
     relay_to_next_cb<split_dispatch_page_preamble_size>(data_ptr, length);
@@ -742,7 +743,7 @@ static inline bool process_cmd_d(uint32_t& cmd_ptr) {
         break;
 
     default:
-        DPRINT << "dispatcher_d invalid command:" << cmd_ptr << " " << cb_fence << " " << " " << dispatch_cb_base << " " << dispatch_cb_end << " " << rd_block_idx << " " << "xx" << ENDL();
+        DPRINT << "dispatcher_d invalid command:" << cmd_ptr << " " << cb_fence << " " << dispatch_cb_base << " " << dispatch_cb_end << " " << rd_block_idx << " " << "xx" << ENDL();
         DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+1) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+2) << ENDL();


### PR DESCRIPTION
Was supplying a preamble per page rather than per command