### PR TITLE
#0: Fix ttnn resnet18

### DIFF
--- a/models/experimental/resnet/tt/ttnn_functional_resnet.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet.py
@@ -43,7 +43,6 @@ def resnet_basic_block(x, *, parameters):
         identity = parameters.downsample(x)
         ttnn.deallocate(x)
 
-    identity = ttnn.reshape(identity, conv2.shape)
     out = ttnn.add_and_apply_activation(conv2, identity, activation="relu", memory_config=ttnn.DRAM_MEMORY_CONFIG)
     ttnn.deallocate(conv2)
     if x is not identity:


### PR DESCRIPTION
- Use the conv calculated input_sharded_memory_config when tx tensor to device
- Remove failing, and unnecessary, reshape