### PR TITLE
#5995: UntilizeWithUnpadding used wrong shard spec for output

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_untilize_with_unpadding.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_untilize_with_unpadding.py
@@ -11,6 +11,12 @@ from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, gene
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
 import tt_lib as ttl
 
+
+def create_grid(x, y):
+    core_range = ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(x - 1, y - 1))
+    return ttl.tensor.CoreRangeSet({core_range})
+
+
 params = [
     pytest.param([[5, 5, 32, 32]], untilize_with_unpadding_args)
     for untilize_with_unpadding_args in generation_funcs.gen_untilize_with_unpadding_args([[5, 5, 32, 32]])
@@ -34,6 +40,31 @@ params += [
             ),
             "output_tensor_start": [0, 0, 0, 0],
             "output_tensor_end": [0, 0, 119, 7299],
+        },
+    )
+]
+
+
+params += [
+    pytest.param(
+        [[1, 1, 128, 32]],
+        {
+            "dtype": [ttl.tensor.DataType.BFLOAT16],
+            "layout": [ttl.tensor.Layout.TILE],
+            "input_mem_config": [
+                ttl.tensor.MemoryConfig(
+                    ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                    ttl.tensor.BufferType.L1,
+                    ttl.tensor.ShardSpec(create_grid(1, 2), [64, 32], ttl.tensor.ShardOrientation.ROW_MAJOR, False),
+                )
+            ],
+            "output_mem_config": ttl.tensor.MemoryConfig(
+                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttl.tensor.BufferType.L1,
+                ttl.tensor.ShardSpec(create_grid(1, 2), [64, 16], ttl.tensor.ShardOrientation.ROW_MAJOR, False),
+            ),
+            "output_tensor_start": [0, 0, 0, 0],
+            "output_tensor_end": [0, 0, 127, 15],
         },
     )
 ]

--- a/tt_eager/tt_dnn/op_library/untilize/kernels/dataflow/writer_unary_unpad_batch_rows_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/kernels/dataflow/writer_unary_unpad_batch_rows_sharded.cpp
@@ -5,12 +5,14 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 
+
 void kernel_main() {
-    // This kernel only supports unpadding the end rows of each batch
-    uint32_t num_unpadded_output_rows   = get_arg_val<uint32_t>(0);
-    uint32_t num_padded_tiles_per_batch = get_arg_val<uint32_t>(1);
-    uint32_t unpadded_block_size_bytes  = get_arg_val<uint32_t>(2);
-    uint32_t batch                      = get_arg_val<uint32_t>(3);
+    uint32_t num_unpadded_output_rows       = get_arg_val<uint32_t>(0);
+    uint32_t num_padded_tiles_per_batch     = get_arg_val<uint32_t>(1);
+    uint32_t num_padded_rows_per_batch      = get_arg_val<uint32_t>(2);
+    uint32_t padded_block_row_size_bytes    = get_arg_val<uint32_t>(3);
+    uint32_t unpadded_block_row_size_bytes  = get_arg_val<uint32_t>(4);
+    uint32_t batch                          = get_arg_val<uint32_t>(5);
 
     constexpr uint32_t cb_id_untilize_out = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
@@ -21,8 +23,13 @@ void kernel_main() {
     for(uint32_t b = 0; b < batch; ++b) {
         cb_wait_front(cb_id_untilize_out, num_padded_tiles_per_batch);
         uint64_t noc_l1_read_addr = get_noc_addr(get_read_ptr(cb_id_untilize_out));
-        noc_async_read(noc_l1_read_addr, l1_write_addr, unpadded_block_size_bytes);
-        l1_write_addr += unpadded_block_size_bytes;
+
+        for (uint32_t row = 0; row < num_padded_rows_per_batch; ++row) {
+            noc_async_read(noc_l1_read_addr, l1_write_addr, unpadded_block_row_size_bytes);
+            noc_l1_read_addr += padded_block_row_size_bytes;
+            l1_write_addr += unpadded_block_row_size_bytes;
+        }
+
         noc_async_read_barrier();
         cb_pop_front(cb_id_untilize_out, num_padded_tiles_per_batch);
     }

--- a/tt_eager/tt_dnn/op_library/untilize/untilize_op.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/untilize_op.cpp
@@ -141,7 +141,10 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor> &input_tensors) c
             TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
             TT_FATAL(input_tensor_a.volume() / (input_tensor_a.get_legacy_shape()[-2] * input_tensor_a.get_legacy_shape()[-1]) == 1, "Can only write unbatched output interleaved");
         } else if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-            // TODO ...
+            if (output_mem_config.is_sharded()) {
+                TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+            }
+            // What else?
         } else if(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
             auto output_shape = this->compute_output_shapes(input_tensors).at(0);
             // Minor host code changes required to remove this restriction


### PR DESCRIPTION
UntilizeWithUnpadding when both input and output are sharded uses the input shard spec to compute the number of output rows, the size of output rows and so on. This commit changes the code to use the output shard spec. We also write the output one row at a time, so that we can support unpadding individual rows.