### PR TITLE
Falcon7b optimize prefill and refactor

### DIFF
--- a/models/demos/falcon7b/demo/demo.py
+++ b/models/demos/falcon7b/demo/demo.py
@@ -3,32 +3,33 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import pytest
+import os
+import time
 from functools import partial
-import tt_lib
+from pathlib import Path
+
+import pytest
 import torch
 import torch.nn.functional as F
+import tt_lib
 from loguru import logger
-import time
-from pathlib import Path
-from transformers import AutoTokenizer
-from transformers.generation.utils import top_k_top_p_filtering
-import os
-from tqdm import tqdm
-
-from models.demos.falcon7b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.falcon7b.reference.hf_modeling_falcon import FalconConfig, FalconForCausalLM
+from models.demos.falcon7b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.falcon7b.tt.model_config import get_model_config, model_config_entries
 from models.utility_functions import (
     disable_compilation_reports,
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
+    is_wormhole_b0,
+    nearest_32,
     profiler,
     torch2tt_tensor,
     tt2torch_tensor,
     tt_tensors_to_torch_tensors,
-    nearest_32,
 )
+from tqdm import tqdm
+from transformers import AutoTokenizer
+from transformers.generation.utils import top_k_top_p_filtering
 
 END_OF_TEXT = 11
 SPACE = 204
@@ -103,8 +104,8 @@ def print_output_prompts(generated_ids, tokenizer, batch_size, num_users_to_disp
         logger.info(f"Output for user {user_id}:\n{output_prompt}")
 
 
-def update_model_config(model, model_config_str):
-    model.model_config.update(get_model_config(model_config_str))
+def update_model_config(model, model_config_str, prefill_seq_len=0):
+    model.model_config.update(get_model_config(model_config_str, prefill_seq_len))
 
 
 def top_pk_logits(logits, p=0.9, k=10, temperature=1.0, return_probs=False):
@@ -162,11 +163,6 @@ def run_falcon_demo_kv(
     if perf_mode:
         logger.info("Running in performance measurement mode (invalid outputs)!")
 
-    model_config = get_model_config(model_config_strs_prefill_decode[0])
-    tt_cache_path = get_tt_cache_path(
-        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
-    )
-
     configuration = FalconConfig(**model_config_entries)
 
     profiler.start(f"loading_inputs")
@@ -179,10 +175,24 @@ def run_falcon_demo_kv(
 
     profiler.end(f"loading_inputs")
 
+    logger.info("Tokenizing inputs...")
+    profiler.start(f"tokenizing_inputs")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_version)
+    prefill_ids, num_users, num_input_tokens = preprocess_and_validate_inputs(
+        input_prompts, tokenizer, max_seq_len, perf_mode
+    )
+    profiler.end(f"tokenizing_inputs")
+
+    model_config = get_model_config(model_config_strs_prefill_decode[0], nearest_32(num_input_tokens))
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
+
     # State dict is needed for embeddings
     logger.info("Loading weights...")
     profiler.start(f"loading_weights")
-    if len(os.listdir(tt_cache_path)) < 261:
+    if len(os.listdir(tt_cache_path)) < 337:
         logger.info("Weights not found on machine; downloading weights...")
         model_name = model_location_generator(model_version, model_subdir="Falcon")
         hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
@@ -200,6 +210,7 @@ def run_falcon_demo_kv(
     profiler.start(f"moving_to_device")
 
     base_url = ""
+
     tt_FalconCausalLM_singlelayer = TtFalconCausalLM(
         devices,
         state_dict,
@@ -209,22 +220,13 @@ def run_falcon_demo_kv(
         max_seq_len,
         model_config,
         tt_cache_path,
+        nearest_32(num_input_tokens),
     )  # single layer only used for compile
 
     logger.info("Moved weights to device!")
     profiler.end(f"moving_to_device")
 
     synchronize_devices(devices)
-
-    logger.info("Tokenizing inputs...")
-    profiler.start(f"tokenizing_inputs")
-
-    tokenizer = AutoTokenizer.from_pretrained(model_version)
-    prefill_ids, num_users, num_input_tokens = preprocess_and_validate_inputs(
-        input_prompts, tokenizer, max_seq_len, perf_mode=perf_mode
-    )
-
-    profiler.end(f"tokenizing_inputs")
 
     logger.info("Initializing KV cache...")
     profiler.start(f"initializing_KV_cache")
@@ -246,7 +248,7 @@ def run_falcon_demo_kv(
             tt_prefill_input_ids,
             tt_prefill_attention_mask,
         ) = tt_FalconCausalLM_singlelayer.model_preprocessing(
-            "prefill", prefill_ids[user_id::batch_size], 0, num_input_tokens=num_input_tokens
+            "prefill", prefill_ids[user_id::batch_size], 0, num_input_tokens=nearest_32(num_input_tokens)
         )
         assert tt_prefill_attention_mask is not None
 
@@ -264,7 +266,13 @@ def run_falcon_demo_kv(
         for i in range(num_devices):
             tt_prefill_input_ids[i].deallocate()
             if tt_prefill_attention_mask is not None:
-                tt_prefill_attention_mask[i].deallocate()
+                if isinstance(tt_prefill_attention_mask[i], tt_lib.tensor.Tensor):
+                    tt_prefill_attention_mask[i].deallocate()
+                elif isinstance(tt_prefill_attention_mask[i], list):
+                    for tt_attention_mask_element in tt_prefill_attention_mask[i]:
+                        tt_attention_mask_element.deallocate()
+                else:
+                    raise ValueError("Invalid type for tt_attention_mask")
             tt_logits[i].deallocate()
 
         time_prefill_compile += time.time() - time_prefill_compile_start
@@ -327,8 +335,9 @@ def run_falcon_demo_kv(
         num_layers,
         configuration,
         max_seq_len,
-        get_model_config(model_config_strs_prefill_decode[0]),
+        get_model_config(model_config_strs_prefill_decode[0], nearest_32(num_input_tokens)),
         tt_cache_path,
+        nearest_32(num_input_tokens),
     )
 
     ### Second prefill run without compile ###
@@ -353,7 +362,7 @@ def run_falcon_demo_kv(
             tt_prefill_input_ids,
             tt_prefill_attention_mask,
         ) = tt_FalconCausalLM.model_preprocessing(
-            "prefill", prefill_ids[user_id::batch_size], 0, num_input_tokens=num_input_tokens
+            "prefill", prefill_ids[user_id::batch_size], 0, num_input_tokens=nearest_32(num_input_tokens)
         )
         assert tt_prefill_attention_mask is not None
 
@@ -367,14 +376,23 @@ def run_falcon_demo_kv(
             use_cache=use_cache,
         )
         synchronize_devices(devices)
+
+        if tt_prefill_attention_mask is not None:
+            for device_id in range(len(tt_prefill_attention_mask)):
+                if isinstance(tt_prefill_attention_mask[device_id], tt_lib.tensor.Tensor):
+                    tt_prefill_attention_mask[device_id].deallocate()
+                elif isinstance(tt_prefill_attention_mask[device_id], list):
+                    for tt_attention_mask_element in tt_prefill_attention_mask[device_id]:
+                        tt_attention_mask_element.deallocate()
+                else:
+                    raise ValueError("Invalid type for tt_attention_mask")
+
         logits = torch.concat(
             [torch_logit.squeeze(1) for torch_logit in tt_tensors_to_torch_tensors(tt_logits)], dim=-2
         )
 
         for j in range(num_devices):
             tt_prefill_input_ids[j].deallocate()
-            if tt_prefill_attention_mask is not None:
-                tt_prefill_attention_mask[j].deallocate()
             tt_logits[j].deallocate()
 
         user_output_ids = post_processor(logits=logits, index=num_input_tokens - 1)
@@ -427,6 +445,7 @@ def run_falcon_demo_kv(
             use_cache=use_cache,
         )
         synchronize_devices(devices)
+
         logits = torch.concat(
             [torch_logit.squeeze(1) for torch_logit in tt_tensors_to_torch_tensors(tt_logits)], dim=-2
         )

--- a/models/demos/falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon7b/tests/test_falcon_causallm.py
@@ -113,6 +113,7 @@ def run_test_FalconCausalLM_inference(
         max_position_embeddings,
         model_config,
         tt_cache_path,
+        seq_len,
     )
 
     # TODO: Generate attention_mask on device
@@ -194,10 +195,12 @@ def run_test_FalconCausalLM_inference(
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
-        ("prefill", 2, 128, 0),
+        ("prefill", 1, 128, 0),
+        ("prefill", 1, 1024, 0),
+        ("prefill", 1, 2048, 0),
         ("decode", 32, 1, 128),
     ),
-    ids=["prefill_seq128", "decode_batch32"],
+    ids=["prefill_seq128", "prefill_seq1024", "prefill_seq2048", "decode_batch32"],
 )
 @pytest.mark.parametrize(
     "num_layers, pcc",
@@ -227,7 +230,7 @@ def test_FalconCausalLM_inference(
 ):
     devices = get_devices_for_t3000(all_devices, num_devices)
 
-    model_config = get_model_config(model_config_str)
+    model_config = get_model_config(model_config_str, seq_len)
     tt_cache_path = get_tt_cache_path(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
     )

--- a/models/demos/falcon7b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon7b/tests/test_falcon_decoder.py
@@ -6,17 +6,13 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib
 from models.demos.falcon7b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )
 from models.demos.falcon7b.tt.falcon_decoder import TtFalconDecoderLayer
-from models.demos.falcon7b.tt.model_config import (
-    get_model_config,
-)
+from models.demos.falcon7b.tt.model_config import get_model_config
 from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_outputs
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
-    comp_allclose,
     comp_pcc,
 )
 from models.utility_functions import get_devices_for_t3000
@@ -149,9 +145,11 @@ def run_test_FalconDecoder_inference(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
         ("prefill", 1, 128, 0),
+        ("prefill", 1, 1024, 0),
+        ("prefill", 1, 2048, 0),
         ("decode", 32, 1, 128),
     ),
-    ids=["prefill_seq128", "decode_batch32"],
+    ids=["prefill_seq128", "prefill_seq1024", "prefill_seq2048", "decode_batch32"],
 )
 @pytest.mark.parametrize(
     "model_version, layer_num, pcc",
@@ -174,7 +172,7 @@ def test_FalconDecoder_inference(
 ):
     devices = get_devices_for_t3000(all_devices, num_devices)
 
-    model_config = get_model_config(model_config_str)
+    model_config = get_model_config(model_config_str, seq_len)
     tt_cache_path = get_tt_cache_path(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
     )

--- a/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
+++ b/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
@@ -120,6 +120,7 @@ def run_test_FalconCausalLM_inference(
         max_position_embeddings,
         model_config,
         tt_cache_path,
+        seq_len,
     )
 
     # TODO: Generate attention_mask on device

--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -133,6 +133,7 @@ def run_test_FalconCausalLM_end_to_end(
         max_position_embeddings,
         model_config,
         tt_cache_path,
+        seq_len,
     )
     profiler.end("TtFalcon_model_setup")
 

--- a/models/demos/falcon7b/tt/falcon_causallm.py
+++ b/models/demos/falcon7b/tt/falcon_causallm.py
@@ -2,15 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import pytest
-from torch import nn
 from typing import Optional, Tuple
 
+import torch
 import tt_lib
-
+from models.demos.falcon7b.tt.falcon_lm_head import falcon_lm_head_matmul_2d
 from models.demos.falcon7b.tt.falcon_model import TtFalconModelShared
 from models.demos.falcon7b.tt.model_utils import get_weights_cached
+from models.utility_functions import torch_tensors_to_tt_tensors
 
 
 class TtFalconCausalLM(TtFalconModelShared):
@@ -24,9 +23,14 @@ class TtFalconCausalLM(TtFalconModelShared):
         max_position_embeddings,
         model_config,
         tt_cache_path,
+        seq_len,
+        optimized=False,
     ):
         assert base_url == "", "base_url should be empty at the root of the model!"
-
+        assert (
+            not optimized
+        ), "CausalLM does not support optimized mode at the moment"  # TODO: remove assert when prog_cache is supported for i2s_partial
+        model_config["OPTIMIZED_MODE"] = optimized
         super().__init__(
             devices=devices,
             state_dict=state_dict,
@@ -39,16 +43,51 @@ class TtFalconCausalLM(TtFalconModelShared):
         )
         self.num_devices = len(devices)
         self.model_config = model_config
+        self.seq_len = seq_len
 
-        lm_head_str = f"lm_head.weight"
+        lm_head_weight = None
+        if self.state_dict:
+            lm_head_weight = self.state_dict["lm_head.weight"]
+            lm_head_weight = torch.transpose(lm_head_weight, -2, -1)
+
+        if self.seq_len > 512:
+            # Optimization for lm_head matmul
+            self.num_slices = 4 if self.seq_len <= 1024 else 8
+            if lm_head_weight is not None:
+                PADDING = torch.zeros([64, lm_head_weight.shape[1] // self.num_slices])
+                lm_head_weights = torch.chunk(lm_head_weight, self.num_slices, dim=-1)
+                lm_head_weights_padded = [torch.cat([weight, PADDING], 0) for weight in lm_head_weights]
+            # Cache sliced weights for lm_head with different seq_len
+            self.lm_head_sliced_weights = [
+                get_weights_cached(
+                    devices,
+                    model_config,
+                    tt_cache_path,
+                    f"lm_head.weight_slice_{i}_of_{self.num_slices}",
+                    weight_config_str="LM_HEAD_MM_WEIGHTS",
+                    weights_to_cache=lm_head_weights_padded[i] if lm_head_weight is not None else None,
+                )
+                for i in range(self.num_slices)
+            ]
+            # Generate padding for lm_head > 512
+            padding = torch.zeros([1, 1, seq_len, 64])
+
+            tt_paddings = torch_tensors_to_tt_tensors(
+                [padding.detach().clone() for _ in range(self.num_devices)],
+                tt_lib.tensor.Layout.TILE,
+                self.model_config["LM_HEAD_MM_INPUT_DTYPE"],
+                self.model_config["LM_HEAD_MM_INPUT_MEMCFG"],
+                self.devices,
+            )
+            self.lm_head_padding = tt_paddings
 
         self.lm_head_weights = get_weights_cached(
             devices,
             model_config,
             tt_cache_path,
-            lm_head_str,
+            f"lm_head.weight",
             weight_config_str="LM_HEAD_MM_WEIGHTS",
-            weights_to_cache=(torch.transpose(self.state_dict[f"lm_head.weight"], -2, -1) if self.state_dict else None),
+            weights_to_cache=lm_head_weight,
         )
 
     def forward(
@@ -71,16 +110,28 @@ class TtFalconCausalLM(TtFalconModelShared):
             use_cache=use_cache,
         )
 
-        lm_logits = []
-        for i in range(self.num_devices):
-            lm_logits.append(
+        if hidden_states[0].get_legacy_shape()[-2] > 512 and self.model_config["OPTIMIZED_MODE"]:
+            lm_logits = [
+                falcon_lm_head_matmul_2d(
+                    hidden_states[device_id],
+                    [weights[device_id] for weights in self.lm_head_sliced_weights],
+                    self.num_slices,
+                    lm_head_padding=self.lm_head_padding[device_id],
+                    out_mem_config=self.model_config["LM_HEAD_MM_OUTPUT_MEMCFG"],
+                    out_dtype=self.model_config["LM_HEAD_MM_OUTPUT_DTYPE"],
+                )
+                for device_id in range(self.num_devices)
+            ]
+        else:
+            lm_logits = [
                 tt_lib.tensor.falcon_lm_head_matmul(
-                    hidden_states[i],
-                    self.lm_head_weights[i],
+                    hidden_states[device_id],
+                    self.lm_head_weights[device_id],
                     bias=None,
                     output_mem_config=self.model_config["LM_HEAD_MM_OUTPUT_MEMCFG"],
                     output_dtype=self.model_config["LM_HEAD_MM_OUTPUT_DTYPE"],
                 )
-            )
+                for device_id in range(self.num_devices)
+            ]
 
         return lm_logits, presents

--- a/models/demos/falcon7b/tt/falcon_mlp.py
+++ b/models/demos/falcon7b/tt/falcon_mlp.py
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from torch import nn
 import tt_lib
-
-from models.utility_functions import torch2tt_tensor
+import ttnn
 from models.demos.falcon7b.tt.model_utils import get_weights_cached
+from models.utility_functions import torch2tt_tensor
+from torch import nn
 
 
-class TtFalconMLP(nn.Module):
+class TtFalconMLPPrefill(nn.Module):
     def __init__(
         self,
         devices,
@@ -18,19 +18,37 @@ class TtFalconMLP(nn.Module):
         base_url,
         layer_num,
         hidden_size: int,
+        max_position_embeddings,
         model_config,
         tt_cache_path,
+        weights_dict=None,
     ):
         super().__init__()
 
         self.state_dict = state_dict
         self.devices = devices
+        self.num_devices = len(devices)
         self.hidden_size = hidden_size
         self.model_config = model_config
+        self.max_position_embeddings = max_position_embeddings
+        self.padding_value = model_config["MLP_PADDING_VALUE"]
+        self.seq_len = model_config["MLP_SEQ_LEN"]
+        # Padding tensor for 1024 and 2048 sequence lengths
 
         layer_name = f"{base_url}.{layer_num}"
         dense_h_to_4h_str = f"{layer_name}.mlp.dense_h_to_4h.weight"
         dense_4h_to_h_str = f"{layer_name}.mlp.dense_4h_to_h.weight"
+
+        custom_output_shape_h_to_4h = (
+            (1, 1, self.padding_value, 4 * self.padding_value)
+            if (self.seq_len in [1024, 2048]) and model_config["OPTIMIZED_MODE"]
+            else None
+        )
+        custom_output_shape_4h_to_h = (
+            (1, 1, 4 * self.padding_value, self.padding_value)
+            if (self.seq_len in [1024, 2048]) and model_config["OPTIMIZED_MODE"]
+            else None
+        )
 
         self.dense_h_to_4h_weights = get_weights_cached(
             devices,
@@ -39,6 +57,8 @@ class TtFalconMLP(nn.Module):
             dense_h_to_4h_str,
             weight_config_str="DENSE_H_TO_4H_MM_WEIGHTS",
             weights_to_cache=(torch.transpose(state_dict[dense_h_to_4h_str], -2, -1) if state_dict else None),
+            weights_dict=weights_dict,
+            custom_output_shape=custom_output_shape_h_to_4h,
         )
         self.dense_4h_to_h_weights = get_weights_cached(
             devices,
@@ -47,11 +67,238 @@ class TtFalconMLP(nn.Module):
             dense_4h_to_h_str,
             weight_config_str="DENSE_4H_TO_H_MM_WEIGHTS",
             weights_to_cache=(torch.transpose(state_dict[dense_4h_to_h_str], -2, -1) if state_dict else None),
+            weights_dict=weights_dict,
+            custom_output_shape=custom_output_shape_4h_to_h,
         )
+
+        if "MLP_PREFILL_PADDING_TENSORS" not in self.model_config and model_config["OPTIMIZED_MODE"]:
+            self._load_mlp_padded_tensors()
+        if "MLP_OUTPUT_TENSORS" not in self.model_config and model_config["OPTIMIZED_MODE"]:
+            self._allocate_output_mlp_tensors()
+
+    def _load_mlp_padded_tensors(self):
+        # Load MLP padded tensors for 1024 and 2048 if they are smaller than max_position_embeddings or equal
+        mlp_padding_tensors = []
+        for device_id in range(self.num_devices):
+            mlp_padding_tensor = dict()
+            for seq_len in [1024, 2048]:
+                # If explicitly set in model config, skip padding for larger sequence lengths, used for demo
+                if seq_len > self.max_position_embeddings:
+                    continue
+                tt_padding = torch.zeros((1, 1, seq_len, 64)).bfloat16().float()  # 4608 - 4544 = 64
+                tt_padding = ttnn.from_torch(
+                    tt_padding,
+                    ttnn.bfloat16,
+                    device=self.devices[device_id],
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
+                mlp_padding_tensor[seq_len] = tt_padding
+            mlp_padding_tensors.append(mlp_padding_tensor)
+
+        self.model_config["MLP_PREFILL_PADDING_TENSORS"] = mlp_padding_tensors
+
+    def _allocate_output_mlp_tensors(self):
+        # prepare output tensor on device
+        out_shape = [(1, 1, self.seq_len, self.dense_4h_to_h_weights[i].shape[-1]) for i in range(len(self.devices))]
+        out_tensors = [torch.zeros(out_shape[i]).bfloat16().float() for i in range(len(self.devices))]
+
+        out_tt = [
+            ttnn.from_torch(
+                out_tensors[i],
+                ttnn.bfloat16,
+                device=self.devices[i],
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            for i in range(len(self.devices))
+        ]
+        self.model_config["MLP_OUTPUT_TENSORS"] = out_tt
+
+    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+        if self.model_config["OPTIMIZED_MODE"] and self.seq_len in [1024, 2048]:
+            for device_id in range(self.num_devices):
+                tt_padding = self.model_config["MLP_PREFILL_PADDING_TENSORS"][device_id][self.seq_len]
+
+                x[device_id] = ttnn.concat([x[device_id], tt_padding], dim=3)
+
+            out_tt = self.model_config["MLP_OUTPUT_TENSORS"]
+
+            num_slices = 2 if self.seq_len == 2048 else 1  # seq_len = 1024 num_slices = 1
+            padded_hidden_size = self.model_config["MLP_PADDING_VALUE"]
+            grid_size = self.model_config["MLP_GRID_SIZE"]
+
+            for slice_idx in range(num_slices):
+                slices = [
+                    tt_lib.tensor.interleaved_to_sharded_partial(
+                        x[device_id],
+                        grid_size,
+                        [self.seq_len // num_slices // grid_size[1], padded_hidden_size // grid_size[0]],
+                        num_slices,
+                        slice_idx,
+                        tt_lib.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+                        tt_lib.tensor.ShardOrientation.ROW_MAJOR,
+                    )
+                    for device_id in range(len(self.devices))
+                ]
+
+                hidden_states = [
+                    ttnn.matmul(
+                        slices[device_id],
+                        self.dense_h_to_4h_weights[device_id],
+                        program_config=self.model_config["DENSE_H_TO_4H_MM_PROGCFG"],
+                        dtype=ttnn.bfloat16,
+                        memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+                        compute_kernel_config=self.model_config["MLP_KERNEL_CONFIG"],
+                    )
+                    for device_id in range(len(self.devices))
+                ]  # 4544 -> 4608
+                for i in range(len(self.devices)):
+                    slices[i].deallocate()
+
+                out_data = [
+                    ttnn.matmul(
+                        hidden_states[device_id],
+                        self.dense_4h_to_h_weights[device_id],
+                        program_config=self.model_config["DENSE_4H_TO_H_MM_PROGCFG"],
+                        dtype=ttnn.bfloat16,
+                        memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+                        compute_kernel_config=self.model_config["MLP_KERNEL_CONFIG"],
+                    )
+                    for device_id in range(len(self.devices))
+                ]
+                for i in range(len(self.devices)):
+                    hidden_states[i].deallocate()
+
+                for device_id in range(len(self.devices)):
+                    tt_lib.tensor.sharded_to_interleaved_partial(
+                        out_data[device_id],
+                        out_tt[device_id],
+                        num_slices,
+                        slice_idx,
+                        self.model_config["MLP_INTERLEAVED_TO_SHARDED_MEM_CFG"],
+                    )
+                    out_data[device_id].deallocate()
+
+            for device_id in range(len(self.devices)):
+                x[device_id].deallocate()
+                hidden_states[device_id].deallocate()
+
+            # remove padding from output
+            hidden_states = [out_tensor[:, :, :, : self.hidden_size] for out_tensor in out_tt]
+        else:
+            hidden_states = []
+            for device_id in range(len(x)):
+                hidden_states.append(
+                    tt_lib.tensor.falcon_dense_h_to_4h_matmul(
+                        x[device_id],
+                        self.dense_h_to_4h_weights[device_id],
+                        fused_activation=[tt_lib.tensor.FusibleActivation.GELU, True],
+                        output_mem_config=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"],
+                        output_dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
+                    )
+                )
+                x[device_id].deallocate()
+            for device_id in range(len(x)):
+                hidden_states[device_id] = tt_lib.tensor.falcon_dense_4h_to_h_matmul(
+                    hidden_states[device_id],
+                    self.dense_4h_to_h_weights[device_id],
+                    output_mem_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
+                    output_dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
+                    packer_l1_acc=True,
+                )
+
+        # return TT Tensor
+        return hidden_states
+
+
+class TtFalconMLPDecode(nn.Module):
+    def __init__(
+        self,
+        devices,
+        state_dict,
+        base_url,
+        layer_num,
+        hidden_size: int,
+        max_position_embeddings,
+        model_config,
+        tt_cache_path,
+        weights_dict=None,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.devices = devices
+        self.hidden_size = hidden_size
+        self.model_config = model_config
+        self.padding_value = model_config["MLP_PADDING_VALUE"]
+        self.prefill_seq_len = model_config["MLP_SEQ_LEN"]
+        self.max_position_embeddings = max_position_embeddings
+        layer_name = f"{base_url}.{layer_num}"
+        dense_h_to_4h_str = f"{layer_name}.mlp.dense_h_to_4h.weight"
+        dense_4h_to_h_str = f"{layer_name}.mlp.dense_4h_to_h.weight"
+
+        custom_output_shape_h_to_4h = (
+            (1, 1, self.padding_value, 4 * self.padding_value)
+            if self.prefill_seq_len in [1024, 2048] and model_config["OPTIMIZED_MODE"]
+            else None
+        )
+        custom_output_shape_4h_to_h = (
+            (1, 1, 4 * self.padding_value, self.padding_value)
+            if self.prefill_seq_len in [1024, 2048] and model_config["OPTIMIZED_MODE"]
+            else None
+        )
+
+        self.dense_h_to_4h_weights = get_weights_cached(
+            devices,
+            model_config,
+            tt_cache_path,
+            dense_h_to_4h_str,
+            weight_config_str="DENSE_H_TO_4H_MM_WEIGHTS",
+            weights_to_cache=(torch.transpose(state_dict[dense_h_to_4h_str], -2, -1) if state_dict else None),
+            weights_dict=weights_dict,
+            custom_output_shape=custom_output_shape_h_to_4h,
+        )
+        self.dense_4h_to_h_weights = get_weights_cached(
+            devices,
+            model_config,
+            tt_cache_path,
+            dense_4h_to_h_str,
+            weight_config_str="DENSE_4H_TO_H_MM_WEIGHTS",
+            weights_to_cache=(torch.transpose(state_dict[dense_4h_to_h_str], -2, -1) if state_dict else None),
+            weights_dict=weights_dict,
+            custom_output_shape=custom_output_shape_4h_to_h,
+        )
+        if "MLP_DECODE_PADDING_TENSORS" not in self.model_config and model_config["OPTIMIZED_MODE"]:
+            self._load_mlp_padded_tensors()
+
+    def _load_mlp_padded_tensors(self):
+        tt_paddings = []
+        for device_id in range(len(self.devices)):
+            tt_padding = torch.zeros((1, 1, 32, 64)).bfloat16().float()  # 4608 - 4544 = 64, batch=32
+            tt_padding = ttnn.from_torch(
+                tt_padding,
+                ttnn.bfloat16,
+                device=self.devices[device_id],
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            tt_paddings.append(tt_padding)
+
+        self.model_config["MLP_DECODE_PADDING_TENSORS"] = tt_paddings
 
     def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
         hidden_states = []
         for device_id in range(len(x)):
+            # pad inputs with padding tensor if not already padded
+            if (
+                x[device_id].shape[-1] < self.padding_value
+                and self.prefill_seq_len in [1024, 2048]
+                and self.model_config["OPTIMIZED_MODE"]
+            ):
+                x[device_id] = ttnn.concat(
+                    [x[device_id], self.model_config["MLP_DECODE_PADDING_TENSORS"][device_id]], dim=3
+                )
             hidden_states.append(
                 tt_lib.tensor.falcon_dense_h_to_4h_matmul(
                     x[device_id],
@@ -70,6 +317,9 @@ class TtFalconMLP(nn.Module):
                 output_dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
                 packer_l1_acc=True,
             )
+        # remove padding from output
+        if self.prefill_seq_len in [1024, 2048] and self.model_config["OPTIMIZED_MODE"]:
+            hidden_states = [hidden_states[i][:, :, :, : self.hidden_size] for i in range(len(self.devices))]
 
         # return TT Tensor
         return hidden_states

--- a/models/demos/falcon7b/tt/model_utils.py
+++ b/models/demos/falcon7b/tt/model_utils.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
 import tt_lib
 
 from models.utility_functions import torch2tt_tensor, pad_by_zero
@@ -17,20 +18,35 @@ def get_weights_cached(
     overwrite=False,
     padzero=False,
     tt_layout=tt_lib.tensor.Layout.TILE,
+    weights_dict=None,
+    custom_output_shape=None,
 ):
     if padzero:
         assert tt_layout == tt_lib.tensor.Layout.TILE, "padding by zero currently only uses TILE layout"
 
-    """Load cached weights and duplicate per device. Store if not cached."""
-    if (
-        not overwrite
-        and (tt_cache_path / f"{weight_cache_str}_{model_config[f'{weight_config_str}_DTYPE'].name}.bin").exists()
-    ):
+    """Load weights from weights_dict or cache and duplicate per device. Store if not cached."""
+    custom_output_shape_str = ""
+    if custom_output_shape is not None:
+        custom_output_shape_str = f"_{custom_output_shape[-2]}_{custom_output_shape[-1]}"
+    path = (
+        tt_cache_path
+        / f"{weight_cache_str}_{model_config[f'{weight_config_str}_DTYPE'].name}{custom_output_shape_str}.bin"
+    )
+
+    if weights_dict and str(path) in weights_dict.keys():
+        weights = weights_dict[str(path)]
+    elif not overwrite and path.exists():
         # Load cached weights
-        weights_host = tt_lib.tensor.load_tensor(
-            str(tt_cache_path / f"{weight_cache_str}_{model_config[f'{weight_config_str}_DTYPE'].name}.bin")
-        )
+        weights_host = tt_lib.tensor.load_tensor(str(path))
+        # Duplicate weights on all devices
+        weights = [weights_host.to(device, model_config[f"{weight_config_str}_MEMCFG"]) for device in devices]
+        # Add to weights_dict
+        if weights_dict is not None:
+            weights_dict[str(path)] = weights
     else:
+        if weights_to_cache is None:
+            raise ValueError(f"weights_to_cache is None for {weight_cache_str}")
+
         if padzero:
             weights_host = pad_by_zero(
                 weights_to_cache,
@@ -39,6 +55,15 @@ def get_weights_cached(
                 tt_dtype=model_config[f"{weight_config_str}_DTYPE"],
             )[0]
         else:
+            if custom_output_shape is not None:
+                padding = (
+                    0,
+                    custom_output_shape[-1] - weights_to_cache.shape[-1],
+                    0,
+                    custom_output_shape[-2] - weights_to_cache.shape[-2],
+                )
+                weights_to_cache = torch.nn.functional.pad(weights_to_cache, padding, "constant", 0.0)
+
             weights_host = torch2tt_tensor(
                 weights_to_cache,
                 tt_device=None,
@@ -46,13 +71,12 @@ def get_weights_cached(
                 tt_memory_config=model_config[f"{weight_config_str}_MEMCFG"],
                 tt_dtype=model_config[f"{weight_config_str}_DTYPE"],
             )
-        # Store weights
-        tt_lib.tensor.dump_tensor(
-            str(tt_cache_path / f"{weight_cache_str}_{model_config[f'{weight_config_str}_DTYPE'].name}.bin"),
-            weights_host,
-        )
 
-    # Duplicate weights on all devices
-    weights = [weights_host.to(device, model_config[f"{weight_config_str}_MEMCFG"]) for device in devices]
+        weights = [weights_host.to(device, model_config[f"{weight_config_str}_MEMCFG"]) for device in devices]
+        # Save weights for reuse between prefill/decode
+        if weights_dict is not None:
+            weights_dict[str(path)] = weights[0]
+        # Store weights
+        tt_lib.tensor.dump_tensor(str(path), weights_host)
 
     return weights


### PR DESCRIPTION
Code contains couple of features: 
- Split decode and prefill implementations of attn and mlp into subclasses
    - prefill and decode reuse weights between object for mlp and attn
    - 
- Optimize Falcon LM head for seq_len > 512
- Optimize prefill for seq_lens 128,1024 and 2048 
