### PR TITLE
[Falcon7b t3000 demo] Disable perf mode, enable async mode, update readme

### DIFF
--- a/models/demos/t3000/falcon7b/README.md
+++ b/models/demos/t3000/falcon7b/README.md
@@ -4,20 +4,20 @@
 
 To run the demo using prewritten prompts for a batch of 256 users split evenly on 8 devices run (currently only supports same token-length inputs):
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-False]`
+`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-False]`
 
 ## Inputs
 
 A sample of input prompts for 256 users is provided in `input_data_t3000.json` in demo directory. If you wish you to run the model using a different set of input prompts you can provide a different path, e.g.:
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-False]`
+`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-False]`
 
 ## Running on a different number of devices
 
 To run the demo on a different number of devices, an input file with the appropriate number of inputs must be prepared (the number of inputs should be (32 x num-devices)). Then, the command above can be modified to replace '8' with
 the desired number of devices. For example, to run with 4 devices:
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-4-False]`
+`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-4-True-False]`
 
 ## Details
 

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -7,8 +7,8 @@ from models.demos.falcon7b.demo.demo import run_falcon_demo_kv
 from models.utility_functions import is_wormhole_b0, get_devices_for_t3000
 
 
-@pytest.mark.parametrize("perf_mode", (True,))  # Option to measure perf using max seq length (with invalid outputs)
-@pytest.mark.parametrize("async_mode", (False,))  # Option to run Falcon in Async mode
+@pytest.mark.parametrize("perf_mode", (False,))  # Option to measure perf using max seq length (with invalid outputs)
+@pytest.mark.parametrize("async_mode", (True,))  # Option to run Falcon in Async mode
 @pytest.mark.parametrize("num_devices", (1, 2, 3, 4, 5, 6, 7, 8))
 def test_demo_multichip(
     perf_mode,


### PR DESCRIPTION
- Commit [e1301ba](https://github.com/tenstorrent/tt-metal/commit/e1301bafa321f203d4ee248748874075b43d90fa#diff-9642f9584b6f6640e7c54dc739486a71304c3de686a809ec856da249cd0172ab) mistakenly set perf_mode to True, this change sets it back to False by default.
- Enable async_mode=True as the default for the falcon7b t3000 demo and update readme command accordingly