### PR TITLE
Adding Uneven Block and Width Shard Padding

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded_tensor.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded_tensor.py
@@ -256,6 +256,18 @@ def get_tensor(shape, dtype):
             ),
             DirectReadWriteType.READ_WRITE,
         ),
+        (
+            ttl.tensor.ShardOrientation.COL_MAJOR,
+            [1, 1, 8192, 512],
+            ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+            (1024, 320),
+            ttl.tensor.CoreRangeSet(
+                {
+                    ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 4)),  # 40 cores
+                }
+            ),
+            DirectReadWriteType.READ_WRITE,
+        ),
     ],
 )
 def test_tensor_conversion_between_torch_and_tt_tile(

--- a/tests/ttnn/integration_tests/stable_diffusion/test_sharded_attention.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_sharded_attention.py
@@ -8,232 +8,10 @@ import pytest
 
 import tt_lib as ttl
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import (
-    skip_for_grayskull,
-)
 from models.utility_functions import comp_pcc, tt2torch_tensor, torch2tt_tensor, skip_for_wormhole_b0
 
 
 # Test matmul attention sequence with InterleavedToShardedPartialOp
-@skip_for_grayskull()
-@pytest.mark.parametrize("seq_len", [4096, 1024])
-@pytest.mark.parametrize("num_slices", [16])
-@pytest.mark.parametrize("num_cores", [64])
-@pytest.mark.parametrize("num_heads", [16])
-@pytest.mark.parametrize("data_format", [ttl.tensor.DataType.BFLOAT16])
-def test_time_sharded_attnention_hwb(
-    device,
-    seq_len,
-    num_slices,
-    num_cores,
-    num_heads,
-    data_format,
-    function_level_defaults,
-):
-    pytest.skip()
-    compute_grid_size = device.compute_with_storage_grid_size()
-    if num_cores > (compute_grid_size.x * compute_grid_size.y):
-        pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
-    grid_size = (8, 8)
-
-    M = seq_len
-    K = 64
-    N = seq_len
-
-    query_layer_shape = [1, num_heads, seq_len, 64]
-    key_layer_transposed_shape = [1, num_heads, 64, seq_len]
-    value_layer_shape = [1, num_heads, seq_len, 64]
-    output_shape = [1, num_heads, seq_len, 64]
-
-    torch_query_layer = torch.randn(query_layer_shape).bfloat16().float()
-    torch_key_layer_transposed = torch.randn(key_layer_transposed_shape).bfloat16().float()
-    torch_value_layer = torch.randn(value_layer_shape).bfloat16().float()
-    torch_output = torch.randn(output_shape).bfloat16().float()
-
-    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.DRAM,
-    )
-
-    height_sharded_mem_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttl.tensor.BufferType.L1
-    )
-    block_sharded_mem_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-        buffer_type=ttl.tensor.BufferType.L1,
-    )
-
-    # compare output to regular case
-    reference_query_layer = torch2tt_tensor(
-        torch_query_layer,
-        device,
-        tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=data_format,
-    )
-    reference_key_layer_transposed = torch2tt_tensor(
-        torch_key_layer_transposed,
-        device,
-        tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=data_format,
-    )
-    reference_value_layer = torch2tt_tensor(
-        torch_value_layer,
-        device,
-        tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=data_format,
-    )
-
-    attn_weights_qkt = torch_query_layer @ torch_key_layer_transposed
-    attn_weights_torch_sm = torch.nn.functional.softmax(attn_weights_qkt, dim=-1)
-    attn_weights_torch = attn_weights_torch_sm @ torch_value_layer
-
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=False,
-    )
-
-    passing = True
-    output = None
-
-    mm_out = torch2tt_tensor(
-        torch_output,
-        device,
-        tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=data_format,
-    )
-
-    tiles_per_shard = math.ceil((((num_heads * seq_len) / num_cores) / num_slices) / 32)
-    mm_output_block_shard_spec = [seq_len // 8, seq_len // 8]
-    tiles_per_shard = math.ceil((((num_heads * seq_len) / num_cores) / num_slices) / 32)
-    mm_output_height_shard_spec = [tiles_per_shard * 32, seq_len]
-
-    heads_per_slice = num_heads // num_slices
-    for i in range(num_slices):
-        q_slice = ttl.tensor.interleaved_to_sharded_partial(
-            reference_query_layer,
-            ttl.tensor.CoreCoord(1, grid_size[0]),
-            [M // grid_size[0], K],
-            num_slices,
-            i,
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
-        )
-        k_slice = ttl.tensor.interleaved_to_sharded_partial(
-            reference_key_layer_transposed,
-            ttl.tensor.CoreCoord(grid_size[1], 1),
-            [K, N // grid_size[1]],
-            num_slices,
-            i,
-            ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
-        )
-
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=grid_size,
-            in0_block_w=K // 32,
-            out_subblock_h=1,
-            out_subblock_w=1,
-            per_core_M=M // (32 * grid_size[0]),
-            per_core_N=N // (32 * grid_size[1]),
-            transpose_mcast=False,
-            fused_activation=None,
-        )
-
-        mm_slice = ttl.operations.primary.matmul(
-            q_slice,
-            k_slice,
-            program_config=program_config,
-            output_mem_config=block_sharded_mem_config,
-            output_dtype=data_format,
-            compute_kernel_config=compute_kernel_config,
-        )
-        # mmt = tt2torch_tensor(mm_slice)
-        # passed, message = comp_pcc(mmt, attn_weights_qkt[:, i * heads_per_slice : (i + 1) * heads_per_slice, :, :])
-        # print(message)
-        # assert passed
-        k_slice.deallocate()
-        q_slice.deallocate()
-
-        height_per_core = seq_len // 64
-        output_shard_grid = ttl.tensor.CoreRangeSet(
-            {ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 7))}
-        )
-        output_shard_spec = ttl.tensor.ShardSpec(
-            output_shard_grid, [height_per_core, seq_len], ttl.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        output_mem_config = ttl.tensor.MemoryConfig(
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1, output_shard_spec
-        )
-        mm_slice = ttl.tensor.reshard(
-            mm_slice,
-            output_mem_config,
-        )
-        mm_slice = ttl.tensor.move_sharded(mm_slice)
-
-        softmax_program_config = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
-            compute_with_storage_grid_size=grid_size,
-            subblock_w=1,
-            block_h=mm_output_height_shard_spec[0] // 32,
-            block_w=mm_output_height_shard_spec[1] // 32,
-        )
-        # print(program_config)
-
-        mm_slice = ttl.operations.primary.softmax_in_place(mm_slice, program_config=softmax_program_config)
-        # mmt = tt2torch_tensor(mm_slice)
-        # passed, message = comp_pcc(mmt, attn_weights_torch_sm[:, i * heads_per_slice : (i + 1) * heads_per_slice, :, :])
-        # print(message)
-        # assert passed
-
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=grid_size,
-            in0_block_w=seq_len // 32,
-            per_core_M=tiles_per_shard,
-            per_core_N=2,
-            out_subblock_h=1,
-            out_subblock_w=1,
-            fuse_batch=True,
-            fused_activation=None,
-            mcast_in0=False,
-        )
-        v_slice = ttl.tensor.unpad(
-            reference_value_layer,
-            (0, (i * heads_per_slice), 0, 0),
-            (0, (i * heads_per_slice) + (heads_per_slice - 1), seq_len - 1, 63),
-            output_mem_config=dram_interleaved_memory_config,
-        )
-
-        mm_slice = ttl.operations.primary.matmul(
-            mm_slice,
-            v_slice,
-            program_config=program_config,
-            output_mem_config=height_sharded_mem_config,
-            output_dtype=data_format,
-            compute_kernel_config=compute_kernel_config,
-        )
-        v_slice.deallocate()
-
-        ttl.tensor.sharded_to_interleaved_partial(
-            mm_slice,
-            mm_out,
-            num_slices,
-            i,
-            dram_interleaved_memory_config,
-        )
-
-        mm_slice.deallocate()
-
-    mm_out_torch = tt2torch_tensor(mm_out)
-
-    passing, output = comp_pcc(mm_out_torch, attn_weights_torch)
-
-    print(output)
-    assert passing
-
-
-# Test matmul attention sequence with InterleavedToShardedPartialOp
-@skip_for_grayskull()
 @pytest.mark.parametrize("seq_len", [4096, 1024])
 @pytest.mark.parametrize("num_slices", [16])
 @pytest.mark.parametrize("num_cores", [64])
@@ -248,7 +26,6 @@ def test_time_sharded_attnention(
     data_format,
     function_level_defaults,
 ):
-    pytest.skip()
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
@@ -312,6 +89,7 @@ def test_time_sharded_attnention(
     tiles_per_shard = math.ceil((((num_heads * seq_len) / num_cores) / num_slices) / 32)
     mm_activations_height_shard_spec = [tiles_per_shard * 32, 2 * 32]
     mm_output_height_shard_spec = [tiles_per_shard * 32, seq_len]
+
     heads_per_slice = num_heads // num_slices
     for i in range(num_slices):
         slice = ttl.tensor.interleaved_to_sharded_partial(
@@ -329,7 +107,7 @@ def test_time_sharded_attnention(
             per_core_M=tiles_per_shard,
             per_core_N=seq_len // 32,
             out_subblock_h=1,
-            out_subblock_w=8,
+            out_subblock_w=1,
             fuse_batch=True,
             fused_activation=None,
             mcast_in0=False,
@@ -357,6 +135,8 @@ def test_time_sharded_attnention(
             subblock_w=1,
             block_h=mm_output_height_shard_spec[0] // 32,
             block_w=mm_output_height_shard_spec[1] // 32,
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            im_data_format=ttl.tensor.DataType.BFLOAT16,
         )
 
         mm_slice = ttl.operations.primary.softmax_in_place(mm_slice, program_config=softmax_program_config)
@@ -367,7 +147,7 @@ def test_time_sharded_attnention(
             per_core_M=tiles_per_shard,
             per_core_N=2,
             out_subblock_h=1,
-            out_subblock_w=2,
+            out_subblock_w=1,
             fuse_batch=True,
             fused_activation=None,
             mcast_in0=False,
@@ -414,7 +194,6 @@ def test_time_sharded_attnention(
 
 
 # Test matmul attention sequence with InterleavedToShardedPartialOp
-@skip_for_grayskull()
 @pytest.mark.parametrize("seq_len", [4096, 1024, 256, 64])
 @pytest.mark.parametrize("kv_len", [96])
 @pytest.mark.parametrize("num_heads", [16])
@@ -429,7 +208,6 @@ def test_cross_attnention(
     reshard_for_softmax,
     function_level_defaults,
 ):
-    pytest.skip()
     if seq_len == 64 and reshard_for_softmax:
         pytest.skip()
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -546,6 +324,8 @@ def test_cross_attnention(
             subblock_w=1,
             block_h=32,
             block_w=3,
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            im_data_format=ttl.tensor.DataType.BFLOAT16,
         )
         mm_slice = ttl.operations.primary.softmax_in_place(mm_slice, program_config=softmax_program_config)
         mm_slice = ttl.tensor.reshard(mm_slice, orig_mem_config)
@@ -556,6 +336,8 @@ def test_cross_attnention(
             subblock_w=1,
             block_h=seq_len // 32,
             block_w=kv_len // 32,
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            im_data_format=ttl.tensor.DataType.BFLOAT16,
         )
         mm_slice = ttl.operations.primary.softmax_in_place(mm_slice, program_config=softmax_program_config)
 
@@ -603,7 +385,6 @@ def test_cross_attnention(
 
 
 # Test matmul attention sequence with InterleavedToShardedPartialOp
-@skip_for_grayskull()
 @pytest.mark.parametrize("seq_len", [1024, 256, 64])
 @pytest.mark.parametrize("num_heads", [16])
 @pytest.mark.parametrize("data_format", [ttl.tensor.DataType.BFLOAT8_B])
@@ -616,7 +397,6 @@ def test_attnention(
     reshard_for_softmax,
     function_level_defaults,
 ):
-    pytest.skip()
     if seq_len == 64 and reshard_for_softmax:
         pytest.skip()
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -736,6 +516,8 @@ def test_attnention(
             subblock_w=1,
             block_h=height_per_core // 32,
             block_w=seq_len // 32,
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            im_data_format=ttl.tensor.DataType.BFLOAT16,
         )
         print(softmax_program_config)
         mm_slice = ttl.operations.primary.softmax_in_place(mm_slice, program_config=softmax_program_config)
@@ -747,6 +529,8 @@ def test_attnention(
             subblock_w=1,
             block_h=seq_len // 32,
             block_w=seq_len // 32,
+            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            im_data_format=ttl.tensor.DataType.BFLOAT16,
         )
         print(softmax_program_config)
         mm_slice = ttl.operations.primary.softmax_in_place(mm_slice, program_config=softmax_program_config)
@@ -795,7 +579,6 @@ def test_attnention(
     assert passing
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("size", [4096, 1024, 256, 64])
 @pytest.mark.parametrize("data_format", [ttl.tensor.DataType.BFLOAT16])
 @pytest.mark.parametrize("interleaved_output", [True, False])
@@ -806,7 +589,6 @@ def test_qkv(
     interleaved_output,
     function_level_defaults,
 ):
-    pytest.skip()
     sizes = {
         4096: [1, 8192, 320, 1536],
         1024: [1, 2048, 640, 2304],
@@ -814,7 +596,6 @@ def test_qkv(
         64: [1, 128, 1280, 3840],
     }
     grid_sizes = {4096: (8, 5), 1024: (8, 5), 256: (8, 8), 64: (4, 8)}
-    out_subblock_hs = {4096: 8, 1024: 8, 256: 2, 64: 1}
     B, M, K, N = sizes[size]
     grid_size = grid_sizes[size]
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -879,11 +660,11 @@ def test_qkv(
 
     Nt = N // 32
     G = grid_size[1]
-    per_core_N = (Nt - 1) // (G - 1) if Nt != 16 else 4
+    per_core_N = (Nt - 1) // (G - 1)
     program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=K // grid_size[1] // 32,
-        out_subblock_h=out_subblock_hs[size] if interleaved_output else 1,
+        out_subblock_h=1,
         out_subblock_w=1,
         per_core_M=M // grid_size[0] // 32,
         per_core_N=per_core_N,
@@ -922,7 +703,11 @@ def test_qkv(
     assert passing
 
 
-@skip_for_grayskull()
+# Test matmul attention sequence with InterleavedToShardedPartialOp
+sizes = {4096: [1, 8192, 320, 512], 1024: [1, 2048, 640, 768], 256: [1, 512, 1280, 1280], 64: [1, 128, 1280, 1280]}
+grid_sizes = {4096: (8, 5), 1024: (8, 5), 256: (8, 8), 64: (4, 8)}
+
+
 @pytest.mark.parametrize("size", [4096, 1024, 256, 64])
 @pytest.mark.parametrize("is_kv", [True, False])
 @pytest.mark.parametrize("data_format", [ttl.tensor.DataType.BFLOAT16])
@@ -935,13 +720,8 @@ def test_q_and_kv(
     interleaved_output,
     function_level_defaults,
 ):
-    pytest.skip()
-    sizes = {4096: [1, 8192, 320, 512], 1024: [1, 2048, 640, 768], 256: [1, 512, 1280, 1280], 64: [1, 128, 1280, 1280]}
-    grid_sizes = {4096: (8, 5), 1024: (8, 5), 256: (8, 8), 64: (4, 8)}
-    out_subblock_hs = {4096: 8, 1024: 8, 256: 2, 64: 1}
-
-    # if size == 4096 and not is_kv:
-    #     pytest.skip()
+    if size == 4096 and not is_kv:
+        pytest.skip()
 
     B, M, K, N = sizes[size]
     if is_kv:
@@ -1013,16 +793,15 @@ def test_q_and_kv(
     program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=K // grid_size[1] // 32,
-        out_subblock_h=out_subblock_hs[size] if interleaved_output else 1,
+        out_subblock_h=1,
         out_subblock_w=1,
         per_core_M=M // grid_size[0] // 32,
         per_core_N=per_core_N,
         fused_activation=None,
         transpose_mcast=True,
     )
-    print(program_config)
-    # print(f"Nt: {Nt}, G: {grid_size[1]}, Nt-1: {(Nt-1)}, G-1: {(grid_size[1]-1)} pcn: {(Nt-1)/(grid_size[1]-1)}")
-    # print(f"Nt/G: {Nt/grid_size[1]}, Nt/(G-1) = {Nt/(grid_size[1]-1)}")
+    print(f"Nt: {Nt}, G: {grid_size[1]}, Nt-1: {(Nt-1)}, G-1: {(grid_size[1]-1)} pcn: {(Nt-1)/(grid_size[1]-1)}")
+    print(f"Nt/G: {Nt/grid_size[1]}, Nt/(G-1) = {Nt/(grid_size[1]-1)}")
 
     compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
         math_fidelity=ttl.tensor.MathFidelity.LoFi,
@@ -1031,7 +810,7 @@ def test_q_and_kv(
         packer_l1_acc=False,
     )
     mm = ttl.operations.primary.matmul(
-        in_0 if size == 4096 and not is_kv else in_0_sharded,
+        in_0_sharded,
         in_1,
         program_config=program_config,
         output_mem_config=dram_interleaved_memory_config if interleaved_output else block_sharded_memory_config,
@@ -1044,277 +823,6 @@ def test_q_and_kv(
     #     l1_interleaved_memory_config,
     #     compute_kernel_config,
     # )
-
-    mm_out_torch = tt2torch_tensor(mm)
-
-    out_torch = in_0_torch @ in_1_torch
-
-    passing, output = comp_pcc(mm_out_torch, out_torch)
-
-    print(output)
-    assert passing
-
-
-@skip_for_grayskull()
-@pytest.mark.parametrize("size", [4096, 1024, 256, 64])
-@pytest.mark.parametrize("data_format", [ttl.tensor.DataType.BFLOAT8_B])
-@pytest.mark.parametrize("interleaved_output", [True, False])
-def test_out(
-    device,
-    size,
-    data_format,
-    interleaved_output,
-    function_level_defaults,
-):
-    pytest.skip()
-    sizes = {4096: [1, 8192, 512, 320], 1024: [1, 2048, 768, 640], 256: [1, 512, 1280, 1280], 64: [1, 128, 1280, 1280]}
-    grid_sizes = {4096: (8, 8), 1024: (8, 4), 256: (8, 5), 64: (4, 8)}
-    shard_direction = {
-        4096: ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-        1024: ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-        256: ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-        64: ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-    }
-    out_subblock_hs = {256: 8, 64: 4}
-
-    B, M, K, N = sizes[size]
-    grid_size = grid_sizes[size]
-    compute_grid_size = device.compute_with_storage_grid_size()
-    num_cores = grid_size[0] * grid_size[1]
-    if num_cores > (compute_grid_size.x * compute_grid_size.y):
-        pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
-
-    in_0_shape = [1, B, M, K]
-    in_1_shape = [1, B, K, N]
-
-    in_0_torch = torch.randn(in_0_shape).bfloat16().float()
-    in_1_torch = torch.randn(in_1_shape).bfloat16().float()
-
-    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.DRAM,
-    )
-    l1_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.L1,
-    )
-
-    height_sharded_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttl.tensor.BufferType.L1
-    )
-
-    block_sharded_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED, buffer_type=ttl.tensor.BufferType.L1
-    )
-
-    # compare output to regular case
-    in_0 = torch2tt_tensor(
-        in_0_torch,
-        device,
-        tt_memory_config=l1_interleaved_memory_config,
-        tt_dtype=data_format,
-    )
-    in_1 = torch2tt_tensor(
-        in_1_torch,
-        device,
-        tt_memory_config=l1_interleaved_memory_config,
-        tt_dtype=data_format,
-    )
-
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=False,
-    )
-
-    passing = True
-    output = None
-
-    hs = shard_direction[size] == ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED
-    if hs:
-        in_0_sharded = ttl.tensor.interleaved_to_sharded(
-            in_0,
-            grid_size,
-            [B * M // num_cores, K],
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
-        )
-        output_mem_config = height_sharded_memory_config
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=grid_size,
-            in0_block_w=K // 32 if hs else 1,
-            per_core_M=B * M // num_cores // 32 if hs else B * M // 32,
-            per_core_N=N // 32 if hs else N // num_cores // 32,
-            out_subblock_h=1 if hs else out_subblock_hs[size],
-            out_subblock_w=2 if hs else 1,
-            fuse_batch=True,
-            fused_activation=None,
-            mcast_in0=False if hs else True,
-        )
-    else:
-        in_0_sharded = ttl.tensor.interleaved_to_sharded(
-            in_0,
-            grid_size,
-            [B * M // grid_size[0], K // grid_size[1]],
-            ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            ttl.tensor.ShardOrientation.COL_MAJOR,
-        )
-        output_mem_config = block_sharded_memory_config
-
-        Nt = N // 32
-        G = grid_size[1]
-        per_core_N = (Nt - 1) // (G - 1) if Nt != 16 else 4
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=grid_size,
-            in0_block_w=K // grid_size[1] // 32,
-            out_subblock_h=1,
-            out_subblock_w=1,
-            per_core_M=M // grid_size[0] // 32,
-            per_core_N=per_core_N,
-            fused_activation=None,
-            transpose_mcast=True,
-        )
-
-    mm = ttl.operations.primary.matmul(
-        in_0_sharded,
-        in_1,
-        program_config=program_config,
-        output_mem_config=l1_interleaved_memory_config if interleaved_output else output_mem_config,
-        output_dtype=data_format,
-        compute_kernel_config=compute_kernel_config,
-    )
-    mm_out_torch = tt2torch_tensor(mm)
-
-    out_torch = in_0_torch @ in_1_torch
-
-    passing, output = comp_pcc(mm_out_torch, out_torch)
-
-    print(output)
-    assert passing
-
-
-@skip_for_grayskull()
-@pytest.mark.parametrize("size", [4096, 1024, 256, 64])
-@pytest.mark.parametrize("data_format", [ttl.tensor.DataType.BFLOAT8_B])
-@pytest.mark.parametrize("interleaved_output", [True, False])
-def test_ff(
-    device,
-    size,
-    data_format,
-    interleaved_output,
-    function_level_defaults,
-):
-    pytest.skip()
-    sizes = {4096: [1, 8192, 1280, 320], 1024: [1, 2048, 640, 768], 256: [1, 512, 1280, 1280], 64: [1, 128, 1280, 1280]}
-    grid_sizes = {4096: (8, 5), 1024: (8, 5), 256: (8, 8), 64: (4, 8)}
-    out_subblock_hs = {4096: 8, 1024: 8, 256: 2, 64: 1}
-
-    # if size == 4096 and not is_kv:
-    #     pytest.skip()
-
-    B, M, K, N = sizes[size]
-
-    grid_size = grid_sizes[size]
-    compute_grid_size = device.compute_with_storage_grid_size()
-    num_cores = grid_size[0] * grid_size[1]
-    if num_cores > (compute_grid_size.x * compute_grid_size.y):
-        pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
-
-    in_0_shape = [1, B, M, K]
-    in_1_shape = [1, B, K, N]
-
-    in_0_torch = torch.randn(in_0_shape).bfloat16().float()
-    in_1_torch = torch.randn(in_1_shape).bfloat16().float()
-
-    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.DRAM,
-    )
-    l1_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.L1,
-    )
-
-    height_sharded_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttl.tensor.BufferType.L1
-    )
-
-    block_sharded_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED, buffer_type=ttl.tensor.BufferType.L1
-    )
-
-    # compare output to regular case
-    in_0 = torch2tt_tensor(
-        in_0_torch,
-        device,
-        tt_memory_config=l1_interleaved_memory_config,
-        tt_dtype=data_format,
-    )
-    in_1 = torch2tt_tensor(
-        in_1_torch,
-        device,
-        tt_memory_config=l1_interleaved_memory_config,
-        tt_dtype=data_format,
-    )
-
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=False,
-    )
-
-    passing = True
-    output = None
-
-    in_0_sharded = ttl.tensor.interleaved_to_sharded(
-        in_0,
-        grid_size,
-        [M // grid_size[0], K // grid_size[1]],
-        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-        ttl.tensor.ShardOrientation.COL_MAJOR,
-    )
-
-    Nt = N // 32
-    G = grid_size[1]
-    per_core_N = (Nt - 1) // (G - 1)
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
-        compute_with_storage_grid_size=grid_size,
-        in0_block_w=K // grid_size[1] // 32,
-        out_subblock_h=out_subblock_hs[size] if interleaved_output else 1,
-        out_subblock_w=1,
-        per_core_M=M // grid_size[0] // 32,
-        per_core_N=per_core_N,
-        fused_activation=None,
-        transpose_mcast=True,
-    )
-    print(program_config)
-    # print(f"Nt: {Nt}, G: {grid_size[1]}, Nt-1: {(Nt-1)}, G-1: {(grid_size[1]-1)} pcn: {(Nt-1)/(grid_size[1]-1)}")
-    # print(f"Nt/G: {Nt/grid_size[1]}, Nt/(G-1) = {Nt/(grid_size[1]-1)}")
-
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=False,
-    )
-    mm = ttl.operations.primary.matmul(
-        in_0_sharded,
-        in_1,
-        program_config=program_config,
-        output_mem_config=dram_interleaved_memory_config if interleaved_output else block_sharded_memory_config,
-        output_dtype=data_format,
-        compute_kernel_config=compute_kernel_config,
-    )
-    if interleaved_output:
-        mm = ttl.tensor.interleaved_to_sharded(
-            mm,
-            grid_size,
-            [mm.shape[-2] // grid_size[0], mm.shape[-1] // grid_size[1]],
-            ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            ttl.tensor.ShardOrientation.COL_MAJOR,
-        )
 
     mm_out_torch = tt2torch_tensor(mm)
 

--- a/tests/ttnn/unit_tests/operations/test_core.py
+++ b/tests/ttnn/unit_tests/operations/test_core.py
@@ -268,6 +268,23 @@ def test_reshard(
                 strategy=ttnn.ShardStrategy.WIDTH,
             ),
         ),
+        # only direct transfers for this size work, there is an interleaved_to_sharded and sharded_to_interleaved bug
+        # Issue: 7725
+        (
+            [1, 1, 8192, 512],
+            [320, 1024],
+            dict(
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 4)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.COL_MAJOR,
+            ),
+        ),
     ],
 )
 def test_shard_with_corerangeset(device, input_shape, input_shard_shape, input_sharded_memory_config_args):

--- a/tests/ttnn/unit_tests/operations/test_core.py
+++ b/tests/ttnn/unit_tests/operations/test_core.py
@@ -9,6 +9,7 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from enum import Enum
 
 
 @pytest.mark.parametrize(
@@ -231,6 +232,22 @@ def test_reshard(
     assert_with_pcc(torch_input_tensor, output, 1.0)
 
 
+class DirectReadWriteType(Enum):
+    READ_ONLY = 0
+    WRITE_ONLY = 1
+    READ_WRITE = 2
+    NONE = 3
+
+
+@pytest.mark.parametrize(
+    "data_transfer_strategy",
+    [
+        (DirectReadWriteType.READ_ONLY),
+        (DirectReadWriteType.WRITE_ONLY),
+        (DirectReadWriteType.NONE),
+        (DirectReadWriteType.READ_WRITE),
+    ],
+)
 @pytest.mark.parametrize(
     "input_shape, input_shard_shape,  input_sharded_memory_config_args",
     [
@@ -287,24 +304,40 @@ def test_reshard(
         ),
     ],
 )
-def test_shard_with_corerangeset(device, input_shape, input_shard_shape, input_sharded_memory_config_args):
+def test_shard_with_corerangeset(
+    device, input_shape, input_shard_shape, input_sharded_memory_config_args, data_transfer_strategy
+):
     if device.core_grid.y == 7 and input_shard_shape == [32, 128]:
+        pytest.skip()
+    if (
+        ((not (input_shape[2] % input_shard_shape[0] == 0)) or (not (input_shape[3] % input_shard_shape[1] == 0)))
+        and (not (data_transfer_strategy == DirectReadWriteType.READ_WRITE))
+        and (not (input_sharded_memory_config_args["strategy"] == ttnn.ShardStrategy.HEIGHT))
+    ):
         pytest.skip()
 
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
-    interleaved_input_tensor = ttnn.from_torch(
-        torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
     input_shard_memory_config = ttnn.create_sharded_memory_config(
         input_shard_shape, **input_sharded_memory_config_args, use_height_and_width_as_shard_shape=True
     )
-    # interleaved_to_sharded
-    sharded_input_tensor = ttnn.to_memory_config(interleaved_input_tensor, input_shard_memory_config)
 
-    # sharded_to_interleaved
-    interleaved_output_tensor = ttnn.to_memory_config(sharded_input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+    if data_transfer_strategy == DirectReadWriteType.READ_ONLY or data_transfer_strategy == DirectReadWriteType.NONE:
+        interleaved_input_tensor = ttnn.from_torch(
+            torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        # interleaved_to_sharded
+        sharded_input_tensor = ttnn.to_memory_config(interleaved_input_tensor, input_shard_memory_config)
+    else:
+        sharded_input_tensor = ttnn.from_torch(
+            torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_shard_memory_config
+        )
 
-    output = ttnn.to_torch(interleaved_output_tensor)
+    if data_transfer_strategy == DirectReadWriteType.WRITE_ONLY or data_transfer_strategy == DirectReadWriteType.NONE:
+        # sharded_to_interleaved
+        interleaved_output_tensor = ttnn.to_memory_config(sharded_input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.to_torch(interleaved_output_tensor)
+    else:
+        output = ttnn.to_torch(sharded_input_tensor)
 
     assert_with_pcc(torch_input_tensor, output, 1.0)
 

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -606,7 +606,9 @@ std::vector<uint32_t> Tensor::host_page_ordering(){
     std::vector<uint32_t> ret_vec;
     ret_vec.reserve(num_pages);
     for(int page_id = 0; page_id <num_pages ; page_id++){
-        ret_vec.push_back(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id]);
+        if(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id].has_value()) {
+            ret_vec.push_back(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id].value());
+        }
     }
     return ret_vec;
 }
@@ -663,6 +665,8 @@ Tensor create_device_tensor(const Shape& shape, DataType data_type, Layout layou
     auto device_buffer = tensor_impl::allocate_buffer_on_device(packed_size_in_bytes, device, shape, data_type, layout, memory_config);
     return Tensor(DeviceStorage{device_buffer}, shape, data_type, layout);
 }
+
+
 
 Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layout layout, Device *device, const MemoryConfig& memory_config) {
     ZoneScoped;

--- a/tt_eager/tensor/tensor_impl.cpp
+++ b/tt_eager/tensor/tensor_impl.cpp
@@ -129,11 +129,11 @@ DeviceBuffer allocate_sharded_buffer_on_device(uint32_t buffer_size_bytes, Devic
     if (memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         TT_ASSERT(total_width == shard_shape[1], fmt::format("Shard shape {} does not divide tensor shape {} correctly according to sharding scheme", shard_shape[1], total_width));
         uint32_t num_shards = div_up(total_height, shard_shape[0]);
-        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} must match number of cores {}", num_shards, num_cores));
+        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} cannot exceed number {}", num_shards, num_cores));
     } else if (memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
         TT_ASSERT(total_height == shard_shape[0], "Shard shape does not divide tensor shape correctly according to sharding scheme");
         uint32_t num_shards = div_up(total_width, shard_shape[1]);
-        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} must match number of cores {}", num_shards, num_cores));
+        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} cannot exceed number {}", num_shards, num_cores));
     } else if (memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         TT_ASSERT(shard_spec.grid.ranges().size() == 1, "Shard grid must be one full rectangular grid for block sharded!");
         uint32_t num_shards_along_height = div_up(total_height, shard_shape[0]);

--- a/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
@@ -564,7 +564,7 @@ std::unordered_map<CoreCoord, std::vector<PageStride>> get_core_page_ranges(
     const auto& input_page_to_local_page_mapping = input_buffer_page_mapping.host_page_to_local_shard_page_mapping_;
     const auto& host_page_to_input_page_mapping = input_buffer_page_mapping.host_page_to_dev_page_mapping_;
 
-    auto num_pages = std::min<uint32_t>(output_shard_to_host_mapping.size(), input_buffer->num_pages());
+    auto num_pages = std::min<uint32_t>(output_shard_to_host_mapping.size(), input_buffer->num_dev_pages());
 
     // First get output_core to vector< pair<input_core, input_page> (num_pages_in_output)
     std::unordered_map<CoreCoord, std::vector<std::pair<CoreCoord, uint32_t>>> output_core_to_vector_input_core_page;
@@ -572,13 +572,15 @@ std::unordered_map<CoreCoord, std::vector<PageStride>> get_core_page_ranges(
     for (uint32_t output_page_id = 0; output_page_id < num_pages; output_page_id++) {
         auto output_core = output_buffer_page_mapping.all_cores_[output_buffer_page_mapping.dev_page_to_core_mapping_[output_page_id]];
         auto host_page = output_shard_to_host_mapping[output_page_id];
-        auto input_page = host_page_to_input_page_mapping[host_page];
-        auto local_input_page = input_page_to_local_page_mapping[host_page];
-        auto input_core = input_buffer_page_mapping.all_cores_[input_buffer_page_mapping.dev_page_to_core_mapping_[input_page]];
-        if (output_core_to_vector_input_core_page.find(output_core) == output_core_to_vector_input_core_page.end()) {
-            output_core_to_vector_input_core_page[output_core] = {{input_core, local_input_page}};
-        } else {
-            output_core_to_vector_input_core_page[output_core].push_back({input_core, local_input_page});
+        if(host_page.has_value()) {
+            auto input_page = host_page_to_input_page_mapping[host_page.value()];
+            auto local_input_page = input_page_to_local_page_mapping[host_page.value()];
+            auto input_core = input_buffer_page_mapping.all_cores_[input_buffer_page_mapping.dev_page_to_core_mapping_[input_page]];
+            if (output_core_to_vector_input_core_page.find(output_core) == output_core_to_vector_input_core_page.end()) {
+                output_core_to_vector_input_core_page[output_core] = {{input_core, local_input_page}};
+            } else {
+                output_core_to_vector_input_core_page[output_core].push_back({input_core, local_input_page});
+            }
         }
     }
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -70,11 +70,16 @@ const DeviceCommand EnqueueReadShardedBufferCommand::create_buffer_transfer_inst
     uint32_t num_cores = this->buffer.num_cores();
 
     auto buffer_page_mapping = generate_buffer_page_mapping(this->buffer);
-    auto core_host_page_indices = buffer_page_mapping.core_host_page_indices_;
     vector<uint32_t> num_pages_in_shards;
     num_pages_in_shards.reserve(num_cores);
     for(size_t core_id = 0; core_id < num_cores; core_id++) {
-        num_pages_in_shards.push_back(core_host_page_indices[core_id].size());
+        if(buffer.buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+            num_pages_in_shards.push_back(buffer_page_mapping.core_host_page_indices_[core_id].size());
+        }
+        else {
+            // WIDTH OR BLOCK SHARDED
+            num_pages_in_shards.push_back(this->buffer.shard_spec().size());
+        }
     }
 
     vector<uint32_t> core_id_x;
@@ -269,11 +274,17 @@ const DeviceCommand EnqueueWriteShardedBufferCommand::create_buffer_transfer_ins
 
     uint32_t num_cores = this->buffer.num_cores();
     auto buffer_page_mapping = generate_buffer_page_mapping(this->buffer);
-    auto core_host_page_indices = buffer_page_mapping.core_host_page_indices_;
     vector<uint32_t> num_pages_in_shards;
     num_pages_in_shards.reserve(num_cores);
+
     for(size_t core_id = 0; core_id < num_cores; core_id++) {
-        num_pages_in_shards.push_back(core_host_page_indices[core_id].size());
+        if(buffer.buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+            num_pages_in_shards.push_back(buffer_page_mapping.core_host_page_indices_[core_id].size());
+        }
+        else {
+            // WIDTH OR BLOCK SHARDED
+            num_pages_in_shards.push_back(this->buffer.shard_spec().size());
+        }
     }
 
     vector<uint32_t> core_id_x;
@@ -856,13 +867,9 @@ void HWCommandQueue::enqueue_command(T& command, bool blocking) {
 
 // TODO: Currently converting page ordering from interleaved to sharded and then doing contiguous read/write
 //  Look into modifying command to do read/write of a page at a time to avoid doing copy
-void * convert_interleaved_to_sharded_on_host(const void* host, const Buffer& buffer) {
+void convert_interleaved_to_sharded_on_host(void * swapped, const void* host, const Buffer& buffer) {
     const uint32_t num_pages = buffer.num_pages();
     const uint32_t page_size = buffer.page_size();
-
-    const uint32_t size_in_bytes = num_pages * page_size;
-
-    void* swapped = malloc(size_in_bytes);
 
     std::set<uint32_t> pages_seen;
     auto buffer_page_mapping = generate_buffer_page_mapping(buffer);
@@ -874,7 +881,6 @@ void * convert_interleaved_to_sharded_on_host(const void* host, const Buffer& bu
         TT_ASSERT(host_page_id < num_pages and host_page_id >= 0);
         memcpy((char*)swapped + dev_page_id * page_size, (char*)host + host_page_id * page_size, page_size);
     }
-    return swapped;
 }
 
 void HWCommandQueue::enqueue_read_buffer(std::shared_ptr<Buffer> buffer, void* dst, bool blocking) {
@@ -890,7 +896,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
     uint32_t read_buffer_command_size = DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
 
     uint32_t padded_page_size = align(buffer.page_size(), 32);
-    uint32_t total_pages_to_read = buffer.num_pages();
+    uint32_t total_pages_to_read = (buffer.buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED) ? buffer.num_pages() : buffer.num_dev_pages();
     uint32_t unpadded_dst_offset = 0;
     uint32_t src_page_index = 0;
 
@@ -983,11 +989,14 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
 
     if (buffer.buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED or
         buffer.buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-        final_src = convert_interleaved_to_sharded_on_host(src, buffer);
+        final_src = malloc(buffer.num_dev_pages() * buffer.page_size());
+        convert_interleaved_to_sharded_on_host(final_src, src, buffer);
     }
 
+
     uint32_t padded_page_size = align(buffer.page_size(), 32);
-    uint32_t total_pages_to_write = buffer.num_pages();
+    uint32_t total_pages_to_write = (buffer.buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED) ? buffer.num_pages() : buffer.num_dev_pages();
+
     const uint32_t command_issue_limit = this->manager.get_issue_queue_limit(this->id);
     uint32_t dst_page_index = 0;
     while (total_pages_to_write > 0) {
@@ -1027,7 +1036,7 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
 
     if (buffer.buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED or
         buffer.buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-            free(final_src);
+        free(final_src);
     }
 
     if (blocking) {
@@ -1118,12 +1127,11 @@ void HWCommandQueue::enqueue_trace() {
 }
 
 void HWCommandQueue::copy_into_user_space(uint32_t event, uint32_t read_ptr, chip_id_t mmio_device_id, uint16_t channel) {
-    const auto& [buffer_layout, page_size, padded_page_size, dev_page_to_host_page_mapping, dst, dst_offset, num_pages_read, cur_host_page_id] =
+    const auto& [buffer_layout, page_size, padded_page_size, dev_page_to_host_page_mapping, dst, dst_offset, num_pages_read, cur_dev_page_id] =
         this->issued_reads.at(event);
 
     uint32_t padded_num_bytes = num_pages_read * padded_page_size;
-    if (buffer_layout == TensorMemoryLayout::INTERLEAVED or
-        buffer_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+    if (!dev_page_to_host_page_mapping.has_value()) {
         void* contiguous_dst = (void*)(uint64_t(dst) + dst_offset);
         if ((page_size % 32) == 0) {
             tt::Cluster::instance().read_sysmem(
@@ -1141,17 +1149,17 @@ void HWCommandQueue::copy_into_user_space(uint32_t event, uint32_t read_ptr, chi
                 dst_offset += page_size;
             }
         }
-    } else if (
-        buffer_layout == TensorMemoryLayout::WIDTH_SHARDED or
-        buffer_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        uint32_t host_page_id = cur_host_page_id;
+    } else  {
+        uint32_t dev_page_id = cur_dev_page_id;
         uint32_t read_src = read_ptr + align(EVENT_PADDED_SIZE, 32);
         for (uint32_t offset = 0; offset < padded_page_size * num_pages_read; offset += padded_page_size) {
-            uint32_t device_page_id = dev_page_to_host_page_mapping[host_page_id];
-            void* page_dst = (void*)(uint64_t(dst) + device_page_id * page_size);
-            tt::Cluster::instance().read_sysmem(
-                page_dst, page_size, read_src + offset, mmio_device_id, channel);
-            host_page_id++;
+            auto host_page_id = dev_page_to_host_page_mapping.value()[dev_page_id];
+            if(host_page_id.has_value()) {
+                void* page_dst = (void*)(uint64_t(dst) + host_page_id.value() * page_size);
+                tt::Cluster::instance().read_sysmem(
+                    page_dst, page_size, read_src + offset, mmio_device_id, channel);
+            }
+            dev_page_id++;
         }
     }
     this->manager.completion_queue_pop_front(padded_num_bytes, this->id);

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -369,7 +369,7 @@ struct IssuedReadData {
     TensorMemoryLayout buffer_layout;
     uint32_t page_size;
     uint32_t padded_page_size;
-    vector<uint32_t> dev_page_to_host_page_mapping;
+    std::optional< vector<std::optional<uint32_t> > > dev_page_to_host_page_mapping;
     void* dst;
     uint32_t dst_offset;
     uint32_t num_pages_read;
@@ -379,7 +379,8 @@ struct IssuedReadData {
         this->buffer_layout = buffer.buffer_layout();
         this->page_size = buffer.page_size();
         this->padded_page_size = padded_page_size;
-        if (this->buffer_layout == TensorMemoryLayout::WIDTH_SHARDED or this->buffer_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        if (this->buffer_layout == TensorMemoryLayout::WIDTH_SHARDED or
+            this->buffer_layout == TensorMemoryLayout::BLOCK_SHARDED) {
             auto buffer_page_mapping = generate_buffer_page_mapping(buffer);
             this->dev_page_to_host_page_mapping = buffer_page_mapping.dev_page_to_host_page_mapping_;
         }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -356,7 +356,7 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
 
 
         int output_page_index = 0;
-        auto total_pages = buffer.num_pages();
+        auto total_pages = buffer.num_dev_pages();
         uint32_t page_size = buffer.page_size();
         uint32_t bytes_per_page_entry = sizeof(uint32_t);
         uint32_t num_entries_per_page = page_size / bytes_per_page_entry;
@@ -368,27 +368,29 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
             auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_id]];
             auto bank_id = device->bank_ids_from_logical_core(core)[0];
             auto host_page_id = buffer_page_mapping.dev_page_to_host_page_mapping_[dev_page_id];
-            if(!shard_order){
-                read_pages_to_host_helper(
-                    device,
-                    buffer,
-                    host_buffer,
-                    page_size,
-                    host_page_id,
-                    dev_page_id,
-                    bank_id
-                );
-            }
-            else{
-                read_pages_to_host_helper(
-                    device,
-                    buffer,
-                    host_buffer,
-                    page_size,
-                    dev_page_id,
-                    dev_page_id,
-                    bank_id
-                );
+            if(host_page_id.has_value()) {
+                if(!shard_order){
+                    read_pages_to_host_helper(
+                        device,
+                        buffer,
+                        host_buffer,
+                        page_size,
+                        host_page_id.value(),
+                        dev_page_id,
+                        bank_id
+                    );
+                }
+                else{
+                    read_pages_to_host_helper(
+                        device,
+                        buffer,
+                        host_buffer,
+                        page_size,
+                        dev_page_id,
+                        dev_page_id,
+                        bank_id
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Needed to change the concept of device pages to include padding while host does not. 

A sharded buffer in host can be uneven shards, while on device its all even to the maximum shard size. Needed to modify underlying structs to support this. 
