### PR TITLE
#0: Revert "#6775: uneven sharding add padding for widht and block"

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_core.py
+++ b/tests/ttnn/unit_tests/operations/test_core.py
@@ -285,23 +285,6 @@ class DirectReadWriteType(Enum):
                 strategy=ttnn.ShardStrategy.WIDTH,
             ),
         ),
-        # only direct transfers for this size work, there is an interleaved_to_sharded and sharded_to_interleaved bug
-        # Issue: 7725
-        (
-            [1, 1, 8192, 512],
-            [320, 1024],
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 4)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.BLOCK,
-                orientation=ttnn.ShardOrientation.COL_MAJOR,
-            ),
-        ),
     ],
 )
 def test_shard_with_corerangeset(

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -606,9 +606,7 @@ std::vector<uint32_t> Tensor::host_page_ordering(){
     std::vector<uint32_t> ret_vec;
     ret_vec.reserve(num_pages);
     for(int page_id = 0; page_id <num_pages ; page_id++){
-        if(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id].has_value()) {
-            ret_vec.push_back(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id].value());
-        }
+        ret_vec.push_back(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id]);
     }
     return ret_vec;
 }
@@ -665,8 +663,6 @@ Tensor create_device_tensor(const Shape& shape, DataType data_type, Layout layou
     auto device_buffer = tensor_impl::allocate_buffer_on_device(packed_size_in_bytes, device, shape, data_type, layout, memory_config);
     return Tensor(DeviceStorage{device_buffer}, shape, data_type, layout);
 }
-
-
 
 Tensor create_sharded_device_tensor(const Shape& shape, DataType data_type, Layout layout, Device *device, const MemoryConfig& memory_config) {
     ZoneScoped;

--- a/tt_eager/tensor/tensor_impl.cpp
+++ b/tt_eager/tensor/tensor_impl.cpp
@@ -129,11 +129,11 @@ DeviceBuffer allocate_sharded_buffer_on_device(uint32_t buffer_size_bytes, Devic
     if (memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         TT_ASSERT(total_width == shard_shape[1], fmt::format("Shard shape {} does not divide tensor shape {} correctly according to sharding scheme", shard_shape[1], total_width));
         uint32_t num_shards = div_up(total_height, shard_shape[0]);
-        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} cannot exceed number {}", num_shards, num_cores));
+        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} must match number of cores {}", num_shards, num_cores));
     } else if (memory_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
         TT_ASSERT(total_height == shard_shape[0], "Shard shape does not divide tensor shape correctly according to sharding scheme");
         uint32_t num_shards = div_up(total_width, shard_shape[1]);
-        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} cannot exceed number {}", num_shards, num_cores));
+        TT_ASSERT(num_shards <= num_cores, fmt::format("Number of shards {} must match number of cores {}", num_shards, num_cores));
     } else if (memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         TT_ASSERT(shard_spec.grid.ranges().size() == 1, "Shard grid must be one full rectangular grid for block sharded!");
         uint32_t num_shards_along_height = div_up(total_height, shard_shape[0]);

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -24,6 +24,7 @@ bool is_sharded(const TensorMemoryLayout & layout){
         layout == TensorMemoryLayout::BLOCK_SHARDED );
 }
 
+
 void validate_buffer_size_and_page_size(uint64_t size, uint64_t page_size, const BufferType &buffer_type, const TensorMemoryLayout &buffer_layout, std::optional<ShardSpecBuffer> shard_parameters) {
     TT_FATAL(size != 0 and page_size != 0, "Buffer size and page size should be larger than 0 bytes!");
     bool valid_page_size = (size % page_size == 0);
@@ -38,7 +39,7 @@ void validate_buffer_size_and_page_size(uint64_t size, uint64_t page_size, const
 }
 
 
-inline std::tuple< std::vector< std::vector<uint32_t> > , std::vector<std::array<uint32_t, 2> > > core_to_host_pages(
+inline std::vector< std::vector<uint32_t> > core_to_host_pages(
                                                     const uint32_t & total_pages,
                                                     const uint32_t & pages_per_shard,
                                                     const uint32_t & num_shards,
@@ -49,10 +50,9 @@ inline std::tuple< std::vector< std::vector<uint32_t> > , std::vector<std::array
 {
 
 
-    std::array<uint32_t, 2> shard_in_pages = {shard_shape[0]/page_shape[0], shard_shape[1]/page_shape[1]};
     std::vector < std::vector<uint32_t> > ret_vec(num_shards);
-    std::vector < std::array<uint32_t, 2> > ret_shard_shape(num_shards, shard_in_pages);
 
+    std::array<uint32_t, 2> shard_in_pages = {shard_shape[0]/page_shape[0], shard_shape[1]/page_shape[1]};
 
     if( layout == TensorMemoryLayout:: HEIGHT_SHARDED) {
         uint32_t num_pages_per_shard = pages_per_shard;
@@ -80,19 +80,16 @@ inline std::tuple< std::vector< std::vector<uint32_t> > , std::vector<std::array
             ret_vec[shard_idx].reserve(pages_per_shard);
 
             uint32_t host_idx = 0;
-            uint32_t i = 0;
-            uint32_t j = 0;
-            for(i=i_offset; i<(shard_in_pages[0] + i_offset); i++) {
+            for(uint32_t i=i_offset; i<(shard_in_pages[0] + i_offset); i++) {
                 if (i >= tensor2d_size[0]) {
                     break;
                 }
-                for(j=j_offset; j<(shard_in_pages[1] + j_offset) and (j < (tensor2d_size[1])); j++) {
+                for(uint32_t j=j_offset; j<(shard_in_pages[1] + j_offset) and (j < (tensor2d_size[1])); j++) {
                     uint32_t host_page = i*tensor2d_size[1] + j;
                     ret_vec[shard_idx].push_back(host_page);
                     host_idx++;
                 }
             }
-            ret_shard_shape[shard_idx] = {i - i_offset, j - j_offset};
             if(((shard_in_row + 1) == (num_shard_columns))) {
                 shard_in_row = 0;
                 j_offset = 0;
@@ -104,7 +101,7 @@ inline std::tuple< std::vector< std::vector<uint32_t> > , std::vector<std::array
             }
         }
     }
-    return {ret_vec, ret_shard_shape};
+    return ret_vec;
 }
 
 
@@ -125,48 +122,32 @@ BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer) {
 
     BufferPageMapping buffer_page_mapping;
     auto row_major = buffer.shard_spec().orientation() == ShardOrientation::ROW_MAJOR;
-    uint32_t num_cores = buffer.num_cores();
-
-    buffer_page_mapping.all_cores_ = corerange_to_cores(buffer.shard_spec().grid(), num_cores, row_major);
-    TT_ASSERT(num_cores == buffer_page_mapping.all_cores_.size());
+    buffer_page_mapping.all_cores_ = corerange_to_cores(buffer.shard_spec().grid(), buffer.num_cores(), row_major);
+    TT_ASSERT(buffer.num_cores() == buffer_page_mapping.all_cores_.size());
     uint32_t core_id = 0;
     for(auto core: buffer_page_mapping.all_cores_){
         buffer_page_mapping.core_to_core_id_.insert({core, core_id });
         core_id++;
     }
+    auto core_host_page_indices = core_to_host_pages(buffer.shard_spec().size() * buffer.num_cores(), buffer.shard_spec().size(), buffer.num_cores(), buffer.buffer_layout(), buffer.shard_spec().page_shape, buffer.shard_spec().shape(), buffer.shard_spec().tensor2d_shape);
 
-    uint32_t num_dev_pages = buffer.shard_spec().size() *  num_cores;
-    auto [core_host_page_indices, shard_shape] = core_to_host_pages(num_dev_pages, buffer.shard_spec().size(), num_cores, buffer.buffer_layout(), buffer.shard_spec().page_shape, buffer.shard_spec().shape(), buffer.shard_spec().tensor2d_shape);
+    auto total_dev_pages = buffer.num_pages();
+    buffer_page_mapping.core_host_page_indices_ = std::vector< std::vector<uint32_t>>(buffer.num_cores());
+    buffer_page_mapping.dev_page_to_host_page_mapping_ = std::vector<uint32_t>(total_dev_pages);
+    buffer_page_mapping.dev_page_to_core_mapping_ = std::vector<uint32_t>(total_dev_pages);
+    buffer_page_mapping.host_page_to_local_shard_page_mapping_ = std::vector<uint32_t>(total_dev_pages);
+    buffer_page_mapping.host_page_to_dev_page_mapping_= std::vector<uint32_t>(total_dev_pages);
 
-    buffer_page_mapping.core_host_page_indices_ = std::vector< std::vector<uint32_t>>(num_cores);
-    buffer_page_mapping.dev_page_to_host_page_mapping_.reserve(num_dev_pages);
-    buffer_page_mapping.dev_page_to_core_mapping_.reserve(num_dev_pages);
-    buffer_page_mapping.host_page_to_local_shard_page_mapping_ = std::vector<uint32_t>(buffer.num_pages());
-    buffer_page_mapping.host_page_to_dev_page_mapping_= std::vector<uint32_t>(buffer.num_pages());
-    buffer_page_mapping.core_shard_shape_ = shard_shape;
     int dev_page_index = 0;
-
-    auto shape_in_pages = buffer.shard_spec().shape_in_pages();
     for(uint32_t core_index = 0; core_index < core_host_page_indices.size() ; core_index++){
-
-        uint32_t valid_shard_page = 0;
-        for(uint32_t shard_page_x = 0; shard_page_x < shape_in_pages[0] ; shard_page_x++){
-            for(uint32_t shard_page_y = 0; shard_page_y < shape_in_pages[1]; shard_page_y++) {
-                uint32_t shard_page_id = shard_page_x * shape_in_pages[1] + shard_page_y;
-                buffer_page_mapping.core_host_page_indices_[core_index].reserve(buffer.shard_spec().size());
-                buffer_page_mapping.dev_page_to_core_mapping_.push_back(core_index);
-                std::optional<uint32_t> host_page_opt = std::nullopt;
-                if(shard_page_x < buffer_page_mapping.core_shard_shape_[core_index][0] and shard_page_y < buffer_page_mapping.core_shard_shape_[core_index][1]) {
-                    auto host_page = core_host_page_indices[core_index][valid_shard_page];
-                    if(host_page < buffer.num_pages()) {
-                        host_page_opt = host_page;
-                        buffer_page_mapping.core_host_page_indices_[core_index].push_back(host_page);
-                        buffer_page_mapping.host_page_to_local_shard_page_mapping_[host_page] = shard_page_id;
-                        buffer_page_mapping.host_page_to_dev_page_mapping_[host_page] = dev_page_index;
-                    }
-                    valid_shard_page++;
-                }
-                buffer_page_mapping.dev_page_to_host_page_mapping_.push_back(host_page_opt);
+        for(uint32_t shard_page_id = 0; shard_page_id < core_host_page_indices[core_index].size() ; shard_page_id++){
+            auto host_page = core_host_page_indices[core_index][shard_page_id];
+            if(host_page < total_dev_pages) {
+                buffer_page_mapping.core_host_page_indices_[core_index].push_back(host_page);
+                buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index] = core_index;
+                buffer_page_mapping.dev_page_to_host_page_mapping_[dev_page_index] = host_page;
+                buffer_page_mapping.host_page_to_local_shard_page_mapping_[host_page] = shard_page_id;
+                buffer_page_mapping.host_page_to_dev_page_mapping_[host_page] = dev_page_index;
                 dev_page_index++;
             }
         }

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -44,11 +44,6 @@ enum class ShardOrientation {
 };
 
 
-uint32_t get_num_cores_from_shape(const TensorMemoryLayout & layout, const uint32_t total_height, const uint32_t total_width, const std::array<uint32_t, 2> & shard_shape);
-
-
-
-
 struct ShardSpec {
     CoreRangeSet grid;
     std::array<uint32_t, 2> shape;
@@ -63,7 +58,7 @@ struct ShardSpec {
                     orientation(shard_orientation_), halo(halo_)
                     {;}
 
-    const uint32_t num_cores() const {return this->grid.num_cores();}
+    const uint32_t num_cores() const { return this->grid.num_cores(); }
     const uint32_t numel() const { return this->shape[0] * this->shape[1]; }
     tt::stl::reflection::Attributes attributes() const;
 
@@ -108,14 +103,11 @@ struct ShardSpecBuffer {
     bool halo() const {
         return tensor_shard_spec.halo;
     }
-    std::array<uint32_t, 2> shape_in_pages() const {
+    uint32_t size() const{
         auto width_in_pages = tensor_shard_spec.shape[0] / page_shape[0];
         auto height_in_pages = tensor_shard_spec.shape[1] / page_shape[1];
-        return {width_in_pages, height_in_pages};
-    }
-    uint32_t size() const{
-        auto shape_in_pages_ = this->shape_in_pages();
-        return shape_in_pages_[0] * shape_in_pages_[1];
+        return width_in_pages * height_in_pages;
+
     }
 };
 
@@ -148,17 +140,11 @@ struct BufferPageMapping {
     std::vector< uint32_t> core_bank_indices_;
     std::vector< std::vector<uint32_t> > core_host_page_indices_;
     std::vector<uint32_t> dev_page_to_core_mapping_;
-
-    //some dev pages don't have mapping to host (in case of padding)
-    std::vector<std::optional<uint32_t> > dev_page_to_host_page_mapping_;
+    std::vector<uint32_t> dev_page_to_host_page_mapping_;
     std::vector<uint32_t> host_page_to_dev_page_mapping_;
     std::unordered_map<CoreCoord, uint32_t> core_to_core_id_;
     std::vector< uint32_t> host_page_to_local_shard_page_mapping_;
-    std::vector < std::array<uint32_t, 2> > core_shard_shape_;
-
 };
-
-
 
 class Buffer {
    public:
@@ -191,15 +177,6 @@ class Buffer {
     uint32_t page_size() const { return page_size_; }
 
     uint32_t num_pages() const { return this->size() / this->page_size(); }
-
-    uint32_t num_dev_pages() const {
-        if (!is_sharded(this->buffer_layout_)) {
-            return this->num_pages();
-        }
-        else {
-            return this->shard_spec().size() * this->num_cores();
-        }
-    }
 
     BufferType buffer_type() const { return buffer_type_; }
 
@@ -235,6 +212,7 @@ class Buffer {
             return this->shard_spec().tensor_shard_spec.grid.num_cores();
         }
     }
+
 
    private:
     void allocate();

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -369,7 +369,7 @@ struct IssuedReadData {
     TensorMemoryLayout buffer_layout;
     uint32_t page_size;
     uint32_t padded_page_size;
-    std::optional< vector<std::optional<uint32_t> > > dev_page_to_host_page_mapping;
+    vector<uint32_t> dev_page_to_host_page_mapping;
     void* dst;
     uint32_t dst_offset;
     uint32_t num_pages_read;
@@ -379,8 +379,7 @@ struct IssuedReadData {
         this->buffer_layout = buffer.buffer_layout();
         this->page_size = buffer.page_size();
         this->padded_page_size = padded_page_size;
-        if (this->buffer_layout == TensorMemoryLayout::WIDTH_SHARDED or
-            this->buffer_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        if (this->buffer_layout == TensorMemoryLayout::WIDTH_SHARDED or this->buffer_layout == TensorMemoryLayout::BLOCK_SHARDED) {
             auto buffer_page_mapping = generate_buffer_page_mapping(buffer);
             this->dev_page_to_host_page_mapping = buffer_page_mapping.dev_page_to_host_page_mapping_;
         }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -356,7 +356,7 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
 
 
         int output_page_index = 0;
-        auto total_pages = buffer.num_dev_pages();
+        auto total_pages = buffer.num_pages();
         uint32_t page_size = buffer.page_size();
         uint32_t bytes_per_page_entry = sizeof(uint32_t);
         uint32_t num_entries_per_page = page_size / bytes_per_page_entry;
@@ -368,29 +368,27 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
             auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_id]];
             auto bank_id = device->bank_ids_from_logical_core(core)[0];
             auto host_page_id = buffer_page_mapping.dev_page_to_host_page_mapping_[dev_page_id];
-            if(host_page_id.has_value()) {
-                if(!shard_order){
-                    read_pages_to_host_helper(
-                        device,
-                        buffer,
-                        host_buffer,
-                        page_size,
-                        host_page_id.value(),
-                        dev_page_id,
-                        bank_id
-                    );
-                }
-                else{
-                    read_pages_to_host_helper(
-                        device,
-                        buffer,
-                        host_buffer,
-                        page_size,
-                        dev_page_id,
-                        dev_page_id,
-                        bank_id
-                    );
-                }
+            if(!shard_order){
+                read_pages_to_host_helper(
+                    device,
+                    buffer,
+                    host_buffer,
+                    page_size,
+                    host_page_id,
+                    dev_page_id,
+                    bank_id
+                );
+            }
+            else{
+                read_pages_to_host_helper(
+                    device,
+                    buffer,
+                    host_buffer,
+                    page_size,
+                    dev_page_id,
+                    dev_page_id,
+                    bank_id
+                );
             }
         }
 


### PR DESCRIPTION
This reverts commit 58dc4f46f9a51ae3c9f11d0d05a7ac6407a94d7d, as it regressed model e2e perf for resnet.

@tarafdarTT @pavlepopovic 