### PR TITLE
 Fix ND EnqueueTrace hangs due to CQ_DISPATCH_CMD_WAIT being NOP within Trace and add test back to CI

### DIFF
--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -32,7 +32,7 @@ jobs:
           {name: eager unit tests 2, cmd: pytest $TT_METAL_HOME/tests/tt_eager/python_api_testing/unit_testing/ -vvv --splits 4 --group 2 },
           {name: eager unit tests 3, cmd: pytest $TT_METAL_HOME/tests/tt_eager/python_api_testing/unit_testing/ -vvv --splits 4 --group 3 },
           {name: eager unit tests 4, cmd: pytest $TT_METAL_HOME/tests/tt_eager/python_api_testing/unit_testing/ -vvv --splits 4 --group 4 },
-          # {name: eager trace tests, cmd: pytest $TT_METAL_HOME/tests/tt_eager/python_api_testing/trace_testing/ -vvv},
+          {name: eager trace tests, cmd: pytest $TT_METAL_HOME/tests/tt_eager/python_api_testing/trace_testing/ -vvv},
           {name: sweep, cmd: pytest $TT_METAL_HOME/tests/tt_eager/python_api_testing/sweep_tests/pytests/ -vvv},
         ]
     name: ${{ matrix.test-group.name }} ${{ matrix.runner-info.arch }} ${{ matrix.runner-info.name }}

--- a/tests/tt_eager/python_api_testing/trace_testing/misc/test_average_pool.py
+++ b/tests/tt_eager/python_api_testing/trace_testing/misc/test_average_pool.py
@@ -79,3 +79,6 @@ def test_run_average_pool(act_shape, dtype, device):
         print(f"Output PCC = {output_pcc}")
 
         assert passing_pcc
+
+    # Done with the trace, can deallocate the buffers now.
+    ttl.device.ReleaseLastTrace(device)

--- a/tests/tt_eager/python_api_testing/trace_testing/misc/test_average_pool.py
+++ b/tests/tt_eager/python_api_testing/trace_testing/misc/test_average_pool.py
@@ -22,7 +22,7 @@ def shape_padded(shape):
 @pytest.mark.parametrize(
     "act_shape",
     (
-        pytest.param([1, 7, 7, 2048], marks=pytest.mark.skip),
+        pytest.param([1, 7, 7, 2048]),
         ([1, 1, 32, 64]),
     ),
     ids=["resnet50_unpadded", "tile_divisible"],
@@ -68,6 +68,7 @@ def test_run_average_pool(act_shape, dtype, device):
             out = out.unpad_from_tile(out_shape)
 
         out_pytorch = out.to_torch()
+        out = out.pad_to_tile(0)  # Undo, so next loop unpad_from_tile works again.
 
         ## reference
         act_channels_first = torch.permute(act, (0, 3, 1, 2))  # Torch operates on channels-first tensors

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -178,6 +178,10 @@ void DeviceModule(py::module &m_device) {
     m_device.def("ExecuteLastTrace", &detail::ExecuteLastTrace, R"doc(
         Execute last captured trace on Device handle
     )doc");
+    m_device.def("ReleaseLastTrace", &detail::ReleaseLastTrace, R"doc(
+        Release last captured Trace on Device handle
+    )doc");
+
 }
 
 void ProfilerModule(py::module &m_profiler) {

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -49,6 +49,7 @@ namespace tt::tt_metal{
         void BeginTraceCapture(Device *device);
         void EndTraceCapture(Device *device);
         void ExecuteLastTrace(Device *device, bool blocking);
+        void ReleaseLastTrace(Device *device);
 
         void BeginTraceCaptures(std::map<chip_id_t, Device *> devices);
         void EndTraceCaptures(std::map<chip_id_t, Device *> devices);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1867,8 +1867,11 @@ void Device::begin_trace() {
 }
 
 void Device::end_trace() {
-    this->trace_insts_.clear();
+
+    // Currently only supports one trace at a time per CQ, so release last trace
+    // before instantiating new ones.
     this->release_last_trace();
+
     for (size_t cq_id = 0; cq_id < num_hw_cqs(); cq_id++) {
         hw_command_queues_[cq_id]->record_end();
         trace_contexts_.at(cq_id)->data = std::move(this->sysmem_manager().get_bypass_data());
@@ -1906,6 +1909,7 @@ void Device::release_last_trace() {
             }
         }
     }
+    this->trace_insts_.clear();
 }
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1379,8 +1379,13 @@ void HWCommandQueue::enqueue_program(
         }
     });
 
-    auto command = EnqueueProgramCommand(this->id, this->device, program, this->manager, this->expected_num_workers_completed);
+    // Snapshot of expected workers from previous programs, used for dispatch_wait cmd generation.
+    uint32_t expected_workers_completed = this->manager.get_bypass_mode() ? this->trace_ctx->num_completion_worker_cores : this->expected_num_workers_completed;
+    auto command = EnqueueProgramCommand(this->id, this->device, program, this->manager, expected_workers_completed);
     this->enqueue_command(command, blocking);
+
+    log_trace(tt::LogMetal, "Created EnqueueProgramCommand (active_cores: {} bypass_mode: {} expected_workers_completed: {})",
+        program.program_transfer_info.num_active_cores, this->manager.get_bypass_mode(), expected_workers_completed);
 
     if (this->manager.get_bypass_mode()) {
         this->trace_ctx->num_completion_worker_cores += program.program_transfer_info.num_active_cores;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -701,6 +701,10 @@ void CloseDevices(std::map<chip_id_t, Device *> devices) {
         device->execute_last_trace(blocking);
     }
 
+    void ReleaseLastTrace(Device *device) {
+        device->release_last_trace();
+    }
+
     void BeginTraceCaptures(std::map<chip_id_t, Device *> devices) {
         for (const auto &[device_id, dev] : devices) {
             dev->begin_trace();


### PR DESCRIPTION
A fix for the hang in this test for issue #7793  and adding the test back to CI, passing now.

Note: Some other Trace issues/potential issues found through this debug, will open another PR for them (they weren't required for this test to pass).


```
pytest tests/tt_eager/python_api_testing/trace_testing/misc/test_average_pool.py::test_run_average_pool[BFLOAT16-resnet50_unpadded]
```