### PR TITLE
#7997: Support non-4D tensor in moreh_softmax

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
@@ -15,12 +15,12 @@ from models.utility_functions import skip_for_wormhole_b0
 @pytest.mark.parametrize(
     "shape_dim",
     (
-        ((1, 1, 32, 32), 3),  # single tile
-        ((1, 1, 32, 32 * 5), 3),  # mutiple tile with dim W
+        ((32, 32), 1),  # single tile
+        ((3, 32, 32 * 5), 2),  # mutiple tile with dim W
         ((5, 6, 32, 32), 3),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 3),  # multiple tiles per core
-        ((1, 1, 32, 32), 2),  # single tile
-        ((1, 1, 32 * 5, 32), 2),  # mutiple tile with dim H
+        ((32, 32), 0),  # single tile
+        ((3, 32 * 5, 32), 1),  # mutiple tile with dim H
         ((5, 6, 32, 32), 2),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 2),  # multiple tiles per core
     ),
@@ -155,12 +155,12 @@ def test_logsoftmax_for_dim_nc(shape_dim, device):
 @pytest.mark.parametrize(
     "shape_dim",
     (
-        ((1, 1, 32, 32), 3),  # single tile
-        ((1, 1, 32, 32 * 2), 3),  # mutiple tile with dim W
+        ((32, 32), 1),  # single tile
+        ((3, 32, 32 * 2), 2),  # mutiple tile with dim W
         ((5, 6, 32, 32), 3),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 3),  # multiple tiles per core
-        ((1, 1, 32, 32), 2),  # single tile
-        ((1, 1, 32 * 5, 32), 2),  # mutiple tile with dim H
+        ((32, 32), 0),  # single tile
+        ((3, 32 * 5, 32), 1),  # mutiple tile with dim H
         ((5, 6, 32, 32), 2),  # multiple cores
         ((10, 20, 32 * 5, 32), 2),  # multiple tiles per core
     ),
@@ -320,7 +320,7 @@ def test_logsoftmax_backward_for_dim_nc(shape_dim, device):
 
 @pytest.mark.parametrize(
     "shape_dim",
-    (((1, 1, 32, 32), 3),),  # single tile
+    (((32, 32), 1),),  # single tile
 )
 @pytest.mark.parametrize(
     "optional_output_tensor",
@@ -357,7 +357,7 @@ def test_logsoftmax_optional_output_tensor(shape_dim, optional_output_tensor, de
 
 @pytest.mark.parametrize(
     "shape_dim",
-    (((1, 1, 32, 32), 3),),  # single tile
+    (((32, 32), 1),),  # single tile
 )
 @pytest.mark.parametrize(
     "optional_output_tensor",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
@@ -13,12 +13,12 @@ from loguru import logger
 @pytest.mark.parametrize(
     "shape_dim",
     (
-        ((1, 1, 32, 32), 3),  # single tile
-        ((1, 1, 32, 32 * 5), 3),  # mutiple tile with dim W
+        ((32, 32), 1),  # single tile
+        ((3, 32, 32 * 5), 2),  # mutiple tile with dim W
         ((5, 6, 32, 32), 3),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 3),  # multiple tiles per core
-        ((1, 1, 32, 32), 2),  # single tile
-        ((1, 1, 32 * 5, 32), 2),  # mutiple tile with dim H
+        ((32, 32), 0),  # single tile
+        ((3, 32 * 5, 32), 1),  # mutiple tile with dim H
         ((5, 6, 32, 32), 2),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 2),  # multiple tiles per core
     ),
@@ -275,8 +275,8 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
 @pytest.mark.parametrize(
     "shape_dim",
     (
-        ((1, 15, 32, 32), 1),  # single tile c
-        ((1, 15, 32 * 7, 32 * 5), 1),  # mutiple cores
+        ((15, 32, 32), 0),  # single tile c
+        ((15, 32 * 7, 32 * 5), 0),  # mutiple cores
         ((109, 15, 32, 32), 1),  # mutiple tiles per cores
         ((15, 1, 32, 32), 0),  # single tile n
         ((15, 1, 32 * 7, 32 * 5), 0),  # mutiple cores
@@ -311,10 +311,10 @@ def test_softmax_backward_for_dim_nc(shape_dim, device):
 @pytest.mark.parametrize(
     "shape_dim_strategy",
     (
-        ((1, 1, 32, 32), 3, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.SMALL_W),
-        ((1, 1, 32, 32), 2, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.SMALL_H),
-        ((1, 1, 32, 32), 3, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_W),
-        ((1, 1, 32, 32), 2, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_H),
+        ((32, 32), 1, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.SMALL_W),
+        ((32, 32), 0, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.SMALL_H),
+        ((32, 32), 1, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_W),
+        ((32, 32), 0, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_H),
         ((1, 1, 32, 32), 1, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_C),
         ((1, 1, 32, 32), 0, ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_C),
     ),
@@ -381,7 +381,7 @@ def test_softmax_backward_callback(shape_dim_strategy, device):
 
 @pytest.mark.parametrize(
     "shape_dim",
-    (((1, 1, 32, 32), 3),),  # single tile
+    (((32, 32), 1),),  # single tile
 )
 @pytest.mark.parametrize(
     "optional_output_tensor",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
@@ -14,12 +14,12 @@ import torch.nn.functional as F
 @pytest.mark.parametrize(
     "shape_dim",
     (
-        ((1, 1, 32, 32), 3),  # single tile
-        ((1, 1, 32, 32 * 5), 3),  # mutiple tile with dim W
+        ((32, 32), 1),  # single tile
+        ((3, 32, 32 * 5), 2),  # mutiple tile with dim W
         ((5, 6, 32, 32), 3),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 3),  # multiple tiles per core
-        ((1, 1, 32, 32), 2),  # single tile
-        ((1, 1, 32 * 5, 32), 2),  # mutiple tile with dim H
+        ((32, 32), 0),  # single tile
+        ((3, 32 * 5, 32), 1),  # mutiple tile with dim H
         ((5, 6, 32, 32), 2),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 2),  # multiple tiles per core
     ),
@@ -154,12 +154,12 @@ def test_softmin_for_dim_nc(shape_dim, device):
 @pytest.mark.parametrize(
     "shape_dim",
     (
-        ((1, 1, 32, 32), 3),  # single tile
-        ((1, 1, 32, 32 * 5), 3),  # mutiple tile with dim W
+        ((32, 32), 1),  # single tile
+        ((3, 32, 32 * 5), 2),  # mutiple tile with dim W
         ((5, 6, 32, 32), 3),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 3),  # multiple tiles per core
-        ((1, 1, 32, 32), 2),  # single tile
-        ((1, 1, 32 * 5, 32), 2),  # mutiple tile with dim H
+        ((32, 32), 0),  # single tile
+        ((3, 32 * 5, 32), 1),  # mutiple tile with dim H
         ((5, 6, 32, 32), 2),  # multiple cores
         ((10, 20, 32 * 3, 32 * 5), 2),  # multiple tiles per core
     ),
@@ -319,7 +319,7 @@ def test_softmin_backward_for_dim_nc(shape_dim, device):
 
 @pytest.mark.parametrize(
     "shape_dim",
-    (((1, 1, 32, 32), 3),),  # single tile
+    (((32, 32), 1),),  # single tile
 )
 @pytest.mark.parametrize(
     "optional_output_tensor",
@@ -356,7 +356,7 @@ def test_softmin_optional_output_tensor(shape_dim, optional_output_tensor, devic
 
 @pytest.mark.parametrize(
     "shape_dim",
-    (((1, 1, 32, 32), 3),),  # single tile
+    (((32, 32), 1),),  # single tile
 )
 @pytest.mark.parametrize(
     "optional_output_tensor",

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
@@ -22,17 +22,12 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
     log_info(LogTest, "Large tensor algorithm selected");
     // split work
     auto shape = input.get_legacy_shape();
-    auto N = shape[0];
-    auto C = shape[1];
-    auto H = shape[2];
-    auto W = shape[3];
+    auto H = shape[-2];
+    auto W = shape[-1];
     auto Ht = H / TILE_HEIGHT;
     auto Wt = W / TILE_WIDTH;
 
-    uint32_t num_tiles = N * Ht * Wt;
-    if (dim == 0) {
-        num_tiles = C * Ht * Wt;
-    }
+    uint32_t num_tiles = input.volume() / shape[dim] / H / W * Ht * Wt;
 
     uint32_t core_w = core_range.end.x - core_range.start.x + 1;
     uint32_t core_h = core_range.end.y - core_range.start.y + 1;
@@ -69,17 +64,12 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
     auto writer_kernel_id = CreateWriteKernel(
         program, "tt_eager/tt_dnn/op_library/moreh_softmax/kernels/writer_moreh_softmax_c.cpp", all_cores, {dst_is_dram}, writer_defines);
 
-    // for C
-    uint32_t outer_stride = C * Ht * Wt;
-    uint32_t inner_size = Wt * Ht;
-    uint32_t dim_size = C;
-
-    // for N
-    if (dim == 0) {
-        outer_stride = N * C * Ht * Wt; // not used
-        inner_size = C * Wt * Ht;
-        dim_size = N;
+    auto outer_stride = Ht * Wt;
+    for(int i = dim ; i < shape.rank() - 2; i++ ) {
+        outer_stride *= shape[i];
     }
+    auto dim_size = shape[dim];
+    auto inner_size = outer_stride / dim_size;
 
     std::map<string, string> compute_defines;
     if (op == MorehSoftmaxOp::SOFTMAX || op == MorehSoftmaxOp::LOGSOFTMAX) compute_defines["SOFTMAX"] = "1";

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
@@ -22,14 +22,13 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
     log_info(LogTest, "Large tensor algorithm selected");
     // split work
     auto shape = input.get_legacy_shape();
-    auto N = shape[0];
-    auto C = shape[1];
-    auto H = shape[2];
-    auto W = shape[3];
+    auto H = shape[-2];
+    auto W = shape[-1];
     auto Ht = H / TILE_HEIGHT;
     auto Wt = W / TILE_WIDTH;
 
-    uint32_t num_cols_tiles = N * C * Wt;
+    auto num = input.volume() / H / W;
+    uint32_t num_cols_tiles = num * Wt;
     uint32_t core_w = core_range.end.x - core_range.start.x + 1;
     uint32_t core_h = core_range.end.y - core_range.start.y + 1;
 
@@ -101,7 +100,7 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
         }
 
         float scaler = 1.0f;
-        uint32_t mask_h = shape.without_padding()[2] % TILE_HEIGHT;
+        uint32_t mask_h = shape.without_padding()[-2] % TILE_HEIGHT;
         if(mask_h == 0) mask_h = TILE_HEIGHT;
         vector<uint32_t> reader_args = {
             input.buffer()->address(), num_tiles_per_core, tile_offset, Ht, Wt, *reinterpret_cast<uint32_t *>(&scaler), mask_h};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
@@ -22,14 +22,14 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
     log_info(LogTest, "Large tensor algorithm selected");
     // split work
     auto shape = input.get_legacy_shape();
-    auto N = shape[0];
-    auto C = shape[1];
-    auto H = shape[2];
-    auto W = shape[3];
+    auto H = shape[-2];
+    auto W = shape[-1];
     auto Ht = H / TILE_HEIGHT;
     auto Wt = W / TILE_WIDTH;
 
-    uint32_t num_kernel_rows = N * C * Ht;
+    auto num = input.volume() / H / W;
+
+    uint32_t num_kernel_rows = num * Ht;
     uint32_t core_w = core_range.end.x - core_range.start.x + 1;
     uint32_t core_h = core_range.end.y - core_range.start.y + 1;
 
@@ -101,7 +101,7 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
         }
 
         float scaler = 1.0f;
-        uint32_t mask_w = shape.without_padding()[3] % TILE_WIDTH;
+        uint32_t mask_w = shape.without_padding()[-1] % TILE_WIDTH;
         if(mask_w == 0) mask_w = TILE_WIDTH;
         vector<uint32_t> reader_args = {
             input.buffer()->address(), num_tiles_per_core, tile_offset, Wt, *reinterpret_cast<uint32_t *>(&scaler), mask_w};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
@@ -22,7 +22,7 @@ namespace primary {
 #define L1_512KB (512 * 1024)
 
 bool is_moreh_softmax_w_small_available(const Tensor &tensor) {
-    auto w = tensor.get_legacy_shape()[3];
+    auto w = tensor.get_legacy_shape()[-1];
     int32_t Wt = (w + TILE_WIDTH - 1) / TILE_WIDTH;
 
     tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(tensor.get_dtype());
@@ -44,14 +44,14 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
     log_info(LogTest, "Small tensor algorithm selected");
     // split work
     auto shape = input.get_legacy_shape();
-    auto N = shape[0];
-    auto C = shape[1];
-    auto H = shape[2];
-    auto W = shape[3];
+    auto H = shape[-2];
+    auto W = shape[-1];
     auto Ht = H / TILE_HEIGHT;
     auto Wt = W / TILE_WIDTH;
 
-    uint32_t num_kernel_rows = N * C * Ht;
+    auto num = input.volume() / H / W;
+
+    uint32_t num_kernel_rows = num * Ht;
     uint32_t core_w = core_range.end.x - core_range.start.x + 1;
     uint32_t core_h = core_range.end.y - core_range.start.y + 1;
 
@@ -122,7 +122,7 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
         }
 
         float scaler = 1.0f;
-        uint32_t mask_w = shape.without_padding()[3] % TILE_WIDTH;
+        uint32_t mask_w = shape.without_padding()[-1] % TILE_WIDTH;
         if(mask_w == 0) mask_w = TILE_WIDTH;
         vector<uint32_t> reader_args = {
             input.buffer()->address(), num_tiles_per_core, tile_offset, Wt, *reinterpret_cast<uint32_t *>(&scaler), mask_w};

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
@@ -111,7 +111,7 @@ MorehSoftmaxBackwardOpParallelizationStrategy MorehSoftmaxBackward::get_parallel
         TT_ASSERT(
             this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_H ||
                 this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_H,
-            fmt::format("Invalid parallelization strategy. {} is not for dim 2", this->strategy));
+            fmt::format("Invalid parallelization strategy. {} is not for dim H", this->strategy));
 
         if (this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_H) {
             TT_ASSERT(
@@ -122,7 +122,7 @@ MorehSoftmaxBackwardOpParallelizationStrategy MorehSoftmaxBackward::get_parallel
         TT_ASSERT(
             this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_W ||
                 this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_W,
-            fmt::format("Invalid parallelization strategy. {} is not for dim 3", this->strategy));
+            fmt::format("Invalid parallelization strategy. {} is not for dim W", this->strategy));
 
         if (this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_W) {
             TT_ASSERT(
@@ -132,7 +132,7 @@ MorehSoftmaxBackwardOpParallelizationStrategy MorehSoftmaxBackward::get_parallel
     } else {
         TT_ASSERT(
             this->strategy == MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_C,
-            "Invalid parallelization strategy. large c is for dim 0, 1");
+            "Invalid parallelization strategy. large c is for dim 0 - (rank - 3)");
     }
 
     return this->strategy;


### PR DESCRIPTION
This PR supports for non-4D tensor in moreh_softmax.