### PR TITLE
#7754: Skip test_ethernet_bidirectional_bandwidth_microbenchmark.py because it's failing with rc != 0

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_bidirectional_bandwidth_microbenchmark.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_ethernet_bidirectional_bandwidth_microbenchmark.py
@@ -11,6 +11,7 @@ from tt_metal.tools.profiler.process_device_log import import_log_run_stats
 import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
 
 
+@pytest.mark.skip("#7754: Failing with rc != 0 in main")
 @pytest.mark.parametrize("sample_counts", [(1, 1024)])  # , 8, 16, 64, 256],
 @pytest.mark.parametrize(
     "sample_sizes",


### PR DESCRIPTION
…