### PR TITLE
#7511: plumb through core_grid to C++ for ttnn matmul/linear and do not call create_matmul_program_config

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -398,23 +398,14 @@ def test_matmul_with_core_grid(device, batch_size):
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    if batch_size == 1:
-        with pytest.raises(RuntimeError) as exception:
-            output_tensor = ttnn.matmul(
-                input_tensor_a,
-                input_tensor_b,
-                core_grid=ttnn.CoreGrid(y=batch_size, x=8),
-            )
-        assert "1D mcast for in0 or in1 is not implemented yet" in str(exception.value)
-    else:
-        output_tensor = ttnn.matmul(
-            input_tensor_a,
-            input_tensor_b,
-            core_grid=ttnn.CoreGrid(y=batch_size, x=8),
-        )
+    output_tensor = ttnn.matmul(
+        input_tensor_a,
+        input_tensor_b,
+        core_grid=ttnn.CoreGrid(y=batch_size, x=8),
+    )
 
-        output_tensor = ttnn.to_torch(output_tensor)
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
 
 
 @skip_for_wormhole_b0()

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -48,7 +48,7 @@ namespace tt::tt_metal::detail
         )doc");
         // *** matrix multiplication ***
         m_tensor.def("matmul", &matmul,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false, R"doc(
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false, py::arg("core_grid_x").noconvert() = std::nullopt, py::arg("core_grid_y").noconvert() = std::nullopt, R"doc(
             Perform a non-batched matrix multiplication ``arg0 x arg1`` with two tensors.
 
             Both input tensors must have BFLOAT16 data type.
@@ -64,7 +64,7 @@ namespace tt::tt_metal::detail
         )doc");
 
         m_tensor.def("bmm", &bmm,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false,  R"doc(
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false, py::arg("core_grid_x").noconvert() = std::nullopt, py::arg("core_grid_y").noconvert() = std::nullopt, R"doc(
             Perform a batched matmul ``arg0 x arg1`` with two tensors, where batch dims match.
 
             Both input tensors must have BFLOAT16 data type.

--- a/ttnn/cpp/pybind11/operations/matmul.hpp
+++ b/ttnn/cpp/pybind11/operations/matmul.hpp
@@ -23,16 +23,18 @@ void py_module(py::module& module) {
            const ttnn::Tensor& input_tensor_b,
            const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
            const std::optional<const DataType> dtype = std::nullopt,
-           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) -> ttnn::Tensor {
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+           const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> ttnn::Tensor  {
             return ttnn::operations::matmul::matmul(
-                input_tensor_a, input_tensor_b, memory_config, dtype, compute_kernel_config);
+                input_tensor_a, input_tensor_b, memory_config, dtype, compute_kernel_config, core_grid);
         },
         py::arg("input_tensor_a"),
         py::arg("input_tensor_b"),
         py::kw_only(),
         py::arg("memory_config") = DRAM_MEMORY_CONFIG,
         py::arg("dtype") = std::nullopt,
-        py::arg("compute_kernel_config") = std::nullopt);
+        py::arg("compute_kernel_config") = std::nullopt,
+	py::arg("core_grid") = std::nullopt);
 
     module.def(
         "matmul",
@@ -66,7 +68,8 @@ void py_module(py::module& module) {
            const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
            const std::optional<const DataType> dtype = std::nullopt,
            const std::optional<const std::string>& activation = std::nullopt,
-           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) -> ttnn::Tensor {
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+           const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> ttnn::Tensor  {
             return ttnn::operations::matmul::linear(
                 input_tensor_a,
                 input_tensor_b,
@@ -74,7 +77,8 @@ void py_module(py::module& module) {
                 memory_config,
                 dtype,
                 activation,
-                compute_kernel_config);
+                compute_kernel_config,
+		core_grid);
         },
         py::arg("input_tensor_a"),
         py::arg("input_tensor_b"),
@@ -83,7 +87,8 @@ void py_module(py::module& module) {
         py::arg("memory_config") = DRAM_MEMORY_CONFIG,
         py::arg("dtype") = std::nullopt,
         py::arg("activation") = std::nullopt,
-        py::arg("compute_kernel_config") = std::nullopt);
+        py::arg("compute_kernel_config") = std::nullopt,
+	py::arg("core_grid") = std::nullopt);
 
     module.def(
         "linear",

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -382,14 +382,6 @@ def matmul(
     if use_1d_systolic_array is not None or core_grid is not None:
         if program_config is not None:
             raise RuntimeError(f"Cannot use program_config with use_1d_systolic_array or core_grid")
-        program_config = create_matmul_program_config(
-            input_tensor_a=input_tensor_a,
-            input_tensor_b=input_tensor_b,
-            core_grid=core_grid or input_tensor_a.device().core_grid,
-            activation=None,
-            use_1d_systolic_array=use_1d_systolic_array,
-            compute_kernel_config=compute_kernel_config,
-        )
 
     if program_config is not None:
         return ttnn._ttnn.operations.matmul.matmul(
@@ -407,6 +399,7 @@ def matmul(
         memory_config=memory_config,
         dtype=dtype,
         compute_kernel_config=compute_kernel_config,
+        core_grid=core_grid,
     )
 
 
@@ -482,14 +475,6 @@ def linear(
     if use_1d_systolic_array is not None or core_grid is not None:
         if program_config is not None:
             raise RuntimeError(f"Cannot use program_config with use_1d_systolic_array or core_grid")
-        program_config = create_matmul_program_config(
-            input_tensor_a=input_tensor_a,
-            input_tensor_b=input_tensor_b,
-            core_grid=core_grid or input_tensor_a.device().core_grid,
-            activation=activation,
-            use_1d_systolic_array=use_1d_systolic_array,
-            compute_kernel_config=compute_kernel_config,
-        )
 
     if program_config is not None:
         return ttnn._ttnn.operations.matmul.linear(
@@ -511,6 +496,7 @@ def linear(
         dtype=dtype,
         activation=activation,
         compute_kernel_config=compute_kernel_config,
+        core_grid=core_grid,
     )
 
 


### PR DESCRIPTION
Plumbs through core_grid to C++ for ttnn matmul/linear and removes the create_matmul_program_config call

Also:
- removes a TODO comment since what the TODO refers to is already done in validate()
- changes a unit test to remove an expected exception
- removes the use of use_1d_systolic_array. It's not applicable to bmm and it's the default behaviour anyway:
get_matmul_program_config() in tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp already uses that as the default for matmul 
```
if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED
              or input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED)
            and (grid_size.x > 1 or grid_size.y > 1)
```
and validate() in tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp requires those layouts
```
            if constexpr (
                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>
            ) {         
... if (program_config.mcast_in0) ...
                        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
... else ...
                        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
```

Testing:
- local unit tests pass:
pytest ./tests/ttnn/unit_tests/operations/test_matmul.py
======================================================================================== 130 passed, 2 skipped in 435.44s (0:07:15) ========================================================================================
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py
======================================================================================= 36 passed, 156 skipped in 102.67s (0:01:42) ========================================================================================
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
================================================================================= 473 passed, 15 skipped, 12 xfailed in 484.40s (0:08:04) ==================================================================================
