### PR TITLE
  Add functionality to offload layout conversions to worker threads. Use this in TTLIB falcon demo

### DIFF
--- a/models/demos/falcon7b/demo/demo.py
+++ b/models/demos/falcon7b/demo/demo.py
@@ -26,6 +26,7 @@ from models.utility_functions import (
     profiler,
     torch2tt_tensor,
     tt2torch_tensor,
+    tt_tensors_to_torch_tensors,
     nearest_32,
 )
 
@@ -366,8 +367,9 @@ def run_falcon_demo_kv(
             use_cache=use_cache,
         )
         synchronize_devices(devices)
-
-        logits = torch.concat([tt2torch_tensor(tt_logits[j]).squeeze(1) for j in range(num_devices)], dim=-2)
+        logits = torch.concat(
+            [torch_logit.squeeze(1) for torch_logit in tt_tensors_to_torch_tensors(tt_logits)], dim=-2
+        )
 
         for j in range(num_devices):
             tt_prefill_input_ids[j].deallocate()
@@ -425,8 +427,9 @@ def run_falcon_demo_kv(
             use_cache=use_cache,
         )
         synchronize_devices(devices)
-
-        logits = torch.concat([tt2torch_tensor(tt_logits[i]).squeeze(1) for i in range(num_devices)], dim=-2)
+        logits = torch.concat(
+            [torch_logit.squeeze(1) for torch_logit in tt_tensors_to_torch_tensors(tt_logits)], dim=-2
+        )
 
         for i in range(num_devices):
             tt_decode_input_ids[i].deallocate()

--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -455,10 +455,14 @@ class TestParametrized:
             pytest.skip(f"kv_cache_len={kv_cache_len} does not fit with L1_SHARDED")
         if async_mode:
             if llm_mode == "prefill" and seq_len == 128:
-                pytest.skip(f"Skipping {llm_mode} with {seq_len} in async mode")
+                pytest.skip(
+                    f"Skipping {llm_mode} with {seq_len} in async mode. Config is supported but provides redundant testing."
+                )
             if llm_mode == "decode" and not (kv_cache_len == 2047):
-                if not (model_config_str == "BFLOAT16-L1_SHARDED" or kv_cache_len == 1024):
-                    pytest.skip(f"Skipping {llm_mode} with {kv_cache_len} in async mode")
+                if not (model_config_str == "BFLOAT16-L1_SHARDED" and kv_cache_len == 1024):
+                    pytest.skip(
+                        f"Skipping {llm_mode} with {kv_cache_len} in async mode. Config is supported but provides redundant testing."
+                    )
 
         devices = get_devices_for_t3000(all_devices, num_devices)
         # Enable Async Mode

--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -187,7 +187,7 @@ struct Tensor {
     Tensor to(
         CommandQueue &queue,
         const MemoryConfig &mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) const;
-    Tensor to(Layout target_layout) const;
+    Tensor to(Layout target_layout, Device* worker = nullptr) const;
 
     Tensor pad(const Shape &output_tensor_shape, const Shape &input_tensor_start, float pad_value) const;
 

--- a/tt_eager/tensor/tensor_utils.cpp
+++ b/tt_eager/tensor/tensor_utils.cpp
@@ -376,7 +376,9 @@ void insert_buffer_and_shape_for_device(Device* target_device, const Tensor& sha
 Tensor copy_borrowed_tensor_in_async_mode(Device* worker, const Tensor& tensor) {
     // When using async mode, tensors with borrowed storage cannot be passed to workers.
     // They need to be copied to owned storage before being passed to the worker.
+    ZoneScopedN("ConvertBorrowedToOwned");
     if (worker->get_worker_mode() == WorkExecutorMode::ASYNCHRONOUS and tensor.storage_type() == StorageType::BORROWED) {
+        ZoneScopedN("CopyBorrowedStorage");
         auto borrowed_buffer = std::get<BorrowedStorage>(tensor.get_storage()).buffer;
         Tensor owned_tensor;
         std::visit([&owned_tensor, &tensor] (auto&& buffer) {


### PR DESCRIPTION
Host <--> Device data movement and layout conversions are a significant bottleneck for Falcon 7B and other models.
Add functionality to offload these steps to worker threads, so that this can be done in parallel.