### PR TITLE
#7712: Update ttnn docs for elu, erf-alike, log-alike ops

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/sweeps/elu.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/elu.py
@@ -17,15 +17,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "alpha": [-0.5, 0, 0.5],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    alpha,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Not Supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/erf.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/erf.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Not Supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/erfc.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/erfc.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Not Supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/erfinv.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/erfinv.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT or input_dtype == ttnn.bfloat8_b:
+        return True, "Not Supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/log10.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/log10.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT or input_dtype == ttnn.bfloat8_b:
+        return True, "Not Supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/log1p.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/log1p.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT or input_dtype == ttnn.bfloat8_b:
+        return True, "Not Supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/log2.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/log2.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT or input_dtype == ttnn.bfloat8_b:
+        return True, "Not Supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/neg.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/neg.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Not Supported"
     return False, None
 
 

--- a/ttnn/ttnn/operations/math.py
+++ b/ttnn/ttnn/operations/math.py
@@ -53,11 +53,15 @@ def register_ttl_math_op_function_unary(name, ttl_math_op_function, op_name):
         return torch_function(input_tensor)
 
     def _math_op_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+        if operation_name in ["ttnn.erfinv", "ttnn.log2", "ttnn.log10", "ttnn.log1p"]:
+            supported_dtypes = (ttnn.bfloat16,)
+        else:
+            supported_dtypes = (ttnn.bfloat16, ttnn.bfloat8_b)
         ttnn.validate_input_tensor(
             operation_name,
             input_tensor,
             ranks=(2, 3, 4),
-            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            dtypes=supported_dtypes,
             layouts=(ttnn.TILE_LAYOUT,),
             can_be_on_device=True,
             can_be_on_cpu=False,
@@ -101,6 +105,8 @@ def register_ttl_math_op_function_unary(name, ttl_math_op_function, op_name):
 
                 >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
                 >>> output = ttnn.{(name)}(tensor)
+
+            {math_op_function.__doc__}
 
             """
     setattr(THIS_MODULE, name, math_op_function)


### PR DESCRIPTION
Issue #7712 , #8143 , #8142 

**Fix Provided**
- Documentation updated with information regarding supported data type and layout for elu, erf, erfc, erfinv, log10, log2, log10, neg ops
- Skipped test for unsupported data type and layout

**Sweep test results :** 
- `tests/ttnn/sweep_tests/sweeps/elu.py` - [elu.csv](https://github.com/tenstorrent/tt-metal/files/15110031/elu.csv)
- `tests/ttnn/sweep_tests/sweeps/erf.py` - [erf.csv](https://github.com/tenstorrent/tt-metal/files/15110041/erf.csv)
- `tests/ttnn/sweep_tests/sweeps/erfc.py` - [erfc.csv](https://github.com/tenstorrent/tt-metal/files/15110054/erfc.csv)
- `tests/ttnn/sweep_tests/sweeps/erfinv.py` - [erfinv.csv](https://github.com/tenstorrent/tt-metal/files/15110063/erfinv.csv)
- `tests/ttnn/sweep_tests/sweeps/neg.py` - [neg.csv](https://github.com/tenstorrent/tt-metal/files/15273038/neg.csv)
- `tests/ttnn/sweep_tests/sweeps/log10.py` - [log10.csv](https://github.com/tenstorrent/tt-metal/files/15273046/log10.csv)
- `tests/ttnn/sweep_tests/sweeps/log1p.py` - [log1p.csv](https://github.com/tenstorrent/tt-metal/files/15273049/log1p.csv)
- `tests/ttnn/sweep_tests/sweeps/log2.py` - [log2.csv](https://github.com/tenstorrent/tt-metal/files/15273051/log2.csv)


**CI Tests**
- All post-commit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8832887155) - PASSED
- [post-commit] Fast Dispatch unit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8832181261) - PASSED
- [post-commit] Slow Dispatch unit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8832889972) - PASSED