### PR TITLE
#0: Update the testing command of SD device-perf test

### DIFF
--- a/models/experimental/functional_stable_diffusion/tests/test_perf_stable_diffusion.py
+++ b/models/experimental/functional_stable_diffusion/tests/test_perf_stable_diffusion.py
@@ -285,7 +285,7 @@ def test_stable_diffusion_device_perf(expected_perf):
     margin = 0.12
     batch = 1
     iterations = 1
-    command = f"pytest tests/ttnn/integration_tests/stable_diffusion/test_unet_2d_condition_model.py::test_unet_2d_condition_model_512x512[batch_size=2-in_channels=4-input_height=64-input_width=64]"
+    command = f"pytest tests/ttnn/integration_tests/stable_diffusion/test_unet_2d_condition_model.py::test_unet_2d_condition_model_512x512[batch_size=2-in_channels=4-input_height=64-input_width=64-device_l1_small_size=32768]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"


### PR DESCRIPTION
it fixes `ERROR: not found` of SD device-perf test (log: https://github.com/tenstorrent/tt-metal/actions/runs/8896958981/job/24430797015)