### PR TITLE
#6115: add a q, k, v heads creation api that can take a split q and k…

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_create_qkv_heads.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_create_qkv_heads.py
@@ -165,3 +165,180 @@ def test_nlp_create_qkv_heads_test(
     run_create_qkv_heads_test(
         batch, seq_len, num_q_heads, num_kv_heads, head_dim, dtype, cores_h, cores_w, device, transpose_k
     )
+
+
+def run_create_q_and_kv_heads_test(
+    batch,
+    q_seq_len,
+    kv_seq_len,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    cores_h,
+    cores_w,
+    device,
+    transpose_k,
+    in_mem_config=None,
+    out_mem_config=None,
+):
+    torch.manual_seed(1234)
+
+    q_shape = [batch, 1, q_seq_len, num_q_heads, head_dim]
+    k_shape = [batch, 1, kv_seq_len, num_kv_heads, head_dim]
+    v_shape = [batch, 1, kv_seq_len, num_kv_heads, head_dim]
+
+    # torch reference vectors
+    if dtype == ttl.tensor.DataType.FLOAT32:
+        torch_dtype = torch.float32
+    else:
+        torch_dtype = torch.bfloat16
+
+    Q = torch.randn(q_shape, dtype=torch_dtype)
+    K = torch.randn(k_shape, dtype=torch_dtype)
+    V = torch.randn(v_shape, dtype=torch_dtype)
+
+    KV = torch.concat([K.flatten(-2, -1), V.flatten(-2, -1)], -1)
+    KV_interleaved = torch.concat([K, V], -1).flatten(-2, -1)
+    Q_flattened = Q.flatten(-2, -1)
+
+    kv_shard_spec = ttl.tensor.ShardSpec(
+        ttl.tensor.CoreRangeSet(
+            {
+                ttl.tensor.CoreRange(
+                    ttl.tensor.CoreCoord(0, 0),
+                    ttl.tensor.CoreCoord(cores_w - 1, cores_h - 1),
+                ),
+            }
+        ),
+        [
+            kv_seq_len,
+            KV_interleaved.shape[-1] // cores_w,
+        ],
+        ttl.tensor.ShardOrientation.ROW_MAJOR,
+        False,
+    )
+
+    q_shard_spec = ttl.tensor.ShardSpec(
+        ttl.tensor.CoreRangeSet(
+            {
+                ttl.tensor.CoreRange(
+                    ttl.tensor.CoreCoord(0, 0),
+                    ttl.tensor.CoreCoord(cores_w - 1, cores_h - 1),
+                ),
+            }
+        ),
+        [
+            q_seq_len,
+            Q_flattened.shape[-1] // cores_w,
+        ],
+        ttl.tensor.ShardOrientation.ROW_MAJOR,
+        False,
+    )
+
+    kv_mem_config = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED, ttl.tensor.BufferType.L1, kv_shard_spec
+    )
+    kv_t = ttl.tensor.Tensor(KV_interleaved, dtype).to(ttl.tensor.Layout.TILE).to(device, kv_mem_config)
+
+    q_mem_config = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED, ttl.tensor.BufferType.L1, q_shard_spec
+    )
+    q_t = ttl.tensor.Tensor(Q_flattened, dtype).to(ttl.tensor.Layout.TILE).to(device, q_mem_config)
+
+    out_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1)
+
+    q, k, v = ttl.tensor.create_qkv_heads_from_separate_tensors(
+        q_t,
+        kv_t,
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        transpose_k_heads=transpose_k,
+        output_mem_config=out_mem_config,
+    )
+
+    assert list(q.get_legacy_shape()) == [batch, num_q_heads, q_seq_len, head_dim]
+    if transpose_k:
+        assert list(k.get_legacy_shape()) == [batch, num_kv_heads, head_dim, kv_seq_len]
+    else:
+        assert list(k.get_legacy_shape()) == [batch, num_kv_heads, kv_seq_len, head_dim]
+
+    assert list(v.get_legacy_shape()) == [batch, num_kv_heads, kv_seq_len, head_dim]
+
+    pyt_got_back_rm_q = tt2torch_tensor(q)
+    pyt_got_back_rm_k = tt2torch_tensor(k)
+    pyt_got_back_rm_v = tt2torch_tensor(v)
+
+    (ref_k, ref_v) = torch.split(KV, [num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1)
+
+    # Additional shuffling for Q, K, V heads
+    ref_q = torch.reshape(Q_flattened, [batch, q_seq_len, num_q_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, kv_seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, kv_seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+
+    if transpose_k:
+        ref_k = torch.transpose(ref_k, -2, -1)
+
+    if dtype == ttl.tensor.DataType.BFLOAT8_B:
+        pcc = 0.99
+    elif (
+        dtype == ttl.tensor.DataType.FLOAT32 and transpose_k
+    ):  # conversion from fp32 to tf32 when unpack writes to register for compute will decrease pcc in the transpose case
+        pcc = 0.9999999
+    else:
+        pcc = 1.0
+
+    passing_pcc_q, output_pcc_q = comp_pcc(ref_q, pyt_got_back_rm_q, pcc)
+    logger.debug(f"Q passing={passing_pcc_q}")
+    logger.debug(f"Q output pcc={output_pcc_q}")
+
+    passing_pcc_k, output_pcc_k = comp_pcc(ref_k, pyt_got_back_rm_k, pcc)
+    logger.debug(f"K passing={passing_pcc_k}")
+    logger.debug(f"K output pcc={output_pcc_k}")
+
+    passing_pcc_v, output_pcc_v = comp_pcc(ref_v, pyt_got_back_rm_v, pcc)
+    logger.debug(f"V passing={passing_pcc_v}")
+    logger.debug(f"V output pcc={output_pcc_v}")
+
+    assert passing_pcc_q
+    assert passing_pcc_k
+    assert passing_pcc_v
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.BFLOAT16),
+    ids=["BFLOAT8_B", "BFLOAT16"],
+)
+@pytest.mark.parametrize(
+    "transpose_k",
+    (True, False),
+)
+@pytest.mark.parametrize(
+    "batch, q_seq_len, kv_seq_len, num_q_heads, num_kv_heads, head_dim, cores_h, cores_w",
+    (
+        (2, 4096, 96, 8, 8, 64, 2, 8),
+        (2, 1024, 96, 8, 8, 96, 2, 8),
+        (2, 256, 96, 8, 8, 160, 2, 8),
+        (2, 64, 96, 8, 8, 160, 2, 4),
+    ),
+)
+def test_nlp_create_q_and_kv_heads_separate_test(
+    batch,
+    q_seq_len,
+    kv_seq_len,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    transpose_k,
+    cores_h,
+    cores_w,
+    dtype,
+    device,
+):
+    if is_grayskull() and dtype == ttl.tensor.DataType.FLOAT32:
+        pytest.skip("Skipping float32 tests on Grayskull")
+
+    run_create_q_and_kv_heads_test(
+        batch, q_seq_len, kv_seq_len, num_q_heads, num_kv_heads, head_dim, dtype, cores_h, cores_w, device, transpose_k
+    )

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -178,6 +178,7 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp \
+	tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp \
 	tt_eager/tt_dnn/op_library/rotate_half/single_core/rotate_half_op_single_core.cpp \
 	tt_eager/tt_dnn/op_library/rotate_half/rotate_half_op.cpp \
 	tt_eager/tt_dnn/op_library/rotary_embedding/multi_core/rotary_embedding_op_multi_core.cpp \

--- a/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_create_qkv_heads_sharded_separate.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_create_qkv_heads_sharded_separate.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t q_shard_ht                = get_compile_time_arg_val(0); // number of Q heads in the group, n
+    constexpr uint32_t q_shard_wt                = get_compile_time_arg_val(1); // number of K heads in the group, expecting 1
+    constexpr uint32_t k_shard_ht                = get_compile_time_arg_val(2); // number of V heads in the group, expecting 1
+    constexpr uint32_t k_shard_wt                = get_compile_time_arg_val(3); // size of a Q head in bytes
+    constexpr uint32_t q_num_heads_per_core      = get_compile_time_arg_val(4);
+    constexpr uint32_t k_num_heads_per_core      = get_compile_time_arg_val(5);
+    constexpr uint32_t tiles_per_head            = get_compile_time_arg_val(6); // size of a K head `` ``
+
+    constexpr uint32_t cb_inq  = tt::CB::c_in0;
+    constexpr uint32_t cb_inkv = tt::CB::c_in1;
+
+    constexpr uint32_t cb_outq = tt::CB::c_out0;
+    #ifdef TRANSPOSE_K_HEADS
+    constexpr uint32_t cb_outk = tt::CB::c_intermed0;
+    #else
+    constexpr uint32_t cb_outk = tt::CB::c_out1;
+    #endif
+    constexpr uint32_t cb_outv = tt::CB::c_out2;
+
+
+    // copy one entire head_dim tile, then go to next sequence tile and do another head_dim.
+    // after that, go to next head (head_dim > sequence * batch > head)
+    // since Q's heads are shuffled and n Q heads are paired with a KV, need to iterate through multiple Q heads before skipping to next sequence tile
+
+    constexpr uint32_t v_shard_ht = k_shard_ht;
+
+    constexpr uint32_t single_tile_size_bytes = get_tile_size(cb_inq);
+    const DataFormat data_format = get_dataformat(cb_inq);
+
+    /**
+     * Iterate over number of heads in each group (n Q, 1 K, 1 V) where total number of groups = total number of KV heads
+     * block_ht is the number of tiles along the batch * seq_len dimension shard
+    */
+
+    uint64_t q_src_noc_addr = get_noc_addr(get_read_ptr(cb_inq));
+    uint32_t q_write_addr = get_write_ptr(cb_outq);
+
+
+    // re-order q
+    constexpr uint32_t q_num_tiles = q_shard_ht * q_shard_wt;
+    constexpr uint32_t q_shard_wt_size_bytes = q_shard_wt * single_tile_size_bytes; // tiles until next sequence
+    constexpr uint32_t q_head_size_bytes = tiles_per_head * single_tile_size_bytes;
+
+    cb_reserve_back(cb_outq, q_num_tiles);
+    uint32_t head_offset = 0;
+    for (uint32_t k = 0; k < q_num_heads_per_core; k++) { // number of kv heads inside the shard
+        uint32_t seq_tile_offset = 0;
+        for (uint32_t i = 0; i < q_shard_ht; i++) { // iterate across seq_len dimension tiles
+            uint64_t q_src_noc_addr_head = q_src_noc_addr + seq_tile_offset + head_offset;
+            noc_async_read(q_src_noc_addr_head, q_write_addr, q_head_size_bytes); // read one head worth of tiles
+            q_write_addr += q_head_size_bytes; // go to output address for next Q head
+            seq_tile_offset += q_shard_wt_size_bytes; // go to next tile along seq_len
+        }
+        head_offset += q_head_size_bytes;
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_outq, q_num_tiles);
+
+    // re-order k
+    uint64_t kv_src_noc_addr = get_noc_addr(get_read_ptr(cb_inkv));
+    constexpr uint32_t k_num_tiles = k_shard_ht * k_shard_wt;
+    constexpr uint32_t kv_shard_wt_size_bytes = k_shard_wt * single_tile_size_bytes * 2;
+    constexpr uint32_t k_head_size_bytes = tiles_per_head * single_tile_size_bytes;
+    constexpr uint32_t kv_group_size_bytes = k_head_size_bytes * 2;
+
+    cb_reserve_back(cb_outk, k_num_tiles);
+    uint32_t k_write_addr = get_write_ptr(cb_outk);
+    head_offset = 0;
+    for (uint32_t k = 0; k < k_num_heads_per_core; k++) { // number of k heads inside the shard
+        #ifdef TRANSPOSE_K_HEADS
+        for (uint32_t k_head_tile_offset = 0; k_head_tile_offset < k_head_size_bytes; k_head_tile_offset += single_tile_size_bytes) { // finish head after sequence length when transposing K
+            uint32_t seq_tile_offset = 0;
+            for (uint32_t i = 0; i < k_shard_ht; i++) { // iterate across seq_len dimension tiles
+                uint64_t k_src_noc_addr = kv_src_noc_addr + seq_tile_offset + head_offset + k_head_tile_offset;
+                noc_async_read(k_src_noc_addr, k_write_addr, single_tile_size_bytes); // read one head worth of tiles
+                k_write_addr += single_tile_size_bytes; // go to output address for next K head
+                seq_tile_offset += kv_shard_wt_size_bytes; // go to next tile along seq_len
+            }
+        }
+        #else
+        uint32_t seq_tile_offset = 0;
+        for (uint32_t i = 0; i < k_shard_ht; i++) { // iterate across seq_len dimension tiles
+            uint64_t k_src_noc_addr = kv_src_noc_addr + seq_tile_offset + head_offset;
+            noc_async_read(k_src_noc_addr, k_write_addr, k_head_size_bytes); // read one head worth of tiles
+            k_write_addr += k_head_size_bytes; // go to output address for next K head
+            seq_tile_offset += kv_shard_wt_size_bytes; // go to next tile along seq_len
+        }
+        #endif
+        head_offset += kv_group_size_bytes;
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_outk, k_num_tiles);
+
+    // re-order v
+    constexpr uint32_t v_num_tiles = k_num_tiles;
+    constexpr uint32_t v_head_size_bytes = k_head_size_bytes;
+    constexpr uint32_t v_num_heads_per_core = k_num_heads_per_core;
+    cb_reserve_back(cb_outv, v_num_tiles);
+    uint32_t v_write_addr = get_write_ptr(cb_outv);
+    head_offset = k_head_size_bytes; // v1 is after one k head
+    for (uint32_t k = 0; k < v_num_heads_per_core; k++) { // number of kv heads inside the shard
+        uint32_t seq_tile_offset = 0;
+        for (uint32_t i = 0; i < v_shard_ht; i++) { // iterate across seq_len dimension tiles
+            uint64_t v_src_noc_addr = kv_src_noc_addr + seq_tile_offset + head_offset;
+            noc_async_read(v_src_noc_addr, v_write_addr, v_head_size_bytes); // read one head worth of tiles
+            v_write_addr += v_head_size_bytes; // go to output address for next V head
+            seq_tile_offset += kv_shard_wt_size_bytes; // go to next tile along seq_len
+        }
+        head_offset += kv_group_size_bytes;
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_outv, v_num_tiles);
+}

--- a/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/nlp_tms/nlp_tms.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+
+using namespace tt::constants;
+using namespace tt;
+
+
+static inline operation::ProgramWithCallbacks create_qkv_separate(const Tensor &input_tensor_q, const Tensor &input_tensor_kv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor> &output, bool transpose_k) {
+
+    const auto &q_shape = input_tensor_q.get_legacy_shape();
+    const auto &kv_shape = input_tensor_kv.get_legacy_shape();
+    auto shard_spec = input_tensor_q.shard_spec().value();
+    auto all_cores = shard_spec.grid;
+    auto bbox = all_cores.bounding_box();
+    ShardOrientation shard_orientation = shard_spec.orientation;
+    bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
+    uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+
+    uint32_t q_shard_wt = (q_shape[3]) / (num_w_cores * TILE_WIDTH); // number of tiles in width dimension  - multiple tiles per head, multiple heads per group, multiple tensors in group, multiple groups per cores
+    uint32_t q_shard_ht = (q_shape[0] * q_shape[2])/ (num_h_cores * TILE_HEIGHT);
+
+    uint32_t k_shard_wt = (kv_shape[3] / (2 * num_w_cores * TILE_WIDTH));
+    uint32_t k_shard_ht = (kv_shape[0] * kv_shape[2])/ (num_h_cores * TILE_HEIGHT);
+
+    uint32_t per_core_q_tiles = q_shard_ht * q_shard_wt;
+    uint32_t per_core_k_tiles = k_shard_ht * k_shard_wt;
+
+    const auto q_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_q.get_dtype());
+    const auto kv_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_kv.get_dtype());
+    uint32_t single_tile_size = tile_size(q_data_format);
+
+    uint32_t q_heads_per_core = num_q_heads / num_w_cores;
+    uint32_t k_heads_per_core = num_kv_heads / num_w_cores;
+
+    Program program = CreateProgram();
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t) q_shard_ht,
+        (std::uint32_t) q_shard_wt,
+        (std::uint32_t) k_shard_ht,
+        (std::uint32_t) k_shard_wt, // shard width for k and v individually, times two for entire kv tensor
+        (std::uint32_t) q_heads_per_core,
+        (std::uint32_t) k_heads_per_core,
+        (std::uint32_t) head_dim / TILE_WIDTH, // tiles per head
+    };
+
+    std::map<string, string> reader_defines;
+    if (transpose_k) {
+        reader_defines["TRANSPOSE_K_HEADS"] = "1";
+    }
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_create_qkv_heads_sharded_separate.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+
+    if (transpose_k)    {
+        std::vector<uint32_t> compute_args = {
+            (std::uint32_t) (per_core_k_tiles), // number of K tiles
+        };
+        auto compute_kernel_id = tt_metal::CreateKernel(
+            program,
+            "tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/transpose_wh_sharded.cpp",
+            all_cores,
+            tt_metal::ComputeConfig{.compile_args = compute_args});
+    }
+
+    uint32_t q_size = per_core_q_tiles * single_tile_size;
+    uint32_t k_size = per_core_k_tiles * single_tile_size;
+    uint32_t v_size = k_size;
+    uint32_t kv_size = 2*k_size;
+
+    // qkv tensor
+    auto c_in0_config = CircularBufferConfig(q_size,
+    {{CB::c_in0, q_data_format}}).set_page_size(CB::c_in0, single_tile_size).set_globally_allocated_address(*input_tensor_q.buffer());
+    auto cb_in0_id = CreateCircularBuffer(program, all_cores, c_in0_config);
+
+    auto c_in1_config = CircularBufferConfig(kv_size, {
+        {CB::c_in1, kv_data_format}}
+        ).set_page_size(CB::c_in1, single_tile_size).set_globally_allocated_address(*input_tensor_kv.buffer());
+    auto cb_in1_id = CreateCircularBuffer(program, all_cores, c_in1_config);
+
+    // q sharded
+    auto c_out0_config = CircularBufferConfig(q_size, {{CB::c_out0, q_data_format}})
+        .set_page_size(CB::c_out0, single_tile_size).set_globally_allocated_address(*output[0].buffer());
+    auto cb_out0_id = CreateCircularBuffer( program, all_cores, c_out0_config );
+    // k sharded
+    auto c_out1_config = CircularBufferConfig(k_size, {{CB::c_out1, kv_data_format}})
+        .set_page_size(CB::c_out1, single_tile_size).set_globally_allocated_address(*output[1].buffer());
+    auto cb_out1_id = CreateCircularBuffer( program, all_cores, c_out1_config );
+    // v sharded
+    auto c_out2_config = CircularBufferConfig(v_size, {{CB::c_out2, kv_data_format}})
+        .set_page_size(CB::c_out2, single_tile_size).set_globally_allocated_address(*output[2].buffer());
+    auto cb_out2_id = CreateCircularBuffer( program, all_cores, c_out2_config );
+
+    if (transpose_k) {
+        auto c_im0_config = CircularBufferConfig(k_size, {{CB::c_intermed0, kv_data_format}})
+            .set_page_size(CB::c_intermed0, single_tile_size);
+        auto cb_im0_id = CreateCircularBuffer(program, all_cores, c_im0_config);
+    }
+
+
+    auto override_runtime_args_callback = [
+        cb_in0_id,
+        cb_in1_id,
+        cb_out0_id,
+        cb_out1_id,
+        cb_out2_id
+        ]
+    (
+        const void* operation,
+        Program& program,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        const std::vector<Tensor>& output_tensors
+    ) {
+        auto in0_buffer = input_tensors.at(0).buffer();
+        auto in1_buffer = input_tensors.at(1).buffer();
+        auto out0_buffer = output_tensors.at(0).buffer();
+        auto out1_buffer = output_tensors.at(1).buffer();
+        auto out2_buffer = output_tensors.at(2).buffer();
+
+        UpdateDynamicCircularBufferAddress(program, cb_in0_id, *in0_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_in1_id, *in1_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_out0_id, *out0_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_out1_id, *out1_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_out2_id, *out2_buffer);
+    };
+
+    return {std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
+
+namespace tt {
+namespace tt_metal {
+
+/**
+ * Combined QKV
+ *
+ * m = num_KV_heads
+ * p = num_Q_heads
+ * n = p/m
+ * i = head index for K/V, corresponding Q group for K/V
+ *
+ * input: [nQi Ki Vi for i in [0, m)] repeated for the sequence length
+ * dims: [B, 1, S, H] Hi = [nQi Ki Vi] for all i kv heads = ((n + 2)*head_dim)
+ *
+ * output: 3 separate tensors organized by heads
+ * [Qs,j for j in [0, p] and s in [0,S)]
+ * dims: [B, p, S, head_dim] (all nQi in the KVi group are stacked together, p = n*m)
+ *
+ * [Ks,i for i in [0, m) and s in [0,S)]
+ * dims: [B, m, S, head_dim]
+ *
+ * [Vs,i for i in [0, m) and s in [0,S)]
+ * dims: [B, m, S, head_dim]
+ *
+ * Tiles stay the same Vi,s[x:x+32] to Vi+32,s[x:x+32] stays in one tile, but now instead of nQi,s and Ki,s tiles there is Vi,s-1 and Vi,s+1
+ *
+ * Shard across each i kv head group (width sharding) and then shard across each token s (height sharding)
+ * Each block: B x [nQi Ki Vi]s (shard across flattened heads and sequence length)
+ *
+ * Combined batch/sequence sharding is possible too...that may best be left as an extension
+*/
+operation::ProgramWithCallbacks multi_core_create_q_and_kv_heads_sharded(const Tensor &input_tensor_q, const Tensor &input_tensor_kv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
+    return create_qkv_separate(input_tensor_q, input_tensor_kv, num_q_heads, num_kv_heads, head_dim, output, transpose_k_heads);
+}
+
+} // namespace tt_metal
+
+} // namespace tt
+
+// batch*seq_len  (num_q_heads/num_kv_heads*Qi Ki Vi)

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -321,7 +321,6 @@ std::vector<Tensor> CreateQKVHeads::create_output_tensors(const std::vector<Tens
     //uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
     uint32_t num_cores = bbox.size();
 
-    const auto &input_shape = input_tensor.get_legacy_shape();
     auto shapes = compute_output_shapes(input_tensors);
     auto q_shape = shapes.at(0);
     auto k_shape = shapes.at(1);
@@ -352,11 +351,150 @@ std::vector<Tensor> CreateQKVHeads::create_output_tensors(const std::vector<Tens
     auto out_tensor_k = create_sharded_device_tensor(k_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_k);
     auto out_tensor_v = create_sharded_device_tensor(v_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_v);
     return {out_tensor_q, out_tensor_k, out_tensor_v};
-
-    return {};
 }
 
 tt::stl::reflection::Attributes CreateQKVHeads::attributes() const {
+    return {
+        {"num_q_heads", this->num_q_heads},
+        {"num_kv_heads", this->num_kv_heads},
+        {"transpose_k_heads", this->transpose_k_heads},
+        {"output_mem_config", this->output_mem_config},
+    };
+}
+
+
+void CreateQKVHeadsSeparateTensors::validate(const std::vector<Tensor> &input_tensors) const {
+    const auto& q_input_tensor = input_tensors.at(0);
+    const auto& kv_input_tensor = input_tensors.at(1);
+
+    TT_FATAL(q_input_tensor.storage_type() == StorageType::DEVICE && kv_input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(q_input_tensor.buffer() != nullptr && kv_input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
+    TT_FATAL(q_input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || q_input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || q_input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
+    TT_FATAL(kv_input_tensor.get_dtype() == q_input_tensor.get_dtype(), "Unsupported data format");
+    TT_FATAL(q_input_tensor.get_layout() == Layout::TILE && kv_input_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(q_input_tensor.is_sharded() && kv_input_tensor.is_sharded(), "Operands to TM must be sharded");
+
+
+    auto bbox = q_input_tensor.shard_spec().value().grid.bounding_box();
+    TT_FATAL((bbox.end.x < q_input_tensor.device()->compute_with_storage_grid_size().x && bbox.end.y < q_input_tensor.device()->compute_with_storage_grid_size().y));
+
+    TT_FATAL(q_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
+    TT_FATAL(kv_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
+
+    ShardOrientation shard_orientation = q_input_tensor.shard_spec().value().orientation;
+    bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
+    uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+
+    TT_FATAL(this->num_q_heads % num_w_cores == 0, fmt::format("Number of q heads {} must fit evenly into cores {}", this->num_q_heads, num_w_cores));
+    TT_FATAL(this->num_kv_heads % num_w_cores == 0, fmt::format("Number of kv heads {} must fit evenly into cores {}", this->num_kv_heads, num_w_cores));
+
+    const auto q_input_shape = q_input_tensor.get_legacy_shape();
+    const auto kv_input_shape = kv_input_tensor.get_legacy_shape();
+    TT_FATAL(q_input_shape[1] == 1 && kv_input_shape[1] == 1, "Unsupported input shape");
+    TT_FATAL(q_input_shape[0] == kv_input_shape[0], fmt::format("Q {} and KV {} batch size must match", q_input_shape[0], kv_input_shape[0]));
+
+    TT_FATAL(q_input_shape[3] % (num_w_cores * TILE_WIDTH) == 0, fmt::format("Flattened hidden dimension {} must be a multiple of width cores {} * tile width {} to ensure that each core gets an even amount of tiles", q_input_shape[3], num_w_cores, TILE_WIDTH));
+    TT_FATAL(q_input_shape[0]*q_input_shape[2] % (num_h_cores * TILE_HEIGHT) == 0, fmt::format("Batch {} * Seq Len {} must be a multiple of height cores {} * tile height {} to ensure that each core gets an even amount of tiles", q_input_shape[0], q_input_shape[2], num_h_cores, TILE_HEIGHT));
+
+    TT_FATAL(kv_input_shape[3] % (num_w_cores * TILE_WIDTH) == 0, fmt::format("Flattened hidden dimension {} must be a multiple of width cores {} * tile width {} to ensure that each core gets an even amount of tiles", kv_input_shape[3], num_w_cores, TILE_WIDTH));
+    TT_FATAL(kv_input_shape[0]*kv_input_shape[2] % (num_h_cores * TILE_HEIGHT) == 0, fmt::format("Batch {} * Seq Len {} must be a multiple of height cores {} * tile height {} to ensure that each core gets an even amount of tiles", kv_input_shape[0], kv_input_shape[2], num_h_cores, TILE_HEIGHT));
+
+    TT_FATAL((q_input_shape[3]/(this->num_q_heads)) == (kv_input_shape[3]/(2 * this->num_kv_heads)), fmt::format("Head dims must be equal in size! Q {} num_heads {} KV {} num_heads {}", q_input_shape[3], num_q_heads, kv_input_shape[3], num_kv_heads));
+
+    uint32_t q_shard_wt = (q_input_shape[3]) / (num_w_cores * TILE_WIDTH); // number of tiles in width dimension  - multiple tiles per head, multiple heads per group, multiple tensors in group, multiple groups per cores
+    uint32_t q_shard_ht = ((q_input_shape[0] * q_input_shape[2]) / (num_w_cores * TILE_HEIGHT));
+    uint32_t k_shard_wt = (kv_input_shape[3] / (2 * num_w_cores * TILE_WIDTH));
+    uint32_t k_shard_ht = ((kv_input_shape[0] * kv_input_shape[2]) / (num_h_cores * TILE_HEIGHT));
+
+    std::cout<<fmt::format("Hidden dimension {} Num W Cores {} Tile Width {}", kv_input_shape[3], num_w_cores, TILE_WIDTH);
+
+    TT_FATAL(q_shard_ht > 0, "0 height shards on Q");
+    TT_FATAL(q_shard_wt > 0, "0 width shards on Q");
+    TT_FATAL(k_shard_ht > 0, "0 height shards on K");
+    TT_FATAL(k_shard_wt > 0, "0 width shards on K");
+
+    uint32_t per_core_q_tiles = q_shard_ht * q_shard_wt;
+    uint32_t per_core_k_tiles = k_shard_ht * k_shard_wt;
+
+    const uint32_t single_tile_size = tt::tile_size(tt_metal::datatype_to_dataformat_converter(q_input_tensor.get_dtype()));
+    TT_FATAL(L1_SIZE >= 2 * (per_core_q_tiles + 2*per_core_k_tiles) * single_tile_size, fmt::format("Workload exceeds L1 capacity"));
+
+    // TODO: Add this back when output is HEIGHT sharded only!
+    // TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+    TT_FATAL(q_input_shape[0] == num_h_cores, fmt::format("Batch size {} must be equal to num cores {}", q_input_shape[0], num_h_cores));
+}
+
+std::vector<Shape> CreateQKVHeadsSeparateTensors::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    std::vector<Shape> output_shape_vec;
+    const auto& input_tensor = input_tensors.at(0);
+    const auto& input_tensor_kv = input_tensors.at(1);
+    const auto input_shape = input_tensor.get_legacy_shape();
+    const auto input_shape_kv = input_tensor_kv.get_legacy_shape();
+
+    const Shape q_output_shape = {input_shape[0], this->num_q_heads, input_shape[2], this->head_dim};
+    const Shape v_output_shape = {input_shape_kv[0], this->num_kv_heads, input_shape_kv[2], this->head_dim};
+    const Shape k_output_shape = this->transpose_k_heads
+                                     ? (Shape){input_shape_kv[0], this->num_kv_heads, head_dim, input_shape_kv[2]}
+                                     : v_output_shape;
+    output_shape_vec = {q_output_shape, k_output_shape, v_output_shape};
+
+    return output_shape_vec;
+}
+
+operation::ProgramWithCallbacks CreateQKVHeadsSeparateTensors::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto& input_tensor_q = input_tensors.at(0);
+    const auto& input_tensor_kv = input_tensors.at(1);
+    CoreCoord compute_with_storage_grid_size = input_tensor_q.device()->compute_with_storage_grid_size();
+    return  multi_core_create_q_and_kv_heads_sharded(input_tensor_q, input_tensor_kv, this->num_q_heads, this->num_kv_heads, this->head_dim, this->transpose_k_heads, output_tensors, compute_with_storage_grid_size);
+}
+
+std::vector<Tensor> CreateQKVHeadsSeparateTensors::create_output_tensors(const std::vector<Tensor>& input_tensors) const  {
+    // no create_output_tensors variant that takes in optional input tensors?
+    const auto& input_tensor = input_tensors.at(0);
+
+    CoreRangeSet all_cores = input_tensor.shard_spec().value().grid;
+    ShardOrientation shard_orientation = input_tensor.shard_spec().value().orientation;
+    auto bbox = all_cores.bounding_box();
+    // TODO: Do we need to know cores along row and col?
+    //bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
+    //uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
+    //uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+    uint32_t num_cores = bbox.size();
+
+    auto shapes = compute_output_shapes(input_tensors);
+    auto q_shape = shapes.at(0);
+    auto k_shape = shapes.at(1);
+    auto v_shape = shapes.at(2);
+
+    // TODO: Do we need?
+    //uint32_t num_kv_heads_per_shard = k_shape[1] / num_w_cores;
+    //uint32_t num_q_heads_per_shard = q_shape[1] / num_w_cores;
+
+    uint32_t q_shard_h = q_shape[0] * q_shape[1] * q_shape[2] / num_cores; // want the API to work for different sequence lengths
+    uint32_t k_shard_h = k_shape[0] * k_shape[1] * k_shape[2] / num_cores; // want the API to work for different sequence lengths
+    uint32_t v_shard_h = v_shape[0] * v_shape[1] * v_shape[2] / num_cores; // want the API to work for different sequence lengths
+
+    auto q_spec = ShardSpec(all_cores, {q_shard_h, q_shape[-1]}, shard_orientation);
+    auto k_spec = ShardSpec(all_cores, {k_shard_h, k_shape[-1]}, shard_orientation);
+    auto v_spec = ShardSpec(all_cores, {v_shard_h, v_shape[-1]}, shard_orientation);
+    // create sharded tensors
+    auto mem_config_q = this->output_mem_config;
+    mem_config_q.shard_spec = q_spec;
+
+    auto mem_config_k = this->output_mem_config;
+    mem_config_k.shard_spec = k_spec;
+
+    auto mem_config_v = this->output_mem_config;
+    mem_config_v.shard_spec = v_spec;
+
+    auto out_tensor_q = create_sharded_device_tensor(q_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_q);
+    auto out_tensor_k = create_sharded_device_tensor(k_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_k);
+    auto out_tensor_v = create_sharded_device_tensor(v_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_v);
+    return {out_tensor_q, out_tensor_k, out_tensor_v};
+}
+
+tt::stl::reflection::Attributes CreateQKVHeadsSeparateTensors::attributes() const {
     return {
         {"num_q_heads", this->num_q_heads},
         {"num_kv_heads", this->num_kv_heads},

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.hpp
@@ -18,6 +18,7 @@ namespace tt_metal {
 
 // operation::ProgramWithCallbacks multi_core_create_qkv_heads_interleaved(const Tensor &input_tensor_qkv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
 operation::ProgramWithCallbacks multi_core_create_qkv_heads_sharded(const Tensor &input_tensor_qkv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_create_q_and_kv_heads_sharded(const Tensor &input_tensor_q, const Tensor &input_tensor_kv, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, const bool transpose_k_heads, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
 
 struct CreateQKVHeads {
     uint32_t num_q_heads;
@@ -34,9 +35,30 @@ struct CreateQKVHeads {
 
 inline std::tuple<Tensor, Tensor, Tensor> create_qkv_heads(const Tensor &input_tensor, const uint32_t num_q_heads, const std::optional<uint32_t> num_kv_heads, const bool transpose_k_heads, const MemoryConfig& output_mem_config) {
     const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_q_heads);
-    TT_FATAL(input_tensor.get_legacy_shape()[3] % (num_q_heads + (2 * num_kv_heads_val)) == 0, "Flattened hidden dimension {} must be a multiple of the combined Q {}, K {} and V {} heads", input_tensor.get_legacy_shape()[3], num_q_heads, num_kv_heads_val, num_kv_heads_val);
+    TT_FATAL(input_tensor.get_legacy_shape()[3] % (num_q_heads + (2 * num_kv_heads_val)) == 0, fmt::format("Flattened hidden dimension {} must be a multiple of the combined Q {}, K {} and V {} heads", input_tensor.get_legacy_shape()[3], num_q_heads, num_kv_heads_val, num_kv_heads_val));
     const uint32_t head_dim = input_tensor.get_legacy_shape()[3] / (num_q_heads + (2 * num_kv_heads_val));
     auto output_tensors = operation::run(CreateQKVHeads{num_q_heads, num_kv_heads_val, head_dim, transpose_k_heads, output_mem_config}, {input_tensor});
+    return {output_tensors.at(0), output_tensors.at(1), output_tensors.at(2)};
+}
+
+struct CreateQKVHeadsSeparateTensors {
+    uint32_t num_q_heads;
+    uint32_t num_kv_heads;
+    uint32_t head_dim;
+    bool transpose_k_heads;
+    MemoryConfig output_mem_config;
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
+    tt::stl::reflection::Attributes attributes() const;
+};
+
+inline std::tuple<Tensor, Tensor, Tensor> create_qkv_heads_from_separate_tensors(const Tensor &input_tensor_q, const Tensor &input_tensor_kv, const uint32_t num_q_heads, const std::optional<uint32_t> num_kv_heads, const bool transpose_k_heads, const MemoryConfig& output_mem_config) {
+    const uint32_t num_kv_heads_val = num_kv_heads.value_or(num_q_heads);
+    TT_FATAL(input_tensor_q.get_legacy_shape()[3] % num_q_heads == 0, fmt::format("Flattened Q hidden dimension {} must be a multiple of Q heads {}", input_tensor_q.get_legacy_shape()[3], num_q_heads));
+    const uint32_t head_dim = input_tensor_q.get_legacy_shape()[3] / (num_q_heads);
+    auto output_tensors = operation::run(CreateQKVHeadsSeparateTensors{num_q_heads, num_kv_heads_val, head_dim, transpose_k_heads, output_mem_config}, {input_tensor_q, input_tensor_kv});
     return {output_tensors.at(0), output_tensors.at(1), output_tensors.at(2)};
 }
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -153,10 +153,21 @@ namespace tt::tt_metal::detail
         py::arg("input").noconvert(),
         py::arg("num_q_heads").noconvert(),
         py::arg("num_kv_heads").noconvert() = std::nullopt,
-        py::arg("transpose_k_heads").noconvert() = false, // change this to true when the transposed impl is done
+        py::arg("transpose_k_heads").noconvert() = false,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         R"doc(
         Splits a [B, 1, Seq_len, H] fused qkv matrix (where H is num_kv_heads * (num_q_heads/num_kv_heads + 2) * head_dim) into a Q tensor [B, num_q_heads, Seq_len, head_dim], K tensor [B, num_kv_heads, Seq_len, head_dim] (with the last two dims transposed if applicable) and V tensor [B, num_kv_heads, Seq_len, head_dim].
+        )doc");
+
+        m_tensor.def("create_qkv_heads_from_separate_tensors", &create_qkv_heads_from_separate_tensors,
+        py::arg("input_q").noconvert(),
+        py::arg("input_kv").noconvert(),
+        py::arg("num_q_heads").noconvert(),
+        py::arg("num_kv_heads").noconvert() = std::nullopt,
+        py::arg("transpose_k_heads").noconvert() = false,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
+        Splits a [B, 1, Seq_len, H] q matrix and fused kv matrix (where H is num_q_heads * head_dim for q and num_kv_heads * head_dim * 2 for kv) into a Q tensor [B, num_q_heads, Seq_len, head_dim], K tensor [B, num_kv_heads, Seq_len, head_dim] (with the last two dims transposed if applicable) and V tensor [B, num_kv_heads, Seq_len, head_dim].
         )doc");
     }
 


### PR DESCRIPTION
…v tensor with differing sequence lengths

- Adds cross-attention support
- Also a step for addressing #7519
- TODO: add batch > rows support