### PR TITLE
Add back uneven sharding

### DIFF
--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -618,7 +618,9 @@ std::vector<uint32_t> Tensor::host_page_ordering(){
     std::vector<uint32_t> ret_vec;
     ret_vec.reserve(num_pages);
     for(int page_id = 0; page_id <num_pages ; page_id++){
-        ret_vec.push_back(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id]);
+        if(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id].has_value()) {
+            ret_vec.push_back(buffer_page_mapping.dev_page_to_host_page_mapping_[page_id].value());
+        }
     }
     return ret_vec;
 }

--- a/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
@@ -568,7 +568,7 @@ std::unordered_map<CoreCoord, std::vector<PageStride>> get_core_page_ranges(
     const auto& input_page_to_local_page_mapping = input_buffer_page_mapping.host_page_to_local_shard_page_mapping_;
     const auto& host_page_to_input_page_mapping = input_buffer_page_mapping.host_page_to_dev_page_mapping_;
 
-    auto num_pages = std::min<uint32_t>(output_shard_to_host_mapping.size(), input_buffer->num_pages());
+    auto num_pages = std::min<uint32_t>(output_shard_to_host_mapping.size(), input_buffer->num_dev_pages());
 
     // First get output_core to vector< pair<input_core, input_page> (num_pages_in_output)
     std::unordered_map<CoreCoord, std::vector<std::pair<CoreCoord, uint32_t>>> output_core_to_vector_input_core_page;
@@ -576,13 +576,15 @@ std::unordered_map<CoreCoord, std::vector<PageStride>> get_core_page_ranges(
     for (uint32_t output_page_id = 0; output_page_id < num_pages; output_page_id++) {
         auto output_core = output_buffer_page_mapping.all_cores_[output_buffer_page_mapping.dev_page_to_core_mapping_[output_page_id]];
         auto host_page = output_shard_to_host_mapping[output_page_id];
-        auto input_page = host_page_to_input_page_mapping[host_page];
-        auto local_input_page = input_page_to_local_page_mapping[host_page];
-        auto input_core = input_buffer_page_mapping.all_cores_[input_buffer_page_mapping.dev_page_to_core_mapping_[input_page]];
-        if (output_core_to_vector_input_core_page.find(output_core) == output_core_to_vector_input_core_page.end()) {
-            output_core_to_vector_input_core_page[output_core] = {{input_core, local_input_page}};
-        } else {
-            output_core_to_vector_input_core_page[output_core].push_back({input_core, local_input_page});
+        if(host_page.has_value()) {
+            auto input_page = host_page_to_input_page_mapping[host_page.value()];
+            auto local_input_page = input_page_to_local_page_mapping[host_page.value()];
+            auto input_core = input_buffer_page_mapping.all_cores_[input_buffer_page_mapping.dev_page_to_core_mapping_[input_page]];
+            if (output_core_to_vector_input_core_page.find(output_core) == output_core_to_vector_input_core_page.end()) {
+                output_core_to_vector_input_core_page[output_core] = {{input_core, local_input_page}};
+            } else {
+                output_core_to_vector_input_core_page[output_core].push_back({input_core, local_input_page});
+            }
         }
     }
 

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -39,7 +39,7 @@ void validate_buffer_size_and_page_size(uint64_t size, uint64_t page_size, const
 }
 
 
-inline std::vector< std::vector<uint32_t> > core_to_host_pages(
+inline std::tuple< std::vector< std::vector<uint32_t> > , std::vector<std::array<uint32_t, 2> > > core_to_host_pages(
                                                     const uint32_t & total_pages,
                                                     const uint32_t & pages_per_shard,
                                                     const uint32_t & num_shards,
@@ -50,9 +50,10 @@ inline std::vector< std::vector<uint32_t> > core_to_host_pages(
 {
 
 
-    std::vector < std::vector<uint32_t> > ret_vec(num_shards);
-
     std::array<uint32_t, 2> shard_in_pages = {shard_shape[0]/page_shape[0], shard_shape[1]/page_shape[1]};
+    std::vector < std::vector<uint32_t> > ret_vec(num_shards);
+    std::vector < std::array<uint32_t, 2> > ret_shard_shape(num_shards, shard_in_pages);
+
 
     if( layout == TensorMemoryLayout:: HEIGHT_SHARDED) {
         uint32_t num_pages_per_shard = pages_per_shard;
@@ -80,16 +81,19 @@ inline std::vector< std::vector<uint32_t> > core_to_host_pages(
             ret_vec[shard_idx].reserve(pages_per_shard);
 
             uint32_t host_idx = 0;
-            for(uint32_t i=i_offset; i<(shard_in_pages[0] + i_offset); i++) {
+            uint32_t i = 0;
+            uint32_t j = 0;
+            for(i=i_offset; i<(shard_in_pages[0] + i_offset); i++) {
                 if (i >= tensor2d_size[0]) {
                     break;
                 }
-                for(uint32_t j=j_offset; j<(shard_in_pages[1] + j_offset) and (j < (tensor2d_size[1])); j++) {
+                for(j=j_offset; j<(shard_in_pages[1] + j_offset) and (j < (tensor2d_size[1])); j++) {
                     uint32_t host_page = i*tensor2d_size[1] + j;
                     ret_vec[shard_idx].push_back(host_page);
                     host_idx++;
                 }
             }
+            ret_shard_shape[shard_idx] = {i - i_offset, j - j_offset};
             if(((shard_in_row + 1) == (num_shard_columns))) {
                 shard_in_row = 0;
                 j_offset = 0;
@@ -101,7 +105,7 @@ inline std::vector< std::vector<uint32_t> > core_to_host_pages(
             }
         }
     }
-    return ret_vec;
+    return {ret_vec, ret_shard_shape};
 }
 
 
@@ -122,32 +126,48 @@ BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer) {
 
     BufferPageMapping buffer_page_mapping;
     auto row_major = buffer.shard_spec().orientation() == ShardOrientation::ROW_MAJOR;
-    buffer_page_mapping.all_cores_ = corerange_to_cores(buffer.shard_spec().grid(), buffer.num_cores(), row_major);
-    TT_ASSERT(buffer.num_cores() == buffer_page_mapping.all_cores_.size());
+    uint32_t num_cores = buffer.num_cores();
+
+    buffer_page_mapping.all_cores_ = corerange_to_cores(buffer.shard_spec().grid(), num_cores, row_major);
+    TT_ASSERT(num_cores == buffer_page_mapping.all_cores_.size());
     uint32_t core_id = 0;
     for(auto core: buffer_page_mapping.all_cores_){
         buffer_page_mapping.core_to_core_id_.insert({core, core_id });
         core_id++;
     }
-    auto core_host_page_indices = core_to_host_pages(buffer.shard_spec().size() * buffer.num_cores(), buffer.shard_spec().size(), buffer.num_cores(), buffer.buffer_layout(), buffer.shard_spec().page_shape, buffer.shard_spec().shape(), buffer.shard_spec().tensor2d_shape);
 
-    auto total_dev_pages = buffer.num_pages();
-    buffer_page_mapping.core_host_page_indices_ = std::vector< std::vector<uint32_t>>(buffer.num_cores());
-    buffer_page_mapping.dev_page_to_host_page_mapping_ = std::vector<uint32_t>(total_dev_pages);
-    buffer_page_mapping.dev_page_to_core_mapping_ = std::vector<uint32_t>(total_dev_pages);
-    buffer_page_mapping.host_page_to_local_shard_page_mapping_ = std::vector<uint32_t>(total_dev_pages);
-    buffer_page_mapping.host_page_to_dev_page_mapping_= std::vector<uint32_t>(total_dev_pages);
+    uint32_t num_dev_pages = buffer.shard_spec().size() *  num_cores;
+    auto [core_host_page_indices, shard_shape] = core_to_host_pages(num_dev_pages, buffer.shard_spec().size(), num_cores, buffer.buffer_layout(), buffer.shard_spec().page_shape, buffer.shard_spec().shape(), buffer.shard_spec().tensor2d_shape);
 
+    buffer_page_mapping.core_host_page_indices_ = std::vector< std::vector<uint32_t>>(num_cores);
+    buffer_page_mapping.dev_page_to_host_page_mapping_.reserve(num_dev_pages);
+    buffer_page_mapping.dev_page_to_core_mapping_.reserve(num_dev_pages);
+    buffer_page_mapping.host_page_to_local_shard_page_mapping_ = std::vector<uint32_t>(buffer.num_pages());
+    buffer_page_mapping.host_page_to_dev_page_mapping_= std::vector<uint32_t>(buffer.num_pages());
+    buffer_page_mapping.core_shard_shape_ = shard_shape;
     int dev_page_index = 0;
+
+    auto shape_in_pages = buffer.shard_spec().shape_in_pages();
     for(uint32_t core_index = 0; core_index < core_host_page_indices.size() ; core_index++){
-        for(uint32_t shard_page_id = 0; shard_page_id < core_host_page_indices[core_index].size() ; shard_page_id++){
-            auto host_page = core_host_page_indices[core_index][shard_page_id];
-            if(host_page < total_dev_pages) {
-                buffer_page_mapping.core_host_page_indices_[core_index].push_back(host_page);
-                buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index] = core_index;
-                buffer_page_mapping.dev_page_to_host_page_mapping_[dev_page_index] = host_page;
-                buffer_page_mapping.host_page_to_local_shard_page_mapping_[host_page] = shard_page_id;
-                buffer_page_mapping.host_page_to_dev_page_mapping_[host_page] = dev_page_index;
+
+        uint32_t valid_shard_page = 0;
+        for(uint32_t shard_page_x = 0; shard_page_x < shape_in_pages[0] ; shard_page_x++){
+            for(uint32_t shard_page_y = 0; shard_page_y < shape_in_pages[1]; shard_page_y++) {
+                uint32_t shard_page_id = shard_page_x * shape_in_pages[1] + shard_page_y;
+                buffer_page_mapping.core_host_page_indices_[core_index].reserve(buffer.shard_spec().size());
+                buffer_page_mapping.dev_page_to_core_mapping_.push_back(core_index);
+                std::optional<uint32_t> host_page_opt = std::nullopt;
+                if(shard_page_x < buffer_page_mapping.core_shard_shape_[core_index][0] and shard_page_y < buffer_page_mapping.core_shard_shape_[core_index][1]) {
+                    auto host_page = core_host_page_indices[core_index][valid_shard_page];
+                    if(host_page < buffer.num_pages()) {
+                        host_page_opt = host_page;
+                        buffer_page_mapping.core_host_page_indices_[core_index].push_back(host_page);
+                        buffer_page_mapping.host_page_to_local_shard_page_mapping_[host_page] = shard_page_id;
+                        buffer_page_mapping.host_page_to_dev_page_mapping_[host_page] = dev_page_index;
+                    }
+                    valid_shard_page++;
+                }
+                buffer_page_mapping.dev_page_to_host_page_mapping_.push_back(host_page_opt);
                 dev_page_index++;
             }
         }

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -58,7 +58,7 @@ struct ShardSpec {
                     orientation(shard_orientation_), halo(halo_)
                     {;}
 
-    const uint32_t num_cores() const { return this->grid.num_cores(); }
+    const uint32_t num_cores() const {return this->grid.num_cores();}
     const uint32_t numel() const { return this->shape[0] * this->shape[1]; }
     tt::stl::reflection::Attributes attributes() const;
 
@@ -103,11 +103,14 @@ struct ShardSpecBuffer {
     bool halo() const {
         return tensor_shard_spec.halo;
     }
-    uint32_t size() const{
+    std::array<uint32_t, 2> shape_in_pages() const {
         auto width_in_pages = tensor_shard_spec.shape[0] / page_shape[0];
         auto height_in_pages = tensor_shard_spec.shape[1] / page_shape[1];
-        return width_in_pages * height_in_pages;
-
+        return {width_in_pages, height_in_pages};
+    }
+    uint32_t size() const{
+        auto shape_in_pages_ = this->shape_in_pages();
+        return shape_in_pages_[0] * shape_in_pages_[1];
     }
 };
 
@@ -140,11 +143,17 @@ struct BufferPageMapping {
     std::vector< uint32_t> core_bank_indices_;
     std::vector< std::vector<uint32_t> > core_host_page_indices_;
     std::vector<uint32_t> dev_page_to_core_mapping_;
-    std::vector<uint32_t> dev_page_to_host_page_mapping_;
+
+    //some dev pages don't have mapping to host (in case of padding)
+    std::vector<std::optional<uint32_t> > dev_page_to_host_page_mapping_;
     std::vector<uint32_t> host_page_to_dev_page_mapping_;
     std::unordered_map<CoreCoord, uint32_t> core_to_core_id_;
     std::vector< uint32_t> host_page_to_local_shard_page_mapping_;
+    std::vector < std::array<uint32_t, 2> > core_shard_shape_;
+
 };
+
+
 
 class Buffer {
    public:
@@ -177,6 +186,15 @@ class Buffer {
     uint32_t page_size() const { return page_size_; }
 
     uint32_t num_pages() const { return this->size() / this->page_size(); }
+
+    uint32_t num_dev_pages() const {
+        if (!is_sharded(this->buffer_layout_)) {
+            return this->num_pages();
+        }
+        else {
+            return this->shard_spec().size() * this->num_cores();
+        }
+    }
 
     BufferType buffer_type() const { return buffer_type_; }
 
@@ -212,7 +230,6 @@ class Buffer {
             return this->shard_spec().tensor_shard_spec.grid.num_cores();
         }
     }
-
 
    private:
     void allocate();

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -70,11 +70,10 @@ const DeviceCommand EnqueueReadShardedBufferCommand::create_buffer_transfer_inst
     uint32_t num_cores = this->buffer.num_cores();
 
     auto buffer_page_mapping = generate_buffer_page_mapping(this->buffer);
-    auto core_host_page_indices = buffer_page_mapping.core_host_page_indices_;
     vector<uint32_t> num_pages_in_shards;
     num_pages_in_shards.reserve(num_cores);
     for(size_t core_id = 0; core_id < num_cores; core_id++) {
-        num_pages_in_shards.push_back(core_host_page_indices[core_id].size());
+        num_pages_in_shards.push_back(this->buffer.shard_spec().size());
     }
 
     vector<uint32_t> core_id_x;
@@ -269,11 +268,10 @@ const DeviceCommand EnqueueWriteShardedBufferCommand::create_buffer_transfer_ins
 
     uint32_t num_cores = this->buffer.num_cores();
     auto buffer_page_mapping = generate_buffer_page_mapping(this->buffer);
-    auto core_host_page_indices = buffer_page_mapping.core_host_page_indices_;
     vector<uint32_t> num_pages_in_shards;
     num_pages_in_shards.reserve(num_cores);
     for(size_t core_id = 0; core_id < num_cores; core_id++) {
-        num_pages_in_shards.push_back(core_host_page_indices[core_id].size());
+        num_pages_in_shards.push_back(this->buffer.shard_spec().size());
     }
 
     vector<uint32_t> core_id_x;
@@ -856,13 +854,9 @@ void HWCommandQueue::enqueue_command(T& command, bool blocking) {
 
 // TODO: Currently converting page ordering from interleaved to sharded and then doing contiguous read/write
 //  Look into modifying command to do read/write of a page at a time to avoid doing copy
-void * convert_interleaved_to_sharded_on_host(const void* host, const Buffer& buffer) {
+void convert_interleaved_to_sharded_on_host(void * swapped, const void* host, const Buffer& buffer) {
     const uint32_t num_pages = buffer.num_pages();
     const uint32_t page_size = buffer.page_size();
-
-    const uint32_t size_in_bytes = num_pages * page_size;
-
-    void* swapped = malloc(size_in_bytes);
 
     std::set<uint32_t> pages_seen;
     auto buffer_page_mapping = generate_buffer_page_mapping(buffer);
@@ -874,7 +868,6 @@ void * convert_interleaved_to_sharded_on_host(const void* host, const Buffer& bu
         TT_ASSERT(host_page_id < num_pages and host_page_id >= 0);
         memcpy((char*)swapped + dev_page_id * page_size, (char*)host + host_page_id * page_size, page_size);
     }
-    return swapped;
 }
 
 void HWCommandQueue::enqueue_read_buffer(std::shared_ptr<Buffer> buffer, void* dst, bool blocking) {
@@ -890,7 +883,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
     uint32_t read_buffer_command_size = DeviceCommand::NUM_BYTES_IN_DEVICE_COMMAND;
 
     uint32_t padded_page_size = align(buffer.page_size(), 32);
-    uint32_t total_pages_to_read = buffer.num_pages();
+    uint32_t total_pages_to_read = buffer.num_dev_pages();
     uint32_t unpadded_dst_offset = 0;
     uint32_t src_page_index = 0;
 
@@ -981,13 +974,24 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
 
     void * final_src = (void *)src;
 
-    if (buffer.buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED or
-        buffer.buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-        final_src = convert_interleaved_to_sharded_on_host(src, buffer);
+    if (is_sharded(buffer.buffer_layout())) {
+        if (buffer.buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED or
+            buffer.buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+            final_src = malloc(buffer.num_dev_pages() * buffer.page_size());
+            convert_interleaved_to_sharded_on_host(final_src, src, buffer);
+        }
+        // HEIGHT SHARDED
+        // No swapping necessary but it adds padding
+        else  if (buffer.num_dev_pages() != buffer.num_pages()){
+            final_src = malloc(buffer.num_dev_pages() * buffer.page_size());
+            memcpy(final_src, src, buffer.num_pages() * buffer.page_size());
+        }
     }
 
+
     uint32_t padded_page_size = align(buffer.page_size(), 32);
-    uint32_t total_pages_to_write = buffer.num_pages();
+    uint32_t total_pages_to_write = buffer.num_dev_pages();
+
     const uint32_t command_issue_limit = this->manager.get_issue_queue_limit(this->id);
     uint32_t dst_page_index = 0;
     while (total_pages_to_write > 0) {
@@ -1025,9 +1029,13 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
         dst_page_index += pages_to_write;
     }
 
-    if (buffer.buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED or
-        buffer.buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+    if (is_sharded(buffer.buffer_layout())) {
+        if ((buffer.buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED or
+            buffer.buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED) or
+            (buffer.buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED
+            and buffer.num_dev_pages() != buffer.num_pages())) {
             free(final_src);
+        }
     }
 
     if (blocking) {
@@ -1118,7 +1126,7 @@ void HWCommandQueue::enqueue_trace() {
 }
 
 void HWCommandQueue::copy_into_user_space(uint32_t event, uint32_t read_ptr, chip_id_t mmio_device_id, uint16_t channel) {
-    const auto& [buffer_layout, page_size, padded_page_size, dev_page_to_host_page_mapping, dst, dst_offset, num_pages_read, cur_host_page_id] =
+    const auto& [buffer_layout, page_size, padded_page_size, dev_page_to_host_page_mapping, dst, dst_offset, num_pages_read, cur_dev_page_id] =
         this->issued_reads.at(event);
 
     uint32_t padded_num_bytes = num_pages_read * padded_page_size;
@@ -1144,14 +1152,16 @@ void HWCommandQueue::copy_into_user_space(uint32_t event, uint32_t read_ptr, chi
     } else if (
         buffer_layout == TensorMemoryLayout::WIDTH_SHARDED or
         buffer_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        uint32_t host_page_id = cur_host_page_id;
+        uint32_t dev_page_id = cur_dev_page_id;
         uint32_t read_src = read_ptr + align(EVENT_PADDED_SIZE, 32);
         for (uint32_t offset = 0; offset < padded_page_size * num_pages_read; offset += padded_page_size) {
-            uint32_t device_page_id = dev_page_to_host_page_mapping[host_page_id];
-            void* page_dst = (void*)(uint64_t(dst) + device_page_id * page_size);
-            tt::Cluster::instance().read_sysmem(
-                page_dst, page_size, read_src + offset, mmio_device_id, channel);
-            host_page_id++;
+            auto host_page_id = dev_page_to_host_page_mapping[dev_page_id];
+            if(host_page_id.has_value()) {
+                void* page_dst = (void*)(uint64_t(dst) + host_page_id.value() * page_size);
+                tt::Cluster::instance().read_sysmem(
+                    page_dst, page_size, read_src + offset, mmio_device_id, channel);
+            }
+            dev_page_id++;
         }
     }
     this->manager.completion_queue_pop_front(padded_num_bytes, this->id);

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -369,7 +369,7 @@ struct IssuedReadData {
     TensorMemoryLayout buffer_layout;
     uint32_t page_size;
     uint32_t padded_page_size;
-    vector<uint32_t> dev_page_to_host_page_mapping;
+    vector<std::optional<uint32_t> > dev_page_to_host_page_mapping;
     void* dst;
     uint32_t dst_offset;
     uint32_t num_pages_read;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -356,7 +356,7 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
 
 
         int output_page_index = 0;
-        auto total_pages = buffer.num_pages();
+        auto total_pages = buffer.num_dev_pages();
         uint32_t page_size = buffer.page_size();
         uint32_t bytes_per_page_entry = sizeof(uint32_t);
         uint32_t num_entries_per_page = page_size / bytes_per_page_entry;
@@ -368,27 +368,29 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
             auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_id]];
             auto bank_id = device->bank_ids_from_logical_core(core)[0];
             auto host_page_id = buffer_page_mapping.dev_page_to_host_page_mapping_[dev_page_id];
-            if(!shard_order){
-                read_pages_to_host_helper(
-                    device,
-                    buffer,
-                    host_buffer,
-                    page_size,
-                    host_page_id,
-                    dev_page_id,
-                    bank_id
-                );
-            }
-            else{
-                read_pages_to_host_helper(
-                    device,
-                    buffer,
-                    host_buffer,
-                    page_size,
-                    dev_page_id,
-                    dev_page_id,
-                    bank_id
-                );
+            if(host_page_id.has_value()) {
+                if(!shard_order){
+                    read_pages_to_host_helper(
+                        device,
+                        buffer,
+                        host_buffer,
+                        page_size,
+                        host_page_id.value(),
+                        dev_page_id,
+                        bank_id
+                    );
+                }
+                else{
+                    read_pages_to_host_helper(
+                        device,
+                        buffer,
+                        host_buffer,
+                        page_size,
+                        dev_page_id,
+                        dev_page_id,
+                        bank_id
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Previous PR (https://github.com/tenstorrent/tt-metal/pull/7658) had to be reverted as it regressed performance in RN50.  Unfortunately it was pushed in while a bug had disabled RN50  and when that bug was enabled and RN50 was added back we saw it regress. 

This PR applies a fix for that case:

Models Perf Pipeline (Currently Running): https://github.com/tenstorrent/tt-metal/actions/runs/8827547642