### PR TITLE
#7869: Resolve issue with missed deallocates

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer.hpp
@@ -91,9 +91,8 @@ inline std::tuple<Tensor, Tensor, Tensor> split_query_key_value_and_split_heads(
             input_shape.with_tile_padding()[1],
             input_shape.with_tile_padding()[2]);
         auto outputs = tt::tt_metal::nlp_create_qkv_heads_falcon7b(input_4d, memory_config.value_or(input_tensor.memory_config()));
-        return {outputs.at(0), outputs.at(1), outputs.at(2)};
-        // return detail::reshape_outputs_of_split_query_key_value_and_split_heads(
-        //     {outputs.at(0), outputs.at(1), outputs.at(2)}, sequence_size, sequence_size_padded, transpose_key);
+        return detail::reshape_outputs_of_split_query_key_value_and_split_heads(
+            {outputs.at(0), outputs.at(1), outputs.at(2)}, sequence_size, sequence_size_padded, transpose_key);
     }
 
     uint32_t hidden_dim_padded = 0, hidden_dim = 0;


### PR DESCRIPTION
OOM on device seen when running end to end TTNN falcon tests with @arakhmati's recent TTNN C++ port.

The reason for this was the reference count being incorrectly incremented when we do something like this:

```
Tensor f(const Tensor& tensor) { return tensor; }
a = f(a);
```

Here, a temporary copy of the tensor is created to populate the return value of `f()`, which invokes the copy ctor and increments the ref count. Additionally, the tensor is then removed by `std::move` on the temp. When the destructor is called on the temp val, the tensor attributes shared ptr is already reset (due to move being called) and hence the ref count is not decremented.

Thus, this identity operation, ends up incrementing the ref count, which is incorrect. The identity op here was `ttnn::reshape`, with the tensor shape and the required shape matching.

This commit resolves the issue by detecting such cases and handling the ref count appropriately.

Passing Post Commit and Multichip Pipelines with reshape enabled:
https://github.com/tenstorrent/tt-metal/actions/runs/8864686318
https://github.com/tenstorrent/tt-metal/actions/runs/8864687539/job/24340129903