### PR TITLE
#0: Specify DEBUG_STATUS as a string literal instead of multiple chars

### DIFF
--- a/docs/source/tt-metalium/tools/watcher.rst
+++ b/docs/source/tt-metalium/tools/watcher.rst
@@ -57,10 +57,10 @@ below:
     #include "debug/status.h"
 
     void noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-        DEBUG_STATUS('N', 'S', 'W');
+        DEBUG_STATUS("NSW");
         while ((*sem_addr) != val)
             ;
-        DEBUG_STATUS('N', 'S', 'D');
+        DEBUG_STATUS("NSD");
     }
 
 Waypoints have no overhead when the watcher is disabled and can be used inside user written kernels.  They indicate
@@ -124,7 +124,7 @@ assert was tripped. An example of an assert and the resulting message is shown b
         uint32_t a = get_arg_val<uint32_t>(0);
         uint32_t b = get_arg_val<uint32_t>(1);
 
-        DEBUG_STATUS('A', 'S', 'T', '1');
+        DEBUG_STATUS("AST1");
         ASSERT(a != b);
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
@@ -18,10 +18,10 @@ void noc_async_read_tile_dram_sharded(uint32_t src_addr, uint32_t dest_addr, uin
     src_addr_ += bank_to_dram_offset[bank_id];
     src_noc_xy = dram_bank_to_noc_xy[noc_index][bank_id];
 
-    DEBUG_STATUS('N', 'R', 'T', 'W');
+    DEBUG_STATUS("NRTW");
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(get_noc_addr_helper(src_noc_xy, src_addr_), dest_addr, page_size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-    DEBUG_STATUS('N', 'R', 'T', 'D');
+    DEBUG_STATUS("NRTD");
 
     if constexpr(use_vc) {
         uint32_t noc_rd_cmd_field = NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/spoof_prefetch.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
     cb_release_pages<dispatch_noc_xy, dispatch_cb_sem>(dispatch_cb_pages * iterations);
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(dispatch_cb_sem));
-    DEBUG_STATUS('Z', 'Z', 'Z');
+    DEBUG_STATUS("ZZZ");
     while (*sem_addr != dispatch_cb_pages * iterations - 96);
     // Send finish, last cmd in the chain
     noc_async_write(cmd_ptr, get_noc_addr_helper(dispatch_noc_xy, dispatch_cb_base), dispatch_cb_page_size);

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
@@ -35,11 +35,11 @@ void MAIN {
 
     // Post a new waypoint with a delay after (to let the watcher poll it)
     hacky_sync(1, sync_wait_cycles, sync_address);
-    DEBUG_STATUS('A', 'A', 'A', 'A');
+    DEBUG_STATUS("AAAA");
     hacky_sync(2, sync_wait_cycles, sync_address);
-    DEBUG_STATUS('B', 'B', 'B', 'B');
+    DEBUG_STATUS("BBBB");
     hacky_sync(3, sync_wait_cycles, sync_address);
-    DEBUG_STATUS('C', 'C', 'C', 'C');
+    DEBUG_STATUS("CCCC");
     hacky_sync(4, sync_wait_cycles, sync_address);
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
 }

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_common_api.h
@@ -20,9 +20,9 @@
  *************************************************************************/
 
 inline void llk_math_wait_for_dest_available() {
-    DEBUG_STATUS('M', 'W', 'D', 'W');
+    DEBUG_STATUS("MWDW");
     _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    DEBUG_STATUS('M', 'W', 'D', 'D');
+    DEBUG_STATUS("MWDD");
 }
 
 template <bool is_fp32_dest_acc_en = false /*not used*/>

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_AB_api.h
@@ -75,7 +75,7 @@ inline void llk_unpack_AB(
     std::uint32_t offset_address_b = MUL_TILE_SIZE_AND_INDEX<true>(unpack_src_format[operandB_id], tile_index_b);
     std::uint32_t address_b = base_address_b + offset_address_b;
 
-    DEBUG_STATUS('U', 'A', 'B', 'W');
+    DEBUG_STATUS("UABW");
     _llk_unpack_AB_<BType>(address_a, address_b, transpose_of_faces > 0);
-    DEBUG_STATUS('U', 'A', 'B', 'D');
+    DEBUG_STATUS("UABD");
 }

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -86,12 +86,12 @@ inline void llk_unpack_AB_matmul(
             std::uint32_t offset_address_b = MUL_TILE_SIZE_AND_INDEX<true>(unpB_src_format, (tile_index_b+ct));
             std::uint32_t address_b = base_address_b + offset_address_b;
 
-            DEBUG_STATUS('U', 'P', 'M', 'W');
+            DEBUG_STATUS("UPMW");
             _llk_unpack_AB_matmul_(
                 address_a,
                 address_b
             );
-            DEBUG_STATUS('U', 'P', 'M', 'D');
+            DEBUG_STATUS("UPMD");
         }
     }
 }

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_A_api.h
@@ -71,9 +71,9 @@ inline void llk_unpack_A(
     std::uint32_t offset_address = MUL_TILE_SIZE_AND_INDEX<true>((uint)unpack_src_format[operand_id], tile_index);
     std::uint32_t address = base_address + offset_address;
 
-    DEBUG_STATUS('U', 'P', 'A', 'W');
+    DEBUG_STATUS("UPAW");
     _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest>(address, transpose_of_faces > 0);
-    DEBUG_STATUS('U', 'P', 'A', 'D');
+    DEBUG_STATUS("UPAD");
 }
 
 
@@ -92,9 +92,9 @@ inline void llk_unpack_A_block(
     std::uint32_t address = base_address;
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
-        DEBUG_STATUS('U', 'P', 'A', 'W');
+        DEBUG_STATUS("UPAW");
         _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest>(address, transpose_of_faces>0);
         address += offset_address;
-        DEBUG_STATUS('U', 'P', 'A', 'D');
+        DEBUG_STATUS("UPAD");
     }
 }

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_reduce_api.h
@@ -45,7 +45,7 @@ inline void llk_unpack_reduce_mop_config() {
 template <PoolType type, ReduceDim dim>
 inline void llk_unpack_reduce_init(const std::uint32_t within_face_16x16_transpose=0) {
 
-    DEBUG_STATUS('U', 'P', 'R', 'W');
+    DEBUG_STATUS("UPRW");
     volatile uint tt_reg_ptr *cfg = get_cfg_pointer();  // get pointer to registers for current state ID
 
     constexpr std::uint32_t unpA_operand_id = 0;
@@ -79,7 +79,7 @@ inline void llk_unpack_reduce_init(const std::uint32_t within_face_16x16_transpo
     cfg[THCON_SEC1_REG3_Base_cntx1_address_ADDR32] = (((uint)l1_buffer) >> 4) - 1;  // Set l1 buffer address
 
     _llk_unpack_reduce_init_<type, dim>(within_face_16x16_transpose);
-    DEBUG_STATUS('U', 'P', 'R', 'D');
+    DEBUG_STATUS("UPRD");
 }
 
 template <PoolType type, ReduceDim dim>
@@ -90,9 +90,9 @@ inline void llk_unpack_reduce(const std::uint32_t operand, const std::uint32_t t
     std::uint32_t offset_address = MUL_TILE_SIZE_AND_INDEX(unpack_src_format[operand_id], tile_index);
     std::uint32_t address = base_address + offset_address;
 
-    DEBUG_STATUS('U', 'P', 'R', 'W');
+    DEBUG_STATUS("UPRW");
     _llk_unpack_reduce_<type, dim>(
         address
     );
-    DEBUG_STATUS('U', 'P', 'R', 'D');
+    DEBUG_STATUS("UPRD");
 }

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_tilize_api.h
@@ -63,14 +63,14 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, s
     std::uint32_t base_address = cb_interface[operand_id].fifo_rd_ptr - 1;  // Remove header size added by descriptor
     std::uint32_t src_format = (uint)unpack_src_format[operand_id];
 
-    DEBUG_STATUS('U', 'P', 'T', 'W');
+    DEBUG_STATUS("UPTW");
     _llk_unpack_tilize_(
         base_address,
         tile_index,
         src_format,
         block_ct_dim
     );
-    DEBUG_STATUS('U', 'P', 'T', 'D');
+    DEBUG_STATUS("UPTD");
 }
 
 inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c_tiles) {
@@ -191,7 +191,7 @@ inline void llk_unpack_tilizeA_B(
     // Program srcA and srcB base addresses
     volatile uint tt_reg_ptr *cfg = get_cfg_pointer();  // get pointer to registers for current state ID
 
-    DEBUG_STATUS('U', 'P', 'T', 'W');
+    DEBUG_STATUS("UPTW");
     const std::uint32_t num_loops = (num_faces>1) ? num_faces/2 : 1;
     for (std::uint32_t n = 0; n < num_loops; n++) {
         std::uint32_t address_a = base_address_a + top_face_offset_address + ((n == 1) ? bot_face_offset_address : 0);
@@ -226,7 +226,7 @@ inline void llk_unpack_tilizeA_B(
         // Switch unpacker config context
         switch_config_context(unp_cfg_context);
     }
-    DEBUG_STATUS('U', 'P', 'T', 'D');
+    DEBUG_STATUS("UPTD");
 }
 
 template <bool reuse_srcB = false>

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_untilize_api.h
@@ -46,7 +46,7 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
 }
 
 inline void llk_unpack_untilize_uninit(uint32_t operand) {
-    DEBUG_STATUS('U', 'P', 'U', 'W');
+    DEBUG_STATUS("UPUW");
     std::uint32_t operand_id = get_operand_id(operand);
     // Check that unpacker is done (all contexts freed up) before starting hw configuration
     wait_for_idle();
@@ -92,7 +92,7 @@ inline void llk_unpack_untilize_uninit(uint32_t operand) {
 
     TTI_WRCFG(p_gpr::ZERO, p_cfg::WRCFG_32b, UNP0_ADDR_BASE_REG_0_Base_ADDR32); // Clear base address register
     TTI_NOP; TTI_NOP;
-    DEBUG_STATUS('U', 'P', 'U', 'D');
+    DEBUG_STATUS("UPUD");
 }
 
 template <bool first_pass = true>
@@ -107,8 +107,8 @@ inline void llk_unpack_untilize_pass(std::uint32_t operand, std::uint32_t block_
 }
 
 inline void llk_unpack_untilize(std::uint32_t operand, std::uint32_t block_c_tiles) {
-    DEBUG_STATUS('U', 'P', 'U', 'W');
+    DEBUG_STATUS("UPUW");
     llk_unpack_untilize_pass<true>(operand, block_c_tiles);
     llk_unpack_untilize_pass<false>(operand, block_c_tiles);
-    DEBUG_STATUS('U', 'P', 'U', 'D');
+    DEBUG_STATUS("UPUD");
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -23,9 +23,9 @@
  *************************************************************************/
 
 inline void llk_math_wait_for_dest_available() {
-    DEBUG_STATUS('M', 'W', 'D', 'W');
+    DEBUG_STATUS("MWDW");
     _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    DEBUG_STATUS('M', 'W', 'D', 'D');
+    DEBUG_STATUS("MWDD");
 }
 
 template <bool is_fp32_dest_acc_en = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -80,9 +80,9 @@ inline void llk_unpack_AB(
     std::uint32_t offset_address_b = cb_interface[operandB_id].fifo_page_size * tile_index_b;
     std::uint32_t address_b = base_address_b + offset_address_b;
 
-    DEBUG_STATUS('U', 'A', 'B', 'W');
+    DEBUG_STATUS("UABW");
     _llk_unpack_AB_<BType>(address_a, address_b, transpose_of_faces > 0);
-    DEBUG_STATUS('U', 'A', 'B', 'D');
+    DEBUG_STATUS("UABD");
 }
 
 template <ReduceDim dim, BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -123,7 +123,7 @@ inline void llk_unpack_AB_matmul(
     std::uint32_t tile_size_a = cb_interface[operandA_id].fifo_page_size;
     std::uint32_t tile_size_b = cb_interface[operandB_id].fifo_page_size;
 
-    DEBUG_STATUS('U', 'P', 'M', 'W');
+    DEBUG_STATUS("UPMW");
     _llk_unpack_AB_matmul_(
         base_address_a,
         base_address_b,
@@ -138,5 +138,5 @@ inline void llk_unpack_AB_matmul(
         ct_dim,
         rt_dim,
         kt_dim);
-    DEBUG_STATUS('U', 'P', 'M', 'D');
+    DEBUG_STATUS("UPMD");
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -90,10 +90,10 @@ inline void llk_unpack_A(
     std::uint32_t offset_address = cb_interface[operand_id].fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
-    DEBUG_STATUS('U', 'P', 'A', 'W');
+    DEBUG_STATUS("UPAW");
     _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         address, transpose_of_faces > 0, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
-    DEBUG_STATUS('U', 'P', 'A', 'D');
+    DEBUG_STATUS("UPAD");
 }
 
 
@@ -110,10 +110,10 @@ inline void llk_unpack_A_block(
     std::uint32_t address = base_address;
 
     for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
-        DEBUG_STATUS('U', 'P', 'A', 'W');
+        DEBUG_STATUS("UPAW");
         _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
             address, transpose_of_faces > 0, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
         address += offset_address;
-        DEBUG_STATUS('U', 'P', 'A', 'D');
+        DEBUG_STATUS("UPAD");
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_reduce_api.h
@@ -88,9 +88,9 @@ inline void llk_unpack_reduce(const std::uint32_t operand, const std::uint32_t t
     std::uint32_t offset_address = cb_interface[operand_id].fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
 
-    DEBUG_STATUS('U', 'P', 'R', 'W');
+    DEBUG_STATUS("UPRW");
     _llk_unpack_reduce_<type, dim>(
         address
     );
-    DEBUG_STATUS('U', 'P', 'R', 'D');
+    DEBUG_STATUS("UPRD");
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -86,7 +86,7 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, s
 
     std::uint32_t base_address = cb_interface[operand_id].fifo_rd_ptr - 1;  // Remove header size added by descriptor
 
-    DEBUG_STATUS('U', 'P', 'T', 'W');
+    DEBUG_STATUS("UPTW");
     _llk_unpack_tilize_(
         base_address,
         tile_index,
@@ -96,7 +96,7 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, s
         num_faces,
         narrow_tile
     );
-    DEBUG_STATUS('U', 'P', 'T', 'D');
+    DEBUG_STATUS("UPTD");
 }
 
 inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c_tiles) {
@@ -233,7 +233,7 @@ inline void llk_unpack_tilizeA_B(
     // Program srcA and srcB base addresses
     volatile uint tt_reg_ptr *cfg = get_cfg_pointer();  // get pointer to registers for current state ID
 
-    DEBUG_STATUS('U', 'P', 'T', 'W');
+    DEBUG_STATUS("UPTW");
     for (std::uint32_t n = 0; n < num_loops; n++) {
         std::uint32_t address_a = base_address_a + top_face_offset_address + ((n == 1) ? bot_face_offset_address : 0);
 
@@ -287,7 +287,7 @@ inline void llk_unpack_tilizeA_B(
         // Switch unpacker config context
         switch_config_context(unp_cfg_context);
     }
-    DEBUG_STATUS('U', 'P', 'T', 'D');
+    DEBUG_STATUS("UPTD");
 }
 
 template <bool zero_srcA = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_untilize_api.h
@@ -63,7 +63,7 @@ inline void llk_unpack_untilize_uninit(const std::uint32_t operand, const std::u
     std::uint32_t unpA_ch1_x_stride = (uint) (unpack_dst_format[operand_id]&0x3) == (uint) DataFormat::Float32 ? 4 : (uint) (unpack_dst_format[operand_id]&0x3) == (uint) DataFormat::Float16 ? 2 : 1;
     std::uint32_t unpA_ch1_y_stride = FACE_C_DIM*FACE_R_DIM*unpA_ch1_x_stride;
 
-    DEBUG_STATUS('U', 'P', 'U', 'W');
+    DEBUG_STATUS("UPUW");
     // Check that unpacker is done (all contexts freed up) before starting hw configuration
     wait_for_idle();
 
@@ -79,7 +79,7 @@ inline void llk_unpack_untilize_uninit(const std::uint32_t operand, const std::u
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32+1, 0, 0xFFFF>(1);
     cfg_reg_rmw_tensix<UNP0_ADDR_CTRL_XY_REG_1_Ystride_ADDR32, UNP0_ADDR_CTRL_XY_REG_0_Ystride_SHAMT, UNP0_ADDR_CTRL_XY_REG_1_Ystride_MASK>(unpA_ch1_y_stride);
     TTI_NOP; TTI_NOP; // Do we need this for WH?
-    DEBUG_STATUS('U', 'P', 'U', 'D');
+    DEBUG_STATUS("UPUD");
 }
 
 template <bool first_pass = true>
@@ -94,8 +94,8 @@ inline void llk_unpack_untilize_pass(std::uint32_t operand, std::uint32_t block_
 }
 
 inline void llk_unpack_untilize(std::uint32_t operand, std::uint32_t block_c_tiles) {
-    DEBUG_STATUS('U', 'P', 'U', 'W');
+    DEBUG_STATUS("UPUW");
     llk_unpack_untilize_pass<true>(operand, block_c_tiles);
     llk_unpack_untilize_pass<false>(operand, block_c_tiles);
-    DEBUG_STATUS('U', 'P', 'U', 'D');
+    DEBUG_STATUS("UPUD");
 }

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -248,9 +248,9 @@ inline void deassert_ncrisc_trisc()
 inline void set_ncrisc_kernel_resume_deassert_address()
 {
     volatile tt_reg_ptr uint32_t* cfg_regs = core.cfg_regs_base(0);
-    DEBUG_STATUS('I', 'N', 'W');
+    DEBUG_STATUS("INW");
     while (mailboxes->ncrisc_halt.resume_addr == 0);
-    DEBUG_STATUS('I', 'N', 'D');
+    DEBUG_STATUS("IND");
     cfg_regs[NCRISC_RESET_PC_PC_ADDR32] = mailboxes->ncrisc_halt.resume_addr;
 }
 
@@ -275,14 +275,14 @@ inline void finish_ncrisc_copy_and_run()
 
 inline void wait_ncrisc_trisc()
 {
-    DEBUG_STATUS('N', 'T', 'W');
+    DEBUG_STATUS("NTW");
     while (mailboxes->slave_sync.all != RUN_SYNC_MSG_ALL_SLAVES_DONE);
-    DEBUG_STATUS('N', 'T', 'D');
+    DEBUG_STATUS("NTD");
 }
 
 int main() {
 
-    DEBUG_STATUS('I');
+    DEBUG_STATUS("I");
 
     int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
     l1_to_local_mem_copy((uint*)__ldm_data_start, (uint tt_l1_ptr *)MEM_BRISC_INIT_LOCAL_L1_BASE, num_words);
@@ -298,9 +298,9 @@ int main() {
     set_ncrisc_kernel_resume_deassert_address();
 
     // Wait for ncrisc to halt
-    DEBUG_STATUS('I', 'N', 'W');
+    DEBUG_STATUS("INW");
     while (mailboxes->slave_sync.ncrisc != RUN_SYNC_MSG_DONE);
-    DEBUG_STATUS('I', 'N', 'D');
+    DEBUG_STATUS("IND");
 
     mailboxes->launch.run = RUN_MSG_DONE;
 
@@ -308,9 +308,9 @@ int main() {
         init_sync_registers();
         assert_just_ncrisc_reset();
 
-        DEBUG_STATUS('G', 'W');
+        DEBUG_STATUS("GW");
         while (mailboxes->launch.run != RUN_MSG_GO);
-        DEBUG_STATUS('G', 'D');
+        DEBUG_STATUS("GD");
 
         {
             DeviceZoneScopedMainN("BRISC-FW");
@@ -332,7 +332,7 @@ int main() {
             finish_ncrisc_copy_and_run();
 
             // Run the BRISC kernel
-            DEBUG_STATUS('R');
+            DEBUG_STATUS("R");
             if (mailboxes->launch.enable_brisc) {
                 setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.max_cb_index, true, true);
                 kernel_init();
@@ -340,7 +340,7 @@ int main() {
                 // This was not initialized in kernel_init
                 noc_local_state_init(noc_index);
             }
-            DEBUG_STATUS('D');
+            DEBUG_STATUS("D");
 
             wait_ncrisc_trisc();
 

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -51,7 +51,7 @@ void __attribute__((section("code_l1"))) risc_init() {
 }
 
 void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
-    DEBUG_STATUS('I');
+    DEBUG_STATUS("I");
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
     // Not using firmware_kernel_common_init since it is copying to registers
@@ -66,7 +66,7 @@ void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
         noc_local_state_init(n);
     }
     ncrisc_noc_full_sync();
-    DEBUG_STATUS('R', 'E', 'W');
+    DEBUG_STATUS("REW");
     uint32_t count = 0;
     while (routing_info->routing_enabled != 1) {
         volatile uint32_t *ptr = (volatile uint32_t *)0xffb2010c;
@@ -74,14 +74,14 @@ void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
         *ptr = 0xAABB0000 | (count & 0xFFFF);
         internal_::risc_context_switch();
     }
-    DEBUG_STATUS('R', 'E', 'D');
+    DEBUG_STATUS("RED");
 
 
     while (routing_info->routing_enabled) {
         // FD: assume that no more host -> remote writes are pending
         if (mailboxes->launch.run == RUN_MSG_GO) {
             DeviceZoneScopedMainN("ERISC-FW");
-            DEBUG_STATUS('R');
+            DEBUG_STATUS("R");
             kernel_init();
         } else {
             internal_::risc_context_switch();

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -71,7 +71,7 @@ void init_sync_registers() {
 
 int main() {
 
-    DEBUG_STATUS('I');
+    DEBUG_STATUS("I");
     int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
     uint32_t *local_mem_ptr = (uint32_t *)__ldm_data_start;
     uint32_t *l1_data_ptr = (uint32_t *)MEM_IERISC_INIT_LOCAL_L1_BASE;
@@ -91,12 +91,12 @@ int main() {
 
         init_sync_registers();
         // Wait...
-        DEBUG_STATUS('G', 'W');
+        DEBUG_STATUS("GW");
         while (mailboxes->launch.run != RUN_MSG_GO)
         {
             RISC_POST_HEARTBEAT(heartbeat);
         };
-        DEBUG_STATUS('G', 'D');
+        DEBUG_STATUS("GD");
 
         {
             DeviceZoneScopedMainN("ERISC-FW");
@@ -107,7 +107,7 @@ int main() {
             setup_cb_read_write_interfaces(0, num_cbs_to_early_init, true, true);
 
             // Run the ERISC kernel
-            DEBUG_STATUS('R');
+            DEBUG_STATUS("R");
             //if (mailboxes->launch.enable_brisc) {
                 //UC FIXME: do i need this?
                 setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.max_cb_index, true, true);
@@ -116,7 +116,7 @@ int main() {
                 // This was not initialized in kernel_init
             //    noc_local_state_init(noc_index);
             //}
-            DEBUG_STATUS('D');
+            DEBUG_STATUS("D");
 
             mailboxes->launch.run = RUN_MSG_DONE;
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -43,7 +43,7 @@ extern "C" void notify_brisc_and_halt(uint32_t status);
 
 int main(int argc, char *argv[]) {
 
-  DEBUG_STATUS('I');
+  DEBUG_STATUS("I");
 
   int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
   l1_to_local_mem_copy((uint*)__ldm_data_start, (uint tt_l1_ptr *)MEM_NCRISC_INIT_LOCAL_L1_BASE, num_words);
@@ -54,16 +54,16 @@ int main(int argc, char *argv[]) {
 
   // Cleanup profiler buffer incase we never get the go message
   while (1) {
-      DEBUG_STATUS('W');
+      DEBUG_STATUS("W");
       notify_brisc_and_halt(RUN_SYNC_MSG_DONE);
       DeviceZoneScopedMainN("NCRISC-FW");
 
 
       setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, true, true);
 
-      DEBUG_STATUS('R');
+      DEBUG_STATUS("R");
       kernel_init();
-      DEBUG_STATUS('D');
+      DEBUG_STATUS("D");
   }
 
   return 0;

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -66,7 +66,7 @@ using namespace ckernel;
 
 int main(int argc, char *argv[])
 {
-    DEBUG_STATUS('I');
+    DEBUG_STATUS("I");
 
     uint tt_l1_ptr *local_l1_start_addr = (uint tt_l1_ptr *)PREPROCESSOR_EXPAND(MEM_TRISC, COMPILE_FOR_TRISC, _INIT_LOCAL_L1_BASE);
     int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
 
     // Cleanup profiler buffer incase we never get the go message
     while (1) {
-        DEBUG_STATUS('W');
+        DEBUG_STATUS("W");
         while (*trisc_run != RUN_SYNC_MSG_GO);
         DeviceZoneScopedMainN("TRISC-FW");
 
@@ -100,9 +100,9 @@ int main(int argc, char *argv[])
         setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, cb_init_read, cb_init_write);
 #endif
 
-        DEBUG_STATUS('R');
+        DEBUG_STATUS("R");
         kernel_init();
-        DEBUG_STATUS('D');
+        DEBUG_STATUS("D");
 
         // Signal completion
         tensix_sync();

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -313,11 +313,11 @@ inline __attribute__((always_inline)) uint32_t get_read_ptr(uint32_t operand) {
 inline void wait_for_sync_register_value(uint32_t addr, int32_t val) {
     volatile tt_reg_ptr uint32_t* reg_ptr = (volatile uint32_t*)addr;
     int32_t reg_value;
-    DEBUG_STATUS('S', 'W');
+    DEBUG_STATUS("SW");
     do {
         reg_value = reg_ptr[0];
     } while (reg_value != val);
-    DEBUG_STATUS('S', 'D');
+    DEBUG_STATUS("SD");
 }
 
 /**
@@ -342,7 +342,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
     uint32_t pages_received = get_cb_tiles_received_ptr(operand)[0];
 
     int32_t free_space_pages;
-    DEBUG_STATUS('C', 'R', 'B', 'W');
+    DEBUG_STATUS("CRBW");
     do {
         // uint16_t's here because Tensix updates the val at tiles_acked_ptr as uint16 in llk_pop_tiles
         // TODO: I think we could have TRISC update tiles_acked_ptr, and we wouldn't need uint16 here
@@ -357,7 +357,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
             cb_interface[operand].fifo_num_pages - (pages_received - pages_acked);
         free_space_pages = (int32_t)free_space_pages_wrap;
     } while (free_space_pages < num_pages);
-    DEBUG_STATUS('C', 'R', 'B', 'D');
+    DEBUG_STATUS("CRBD");
 }
 
 /**
@@ -389,11 +389,11 @@ void cb_wait_front(int32_t operand, int32_t num_pages) {
 
     uint16_t pages_received;
 
-    DEBUG_STATUS('C', 'W', 'F', 'W');
+    DEBUG_STATUS("CWFW");
     do {
         pages_received = ((uint16_t)reg_read(pages_received_ptr)) - pages_acked;
     } while (pages_received < num_pages);
-    DEBUG_STATUS('C', 'W', 'F', 'D');
+    DEBUG_STATUS("CWFD");
 }
 
 // NOC transfers
@@ -512,10 +512,10 @@ void noc_async_read(std::uint64_t src_noc_addr, std::uint32_t dst_local_l1_addr,
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
-    DEBUG_STATUS('N', 'A', 'R', 'W');
+    DEBUG_STATUS("NARW");
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(src_noc_addr, dst_local_l1_addr, size);
     ncrisc_noc_fast_read_any_len(noc_index, NCRISC_RD_CMD_BUF, src_noc_addr, dst_local_l1_addr, size);
-    DEBUG_STATUS('N', 'A', 'R', 'D');
+    DEBUG_STATUS("NARD");
 }
 
 // TODO: write docs
@@ -527,11 +527,11 @@ void noc_async_read_one_packet(std::uint64_t src_noc_addr, std::uint32_t dst_loc
         Read responses - assigned VCs dynamically
     */
 
-    DEBUG_STATUS('R', 'P', 'W');
+    DEBUG_STATUS("RPW");
     while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-    DEBUG_STATUS('R', 'P', 'D');
+    DEBUG_STATUS("RPD");
 
-    DEBUG_STATUS('N', 'A', 'R', 'W');
+    DEBUG_STATUS("NARW");
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(src_noc_addr, dst_local_l1_addr, size);
 
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dst_local_l1_addr);
@@ -541,7 +541,7 @@ void noc_async_read_one_packet(std::uint64_t src_noc_addr, std::uint32_t dst_loc
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     noc_reads_num_issued[noc_index] += 1;
 
-    DEBUG_STATUS('N', 'A', 'R', 'D');
+    DEBUG_STATUS("NARD");
 }
 
 // TODO: write docs
@@ -553,17 +553,17 @@ void noc_async_read_one_packet_set_state(std::uint64_t src_noc_addr, std::uint32
         Read responses - assigned VCs dynamically
     */
 
-    DEBUG_STATUS('R', 'P', 'W');
+    DEBUG_STATUS("RPW");
     while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-    DEBUG_STATUS('R', 'P', 'D');
+    DEBUG_STATUS("RPD");
 
-    DEBUG_STATUS('N', 'A', 'R', 'W');
+    DEBUG_STATUS("NARW");
     DEBUG_SANITIZE_NOC_ADDR(src_noc_addr, size);
 
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID, src_noc_addr >> 32);
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE, size);
 
-    DEBUG_STATUS('N', 'A', 'R', 'D');
+    DEBUG_STATUS("NARD");
 }
 
 // TODO: write docs
@@ -576,11 +576,11 @@ void noc_async_read_one_packet_with_state(std::uint32_t src_noc_addr, std::uint3
         Read responses - assigned VCs dynamically
     */
 
-    DEBUG_STATUS('R', 'P', 'W');
+    DEBUG_STATUS("RPW");
     while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-    DEBUG_STATUS('R', 'P', 'D');
+    DEBUG_STATUS("RPD");
 
-    DEBUG_STATUS('N', 'A', 'R', 'W');
+    DEBUG_STATUS("NARW");
 
     // TODO: need a way sanitize size + addr w/o directly providing x/y here (grab x/y form state?)
     // DEBUG_SANITIZE_READ_NOC_TRANSACTION(src_noc_addr, dst_local_l1_addr, size);
@@ -593,7 +593,7 @@ void noc_async_read_one_packet_with_state(std::uint32_t src_noc_addr, std::uint3
         noc_reads_num_issued[noc_index] += 1;
     }
 
-    DEBUG_STATUS('N', 'A', 'R', 'D');
+    DEBUG_STATUS("NARD");
 }
 
 // TODO: write docs
@@ -604,17 +604,17 @@ void noc_async_read_set_state(std::uint64_t src_noc_addr) {
         Read responses - assigned VCs dynamically
     */
 
-    DEBUG_STATUS('N', 'A', 'R', 'W');
-    DEBUG_STATUS('R', 'P', 'W');
+    DEBUG_STATUS("NARW");
+    DEBUG_STATUS("RPW");
     while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-    DEBUG_STATUS('R', 'P', 'D');
+    DEBUG_STATUS("RPD");
 
     // TODO: need to sanitize in noc_async_read_with_state
     // DEBUG_SANITIZE_NOC_ADDR(src_noc_addr, size);
 
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID, src_noc_addr >> 32);
 
-    DEBUG_STATUS('N', 'A', 'R', 'D');
+    DEBUG_STATUS("NARD");
 }
 
 // TODO: write docs
@@ -625,16 +625,16 @@ void noc_async_read_with_state(std::uint32_t src_noc_addr, std::uint32_t dst_loc
         Read requests - use static VC
         Read responses - assigned VCs dynamically
     */
-    DEBUG_STATUS('N', 'A', 'R', 'W');
+    DEBUG_STATUS("NARW");
 
     // TODO: need a way sanitize size + addr w/o directly providing x/y here (grab x/y form state?)
     // DEBUG_SANITIZE_NOC_ADDR(src_noc_addr, size);
     DEBUG_SANITIZE_WORKER_ADDR(dst_local_l1_addr, size);
 
     while (size > NOC_MAX_BURST_SIZE) {
-        DEBUG_STATUS('R', 'P', 'W');
+        DEBUG_STATUS("RPW");
         while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-        DEBUG_STATUS('R', 'P', 'D');
+        DEBUG_STATUS("RPD");
 
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dst_local_l1_addr);
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_noc_addr);
@@ -649,9 +649,9 @@ void noc_async_read_with_state(std::uint32_t src_noc_addr, std::uint32_t dst_loc
     }
 
     // left-over packet
-    DEBUG_STATUS('R', 'P', 'W');
+    DEBUG_STATUS("RPW");
     while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-    DEBUG_STATUS('R', 'P', 'D');
+    DEBUG_STATUS("RPD");
 
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dst_local_l1_addr);
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_noc_addr);
@@ -661,7 +661,7 @@ void noc_async_read_with_state(std::uint32_t src_noc_addr, std::uint32_t dst_loc
         noc_reads_num_issued[noc_index] += 1;
     }
 
-    DEBUG_STATUS('N', 'A', 'R', 'D');
+    DEBUG_STATUS("NARD");
 }
 
 FORCE_INLINE
@@ -674,10 +674,10 @@ void noc_async_read_inc_num_issued(std::uint32_t num_issued_reads_inc) {
 FORCE_INLINE
 void noc_async_write_one_packet(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size) {
 
-    DEBUG_STATUS('N', 'W', 'P', 'W');
+    DEBUG_STATUS("NWPW");
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(dst_noc_addr, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
-    DEBUG_STATUS('N', 'W', 'P', 'D');
+    DEBUG_STATUS("NWPD");
 
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
                                 NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) | 0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
@@ -700,10 +700,10 @@ template <bool non_posted = true>
 FORCE_INLINE
 void noc_async_write_one_packet_set_state(std::uint64_t dst_noc_addr, std::uint32_t size) {
 
-    DEBUG_STATUS('N', 'W', 'P', 'W');
+    DEBUG_STATUS("NWPW");
     DEBUG_SANITIZE_NOC_ADDR(dst_noc_addr, size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
-    DEBUG_STATUS('N', 'W', 'P', 'D');
+    DEBUG_STATUS("NWPD");
 
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
                                 NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) | 0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
@@ -721,11 +721,11 @@ template <bool non_posted = true>
 FORCE_INLINE
 void noc_async_write_one_packet_with_state(std::uint32_t src_local_l1_addr, std::uint32_t dst_noc_addr) {
 
-    DEBUG_STATUS('N', 'W', 'P', 'W');
+    DEBUG_STATUS("NWPW");
     // TODO: need a way sanitize size + addr w/o directly providing x/y here (grab x/y form state?)
     // DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(dst_noc_addr, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
-    DEBUG_STATUS('N', 'W', 'P', 'D');
+    DEBUG_STATUS("NWPD");
 
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO, src_local_l1_addr);
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO, dst_noc_addr);
@@ -900,10 +900,10 @@ struct InterleavedAddrGenFast {
             src_noc_xy = l1_bank_to_noc_xy[noc_index][bank_id];
         }
 
-        DEBUG_STATUS('N', 'R', 'T', 'W');
+        DEBUG_STATUS("NRTW");
         DEBUG_SANITIZE_NOC_READ_TRANSACTION(get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, this->page_size);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-        DEBUG_STATUS('N', 'R', 'T', 'D');
+        DEBUG_STATUS("NRTD");
 
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);      // (uint32_t)src_addr
@@ -947,10 +947,10 @@ struct InterleavedAddrGenFast {
             dest_noc_xy = l1_bank_to_noc_xy[noc_index][bank_id];
         }
 
-        DEBUG_STATUS('N', 'W', 'T', 'W');
+        DEBUG_STATUS("NWTW");
         DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr, this->page_size);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
-        DEBUG_STATUS('N', 'W', 'T', 'D');
+        DEBUG_STATUS("NWTD");
 
         uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
                                  NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) | 0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
@@ -1003,10 +1003,10 @@ struct InterleavedPow2AddrGenFast {
             src_noc_xy = l1_bank_to_noc_xy[noc_index][bank_id];
         }
 
-        DEBUG_STATUS('N', 'R', 'P', 'W');
+        DEBUG_STATUS("NRPW");
         DEBUG_SANITIZE_NOC_READ_TRANSACTION(get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, log_base_2_of_page_size);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-        DEBUG_STATUS('N', 'R', 'P', 'D');
+        DEBUG_STATUS("NRPD");
 
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);      // (uint32_t)src_addr
@@ -1044,9 +1044,9 @@ struct InterleavedPow2AddrGenFast {
             src_noc_xy = l1_bank_to_noc_xy[noc_index][bank_id];
         }
 
-        DEBUG_STATUS('R', 'P', 'W');
+        DEBUG_STATUS("RPW");
         while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-        DEBUG_STATUS('R', 'P', 'D');
+        DEBUG_STATUS("RPD");
 
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);      // (uint32_t)src_addr
@@ -1084,10 +1084,10 @@ struct InterleavedPow2AddrGenFast {
             dest_noc_xy = l1_bank_to_noc_xy[noc_index][bank_id];
         }
 
-        DEBUG_STATUS('N', 'W', 'P', 'W');
+        DEBUG_STATUS("NWPW");
         DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr,write_size_bytes);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
-        DEBUG_STATUS('N', 'W', 'P', 'D');
+        DEBUG_STATUS("NWPD");
 
         uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
                                  NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) | 0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
@@ -1193,7 +1193,7 @@ FORCE_INLINE void noc_async_read_tile(
  */
 inline
 void noc_async_write(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size) {
-    DEBUG_STATUS('N', 'A', 'W', 'W');
+    DEBUG_STATUS("NAWW");
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(dst_noc_addr, src_local_l1_addr,size);
     ncrisc_noc_fast_write_any_len(
         noc_index,
@@ -1206,7 +1206,7 @@ void noc_async_write(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr
         false,
         1,
         true);
-    DEBUG_STATUS('N', 'A', 'W', 'D');
+    DEBUG_STATUS("NAWD");
 }
 
 template <bool DRAM>
@@ -1227,7 +1227,7 @@ uint32_t eth_get_semaphore(uint32_t semaphore_id) {
 
 inline
 void noc_semaphore_set_remote(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr) {
-    DEBUG_STATUS('N', 'S', 'S', 'W');
+    DEBUG_STATUS("NSSW");
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(dst_noc_addr, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len(
         noc_index,
@@ -1240,7 +1240,7 @@ void noc_semaphore_set_remote(std::uint32_t src_local_l1_addr, std::uint64_t dst
         false,
         1,
         true);
-    DEBUG_STATUS('N', 'S', 'S', 'D');
+    DEBUG_STATUS("NSSD");
 }
 
 /**
@@ -1282,7 +1282,7 @@ void noc_async_write_multicast(
     std::uint32_t num_dests,
     bool linked = false,
     bool multicast_path_reserve = true) {
-    DEBUG_STATUS('N', 'M', 'W', 'W');
+    DEBUG_STATUS("NMWW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr,size);
     ncrisc_noc_fast_write_any_len(
         noc_index,
@@ -1295,7 +1295,7 @@ void noc_async_write_multicast(
         linked,
         num_dests,
         multicast_path_reserve);
-    DEBUG_STATUS('N', 'M', 'W', 'D');
+    DEBUG_STATUS("NMWD");
 }
 
 /**
@@ -1320,7 +1320,7 @@ void noc_async_write_multicast(
 inline
 void noc_semaphore_set_multicast(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr_multicast, std::uint32_t num_dests, bool linked = false, bool multicast_path_reserve = true) {
-    DEBUG_STATUS('N', 'S', 'M', 'W');
+    DEBUG_STATUS("NSMW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len(
         noc_index,
@@ -1333,13 +1333,13 @@ void noc_semaphore_set_multicast(
         linked,
         num_dests,
         multicast_path_reserve);
-    DEBUG_STATUS('N', 'S', 'M', 'D');
+    DEBUG_STATUS("NSMD");
 }
 
 inline
 void noc_semaphore_set_multicast_loopback_src(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr_multicast, std::uint32_t num_dests, bool linked = false, bool multicast_path_reserve = true) {
-    DEBUG_STATUS('N', 'S', 'M', 'W');
+    DEBUG_STATUS("NSMW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len_loopback_src(
         noc_index,
@@ -1352,7 +1352,7 @@ void noc_semaphore_set_multicast_loopback_src(
         linked,
         num_dests,
         multicast_path_reserve);
-    DEBUG_STATUS('N', 'S', 'M', 'D');
+    DEBUG_STATUS("NSMD");
 }
 
 inline
@@ -1363,7 +1363,7 @@ void noc_async_write_multicast_loopback_src(
     std::uint32_t num_dests,
     bool linked = false,
     bool multicast_path_reserve = true) {
-    DEBUG_STATUS('N', 'M', 'L', 'W');
+    DEBUG_STATUS("NMLW");
     DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, size);
     ncrisc_noc_fast_write_any_len_loopback_src(
         noc_index,
@@ -1376,7 +1376,7 @@ void noc_async_write_multicast_loopback_src(
         linked,
         num_dests,
         multicast_path_reserve);
-    DEBUG_STATUS('N', 'M', 'L', 'D');
+    DEBUG_STATUS("NMLD");
 }
 
 /**
@@ -1389,10 +1389,10 @@ void noc_async_write_multicast_loopback_src(
  */
 FORCE_INLINE
 void noc_async_read_barrier() {
-    DEBUG_STATUS('N', 'R', 'B', 'W');
+    DEBUG_STATUS("NRBW");
     while (!ncrisc_noc_reads_flushed(noc_index))
         ;
-    DEBUG_STATUS('N', 'R', 'B', 'D');
+    DEBUG_STATUS("NRBD");
 }
 
 /**
@@ -1405,10 +1405,10 @@ void noc_async_read_barrier() {
  */
 FORCE_INLINE
 void noc_async_write_barrier() {
-    DEBUG_STATUS('N', 'W', 'B', 'W');
+    DEBUG_STATUS("NWBW");
     while (!ncrisc_noc_nonposted_writes_flushed(noc_index))
         ;
-    DEBUG_STATUS('N', 'W', 'B', 'D');
+    DEBUG_STATUS("NWBD");
 }
 
 /**
@@ -1418,10 +1418,10 @@ void noc_async_write_barrier() {
 */
 FORCE_INLINE
 void noc_async_writes_flushed() {
-    DEBUG_STATUS('N', 'W', 'B', 'W');
+    DEBUG_STATUS("NWBW");
     while (!ncrisc_noc_nonposted_writes_sent(noc_index))
         ;
-    DEBUG_STATUS('N', 'W', 'B', 'D');
+    DEBUG_STATUS("NWBD");
 }
 
 /**
@@ -1434,10 +1434,10 @@ void noc_async_writes_flushed() {
  */
 FORCE_INLINE
 void noc_async_atomic_barrier() {
-    DEBUG_STATUS('N', 'A', 'B', 'W');
+    DEBUG_STATUS("NABW");
     while (!ncrisc_noc_nonposted_atomics_flushed(noc_index))
         ;
-    DEBUG_STATUS('N', 'A', 'B', 'D');
+    DEBUG_STATUS("NABD");
 }
 
 /**
@@ -1455,10 +1455,10 @@ void noc_async_atomic_barrier() {
  */
 FORCE_INLINE
 void noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-    DEBUG_STATUS('N', 'S', 'W');
+    DEBUG_STATUS("NSW");
     while ((*sem_addr) != val)
         ;
-    DEBUG_STATUS('N', 'S', 'D');
+    DEBUG_STATUS("NSD");
 }
 
 /**
@@ -1476,10 +1476,10 @@ void noc_semaphore_wait(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
  */
 FORCE_INLINE
 void noc_semaphore_wait_min(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
-    DEBUG_STATUS('N', 'S', 'M', 'W');
+    DEBUG_STATUS("NSMW");
     while ((*sem_addr) < val)
         ;
-    DEBUG_STATUS('N', 'S', 'M', 'D');
+    DEBUG_STATUS("NSMD");
 }
 
 /**
@@ -1525,7 +1525,7 @@ void noc_semaphore_set(volatile tt_l1_ptr uint32_t* sem_addr, uint32_t val) {
 FORCE_INLINE
 void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF) {
 
-    DEBUG_STATUS('N', 'W', 'I', 'W');
+    DEBUG_STATUS("NWIW");
     DEBUG_SANITIZE_NOC_ADDR(addr, 4);
     noc_fast_write_dw_inline(
                 noc_index,
@@ -1537,7 +1537,7 @@ void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF) {
                 false, // mcast
                 false // posted
             );
-    DEBUG_STATUS('N', 'W', 'I', 'D');
+    DEBUG_STATUS("NWID");
 }
 
 
@@ -1561,10 +1561,10 @@ void noc_semaphore_inc(uint64_t addr, uint32_t incr) {
     [REFER TO grayskull/noc/noc.h for the documentation of noc_atomic_increment()]
     Generic increment with 32-bit wrap.
   */
-    DEBUG_STATUS('N', 'S', 'I', 'W');
+    DEBUG_STATUS("NSIW");
     DEBUG_SANITIZE_NOC_ADDR(addr, 4);
     noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, addr, NOC_UNICAST_WRITE_VC, incr, 31 /*wrap*/, false /*linked*/, false /*posted*/);
-    DEBUG_STATUS('N', 'S', 'I', 'D');
+    DEBUG_STATUS("NSID");
 }
 
 inline void RISC_POST_HEARTBEAT(uint32_t &heartbeat) {

--- a/tt_metal/hw/inc/dataflow_internal.h
+++ b/tt_metal/hw/inc/dataflow_internal.h
@@ -28,14 +28,14 @@ void noc_fast_read_set_len(uint32_t len_bytes) {
 
 FORCE_INLINE
 void noc_fast_read(uint32_t src_addr, uint32_t dest_addr) {
-    DEBUG_STATUS('N', 'F', 'R', 'W');
+    DEBUG_STATUS("NFRW");
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(
         (uint64_t)(src_addr) | (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32,
         dest_addr,
         NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE)
     );
     while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
-    DEBUG_STATUS('N', 'F', 'R', 'D');
+    DEBUG_STATUS("NFRD");
 
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);

--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -208,14 +208,14 @@ void debug_print(DebugPrinter &dp, DebugPrintData data) {
     auto sum_sz = payload_sz + code_sz + sz_sz;
     if (dp.data() + wpos + sum_sz >= dp.bufend()) {
         // buffer is full - wait for the host reader to flush+update rpos
-        DEBUG_STATUS('D', 'P', 'W');
+        DEBUG_STATUS("DPW");
         while (*dp.rpos() < *dp.wpos()) {
 #if defined(COMPILE_FOR_ERISC)
             internal_::risc_context_switch();
 #endif
             ; // wait for host to catch up to wpos with it's rpos
         }
-        DEBUG_STATUS('D', 'P', 'D');
+        DEBUG_STATUS("DPD");
         *dp.wpos() = 0;
         // TODO(AP): are these writes guaranteed to be ordered?
         *dp.rpos() = 0;

--- a/tt_metal/hw/inc/debug/pause.h
+++ b/tt_metal/hw/inc/debug/pause.h
@@ -15,13 +15,13 @@ void watcher_pause() {
     pause_msg->flags[debug_get_which_riscv()] = 1;
 
     // Wait for the pause flag to be cleared.
-    DEBUG_STATUS('P', 'A', 'S', 'W');
+    DEBUG_STATUS("PASW");
     while (pause_msg->flags[debug_get_which_riscv()]) {
 #if defined(COMPILE_FOR_ERISC)
         internal_::risc_context_switch();
 #endif
     }
-    DEBUG_STATUS('P', 'A', 'S', 'D');
+    DEBUG_STATUS("PASD");
 }
 
 // The do... while(0) in this macro allows for it to be called more flexibly, e.g. in an if-else

--- a/tt_metal/hw/inc/debug/status.h
+++ b/tt_metal/hw/inc/debug/status.h
@@ -13,25 +13,25 @@
 //
 #pragma once
 
+#include <utility>
+
 #include "dev_msgs.h"
 
-#if defined (WATCHER_ENABLED) && !defined(WATCHER_DISABLE_STATUS)
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_STATUS)
 
-inline uint32_t get_debug_status()
-{
-    return 0;
+template <size_t N, size_t... Is>
+constexpr uint32_t fold(const char (&s)[N], std::index_sequence<Is...>) {
+    static_assert(sizeof...(Is) <= 4, "Up to 4 characters allowed in DEBUG_STATUS");
+    return ((static_cast<uint32_t>(s[Is]) << (8 * Is)) | ...);
 }
 
-template<typename... Types>
-inline uint32_t get_debug_status(uint32_t c, Types... rest)
-{
-    return (c == 0) ? 0 : (get_debug_status(rest...) << 8) | c;
+template <size_t N>
+constexpr uint32_t helper(const char (&s)[N]) {
+    return fold(s, std::make_index_sequence<N - 1>{});
 }
 
-template<typename... Types>
-inline void write_debug_status(volatile tt_l1_ptr uint32_t *debug_status, uint32_t c, Types... rest)
-{
-    uint32_t x = get_debug_status(c, rest...);
+template<uint32_t x>
+inline void write_debug_status(volatile tt_l1_ptr uint32_t *debug_status) {
     *debug_status = x;
 }
 
@@ -47,12 +47,13 @@ inline void write_debug_status(volatile tt_l1_ptr uint32_t *debug_status, uint32
 #define DEBUG_STATUS_MAILBOX_OFFSET (2 + COMPILE_FOR_TRISC)
 #endif
 
-#define DEBUG_STATUS_MAILBOX (volatile tt_l1_ptr uint32_t *)&((*GET_MAILBOX_ADDRESS_DEV(debug_status))[DEBUG_STATUS_MAILBOX_OFFSET])
+#define DEBUG_STATUS_MAILBOX \
+    (volatile tt_l1_ptr uint32_t *)&((*GET_MAILBOX_ADDRESS_DEV(debug_status))[DEBUG_STATUS_MAILBOX_OFFSET])
 
-#define DEBUG_STATUS(x...) write_debug_status(DEBUG_STATUS_MAILBOX, x, 0)
+#define DEBUG_STATUS(x) write_debug_status<helper(x)>(DEBUG_STATUS_MAILBOX)
 
-#else // !WATCHER_ENABLED
+#else  // !WATCHER_ENABLED
 
-#define DEBUG_STATUS(x...)
+#define DEBUG_STATUS(x)
 
-#endif // WATCHER_ENABLED
+#endif  // WATCHER_ENABLED

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -31,10 +31,10 @@ FORCE_INLINE
 void cb_wait_all_pages(uint32_t n) {
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(sem_id));
-    DEBUG_STATUS('T', 'A', 'P', 'W');
+    DEBUG_STATUS("TAPW");
     // TODO: this masks off the upper bit used by mux/dmux for terminate, remove
     while ((*sem_addr & 0x7FFFFFFF) != n);
-    DEBUG_STATUS('T', 'A', 'P', 'D');
+    DEBUG_STATUS("TAPD");
 }
 
 template<uint32_t noc_xy, uint32_t sem_id>
@@ -48,9 +48,9 @@ void cb_acquire_pages(uint32_t n) {
     noc_async_write_barrier(); // XXXX TODO(pgk) can we do better on wormhole?
     noc_async_atomic_barrier();
 
-    DEBUG_STATUS('D', 'A', 'P', 'W');
+    DEBUG_STATUS("DAPW");
     while (*sem_addr < n);
-    DEBUG_STATUS('D', 'A', 'P', 'D');
+    DEBUG_STATUS("DAPD");
     noc_semaphore_inc(get_noc_addr_helper(noc_xy, (uint32_t)sem_addr), -n);
 }
 
@@ -78,9 +78,9 @@ uint32_t cb_acquire_pages(uint32_t cb_fence,
         noc_async_write_barrier(); // XXXX TODO(pgk) can we do better on wormhole?
         noc_async_atomic_barrier();
 
-        DEBUG_STATUS('U', 'A', 'P', 'W');
+        DEBUG_STATUS("UAPW");
         while ((available = *sem_addr) == 0);
-        DEBUG_STATUS('U', 'A', 'P', 'D');
+        DEBUG_STATUS("UAPD");
     }
 
     // Set a fence to limit how much is processed at once

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -84,7 +84,7 @@ FORCE_INLINE volatile uint32_t* get_cq_completion_write_ptr() {
 
 FORCE_INLINE
 void completion_queue_reserve_back(uint32_t num_pages) {
-    DEBUG_STATUS('Q', 'R', 'B', 'W');
+    DEBUG_STATUS("QRBW");
     // Transfer pages are aligned
     uint32_t data_size_16B = num_pages * completion_queue_page_size_16B;
     uint32_t completion_rd_ptr_and_toggle;
@@ -104,7 +104,7 @@ void completion_queue_reserve_back(uint32_t num_pages) {
                           (completion_queue_size_16B - (cq_write_interface.completion_fifo_wr_ptr - completion_rd_ptr));
     } while (data_size_16B > available_space);
 
-    DEBUG_STATUS('Q', 'R', 'B', 'D');
+    DEBUG_STATUS("QRBD");
 }
 
 FORCE_INLINE
@@ -630,7 +630,7 @@ static uint32_t process_debug_cmd(uint32_t cmd_ptr) {
     }
 
     if (checksum != cmd->debug.checksum) {
-        DEBUG_STATUS('!', 'C', 'H', 'K');
+        DEBUG_STATUS("!CHK");
         ASSERT(0);
     }
 
@@ -650,7 +650,7 @@ static void process_wait() {
         noc_async_write_barrier();
     }
 
-    DEBUG_STATUS('P', 'W', 'W');
+    DEBUG_STATUS("PWW");
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(addr);
     DPRINT << " DISPATCH WAIT " << HEX() << addr << DEC() << " count " << count << ENDL();
@@ -662,7 +662,7 @@ static void process_wait() {
         RISC_POST_HEARTBEAT(heartbeat);
 #endif
     }
-    DEBUG_STATUS('P', 'W', 'D');
+    DEBUG_STATUS("PWD");
 
     if (clear_count) {
         *sem_addr = 0;
@@ -692,10 +692,10 @@ static inline bool process_cmd_d(uint32_t& cmd_ptr) {
 
     switch (cmd->base.cmd_id) {
     case CQ_DISPATCH_CMD_WRITE_LINEAR:
-        DEBUG_STATUS('D', 'W', 'B');
+        DEBUG_STATUS("DWB");
         DPRINT << "cmd_write\n";
         process_write();
-        DEBUG_STATUS('D', 'W', 'D');
+        DEBUG_STATUS("DWD");
         break;
 
     case CQ_DISPATCH_CMD_WRITE_LINEAR_H:
@@ -773,7 +773,7 @@ static inline bool process_cmd_d(uint32_t& cmd_ptr) {
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+1) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+2) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+3) << ENDL();
-        DEBUG_STATUS('!', 'C', 'M', 'D');
+        DEBUG_STATUS("!CMD");
         ASSERT(0);
     }
 
@@ -809,7 +809,7 @@ static inline bool process_cmd_h(uint32_t& cmd_ptr) {
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+1) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+2) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+3) << ENDL();
-        DEBUG_STATUS('!', 'C', 'M', 'D');
+        DEBUG_STATUS("!CMD");
         ASSERT(0);
     }
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -216,11 +216,11 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
         } else {
             // By here, prefetch_q_ready must be false
             // Nothing to fetch, nothing pending, nothing available, stall on host
-            DEBUG_STATUS('H', 'Q', 'W');
+            DEBUG_STATUS("HQW");
             DPRINT << "fetch_q_get_cmds stall" << ENDL();
             while ((fetch_size = *prefetch_q_rd_ptr) == 0);
             fetch_q_get_cmds<preamble_size>(fence, cmd_ptr, pcie_read_ptr);
-            DEBUG_STATUS('H', 'Q', 'D');
+            DEBUG_STATUS("HQD");
         }
     }
 }
@@ -246,7 +246,7 @@ uint32_t process_debug_cmd(uint32_t cmd_ptr) {
     }
 
     if (checksum != cmd->debug.checksum) {
-        DEBUG_STATUS('!', 'C', 'H', 'K');
+        DEBUG_STATUS("!CHK");
         ASSERT(0);
     }
 
@@ -628,7 +628,7 @@ uint32_t process_stall(uint32_t cmd_ptr) {
 
     count++;
 
-    DEBUG_STATUS('P', 'S', 'W');
+    DEBUG_STATUS("PSW");
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(downstream_sync_sem_id));
 #if defined(COMPILE_FOR_IDLE_ERISC)
@@ -639,7 +639,7 @@ uint32_t process_stall(uint32_t cmd_ptr) {
         RISC_POST_HEARTBEAT(heartbeat);
 #endif
     }
-    DEBUG_STATUS('P', 'S', 'D');
+    DEBUG_STATUS("PSD");
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
@@ -852,7 +852,7 @@ bool process_cmd(uint32_t& cmd_ptr,
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+2) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+3) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+4) << ENDL();
-        DEBUG_STATUS('!', 'C', 'M', 'D');
+        DEBUG_STATUS("!CMD");
         ASSERT(0);
     }
 
@@ -959,9 +959,9 @@ void process_exec_buf_cmd_h() {
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(dispatch_h_exec_buf_sem_id));
 
-    DEBUG_STATUS('E', 'B', 'C', 'W');
+    DEBUG_STATUS("EBCW");
     while (*sem_addr == 0);
-    DEBUG_STATUS('E', 'B', 'C', 'D');
+    DEBUG_STATUS("EBCD");
     *sem_addr = 0;
 }
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.hpp
@@ -164,7 +164,7 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
         } else {
             // By here, prefetch_q_ready must be false
             // Nothing to fetch, nothing pending, nothing available, stall on host
-            DEBUG_STATUS('H', 'Q', 'W');
+            DEBUG_STATUS("HQW");
             DPRINT << "prefetcher stall" << ENDL();
             while ((fetch_size = *prefetch_q_rd_ptr) == 0);
             DPRINT << "recurse" << ENDL();
@@ -177,7 +177,7 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
                              prefetch_q_log_minsize,
                              prefetch_q_rd_ptr_addr,
                              preamble_size>(fence, cmd_ptr, pcie_read_ptr);
-            DEBUG_STATUS('H', 'Q', 'D');
+            DEBUG_STATUS("HQD");
         }
     }
 }
@@ -205,7 +205,7 @@ uint32_t process_debug_cmd(uint32_t cmd_ptr) {
     }
 
     if (checksum != cmd->debug.checksum) {
-        DEBUG_STATUS('!', 'C', 'H', 'K');
+        DEBUG_STATUS("!CHK");
         ASSERT(0);
     }
 
@@ -548,11 +548,11 @@ uint32_t process_stall(uint32_t cmd_ptr) {
 
     count++;
 
-    DEBUG_STATUS('P', 'S', 'W');
+    DEBUG_STATUS("PSW");
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(dispatch_sync_sem_id));
     while (*sem_addr != count);
-    DEBUG_STATUS('P', 'S', 'D');
+    DEBUG_STATUS("PSD");
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
@@ -666,7 +666,7 @@ bool process_cmd(uint32_t cmd_ptr,
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+2) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+3) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+4) << ENDL();
-        DEBUG_STATUS('!', 'C', 'M', 'D');
+        DEBUG_STATUS("!CMD");
         ASSERT(0);
     }
 


### PR DESCRIPTION
This PR allows one to pass string literals to the `DEBUG_STATUS` macro. The string literal is packed into a `uint32_t` value at compile time, while the current implementation runs a loop over the char arguments at run time.