### PR TITLE
#7865: Add custom reduction kernel for Mamba SSM block

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_1d_sum_reduce.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_1d_sum_reduce.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+
+import tt_lib as ttl
+import pytest
+from loguru import logger
+
+from models.utility_functions import tt2torch_tensor, comp_pcc
+
+
+def run_ssm_1d_sum_reduce(H: int, W: int, latent_size: int, dtype, in_mem_config, out_mem_config, device):
+    torch.manual_seed(0)
+
+    input_shape = [1, 1, H, W]
+    x = torch.randn(input_shape)
+    expected = torch.sum(x.reshape((1, 1, H, W // latent_size, latent_size)), dim=-1)
+
+    x = ttl.tensor.Tensor(x, dtype).to(ttl.tensor.Layout.TILE).to(device, in_mem_config)
+    actual = ttl.operations.primary.transformers.ssm_1d_sum_reduce(
+        x, output_mem_config=out_mem_config, output_dtype=dtype
+    )
+
+    assert list(actual.get_legacy_shape()) == [1, 1, H, W // latent_size]
+
+    actual = tt2torch_tensor(actual)
+    passing_pcc, output_pcc = comp_pcc(actual, expected, 0.9999)
+    logger.debug(f"Out passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
+
+    assert passing_pcc
+
+
+@pytest.mark.parametrize(
+    "out_mem_config",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+)
+@pytest.mark.parametrize(
+    "in_mem_config",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttl.tensor.DataType.BFLOAT16,),
+)
+@pytest.mark.parametrize(
+    "H, W, latent_size",
+    (
+        (32, 1024, 32),
+        (32, 163840, 32),
+    ),
+)
+def test_ssm_reduce(H, W, latent_size, dtype, out_mem_config, in_mem_config, device):
+    run_ssm_1d_sum_reduce(H, W, latent_size, dtype, out_mem_config, in_mem_config, device)
+
+
+def test_ssm_1d_sum_reduce_with_program_cache(device, use_program_cache):
+    H, W, latent = 32, 163840, 32
+    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    dtype = ttl.tensor.DataType.BFLOAT16
+
+    for _ in range(2):
+        run_ssm_1d_sum_reduce(H, W, latent, dtype, mem_config, mem_config, device)
+        dummy_shape = [1, 1, 32, 32]
+        py_dummy_tensor = torch.randn(dummy_shape)
+        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
+
+    assert device.num_program_cache_entries() == 1

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -170,6 +170,7 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp \
 	tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_eltwise_mul/multi_core_ssm_eltwise_mul.cpp \
 	tt_eager/tt_dnn/op_library/operation.cpp \
+	tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_1d_sum_reduce/multi_core_ssm_1d_sum_reduce.cpp \
 	tt_eager/tt_dnn/op_library/run_operation.cpp \
 	tt_eager/tt_dnn/op_library/split/split_tiled.cpp \
 	tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.cpp \

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_1d_sum_reduce.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_1d_sum_reduce.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#define REDUCE_OP PoolType::SUM
+#define REDUCE_DIM ReduceDim::REDUCE_COL
+
+#include <cstdint>
+
+#include "compute_kernel_api/reduce.h"
+#include "compute_kernel_api/transpose_wh.h"
+
+constexpr uint32_t ONE_TILE = 1;
+
+FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
+    cb_wait_front(cb_in, ONE_TILE);
+
+    tile_regs_acquire();
+    tile_regs_wait();
+
+    transpose_wh_init_short(cb_in);
+    transpose_wh_tile(cb_in, 0, 0);
+
+    cb_reserve_back(cb_out, ONE_TILE);
+    pack_tile(0, cb_out);
+
+    tile_regs_commit();
+    tile_regs_release();
+
+    cb_push_back(cb_out, ONE_TILE);
+    cb_pop_front(cb_in, ONE_TILE);
+}
+
+FORCE_INLINE void reduce(uint32_t cb_in, uint32_t cb_scalar, uint32_t cb_out) {
+    cb_wait_front(cb_in, ONE_TILE);
+
+    tile_regs_acquire();
+    tile_regs_wait();
+
+    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM, cb_in, cb_scalar, cb_out);
+    reduce_tile(cb_in, cb_scalar, 0, 0, 0);
+    reduce_revert_delta<REDUCE_DIM>(cb_out);
+
+    cb_reserve_back(cb_out, ONE_TILE);
+    pack_tile(0, cb_out);
+
+    tile_regs_commit();
+    tile_regs_release();
+
+    cb_push_back(cb_out, ONE_TILE);
+    cb_pop_front(cb_in, ONE_TILE);
+}
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t num_blocks = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t scalar_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t intermed_cb_id0 = get_compile_time_arg_val(2);
+    constexpr uint32_t intermed_cb_id1 = get_compile_time_arg_val(3);
+    constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(4);
+    constexpr uint32_t output_cb_id = get_compile_time_arg_val(5);
+
+    reduce_init<true>(REDUCE_OP, REDUCE_DIM, input_cb_id, scalar_cb_id);
+    reduce_revert_delta<REDUCE_DIM>(intermed_cb_id1);  // Required or else the first tile is wrong
+
+    cb_wait_front(scalar_cb_id, ONE_TILE);
+
+    for (uint32_t output_idx = 0; output_idx < num_blocks; output_idx++) {
+        for (uint32_t slice_idx = 0; slice_idx < TILE_WIDTH; slice_idx++) {
+            transpose(input_cb_id, intermed_cb_id0);                 // 32 x B
+            reduce(intermed_cb_id0, scalar_cb_id, intermed_cb_id1);  // 1 x B
+        }
+        // Get full tile back from writer and transpose it
+        transpose(intermed_cb_id2, output_cb_id);
+    }
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_1d_sum_reduce.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_1d_sum_reduce.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t DATA_FORMAT_BYTES = 2;
+    constexpr uint32_t FACE_WIDTH = 16;
+    constexpr uint32_t FACE_WIDTH_BYTES = FACE_WIDTH * DATA_FORMAT_BYTES;
+    constexpr uint32_t FACE_SIZE = 16 * 16;
+    constexpr uint32_t FACE_SIZE_BYTES = FACE_SIZE * DATA_FORMAT_BYTES;
+
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_output_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t intermed_cb_id1 = get_compile_time_arg_val(0);
+    constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(1);
+    constexpr uint32_t output_cb_id = get_compile_time_arg_val(2);
+    constexpr bool output_is_dram = get_compile_time_arg_val(3) == 1;
+
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(output_cb_id);
+    const DataFormat data_format = get_dataformat(output_cb_id);
+
+    const InterleavedAddrGenFast<output_is_dram> s = {
+        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    const uint32_t end_id = start_id + num_output_tiles;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_reserve_back(intermed_cb_id2, onetile);
+        uint32_t dst = get_write_ptr(intermed_cb_id2);
+
+        // Manually unroll copying into destination face 1+2 and 3+4 to avoid conditional inside loop
+        for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
+            cb_wait_front(intermed_cb_id1, onetile);
+            uint64_t src = get_noc_addr(get_read_ptr(intermed_cb_id1));
+
+            noc_async_read(src, dst, FACE_WIDTH_BYTES);
+            noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
+            noc_async_read_barrier();
+
+            cb_pop_front(intermed_cb_id1, onetile);
+
+            dst += FACE_WIDTH_BYTES;
+        }
+        dst += FACE_SIZE_BYTES;
+
+        // Copy face 3/4 into the destination
+        for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
+            cb_wait_front(intermed_cb_id1, onetile);
+            uint64_t src = get_noc_addr(get_read_ptr(intermed_cb_id1));
+
+            noc_async_read(src, dst, FACE_WIDTH_BYTES);
+            noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
+            noc_async_read_barrier();
+
+            cb_pop_front(intermed_cb_id1, onetile);
+
+            dst += FACE_WIDTH_BYTES;
+        }
+        cb_push_back(intermed_cb_id2, onetile);
+
+        cb_wait_front(output_cb_id, onetile);
+        uint32_t l1_read_addr = get_read_ptr(output_cb_id);
+        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(output_cb_id, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_1d_sum_reduce/multi_core_ssm_1d_sum_reduce.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_1d_sum_reduce/multi_core_ssm_1d_sum_reduce.cpp
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/transformer_tms/transformer_tms.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+using namespace tt::constants;
+using namespace tt;
+
+namespace tt {
+namespace operations {
+namespace primary {
+namespace transformers {
+
+operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(
+    const Tensor& a, Tensor& output, CoreCoord compute_with_storage_grid_size) {
+    constexpr uint32_t ONE_TILE = 1;
+    constexpr uint32_t TILE_WIDTH = 32;
+    constexpr uint32_t LATENT_DIM = TILE_WIDTH;
+
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    const auto* input_buffer = a.buffer();
+    const bool input_is_dram = input_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+
+    tt_metal::Buffer* out_buffer = output.buffer();
+    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+    const bool output_is_dram = out_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+
+    auto num_output_blocks_total = a.get_legacy_shape()[-1] / (TILE_WIDTH * TILE_WIDTH);
+
+    const bool row_major = false;
+    const auto
+        [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
+            split_work_to_cores(compute_with_storage_grid_size, num_output_blocks_total, row_major);
+
+    const auto create_circular_buffer = [&program, &cores = all_cores](
+                                            uint32_t index,
+                                            uint32_t num_tiles,
+                                            uint32_t tile_size,
+                                            const tt::DataFormat& format) -> tt_metal::CBHandle {
+        const tt_metal::CircularBufferConfig config =
+            tt_metal::CircularBufferConfig(num_tiles * tile_size, {{index, format}}).set_page_size(index, tile_size);
+        return tt_metal::CreateCircularBuffer(program, cores, config);
+    };
+
+    TT_ASSERT(a.get_dtype() == output.get_dtype(), "Input and output tensors must be of same type");
+
+    const tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    const uint32_t tile_size = tt_metal::detail::TileSize(data_format);
+    const uint32_t cb_size = 2;
+
+    // Reader writes input tiles to this
+    const uint32_t input_cb_id = tt::CB::c_in0;
+    const auto input_cb = create_circular_buffer(input_cb_id, cb_size, tile_size, data_format);
+
+    // Reader writes scaling tile to this CB. We need it because the reduce LLK requires a scaling factor tile.
+    const uint32_t scalar_cb_id = tt::CB::c_in2;
+    const auto scalar_cb = create_circular_buffer(scalar_cb_id, cb_size, tile_size, data_format);
+
+    // Compute writes transposed tile (loopback)
+    const uint32_t intermed_cb_id0 = tt::CB::c_intermed0;
+    const auto intermed_cb0 = create_circular_buffer(intermed_cb_id0, cb_size, tile_size, data_format);
+
+    // Compute writes reduced tile for writer
+    const uint32_t intermed_cb_id1 = tt::CB::c_intermed1;
+    const auto intermed_cb1 = create_circular_buffer(intermed_cb_id1, cb_size, tile_size, data_format);
+
+    // Writer concats and writes back to compute
+    const uint32_t intermed_cb_id2 = tt::CB::c_intermed2;
+    const auto intermed_cb2 = create_circular_buffer(intermed_cb_id2, cb_size, tile_size, data_format);
+
+    // Compute transposes and writes back to writer
+    const uint32_t output_cb_id = tt::CB::c_out0;
+    const auto output_cb = create_circular_buffer(output_cb_id, cb_size, tile_size, data_format);
+
+    const bfloat16 bfloat_scaler_value = bfloat16(1.0f);
+    const uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    std::vector<uint32_t> reader_compile_time_args = {input_is_dram, packed_scaler_value};
+    std::vector<uint32_t> writer_compile_time_args = {
+        intermed_cb_id1,
+        intermed_cb_id2,
+        output_cb_id,
+        output_is_dram,
+    };
+    std::vector<uint32_t> compute_compile_time_args = {
+        input_cb_id,
+        scalar_cb_id,
+        intermed_cb_id0,
+        intermed_cb_id1,
+        intermed_cb_id2,
+        output_cb_id,
+    };
+
+    // Reuse the reader from reduce since we want the same behavior
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/reduce/kernels/dataflow/reader_unary_reduce_interleaved_start_id.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_1d_sum_reduce.cpp",
+        all_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_1d_sum_reduce.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+
+    uint32_t g1_numcores = core_group_1.num_cores();
+    uint32_t g2_numcores = core_group_2.num_cores();
+    std::vector<CoreCoord> cores =
+        grid_to_cores(num_cores, compute_with_storage_grid_size.x, compute_with_storage_grid_size.y, row_major);
+    auto set_runtime_args = [reader_kernel_id,
+                             writer_kernel_id,
+                             compute_kernel_id,
+                             num_cores = num_cores,
+                             all_cores = all_cores,
+                             cores = cores,
+                             g1_numcores = g1_numcores,
+                             g2_numcores = g2_numcores,
+                             num_blocks_per_core_group_1 = num_blocks_per_core_group_1,
+                             num_blocks_per_core_group_2 = num_blocks_per_core_group_2](
+                                Program& program, const Tensor& a, const Tensor& output) {
+        tt_metal::Buffer* input_buffer = a.buffer();
+        tt_metal::Buffer* output_buffer = output.buffer();
+
+        uint32_t num_blocks_per_core = 0;
+
+        std::vector<std::vector<uint32_t>> reader_runtime_args = {
+            cores.size(), {0, 0, 0}};  // (src_addr, num_tiles, start_id)
+
+        std::vector<std::vector<uint32_t>> writer_runtime_args = {
+            cores.size(), {0, 0, 0}};  // (dst_addr, num_tiles, start_id)
+
+        std::vector<std::vector<uint32_t>> compute_runtime_args = {cores.size(), {0}};
+
+        for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
+            const CoreCoord& core = cores.at(i);
+
+            if (i < g1_numcores) {
+                num_blocks_per_core = num_blocks_per_core_group_1;
+            } else {
+                num_blocks_per_core = num_blocks_per_core_group_2;
+            }
+
+            reader_runtime_args[i][0] = input_buffer->address();
+            reader_runtime_args[i][1] = num_blocks_per_core * LATENT_DIM;
+            reader_runtime_args[i][2] = num_blocks_written * LATENT_DIM;
+
+            writer_runtime_args[i][0] = output_buffer->address();
+            writer_runtime_args[i][1] = num_blocks_per_core;
+            writer_runtime_args[i][2] = num_blocks_written;
+
+            compute_runtime_args[i][0] = num_blocks_per_core;
+
+            num_blocks_written += num_blocks_per_core;
+        }
+
+        SetRuntimeArgs(program, reader_kernel_id, cores, reader_runtime_args);
+        SetRuntimeArgs(program, writer_kernel_id, cores, writer_runtime_args);
+        SetRuntimeArgs(program, compute_kernel_id, cores, compute_runtime_args);
+    };
+
+    set_runtime_args(program, a, output);
+
+    auto override_runtime_arguments_callback = [set_runtime_args](
+                                                   const void* operation,
+                                                   Program& program,
+                                                   const std::vector<Tensor>& input_tensors,
+                                                   const std::vector<std::optional<const Tensor>>&,
+                                                   const std::vector<Tensor>& output_tensors) {
+        const auto& output_tensor = output_tensors.at(0);
+        set_runtime_args(program, input_tensors.at(0), output_tensor);
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace transformers
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
@@ -53,6 +53,11 @@ void py_module(py::module& m_transformers) {
         Performs a special eltwise multiply for SSM models. Given tensor A with shape [1, 1, 32, 32] and tensor B with shape [1, 1, 32, W] where W is some multiple of 32, perform the following PyTorch equivalent:
             A.repeat(1, 1, 1, W) * B.repeat_interleave(32, dim=-1)
     )doc");
+    m_transformers.def("ssm_1d_sum_reduce", &ssm_1d_sum_reduce,
+        py::arg().noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, R"doc(
+        Performs a custom reduction along dim 3 which is used in the SSM block of the Mamba architecture. Performs the following PyTorch equivalent (where latent_size = 32):
+            x = torch.sum(x.reshape(1, 1, shape[2], shape[3] // latent_size, latent_size), dim=-1).reshape(1, 1, shape[2], shape[3] // latent_size)
+    )doc");
 
     py::class_<SoftmaxProgramConfig>(m_transformers, "SoftmaxProgramConfig").def(py::init<>());
 


### PR DESCRIPTION
This PR implements a custom kernel needed for the Mamba SSM block that is equivalent the following operation:

```python
x = torch.sum(x.reshape(1, 1, shape[2], shape[3] // self.latent_size, self.latent_size), dim=-1).reshape(
            1, 1, shape[2], shape[3] // self.latent_size)
```

The following diagram captures design of the kernel:

![image](https://github.com/tenstorrent/tt-metal/assets/159198142/f95efb3e-4bd1-4844-91ed-eb69466d7ecd)

Each core takes a (B, 32N) input and does a sum reduce on it by N to obtain (B,32). Currently, only N=32 (latent dimension size) and B=32 (batch size) are supported. 

For more context on why this is needed see here: https://github.com/tenstorrent/tt-metal/issues/7647.