### PR TITLE
#7625: Switch untilize and tilize ops to use multi_core by default in pybinds

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_untilize.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_untilize.py
@@ -14,7 +14,7 @@ import tt_lib as ttl
 
 @pytest.mark.parametrize(
     "input_shapes",
-    (([[1, 1, 32, 32]], [[3, 1, 320, 384]], [[1, 1, 128, 7328]])),
+    (([[1, 1, 32, 32]], [[3, 1, 320, 384]], [[1, 1, 128, 1856]])),
 )
 @pytest.mark.parametrize(
     "untilize_args",

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
@@ -151,7 +151,7 @@ namespace tt::tt_metal::detail{
 
         m_tensor.def("tilize", &tilize,
             py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt,
-            py::arg("use_multicore").noconvert() = false, R"doc(
+            py::arg("use_multicore").noconvert() = true, R"doc(
             Changes data layout of input tensor to TILE.
 
             Input tensor must be on TT accelerator device, in ROW_MAJOR layout, and have BFLOAT16 data type.
@@ -197,7 +197,7 @@ namespace tt::tt_metal::detail{
         m_tensor.def("untilize", &untilize,
             py::arg("input").noconvert(),
             py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            py::arg("use_multicore").noconvert() = false,
+            py::arg("use_multicore").noconvert() = true,
             py::arg("use_pack_untilize").noconvert() = true,
             R"doc(
             Changes data layout of input tensor to ROW_MAJOR.


### PR DESCRIPTION
- Lower width for tt-dnn untilize sweep test