### PR TITLE
#6872: Use HiFi2 to improve Falcon40b prefill PCC with activations in FP16

### DIFF
--- a/models/demos/falcon40b/demo/demo.py
+++ b/models/demos/falcon40b/demo/demo.py
@@ -583,7 +583,7 @@ def test_demo(
 
     # Set it up for prefill initially and change the model_config to decode
     model_config_str_for_decode = "BFLOAT8_B-SHARDED"  # Decode model config
-    model_config = get_model_config("BFLOAT8_B-DRAM", "prefill", [1, 32], num_devices)  # Prefill model config
+    model_config = get_model_config("BFLOAT16-DRAM", "prefill", [1, 32], num_devices)  # Prefill model config
     model_version = model_config_entries["_name_or_path"]
     tt_cache_path = get_tt_cache_path(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]

--- a/models/demos/falcon40b/tests/ci/test_falcon_end_to_end_t3000_prefill.py
+++ b/models/demos/falcon40b/tests/ci/test_falcon_end_to_end_t3000_prefill.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from models.demos.falcon40b.tests.test_falcon_end_to_end import run_test_FalconCausalLM_end_to_end
+from models.demos.falcon40b.tt.model_config import (
+    get_model_config,
+)
+from models.utility_functions import (
+    disable_persistent_kernel_cache,
+    disable_compilation_reports,
+    skip_for_grayskull,
+    get_devices_for_t3000,
+)
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "llm_mode, batch, seq_len, kv_cache_len",
+    (
+        ("prefill", 1, 128, 0),
+        ("prefill", 1, 2048, 0),
+    ),
+    ids=[
+        "prefill_seq128",
+        "prefill_seq2048",
+    ],
+)
+@pytest.mark.parametrize(
+    "num_layers, out_pcc, cache_pcc, token_pcc",
+    ((1, 0.99, 0.99, 0.99),),
+    ids=["layers_1"],
+)
+@pytest.mark.parametrize(
+    "model_version",
+    ("tiiuae/falcon-40b-instruct",),
+    ids=["falcon_40b"],
+)
+@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-DRAM", "BFLOAT16-DRAM"))
+def test_FalconCausalLM_prefill_end_to_end_t3000_ci(
+    model_version,
+    llm_mode,
+    batch,
+    seq_len,
+    kv_cache_len,
+    num_layers,
+    out_pcc,
+    cache_pcc,
+    token_pcc,
+    model_config_str,
+    model_location_generator,
+    get_tt_cache_path,
+    all_devices,
+    use_program_cache,
+):
+    num_devices = 8
+    input_shape = [batch, seq_len]
+    model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
+    devices = get_devices_for_t3000(all_devices, num_devices)
+    compute_grid_size = devices[0].compute_with_storage_grid_size()
+    if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
+        pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
+
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
+
+    disable_persistent_kernel_cache()
+    disable_compilation_reports()
+
+    run_test_FalconCausalLM_end_to_end(
+        devices,
+        model_version,
+        llm_mode,
+        batch,
+        seq_len,
+        kv_cache_len,
+        num_layers,
+        out_pcc,
+        cache_pcc,
+        token_pcc,
+        model_config,
+        tt_cache_path,
+        model_location_generator,
+    )

--- a/models/demos/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/falcon40b/tests/test_falcon_attention.py
@@ -342,8 +342,9 @@ def run_test_FalconAttention_inference(
         ("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99),
         ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99),
         ("BFLOAT8_B-DRAM", 0.99, 0.99, 0.99),
+        ("BFLOAT16-DRAM", 0.99, 0.99, 0.99),
     ],
-    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM"],
+    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
 def test_FalconAttention_inference(
     num_devices,
@@ -361,7 +362,7 @@ def test_FalconAttention_inference(
     all_devices,
     # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
-    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
     if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
         pytest.skip("Decode is only supported for SHARDED memory config!")

--- a/models/demos/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon40b/tests/test_falcon_causallm.py
@@ -322,8 +322,9 @@ def run_test_FalconCausalLM_inference(
         ("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99),
         ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99),
         ("BFLOAT8_B-DRAM", 0.99, 0.99, 0.99),
+        ("BFLOAT16-DRAM", 0.99, 0.99, 0.99),
     ],
-    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM"],
+    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
 def test_FalconCausalLM_inference(
     num_devices,
@@ -343,7 +344,7 @@ def test_FalconCausalLM_inference(
     all_devices,
     # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
-    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
     if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
         pytest.skip("Decode is only supported for SHARDED memory config!")

--- a/models/demos/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon40b/tests/test_falcon_decoder.py
@@ -366,8 +366,9 @@ def run_test_FalconDecoder_inference(
         ("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99),
         ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99),
         ("BFLOAT8_B-DRAM", 0.99, 0.99, 0.99),
+        ("BFLOAT8_B-DRAM", 0.99, 0.99, 0.99),
     ],
-    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM"],
+    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
 def test_FalconDecoder_inference(
     num_devices,
@@ -387,7 +388,7 @@ def test_FalconDecoder_inference(
     all_devices,
     # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
-    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
     if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
         pytest.skip("Decode is only supported for SHARDED memory config!")

--- a/models/demos/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon40b/tests/test_falcon_end_to_end.py
@@ -414,7 +414,7 @@ def run_test_FalconCausalLM_end_to_end(
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
-@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-SHARDED", "BFLOAT8_B-DRAM"))
+@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"))
 def test_FalconCausalLM_end_to_end_with_program_cache(
     num_devices,
     model_version,
@@ -434,13 +434,10 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     all_devices,
     # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
-    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
-        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config and 8 chips!")
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
     if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
         pytest.skip("Decode is only supported for SHARDED memory config!")
-
-    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
-        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config and 8 chips!")
 
     if llm_mode == "prefill":
         if num_layers == 60:

--- a/models/demos/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/falcon40b/tests/test_falcon_mlp.py
@@ -125,8 +125,9 @@ def run_test_FalconMLP_inference(
         ("BFLOAT8_B-SHARDED", 0.9986),
         ("BFLOAT16-SHARDED", 0.9986),
         ("BFLOAT8_B-DRAM", 0.9983),
+        ("BFLOAT16-DRAM", 0.9986),
     ],
-    ids=("BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM"),
+    ids=("BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"),
 )
 def test_FalconMLP_inference(
     num_devices,
@@ -141,8 +142,8 @@ def test_FalconMLP_inference(
     all_devices,
     # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
-    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
-        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config and 8 chips!")
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
     if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
         pytest.skip("Decode is only supported for SHARDED memory config!")
 

--- a/models/demos/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/falcon40b/tests/test_falcon_model.py
@@ -320,8 +320,9 @@ def run_test_FalconModel_inference(
         ("BFLOAT8_B-SHARDED", 0.99, 0.99, 0.99),
         ("BFLOAT16-SHARDED", 0.99, 0.99, 0.99),
         ("BFLOAT8_B-DRAM", 0.99, 0.99, 0.99),
+        ("BFLOAT16-DRAM", 0.99, 0.99, 0.99),
     ],
-    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM"],
+    ids=["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"],
 )
 def test_FalconModel_inference(
     num_devices,
@@ -340,8 +341,8 @@ def test_FalconModel_inference(
     all_devices,
     # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
 ):
-    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
-        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config and 8 chips!")
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
     if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
         pytest.skip("Decode is only supported for SHARDED memory config!")
 

--- a/models/demos/falcon40b/tests/test_falcon_prefill_determinism.py
+++ b/models/demos/falcon40b/tests/test_falcon_prefill_determinism.py
@@ -250,7 +250,13 @@ def run_test_falcon_prefill_end_to_end_determinism(
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
-@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-DRAM",))
+@pytest.mark.parametrize(
+    "model_config_str",
+    (
+        "BFLOAT8_B-DRAM",
+        "BFLOAT16-DRAM",
+    ),
+)
 def test_falcon_prefill_end_to_end_determinism(
     generate_weights,
     enable_program_cache,
@@ -267,8 +273,6 @@ def test_falcon_prefill_end_to_end_determinism(
     all_devices,
 ):
     num_devices = 8
-    if model_config_str not in ["BFLOAT8_B-DRAM"]:
-        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config!")
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, "prefill", input_shape, num_devices)

--- a/models/demos/falcon40b/tt/falcon_attention.py
+++ b/models/demos/falcon40b/tt/falcon_attention.py
@@ -485,7 +485,7 @@ class TtFalconAttention:
                 tt_lib.operations.primary.matmul(
                     q_slices[i],
                     key_layer_transposed[i],
-                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_HIFI2_CONFIG_FP16_DEST"],
+                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_FP16_ACC_CONFIG"],
                     output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
                     program_config=self.model_config["ATTENTION_MM_PROGCFG"],
                     output_dtype=self.model_config["ATTENTION_DTYPE"],
@@ -508,7 +508,7 @@ class TtFalconAttention:
                 tt_lib.operations.primary.matmul(
                     attn_weights[i],
                     value_layer[i],
-                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_HIFI2_CONFIG_FP16_DEST"],
+                    compute_kernel_config=self.model_config["COMPUTE_KERNEL_FP16_ACC_CONFIG"],
                     output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
                     program_config=self.model_config["ATTENTION_MM_2_PROGCFG"],
                     output_dtype=self.model_config["ATTENTION_DTYPE"],

--- a/models/demos/falcon40b/tt/model_config.py
+++ b/models/demos/falcon40b/tt/model_config.py
@@ -793,19 +793,13 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
         "ALL_GATHER_NUM_LINKS": 2 if num_devices == 4 else 1,
         "DEFAULT_CACHE_PATH": Path(f"models/demos/falcon40b/datasets/"),
         "COMPUTE_KERNEL_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            math_fidelity=ttl.tensor.MathFidelity.HiFi2,
             math_approx_mode=True,
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         ),
-        "COMPUTE_KERNEL_HIFI2_CONFIG_FP16_DEST": ttl.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttl.tensor.MathFidelity.HiFi2,
-            math_approx_mode=True,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=True,
-        ),
         "COMPUTE_KERNEL_FP16_ACC_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            math_fidelity=ttl.tensor.MathFidelity.HiFi2,
             math_approx_mode=True,
             fp32_dest_acc_en=False,
             packer_l1_acc=True,

--- a/tests/scripts/multi_chip/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/multi_chip/run_pre_post_commit_regressions_multi_device.sh
@@ -33,10 +33,8 @@ pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausal
 pytest models/demos/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips-enable_program_cache]
 pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips-enable_program_cache]
 
-# Falcon40B 8 chip prefill tests; we need 8x8 grid size for prefill tests on wormhole_b0
-WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq32-8chips-disable_program_cache]
-WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips-disable_program_cache]
-WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq2048-8chips-disable_program_cache]
+# Falcon40B 8 chip prefill tests; we need 8x8 grid size
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon40b/tests/ci/test_falcon_end_to_end_t3000_prefill.py
 
 pytest tests/ttnn/unit_tests/test_multi_device.py
 pytest tests/ttnn/unit_tests/test_multi_device_async.py


### PR DESCRIPTION
Using HiFi2 with FP16 activations brings us to 0.99 PCC on both output and K/V cache.

With LoFi we had a big PCC drop throughout the layers (down to 0.6). More info in the issue: https://github.com/tenstorrent/tt-metal/issues/6872.

Multi chip post commit: https://github.com/tenstorrent/tt-metal/actions/runs/8830484126