### PR TITLE
#0: Expire the trace context to avoid pro-longed owernship of internal objects leading to bad device closure states

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
@@ -371,7 +371,6 @@ TEST_F(CommandQueueFixture, EnqueueProgramDeviceCapture) {
 }
 
 TEST_F(CommandQueueFixture, EnqueueTwoProgramTrace) {
-    GTEST_SKIP();
     // Get command queue from device for this test, since its running in async mode
     CommandQueue& command_queue = this->device_->command_queue();
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1657,6 +1657,20 @@ volatile bool HWCommandQueue::is_noc_hung() {
     return illegal_noc_txn_hang;
 }
 
+void HWCommandQueue::record_begin(std::shared_ptr<detail::TraceDescriptor> ctx) {
+    // Issue event as a barrier and a counter reset
+    std::shared_ptr<Event> event = std::make_shared<Event>();
+    this->enqueue_record_event(event, true);
+    // Record commands using bypass mode
+    this->trace_ctx = ctx;
+    this->manager.set_bypass_mode(true, true);  // start
+}
+
+void HWCommandQueue::record_end() {
+    this->trace_ctx = nullptr;
+    this->manager.set_bypass_mode(false, false);  // stop
+}
+
 void HWCommandQueue::terminate() {
     ZoneScopedN("HWCommandQueue_terminate");
     tt::log_debug(tt::LogDispatch, "Terminating dispatch kernels for command queue {}", this->id);

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -464,18 +464,8 @@ class HWCommandQueue {
     volatile bool is_dprint_server_hung();
     volatile bool is_noc_hung();
 
-    void record_begin(std::shared_ptr<detail::TraceDescriptor> ctx) {
-        // Issue event as a barrier and a counter reset
-        std::shared_ptr<Event> event = std::make_shared<Event>();
-        this->enqueue_record_event(event, true);
-        // Record commands using bypass mode
-        this->trace_ctx = ctx;
-        this->manager.set_bypass_mode(true, true);  // start
-    }
-
-    void record_end() {
-        this->manager.set_bypass_mode(false, false);  // stop
-    }
+    void record_begin(std::shared_ptr<detail::TraceDescriptor> ctx);
+    void record_end();
 
     // Record all commands and metadata from run_commands function
     template <typename Func>


### PR DESCRIPTION
#0: Expire the trace context to avoid pro-longed owernship of internal objects leading to bad device closure states