### PR TITLE
#7052: Fix ttnn std

### DIFF
--- a/ttnn/ttnn/operations/reduction.py
+++ b/ttnn/ttnn/operations/reduction.py
@@ -52,10 +52,13 @@ def std(
 
     if isinstance(dim, tuple):
         if dim == (rank - 1,):
+            reduce_index = input_shape[-1]
             reduce_op_dim = ttl.tensor.ReduceOpDim.W
         elif dim == (rank - 2,):
+            reduce_index = input_shape[-2]
             reduce_op_dim = ttl.tensor.ReduceOpDim.H
         elif dim == (rank - 1, rank - 2):
+            reduce_index = input_shape[-1] * input_shape[-2]
             reduce_op_dim = ttl.tensor.ReduceOpDim.HW
         else:
             raise RuntimeError("Unsupported dim")
@@ -76,9 +79,9 @@ def std(
 
     input_tensor = ttnn.unsqueeze_to_4D(input_tensor)
 
-    mean_tensor = ttl.tensor.reduce(input_tensor, ttl.tensor.ReduceOpMath.SUM, reduce_op_dim, 1 / input_shape[-1])
+    mean_tensor = ttl.tensor.reduce(input_tensor, ttl.tensor.ReduceOpMath.SUM, reduce_op_dim, 1 / reduce_index)
     mean_square_tensor = ttl.tensor.reduce(
-        ttl.tensor.pow(input_tensor, 2.0), ttl.tensor.ReduceOpMath.SUM, reduce_op_dim, 1 / input_shape[-1]
+        ttl.tensor.pow(input_tensor, 2.0), ttl.tensor.ReduceOpMath.SUM, reduce_op_dim, 1 / reduce_index
     )
     output_tensor = ttl.tensor.sqrt(ttl.tensor.sub(mean_square_tensor, (ttl.tensor.pow(mean_tensor, 2.0))))
     output_tensor = ttnn.reshape(output_tensor, ttnn.Shape(output_shape, padded_output_shape))


### PR DESCRIPTION
Fix provided for Issue #7052 

Test result : `tests/ttnn/python_api_testing/non_working_unit_tests/grayskull/test_std.py`
<img width="777" alt="Screenshot 2024-04-30 at 4 05 37 PM" src="https://github.com/tenstorrent/tt-metal/assets/138196495/54bc3494-2908-4b50-8318-d86647031166">

CI: 
- All post-commit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8893171046) - PASSED
- [post-commit] Fast Dispatch unit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8893172719) - PASSED
- [post-commit] Slow Dispatch unit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8893181806) - PASSED