### PR TITLE
#7872: Fix to handle batch broadcast in 3D tensor

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_add.py
+++ b/tests/ttnn/unit_tests/operations/test_add.py
@@ -115,6 +115,36 @@ def test_expand_and_broadcast(device, h, w):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
+@pytest.mark.parametrize("h", [500])
+@pytest.mark.parametrize("w", [512])
+def test_expand_and_broadcast_3D(device, h, w):
+    torch_input_tensor_a = torch.rand((8, h, w), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand((1, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
+@pytest.mark.parametrize("h", [500])
+@pytest.mark.parametrize("w", [512])
+def test_expand_and_broadcast_channel_4D(device, h, w):
+    torch_input_tensor_a = torch.rand((1, 8, h, w), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.add(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
 @pytest.mark.skip(reason="4005: Unable to broadcast on batch or seq dimension")
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])

--- a/ttnn/cpp/ttnn/op_library/binary/binary_op.hpp
+++ b/ttnn/cpp/ttnn/op_library/binary/binary_op.hpp
@@ -113,6 +113,20 @@ struct MakeBinary {
                     input_tensor_b = repeat(input_tensor_b, repeats.value(), output_memory_config);
                 }
 
+                if (input_shape_a.rank() == 3 and input_shape_b.rank() == 3 and input_shape_a[0] > input_shape_b[0] and
+                    input_shape_a[-1] == input_shape_b[-1] and input_shape_a[-2] == input_shape_b[-2] ) {
+                    tt::log_warning(tt::LogOp, "Using repeat op to broadcast batch dim for rank 3");
+                    Shape repeats({input_shape_a[0], 1, 1});
+                    input_tensor_b = repeat(input_tensor_b, repeats.value(), output_memory_config);
+                }
+                if (input_shape_a.rank() == 4 and input_shape_b.rank() == 4 and input_shape_a[1] > input_shape_b[1] and
+                    input_shape_a[-1] == input_shape_b[-1] and input_shape_a[-2] == input_shape_b[-2] and
+                    input_shape_a[-4] == input_shape_b[-4]) {
+                    tt::log_warning(tt::LogOp, "Using repeat op to broadcast channel dim");
+                    Shape repeats({1, input_shape_a[1], 1, 1});
+                    input_tensor_b = repeat(input_tensor_b, repeats.value(), output_memory_config);
+                }
+
                 return operation::run(
                     Binary{BinaryProgramConfig{
                         binary_op_type,


### PR DESCRIPTION
Primary issue : #7872 
Handle batch broadcast in 3D input tensor for ttnn binary operation. 
Also add channel[dim=1] broadcast in 4D input tensor for ttnn binary operation. 
CI test: https://github.com/tenstorrent/tt-metal/actions/runs/8878294110