### PR TITLE
#5480: FD2 ensure dispatch/prefetch credits match at teardown

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -16,6 +16,17 @@ uint32_t round_up_pow2(uint32_t v, uint32_t pow2_size) {
     return (v + (pow2_size - 1)) & ~(pow2_size - 1);
 }
 
+template<uint32_t sem_id>
+FORCE_INLINE
+void cb_wait_all_pages(uint32_t n) {
+    volatile tt_l1_ptr uint32_t* sem_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(sem_id));
+    DEBUG_STATUS('T', 'A', 'P', 'W');
+    // TODO: this masks off the upper bit used by mux/dmux for terminate, remove
+    while ((*sem_addr & 0x7FFFFFFF) != n);
+    DEBUG_STATUS('T', 'A', 'P', 'D');
+}
+
 template<uint32_t noc_xy, uint32_t sem_id>
 FORCE_INLINE
 void cb_acquire_pages(uint32_t n) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1074,6 +1074,7 @@ void kernel_main_hd() {
 
 void kernel_main() {
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
+
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();
     } else if (is_h_variant) {
@@ -1083,5 +1084,9 @@ void kernel_main() {
     } else {
         ASSERT(0);
     }
+
+    // Confirm expected number of pages, spinning here is a leak
+    cb_wait_all_pages<my_downstream_cb_sem_id>(downstream_cb_pages);
+
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": out" << ENDL();
 }


### PR DESCRIPTION
Wait until credits match at teardown
Plus 2 fixes to make this work
Plus fix some dprints