### PR TITLE
#7521: fix_moreh_logsoftmax_backward

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
@@ -190,7 +190,6 @@ def test_logsoftmax_backward_for_dim_hw(shape_dim, device):
     assert passing
 
 
-@skip_for_wormhole_b0("watcher error, see issue #7521")
 @pytest.mark.parametrize(
     "shape_dim",
     (

--- a/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
@@ -435,6 +435,7 @@ ALWI void reduce_tile_to_cb(
         constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
         reduce_tile(icb0, icb1, x, bcast_scaler0, dst0);
     }
+    reduce_revert_delta();
     tile_regs_commit();
 
     if (pop0)
@@ -442,7 +443,6 @@ ALWI void reduce_tile_to_cb(
     if (pop1)
         cb_pop_front(icb1, pop1);
 
-    reduce_revert_delta();
 
     tile_regs_wait();
     pack_tile(dst0, ocb);

--- a/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
@@ -55,10 +55,14 @@ ALWI void mul_tiles_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     mul_tiles_init();
     mul_tiles(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -83,13 +87,17 @@ ALWI void mul_tiles_and_negative_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     mul_tiles_init();
     mul_tiles(icb0, icb1, itile0, itile1, dst0);
 
     negative_tile_init();
     negative_tile(dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -118,6 +126,7 @@ ALWI void mul_tiles_and_mask_tile_to_cb(
     cb_wait_front(icb1, itile1 + 1);
     cb_wait_front(maskcb, mtile + 1);
 
+    tile_regs_acquire();
     mul_tiles_init();
     mul_tiles(icb0, icb1, itile0, itile1, dst0);
 
@@ -127,8 +136,11 @@ ALWI void mul_tiles_and_mask_tile_to_cb(
 
     mask_tile_init();
     mask_tile(dst0, dst_mask);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -155,13 +167,17 @@ ALWI void mul_tiles_log_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     mul_tiles_init();
     mul_tiles(icb0, icb1, itile0, itile1, dst0);
 
     log_tile_init();
     log_tile(dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -187,10 +203,14 @@ ALWI void mul_tiles_bcast_rows_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     mul_bcast_rows_init_short();
     mul_tiles_bcast_rows(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -216,13 +236,17 @@ ALWI void mul_tiles_bcast_rows_log_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     mul_bcast_rows_init_short();
     mul_tiles_bcast_rows(icb0, icb1, itile0, itile1, dst0);
 
     log_tile_init();
     log_tile(dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -248,10 +272,14 @@ ALWI void mul_tiles_bcast_cols_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     mul_bcast_cols_init_short();
     mul_tiles_bcast_cols(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -277,13 +305,17 @@ ALWI void mul_tiles_bcast_cols_log_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     mul_bcast_cols_init_short();
     mul_tiles_bcast_cols(icb0, icb1, itile0, itile1, dst0);
 
     log_tile_init();
     log_tile(dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -300,9 +332,14 @@ ALWI void copy_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32
     cb_reserve_back(ocb, onetile);
     cb_wait_front(icb, itile + 1);
 
+    tile_regs_acquire();
     copy_tile_init();
     copy_tile(icb, itile, dst0);
+    tile_regs_commit();
+
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop)
         cb_pop_front(icb, pop);
@@ -324,10 +361,14 @@ ALWI void add_tiles_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     add_tiles_init();
     add_tiles(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -346,6 +387,7 @@ ALWI void mask_tile_to_cb(uint32_t icb, uint32_t maskcb, uint32_t ocb, uint32_t 
     cb_wait_front(icb, itile + 1);
     cb_wait_front(maskcb, mtile + 1);
 
+    tile_regs_acquire();
     copy_tile_init();
     copy_tile(icb, itile, dst0);
 
@@ -355,7 +397,11 @@ ALWI void mask_tile_to_cb(uint32_t icb, uint32_t maskcb, uint32_t ocb, uint32_t 
     mask_tile_init();
     mask_tile(dst0, dst_mask);
 
+    tile_regs_commit();
+
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop)
         cb_pop_front(icb, pop);
@@ -378,6 +424,8 @@ ALWI void reduce_tile_to_cb(
     constexpr int dst0 = 0;
 
     cb_reserve_back(ocb, onetile);
+
+    tile_regs_acquire();
     cb_wait_front(icb1, onetile);
 
     reduce_init_delta<false>(reduce_op, dim);
@@ -387,13 +435,19 @@ ALWI void reduce_tile_to_cb(
         constexpr uint32_t bcast_scaler0 = 0;  // 0th index from bcast_scaler CB
         reduce_tile(icb0, icb1, x, bcast_scaler0, dst0);
     }
+    tile_regs_commit();
+
     if (pop0)
         cb_pop_front(icb0, pop0);
     if (pop1)
         cb_pop_front(icb1, pop1);
 
     reduce_revert_delta();
+
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
+
     cb_push_back(ocb, onetile);
 }
 
@@ -413,10 +467,14 @@ ALWI void sub_tiles_bcast_cols_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     sub_bcast_cols_init_short();
     sub_tiles_bcast<BroadcastType::COL>(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -442,14 +500,18 @@ ALWI void sub_tiles_bcast_rows_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     // sub_bcast_rows_init_short();
     {
         MATH((llk_math_eltwise_binary_init<ELWSUB, BroadcastType::ROW, MATH_FIDELITY>()));
         UNPACK((llk_unpack_AB_init<BroadcastType::ROW>(0, 1)));
     }
     sub_tiles_bcast<BroadcastType::ROW>(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -474,10 +536,14 @@ ALWI void sub_tiles_to_cb(
     cb_wait_front(icb0, itile0 + 1);
     cb_wait_front(icb1, itile1 + 1);
 
+    tile_regs_acquire();
     sub_tiles_init();
     sub_tiles(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop0)
         cb_pop_front(icb0, pop0);
@@ -493,13 +559,17 @@ ALWI void exp_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32_
     cb_reserve_back(ocb, onetile);
     cb_wait_front(icb, itile + 1);
 
+    tile_regs_acquire();
     copy_tile_init();
     copy_tile(icb, itile, dst);
 
     exp_tile_init();
     exp_tile(dst);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst, ocb);
+    tile_regs_release();
 
     if (pop)
         cb_pop_front(icb, pop);
@@ -512,6 +582,7 @@ ALWI void rexp_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32
     cb_reserve_back(ocb, onetile);
     cb_wait_front(icb, itile + 1);
 
+    tile_regs_acquire();
     copy_tile_init();
     copy_tile(icb, itile, dst);
 
@@ -520,8 +591,11 @@ ALWI void rexp_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32
 
     exp_tile_init();
     exp_tile(dst);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst, ocb);
+    tile_regs_release();
 
     if (pop)
         cb_pop_front(icb, pop);
@@ -544,6 +618,7 @@ ALWI void exp_tile_and_mask_tile_to_cb(
     cb_wait_front(icb, itile + 1);
     cb_wait_front(maskcb, mtile + 1);
 
+    tile_regs_acquire();
     copy_tile_init();
     copy_tile(icb, itile, dst);
 
@@ -558,11 +633,14 @@ ALWI void exp_tile_and_mask_tile_to_cb(
 
     mask_tile_init();
     mask_tile(dst, dst_mask);
+    tile_regs_commit();
 
     if (popm)
         cb_pop_front(maskcb, popm);
 
+    tile_regs_wait();
     pack_tile(dst, ocb);
+    tile_regs_release();
 
     cb_push_back(ocb, onetile);
 }
@@ -583,6 +661,7 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
     cb_wait_front(icb, itile + 1);
     cb_wait_front(maskcb, mtile + 1);
 
+    tile_regs_acquire();
     copy_tile_init();
     copy_tile(icb, itile, dst);
 
@@ -600,11 +679,14 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
 
     mask_tile_init();
     mask_tile(dst, dst_mask);
+    tile_regs_commit();
 
     if (popm)
         cb_pop_front(maskcb, popm);
 
+    tile_regs_wait();
     pack_tile(dst, ocb);
+    tile_regs_release();
 
     cb_push_back(ocb, onetile);
 }
@@ -616,13 +698,17 @@ ALWI void recip_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint3
     cb_reserve_back(ocb, onetile);
     cb_wait_front(icb, itile + 1);
 
+    tile_regs_acquire();
     copy_tile_init();
     copy_tile(icb, itile, dst0);
 
     recip_tile_init();
     recip_tile(dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
 
     if (pop)
         cb_pop_front(icb, pop);
@@ -644,6 +730,7 @@ ALWI void reduce_tile_and_recip_tile_to_cb(
     cb_reserve_back(ocb, onetile);
     cb_wait_front(icb1, onetile);
 
+    tile_regs_acquire();
     reduce_init_delta<false>(reduce_op, dim);
     for (uint32_t x = 0; x < size; ++x) {
         cb_wait_front(icb0, x + 1);  // must be a cumulative wait for correctness
@@ -660,8 +747,12 @@ ALWI void reduce_tile_and_recip_tile_to_cb(
 
     recip_tile_init();
     recip_tile(dst0);
+    tile_regs_commit();
 
+    tile_regs_wait();
     pack_tile(dst0, ocb);
+    tile_regs_release();
+
     cb_push_back(ocb, onetile);
 }
 

--- a/tt_eager/tt_dnn/op_library/moreh_sgd/kernels/moreh_sgd.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sgd/kernels/moreh_sgd.cpp
@@ -38,13 +38,9 @@ void MAIN {
         uint32_t cb_grad_tmp = cb_grad;
         #if defined(WEIGHT_DECAY)
             // grad += param * weight_decay
-            ACQ();
             mul_tiles_to_cb(cb_param_in, cb_scalar_args, cb_tmp1, 0, weight_decay_tile, /*pop0=*/0, /*pop1=*/0);
-            REL();
 
-            ACQ();
             add_tiles_to_cb(cb_grad, cb_tmp1, cb_tmp2, 0, 0, /*pop0=*/1, /*pop1=*/1);
-            REL();
 
             cb_grad_tmp = cb_tmp2;
         #endif // WEIGHT_DECAY
@@ -53,40 +49,26 @@ void MAIN {
             uint32_t cb_momentum_tmp = cb_grad_tmp;
             #if defined(MOMENTUM_INITIALIZED)
                 // grad * (1 - dampening)
-                ACQ();
                 sub_tiles_to_cb(cb_scalar_args, cb_scalar_args, cb_tmp1, one_tile, dampening_tile, /*pop0=*/0, /*pop0=*/0);
-                REL();
 
-                ACQ();
                 mul_tiles_to_cb(cb_grad_tmp, cb_tmp1, cb_tmp3, 0, 0, /*pop0=*/0, /*pop0=*/1);
-                REL();
 
                 // momentum_v * momentum
-                ACQ();
                 mul_tiles_to_cb(cb_momentum_in, cb_scalar_args, cb_tmp4, 0, momentum_tile, /*pop0=*/1, /*pop0=*/0);
-                REL();
 
-                ACQ();
                 add_tiles_to_cb(cb_tmp3, cb_tmp4, cb_tmp1, 0, 0, /*pop0=*/1, /*pop1=*/1);
-                REL();
 
                 cb_momentum_tmp = cb_tmp1;
             #endif
 
-            ACQ();
             copy_tile_to_cb(cb_momentum_tmp, cb_momentum_out, 0, /*pop=*/0);
-            REL();
 
             #if defined(NESTEROV)
                 // grad = grad + momentum_v * momentum
-                ACQ();
                 uint32_t pop_momentum = (cb_grad_tmp != cb_momentum_tmp);
                 mul_tiles_to_cb(cb_momentum_tmp, cb_scalar_args, cb_tmp3, 0, momentum_tile, /*pop0=*/pop_momentum, /*pop1=*/0);
-                REL();
 
-                ACQ();
                 add_tiles_to_cb(cb_tmp3, cb_grad_tmp, cb_tmp4, 0, 0, /*pop0=*/1, /*pop1=*/1);
-                REL();
 
                 cb_grad_tmp = cb_tmp4;
             #else
@@ -103,13 +85,9 @@ void MAIN {
         #endif // MOMENTUM
 
         // param_out = param_in - lr * grad
-        ACQ();
         mul_tiles_to_cb(cb_scalar_args, cb_grad_tmp, cb_tmp3, lr_tile, 0, /*pop0=*/0, /*pop1=*/1);
-        REL();
 
-        ACQ();
         sub_tiles_to_cb(cb_param_in, cb_tmp3, cb_param_out, 0, 0, /*pop0=*/1, /*pop1=*/1);
-        REL();
     }
 }
 }  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/kernels/moreh_softmax_c_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/kernels/moreh_softmax_c_large.cpp
@@ -27,50 +27,38 @@ void MAIN {
     for (uint32_t n = 0; n < N; ++n) {
         // step 1, compute exp(x)
         for (uint32_t i = 0; i < dim_size; ++i) {
-            ACQ();
             #ifdef SOFTMAX
                 exp_tile_to_cb(cb_in0, cb_exps);
             #else
                 rexp_tile_to_cb(cb_in0, cb_exps);
             #endif
-            REL();
 
             if (i == 0) {
-                ACQ();
                 copy_tile_to_cb(cb_exps, cb_add);
-                REL();
             } else {
-                ACQ();
                 add_tiles_to_cb(cb_add, cb_exps, cb_add);
-                REL();
             }
         }
 
         // step 2, compute 1/sum(exp(x))
-        ACQ();
         recip_tile_to_cb(cb_add, cb_recipsumexps);
-        REL();
 
         // step 3, compute final result
         cb_wait_front(cb_recipsumexps, onetile);
         for (uint32_t i = 0; i < dim_size; ++i) {
             // compute exp(x)
-            ACQ();
             #ifdef SOFTMAX
                 exp_tile_to_cb(cb_in0, cb_exps);
             #else
                 rexp_tile_to_cb(cb_in0, cb_exps);
             #endif
-            REL();
 
             // multiply recip
-            ACQ();
             #ifdef LOG
                 mul_tiles_log_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
             #else
                 mul_tiles_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
             #endif
-            REL();
         }
 
         cb_pop_front(cb_recipsumexps, onetile);

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/kernels/moreh_softmax_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/kernels/moreh_softmax_h_large.cpp
@@ -29,7 +29,6 @@ void MAIN {
     for (uint32_t n = 0; n < N; ++n) {
         // step 1, compute exp(x)
         for (uint32_t h = 0; h < Ht; ++h) {
-            ACQ();
             if (h == Ht - 1) {
                 #ifdef SOFTMAX
                     exp_tile_and_mask_tile_to_cb(
@@ -57,44 +56,33 @@ void MAIN {
                     rexp_tile_to_cb(cb_in0, cb_exps);
                 #endif
             }
-            REL();
 
             if (h == 0) {
-                ACQ();
                 copy_tile_to_cb(cb_exps, cb_add);
-                REL();
             } else {
-                ACQ();
                 add_tiles_to_cb(cb_add, cb_exps, cb_add);
-                REL();
             }
         }
 
         // step 2, compute 1/sum(exp(x))
-        ACQ();
         reduce_tile_and_recip_tile_to_cb(
             REDUCE_OP, REDUCE_DIM, cb_add, cb_bcast_scaler, cb_recipsumexps, /*size=*/1, /*pop0=*/1, /*pop1=*/0);
-        REL();
 
         // step 3, compute final result
         for (uint32_t h = 0; h < Ht; h += onetile) {
             // compute exp(x)
-            ACQ();
             #ifdef SOFTMAX
                 exp_tile_to_cb(cb_in0, cb_exps);
             #else
                 rexp_tile_to_cb(cb_in0, cb_exps);
             #endif
-            REL();
 
             // compute exp(x)/sum(exp(x))
-            ACQ();
             #ifdef LOG
                 mul_tiles_bcast_rows_log_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
             #else
                 mul_tiles_bcast_rows_to_cb(cb_exps, cb_recipsumexps, cb_out0, 0, 0, /*pop0=*/1, /*pop1=*/0);
             #endif
-            REL();
         }
         cb_pop_front(cb_recipsumexps, onetile);
     }

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/kernels/moreh_softmax_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/kernels/moreh_softmax_w.cpp
@@ -31,7 +31,6 @@ void MAIN {
     for (uint32_t n = 0; n < N; ++n) {
         // step 1, compute exp(x)
         for (uint32_t w = 0; w < Wt; ++w) {
-            ACQ();
             if (w == Wt - 1) {
                 #ifdef SOFTMAX
                     exp_tile_and_mask_tile_to_cb(
@@ -59,24 +58,19 @@ void MAIN {
                     rexp_tile_to_cb(cb_in0, cb_exps);
                 #endif
             }
-            REL();
         }
 
         // step 2, compute 1/sum(exp(x))
-        ACQ();
         reduce_tile_and_recip_tile_to_cb(
             REDUCE_OP, REDUCE_DIM, cb_exps, cb_bcast_scaler, cb_recipsumexps, Wt, /*pop0=*/0, /*pop1=*/0);
-        REL();
 
         // step 3, compute final result
         for (uint32_t w = 0; w < Wt; w += onetile) {
-            ACQ();
             #ifdef LOG
                 mul_tiles_bcast_cols_log_to_cb(cb_exps, cb_recipsumexps, cb_out0, w, 0, /*pop0=*/0, /*pop1=*/0);
             #else
                 mul_tiles_bcast_cols_to_cb(cb_exps, cb_recipsumexps, cb_out0, w, 0, /*pop0=*/0, /*pop1=*/0);
             #endif
-            REL();
         }
 
         cb_pop_front(cb_recipsumexps, onetile);

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/kernels/moreh_softmax_backward_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/kernels/moreh_softmax_backward_h_large.cpp
@@ -36,53 +36,35 @@ void MAIN {
             for (uint32_t h = 0; h < Ht; ++h) {
                 if (h == Ht - 1) {
                     if (h == 0){
-                        ACQ();
                         mask_tile_to_cb(cb_dy, cb_mask, cb_add, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
-                        REL();
                     } else {
                         constexpr auto cb_inter0 = tt::CB::c_intermed0;
-                        ACQ();
                         mask_tile_to_cb(cb_dy, cb_mask, cb_inter0, /*itile=*/0, /*mtile=*/0, /*pop=*/1, /*popm=*/0);
-                        REL();
 
-                        ACQ();
                         add_tiles_to_cb(cb_add, cb_inter0, cb_add);
-                        REL();
                     }
                 } else {
                     if (h == 0) {
-                        ACQ();
                         copy_tile_to_cb(cb_dy, cb_add);
-                        REL();
                     }
                     else {
-                        ACQ();
                         add_tiles_to_cb(cb_add, cb_dy, cb_add);
-                        REL();
                     }
                 }
             }
 
-            ACQ();
             reduce_tile_to_cb(REDUCE_OP, REDUCE_DIM, cb_add, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop1=*/0);
-            REL();
 
             for (uint32_t h = 0; h < Ht; ++h) {
                 // exp(y)
                 constexpr auto cb_exp = tt::CB::c_intermed0;
-                ACQ();
                 exp_tile_to_cb(cb_y, cb_exp, 0);
-                REL();
 
                 // sum * exp(y)
-                ACQ();
                 mul_tiles_bcast_rows_to_cb(cb_exp, cb_sum, cb_inter2, 0, 0, /*pop0=*/1, /*pop1=*/0);
-                REL();
 
                 // dy - sum * exp(y)
-                ACQ();
                 sub_tiles_to_cb(cb_dy, cb_inter2, cb_dx);
-                REL();
             }
 
             cb_pop_front(cb_sum, onetile);
@@ -90,39 +72,28 @@ void MAIN {
 
             // step 1, compute y * dy
             for (uint32_t h = 0; h < Ht; ++h) {
-                ACQ();
                 if (h == Ht - 1) {
                     mul_tiles_and_mask_tile_to_cb(
                         cb_y, cb_dy, cb_mask, cb_ydy, 0, 0, 0, /*pop0=*/1, /*pop1=*/1, /*popm=*/0);
                 } else {
                     mul_tiles_to_cb(cb_y, cb_dy, cb_ydy);
                 }
-                REL();
 
                 if (h == 0) {
-                    ACQ();
                     copy_tile_to_cb(cb_ydy, cb_add);
-                    REL();
                 } else {
-                    ACQ();
                     add_tiles_to_cb(cb_add, cb_ydy, cb_add);
-                    REL();
                 }
             }
 
             // step 2, compute sum(y * dy)
-            ACQ();
             reduce_tile_to_cb(REDUCE_OP, REDUCE_DIM, cb_add, cb_bcast_scaler, cb_sum, /*size=*/1, /*pop0=*/1, /*pop1=*/0);
-            REL();
 
             // step 3, compute final result
             for (uint32_t h = 0; h < Ht; ++h) {
                 // dy - sum
-                ACQ();
                 sub_tiles_bcast_rows_to_cb(cb_dy, cb_sum, cb_inter2, 0, 0, /*pop0=*/1, /*pop1=*/0);
-                REL();
 
-                ACQ();
                 #ifdef SOFTMAX
                     // (dy - sum) * y
                     mul_tiles_to_cb(cb_y, cb_inter2, cb_dx);
@@ -130,7 +101,6 @@ void MAIN {
                     // -(dy - sum) * y
                     mul_tiles_and_negative_to_cb(cb_y, cb_inter2, cb_dx);
                 #endif
-                REL();
             }
 
             cb_pop_front(cb_sum, onetile);

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/kernels/moreh_softmax_backward_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/kernels/moreh_softmax_backward_w.cpp
@@ -34,53 +34,34 @@ void MAIN {
             // sum(dy)
             if (Wt == 1) {
                 // apply mask
-                ACQ();
                 mask_tile_to_cb(cb_dy, cb_mask, cb_inter2, /*itile=*/0, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
-                REL();
 
-                ACQ();
                 reduce_tile_to_cb(REDUCE_OP, REDUCE_DIM, cb_inter2, cb_bcast_scaler, cb_sum, 1, /*pop0=*/1, /*pop=1*/0);
-                REL();
             } else {
                 constexpr auto cb_inter0 = tt::CB::c_intermed0;
-                ACQ();
                 reduce_tile_to_cb(REDUCE_OP, REDUCE_DIM, cb_dy, cb_bcast_scaler, cb_inter0, Wt - 1, /*pop0=*/0, /*pop=1*/0);
-                REL();
 
                 constexpr auto cb_inter1 = tt::CB::c_intermed1;
-                ACQ();
                 mask_tile_to_cb(cb_dy, cb_mask, cb_inter1, /*itile=*/Wt - 1, /*mtile=*/0, /*pop=*/0, /*popm=*/0);
-                REL();
 
                 constexpr auto cb_inter2 = tt::CB::c_intermed2;
-                ACQ();
                 reduce_tile_to_cb(REDUCE_OP, REDUCE_DIM, cb_inter1, cb_bcast_scaler, cb_inter2, 1, /*pop0=*/1, /*pop=1*/0);
-                REL();
 
-                ACQ();
                 add_tiles_to_cb(cb_inter0, cb_inter2, cb_sum);
-                REL();
             }
-
 
             // dy - sum * exp(y)
             constexpr auto cb_exp = tt::CB::c_intermed0;  // y * dy
 
             for (uint32_t w = 0; w < Wt; w += onetile) {
                 // exp(y)
-                ACQ();
                 exp_tile_to_cb(cb_y, cb_exp, w, /*dst=*/0, /*pop=*/0);
-                REL();
 
                 // sum * exp(y)
-                ACQ();
                 mul_tiles_bcast_cols_to_cb(cb_exp, cb_sum, cb_inter2, 0, 0, /*pop0=*/1, /*pop1=*/0);
-                REL();
 
                 // dy - sum * exp(y)
-                ACQ();
                 sub_tiles_to_cb(cb_dy, cb_inter2, cb_dx, w, 0, /*pop0=*/0, /*pop1=*/1);
-                REL();
             }
 
             cb_pop_front(cb_sum, onetile);
@@ -89,29 +70,22 @@ void MAIN {
         #else
             // step 1, compute y * dy
             for (uint32_t w = 0; w < Wt; ++w) {
-                ACQ();
                 if (w == Wt - 1) {
                     mul_tiles_and_mask_tile_to_cb(
                         cb_y, cb_dy, cb_mask, cb_ydy, w, w, 0, /*pop0=*/0, /*pop1=*/0, /*popm=*/0);
                 } else {
                     mul_tiles_to_cb(cb_y, cb_dy, cb_ydy, w, w, /*pop0=*/0, /*pop1=*/0);
                 }
-                REL();
             }
 
             // step 2, compute sum(y * dy)
-            ACQ();
             reduce_tile_to_cb(REDUCE_OP, REDUCE_DIM, cb_ydy, cb_bcast_scaler, cb_sum, Wt, /*pop0=*/Wt, /*pop=1*/0);
-            REL();
 
             // step 3, compute final result
             for (uint32_t w = 0; w < Wt; w += onetile) {
                 // dy - sum
-                ACQ();
                 sub_tiles_bcast_cols_to_cb(cb_dy, cb_sum, cb_inter2, w, 0, /*pop0=*/0, /*pop1=*/0);
-                REL();
 
-                ACQ();
                 #ifdef SOFTMAX
                     // (dy - sum) * y
                     mul_tiles_to_cb(cb_y, cb_inter2, cb_dx, w, 0, /*pop0=*/0, /*pop1=*/1);
@@ -119,7 +93,6 @@ void MAIN {
                     // -(dy - sum) * y
                     mul_tiles_and_negative_to_cb(cb_y, cb_inter2, cb_dx, w, 0, /*pop0=*/0, /*pop1=*/1);
                 #endif
-                REL();
             }
 
             cb_pop_front(cb_sum, onetile);


### PR DESCRIPTION
I found that using the `tile_regs_acquire` API instead of `acquire_dst` and `release_dst`e does not reproduce the issue, so I applied it.