### PR TITLE
#7921 Fix a few warnings surfacing from GCC 13

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -1481,10 +1481,7 @@ void prepare_inputs(
 }
 
 float to_float(bfloat16 bfloat16_num) {
-    uint16_t uint16_data = *reinterpret_cast<uint16_t*>(&bfloat16_num);
-    uint32_t uint32_data = (uint16_data << 16);
-    float float_data = *reinterpret_cast<float*>(&uint32_data);
-    return float_data;
+    return bfloat16_num.to_float();
 }
 
 bool validation_single_core(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     uint32_t num_cores_r = 0;
     uint32_t num_cores_c = 0;
     uint32_t num_tiles = 204800;
-    uint32_t noc_index;
+    uint32_t noc_index = 0;
     uint32_t noc_direction = 0;
     uint32_t access_type = 0;
     uint32_t tiles_per_transfer;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
     uint32_t num_cores_r = 0;
     uint32_t num_cores_c = 0;
     uint32_t num_tiles = 204800;
-    uint32_t noc_index;
+    uint32_t noc_index = 0;
     uint32_t access_type = 0;
     uint32_t num_tests = 10;
     bool use_device_profiler = false;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -229,10 +229,13 @@ inline void generate_random_packed_payload(vector<uint32_t>& cmds,
 
 inline void add_bare_dispatcher_cmd(vector<uint32_t>& cmds,
                                     CQDispatchCmd cmd) {
+    static_assert(sizeof(CQDispatchCmd) % sizeof(uint32_t) == 0, "CQDispatchCmd size must be a multiple of uint32_t size");
+    const size_t num_uint32s = sizeof(CQDispatchCmd) / sizeof(uint32_t);
+    uint32_t buf[num_uint32s];
 
-    uint32_t *ptr = (uint32_t *)&cmd;
-    for (int i = 0; i < sizeof(CQDispatchCmd) / sizeof(uint32_t); i++) {
-        cmds.push_back(*ptr++);
+    memcpy(buf, &cmd, sizeof(cmd));
+    for (size_t i = 0; i < num_uint32s; i++) {
+        cmds.push_back(buf[i]);
     }
 }
 

--- a/tt_eager/tensor/serialization.cpp
+++ b/tt_eager/tensor/serialization.cpp
@@ -4,6 +4,7 @@
 
 #include "tensor/serialization.hpp"
 
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <string>

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tensor/tensor.hpp"
+#include <cstdint>
 #include <memory>
 
+#include "tensor/tensor.hpp"
 #include "tensor/tensor_impl.hpp"
 #include "tensor/tensor_impl_wrapper.hpp"
 #include "tensor/tensor_utils.hpp"

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 
 #include "tensor/borrowed_buffer_functions.hpp"
 #include "tensor/owned_buffer_functions.hpp"

--- a/tt_eager/tensor/tensor_utils.hpp
+++ b/tt_eager/tensor/tensor_utils.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "tensor/tensor.hpp"
 
 namespace tt {

--- a/tt_eager/tensor/types.cpp
+++ b/tt_eager/tensor/types.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #include "tensor/types.hpp"
 
 #include "third_party/magic_enum/magic_enum.hpp"

--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <variant>

--- a/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #ifndef REDUCE_OP
 #define REDUCE_OP PoolType::SUM
 #endif

--- a/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
+
 #include "tt_dnn/op_library/bcast/bcast_op.hpp"
 #include "tt_metal/common/assert.hpp"
 #include "impl/buffers/buffer.hpp"

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -47,7 +47,7 @@ void validate_op_launch(Device* worker) {
     }
 }
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 void override_addresses(
     const OverrideAddressesCallback& override_addresses_callback,
     const Program &program,
@@ -114,7 +114,7 @@ constexpr auto decorate_device_operation(const Function& function) {
     };
 }
 
-template<typename OutputTensors = Tensors>
+template<typename OutputTensors>
 OutputTensors run_host_operation(const HostOperation<OutputTensors>& operation, const Tensors& input_tensors) {
     ZoneScopedN("TT_DNN_HOST_OP");
     uint32_t op_id = assign_id();
@@ -132,7 +132,7 @@ template OptionalTensors run_host_operation(const HostOperation<OptionalTensors>
 
 inline const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
 
-template<typename OutputTensors = Tensors>
+template<typename OutputTensors>
 OutputTensors run_device_operation(
     std::optional<std::reference_wrapper<CommandQueue>> queue,
     const DeviceOperation<OutputTensors>& operation,
@@ -255,7 +255,7 @@ template OptionalTensors run_device_operation(
     const OptionalConstTensors& optional_input_tensors,
     const OptionalTensors& optional_output_tensors);
 
-template<typename OutputTensors = Tensors>
+template<typename OutputTensors>
 OutputTensors run_multi_device_operation(
     std::optional<std::reference_wrapper<CommandQueue>> queue,
     const DeviceOperation<OutputTensors>& operation,
@@ -352,14 +352,14 @@ template Tensors run_multi_device_operation(
 
 }  // namespace detail
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 OutputTensors run(const HostOperation<OutputTensors>& operation, const Tensors& input_tensors) {
     return detail::decorate_host_operation(detail::run_host_operation<OutputTensors>)(operation, input_tensors);
 }
 template Tensors run(const HostOperation<Tensors>& operation, const Tensors& input_tensors);
 template OptionalTensors run(const HostOperation<OptionalTensors>& operation, const Tensors& input_tensors);
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 OutputTensors run(
     CommandQueue& queue,
     const DeviceOperation<OutputTensors>& operation,
@@ -398,7 +398,7 @@ template OptionalTensors run(
     const OptionalConstTensors& optional_input_tensors,
     const OptionalTensors& optional_output_tensors);
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 OutputTensors run(
     const DeviceOperation<OutputTensors>& operation,
     const Tensors& input_tensors,
@@ -438,7 +438,7 @@ template OptionalTensors run(
     const OptionalConstTensors& optional_input_tensors,
     const OptionalTensors& optional_output_tensors);
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 OutputTensors run_without_autoformat(
     const DeviceOperation<OutputTensors>& operation,
     const Tensors& input_tensors,
@@ -480,7 +480,7 @@ template OptionalTensors run_without_autoformat<OptionalTensors>(
     const OptionalConstTensors& optional_input_tensors
 );
 
-template<class OutputTensors=Tensors>
+template<class OutputTensors>
 OutputTensors run_without_autoformat(
     const DeviceOperation<OutputTensors>& operation,
     const Tensors& input_tensors,

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -61,13 +61,22 @@ class LockFreeQueue {
         bool empty() const {
             return head.load() == tail.load();
         }
-        class Iterator : public std::iterator<std::forward_iterator_tag, T> {
+        class Iterator {
+           public:
+            using iterator_category = std::forward_iterator_tag;
+            using value_type = T;
+            using difference_type = std::ptrdiff_t;
+            using pointer = T*;
+            using reference = T&;
+
            private:
             Node* current;
 
            public:
+            // Constructor initializes the iterator with a pointer to a Node
             Iterator(Node* start) : current(start) {}
 
+            // Prefix increment operator overloading
             Iterator& operator++() {
                 if (current != nullptr) {
                     current = current->next;
@@ -75,8 +84,10 @@ class LockFreeQueue {
                 return *this;
             }
 
+            // Inequality operator overloading
             bool operator!=(const Iterator& other) const { return current != other.current; }
 
+            // Dereference operator overloading
             const T& operator*() const { return *(current->data); }
         };
 


### PR DESCRIPTION
These fixes are for new warnings produced by GCC 13 (as shipped in Ubuntu LTS 24.04):

Olof Johansson (7):
      #7921 lock_free_queue: Fix C++17 warnings around iterator
      #7921 core_coord: simplify merge logic in CoreRangeSet
      #7921 tt_dnn: Fixup GCC 13 template build error
      #7921 tt_eager: Add missing <cstdint> includes
      #7921 test_noc_adjacent: Silence uninitialized variable warning
      #7921 tests/tt_metal: use standard bfloat16 to_float()
      #7921 tt_metal/perf_microbenchmark: fixup warnings with newer GCC
