### PR TITLE
#7699 support non4d tensor in moreh softmax backward

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
@@ -31,12 +31,7 @@ def test_logsoftmax_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
@@ -65,12 +60,7 @@ def test_logsoftmax_large_algorithm_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
@@ -105,12 +95,7 @@ def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = (
         ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16)
@@ -121,7 +106,7 @@ def test_logsoftmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     tt_cpu = F.log_softmax(x, dim)
     tt_npu = ttl.operations.primary.moreh_logsoftmax(dev_x, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
@@ -148,12 +133,7 @@ def test_logsoftmax_for_dim_nc(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = (
         ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).pad_to_tile(float("7")).to(ttl.tensor.Layout.TILE).to(device)
@@ -161,7 +141,7 @@ def test_logsoftmax_for_dim_nc(shape_dim, device):
 
     tt_cpu = F.log_softmax(x, dim)
     tt_npu = ttl.operations.primary.moreh_logsoftmax(dev_x, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
@@ -190,22 +170,12 @@ def test_logsoftmax_backward_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.log_softmax(x, dim)
     dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
@@ -233,22 +203,12 @@ def test_logsoftmax_backward_large_algorithm_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.log_softmax(x, dim)
     dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
@@ -282,17 +242,7 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.log_softmax(x, dim)
     dev_y = (
@@ -302,7 +252,7 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
         .to(device)
     )
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = (
         ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16)
         .pad_to_tile(float("200"))
@@ -312,7 +262,7 @@ def test_logsoftmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     y.backward(dy)
     tt_npu = ttl.operations.primary.moreh_logsoftmax_backward(dev_y, dev_dy, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
@@ -339,17 +289,7 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.log_softmax(x, dim)
     dev_y = (
@@ -359,7 +299,7 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, device):
         .to(device)
     )
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = (
         ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16)
         .pad_to_tile(float("10"))
@@ -369,7 +309,7 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, device):
 
     y.backward(dy)
     tt_npu = ttl.operations.primary.moreh_logsoftmax_backward(dev_y, dev_dy, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
@@ -393,12 +333,7 @@ def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, de
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     # cpu calculation
     tt_cpu = F.log_softmax(x, dim)
@@ -434,21 +369,11 @@ def test_logsoftmax_backward_optional_output_tensor(shape_dim, optional_output_t
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
     # cpu calculation
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.log_softmax(x, dim)
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     y.backward(dy)
 
     # npu calculation

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
@@ -29,12 +29,7 @@ def test_softmax_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
@@ -63,12 +58,7 @@ def test_softmax_large_algorithm_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
@@ -104,12 +94,7 @@ def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = (
         ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16)
@@ -120,7 +105,7 @@ def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     tt_cpu = torch.softmax(x, dim)
     tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
@@ -147,12 +132,7 @@ def test_softmax_for_dim_nc(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = (
         ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).pad_to_tile(float("7")).to(ttl.tensor.Layout.TILE).to(device)
@@ -160,7 +140,7 @@ def test_softmax_for_dim_nc(shape_dim, device):
 
     tt_cpu = torch.softmax(x, dim)
     tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
@@ -221,7 +201,7 @@ def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    x = torch.randint(low=0, high=4, size=shape).reshape(shape).to(torch.bfloat16).requires_grad_(True)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = torch.softmax(x, dim)
     dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
@@ -345,12 +325,7 @@ def test_softmax_callback(shape_dim_strategy, device):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
@@ -418,12 +393,7 @@ def test_softmax_optional_output_tensor(shape_dim, optional_output_tensor, devic
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     # cpu calculation
     tt_cpu = torch.softmax(x, dim)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
@@ -174,12 +174,12 @@ def test_softmax_for_dim_nc(shape_dim, device):
 @pytest.mark.parametrize(
     "shape_dim",
     (
-        ((1, 1, 32, 32), 3),  # single tile
-        ((1, 1, 32, 32 * 5), 3),  # mutiple tile with dim W
+        ((32, 32), 1),  # single tile
+        ((3, 32, 32 * 5), 2),  # mutiple tile with dim W
         ((5, 6, 32, 32), 3),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 3),  # multiple tiles per core
-        ((1, 1, 32, 32), 2),  # single tile
-        ((1, 1, 32 * 5, 32), 2),  # mutiple tile with dim H
+        ((32, 32), 0),  # single tile
+        ((3, 32 * 5, 32), 1),  # mutiple tile with dim H
         ((5, 6, 32, 32), 2),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 2),  # multiple tiles per core
     ),
@@ -189,22 +189,12 @@ def test_softmax_backward_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = torch.softmax(x, dim)
     dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
@@ -231,22 +221,12 @@ def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).reshape(shape).to(torch.bfloat16).requires_grad_(True)
 
     y = torch.softmax(x, dim)
     dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
@@ -281,17 +261,7 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = torch.softmax(x, dim)
     dev_y = (
@@ -301,7 +271,7 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
         .to(device)
     )
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = (
         ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16)
         .pad_to_tile(float("20"))
@@ -311,7 +281,7 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     y.backward(dy)
     tt_npu = ttl.operations.primary.moreh_softmax_backward(dev_y, dev_dy, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
@@ -338,37 +308,17 @@ def test_softmax_backward_for_dim_nc(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = torch.softmax(x, dim)
-    dev_y = (
-        ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16)
-        .pad_to_tile(float("10"))
-        .to(ttl.tensor.Layout.TILE)
-        .to(device)
-    )
+    dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
-    dev_dy = (
-        ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16)
-        .pad_to_tile(float("10"))
-        .to(ttl.tensor.Layout.TILE)
-        .to(device)
-    )
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
+    dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
     tt_npu = ttl.operations.primary.moreh_softmax_backward(dev_y, dev_dy, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR)
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
@@ -420,10 +370,10 @@ def test_softmax_callback(shape_dim_strategy, device):
 @pytest.mark.parametrize(
     "shape_dim_strategy",
     (
-        ((1, 1, 32, 32), 3, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.SMALL_W),
-        ((1, 1, 32, 32), 2, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.SMALL_H),
-        ((1, 1, 32, 32), 3, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_W),
-        ((1, 1, 32, 32), 2, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_H),
+        ((32, 32), 1, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.SMALL_W),
+        ((32, 32), 0, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.SMALL_H),
+        ((32, 32), 1, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_W),
+        ((32, 32), 0, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_H),
         ((1, 1, 32, 32), 1, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_C),
         ((1, 1, 32, 32), 0, ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_C),
     ),
@@ -433,22 +383,12 @@ def test_softmax_backward_callback(shape_dim_strategy, device):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = torch.softmax(x, dim)
     dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
@@ -508,7 +448,7 @@ def test_softmax_optional_output_tensor(shape_dim, optional_output_tensor, devic
 
 @pytest.mark.parametrize(
     "shape_dim",
-    (((1, 1, 32, 32), 3),),  # single tile
+    (((32, 32), 1),),  # single tile
 )
 @pytest.mark.parametrize(
     "optional_output_tensor",
@@ -519,21 +459,11 @@ def test_softmax_backward_optional_output_tensor(shape_dim, optional_output_tens
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
     # cpu calculation
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = torch.softmax(x, dim)
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     y.backward(dy)
 
     # npu calculation

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
@@ -30,12 +30,7 @@ def test_softmin_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
@@ -64,12 +59,7 @@ def test_softmin_large_algorithm_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
@@ -104,12 +94,7 @@ def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = (
         ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16)
@@ -120,7 +105,7 @@ def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     tt_cpu = F.softmin(x, dim)
     tt_npu = ttl.operations.primary.moreh_softmin(dev_x, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
@@ -147,12 +132,7 @@ def test_softmin_for_dim_nc(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = (
         ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).pad_to_tile(float("7")).to(ttl.tensor.Layout.TILE).to(device)
@@ -160,7 +140,7 @@ def test_softmin_for_dim_nc(shape_dim, device):
 
     tt_cpu = F.softmin(x, dim)
     tt_npu = ttl.operations.primary.moreh_softmin(dev_x, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
@@ -189,22 +169,12 @@ def test_softmin_backward_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.softmin(x, dim)
     dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
@@ -231,22 +201,12 @@ def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.softmin(x, dim)
     dev_y = ttl.tensor.Tensor(y, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
@@ -280,17 +240,7 @@ def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.softmin(x, dim)
     dev_y = (
@@ -300,7 +250,7 @@ def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
         .to(device)
     )
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = (
         ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16)
         .pad_to_tile(float("20"))
@@ -310,7 +260,7 @@ def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
 
     y.backward(dy)
     tt_npu = ttl.operations.primary.moreh_softmin_backward(dev_y, dev_dy, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.to_torch().to(torch.bfloat16)
@@ -337,17 +287,7 @@ def test_softmin_backward_for_dim_nc(shape_dim, device):
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.softmin(x, dim)
     dev_y = (
@@ -357,7 +297,7 @@ def test_softmin_backward_for_dim_nc(shape_dim, device):
         .to(device)
     )
 
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     dev_dy = (
         ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16)
         .pad_to_tile(float("10"))
@@ -367,7 +307,7 @@ def test_softmin_backward_for_dim_nc(shape_dim, device):
 
     y.backward(dy)
     tt_npu = ttl.operations.primary.moreh_softmin_backward(dev_y, dev_dy, dim)
-    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((N, C, H, W))
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)
 
@@ -391,12 +331,7 @@ def test_softmin_optional_output_tensor(shape_dim, optional_output_tensor, devic
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
-    x = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     # cpu calculation
     tt_cpu = F.softmin(x, dim)
@@ -432,21 +367,11 @@ def test_softmin_backward_optional_output_tensor(shape_dim, optional_output_tens
     shape, dim = shape_dim
     torch.manual_seed(0)
 
-    N = shape[0]
-    C = shape[1]
-    H = shape[2]
-    W = shape[3]
-
     # cpu calculation
-    x = (
-        torch.randint(low=0, high=4, size=(N * C * H * W,))
-        .reshape((N, C, H, W))
-        .to(torch.bfloat16)
-        .requires_grad_(True)
-    )
+    x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
     y = F.softmin(x, dim)
-    dy = torch.randint(low=0, high=4, size=(N * C * H * W,)).reshape((N, C, H, W)).to(torch.bfloat16)
+    dy = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
     y.backward(dy)
 
     # npu calculation

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
@@ -87,31 +87,25 @@ MorehSoftmaxBackwardOpParallelizationStrategy MorehSoftmaxBackward::get_parallel
     const std::vector<Tensor>& input_tensors) const {
     auto& output = input_tensors.at(0);
 
+    auto rank = output.get_legacy_shape().rank();
+
     if (this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::NONE) {
-        if (this->dim == 0 || this->dim == 1) {
-            return MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_C;
-        }
-
-        if (is_moreh_softmax_backward_w_small_available(output) && this->dim == 3) {
-            return MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_W;
-        }
-        if (is_moreh_softmax_backward_h_small_available(output) && this->dim == 2) {
-            return MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_H;
-        }
-
-        if (this->dim == 3) {
+        if (rank - 1 == this->dim) {
+            if (is_moreh_softmax_backward_w_small_available(output)) {
+                return MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_W;
+            }
             return MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_W;
-        } else {
+        }
+        if (rank - 2 == this->dim) {
+            if (is_moreh_softmax_backward_h_small_available(output)) {
+                return MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_H;
+            }
             return MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_H;
         }
+        return MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_C;
     }
 
-    if (this->dim == 0 || this->dim == 1) {
-        TT_ASSERT(
-            this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_C,
-            "Invalid parallelization strategy. large c is for dim 0, 1");
-    }
-    if (this->dim == 2) {
+    if (rank - 2 == this->dim) {
         TT_ASSERT(
             this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_H ||
                 this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_H,
@@ -122,8 +116,7 @@ MorehSoftmaxBackwardOpParallelizationStrategy MorehSoftmaxBackward::get_parallel
                 is_moreh_softmax_backward_h_small_available(output),
                 fmt::format("not enough circular buffer memory for {}", this->strategy));
         }
-    }
-    if (this->dim == 3) {
+    } else if (rank - 1 == this->dim) {
         TT_ASSERT(
             this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_W ||
                 this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_W,
@@ -134,6 +127,10 @@ MorehSoftmaxBackwardOpParallelizationStrategy MorehSoftmaxBackward::get_parallel
                 is_moreh_softmax_backward_w_small_available(output),
                 fmt::format("not enough circular buffer memory for {}", this->strategy));
         }
+    } else {
+        TT_ASSERT(
+            this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_C,
+            "Invalid parallelization strategy. large c is for dim 0, 1");
     }
 
     return this->strategy;

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -23,14 +23,14 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
 
     // split work
     auto shape = input_grad.get_legacy_shape();
-    auto N = shape[0];
-    auto C = shape[1];
-    auto H = shape[2];
-    auto W = shape[3];
+    auto H = shape[-2];
+    auto W = shape[-1];
     auto Ht = H / TILE_HEIGHT;
     auto Wt = W / TILE_WIDTH;
 
-    uint32_t num_cols_tiles = N * C * Wt;
+    auto num = input_grad.volume() / H / W;
+
+    uint32_t num_cols_tiles = num * Wt;
     uint32_t core_w = core_range.end.x - core_range.start.x + 1;
     uint32_t core_h = core_range.end.y - core_range.start.y + 1;
 
@@ -106,7 +106,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
         }
 
         float scaler = 1.0f;
-        uint32_t mask_h = shape.without_padding()[2] % TILE_HEIGHT;
+        uint32_t mask_h = shape.without_padding()[-2] % TILE_HEIGHT;
         if(mask_h == 0) mask_h = TILE_HEIGHT;
         vector<uint32_t> reader_args = {
             output.buffer()->address(),

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -22,7 +22,7 @@ namespace primary {
 #define L1_512KB (512 * 1024)
 
 bool is_moreh_softmax_backward_h_small_available(const Tensor &tensor) {
-    auto h = tensor.get_legacy_shape()[2];
+    auto h = tensor.get_legacy_shape()[-2];
     int32_t Ht = (h + TILE_HEIGHT - 1) / TILE_HEIGHT;
 
     tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());
@@ -46,15 +46,14 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
     log_info(LogTest, "Small tensor algorithm selected");
     // split work
     auto shape = input_grad.get_legacy_shape();
-    auto N = shape[0];
-    auto C = shape[1];
-    auto H = shape[2];
-    auto W = shape[3];
-
+    auto H = shape[-2];
+    auto W = shape[-1];
     auto Ht = H / TILE_HEIGHT;
     auto Wt = W / TILE_WIDTH;
 
-    uint32_t num_cols_tiles = N * C * Wt;
+    auto num = input_grad.volume() / H / W;
+
+    uint32_t num_cols_tiles = num * Wt;
     uint32_t core_w = core_range.end.x - core_range.start.x + 1;
     uint32_t core_h = core_range.end.y - core_range.start.y + 1;
 
@@ -128,7 +127,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
         }
 
         float scaler = 1.0f;
-        uint32_t mask_h = shape.without_padding()[2] % TILE_HEIGHT;
+        uint32_t mask_h = shape.without_padding()[-2] % TILE_HEIGHT;
         if(mask_h == 0) mask_h = TILE_HEIGHT;
         vector<uint32_t> reader_args = {
             output.buffer()->address(),

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -22,14 +22,14 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
     log_info(LogTest, "Large tensor algorithm selected");
     // split work
     auto shape = input_grad.get_legacy_shape();
-    auto N = shape[0];
-    auto C = shape[1];
-    auto H = shape[2];
-    auto W = shape[3];
+    auto H = shape[-2];
+    auto W = shape[-1];
     auto Ht = H / TILE_HEIGHT;
     auto Wt = W / TILE_WIDTH;
 
-    uint32_t num_kernel_rows = N * C * Ht;
+    auto num = input_grad.volume() / H / W;
+
+    uint32_t num_kernel_rows = num * Ht;
     uint32_t core_w = core_range.end.x - core_range.start.x + 1;
     uint32_t core_h = core_range.end.y - core_range.start.y + 1;
 
@@ -105,7 +105,7 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
         }
 
         float scaler = 1.0f;
-        uint32_t mask_w = shape.without_padding()[3] % TILE_WIDTH;
+        uint32_t mask_w = shape.without_padding()[-1] % TILE_WIDTH;
         if(mask_w == 0) mask_w = TILE_WIDTH;
         vector<uint32_t> reader_args = {
             output.buffer()->address(),


### PR DESCRIPTION
I will modify moreh softmax backward to accept tensors that are not 4D.

