### PR TITLE
#0: Skip op profiling test for WH B0 because no underlying tests are run currently and therefore it fails on csv collection

### DIFF
--- a/tests/tt_eager/ops_device_perf/run_op_profiling.py
+++ b/tests/tt_eager/ops_device_perf/run_op_profiling.py
@@ -10,6 +10,7 @@ import pytest
 
 from tt_metal.tools.profiler.process_model_log import run_device_profiler, post_process_ops_log
 
+from models.utility_functions import skip_for_wormhole_b0
 
 from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
 
@@ -134,6 +135,7 @@ def run_op_test():
         assert is_within_range
 
 
+@skip_for_wormhole_b0()
 @pytest.mark.models_device_performance_bare_metal
 def test_run_op_test():
     run_op_test()


### PR DESCRIPTION
…r