### PR TITLE
#7709: Fix exp like ops ttnn doc issues

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/sweeps/exp.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/exp.py
@@ -16,11 +16,25 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
+
+
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Skipped as ROW_MAJOR not supported"
+    return False, None
 
 
 def run(
@@ -36,8 +50,8 @@ def run(
 ) -> Tuple[bool, Optional[str]]:
     input_shape = (*batch_sizes, height, width)
 
-    low = -0.1
-    high = 0.1
+    low = -1
+    high = 1
 
     torch_input_tensor = torch_random(input_shape, low, high, dtype=torch.float32)
     torch_output_tensor = torch.exp(torch_input_tensor)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/exp2.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/exp2.py
@@ -16,11 +16,25 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
+
+
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Skipped as ROW_MAJOR not supported"
+    return False, None
 
 
 def run(

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/expm1.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/expm1.py
@@ -16,11 +16,25 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
+
+
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Skipped as ROW_MAJOR not supported"
+    return False, None
 
 
 def run(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -188,11 +188,13 @@ void bind_unary_operation_overload_complex_return_complex(py::module& module, co
 }
 
 template <typename unary_operation_t>
-void bind_unary_operation_with_fast_and_approximate_mode(py::module& module, const unary_operation_t& operation) {
+void bind_unary_operation_with_fast_and_approximate_mode(py::module& module, const unary_operation_t& operation, const std::string& info_doc = "" ) {
     auto doc = fmt::format(
         R"doc({0}(input_tensor: ttnn.Tensor, *, fast_and_approximate_mode: bool = False, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
 
             Applies {0} to :attr:`input_tensor` element-wise.
+
+            {2}
 
             .. math::
                 {0}(\\mathrm{{input\\_tensor}}_i)
@@ -212,7 +214,8 @@ void bind_unary_operation_with_fast_and_approximate_mode(py::module& module, con
                 >>> output = {1}(tensor, fast_and_approximate_mode=true)
         )doc",
         operation.base_name(),
-        operation.python_fully_qualified_name());
+        operation.python_fully_qualified_name(),
+        info_doc);
 
     bind_registered_operation(
         module,
@@ -1239,8 +1242,22 @@ void py_module(py::module& module) {
     detail::bind_unary_operation(module, ttnn::atan);
     detail::bind_unary_operation(module, ttnn::cos);
     detail::bind_unary_operation(module, ttnn::erfinv);
-    detail::bind_unary_operation(module, ttnn::exp2);
-    detail::bind_unary_operation(module, ttnn::expm1);
+    detail::bind_unary_operation(module, ttnn::exp2,
+    R"doc(Supported dtypes, layouts, and ranks:
+
+        +----------------------------+---------------------------------+-------------------+
+        |     Dtypes                 |         Layouts                 |     Ranks         |
+        +----------------------------+---------------------------------+-------------------+
+        |    BFLOAT16, BFLOAT8_B     |          TILE                   |      2, 3, 4      |
+        +----------------------------+---------------------------------+-------------------+)doc");
+    detail::bind_unary_operation(module, ttnn::expm1,
+    R"doc(Supported dtypes, layouts, and ranks:
+
+        +----------------------------+---------------------------------+-------------------+
+        |     Dtypes                 |         Layouts                 |     Ranks         |
+        +----------------------------+---------------------------------+-------------------+
+        |    BFLOAT16, BFLOAT8_B     |          TILE                   |      2, 3, 4      |
+        +----------------------------+---------------------------------+-------------------+)doc");
     detail::bind_unary_operation(module, ttnn::eqz);
     detail::bind_unary_operation(module, ttnn::floor, "Available for Wormhole_B0 only");
     detail::bind_unary_operation(module, ttnn::ceil, "Available for Wormhole_B0 only");
@@ -1275,7 +1292,14 @@ void py_module(py::module& module) {
     detail::bind_unary_operation(module, ttnn::log_sigmoid);
 
     //  Unaries with fast_and_approximate_mode
-    detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::exp);
+    detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::exp,
+    R"doc(Supported dtypes, layouts, and ranks:
+
+        +----------------------------+---------------------------------+-------------------+
+        |     Dtypes                 |         Layouts                 |     Ranks         |
+        +----------------------------+---------------------------------+-------------------+
+        |    BFLOAT16, BFLOAT8_B     |          TILE                   |      2, 3, 4      |
+        +----------------------------+---------------------------------+-------------------+)doc");
     detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::erf);
     detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::erfc);
     detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::gelu);


### PR DESCRIPTION
Fix issue #7709 
Modify sweep tests to skip only the unsupported datatypes/layouts and updated the doc

Sweep test results:
[exp.csv](https://github.com/tenstorrent/tt-metal/files/15130394/exp.csv)
[exp2.csv](https://github.com/tenstorrent/tt-metal/files/15130395/exp2.csv)
[expm1.csv](https://github.com/tenstorrent/tt-metal/files/15130396/expm1.csv)

All post commit test : https://github.com/tenstorrent/tt-metal/actions/runs/8848014949
