### PR TITLE
Add falcon7b t3000 tests to new multi-device perf pipeline

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -13,3 +13,4 @@ markers =
     models_performance_bare_metal: mark model silicon tests for performance on bare metal
     models_performance_virtual_machine: mark model silicon tests for performance on virtual_machine
     models_device_performance_bare_metal: mark model silicon tests for device performance on bare metal
+    models_performance_bare_metal_multi_device: mark model silicon tests for performance on multi-chip bare metal

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -52,7 +52,10 @@ run_perf_models_llm_javelin_multi_device() {
     local tt_arch=$1
     local test_marker=$2
 
-    # Add tests here
+    env pytest models/demos/falcon7b/tests -m $test_marker
+
+    ## Merge all the generated reports
+    env python models/perf/merge_perf_results.py
 }
 
 run_perf_models_cnn_javelin() {
@@ -74,6 +77,9 @@ run_perf_models_cnn_javelin_multi_device() {
     local test_marker=$2
 
     # Add tests here
+
+    ## Merge all the generated reports
+    env python models/perf/merge_perf_results.py
 }
 
 run_device_perf_models() {


### PR DESCRIPTION
- Add `models_performance_bare_metal_multi_device` to pytest markers
- Add falcon7b prefill + decode and sync/async multi-chip (only 4 chips for now) tests to t3000 model perf pipeline