### PR TITLE
#7502: Run non-perf tests only for ttnn integration tests. That should fix breaking perf test in nightly pipeline

### DIFF
--- a/tests/scripts/nightly/run_ttnn.sh
+++ b/tests/scripts/nightly/run_ttnn.sh
@@ -9,4 +9,4 @@ fi
 
 echo "Running ttnn nightly tests for GS only"
 
-env pytest tests/ttnn/integration_tests
+env pytest tests/ttnn/integration_tests -m "not models_performance_bare_metal and not models_device_performance_bare_metal"


### PR DESCRIPTION
…