### PR TITLE
#7512: remove tt::tt_metal::Matmul struct

### DIFF
--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -516,128 +516,6 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(const Ten
 namespace tt {
 namespace tt_metal {
 
-    /*
-void Matmul::validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    const auto& input_tensor_b = input_tensors.at(1);
-    TT_FATAL((input_tensor_a.get_layout() == Layout::TILE && input_tensor_b.get_layout() == Layout::TILE), "Inputs to matmul must be tilized");
-    if (this->bcast_batch) {
-        TT_FATAL(input_tensor_b.get_legacy_shape()[0] * input_tensor_b.get_legacy_shape()[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
-    } else {
-        TT_FATAL(input_tensor_a.get_legacy_shape()[1] == input_tensor_b.get_legacy_shape()[1] && input_tensor_a.get_legacy_shape()[0] == input_tensor_b.get_legacy_shape()[0] && "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
-    }
-    TT_FATAL(input_tensor_a.get_legacy_shape()[3] == input_tensor_b.get_legacy_shape()[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
-
-    // TODO: Uplift get_parallelization_strategy to be struct param? We should do separate dtype validations for different parallelizations
-    // This requires sweeping across shapes with different dtypes/dataformats; for now, ignore dtype assertions here and uplift to actual matmul/bmm implementations
-    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
-    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE, "Operands to matmul need to be on device!");
-    TT_FATAL(input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
-
-    if (this->untilize_out) {
-        TT_FATAL(this->output_dtype == DataType::BFLOAT16);
-    }
-}
-*/
-
-/*
-std::vector<Shape> Matmul::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
-    const auto input_shape_a = input_tensors.at(0).get_legacy_shape();
-    const auto input_shape_b = input_tensors.at(1).get_legacy_shape();
-
-    auto output_shape = input_shape_a;
-    output_shape[-1] = input_shape_b[-1];
-    auto dimensions_pads = std::vector<Padding::PadDimension>();
-    for (auto index = 0; index < input_shape_a.rank() - 1; index++) {
-        dimensions_pads.push_back(input_shape_a.padding()[index]);
-    }
-    dimensions_pads.push_back(input_shape_b.padding()[input_shape_b.rank() - 1]);
-    const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
-    return {Shape(output_shape, padding)};
-}
-*/
-
-/*
-std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
-    return operation::generic_create_output_tensors(*this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
-}
-*/
-
-/*
-operation::ProgramWithCallbacks Matmul::create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    const auto& input_tensor_b = input_tensors.at(1);
-    auto& output_tensor = output_tensors.at(0);
-
-    auto parallelization_strategy = this->get_parallelization_strategy(input_tensors);
-    tt::operations::primary::MatmulMultiCoreReuseMultiCast1DProgramConfig config;
-    switch (parallelization_strategy){
-        case MatmulParallelizationStrategy::MULTI_CORE:
-            return matmul_multi_core(input_tensor_a, input_tensor_b, output_tensor, this->bcast_batch);
-        case MatmulParallelizationStrategy::MULTI_CORE_REUSE:
-            return matmul_multi_core_reuse(input_tensor_a, input_tensor_b, output_tensor, this->bcast_batch);
-        case MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_2D_OPTIMIZED:
-            return matmul_multi_core_reuse_mcast_2d_optimized(
-                input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
-                this->bcast_batch,
-                input_tensor_a.device()->compute_with_storage_grid_size(),
-                // MathFidelity::HiFi4, false, true, false,
-                this->compute_kernel_config,
-                2, 4, 2,
-                16, 16, false, false, std::nullopt,
-                this->untilize_out
-            );
-        case MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN0_OPTIMIZED:
-            config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, false, std::nullopt, true, false);
-            return matmul_multi_core_reuse_mcast_1d_optimized(
-                input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
-                this->bcast_batch,
-                input_tensor_a.device()->compute_with_storage_grid_size(),
-                // MathFidelity::HiFi4, false, true, false,
-                this->compute_kernel_config,
-                config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
-                config.per_core_M, config.per_core_N, false, std::nullopt, true,
-                this->untilize_out
-            );
-        case MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN1_OPTIMIZED:
-            config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, false, std::nullopt, false, false);
-            return matmul_multi_core_reuse_mcast_1d_optimized(
-                input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
-                this->bcast_batch,
-                input_tensor_a.device()->compute_with_storage_grid_size(),
-                // MathFidelity::HiFi4, false, true, false,
-                this->compute_kernel_config,
-                config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
-                config.per_core_M, config.per_core_N, false, std::nullopt, false,
-                this->untilize_out
-            );
-        case MatmulParallelizationStrategy::MULTI_CORE_REUSE_PADDING:
-            return matmul_multi_core_reuse_padding(input_tensor_a, input_tensor_b, output_tensor, this->bcast_batch);
-        case MatmulParallelizationStrategy::SINGLE_CORE:
-        default:
-            return matmul_single_core(input_tensor_a, input_tensor_b, output_tensor, this->bcast_batch);
-    }
-
-}
-*/
-
-/*
-operation::OpPerformanceModel Matmul::create_op_performance_model(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor> &output_tensors
-    ) const {
-        return ::create_op_performance_model_for_matmul(input_tensors, optional_input_tensors, output_tensors, this->compute_kernel_config);
-}
-*/
-/*
-MatmulParallelizationStrategy Matmul::get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const {
-    return bmm_op_utils::get_parallelization_strategy(input_tensors);
-}
-*/
-
 /**
  * Bert large matmuls using operations::primary::matmul + program_config
  */
@@ -1228,14 +1106,15 @@ operation::ProgramWithCallbacks Matmul::create_program(
     bool fuse_batch = true;
     // TODO: If input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] == 1, does matmuls work if we treat it as bmm
     // TODO: Only for MatmulMultiCoreReuseProgramConfig we allow this as single core matmul/bmm
-    bool broadcast_batch = input_tensor_b.get_legacy_shape()[0] * input_tensor_b.get_legacy_shape()[1] == 1;
+    bool broadcast_batch = this->bcast_batch;
+
 
     return std::visit(
         [&](const auto& program_config) -> operation::ProgramWithCallbacks {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, MatmulDefaultProgramConfig>) {
                 auto parallelization_strategy = bmm_op_utils::get_parallelization_strategy(input_tensors);
-		MatmulMultiCoreReuseMultiCast1DProgramConfig config;
+		MatmulMultiCoreReuseMultiCast1DProgramConfig config{};
                 switch (parallelization_strategy){
                     case MatmulParallelizationStrategy::MULTI_CORE:
                         return matmul_multi_core(input_tensor_a, input_tensor_b, output_tensor, broadcast_batch);
@@ -1258,10 +1137,6 @@ operation::ProgramWithCallbacks Matmul::create_program(
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
                             this->compute_kernel_config,
-			    /*
-                            2, 4, 2,
-                            16, 16, false, std::nullopt, true,
-			    */
 			    config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
 			    config.per_core_M, config.per_core_N, false, std::nullopt, true,
                             this->untilize_out
@@ -1273,10 +1148,6 @@ operation::ProgramWithCallbacks Matmul::create_program(
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
                             this->compute_kernel_config,
-			    /*
-                            2, 4, 2,
-                            16, 16, false, std::nullopt, false,
-			    */
 			    config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
 			    config.per_core_M, config.per_core_N, false, std::nullopt, false,
                             this->untilize_out
@@ -1289,7 +1160,6 @@ operation::ProgramWithCallbacks Matmul::create_program(
                 }
             }
             else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
-                //broadcast_batch &= input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] > 1;
                 return bmm_multi_core_reuse_optimized(
                     input_tensor_a, input_tensor_b, output_tensor,
                     broadcast_batch,

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -516,6 +516,7 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(const Ten
 namespace tt {
 namespace tt_metal {
 
+    /*
 void Matmul::validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
@@ -538,7 +539,9 @@ void Matmul::validate(const std::vector<Tensor>& input_tensors, const std::vecto
         TT_FATAL(this->output_dtype == DataType::BFLOAT16);
     }
 }
+*/
 
+/*
 std::vector<Shape> Matmul::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
     const auto input_shape_a = input_tensors.at(0).get_legacy_shape();
     const auto input_shape_b = input_tensors.at(1).get_legacy_shape();
@@ -553,12 +556,16 @@ std::vector<Shape> Matmul::compute_output_shapes(const std::vector<Tensor>& inpu
     const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
     return {Shape(output_shape, padding)};
 }
+*/
 
+/*
 std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     return operation::generic_create_output_tensors(*this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
 }
+*/
 
+/*
 operation::ProgramWithCallbacks Matmul::create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
@@ -614,7 +621,9 @@ operation::ProgramWithCallbacks Matmul::create_program(const std::vector<Tensor>
     }
 
 }
+*/
 
+/*
 operation::OpPerformanceModel Matmul::create_op_performance_model(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
@@ -622,9 +631,12 @@ operation::OpPerformanceModel Matmul::create_op_performance_model(
     ) const {
         return ::create_op_performance_model_for_matmul(input_tensors, optional_input_tensors, output_tensors, this->compute_kernel_config);
 }
+*/
+/*
 MatmulParallelizationStrategy Matmul::get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const {
     return bmm_op_utils::get_parallelization_strategy(input_tensors);
 }
+*/
 
 /**
  * Bert large matmuls using operations::primary::matmul + program_config
@@ -792,7 +804,7 @@ Tensor falcon_dense_h_to_4h_matmul(const Tensor &input_tensor_a, const Tensor &i
         TT_FATAL((input_tensor_a.get_legacy_shape() == Shape({1, 1, seq_len, 4544})), "Unsupported input shape");
         TT_FATAL((input_tensor_b.get_legacy_shape() == Shape({1, 1, 4544, 18176})), "Unsupported input shape");
         TT_FATAL(!fused_activation.has_value());
-        return operation::run_with_autoformat(Matmul{.bcast_batch=true, .output_mem_config=mem_config, .output_dtype=output_dtype.value_or(input_tensor_a.get_dtype())}, {input_tensor_a, input_tensor_b}).at(0);
+        return operation::run_with_autoformat(tt::operations::primary::Matmul{.program_config=tt::operations::primary::MatmulDefaultProgramConfig{}, .bcast_batch=true, .output_mem_config=mem_config, .output_dtype=output_dtype.value_or(input_tensor_a.get_dtype())}, {input_tensor_a, input_tensor_b}).at(0);
     } else {
         CoreCoord grid_size = get_falcon_matmul_grid_size(input_tensor_a.device());
         auto program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, true, fused_activation, true, mem_config.is_sharded(), grid_size);
@@ -816,7 +828,7 @@ Tensor falcon_lm_head_matmul(const Tensor &input_tensor_a, const Tensor &input_t
                 TT_FATAL(seq_len >=  128, "Falcon mm's seq_len must be greater than 128!");
                 TT_FATAL((input_tensor_a.get_legacy_shape() == Shape({1, 1, seq_len, 4544})), "Unsupported input shape");
                 TT_FATAL((input_tensor_b.get_legacy_shape() == Shape({1, 1, 4544, 65024})), "Unsupported input shape");
-                return operation::run_with_autoformat(Matmul{.bcast_batch=true, .output_mem_config=mem_config, .output_dtype=output_dtype.value_or(input_tensor_a.get_dtype())}, {input_tensor_a, input_tensor_b}, {bias});
+                return operation::run_with_autoformat(tt::operations::primary::Matmul{.program_config=tt::operations::primary::MatmulDefaultProgramConfig{}, .bcast_batch=true, .output_mem_config=mem_config, .output_dtype=output_dtype.value_or(input_tensor_a.get_dtype())}, {input_tensor_a, input_tensor_b}, {bias});
             },
         {input_tensor_a, input_tensor_b}, output_tensors, {bias});
 
@@ -1223,6 +1235,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, MatmulDefaultProgramConfig>) {
                 auto parallelization_strategy = bmm_op_utils::get_parallelization_strategy(input_tensors);
+		MatmulMultiCoreReuseMultiCast1DProgramConfig config;
                 switch (parallelization_strategy){
                     case MatmulParallelizationStrategy::MULTI_CORE:
                         return matmul_multi_core(input_tensor_a, input_tensor_b, output_tensor, broadcast_batch);
@@ -1239,23 +1252,33 @@ operation::ProgramWithCallbacks Matmul::create_program(
                             this->untilize_out
                         );
                     case MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN0_OPTIMIZED:
+			config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, false, std::nullopt, true, false);
                         return matmul_multi_core_reuse_mcast_1d_optimized(
                             input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
                             this->compute_kernel_config,
+			    /*
                             2, 4, 2,
                             16, 16, false, std::nullopt, true,
+			    */
+			    config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
+			    config.per_core_M, config.per_core_N, false, std::nullopt, true,
                             this->untilize_out
                         );
                     case MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN1_OPTIMIZED:
+			config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, false, std::nullopt, false, false);
                         return matmul_multi_core_reuse_mcast_1d_optimized(
                             input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
                             this->compute_kernel_config,
+			    /*
                             2, 4, 2,
                             16, 16, false, std::nullopt, false,
+			    */
+			    config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
+			    config.per_core_M, config.per_core_N, false, std::nullopt, false,
                             this->untilize_out
                         );
                     case MatmulParallelizationStrategy::MULTI_CORE_REUSE_PADDING:
@@ -1266,7 +1289,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
                 }
             }
             else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
-                broadcast_batch &= input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] > 1;
+                //broadcast_batch &= input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] > 1;
                 return bmm_multi_core_reuse_optimized(
                     input_tensor_a, input_tensor_b, output_tensor,
                     broadcast_batch,

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
@@ -39,39 +39,6 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast  (const Tensor &in
 operation::ProgramWithCallbacks matmul_multi_core_reuse_padding (const Tensor &input_tensor_a, const Tensor &input_tensor_b, Tensor& output_tensor, bool bcast_batch);
 operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_padding (const Tensor &input_tensor_a, const Tensor &input_tensor_b, Tensor& output_tensor, bool bcast_batch);
 
-/*
-struct Matmul {
-    bool bcast_batch;
-    const MemoryConfig output_mem_config;
-    const DataType output_dtype; // TODO: Uplift output_dtype as an option for general matmul/bmm
-    const DeviceComputeKernelConfig compute_kernel_config;
-    const bool untilize_out;
-
-    void validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
-    std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const;
-    operation::OpPerformanceModel create_op_performance_model(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor> &output_tensors
-    ) const;
-    MatmulParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
-
-    static constexpr auto attribute_names =
-        std::make_tuple("bcast_batch", "output_mem_config", "output_dtype", "compute_kernel_config", "untilize_out");
-    const auto attribute_values() const {
-        return std::make_tuple(
-            std::cref(this->bcast_batch),
-            std::cref(this->output_mem_config),
-            std::cref(this->output_dtype),
-            std::cref(this->compute_kernel_config),
-            std::cref(this->untilize_out));
-    }
-};
-*/
-
-
 operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const std::optional<const Tensor> bias, Tensor &output_tensor, bool bcast_batch, CoreCoord compute_with_storage_grid_size, DeviceComputeKernelConfig compute_kernel_config, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0, bool untilize_out);
 operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const std::optional<const Tensor> bias, Tensor &output_tensor, bool bcast_batch, CoreCoord compute_with_storage_grid_size, DeviceComputeKernelConfig compute_kernel_config, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, bool transpose_mcast, std::optional<UnaryWithParam> fused_activation, bool untilize_out);
 operation::ProgramWithCallbacks bmm_multi_core_reuse_optimized(const Tensor& input_tensor_a, const Tensor& input_tensor_b, Tensor &output_tensor, bool bcast_batch, CoreCoord compute_with_storage_grid_size, tt::tt_metal::DataType output_dtype, DeviceComputeKernelConfig compute_kernel_config, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, bool untilize_out);


### PR DESCRIPTION
Removes tt::tt_metal::Matmul strut and points to primary::Matmul struct

Changes primary::Matmul struct to have bcast and retain bcast behaviour and changes hardcoded 1D_IN*_OPTIMIZED behaviour to use non-hardcoded values.

Performance Testing:

metal - Run microbenchmarks passes: https://github.com/tenstorrent/tt-metal/actions/runs/8807195711
Device perf regressions and output report passes: https://github.com/tenstorrent/tt-metal/actions/runs/8807190711/job/24178065279
Model perf regressions and output report passes except for other GS: https://github.com/tenstorrent/tt-metal/actions/runs/8807201739/job/24175297684
The failure is the same as in main: https://github.com/tenstorrent/tt-metal/actions/runs/8804337427/job/24164789238

Unit Testing:
No failures across 3 tests
pytest ./tests/ttnn/unit_tests/operations/test_matmul.py
========================================================= 130 passed, 2 skipped in 538.96s (0:08:58) ========================================================== 
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py # seems good
=================================================== 473 passed, 15 skipped, 12 xfailed in 502.98s (0:08:22) ===================================================
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py
========================================================= 36 passed, 156 skipped in 108.62s (0:01:48) =========================================================


