### PR TITLE
#7744: Add support for non-4D tensor in moreh_sum, moreh_sum_backward

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sum.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sum.py
@@ -13,7 +13,7 @@ TILE_HEIGHT = 32
 TILE_WIDTH = 32
 
 
-def get_tensors(input_shape, output_shape, device):
+def get_tensors(input_shape, output_shape, device, *, with_padding=True):
     npu_dtype = ttl.tensor.DataType.BFLOAT16
     cpu_dtype = torch.bfloat16
     npu_layout = ttl.tensor.Layout.TILE
@@ -21,13 +21,17 @@ def get_tensors(input_shape, output_shape, device):
     torch_input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype, requires_grad=True)
     torch_output = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
 
-    tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-    tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    if with_padding:
+        tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+        tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    else:
+        tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).to(npu_layout).to(device)
+        tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).to(npu_layout).to(device)
 
     return tt_input, tt_output, torch_input
 
 
-def get_backward_tensors(output_grad_shape, input_grad_shape, device):
+def get_backward_tensors(output_grad_shape, input_grad_shape, device, *, with_padding=True):
     npu_dtype = ttl.tensor.DataType.BFLOAT16
     cpu_dtype = torch.bfloat16
     npu_layout = ttl.tensor.Layout.TILE
@@ -35,20 +39,24 @@ def get_backward_tensors(output_grad_shape, input_grad_shape, device):
     torch_output_grad = torch.randint(-2, 3, output_grad_shape, dtype=cpu_dtype, requires_grad=True)
     torch_input_grad = torch.randint(-2, 3, input_grad_shape, dtype=cpu_dtype)
 
-    tt_output_grad = ttl.tensor.Tensor(torch_output_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-    tt_input_grad = ttl.tensor.Tensor(torch_input_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    if with_padding:
+        tt_output_grad = (
+            ttl.tensor.Tensor(torch_output_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+        )
+        tt_input_grad = (
+            ttl.tensor.Tensor(torch_input_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+        )
+    else:
+        tt_output_grad = ttl.tensor.Tensor(torch_output_grad, npu_dtype).to(npu_layout).to(device)
+        tt_input_grad = ttl.tensor.Tensor(torch_input_grad, npu_dtype).to(npu_layout).to(device)
 
     return tt_output_grad, tt_input_grad, torch_output_grad
 
 
 @pytest.mark.parametrize(
     "input_shape",
-    (
-        ([1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1]),
-        ([4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 12 - 1]),
-    ),
+    (([4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 12 - 1]),),
     ids=[
-        "1, 1, TILE_HEIGHT - 1,TILE_WIDTH - 1",
         "4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 12 - 1",
     ],
 )
@@ -97,6 +105,62 @@ def test_moreh_sum(input_shape, dims, use_provide_output, device):
 
     # test for equivalance
     # TODO(Dongjin) : check while changing rtol after enabling fp32_dest_acc_en
+    rtol = atol = 0.12
+    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
+
+    assert passing
+
+
+def reduce_rows(x, dims):
+    index_tuple = tuple(slice(0, 1) if i in dims else slice(None) for i in range(x.dim()))
+    return x[index_tuple]
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        ([TILE_HEIGHT, TILE_WIDTH]),
+        ([TILE_HEIGHT * 3, TILE_WIDTH * 3]),
+        ([4, TILE_HEIGHT * 2, TILE_WIDTH * 2]),
+    ),
+    ids=[
+        "TILE_HEIGHT, TILE_WIDTH",
+        "TILE_HEIGHT * 3, TILE_WIDTH * 3",
+        "4, TILE_HEIGHT * 2, TILE_WIDTH * 2",
+    ],
+)
+@pytest.mark.parametrize(
+    "dims",
+    (
+        [0],
+        [0, 1],
+        [0, 1, 2],
+        [0, 2],
+        [1],
+        [1, 2],
+        [2],
+    ),
+    ids=["0", "0,1", "0,1,2", "0, 2", "1", "1,2", "2"],
+)
+def test_moreh_sum_non_4d(input_shape, dims, device):
+    torch.manual_seed(2023)
+    output_shape = input_shape.copy()
+
+    input_rank = len(input_shape)
+    for dim in dims:
+        if dim >= input_rank:
+            pytest.skip(f"input dim {dim} exceeds the dims of input tensor {len(input_shape)}.")
+
+    (tt_input, _, torch_input) = get_tensors(input_shape, output_shape, device, with_padding=False)
+
+    torch_output = torch.sum(torch_input, dims, True)
+    cpu_layout = ttl.tensor.Layout.ROW_MAJOR
+    tt_output_cpu = ttl.operations.primary.moreh_sum(tt_input, dims=dims, output=None).cpu().to(cpu_layout).to_torch()
+
+    tt_output_cpu = reduce_rows(tt_output_cpu, dims)
     rtol = atol = 0.12
     passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
 

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 #include <vector>
+#include <tuple>
 
 #include "tt_dnn/op_library/run_operation.hpp"
 #include "tt_eager/tensor/tensor.hpp"
@@ -19,6 +20,22 @@ namespace operations {
 namespace primary {
 
 using namespace tt_metal;
+
+inline
+std::tuple<uint32_t, uint32_t, uint32_t> extract_spatial_dims(const Shape& shape) {
+    const auto rank = shape.rank();
+
+    TT_FATAL(rank >= 2, "Shape must have at least two dims.");
+    uint32_t W = shape[-1];
+    uint32_t H = shape[-2];
+
+    uint32_t other_dims_product = 1;
+    for (auto i = 0; i < rank - 2; ++i) {
+        other_dims_product *= shape[i];
+    }
+
+    return { W, H, other_dims_product};
+}
 
 struct MorehSum {
     int64_t dim;

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_sum_w_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_sum_w_impl.cpp
@@ -24,15 +24,15 @@ operation::ProgramWithCallbacks moreh_sum_w_impl(const Tensor &a, const Tensor &
     float scaler = 1.0f;
 
     const auto shape = a.get_legacy_shape();
-    uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
-    uint32_t HW = H * W;
+    const auto [W, H, other_dims_product] = extract_spatial_dims(shape);
 
+    uint32_t HW = H * W;
     uint32_t Wt = W / TILE_WIDTH;
     uint32_t Ht = H / TILE_HEIGHT;
 
     // check mask for w-dim
     const auto input_shape_without_padding = shape.without_padding();
-    const auto origin_W = input_shape_without_padding[3];
+    const auto origin_W = input_shape_without_padding[-1];
     const bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
     const auto mask_w = do_mask_w ? origin_W % TILE_WIDTH : TILE_WIDTH;
 
@@ -57,7 +57,7 @@ operation::ProgramWithCallbacks moreh_sum_w_impl(const Tensor &a, const Tensor &
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto num_rows = NC * Ht;
+    auto num_rows = other_dims_product * Ht;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
         split_work_to_cores(compute_with_storage_grid_size, num_rows);

--- a/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/kernels/moreh_sum_backward.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/kernels/moreh_sum_backward.cpp
@@ -7,10 +7,8 @@ namespace NAMESPACE {
 void MAIN {
     ArgFetcher arg_fetcher;
     const auto num_output_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto n_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto c_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto ht_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
     const auto wt_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto ht_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
 
     constexpr auto cb_in0 = tt::CB::c_in0;  // input
     constexpr auto cb_in1 = tt::CB::c_in1;  // zero tile

--- a/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/kernels/reader_moreh_sum_backward.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/kernels/reader_moreh_sum_backward.cpp
@@ -3,6 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp"
+static constexpr int32_t MAX_NUM_DIMENSIONS = 8;
+
+inline uint32_t get_output_grad_tile(uint32_t idx, uint32_t* output_grad_dim, uint32_t* output_grad_stride, uint32_t* input_grad_dim, uint32_t* input_grad_stride, bool* need_bcast_dim) {
+    uint32_t cur_idx[MAX_NUM_DIMENSIONS];
+
+    for (auto i = 0; i < MAX_NUM_DIMENSIONS; ++i) {
+        cur_idx[i] = (need_bcast_dim[i]) ? (0) : ((idx / input_grad_stride[i]) % input_grad_dim[i]);
+    }
+
+    auto read_tile_id = 0;
+    for (auto i = 0; i < MAX_NUM_DIMENSIONS; ++i) {
+        read_tile_id += (cur_idx[i] * output_grad_stride[i]);
+    }
+
+    return read_tile_id;
+}
 
 void kernel_main() {
     ArgFetcher arg_fetcher;
@@ -11,26 +27,32 @@ void kernel_main() {
     const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
     const auto output_grad_is_dram = (arg_fetcher.get_next_arg_val<uint32_t>() == 1);
 
-    const auto output_grad_n = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto output_grad_c = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto output_grad_ht = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto output_grad_wt = arg_fetcher.get_next_arg_val<uint32_t>();
+    uint32_t output_grad_dim[MAX_NUM_DIMENSIONS];
+    for (auto i = 0; i < MAX_NUM_DIMENSIONS;++i) {
+        output_grad_dim[i] = arg_fetcher.get_next_arg_val<uint32_t>();
+    }
 
-    const auto input_grad_n = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto input_grad_c = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto input_grad_ht = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto input_grad_wt = arg_fetcher.get_next_arg_val<uint32_t>();
+    uint32_t input_grad_dim[MAX_NUM_DIMENSIONS];
+    for (auto i = 0; i < MAX_NUM_DIMENSIONS;++i) {
+        input_grad_dim[i] = arg_fetcher.get_next_arg_val<uint32_t>();
+    }
 
-    const auto n_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto c_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto ht_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto wt_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
+    bool need_bcast_dim[MAX_NUM_DIMENSIONS];
+    for (auto i = 0; i < MAX_NUM_DIMENSIONS;++i) {
+        need_bcast_dim[i] = (arg_fetcher.get_next_arg_val<uint32_t>() == 1);
+    }
 
-    const auto output_grad_HtWt = output_grad_ht * output_grad_wt;
-    const auto output_grad_CHtWt = output_grad_c * output_grad_HtWt;
+    uint32_t output_grad_stride[MAX_NUM_DIMENSIONS];
+    output_grad_stride[0] = 1;
+    for (auto i = 1; i < MAX_NUM_DIMENSIONS;++i) {
+        output_grad_stride[i] = output_grad_stride[i - 1] * output_grad_dim[i - 1];
+    }
 
-    const auto input_grad_HtWt = input_grad_ht * input_grad_wt;
-    const auto input_grad_CHtWt = input_grad_c * input_grad_HtWt;
+    uint32_t input_grad_stride[MAX_NUM_DIMENSIONS];
+    input_grad_stride[0] = 1;
+    for (auto i = 1; i < MAX_NUM_DIMENSIONS;++i) {
+        input_grad_stride[i] = input_grad_stride[i - 1] * input_grad_dim[i - 1];
+    }
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t cb_id_in0 = 0;
@@ -57,18 +79,7 @@ void kernel_main() {
         .data_format = output_grad_data_format};
 
     for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
-        const auto cur_n = i / input_grad_CHtWt;
-        const auto cur_c = (i / input_grad_HtWt) % input_grad_c;
-        const auto cur_ht = (i / input_grad_wt) % input_grad_ht;
-        const auto cur_wt = i % input_grad_wt;
-
-        const auto target_n = (n_need_bcast) ? (0) : (cur_n);
-        const auto target_c = (c_need_bcast) ? (0) : (cur_c);
-        const auto target_ht = (ht_need_bcast) ? (0) : (cur_ht);
-        const auto target_wt = (wt_need_bcast) ? (0) : (cur_wt);
-
-        auto read_tile_id =
-            target_n * output_grad_CHtWt + target_c * output_grad_HtWt + target_ht * output_grad_wt + target_wt;
+        auto read_tile_id = get_output_grad_tile(i, output_grad_dim, output_grad_stride, input_grad_dim, input_grad_stride, need_bcast_dim);
 
         cb_reserve_back(cb_id_in0, onetile);
         l1_write_addr_in0 = get_write_ptr(cb_id_in0);

--- a/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/moreh_sum_backward_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/moreh_sum_backward_impl.cpp
@@ -9,11 +9,36 @@
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
 
+#include <vector>
 namespace tt {
 using namespace constants;
 namespace operations {
 
 namespace primary {
+
+namespace {
+
+void get_tensor_dim(std::vector<uint32_t> &dim, const Shape& shape) {
+    const auto rank = shape.rank();
+    for (auto i = 0; i < rank; ++i) {
+        auto idx = rank - 1 - i;
+
+        // last 2-dim
+        if (idx == rank - 1 || idx == rank - 2) {
+            dim[i] = shape[idx] / TILE_HEIGHT;
+        }
+        else {
+            dim[i] = shape[idx];
+        }
+    }
+
+    log_debug(LogOp, "rank {}", rank);
+    for (auto i = 0; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+        log_debug(LogOp, "dim[{}] = {}", i, dim[i]);
+    }
+}
+
+}
 
 operation::ProgramWithCallbacks moreh_sum_backward_impl(const Tensor &output_grad, const Tensor &input_grad) {
     ////////////////////////////////////////////////////////////////////////////
@@ -30,27 +55,38 @@ operation::ProgramWithCallbacks moreh_sum_backward_impl(const Tensor &output_gra
 
     const auto &output_grad_shape = output_grad.get_legacy_shape();
     const auto &output_grad_shape_wo_padding = output_grad_shape.without_padding();
-    const auto output_grad_n = output_grad_shape[0];
-    const auto output_grad_c = output_grad_shape[1];
-    const auto output_grad_ht = output_grad_shape[2] / TILE_HEIGHT;
-    const auto output_grad_wt = output_grad_shape[3] / TILE_WIDTH;
-    const auto output_grad_origin_h = output_grad_shape_wo_padding[2];
-    const auto output_grad_origin_w = output_grad_shape_wo_padding[3];
+    const auto output_grad_rank = output_grad_shape.rank();
+
+    std::vector<uint32_t> output_grad_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    log_debug(LogOp, "output_grad");
+    get_tensor_dim(output_grad_dim, output_grad_shape);
 
     const auto &input_grad_shape = input_grad.get_legacy_shape();
     const auto &input_grad_shape_wo_padding = input_grad_shape.without_padding();
-    const auto input_grad_n = input_grad_shape[0];
-    const auto input_grad_c = input_grad_shape[1];
-    const auto input_grad_ht = input_grad_shape[2] / TILE_HEIGHT;
-    const auto input_grad_wt = input_grad_shape[3] / TILE_WIDTH;
-    const auto input_grad_origin_h = input_grad_shape_wo_padding[2];
-    const auto input_grad_origin_w = input_grad_shape_wo_padding[3];
+    const auto input_grad_rank = input_grad_shape.rank();
 
-    const auto n_need_bcast = (output_grad_n != input_grad_n);
-    const auto c_need_bcast = (output_grad_c != input_grad_c);
-    const auto ht_need_bcast = (output_grad_origin_h != input_grad_origin_h);
-    const auto wt_need_bcast = (output_grad_origin_w != input_grad_origin_w);
+    std::vector<uint32_t> input_grad_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+    log_debug(LogOp, "input_grad");
+    get_tensor_dim(input_grad_dim, input_grad_shape);
+
+    std::vector<uint32_t> need_bcast_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 0);
+    for (auto i = 0; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+        // TODO: both rank can be different when keepdim=false
+        auto idx = input_grad_rank - 1 - i;
+
+        // last 2-dim
+        if (idx == input_grad_rank - 1 || idx == input_grad_rank - 2) {
+            need_bcast_dim[i] = (output_grad_shape_wo_padding[idx] != input_grad_shape_wo_padding[idx]);
+        } else {
+            need_bcast_dim[i] = (output_grad_shape[idx] != input_grad_shape[idx]);
+        }
+    }
     const auto num_input_grad_tiles = input_grad.volume() / TILE_HW;
+
+    for (auto i = 0; i < tt::tt_metal::MAX_NUM_DIMENSIONS; ++i) {
+        log_debug(LogOp, "need_bcast_dim [{}] = {}", i, need_bcast_dim[i]);
+    }
+    log_debug(LogOp, "num_input_grad_tiles {}", num_input_grad_tiles);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
@@ -127,26 +163,21 @@ operation::ProgramWithCallbacks moreh_sum_backward_impl(const Tensor &output_gra
             TT_THROW("Core not in specified core ranges.");
         }
 
+        std::vector<uint32_t> reader_rt_args;
+        reader_rt_args.push_back(output_grad.buffer()->address());
+        reader_rt_args.push_back(num_tiles_per_core);
+        reader_rt_args.push_back(tile_offset);
+        reader_rt_args.push_back(static_cast<uint32_t>(is_dram(output_grad)));
+        reader_rt_args.insert(reader_rt_args.end(), output_grad_dim.begin(), output_grad_dim.end());
+        reader_rt_args.insert(reader_rt_args.end(), input_grad_dim.begin(), input_grad_dim.end());
+        reader_rt_args.insert(reader_rt_args.end(), need_bcast_dim.begin(), need_bcast_dim.end());
+
         SetRuntimeArgs(
             program,
             reader_kernel_id,
             core,
-            {output_grad.buffer()->address(),
-             num_tiles_per_core,
-             tile_offset,
-             static_cast<uint32_t>(is_dram(output_grad)),
-             output_grad_n,
-             output_grad_c,
-             output_grad_ht,
-             output_grad_wt,
-             input_grad_n,
-             input_grad_c,
-             input_grad_ht,
-             input_grad_wt,
-             n_need_bcast,
-             c_need_bcast,
-             ht_need_bcast,
-             wt_need_bcast});
+            reader_rt_args
+        );
 
         SetRuntimeArgs(
             program,
@@ -157,19 +188,23 @@ operation::ProgramWithCallbacks moreh_sum_backward_impl(const Tensor &output_gra
              tile_offset,
              static_cast<uint32_t>(is_dram(input_grad))});
 
+        std::vector<uint32_t> compute_rt_args;
+        compute_rt_args.push_back(num_tiles_per_core);
+        compute_rt_args.insert(compute_rt_args.end(), need_bcast_dim.begin(), need_bcast_dim.end());
+
         if (core_group_1.core_coord_in_core_ranges(core)) {
             SetRuntimeArgs(
                 program,
                 compute_kernel_1_id,
                 core,
-                {num_tiles_per_core, n_need_bcast, c_need_bcast, ht_need_bcast, wt_need_bcast});
+                {num_tiles_per_core, need_bcast_dim[0], need_bcast_dim[1]});
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
             TT_ASSERT(compute_kernel_2_id.has_value());
             SetRuntimeArgs(
                 program,
                 compute_kernel_2_id.value(),
                 core,
-                {num_tiles_per_core, n_need_bcast, c_need_bcast, ht_need_bcast, wt_need_bcast});
+                {num_tiles_per_core, need_bcast_dim[0], need_bcast_dim[1]});
         } else {
             TT_ASSERT(false, "Core not in specified core ranges.");
         }


### PR DESCRIPTION
This PR supports for  non-4D tensor in moreh_sum, moreh_sum_backward.