### PR TITLE
Use HiFi4 for attention matmuls in F40B Prefill

### DIFF
--- a/models/experimental/falcon40b/tt/falcon_attention.py
+++ b/models/experimental/falcon40b/tt/falcon_attention.py
@@ -563,9 +563,7 @@ class TtFalconAttention:
                     value_layer[i],
                     compute_kernel_config=self.model_config["COMPUTE_KERNEL_HIFI4_CONFIG_FP16_DEST"],
                     output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
-                    program_config=self.model_config[
-                        "ATTENTION_MM_2_PROGCFG"
-                    ],  # TODO: comment this line to workaround the bad PCC issue!!
+                    program_config=self.model_config["ATTENTION_MM_2_PROGCFG"],
                     output_dtype=self.model_config["ATTENTION_DTYPE"],
                 )
             )

--- a/models/experimental/falcon40b/tt/falcon_attention.py
+++ b/models/experimental/falcon40b/tt/falcon_attention.py
@@ -530,33 +530,19 @@ class TtFalconAttention:
         return attn_output_slice
 
     def scaled_product_attention(self, q_slices, key_layer_transposed, attn_mask_slices, value_layer, q_len):
-        q_slices = convert_to_layout(  # TODO: remove when PCC issue fixed
-            q_slices, self.model_config["QUERY_HEIGHT_SHARDED_MEMCFG"], self.model_config["DRAM_MEMCFG"]
-        )
-
         # Q * KˆT
         attn_weights = []
-        # program_config = tt_lib.operations.primary.MatmulDefaultProgramConfig()
-        # program_config.out_subblock_h = 1
-        # program_config.out_subblock_w = 1
         for i in range(len(q_slices)):
             attn_weights.append(
                 tt_lib.operations.primary.matmul(
                     q_slices[i],
                     key_layer_transposed[i],
-                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
-                    output_mem_config=self.model_config["DRAM_MEMCFG"],
-                    # output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
-                    program_config=self.model_config[
-                        "ATTENTION_MM_PROGCFG"
-                    ],  # TODO: comment this line to workaround the bad PCC issue!!
+                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_HIFI4_CONFIG"],
+                    output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
+                    program_config=self.model_config["ATTENTION_MM_PROGCFG"],
                     output_dtype=self.model_config["ATTENTION_DTYPE"],
                 )
             )
-
-        attn_weights = convert_to_layout(  # TODO: remove when PCC issue fixed
-            attn_weights, self.model_config["DRAM_MEMCFG"], self.model_config["SOFTMAX_HEIGHT_SHARDED_MEMCFG"]
-        )
 
         # Softmax
         for i in range(len(attn_weights)):
@@ -568,32 +554,22 @@ class TtFalconAttention:
                 is_causal_mask=True,
             )
 
-        attn_weights = convert_to_layout(  # TODO: remove when PCC issue fixed
-            attn_weights, self.model_config["SOFTMAX_HEIGHT_SHARDED_MEMCFG"], self.model_config["DRAM_MEMCFG"]
-        )
-
         # Attention score * V
         attn_output_slice = []
-        # program_config = tt_lib.operations.primary.MatmulDefaultProgramConfig()
-        # program_config.out_subblock_h = 1
-        # program_config.out_subblock_w = 1
         for i in range(len(attn_weights)):
             attn_output_slice.append(
                 tt_lib.operations.primary.matmul(
                     attn_weights[i],
                     value_layer[i],
-                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
-                    output_mem_config=self.model_config["DRAM_MEMCFG"],
-                    # output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
-                    # program_config=self.model_config["ATTENTION_MM_2_PROGCFG"], # TODO: comment this line to workaround the bad PCC issue!!
+                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_HIFI4_CONFIG_FP16_DEST"],
+                    output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
+                    program_config=self.model_config[
+                        "ATTENTION_MM_2_PROGCFG"
+                    ],  # TODO: comment this line to workaround the bad PCC issue!!
                     output_dtype=self.model_config["ATTENTION_DTYPE"],
                 )
             )
             attn_weights[i].deallocate(True)
-
-        attn_output_slice = convert_to_layout(  # TODO: remove when PCC issue fixed
-            attn_output_slice, self.model_config["DRAM_MEMCFG"], self.model_config["ATTN_OUTPUT_HEIGHT_SHARDED_MEMCFG"]
-        )
 
         return attn_output_slice
 

--- a/models/experimental/falcon40b/tt/model_config.py
+++ b/models/experimental/falcon40b/tt/model_config.py
@@ -797,6 +797,24 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         ),
+        "COMPUTE_KERNEL_HIFI4_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        ),
+        "COMPUTE_KERNEL_HIFI4_CONFIG_FP16_DEST": ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        ),
+        "DEFAULT_MATMUL_EQUIVALENT_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        ),
         "COMPUTE_KERNEL_FP16_ACC_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
             math_fidelity=ttl.tensor.MathFidelity.LoFi,
             math_approx_mode=True,

--- a/models/experimental/falcon40b/tt/model_config.py
+++ b/models/experimental/falcon40b/tt/model_config.py
@@ -809,12 +809,6 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
             fp32_dest_acc_en=False,
             packer_l1_acc=True,
         ),
-        "DEFAULT_MATMUL_EQUIVALENT_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=False,
-        ),
         "COMPUTE_KERNEL_FP16_ACC_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
             math_fidelity=ttl.tensor.MathFidelity.LoFi,
             math_approx_mode=True,


### PR DESCRIPTION
Use HiFi4 for first and second attention matmuls in F40B.
Switch to sharded attention, as pcc issues are gone.