### PR TITLE
#7826: Update ttnn doc for abs

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/sweeps/abs.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/abs.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Not Supported"
     return False, None
 
 

--- a/ttnn/ttnn/operations/math.py
+++ b/ttnn/ttnn/operations/math.py
@@ -102,6 +102,8 @@ def register_ttl_math_op_function_unary(name, ttl_math_op_function, op_name):
                 >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
                 >>> output = ttnn.{(name)}(tensor)
 
+            {math_op_function.__doc__}
+
             """
     setattr(THIS_MODULE, name, math_op_function)
 


### PR DESCRIPTION
Issue #7826  

**Fix Provided**
- Documentation updated with information regarding supported data type and layout for abs
- Skipped test for unsupported layout

**Sweep test results :** 
- `tests/ttnn/sweep_tests/sweeps/abs.py` - [abs.csv](https://github.com/tenstorrent/tt-metal/files/15131311/abs.csv)
