### PR TITLE
Add Mixtral8x7b Model to T3000 demos

### DIFF
--- a/models/demos/t3000/mixtral8x7b/README.md
+++ b/models/demos/t3000/mixtral8x7b/README.md
@@ -1,0 +1,62 @@
+# Mixtral8x7b Demo
+
+## How to Run
+
+### Download the weights and repack
+
+1. Download the weights from Huggingface.
+- [Instruct weights](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1)
+- [General weights](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1)
+
+2. Repack the weights using the provided script in `models/demos/t3000/mixtral8x7b/scripts/repack_weights.py`. It requires the consolidated weights from Huggingface to be inside `<path_to_checkpoint_dir>`.
+
+```
+# This separates the 8 experts to facilitate sending them to multiple devices.
+python models/demos/t3000/mixtral8x7b/scripts/repack_weights.py <path_to_checkpoint_dir> <repacked_output_dir>
+```
+
+### Set up environment
+
+1. Prepare the weight cache directory:
+
+```
+# Make a directory for ttnn us to cache weights into. This speeds up subsequent runs.
+mkdir <weight_cache_dir>
+```
+
+2. Set up environment variables:
+```
+export MIXTRAL_CKPT_DIR=<repacked_output_dir>
+export MIXTRAL_TOKENIZER_PATH=<path_to_tokenizer_dir>
+export MIXTRAL_CACHE_PATH=<weights_cache_dir>
+```
+
+Note that the cached weights folder structure will contain the general and instruct cached weights in separate directories, like so:
+
+```
+<weights_cache_dir>
+  /mixtral_tensor_cache_bfp8
+  /mixtral_tensor_cache_instruct_bfp8
+  ...
+```
+
+3. Cache the weights (first-time setup):
+```
+# Build a full 32 layer model to cache the weights. This will take some time.
+pytest -svv models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[1-32]
+```
+
+### Run the demo
+```
+# Run the demo with a pre-written batch of 32 user prompts
+pytest -svv models/demos/t3000/mixtral8x7b/demo/demo.py::test_mixtral8x7b_demo[general_weights]
+```
+
+We also provide an input file with 32 user question-prompt for instruct weights (don't forget to update your flags to the correct weights):
+```
+pytest -svv models/demos/t3000/mixtral8x7b/demo/demo.py::test_mixtral8x7b_demo[instruct_weights]
+```
+
+Both input files are provided inside `models/demos/t3000/mixtral8x7b/demo/`.
+
+If you wish you to run the model using a different set of input prompts you can provide a different path to pytest inside the demo code. Keep in mind that for the instruct-mode, the prompts are automatically prefixed and suffixed by `[INST]` and `[/INST]`, respectively, so there's no need to add them to your file.

--- a/models/demos/t3000/mixtral8x7b/demo/demo.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import json
+import tt_lib as ttl
+import pytest
+from loguru import logger
+from time import time
+import ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import prepare_inputs_ttnn, sample
+from models.demos.t3000.mixtral8x7b.tt.mixtral_model import TtTransformer
+from models.demos.t3000.mixtral8x7b.tt.mixtral_embedding import TtMixtralEmbedding
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
+from models.utility_functions import get_devices_for_t3000
+
+
+class Emb(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = torch.nn.Embedding(32000, 4096)
+
+    def forward(self, x):
+        return self.emb(x)
+
+
+# load from json, return as a list
+def load_inputs(user_input, batch):
+    if isinstance(user_input, str):
+        with open(user_input, "r") as f:
+            user_input = json.load(f)
+    assert len(user_input) >= batch, f"Number of users (batch) must be {batch}!"
+    in_prompt = []
+    for i in range(batch):
+        in_prompt.append(user_input[i]["prompt"])
+    return in_prompt
+
+
+def preprocess_inputs(input_prompts, tokenizer, model_args, dtype, instruct, devices):
+    """
+    Run tokenizer on inputs, and create embeddings for the first token of each input
+    """
+    if instruct:
+        # Pre append [INST] and post append [/INST] to the encoded prompts if instruct mode
+        encoded_prompts = [tokenizer.encode("[INST] " + prompt + " [/INST]") for prompt in input_prompts]
+    else:
+        encoded_prompts = [tokenizer.encode(prompt) for prompt in input_prompts]
+
+    prompt_lens = [len(x) for x in encoded_prompts]
+
+    # Pad the inputs to the max length prompt
+    max_prompt_len = max(prompt_lens)
+    input_tokens = torch.full((len(input_prompts), max_prompt_len), tokenizer.pad_id, dtype=torch.int32)
+
+    logger.info(f"# of users: {len(encoded_prompts)}")
+    for i, encoded in enumerate(encoded_prompts):
+        # Right padding
+        input_tokens[i, : len(encoded)] = torch.tensor(encoded).to(input_tokens)
+
+    input_mask_bool = input_tokens != tokenizer.pad_id
+    input_mask = input_mask_bool.int()  # from_torch doesn't support bool type
+
+    # convert to ttnn tensor
+    # Encoded input tokens need to be uint32 for embedding. Otherwise the dtype conversion to bfloat16 will change the tokenizer ID
+    input_tokens_tt = [
+        [
+            ttnn.from_torch(
+                input_tokens[:, i].unsqueeze(0), device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT
+            )
+            for device in devices
+        ]
+        for i in range(max_prompt_len)
+    ]
+    input_mask_tt = [
+        [
+            ttnn.from_torch(
+                input_mask[:, i].unsqueeze(0), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT
+            )
+            for device in devices
+        ]
+        for i in range(max_prompt_len)
+    ]
+    return input_tokens_tt, max_prompt_len, input_mask_tt, input_tokens, input_mask_bool
+
+
+@torch.no_grad()
+def run_mixtral_demo(user_input, batch_size, devices, instruct_mode):
+    assert batch_size == 32, "Batch size must be 32"
+
+    dtype = ttnn.bfloat8_b
+
+    embed_on_host = True  # Do embedding and argmax on host. TODO Seeing bad output when on device
+    seqlen = 1  # Generating one token per user at a time
+
+    logger.info(f"Reading inputs...")
+    if len(user_input) == 1:
+        input_prompts = user_input * 32  # Always process 32 users
+    else:
+        input_prompts = load_inputs(user_input, 32)
+
+    # Load model args, weights, and tokenizer
+    model_args = TtModelArgs(devices[0], instruct=instruct_mode)
+    tokenizer = Tokenizer(model_args.tokenizer_path)
+
+    model_args.n_layers = 32  # Full model
+
+    logger.info("Loading weights...")
+    state_dict = torch.load(model_args.state_dict_path)
+    # If not using the full model, remove the layers that are not used
+    keys_dict = list(state_dict.keys())[:]
+    remv = [f"layers.{i}" for i in range(model_args.n_layers, 32)]
+    for k in keys_dict:
+        if any([r in k for r in remv]):
+            state_dict.pop(k)
+
+    # Embedding on host
+    if embed_on_host:
+        embd = Emb()
+        embd.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
+
+    logger.info("Loading weights finished!")
+
+    # Preprocess initial prompt inputs
+    input_tokens_tt, max_prompt_len, input_mask, input_tokens_pt, input_mask_pt = preprocess_inputs(
+        input_prompts, tokenizer, model_args, dtype, instruct_mode, devices
+    )
+
+    # TODO should we just change the pad after initial pad of the inputs?
+    if instruct_mode:
+        tokenizer._model.pad_id = tokenizer._model.eos_id
+
+    # Load TTNN mixtral model
+    logger.info("Loading weights to device...")
+    tt_model = TtTransformer(
+        devices=devices,
+        state_dict=state_dict,
+        args=model_args,
+        layers=list(range(model_args.n_layers)),
+        dtype=dtype,
+    )
+
+    if not embed_on_host:
+        tt_embds = [
+            TtMixtralEmbedding(
+                device=devices[i],
+                args=model_args,
+                weight_cache_path=model_args.weight_cache_path(dtype),
+                state_dict=state_dict,
+                dtype=ttnn.bfloat16,  # Row major layout requires bfloat16
+            )
+            for i in range(len(devices))
+        ]
+
+    logger.info("Finished loading weights to device.")
+
+    # Prepare the first token embedding for each user
+    if embed_on_host:
+        pt_decode_input = embd(input_tokens_pt[:, 0]).view(batch_size, seqlen, -1)
+    else:  # Embedding on device
+        # Each device does its own embedding
+        decode_input_11BH = [tt_embds[i](input_tokens_tt[0][i]) for i in range(len(devices))]
+        # Reshape and change row major to tile layout
+        decode_input_11BH = [
+            ttnn.reshape(decode_input_11BH[i], ttnn.Shape([1, 1, batch_size, model_args.dim]))
+            for i in range(len(devices))
+        ]
+        decode_input_11BH = [ttnn.to_layout(decode_input_11BH[i], layout=ttnn.TILE_LAYOUT) for i in range(len(devices))]
+        # decode_input_11BH = [ttnn.experimental.tensor.tilize(decode_input_11BH[i]) for i in range(len(devices))]
+        # decode_input_11BH = [ttnn.experimental.tensor.tilize_with_val_padding(decode_input_11BH[i], ) for i in range(len(devices))]
+    logger.info("Finished first token embedding. Starting inference...")
+
+    generation_start_pos = 0
+    max_generated_tokens = 10  # TODO Increase to around 100 tokens
+
+    # Keep track of generated outputs to print out every iteration
+    all_outputs = [[] for _ in range(batch_size)]
+
+    # Prepare inputs for decode mode (rotary embeddings, attention mask, padding)
+
+    if not embed_on_host:  # embed on device
+        rot_mats = prepare_inputs_ttnn(
+            None,
+            model_args.dim,
+            model_args.head_dim,
+            model_args.max_seq_len,
+            tt_model.devices,
+        )
+        # TODO Debug (only device 0 is doing argmax, otherwise it throws an error)
+        # Alternatively, send the output back to device: tt_lib.tensor.Tensor.to()
+        ttl.device.SetDefaultDevice(devices[0])
+
+    # Keep running inference as long as there is a user in the batch still decoding or max tokens per user are decoded
+    for iteration in range(max_generated_tokens):
+        iteration_time_start = time()
+        start_pos = generation_start_pos + iteration
+        current_pos = start_pos % model_args.sliding_window
+
+        if embed_on_host:
+            decode_input_11BH, rot_mats = prepare_inputs_ttnn(
+                pt_decode_input,
+                model_args.dim,
+                model_args.head_dim,
+                model_args.max_seq_len,
+                tt_model.devices,
+            )
+        # Run ttnn mixtral model
+        tt_out_11BH = tt_model(decode_input_11BH, start_pos, current_pos, rot_mats)
+
+        if embed_on_host:
+            # Convert ttnn tensor to torch tensor
+            tt_output_torch = ttnn.to_torch(tt_out_11BH[0]).squeeze(1).view(batch_size, seqlen, -1).detach().float()
+            # tt_token_batch = tt_output_torch.squeeze().argmax(axis=-1)
+            # Argmax on host to get the new generated tokens
+            tt_token_batch = sample(tt_output_torch, temperature=0, top_p=0.8)
+            # Update the users that are still in prefill and the ones generating new tokens
+            if iteration < max_prompt_len:
+                tt_token_batch = torch.where(
+                    input_mask_pt[:, iteration], input_tokens_pt[:, iteration], tt_token_batch[:, 0]
+                ).unsqueeze(1)
+            # Next PT input embedding
+            pt_decode_input = embd(tt_token_batch).view(batch_size, seqlen, -1)
+        else:  # Embedding/argmax on device
+            for i in range(len(devices)):
+                # TODO Update argmax to ttnn when OP becomes available
+                tt_out_B11B = ttnn.experimental.tensor.argmax(tt_out_11BH[i], dim=-1)
+                tt_out_1B = ttnn.reshape(tt_out_B11B[:1, :, :, :], ttnn.Shape([1, batch_size]))  # [1, 32] Bfloat16
+                # Update the users that are still in prefill and the ones generating new tokens
+                if iteration < max_prompt_len:
+                    decode_input_1B = ttnn.where(input_mask[iteration][i], input_tokens_tt[iteration][i], tt_out_1B)
+                else:
+                    decode_input_1B = tt_out_1B
+
+                # Next TT input embeddings
+                decode_input_1BH = tt_embds[i](decode_input_1B)
+                decode_input_11BH[i] = ttnn.reshape(decode_input_1BH, ttnn.Shape([1, 1, batch_size, model_args.dim]))
+                decode_input_11BH[i] = ttnn.to_layout(decode_input_11BH[i], layout=ttnn.TILE_LAYOUT)
+
+            # Convert ttnn tensor to torch tensor and print decoded output (from a single device)
+            # tt_output_torch = ttnn.to_torch(decode_input_1B).transpose(0, 1)
+            tt_token_batch = ttnn.to_torch(decode_input_1B).transpose(0, 1)
+
+        # Get the generated tokens for each user for printing in the log
+        for user in range(batch_size):
+            user_tok = int(tt_token_batch[user].item())
+            if user_tok != tokenizer.eos_id:  # Stop saving the ouput after hitting the EOS token
+                all_outputs[user].append(user_tok)
+
+        iteration_time = time() - iteration_time_start
+        tokens_per_second_per_user = 1 / iteration_time
+        # Print out generated outputs for each user at the end of every iteration
+        if len(user_input) == 1:
+            logger.info("[User 0] {}".format("".join(tokenizer.decode(all_outputs[0]))))
+        else:
+            for user in range(batch_size):
+                logger.info("[User {}] {}".format(user, "".join(tokenizer.decode(all_outputs[user]))))
+
+        logger.info(
+            f"Iteration {iteration}: {1000*iteration_time:.2f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({batch_size*tokens_per_second_per_user:.1f} tok/s throughput)"
+        )
+
+
+@pytest.mark.timeout(10000)
+@pytest.mark.parametrize(
+    "input_prompts, instruct_weights",
+    [
+        ("models/demos/t3000/mixtral8x7b/demo/input_data.json", False),
+        ("models/demos/t3000/mixtral8x7b/demo/input_data_questions.json", True),
+    ],
+    ids=["general_weights", "instruct_weights"],
+)
+def test_mixtral8x7b_demo(all_devices, use_program_cache, input_prompts, instruct_weights):
+    devices = get_devices_for_t3000(all_devices, 8)
+    return run_mixtral_demo(user_input=input_prompts, batch_size=32, devices=devices, instruct_mode=instruct_weights)

--- a/models/demos/t3000/mixtral8x7b/demo/input_data.json
+++ b/models/demos/t3000/mixtral8x7b/demo/input_data.json
@@ -1,0 +1,97 @@
+[
+   {
+"prompt": "This is a test."
+           },
+        {
+"prompt": "It was the best of times, it was the worst"
+           },
+        {
+"prompt": "Run to the hills"
+           },
+        {
+"prompt": "You've got another thing coming"
+           },
+        {
+"prompt": "The meaning of life is"
+           },
+        {
+"prompt": "write a short poem about London in English"
+           },
+        {
+"prompt": "How to tie your shoes"
+           },
+        {
+"prompt": "Give me the address of the closest bakery"
+           },
+        {
+"prompt": "In a world far far away"
+           },
+        {
+"prompt": "A poem about trees and nature:"
+           },
+        {
+"prompt": "Egg fried rice is a delicacy"
+           },
+        {
+"prompt": "This is another test"
+           },
+        {
+"prompt": "This is yet another test"
+           },
+        {
+"prompt": "Large language models are"
+           },
+        {
+"prompt": "The capital of Portugal"
+           },
+        {
+"prompt": "The word 'dog' in French"
+           },
+        {
+"prompt": "Water is essential for"
+           },
+        {
+"prompt": "My favorite hobby is videogames"
+           },
+        {
+"prompt": "The best way to cook a steak"
+           },
+        {
+"prompt": "Top 10 things to do"
+           },
+        {
+"prompt": "The job of a computer architect is"
+           },
+        {
+"prompt": "The number you have dialled is not"
+           },
+        {
+"prompt": "The best way to learn a new language"
+           },
+        {
+"prompt": "Madrid is the capital"
+           },
+        {
+"prompt": "A good night's sleep is essential"
+           },
+        {
+"prompt": "Typing prompts can be fun"
+           },
+        {
+"prompt": "I'm going to the store"
+           },
+        {
+"prompt": "I am a world renown spy"
+           },
+        {
+"prompt": "Ready, set, go"
+           },
+        {
+"prompt": "Climate change is the most important issue"
+           },
+        {
+"prompt": "Tell me the story of the three little pigs"
+           },
+        {
+"prompt": "Once upon a time in a land far far away"}
+       ]

--- a/models/demos/t3000/mixtral8x7b/demo/input_data_questions.json
+++ b/models/demos/t3000/mixtral8x7b/demo/input_data_questions.json
@@ -1,0 +1,97 @@
+[
+   {
+"prompt": "What is your favourite condiment?"
+           },
+        {
+"prompt": "Hello, how are you?"
+           },
+        {
+"prompt": "Do you have mayonnaise recipes?"
+           },
+        {
+"prompt": "Which color do you get if you mix yellow and blue?"
+           },
+        {
+"prompt": "What is the ideal room temperature?"
+           },
+        {
+"prompt": "Can you tell me a joke?"
+           },
+        {
+"prompt": "What are you good at?"
+           },
+        {
+"prompt": "What is 2+2?"
+           },
+        {
+"prompt": "what is the capital of USA?"
+           },
+        {
+"prompt": "what is the capital of Canada?"
+           },
+        {
+"prompt": "what is the capital of UK?"
+           },
+        {
+"prompt": "what is the capital of Germany?"
+           },
+        {
+"prompt": "what is the capital of France?"
+           },
+        {
+"prompt": "what is the capital of Japan?"
+           },
+        {
+"prompt": "what is the capital of Portugal?"
+           },
+        {
+"prompt": "what is the capital of China?"
+           },
+        {
+"prompt": "what is the currency of Cuba?"
+           },
+        {
+"prompt": "what is the currency of Lebanon?"
+           },
+        {
+"prompt": "what is the currency of Brazil?"
+           },
+        {
+"prompt": "what is the currency of Australia?"
+           },
+        {
+"prompt": "what is the currency of Jamaica?"
+           },
+        {
+"prompt": "what is the currency of Egypt?"
+           },
+        {
+"prompt": "what is the currency of Uzbekistan?"
+           },
+        {
+"prompt": "what is the currency of Argentina?"
+           },
+        {
+"prompt": "Are birds mammals?"
+           },
+        {
+"prompt": "How do you play tennis?"
+           },
+        {
+"prompt": "Suggest cities to visit in Japan"
+           },
+        {
+"prompt": "How far away is the moon from the earth?"
+           },
+        {
+"prompt": "What is a black hole?"
+           },
+        {
+"prompt": "How do you play golf?"
+           },
+        {
+"prompt": "Recommend me a movie"
+           },
+        {
+"prompt": "what is the capital of Spain?"}
+       ]

--- a/models/demos/t3000/mixtral8x7b/reference/demo_ref.py
+++ b/models/demos/t3000/mixtral8x7b/reference/demo_ref.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from loguru import logger
+import json
+
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+from models.demos.t3000.mixtral8x7b.reference.model import Transformer
+from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
+
+
+class Emb(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = torch.nn.Embedding(32000, 4096)
+
+    def forward(self, x):
+        return self.emb(x)
+
+
+# load from json, return as a list
+def load_inputs(user_input, batch):
+    if isinstance(user_input, str):
+        with open(user_input, "r") as f:
+            user_input = json.load(f)
+    assert len(user_input) >= batch, f"Number of users (batch) must be {batch}!"
+    in_prompt = []
+    for i in range(batch):
+        in_prompt.append(user_input[i]["prompt"])
+    return in_prompt
+
+
+def preprocess_inputs(input_prompts, tokenizer, model_args, embd):
+    """
+    Run tokenizer on inputs, and create embeddings for the first token of each input
+    """
+    encoded_prompts = [tokenizer.encode(prompt) for prompt in input_prompts]
+
+    prompt_lens = [len(x) for x in encoded_prompts]
+
+    # Pad the inputs to the max length prompt
+    max_prompt_len = max(prompt_lens)
+    input_tokens = torch.full((len(input_prompts), max_prompt_len), tokenizer.pad_id, dtype=torch.long)
+
+    # TODO Change padding to be left padding instead of right padding
+    for i, encoded in enumerate(encoded_prompts):
+        input_tokens[i, : len(encoded)] = torch.tensor(encoded).to(input_tokens)
+    input_mask = input_tokens != tokenizer.pad_id
+
+    num_users = len(encoded_prompts)
+    logger.info(f"# of users: {num_users}")
+    return input_tokens, max_prompt_len, input_mask
+
+
+@torch.no_grad()
+def run_mixtral_demo(user_input, batch_size):
+    assert batch_size == 32, "Batch size must be 32"
+
+    logger.info(f"Reading inputs...")
+    if len(user_input) == 1:
+        input_prompts = user_input * 32  # Always process 32 users
+    else:
+        input_prompts = load_inputs(user_input, 32)
+
+    # Load model args, weights, and tokenizer
+    model_args = TtModelArgs()
+    tokenizer = Tokenizer(model_args.tokenizer_path)
+
+    logger.info("Loading weights...")
+    state_dict = torch.load(model_args.state_dict_path)
+
+    # Embedding on host
+    embd = Emb()
+    embd.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
+
+    pt_encoded_input, max_prompt_len, input_mask = preprocess_inputs(
+        input_prompts,
+        tokenizer,
+        model_args,
+        embd,
+    )
+
+    # Load TTNN mixtral model
+    logger.info("Loading weights to device...")
+    reference_model = Transformer(args=model_args)
+    reference_model.load_state_dict(state_dict)
+    reference_model.eval()
+
+    logger.info("Finished loading weights to device. Starting inference...")
+
+    generation_start_pos = 0
+    max_generated_tokens = 150
+    users_decoding = True
+
+    # Keep track of generated outputs to print out every iteration
+    all_outputs = [[] for _ in range(batch_size)]
+    user_done = [False] * batch_size  # Keeps track when a user reaches EoD token
+    pt_decode_input = embd(pt_encoded_input[:, 0]).view(batch_size, 1, -1)
+
+    iteration = 0
+    # Keep running inference as long as there is a user in the batch still decoding or max tokens per user are decoded
+    while users_decoding:
+        start_pos = generation_start_pos + iteration
+
+        positions = torch.LongTensor([start_pos])
+        # mask = tt2torch_tensor(attn_mask[0])
+        ref_output = reference_model(pt_decode_input, positions)  # mask)
+        # If temperature is 0, does greedy decoding (top-1)
+        pt_out_tok = torch.argmax(torch.nn.functional.log_softmax(ref_output, dim=-1), dim=-1).squeeze(1)
+
+        if iteration < input_mask.shape[1]:  # If prefill
+            # If token is pad token, start generating new token, otherwise, push the next prompt token to the model
+            pt_out_tok = torch.where(input_mask[:, iteration], pt_encoded_input[:, iteration], pt_out_tok[:])
+
+        # Save output token to print out later
+        for user in range(batch_size):
+            user_tok = pt_out_tok[user].item()
+            if user_tok != tokenizer.eos_id:  # Stop saving the ouput after hitting the EOS token
+                all_outputs[user].append(user_tok)
+            else:
+                if (
+                    iteration < input_mask.shape[1]
+                ):  # Still in prefill, so ignore EOS token and save the generated token
+                    all_outputs[user].append(user_tok)
+                else:
+                    logger.trace(f"[User {user}] Finished decoding at iteration {iteration}")
+                    user_done[user] = True
+                    if all(user_done):
+                        users_decoding = False
+
+        pt_decode_input = embd(pt_out_tok).view(batch_size, 1, -1)
+
+        # Print out generated outputs for each user at the end of every iteration
+        if len(user_input) == 1:
+            logger.info("[User 0] {}".format("".join(tokenizer.decode(all_outputs[0]))))
+        else:
+            for user in range(batch_size):
+                logger.info("[User {}] {}".format(user, "".join(tokenizer.decode(all_outputs[user]))))
+
+        iteration += 1
+
+        # Upper limit of generated tokens for each user (to avoid infinite generation in case eos is not seen)
+        if iteration >= max_generated_tokens:
+            users_decoding = False
+
+
+def test_ref_demo(user_input="models/demos/mixtral8x7b/reference/input_data.json", batch_size=32):
+    return run_mixtral_demo(user_input=user_input, batch_size=batch_size)

--- a/models/demos/t3000/mixtral8x7b/reference/input_data.json
+++ b/models/demos/t3000/mixtral8x7b/reference/input_data.json
@@ -1,0 +1,97 @@
+[
+    {
+ "prompt": "This is a test."
+            },
+         {
+ "prompt": "It was the best of times, it was the worst"
+            },
+         {
+ "prompt": "Run to the hills"
+            },
+         {
+ "prompt": "You've got another thing coming"
+            },
+         {
+ "prompt": "The meaning of life is"
+            },
+         {
+ "prompt": "write a short poem about London in English"
+            },
+         {
+ "prompt": "How to tie your shoes"
+            },
+         {
+ "prompt": "Give me the address of the closest bakery"
+            },
+         {
+ "prompt": "In a world far far away"
+            },
+         {
+ "prompt": "A poem about trees and nature:"
+            },
+         {
+ "prompt": "Egg fried rice is a delicacy"
+            },
+         {
+ "prompt": "This is another test"
+            },
+         {
+ "prompt": "This is yet another test"
+            },
+         {
+ "prompt": "Large language models are"
+            },
+         {
+ "prompt": "The capital of Portugal"
+            },
+         {
+ "prompt": "The word 'dog' in French"
+            },
+         {
+ "prompt": "Water is essential for"
+            },
+         {
+ "prompt": "My favorite hobby is videogames"
+            },
+         {
+ "prompt": "The best way to cook a steak"
+            },
+         {
+ "prompt": "Top 10 things to do"
+            },
+         {
+ "prompt": "The job of a computer architect is"
+            },
+         {
+ "prompt": "The number you have dialled is not"
+            },
+         {
+ "prompt": "The best way to learn a new language"
+            },
+         {
+ "prompt": "Madrid is the capital"
+            },
+         {
+ "prompt": "A good night's sleep is essential"
+            },
+         {
+ "prompt": "Typing prompts can be fun"
+            },
+         {
+ "prompt": "I'm going to the store"
+            },
+         {
+ "prompt": "I am a world renown spy"
+            },
+         {
+ "prompt": "Ready, set, go"
+            },
+         {
+ "prompt": "Climate change is the most important issue"
+            },
+         {
+ "prompt": "Tell me the story of the three little pigs"
+            },
+         {
+ "prompt": "Once upon a time in a land far far away"}
+        ]

--- a/models/demos/t3000/mixtral8x7b/reference/input_data_questions.json
+++ b/models/demos/t3000/mixtral8x7b/reference/input_data_questions.json
@@ -1,0 +1,97 @@
+[
+    {
+ "prompt": "What is your favourite condiment?"
+            },
+         {
+ "prompt": "Hello, how are you?"
+            },
+         {
+ "prompt": "Do you have mayonnaise recipes?"
+            },
+         {
+ "prompt": "Which color do you get if you mix yellow and blue?"
+            },
+         {
+ "prompt": "What is the ideal room temperature?"
+            },
+         {
+ "prompt": "Can you tell me a joke?"
+            },
+         {
+ "prompt": "What are you good at?"
+            },
+         {
+ "prompt": "What is 2+2?"
+            },
+         {
+ "prompt": "what is the capital of USA?"
+            },
+         {
+ "prompt": "what is the capital of Canada?"
+            },
+         {
+ "prompt": "what is the capital of UK?"
+            },
+         {
+ "prompt": "what is the capital of Germany?"
+            },
+         {
+ "prompt": "what is the capital of France?"
+            },
+         {
+ "prompt": "what is the capital of Japan?"
+            },
+         {
+ "prompt": "what is the capital of Portugal?"
+            },
+         {
+ "prompt": "what is the capital of China?"
+            },
+         {
+ "prompt": "what is the currency of Cuba?"
+            },
+         {
+ "prompt": "what is the currency of Lebanon?"
+            },
+         {
+ "prompt": "what is the currency of Brazil?"
+            },
+         {
+ "prompt": "what is the currency of Australia?"
+            },
+         {
+ "prompt": "what is the currency of Jamaica?"
+            },
+         {
+ "prompt": "what is the currency of Egypt?"
+            },
+         {
+ "prompt": "what is the currency of Uzbekistan?"
+            },
+         {
+ "prompt": "what is the currency of Argentina?"
+            },
+         {
+ "prompt": "Are birds mammals?"
+            },
+         {
+ "prompt": "How do you play tennis?"
+            },
+         {
+ "prompt": "Suggest cities to visit in Japan"
+            },
+         {
+ "prompt": "How far away is the moon from the earth?"
+            },
+         {
+ "prompt": "What is a black hole?"
+            },
+         {
+ "prompt": "How do you play golf?"
+            },
+         {
+ "prompt": "Recommend me a movie"
+            },
+         {
+ "prompt": "what is the capital of Spain?"}
+        ]

--- a/models/demos/t3000/mixtral8x7b/reference/model.py
+++ b/models/demos/t3000/mixtral8x7b/reference/model.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+#################################################################################################################
+# Link: https://github.com/mistralai/mistral-src/blob/main/one_file_ref.py
+# NOTE: changed the device from CUDA to CPU and dtype to float32
+#################################################################################################################
+
+# coding=utf-8
+# Copyright 2023 Mistral AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch import nn
+from typing import Optional, Tuple
+from models.demos.t3000.mixtral8x7b.reference.moe import MoeLayer
+
+
+def repeat_kv(keys: torch.Tensor, values: torch.Tensor, repeats: int):
+    keys = torch.repeat_interleave(keys, repeats=repeats, dim=2)
+    values = torch.repeat_interleave(values, repeats=repeats, dim=2)
+    return keys, values
+
+
+def _reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    """
+    freqs_cis: complex - (seq_len, head_dim / 2)
+    x: complex - (bsz, seq_len, head_dim / 2)
+    """
+    ndim = x.ndim
+    assert 1 < ndim
+    assert freqs_cis.shape == (x.shape[1], x.shape[-1]), (
+        freqs_cis.shape,
+        (x.shape[1], x.shape[-1]),
+    )
+    shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
+    return freqs_cis.view(*shape)
+
+
+def apply_rotary_emb(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    freqs_cis: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+    freqs_cis = _reshape_for_broadcast(freqs_cis, xq_)
+    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+class Attention(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.args = args
+
+        self.n_heads: int = args.n_heads
+        self.n_kv_heads: int = args.n_kv_heads
+
+        self.repeats = self.n_heads // self.n_kv_heads
+        self.sliding_window = self.args.sliding_window
+
+        self.scale = self.args.head_dim**-0.5
+
+        self.wq = nn.Linear(args.dim, args.n_heads * args.head_dim, bias=False)
+        self.wk = nn.Linear(args.dim, args.n_kv_heads * args.head_dim, bias=False)
+        self.wv = nn.Linear(args.dim, args.n_kv_heads * args.head_dim, bias=False)
+        self.wo = nn.Linear(args.n_heads * args.head_dim, args.dim, bias=False)
+        self.cache_k = torch.empty(
+            args.max_batch_size,
+            args.sliding_window,
+            self.n_kv_heads,
+            self.args.head_dim,
+        )
+        self.cache_v = torch.empty(
+            args.max_batch_size,
+            args.sliding_window,
+            self.n_kv_heads,
+            self.args.head_dim,
+        )
+
+    def forward(
+        self, x: torch.Tensor, freqs_cis: torch.Tensor, positions: torch.Tensor, mask: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        bsz, seqlen, _ = x.shape
+
+        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+        xq = xq.view(bsz, seqlen, self.n_heads, self.args.head_dim)
+        xk = xk.view(bsz, seqlen, self.n_kv_heads, self.args.head_dim)
+        xv = xv.view(bsz, seqlen, self.n_kv_heads, self.args.head_dim)
+        xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
+
+        # The cache is a rotating buffer
+        scatter_pos = (positions % self.args.max_seq_len)[None, :, None, None]
+        scatter_pos = scatter_pos.repeat(bsz, 1, self.n_kv_heads, self.args.head_dim)
+        self.cache_k[:bsz].scatter_(dim=1, index=scatter_pos, src=xk)
+        self.cache_v[:bsz].scatter_(dim=1, index=scatter_pos, src=xv)
+
+        # positions = [0].. 1D [0,1]
+        # src = [32,1,8,64]
+        # index = [32,1,8,64] -> [None, -1, :, :] [32,1,8,64] + [32,1,8,64]
+        # self = [32,4096,8,64]
+
+        if positions.shape[0] > 1:
+            # prefill
+            key, value = repeat_kv(xk, xv, self.repeats)
+        else:
+            assert mask is None
+            cur_pos = int(positions[-1].item() + 1)
+            key, value = repeat_kv(self.cache_k[:bsz, :cur_pos, ...], self.cache_v[:bsz, :cur_pos, ...], self.repeats)
+
+        query = xq.transpose(1, 2)
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+        # scores : [bsz, n_heads, seqlen | 1, seqlen]
+        scores = torch.matmul(query, key.transpose(2, 3)) * self.scale
+
+        if mask is not None:
+            scores += mask[None, None, ...]
+
+        scores = scores.float()
+        scores = nn.functional.softmax(scores, dim=-1).type_as(query)
+        output = torch.matmul(scores, value)  # (bs, n_local_heads, slen, head_dim)
+        output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+        return self.wo(output)
+
+
+class FeedForward(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+
+        self.w1 = nn.Linear(args.dim, args.hidden_dim, bias=False)
+        self.w2 = nn.Linear(args.hidden_dim, args.dim, bias=False)
+        self.w3 = nn.Linear(args.dim, args.hidden_dim, bias=False)
+
+    def forward(self, x) -> torch.Tensor:
+        return self.w2(nn.functional.silu(self.w1(x)) * self.w3(x))
+
+
+class RMSNorm(torch.nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.n_heads = args.n_heads
+        self.dim = args.dim
+        self.attention = Attention(args)
+        self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
+        self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
+        self.args = args
+        self.feed_forward: nn.Module
+        if args.moe is not None:
+            self.feed_forward = MoeLayer(
+                experts=[FeedForward(args=args) for _ in range(args.num_experts)],
+                gate=nn.Linear(args.dim, args.num_experts, bias=False),
+                moe_args=args,
+            )
+        else:
+            self.feed_forward = FeedForward(args=args)
+        self.comps = []
+
+    def forward(
+        self, x: torch.Tensor, freqs_cis: torch.Tensor, positions: torch.Tensor, mask: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        x1 = self.attention_norm(x)
+        self.comps.append(x1)
+        r = self.attention.forward(x1, freqs_cis, positions, mask)
+        self.comps.append(r)
+        h = x + r
+        self.comps.append(h)
+        h1 = self.ffn_norm(h)
+        self.comps.append(h1)
+        r = self.feed_forward.forward(h1)
+        self.comps.append(r)
+        out = h + r
+        self.comps.append(out)
+        return out
+
+
+def precompute_freqs_cis(dim: int, end: int, theta: float = 1000000.0) -> torch.Tensor:
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)  # type: ignore
+    freqs = torch.outer(t, freqs).float()  # type: ignore
+    return torch.polar(torch.ones_like(freqs), freqs)  # complex64
+
+
+class Transformer(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.n_layers = args.n_layers
+        assert self.vocab_size > 0
+
+        self.layers = torch.nn.ModuleList([TransformerBlock(args=args) for _ in range(args.n_layers)])
+
+        self.norm = RMSNorm(args.dim, eps=args.norm_eps)
+
+        self.output = nn.Linear(args.dim, args.vocab_size, bias=False)
+
+        self.freqs_cis = precompute_freqs_cis(self.args.head_dim, 128_000)
+        self.tok_embeddings = nn.Embedding(args.vocab_size, args.dim)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+    ):
+        h = input_ids
+        freqs_cis = self.freqs_cis[positions]
+
+        mask: Optional[torch.Tensor] = None
+        if input_ids.shape[1] > 1:
+            seqlen = input_ids.shape[1]
+            tensor = torch.full(
+                (seqlen, seqlen),
+                dtype=h.dtype,
+                fill_value=1,
+                device=h.device,
+            )
+            mask = torch.tril(tensor, diagonal=0).to(h.dtype)
+            # make the mask banded to account for sliding window
+            # mask = torch.triu(mask, diagonal=-self.args.sliding_window)
+            mask = torch.log(mask)
+        for layer in self.layers:
+            h = layer(h, freqs_cis, positions, mask)
+
+        return self.output(self.norm(h)).float()

--- a/models/demos/t3000/mixtral8x7b/reference/moe.py
+++ b/models/demos/t3000/mixtral8x7b/reference/moe.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+#################################################################################################################
+# Link: https://github.com/mistralai/mistral-src/blob/main/one_file_ref.py
+# NOTE: changed the device from CUDA to CPU and dtype to float32
+#################################################################################################################
+
+# coding=utf-8
+# Copyright 2023 Mistral AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import dataclasses
+from typing import List
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+@dataclasses.dataclass
+class MoeArgs:
+    num_experts: int
+    num_experts_per_tok: int
+
+
+class MoeLayer(nn.Module):
+    def __init__(self, experts: List[nn.Module], gate: nn.Module, moe_args: MoeArgs):
+        super().__init__()
+        assert len(experts) > 0
+        self.experts = nn.ModuleList(experts)
+        self.gate = gate
+        self.args = moe_args
+
+    def forward(self, inputs: torch.Tensor):
+        org_input_shape = inputs.shape
+        inputs = inputs.view(-1, inputs.shape[-1])
+        gate_logits = self.gate(inputs)
+        weights, selected_experts = torch.topk(gate_logits, self.args.num_experts_per_tok)
+        weights = F.softmax(weights, dim=-1, dtype=torch.float).to(inputs.dtype)
+        results = torch.zeros_like(inputs)
+        for i, expert in enumerate(self.experts):
+            batch_idx, nth_expert = torch.where(selected_experts == i)
+            expert_ouput = expert(inputs[batch_idx])
+            results[batch_idx] += weights[batch_idx, nth_expert, None] * expert_ouput
+        return results.view(org_input_shape)

--- a/models/demos/t3000/mixtral8x7b/reference/run_ref.py
+++ b/models/demos/t3000/mixtral8x7b/reference/run_ref.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from loguru import logger
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+from models.demos.t3000.mixtral8x7b.reference.model import Transformer
+from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
+
+
+class Emb(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = torch.nn.Embedding(32000, 4096)
+
+    def forward(self, x):
+        return self.emb(x)
+
+
+def main():
+    n_layers = 32
+    iterations = 20
+
+    # Can avoid running reference model to speed up the test (unless measuring PCC)
+    run_ref_pt = True
+
+    model_args = TtModelArgs()
+    model_args.n_layers = n_layers
+
+    state_dict = {}
+    for i in range(1 + (n_layers - 1) // 4):
+        state_dict_i = torch.load(model_args.consolidated_weights_path(i), map_location="cpu")
+        state_dict.update(state_dict_i)
+
+    tokenizer = Tokenizer(model_args.tokenizer_path)
+
+    # TODO Update the prompt
+    # prompts = ["It_was_the_best_of_times_"] * 32
+    prompts = [""] * 32
+    # Space token -> (U+2581) == "▁"
+
+    encoded_prompts = [tokenizer.encode(prompt) for prompt in prompts]
+
+    if run_ref_pt:
+        reference_model = Transformer(args=model_args)
+        reference_model.load_state_dict(torch.load(model_args.state_dict_path))
+
+    # Embedding on host
+    embd = Emb()
+    embd.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
+
+    generation_start_pos = 0
+    generation_length = iterations
+    if run_ref_pt:
+        all_tests_pass = True
+
+    seqlen = 1  # Generating one token per user at a time
+    batch = 32
+
+    # Select the first token from the prompts for initial decoding
+    encoded_prompts_tensor = torch.tensor(encoded_prompts)  # [:,0]
+    pt_decode_input = embd(encoded_prompts_tensor[:, 0]).view(batch, seqlen, -1)
+
+    # Keep track of generated outputs to print out later
+    if run_ref_pt:
+        all_outputs_ref = []
+        all_logits = []
+
+    # After loading the model weights, wait for an input to start the generation
+    # print("Waiting for an input to start...")
+    # input()
+
+    for i in range(generation_length):
+        print(f"[Decode] Generating token {i}")
+
+        start_pos = generation_start_pos + i
+
+        if run_ref_pt:  # Run reference model
+            positions = torch.LongTensor([start_pos])
+            print(f"pt_decode_input = {pt_decode_input.shape}")
+            ref_output = reference_model(pt_decode_input, positions)  # mask)
+            all_logits.append(ref_output)
+
+        print(f"encoded_prompts[0] = {len(encoded_prompts[0])}")
+
+        if run_ref_pt:
+            pt_out_tok = torch.argmax(ref_output, dim=-1).squeeze(1)
+            pt_decode_input = embd(pt_out_tok).view(batch, seqlen, -1)
+            all_outputs_ref.append(pt_out_tok[0].tolist())
+            torch.save(all_logits, "ref_logits.pt")
+
+        # TODO Space decoding is currently not working as expected
+        # TODO print All 32 users
+        if run_ref_pt:
+            print("[User 0] Ref generation: ", "".join(tokenizer.decode(all_outputs_ref)))
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/t3000/mixtral8x7b/reference/tokenizer.py
+++ b/models/demos/t3000/mixtral8x7b/reference/tokenizer.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+#################################################################################################################
+# Link: https://github.com/mistralai/mistral-src/blob/main/one_file_ref.py
+# NOTE: changed the device from CUDA to CPU and dtype to float32
+#################################################################################################################
+
+# coding=utf-8
+# Copyright 2023 Mistral AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sentencepiece import SentencePieceProcessor
+from pathlib import Path
+from typing import List
+
+
+class Tokenizer:
+    def __init__(self, model_path: str):
+        assert Path(model_path).exists(), model_path
+        self._model = SentencePieceProcessor(model_file=model_path)
+        assert self._model.vocab_size() == self._model.get_piece_size()
+
+    @property
+    def n_words(self) -> int:
+        return self._model.vocab_size()
+
+    @property
+    def bos_id(self) -> int:
+        return self._model.bos_id()
+
+    @property
+    def eos_id(self) -> int:
+        return self._model.eos_id()
+
+    @property
+    def pad_id(self) -> int:
+        return self._model.pad_id()
+
+    def encode(self, s: str, bos: bool = True) -> List[int]:
+        assert isinstance(s, str)
+        t = self._model.encode(s)
+        if bos:
+            t = [self.bos_id, *t]
+        return t
+
+    def decode(self, t: List[int]) -> str:
+        return self._model.decode(t)

--- a/models/demos/t3000/mixtral8x7b/scripts/repack_weights.py
+++ b/models/demos/t3000/mixtral8x7b/scripts/repack_weights.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import argparse
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+# Helper function to recreate Mixtral state dictionary.
+# Reads the consolidated weights provided in HuggingFace,
+# separates the 8 experts and saves the updated dict into a new single file.
+def repack_mixtral_weights(ckpt_dir, repack_dir):
+    state_dict = {}
+    model_args = TtModelArgs()
+    consolidated_weights_path = lambda i: str(ckpt_dir + f"/consolidated.{i:02d}.pt")
+
+    for i in range(1 + (model_args.n_layers - 1) // 4):
+        print(f"Loading consolidated.0{i}.pt...")
+        state_dict_i = torch.load(consolidated_weights_path(i), map_location="cpu")
+        state_dict.update(state_dict_i)
+
+    repack_state_dict = {
+        k: v
+        for k, v in state_dict.items()
+        if (
+            any([f"layers.{i}." in k for i in range(model_args.n_layers)])
+            or k in ["tok_embeddings.weight", "norm.weight", "output.weight"]
+        )
+    }
+
+    base_address = "feed_forward."
+    for l in range(model_args.n_layers):
+        print(f"Updating layer {l}...")
+        pre = f"layers.{l}."
+        repack_state_dict[pre + base_address + "gate.weight"] = repack_state_dict[pre + "block_sparse_moe.gate.weight"]
+        del repack_state_dict[pre + "block_sparse_moe.gate.weight"]
+
+        w1 = repack_state_dict[pre + "block_sparse_moe.w1"].contiguous().clone()
+        w2 = repack_state_dict[pre + "block_sparse_moe.w2"].contiguous().clone()
+        w3 = repack_state_dict[pre + "block_sparse_moe.w3"].contiguous().clone()
+        ffn_dim = 14336
+        for i in range(8):
+            repack_state_dict[pre + base_address + f"experts.{i}.w1.weight"] = (
+                w1[ffn_dim * i : ffn_dim * (i + 1), :].contiguous().clone()
+            )
+            repack_state_dict[pre + base_address + f"experts.{i}.w2.weight"] = (
+                w2[ffn_dim * i : ffn_dim * (i + 1), :].T.clone().contiguous()
+            )
+            repack_state_dict[pre + base_address + f"experts.{i}.w3.weight"] = (
+                w3[ffn_dim * i : ffn_dim * (i + 1), :].contiguous().clone()
+            )
+        repack_state_dict.pop(pre + "block_sparse_moe.w1")
+        repack_state_dict.pop(pre + "block_sparse_moe.w2")
+        repack_state_dict.pop(pre + "block_sparse_moe.w3")
+    print(f"Saving repacked weights to {repack_dir}/repack_weights.pt")
+    torch.save(repack_state_dict, repack_dir + "/repack_weights.pt")
+
+
+if __name__ == "__main__":
+    # Take in command line arguments
+    parser = argparse.ArgumentParser(description="Repack mixtral8x7b weights")
+    parser.add_argument("ckpt_dir", type=str, help="input checkpoint directory")
+    parser.add_argument("out_dir", type=str, help="output repack directory")
+    args = parser.parse_args()
+    repack_mixtral_weights(args.ckpt_dir, args.out_dir)

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+import pytest
+from loguru import logger
+
+import ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_attention import TtMixtralAttention
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
+    prepare_inputs_ttnn,
+)
+from models.demos.t3000.mixtral8x7b.reference.model import Attention, precompute_freqs_cis
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+from models.utility_functions import get_devices_for_t3000
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+def test_mixtral_attention_inference(all_devices, use_program_cache, reset_seeds):
+    pcc = 0.99
+    dtype = ttnn.bfloat8_b
+    devices = all_devices
+    num_devices = len(devices)
+    assert num_devices == 8, f"This test requires a T3000 (8 devices), found {num_devices} devices."
+    devices = get_devices_for_t3000(devices, num_devices)  # [ttnn.open_device(device_id=i) for i in range(8)]
+
+    model_args = TtModelArgs(devices[0])
+    state_dict = torch.load(model_args.consolidated_weights_path(0), map_location="cpu")
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    partial_state_dict = {k[19:]: v for k, v in state_dict.items() if (k.startswith("layers.0.attention."))}
+
+    reference_model = Attention(args=model_args)
+    reference_model.load_state_dict(partial_state_dict)
+
+    batch = 32
+    seq_len = 1  # length to generate
+
+    tt_model = TtMixtralAttention(devices, state_dict, args=model_args, layer_num=0, dtype=dtype)
+    generation_start_pos = 0
+    generation_length = 1
+    all_tests_pass = True
+
+    for i in range(generation_length):
+        pt_attention_input = (torch.rand(batch, seq_len, model_args.dim) * 2) - 1
+        tt_attention_input = pt_attention_input.clone()
+        start_pos = generation_start_pos + i
+        attention_input, rot_mat = prepare_inputs_ttnn(
+            tt_attention_input,
+            tt_model.hidden_size,
+            tt_model.head_dim,
+            tt_model.max_seq_len,
+            tt_model.devices,
+        )
+        current_pos = start_pos % model_args.sliding_window
+        tt_out = tt_model(
+            attention_input,
+            start_pos,
+            current_pos,
+            rot_mat,
+        )
+        assert isinstance(tt_out, list)  # tt_out should be replicated on N devices
+        tt_out = tt_out[0]
+        tt_output_torch = ttnn.to_torch(tt_out).squeeze(2).view(batch, 1, -1)  # [ batch, seq, hidden_dim]
+        positions = torch.LongTensor([start_pos])
+        freqs_cis_i = precompute_freqs_cis(model_args.head_dim, 128_000)[positions]
+        reference_output = reference_model(pt_attention_input, freqs_cis_i, positions, mask=None)
+        passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc)
+
+        logger.info(comp_allclose(reference_output, tt_output_torch))
+        logger.info(pcc_message)
+
+        if passing:
+            logger.info(f"[start_pos={start_pos}] Mistral_Attention Passed!")
+        else:
+            logger.warning(f"[start_pos={start_pos}] Mistral_Attention Failed!")
+            all_tests_pass = False
+
+        # Check kv cache
+        # PyTorch output --------------------------------------------------------------------
+        pytorch_layer_present = [
+            reference_model.cache_k.clone().permute(2, 0, 1, 3),  # [n_kv_heads, batch, seq, head_dim]
+            reference_model.cache_v.clone().permute(2, 0, 1, 3),  # [n_kv_heads, batch, seq, head_dim]
+        ]
+        # TT hardware execution -------------------------------------------------------------
+        tt_layer_present = []
+        for layer_past in tt_model.layer_past_list:
+            tt_layer_present.append([ttnn.to_torch(cache) for cache in layer_past])
+        # concat the pasts by heads
+        if len(devices) > 1:
+            tt_layer_present = [
+                torch.cat([tt_cache for tt_cache in tt_cache_head], dim=0) for tt_cache_head in zip(*tt_layer_present)
+            ]
+        else:
+            tt_layer_present = tt_layer_present[0]
+
+        for i, (cache_pt, cache_tt) in enumerate(zip(pytorch_layer_present, tt_layer_present)):
+            cache_length_to_check = min(model_args.sliding_window, generation_start_pos + generation_length + 1)
+            cache_pt = cache_pt[:, :, generation_start_pos:cache_length_to_check, :]
+            cache_tt = cache_tt[:, :, generation_start_pos:cache_length_to_check, :]
+            does_pass, output_pcc = comp_pcc(cache_pt, cache_tt, pcc)
+            if i == 0:
+                logger.info(f"K cache output: {output_pcc}")
+            else:
+                logger.info(f"V cache output: {output_pcc}")
+
+            if does_pass:
+                if i == 0:
+                    logger.info(f"K Cache Passed!")
+                else:
+                    logger.info(f"V Cache Passed!")
+            else:
+                if i == 0:
+                    logger.warning(f"K Cache Failed! PCC value is lower than {pcc}")
+                else:
+                    logger.warning(f"V Cache Failed! PCC value is lower than {pcc}")
+                all_tests_pass = False
+
+    if all_tests_pass:
+        logger.info("Mistral Attention output Passed!")
+    else:
+        logger.warning("Mistral Attention output Failed!")
+        assert all_tests_pass, f"PCC value is lower than {pcc} for some of the outputs. Check Warnings!"

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
+    prepare_inputs_ttnn,
+)
+from models.demos.t3000.mixtral8x7b.tt.mixtral_decoder import TtTransformerBlock
+from models.demos.t3000.mixtral8x7b.reference.model import TransformerBlock, precompute_freqs_cis
+from models.utility_functions import comp_pcc, comp_allclose, get_devices_for_t3000
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+def test_mixtral_decoder_inference(all_devices, use_program_cache, reset_seeds):
+    """
+    b: batch
+    s: sequence length
+    h: hidden size
+    """
+    pcc = 0.99
+    dtype = ttnn.bfloat8_b
+
+    devices = all_devices
+    num_devices = len(devices)
+    assert num_devices == 8, "This test requires a T3000 (8 devices)"
+    devices = get_devices_for_t3000(devices, num_devices)  # [ttnn.open_device(device_id=i) for i in range(8)]
+
+    model_args = TtModelArgs(devices[0])
+    state_dict = torch.load(model_args.state_dict_path)
+    partial_state_dict = {k[9:]: v for k, v in state_dict.items() if (k.startswith("layers.0."))}
+    reference_model = TransformerBlock(args=model_args)
+    reference_model.load_state_dict(partial_state_dict)
+
+    # Initialize TT model
+    tt_model = TtTransformerBlock(
+        devices=devices,
+        state_dict=state_dict,
+        args=model_args,
+        layer_num=0,
+        dtype=dtype,
+    )
+
+    generation_start_pos = 0
+    generation_length = 1
+    all_tests_pass = True
+
+    seqlen = 1
+    batch = 32
+
+    for i in range(generation_length):
+        logger.info(f"[Decoder] Generating token {i}")
+
+        # input = torch.randn(1, 32, 4096)
+        pt_decode_input_bsh = (torch.rand(batch, seqlen, model_args.dim) * 2) - 1
+        start_pos = generation_start_pos + i
+        current_pos = start_pos % model_args.sliding_window
+
+        decode_input_b1sh, rot_mat = prepare_inputs_ttnn(
+            pt_decode_input_bsh.clone(),
+            tt_model.hidden_size,
+            tt_model.head_dim,
+            tt_model.max_seq_len,
+            tt_model.devices,
+        )
+        # Run TT model
+        tt_out_b1sh = tt_model(decode_input_b1sh, start_pos, current_pos, rot_mat)
+        tt_output_torch_b1h = ttnn.to_torch(tt_out_b1sh[0]).squeeze(1).view(batch, 1, -1)
+
+        # Reference model
+        positions = torch.LongTensor([start_pos])
+        freqs_cis_i = precompute_freqs_cis(model_args.head_dim, 128_000)[positions]
+        ref_output_bsh = reference_model(pt_decode_input_bsh, freqs_cis_i, positions, mask=None)
+
+        passing, pcc_message = comp_pcc(ref_output_bsh, tt_output_torch_b1h, pcc)
+
+        logger.info(comp_allclose(ref_output_bsh, tt_output_torch_b1h))
+        logger.info(pcc_message)
+
+        if passing:
+            logger.info("Mistral Decoder Block Passed!")
+        else:
+            logger.warning("Mistral Decoder Block Failed!")
+            all_tests_pass = False
+
+    if all_tests_pass:
+        logger.info(f"All {generation_length} Mistral decode iterations Passed!")
+    else:
+        logger.warning("One or more iterations of Mistral decode Failed!")
+        assert all_tests_pass, f"PCC value is lower than {pcc} for some of the outputs. Check Warnings!"

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_embedding import TtMixtralEmbedding
+from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+class Emb(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = torch.nn.Embedding(32000, 4096)
+
+    def forward(self, x):
+        return self.emb(x)
+
+
+def test_mixtral_embedding(device, use_program_cache, reset_seeds):
+    dtype = ttnn.bfloat16
+
+    model_args = TtModelArgs(device)
+    state_dict = torch.load(model_args.state_dict_path)
+    tokenizer = Tokenizer(model_args.tokenizer_path)
+
+    reference_emb = Emb()
+    reference_emb.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
+
+    tt_emb = TtMixtralEmbedding(
+        device=device,
+        args=model_args,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        state_dict=state_dict,
+        dtype=dtype,
+    )
+
+    prompts = ["Joy"] * 32
+    pt_input = torch.tensor([tokenizer.encode(prompt) for prompt in prompts])
+    reference_output = reference_emb(pt_input)
+    logger.info(f"reference_output: {reference_output.shape}")
+
+    tt_input = ttnn.from_torch(pt_input, device=device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    tt_output = tt_emb(tt_input)
+    tt_output_torch = ttnn.to_torch(tt_output)
+    logger.info(f"tt_output_torch: {tt_output_torch.shape}")
+
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch)
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(pcc_message)
+
+    if passing:
+        logger.info("Mixtral_embedding Passed!")
+    else:
+        logger.warning("Mixtral_embedding Failed!")
+
+    assert passing, f"Mixtral_embedding output does not meet PCC requirement {0.99}."

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+from loguru import logger
+import ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_mlp import TtMixtralMLP
+from models.demos.t3000.mixtral8x7b.reference.model import FeedForward, RMSNorm
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+def test_mixtral_mlp_inference(device, use_program_cache, reset_seeds):
+    # Specify different dtypes for each feedForward weights
+    dtypes = {
+        "w1": ttnn.bfloat4_b,
+        "w2": ttnn.bfloat8_b,
+        "w3": ttnn.bfloat4_b,
+    }
+
+    model_args = TtModelArgs(device)
+    state_dict = torch.load(model_args.state_dict_path)
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    partial_state_dict = {
+        k: v for k, v in state_dict.items() if (k.startswith("layers.0.") and "attention" not in k and "norm" not in k)
+    }
+
+    partial_state_dict_ref = {k[32:]: v for k, v in partial_state_dict.items() if "experts.0" in k}
+    reference_model = FeedForward(args=model_args)
+    reference_model.load_state_dict(partial_state_dict_ref)
+
+    tt_model = TtMixtralMLP(
+        device=device,
+        state_dict=partial_state_dict,
+        args=model_args,
+        layer_num=0,
+        expert_num=0,
+        dtypes=dtypes,
+    )
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    rms_state_dict = {k[18:]: v for k, v in state_dict.items() if (k.startswith("layers.0.ffn_norm."))}
+    rms = RMSNorm(dim=model_args.dim)
+    rms.load_state_dict(rms_state_dict)
+
+    torch_input = (torch.rand(1, 1, 32, model_args.dim) * 2) - 1
+    torch_input = rms(torch_input)  # apply rmsnorm to input
+
+    reference_output = reference_model(torch_input)
+    tt_input = ttnn.from_torch(
+        torch_input, device=device, dtype=ttnn.bfloat16, memory_config=ttnn.L1_MEMORY_CONFIG, layout=ttnn.TILE_LAYOUT
+    )
+
+    logger.info("Compilation pass for Mistral_MLP")
+    tt_output = tt_model(tt_input)
+
+    logger.info("Performance pass for Mistral_MLP")
+    tt_output = tt_model(tt_input)
+    tt_output_torch = ttnn.to_torch(tt_output)
+
+    pcc_required = 0.99
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(pcc_message)
+
+    if passing:
+        logger.info("Mistral_MLP Passed!")
+    else:
+        logger.warning("Mistral_MLP Failed!")
+
+    assert passing, f"Mistral_MLP output does not meet PCC requirement {pcc_required}: {pcc_message}."

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+import pytest
+import numpy as np
+from loguru import logger
+from sklearn.metrics import top_k_accuracy_score
+import ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
+    prepare_inputs_ttnn,
+)
+from models.demos.t3000.mixtral8x7b.tt.mixtral_model import TtTransformer
+from models.demos.t3000.mixtral8x7b.reference.model import Transformer
+from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
+from models.utility_functions import comp_pcc, comp_allclose, get_devices_for_t3000
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+class Emb(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = torch.nn.Embedding(32000, 4096)
+
+    def forward(self, x):
+        return self.emb(x)
+
+
+@pytest.mark.parametrize(
+    "validation_type",
+    ("pcc", "output"),
+)
+@pytest.mark.parametrize(
+    "n_layers",
+    (1, 32),
+)
+@pytest.mark.parametrize(
+    "iterations",
+    (1, 10, 127),
+)
+def test_mixtral_model_inference(all_devices, iterations, n_layers, validation_type, use_program_cache, reset_seeds):
+    pcc = 0.99
+    dtype = ttnn.bfloat8_b
+
+    devices = all_devices
+    num_devices = len(devices)
+    assert num_devices == 8, "This test requires a T3000 (8 devices)"
+    devices = get_devices_for_t3000(devices, num_devices)
+
+    model_args = TtModelArgs(devices[0])
+    model_args.n_layers = n_layers
+
+    state_dict = torch.load(model_args.state_dict_path)
+    keys_dict = list(state_dict.keys())[:]
+    remv = [f"layers.{i}" for i in range(n_layers, 32)]
+    for k in keys_dict:
+        if any([r in k for r in remv]):
+            state_dict.pop(k)
+
+    tokenizer = Tokenizer(model_args.tokenizer_path)
+
+    prompts = ["Once"] * 32
+
+    encoded_prompts = [tokenizer.encode(prompt) for prompt in prompts]
+
+    if validation_type == "pcc":
+        reference_model = Transformer(args=model_args)
+        reference_model.load_state_dict(state_dict)
+        reference_model.eval()
+
+    # Embedding on host
+    embd = Emb()
+    embd.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
+
+    # Load TTNN model
+    tt_model = TtTransformer(
+        devices=devices,
+        state_dict=state_dict,
+        args=model_args,
+        layers=list(range(model_args.n_layers)),
+        dtype=dtype,
+    )
+
+    generation_start_pos = 0
+    generation_length = iterations
+    all_tests_pass = True
+
+    seqlen = 1  # Generating one token per user at a time
+    batch = 32
+
+    # Select the first token from the prompts for initial decoding
+    encoded_prompts_tensor = torch.tensor(encoded_prompts)  # [:,0]
+    pt_decode_input = embd(encoded_prompts_tensor[:, 0]).view(batch, seqlen, -1)
+
+    tt_decode_input = pt_decode_input
+    ref_tokens = []
+    tt_tokens = []
+    for i in range(generation_length):
+        logger.info(f"[Decode] Generating token {i}")
+
+        start_pos = generation_start_pos + i
+        current_pos = start_pos % model_args.sliding_window
+
+        decode_input, rot_mat = prepare_inputs_ttnn(
+            tt_decode_input,
+            model_args.dim,
+            model_args.head_dim,
+            model_args.max_seq_len,
+            tt_model.devices,
+        )
+
+        # Run TT model
+        tt_out = tt_model(decode_input, start_pos, current_pos, rot_mat)
+
+        # Convert ttnn tensor to torch tensor
+        tt_output_torch = ttnn.to_torch(tt_out[0]).squeeze(1).view(batch, seqlen, -1).detach().float()
+
+        if validation_type == "pcc":
+            positions = torch.LongTensor([start_pos])
+            ref_output = reference_model(pt_decode_input, positions).detach().float()
+
+        # Measure PCC
+        if validation_type == "pcc":
+            passing, pcc_message = comp_pcc(
+                ref_output.view(batch, seqlen, -1), tt_output_torch.view(batch, seqlen, -1), pcc
+            )
+            logger.info(comp_allclose(ref_output, tt_output_torch))
+            logger.info(pcc_message)
+
+            reference_top1 = np.argmax(ref_output, axis=-1).squeeze()
+            top1_acc = top_k_accuracy_score(
+                reference_top1, tt_output_torch.squeeze(), k=1, labels=np.arange(tt_output_torch.shape[-1])
+            )
+            top5_acc = top_k_accuracy_score(
+                reference_top1, tt_output_torch.squeeze(), k=5, labels=np.arange(tt_output_torch.shape[-1])
+            )
+            logger.info(f"Mean Top-1: {top1_acc}")
+            logger.info(f"Mean Top-5: {top5_acc}")
+
+            ref_token_batch = ref_output.squeeze().argmax(axis=-1)
+            ref_tokens.append(ref_token_batch[0].item())
+            logger.info(f'ref_output: {"".join(tokenizer.decode(ref_tokens))}')
+            pt_decode_input = embd(ref_token_batch).view(batch, seqlen, -1)
+
+        tt_token_batch = tt_output_torch.squeeze().argmax(axis=-1)
+        tt_tokens.append(tt_token_batch[0].item())
+        logger.info(f'tt_output_torch: {"".join(tokenizer.decode(tt_tokens))}')
+        tt_decode_input = embd(tt_token_batch).view(batch, seqlen, -1)
+
+        if validation_type == "pcc":
+            if passing:
+                logger.info("Mistral Model Passed!")
+            else:
+                logger.warning("Mistral Model Failed!")
+                all_tests_pass = False
+
+    if validation_type == "output":
+        if iterations == 1:  # First generated token will be a empty character, so just ignore output validation
+            all_tests_pass = True
+        elif iterations == 10:
+            expected_output = "# The 10 Best Places to Live"
+            logger.info(f"Expected output: {expected_output}")
+            if "".join(tokenizer.decode(tt_tokens)) == expected_output:
+                all_tests_pass = True
+            else:
+                all_tests_pass = False
+        elif iterations == 127:  # TODO Check the baseline output for 127 iterations
+            logger.info("Output validation not yet implemented for 127 iterations.")
+            all_tests_pass = True
+        else:
+            logger.info("Output validation not  implemented for this iteration count!")
+            all_tests_pass = True
+
+    if all_tests_pass:
+        logger.info(f"All {generation_length} Mistral decode iterations Passed!")
+    else:
+        logger.warning("One or more iterations of Mistral decode Failed!")
+        if validation_type == "pcc":
+            assert all_tests_pass, f"PCC value is lower than {pcc} for some of the outputs. Check Warnings!"
+        else:
+            logger.info(f'Generated output: {"".join(tokenizer.decode(tt_tokens))}')
+            assert all_tests_pass, f"Expected output did not match the generated output!"

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_mlp import TtMixtralMLP
+from models.demos.t3000.mixtral8x7b.tt.mixtral_moe import TtMoeLayer
+from models.demos.t3000.mixtral8x7b.reference.moe import MoeLayer
+from models.demos.t3000.mixtral8x7b.reference.model import FeedForward
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+from models.utility_functions import get_devices_for_t3000
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+def test_mixtral_moe_inference(all_devices, use_program_cache, reset_seeds):
+    pcc = 0.99
+    iterations = 1
+    dtype = ttnn.bfloat8_b
+
+    devices = all_devices
+    num_devices = len(devices)
+    assert num_devices in (4, 8), "This test requires a T3000 (4 or 8 devices)"
+
+    devices = get_devices_for_t3000(devices, num_devices)  # [ttnn.open_device(device_id=i) for i in range(8)]
+    if num_devices == 4:
+        devices += devices
+
+    model_args = TtModelArgs(devices[0])
+    state_dict = torch.load(model_args.state_dict_path)
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    partial_state_dict = {
+        k[9:]: v
+        for k, v in state_dict.items()
+        if (k.startswith("layers.0.") and "attention" not in k and "norm" not in k)
+    }
+
+    partial_state_dict_ref = {k[13:]: v for k, v in partial_state_dict.items()}
+    reference_model = MoeLayer(
+        experts=[FeedForward(args=model_args) for _ in range(8)],
+        gate=torch.nn.Linear(model_args.dim, 8, bias=False),
+        moe_args=model_args,
+    )
+    reference_model.load_state_dict(partial_state_dict_ref)
+    # Initialize TT models
+
+    experts = [
+        TtMixtralMLP(
+            device=devices[i],
+            state_dict=state_dict,
+            args=model_args,
+            layer_num=0,
+            expert_num=i,
+            dtypes={
+                "w1": ttnn.bfloat4_b,
+                "w2": ttnn.bfloat8_b,
+                "w3": ttnn.bfloat4_b,
+            },
+        )
+        for i in range(len(devices))
+    ]
+
+    tt_model = TtMoeLayer(
+        devices=devices,
+        state_dict=state_dict,
+        experts=experts,
+        args=model_args,
+        layer_num=0,
+        dtype=dtype,
+    )
+
+    all_tests_pass = True
+
+    seqlen = 1
+    batch = 32
+
+    # TODO Update start_pos (check llama test for reference)
+    for i in range(iterations):
+        logger.info(f"[Decoder] Generating token {i}")
+
+        # input = torch.randn(1, 32, 4096)
+        pt_decode_input = (torch.rand(batch, seqlen, model_args.dim) * 2) - 1
+        tt_decode_input = [
+            ttnn.from_torch(
+                pt_decode_input.clone().unsqueeze(1).view(1, 1, 32, 4096),
+                device=device,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+                layout=ttnn.TILE_LAYOUT,
+            )
+            for device in devices
+        ]
+        # Run TT model
+        tt_out = tt_model(tt_decode_input)
+        tt_output_torch = ttnn.to_torch(tt_out[0]).squeeze(2).view(batch, 1, -1)
+
+        # Reference model
+        ref_output = reference_model(pt_decode_input)
+        passing, pcc_message = comp_pcc(ref_output, tt_output_torch, pcc)
+
+        logger.info(comp_allclose(ref_output, tt_output_torch))
+        logger.info(pcc_message)
+
+        if passing:
+            logger.info("Mistral MOE Passed!")
+        else:
+            logger.warning("Mistral MOE Failed!")
+            all_tests_pass = False
+
+    if all_tests_pass:
+        logger.info(f"All {iterations} Mistral MOE iterations Passed!")
+    else:
+        logger.warning("One or more iterations of Mistral MOE Failed!")
+        assert all_tests_pass, f"PCC value is lower than {pcc} for some of the outputs. Check Warnings!"

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+import ttnn
+import os
+
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
+    prepare_inputs_ttnn,
+)
+from models.demos.t3000.mixtral8x7b.tt.mixtral_model import TtTransformer
+from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
+from models.utility_functions import get_devices_for_t3000
+
+
+from models.perf.perf_utils import prep_perf_report
+from models.utility_functions import profiler, enable_persistent_kernel_cache
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+class Emb(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = torch.nn.Embedding(32000, 4096)
+
+    def forward(self, x):
+        return self.emb(x)
+
+
+@pytest.mark.models_performance_bare_metal_multi_device
+@pytest.mark.parametrize(
+    "expected_compile_time, expected_inference_time",
+    ((200, 8.5),),
+)
+def test_mixtral_model_perf(
+    all_devices, expected_compile_time, expected_inference_time, use_program_cache, reset_seeds
+):
+    dtype = ttnn.bfloat8_b
+
+    devices = all_devices
+    num_devices = len(devices)
+    assert num_devices == 8, "This test requires a T3000 (8 devices)"
+    devices = get_devices_for_t3000(devices, num_devices)
+
+    model_args = TtModelArgs(devices[0])
+    model_args.n_layers = 32
+    tokenizer = Tokenizer(model_args.tokenizer_path)
+
+    # Clear global profiler state before starting measurements
+    profiler.clear()
+
+    profiler.start("weight_loading")
+    state_dict = torch.load(model_args.state_dict_path)
+    keys_dict = list(state_dict.keys())[:]
+    # If needed to test with fewer layers, remove the rest of the layers
+    remv = [f"layers.{i}" for i in range(model_args.n_layers, 32)]
+    for k in keys_dict:
+        if any([r in k for r in remv]):
+            state_dict.pop(k)
+
+    profiler.end("weight_loading")
+
+    prompts = ["Once"] * 32
+    encoded_prompts = [tokenizer.encode(prompt) for prompt in prompts]
+
+    # Embedding on host
+    embd = Emb()
+    embd.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
+
+    generation_start_pos = 0
+    generation_length = 1
+
+    profiler.start("Mixtral_model_setup")
+
+    # Load TTNN model
+    tt_model = TtTransformer(
+        devices=devices,
+        state_dict=state_dict,
+        args=model_args,
+        layers=list(range(model_args.n_layers)),
+        dtype=dtype,
+    )
+    profiler.end("TtMistral_model_setup")
+
+    # Call the function
+    profiler.start(f"end_to_end_inference_with_compile")
+    run_inference(tt_model, embd, encoded_prompts, generation_start_pos, generation_length)
+    profiler.end(f"end_to_end_inference_with_compile")
+    profiler.print()
+    compile_and_iter_time = profiler.get("model_run_for_inference_0")
+
+    profiler.clear()
+    profiler.start(f"end_to_end_inference")
+    run_inference(tt_model, embd, encoded_prompts, generation_start_pos, generation_length)
+    profiler.end(f"end_to_end_inference")
+    profiler.print()
+    iter_time = profiler.get("model_run_for_inference_0")
+
+    comment = f"num_layers={model_args.n_layers}"
+
+    prep_perf_report(
+        model_name=f"Mixtral8x7B",
+        batch_size=model_args.max_batch_size,
+        inference_and_compile_time=compile_and_iter_time,
+        inference_time=iter_time,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments=comment,
+    )
+
+
+def run_inference(tt_model, embd, encoded_prompts, generation_start_pos, generation_length):
+    seqlen = 1  # Generating one token per user at a time
+    batch = tt_model.args.max_batch_size
+
+    # Select the first token from the prompts for initial decoding
+    encoded_prompts_tensor = torch.tensor(encoded_prompts)  # [:,0]
+    pt_decode_input = embd(encoded_prompts_tensor[:, 0]).view(batch, seqlen, -1)
+    tt_decode_input = pt_decode_input
+
+    for i in range(generation_length):
+        start_pos = generation_start_pos + i
+        current_pos = start_pos % tt_model.args.sliding_window
+
+        decode_input, rot_mat = prepare_inputs_ttnn(
+            tt_decode_input,
+            tt_model.args.dim,
+            tt_model.args.head_dim,
+            tt_model.args.max_seq_len,
+            tt_model.devices,
+        )
+
+        # Run TT model
+        profiler.start(f"model_run_for_inference_{i}")
+        tt_out = tt_model(decode_input, start_pos, current_pos, rot_mat)
+
+        # Convert ttnn tensor to torch tensor
+        profiler.start(f"result_wait_for_inference_{i}")
+        tt_output_torch = ttnn.to_torch(tt_out[0]).squeeze(1).view(batch, seqlen, -1).detach().float()
+
+        profiler.end(f"model_run_for_inference_{i}")
+        profiler.end(f"result_wait_for_inference_{i}")
+
+        # Greedy decode the generated token and pass it back in, this is just a perf test
+        tt_token_batch = tt_output_torch.squeeze().argmax(axis=-1)
+        tt_decode_input = embd(tt_token_batch).view(batch, seqlen, -1)

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+import pytest
+from loguru import logger
+import ttnn
+
+from models.demos.t3000.mixtral8x7b.tt.mixtral_rms_norm import TtRMSNorm
+from models.demos.t3000.mixtral8x7b.reference.model import RMSNorm
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+def test_mistral_rms_norm_inference(device, use_program_cache, reset_seeds):
+    dtype = ttnn.bfloat8_b
+    model_args = TtModelArgs(device)
+    state_dict = torch.load(model_args.consolidated_weights_path(0))
+
+    # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
+    partial_state_dict = {k[24:]: v for k, v in state_dict.items() if (k.startswith("layers.0.attention_norm."))}
+    reference_model = RMSNorm(dim=model_args.dim)
+    reference_model.load_state_dict(partial_state_dict)
+
+    tt_model = TtRMSNorm(
+        device=device,
+        state_dict=state_dict,
+        args=model_args,
+        dtype=dtype,
+        layer_num=0,
+        weight_key="attention_norm",
+    )
+    input = torch.rand(1, 32, 4096)
+    reference_output = reference_model(input)
+
+    tt_input = ttnn.from_torch(input, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+
+    tt_output = tt_model(tt_input)
+    tt_output_torch = ttnn.to_torch(tt_output).squeeze(0)
+
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch)
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(pcc_message)
+
+    if passing:
+        logger.info("Mixtral_rms_norm Passed!")
+    else:
+        logger.warning("Mixtral_rms_norm Failed!")
+
+    assert passing, f"Mixtral_rms_norm output does not meet PCC requirement {0.99}."

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -1,0 +1,307 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+from models.utility_functions import nearest_32
+
+
+class TtMixtralAttention(torch.nn.Module):
+    def __init__(self, devices, state_dict, args, layer_num, dtype):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.devices = devices
+        self.num_devices = len(devices)
+        self.model_args = args
+
+        self.hidden_size = args.dim
+        self.n_heads = args.n_heads
+        self.head_dim = self.hidden_size // self.n_heads
+        self.max_seq_len = args.max_seq_len
+        self.max_batch_size = args.max_batch_size
+        self.n_kv_heads = args.n_kv_heads
+        self.sliding_window = args.sliding_window
+
+        self.n_local_heads = self.n_heads // self.num_devices
+        self.n_local_kv_heads = self.n_kv_heads // self.num_devices
+
+        self.dtype = dtype
+
+        self.model_config = self.model_args.get_model_config()
+
+        layer_name = f"layers.{layer_num}.attention"
+        cache_name = lambda name: self.model_args.weight_cache_path(dtype) / (f"{layer_name}.{name}")
+
+        wq_str = f"{layer_name}.wq.weight"
+        wk_str = f"{layer_name}.wk.weight"
+        wv_str = f"{layer_name}.wv.weight"
+        wo_str = f"{layer_name}.wo.weight"
+
+        # when splitting the devices, we need to make sure that the number of heads is divisible by the number of devices
+        assert self.n_heads % self.num_devices == 0
+        assert self.n_kv_heads % self.num_devices == 0
+
+        self.wqkv_list = []
+        self.wo_list = []
+        self.layer_past_list = []
+
+        for i in range(self.num_devices):
+            wqkv = ttnn.as_tensor(
+                torch.concat(
+                    [
+                        torch.transpose(
+                            torch.chunk(self.state_dict[wq_str], self.num_devices)[i],
+                            -2,
+                            -1,
+                        ),
+                        torch.transpose(
+                            torch.chunk(self.state_dict[wk_str], self.num_devices)[i],
+                            -2,
+                            -1,
+                        ),
+                        torch.transpose(
+                            torch.chunk(self.state_dict[wv_str], self.num_devices)[i],
+                            -2,
+                            -1,
+                        ),
+                    ],
+                    dim=-1,
+                ),
+                device=self.devices[i],
+                dtype=self.dtype,
+                memory_config=self.model_config["ATTN_WEIGHTS_MEMCFG"],
+                layout=self.model_config["ATTN_W_LAYOUT_TILE"],
+                cache_file_name=cache_name(f"wqkv_{i}_"),
+            )
+            wo = ttnn.as_tensor(
+                torch.transpose(
+                    torch.chunk(self.state_dict[wo_str], self.num_devices, dim=-1)[i],
+                    -2,
+                    -1,
+                ),
+                device=self.devices[i],
+                dtype=self.dtype,
+                memory_config=self.model_config["ATTN_WEIGHTS_MEMCFG"],
+                layout=self.model_config["ATTN_W_LAYOUT_TILE"],
+                cache_file_name=cache_name(f"wo_{i}_"),
+            )
+
+            cache_k = torch.zeros(
+                (
+                    self.n_kv_heads // self.num_devices,
+                    self.max_batch_size,
+                    self.sliding_window,
+                    self.head_dim,
+                )
+            )
+            cache_v = torch.zeros(
+                (
+                    self.n_kv_heads // self.num_devices,
+                    self.max_batch_size,
+                    self.sliding_window,
+                    self.head_dim,
+                )
+            )
+            layer_past = [cache_k, cache_v]
+            layer_past = [
+                ttnn.from_torch(
+                    lp, device=self.devices[i], layout=self.model_config["ATTN_W_LAYOUT_TILE"], dtype=ttnn.bfloat16
+                )
+                for lp in layer_past
+            ]
+
+            # add to the list
+            self.wqkv_list.append(wqkv)
+            self.wo_list.append(wo)
+            self.layer_past_list.append(layer_past)
+
+        # Scale tensor for q_heads to avoid falling back to host.
+        self.head_dims = [
+            ttnn.from_torch(
+                torch.ones(1, self.n_local_heads, self.max_batch_size, self.head_dim) * (self.head_dim**-0.5),
+                device=self.devices[i],
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat16,
+            )
+            for i in range(self.num_devices)
+        ]
+        reduce_mask_torch = torch.zeros(1, 1, self.max_batch_size, self.max_batch_size * len(self.devices))
+        for i in range(self.max_batch_size):
+            reduce_mask_torch[:, :, i, range(i, self.max_batch_size * len(self.devices), self.max_batch_size)] = 1
+        self.reduce_mask = [
+            ttnn.from_torch(reduce_mask_torch, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT)
+            for device in self.devices
+        ]
+
+        self.compute_kernel = self.model_args.get_compute_kernel_config()
+        self.compute_kernel_attn = self.model_args.get_compute_kernel_attn_config()
+
+        self.core_grid = self.model_args.max_grid_size
+        self.core_grid_attention = self.model_args.core_grid_attention
+
+    def forward(
+        self,
+        xs,
+        start_pos,
+        current_pos,
+        rot_mats,
+    ):
+        """
+        x: (seq_len, 1, batch, hidden_dim)
+        start_pos: the length of the KV cache. Same as current token's index.
+        current_pos: start_pos % self.sliding_window
+        rot_mats: list of rotation matrices for each device
+
+        Tensors are postfixed with 4 characters that represent their 4-D shape:
+        B : batch_size (32)
+        H : dim (4096)
+        D : head_dim (128)
+        P : padded_layer_past_len
+        """
+        padded_layer_past_len = min(nearest_32(start_pos + 1), self.sliding_window)
+        layer_slice = min((start_pos + 1), self.sliding_window)
+        dense_outputs_11BH = []
+
+        for i in range(self.num_devices):
+            x_11BH = xs[i]
+            wqkv = self.wqkv_list[i]
+            wo = self.wo_list[i]
+            layer_past = self.layer_past_list[i]
+            rot_mat = rot_mats[i][start_pos]
+            head_dim_14BD = self.head_dims[i]
+            ###
+            # QKV matmuls
+            ###
+            xqkv_fused = ttnn.linear(
+                x_11BH,
+                wqkv,
+                dtype=ttnn.bfloat16,
+                memory_config=self.model_config["XQKV_MM_OUTPUT_MEMCFG"],
+                core_grid=self.core_grid,
+                compute_kernel_config=self.compute_kernel,
+            )
+
+            # split qkv into heads
+            (
+                q_heads_14BD,
+                k_heads_11BD,
+                v_heads_11BD,
+            ) = ttnn.experimental.tensor.nlp_create_qkv_heads(
+                xqkv_fused,
+                num_heads=self.n_local_heads,
+                num_kv_heads=self.n_local_kv_heads,
+                transpose_k_heads=False,
+                output_mem_config=self.model_config["QKV_HEADS_OUTPUT_MEMCFG"],
+            )
+
+            ###
+            # Rotary embeddings
+            ###
+            q_heads_14BD = ttnn.linear(
+                q_heads_14BD,
+                rot_mat,
+                core_grid=self.core_grid,
+                use_1d_systolic_array=True,
+                memory_config=self.model_config["QV_ROT_EMB_OUTPUT_MEMCFG"],
+            )
+            k_heads_11BD = ttnn.linear(
+                k_heads_11BD,
+                rot_mat,
+                core_grid=self.core_grid,
+                use_1d_systolic_array=True,
+                memory_config=self.model_config["QV_ROT_EMB_OUTPUT_MEMCFG"],
+            )
+
+            q_heads_14BD = q_heads_14BD * head_dim_14BD  # Scale q_heads
+            q_heads_14BD = ttnn.pad(
+                q_heads_14BD, ((0, 0), (0, self.max_batch_size - self.n_local_heads), (0, 0), (0, 0)), value=0
+            )
+            q_heads_1B4D = ttnn.permute(q_heads_14BD, (0, 2, 1, 3))
+            k_heads_11BD = ttnn.pad(k_heads_11BD, ((0, 0), (0, self.max_batch_size - 1), (0, 0), (0, 0)), value=0)
+            k_heads_1B1D = ttnn.permute(k_heads_11BD, (0, 2, 1, 3))
+            v_heads_11BD = ttnn.pad(v_heads_11BD, ((0, 0), (0, self.max_batch_size - 1), (0, 0), (0, 0)), value=0)
+            v_heads_1B1D = ttnn.permute(v_heads_11BD, (0, 2, 1, 3))
+            ###
+            # KV update
+            ###
+            keys_1BPD = layer_past[0]
+            values_1BPD = layer_past[1]
+            ttnn.kv_cache.update_cache_for_token_(keys_1BPD, k_heads_1B1D, current_pos)
+            ttnn.kv_cache.update_cache_for_token_(values_1BPD, v_heads_1B1D, current_pos)
+            self.layer_past_list[i] = [keys_1BPD, values_1BPD]
+            keys_1BPD = keys_1BPD[:, :, :padded_layer_past_len, :]
+            values_1BPD = values_1BPD[:, :, :layer_slice, :]
+
+            ###
+            # Attention
+            ###
+            # transpose keys
+            keys_1BDP = ttnn.permute(keys_1BPD, (0, 1, 3, 2))
+
+            # pad, transpose, scale, and shard q head
+            # q_heads_1B4D = ttnn.to_memory_config(q_heads_1B4D, self.model_config["Q_TRANSPOSE_MEMCFG"])
+
+            # shard keys
+            # k_cache_memcfg = self.model_config["K_CACHE_SLICE_OUTPUT_MEMCFG"](padded_layer_past_len)
+            # keys_1BDP = ttnn.to_memory_config(keys_1BDP, k_cache_memcfg)
+            # shard values
+            # v_cache_memcfg = self.model_config["V_CACHE_SLICE_OUTPUT_MEMCFG"](padded_layer_past_len)
+            # values_1BPD = ttnn.to_memory_config(values_1BPD, v_cache_memcfg)
+            # create out cfg
+            # attn_output_memcfg = self.model_config["ATTN_BATCHED_MM_OUTPUT_MEMCFG"](padded_layer_past_len)
+
+            # scores matmul
+            attn_1B4P = ttnn.matmul(
+                q_heads_1B4D,
+                keys_1BDP,
+                dtype=ttnn.bfloat16,
+                # memory_config=attn_output_memcfg,
+                core_grid=self.core_grid_attention,
+                compute_kernel_config=self.compute_kernel_attn,
+            )
+            # scores slice and softmax
+            attn_1B4P = attn_1B4P[:, :, :, :layer_slice]
+            attn_1B4P = ttnn.softmax(attn_1B4P, dim=-1)  # , memory_config=attn_output_memcfg_post_sm)
+            # values matmul
+            attn_output_1B4D = ttnn.matmul(
+                attn_1B4P,
+                values_1BPD,
+                dtype=ttnn.bfloat16,
+                memory_config=self.model_config["QKV_MM_OUTPUT_MEMCFG"],
+                core_grid=self.core_grid_attention,
+                compute_kernel_config=self.compute_kernel_attn,
+            )
+
+            # transpose attn
+            attn_output_14BD = ttnn.permute(attn_output_1B4D, (0, 2, 1, 3))
+            # unpad attn
+            attn_output_14BD = attn_output_14BD[:, : self.n_local_heads, :, :]
+
+            attn_output_11BH = ttnn.experimental.tensor.nlp_concat_heads(
+                attn_output_14BD,
+                output_mem_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
+            )
+
+            ###
+            # Output matmul
+            ###
+            dense_out_11BH = ttnn.linear(
+                attn_output_11BH,
+                wo,
+                memory_config=self.model_config["LM_HEAD_OUTPUT_MEMCFG"],
+                core_grid=self.core_grid,
+                compute_kernel_config=self.compute_kernel,
+                dtype=ttnn.bfloat8_b,
+            )
+            dense_outputs_11BH.append(dense_out_11BH)
+
+        # All gather
+        dense_outputs_11BH = ttnn.experimental.tensor.all_gather(dense_outputs_11BH, dim=2, num_links=1)
+
+        # return the sum of the outputs
+        for i in range(len(dense_outputs_11BH)):
+            dense_outputs_11BH[i] = ttnn.matmul(self.reduce_mask[i], dense_outputs_11BH[i])
+
+        return dense_outputs_11BH

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+
+def precompute_freqs(dim: int, end: int, theta: float = 1000000.0):
+    """
+    Precompute the frequency tensor for sine and cosine values with given dimensions.
+
+    Args:
+        dim (int): Dimension of the frequency tensor.
+        end (int): End index for precomputing frequencies.
+        theta (float, optional): Scaling factor for frequency computation. Defaults to 10000.0.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: Tensors containing cosine and sine values.
+    """
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end)
+    freqs = torch.outer(t, freqs).float()
+    return torch.cos(freqs), torch.sin(freqs)
+
+
+def freqs_to_rotation_matrix(cos_freqs, sin_freqs):
+    """
+    Transform cos/sin frequencies to a rotation matrix.
+    """
+    emb_size, emb_dim = cos_freqs.shape
+    dhead = emb_dim * 2
+    rot_emb_matrix = torch.zeros(emb_size, dhead, dhead)
+    rot_emb_matrix[..., torch.arange(0, dhead, 2), torch.arange(0, dhead, 2)] = cos_freqs.clone()
+    rot_emb_matrix[..., torch.arange(1, dhead, 2), torch.arange(1, dhead, 2)] = cos_freqs.clone()
+    rot_emb_matrix[..., torch.arange(0, dhead, 2), torch.arange(1, dhead, 2)] = -sin_freqs.clone()
+    rot_emb_matrix[..., torch.arange(1, dhead, 2), torch.arange(0, dhead, 2)] = sin_freqs.clone()
+
+    rot_emb_matrix = rot_emb_matrix.transpose(-1, -2)  # Necessary for correct rotation when applied as (x @ R)
+    return rot_emb_matrix, emb_size
+
+
+def get_rotation_mat(dhead, end):
+    cos, sin = precompute_freqs(dhead, end)
+    rot_mat, emb_size = freqs_to_rotation_matrix(cos, sin)
+    rot_mat = [rot_mat[i, :, :] for i in range(emb_size)]
+    return rot_mat
+
+
+def prepare_inputs_ttnn(x_bsh, hidden_size, head_dim, max_seq_len, devices):
+    """
+    Prepare inputs for decode mode. Assume that current token is at
+    start_pos, and KV cache has valid data up to start_pos.
+    x: (batch, seq, hidden_dim)
+    start_pos: int
+
+    B: batch (32)
+    S: sequence len (1)
+    H: dim (4096)
+    """
+    if x_bsh is None:  # First token
+        rot_mat = get_rotation_mat(dhead=head_dim, end=max_seq_len * 2)
+        rot_mats = []
+        for device in devices:
+            rot_mats.append(
+                [
+                    ttnn.from_torch(rot_mat_i, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+                    for rot_mat_i in rot_mat
+                ]
+            )
+        return rot_mats
+    else:
+        assert x_bsh.size(2) == hidden_size
+        assert len(x_bsh.size()) == 3
+
+        batch = x_bsh.size(0)
+        seq_len = x_bsh.size(1)
+        assert seq_len == 1, "Only supporting decode mode"
+
+        rot_mat = get_rotation_mat(dhead=head_dim, end=max_seq_len * 2)
+
+        x_1SBH = x_bsh.view(1, seq_len, batch, hidden_size)
+
+        xs_1SBH, rot_mats = [], []
+        for device in devices:
+            xs_1SBH.append(ttnn.from_torch(x_1SBH, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT))
+            rot_mats.append(
+                [
+                    ttnn.from_torch(rot_mat_i, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+                    for rot_mat_i in rot_mat
+                ]
+            )
+        return (
+            xs_1SBH,
+            rot_mats,
+        )
+
+
+# Sample logits from a distribution
+def sample_top_p(probs: torch.Tensor, p: float):
+    assert 0 <= p <= 1
+
+    probs_sort, probs_idx = torch.sort(probs, dim=-1, descending=True)
+    probs_sum = torch.cumsum(probs_sort, dim=-1)
+    mask = probs_sum - probs_sort > p
+    probs_sort[mask] = 0.0
+    probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
+
+    next_token = torch.multinomial(probs_sort, num_samples=1)
+    return torch.gather(probs_idx, -1, next_token)
+
+
+def sample(logits: torch.Tensor, temperature: float, top_p: float):
+    if temperature > 0:
+        probs = torch.softmax(logits / temperature, dim=-1)
+        next_token = sample_top_p(probs.squeeze(), top_p)
+    else:
+        next_token = torch.argmax(logits, dim=-1)
+
+    return next_token

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_decoder.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_attention import TtMixtralAttention
+from models.demos.t3000.mixtral8x7b.tt.mixtral_mlp import TtMixtralMLP
+from models.demos.t3000.mixtral8x7b.tt.mixtral_rms_norm import TtRMSNormSharded
+from models.demos.t3000.mixtral8x7b.tt.mixtral_moe import TtMoeLayer
+
+
+class TtTransformerBlock(torch.nn.Module):
+    def __init__(
+        self,
+        devices,
+        state_dict,
+        args,
+        layer_num,
+        dtype,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.devices = devices
+        self.num_devices = len(devices)
+
+        self.args = args
+        self.hidden_size = args.dim
+        self.n_heads = args.n_heads
+        self.head_dim = self.hidden_size // self.n_heads
+        self.max_seq_len = args.max_seq_len
+        self.dim = args.dim
+        self.max_batch_size = args.max_batch_size
+        self.n_kv_heads = args.n_kv_heads
+        self.sliding_window = args.sliding_window
+
+        self.layer_num = layer_num
+        self.n_local_heads = self.n_heads // len(devices)
+        self.n_local_kv_heads = self.n_kv_heads // len(devices)
+
+        self.attention = TtMixtralAttention(
+            devices=devices,
+            state_dict=state_dict,
+            args=args,
+            layer_num=layer_num,
+            dtype=dtype,
+        )
+
+        self.feed_forward = TtMoeLayer(
+            devices=devices,
+            state_dict=state_dict,
+            experts=[
+                TtMixtralMLP(
+                    device=devices[i],
+                    state_dict=state_dict,
+                    args=args,
+                    layer_num=layer_num,
+                    expert_num=i,
+                    dtypes={
+                        "w1": ttnn.bfloat4_b,
+                        "w2": ttnn.bfloat8_b,
+                        "w3": ttnn.bfloat4_b,
+                    },
+                )
+                for i in range(args.num_experts)
+            ],
+            args=args,
+            layer_num=layer_num,
+            dtype=dtype,
+        )
+        self.attention_norm = [
+            TtRMSNormSharded(
+                device=dev,
+                state_dict=state_dict,
+                args=args,
+                dtype=ttnn.bfloat16,
+                layer_num=layer_num,
+                weight_key="attention_norm",
+            )
+            for dev in self.devices
+        ]
+        self.ffn_norm = [
+            TtRMSNormSharded(
+                device=dev,
+                state_dict=state_dict,
+                args=args,
+                dtype=ttnn.bfloat16,
+                layer_num=layer_num,
+                weight_key="ffn_norm",
+            )
+            for dev in self.devices
+        ]
+
+    def forward(
+        self,
+        xs_1SBH,
+        start_pos,
+        current_pos,
+        rot_mats,
+    ) -> ttnn.Tensor:
+        """
+        Tensors are postfixed with 4 characters that represent their 4-D shape:
+        B: batch dim (32)
+        S: seq dim (1)
+        1: unary dim
+        H: hidden dim (4096)
+        """
+        assert isinstance(xs_1SBH, list)
+
+        attn_norm_1SBH = [self.attention_norm[i](xs_1SBH[i]) for i in range(self.num_devices)]
+
+        attn_1SBH = self.attention(
+            attn_norm_1SBH,
+            start_pos,
+            current_pos,
+            rot_mats,
+        )
+        hs_1SBH = [ttnn.add(xs_1SBH[i], attn_1SBH[i]) for i in range(self.num_devices)]
+
+        ffn_norm_1SBH = [self.ffn_norm[i](hs_1SBH[i]) for i in range(self.num_devices)]
+        ffn_1SBH = self.feed_forward(ffn_norm_1SBH)
+        out_1SBH = [ttnn.add(hs_1SBH[i], ffn_1SBH[i]) for i in range(self.num_devices)]
+
+        return out_1SBH

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_embedding.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_embedding.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+
+class TtMixtralEmbedding(torch.nn.Module):
+    def __init__(
+        self,
+        device,
+        args,
+        weight_cache_path,
+        state_dict,
+        dtype,
+    ):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.device = device
+
+        base_name = "tok_embeddings.weight"
+        torch_weight = self.state_dict[base_name]
+        cache_name = weight_cache_path / base_name
+        self.weights = ttnn.as_tensor(
+            torch_weight,
+            dtype=dtype,
+            device=self.device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=args.get_model_config()["EMB_WEIGHTS_MEMCFG"],
+            cache_file_name=cache_name,
+        )
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        return ttnn.embedding(x, self.weights)

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+
+class TtMixtralMLP(torch.nn.Module):
+    def __init__(self, device, state_dict, args, layer_num, expert_num, dtypes):
+        super().__init__()
+
+        self.state_dict = state_dict
+        self.device = device
+        self.dtypes = dtypes
+        self.model_args = args
+        self.model_config = args.get_model_config()
+
+        base_name = f"layers.{layer_num}.feed_forward.experts.{expert_num}"
+        torch_weight = lambda name: self.state_dict[f"{base_name}.{name}.weight"].permute(1, 0)
+        cache_name = lambda name: args.weight_cache_path(dtypes[name]) / (f"{base_name}.{expert_num}.{name}")
+        as_tensor = lambda name: ttnn.as_tensor(
+            torch_weight(name),
+            dtype=dtypes[name],
+            device=self.device,
+            layout=self.model_config["MLP_W_LAYOUT_TILE"],
+            memory_config=self.model_config["MLP_WEIGHTS_MEMCFG"],
+            cache_file_name=cache_name(name),
+        )
+
+        self.w1 = as_tensor("w1")
+        self.w2 = as_tensor("w2")
+        self.w3 = as_tensor("w3")
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        w1 -> gate_proj
+        w2 -> down_proj
+        w3 -> up_proj
+        HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        """
+        w1_out = ttnn.linear(
+            x,
+            self.w1,
+            activation="silu",
+            core_grid=self.model_args.max_grid_size,
+            use_1d_systolic_array=True,
+            memory_config=self.model_config["FF1_OUTPUT_MEMCFG"],
+            compute_kernel_config=self.model_args.get_compute_kernel_config(),
+        )
+
+        w3_out = ttnn.matmul(
+            x,
+            self.w3,
+            core_grid=self.model_args.max_grid_size,
+            use_1d_systolic_array=True,
+            memory_config=self.model_config["FF3_OUTPUT_MEMCFG"],
+            compute_kernel_config=self.model_args.get_compute_kernel_config(),
+        )
+        w2_in = ttnn.mul(w1_out, w3_out)
+        w2_out = ttnn.matmul(
+            w2_in,
+            self.w2,
+            core_grid=self.model_args.max_grid_size,
+            use_1d_systolic_array=True,
+            memory_config=self.model_config["FF2_OUTPUT_MEMCFG"],
+            compute_kernel_config=self.model_args.get_compute_kernel_config(),
+        )
+
+        return w2_out

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+from models.demos.t3000.mixtral8x7b.tt.mixtral_decoder import TtTransformerBlock
+from models.demos.t3000.mixtral8x7b.tt.mixtral_rms_norm import TtRMSNormSharded
+
+
+class TtTransformer(torch.nn.Module):
+    def __init__(
+        self,
+        devices,
+        state_dict,
+        args,
+        dtype,
+        layers,
+    ):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.n_layers = args.n_layers
+        self.devices = devices
+        self.model_config = args.get_model_config()
+        assert self.vocab_size > 0
+
+        self.layers = torch.nn.ModuleList(
+            [
+                TtTransformerBlock(
+                    devices=devices,
+                    state_dict=state_dict,
+                    args=args,
+                    dtype=dtype,
+                    layer_num=i,
+                )
+                for i in layers
+            ]
+        )
+        self.norm = [
+            TtRMSNormSharded(
+                device=dev,
+                state_dict=state_dict,
+                args=args,
+                dtype=ttnn.bfloat16,
+                layer_num=None,
+                weight_key="norm",
+            )
+            for dev in self.devices
+        ]
+        self.state_dict = state_dict
+
+        self.output_weight = [
+            ttnn.as_tensor(
+                self.state_dict["output.weight"].permute(1, 0),
+                device=dev,
+                layout=self.model_config["OUTPUT_W_LAYOUT_TILE"],
+                dtype=dtype,
+                memory_config=self.model_config["OUTPUT_WEIGHTS_MEMCFG"],
+                cache_file_name=args.weight_cache_path(dtype) / "output.weight",
+            )
+            for dev in self.devices
+        ]
+
+        self.compute_kernel = self.args.get_compute_kernel_config()
+
+    def forward(
+        self,
+        x,
+        start_pos,
+        current_pos,
+        rot_mats,
+    ):
+        for i, layer in enumerate(self.layers):
+            x = layer(x, start_pos, current_pos, rot_mats)
+
+        outputs = []
+        x_norm = []
+        for i in range(len(self.devices)):
+            x_norm.append(self.norm[i](x[i]))
+            output_i = ttnn.linear(
+                x_norm[i],
+                self.output_weight[i],
+                core_grid=self.args.max_grid_size,
+                use_1d_systolic_array=True,
+                memory_config=self.model_config["OUTPUT_MM_MEMCFG"],
+                compute_kernel_config=self.compute_kernel,
+            )
+            outputs.append(output_i)
+
+        return outputs

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+
+def top_2(gate_logits_1SB8, top_2_mask, expert_mask, ones_1118, ones_11B1, compute_kernel):
+    # get the highest value and position
+    weights_ex0_1SB1 = ttnn.experimental.tensor.max(gate_logits_1SB8, dim=3)
+    exp_0_repeated = ttnn.matmul(weights_ex0_1SB1, ones_1118, compute_kernel_config=compute_kernel)
+    cond0 = ttnn.eq(gate_logits_1SB8, exp_0_repeated)
+
+    # mask out the maximum value
+    gate_logits_1SB8_masked = ttnn.where(cond0, top_2_mask, gate_logits_1SB8)
+
+    # get the second highest value and position
+    weights_ex1_1SB1 = ttnn.experimental.tensor.max(gate_logits_1SB8_masked, dim=3)
+    exp_1_repeated = ttnn.matmul(weights_ex1_1SB1, ones_1118, compute_kernel_config=compute_kernel)
+    cond1 = ttnn.eq(gate_logits_1SB8, exp_1_repeated)
+
+    # calculate the softmax
+    weights_exp = ttnn.exp(weights_ex1_1SB1 - weights_ex0_1SB1)
+    weights_1SB1_pre_softmax = ttnn.reciprocal(ones_11B1 + weights_exp)
+
+    # select whether a batch for was selected first or second for the i-th head
+    cond0 = ttnn.matmul(cond0, expert_mask, compute_kernel_config=compute_kernel)
+    cond1 = ttnn.matmul(cond1, expert_mask, compute_kernel_config=compute_kernel)
+
+    # calculate the weight
+    weights_1SB1 = cond0 * weights_1SB1_pre_softmax - cond1 * (weights_1SB1_pre_softmax - ones_11B1)
+
+    return weights_1SB1
+
+
+class TtMoeLayer(torch.nn.Module):
+    def __init__(self, devices, state_dict, experts, args, layer_num, dtype):
+        super().__init__()
+        assert len(experts) > 0
+        self.devices = devices
+        self.experts = experts
+        self.args = args
+        self.dtype = dtype
+        self.model_config = args.get_model_config()
+
+        gate_name = f"layers.{layer_num}.feed_forward.gate.weight"
+        self.gates_H8 = [
+            ttnn.as_tensor(
+                state_dict[gate_name].permute(1, 0),
+                dtype=ttnn.bfloat16,
+                device=device,
+                layout=self.model_config["GATE_W_LAYOUT_TILE"],
+                memory_config=self.model_config["GATE_WEIGHTS_MEMCFG"],
+                cache_file_name=args.weight_cache_path(dtype) / gate_name,
+            )
+            for device in self.devices
+        ]
+        self.num_devices = len(devices)
+        self.compute_kernel = args.get_compute_kernel_attn_config()
+
+        self.top_2_mask = [
+            ttnn.from_torch(
+                torch.full(
+                    (1, 1, self.args.max_batch_size, self.args.num_experts), fill_value=torch.finfo(torch.float).min
+                ),
+                dtype=ttnn.bfloat16,
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+            )
+            for device in self.devices
+        ]
+        self.expert_mask = []
+        for i in range(len(self.devices)):
+            torch_tensor = torch.zeros(1, 1, self.args.num_experts, 1)
+            torch_tensor[:, :, i, :] = 1
+            self.expert_mask.append(
+                ttnn.from_torch(torch_tensor, dtype=ttnn.bfloat16, device=self.devices[i], layout=ttnn.TILE_LAYOUT)
+            )
+
+        self.ones_1118 = [
+            ttnn.from_torch(
+                torch.ones(1, 1, 1, self.args.num_experts), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT
+            )
+            for device in self.devices
+        ]
+
+        self.ones_11B1 = [
+            ttnn.from_torch(
+                torch.ones(1, 1, self.args.max_batch_size, 1),
+                device=device,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+            )
+            for device in self.devices
+        ]
+        reduce_mask_torch = torch.zeros(1, 1, self.args.max_batch_size, self.args.max_batch_size * len(self.devices))
+        for i in range(self.args.max_batch_size):
+            reduce_mask_torch[
+                :, :, i, range(i, self.args.max_batch_size * len(self.devices), self.args.max_batch_size)
+            ] = 1
+        self.reduce_mask = [
+            ttnn.from_torch(reduce_mask_torch, device=device, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT)
+            for device in self.devices
+        ]
+
+    def forward(self, inputs):
+        """
+        inputs: (seq_len, 1, batch, hidden_dim)
+
+        Tensors are postfixed with 4 characters that represent their 4-D shape:
+        B : batch_size (32)
+        H : dim (4096)
+        S : seq len (1)
+        """
+        output_11BH = []
+        for i in range(len(self.devices)):
+            self.devices[i] = self.devices[i]
+            input_i_1SBH = inputs[i]
+            expert_i_HH = self.experts[i]
+
+            # get logits for the experts
+            gate_logits_1SB8 = ttnn.linear(
+                input_i_1SBH,
+                self.gates_H8[i],
+                memory_config=self.model_config["GATE_MM_OUTPUT_MEMCFG"],
+                compute_kernel_config=self.compute_kernel,
+                use_1d_systolic_array=True,
+            )
+
+            # get weights for top-2 experts
+            weights_1SB1 = top_2(
+                gate_logits_1SB8,
+                self.top_2_mask[i],
+                self.expert_mask[i],
+                self.ones_1118[i],
+                self.ones_11B1[i],
+                self.compute_kernel,
+            )
+
+            # MLP and masking
+            results_11BH = expert_i_HH(input_i_1SBH) * weights_1SB1
+
+            # convert to bfp8
+            results_11BH = ttnn.clone(results_11BH, dtype=ttnn.bfloat8_b, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+            output_11BH.append(results_11BH)
+
+        # all gather
+        output_11BH_gathered = ttnn.experimental.tensor.all_gather(output_11BH, dim=2, num_links=1)
+
+        # sum on each device
+        for i in range(len(output_11BH_gathered)):
+            output_11BH_gathered[i] = ttnn.matmul(self.reduce_mask[i], output_11BH_gathered[i])
+        return output_11BH_gathered

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_rms_norm.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import ttnn
+
+
+class TtRMSNorm(torch.nn.Module):
+    def __init__(
+        self,
+        device,
+        state_dict,
+        args,
+        dtype,
+        layer_num,
+        weight_key,
+        eps: float = 1e-05,
+    ):
+        super().__init__()
+        self.device = device
+        self.eps = eps
+        self.state_dict = state_dict
+        self.model_config = args.get_model_config()
+
+        if layer_num is None:
+            weight_name = f"{weight_key}.weight"
+        else:
+            weight_name = f"layers.{layer_num}.{weight_key}.weight"
+
+        torch_weight = self.state_dict[weight_name].unsqueeze(0).expand(32, -1)
+        cache_name = args.weight_cache_path(dtype) / weight_name
+
+        self.weight = ttnn.as_tensor(
+            torch_weight,
+            device=self.device,
+            dtype=dtype,
+            layout=self.model_config["NORM_W_LAYOUT_TILE"],
+            memory_config=self.model_config["NORM_WEIGHTS_MEMCFG"],
+            cache_file_name=cache_name,
+        )
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        x = ttnn.rms_norm(x, weight=self.weight, epsilon=self.eps)
+        return x
+
+
+class TtRMSNormSharded(torch.nn.Module):
+    def __init__(
+        self,
+        device,
+        state_dict,
+        args,
+        dtype,
+        layer_num,
+        weight_key,
+        eps: float = 1e-05,
+    ):
+        super().__init__()
+        self.device = device
+        self.eps = eps
+        self.state_dict = state_dict
+        self.model_config = args.get_model_config()
+
+        if layer_num is None:
+            weight_name = f"{weight_key}.weight"
+        else:
+            weight_name = f"layers.{layer_num}.{weight_key}.weight"
+
+        torch_weight = self.state_dict[weight_name].unsqueeze(0).reshape([1, 1, -1, 32])
+        cache_name = args.weight_cache_path(dtype) / (weight_name + ".reshaped")
+
+        self.weight = ttnn.as_tensor(
+            torch_weight,
+            device=self.device,
+            dtype=dtype,
+            memory_config=self.model_config["NORM_WEIGHTS_MEMCFG"],
+            cache_file_name=cache_name,
+        )
+
+    def forward(self, x: ttnn.Tensor, out_sharded=False) -> ttnn.Tensor:
+        x = ttnn.experimental.tensor.interleaved_to_sharded(
+            x, sharded_mem_config=self.model_config["SHARDED_NORM_INPUT_MEMCFG"]
+        )
+        x = ttnn.experimental.operations.primary.rmsnorm(
+            x,
+            self.eps,
+            self.weight,
+            program_config=self.model_config["SHARDED_NORM_PRGM_CFG"],
+            output_mem_config=self.model_config["SHARDED_NORM_OUTPUT_MEMCFG"],
+        )
+        if out_sharded:
+            return x
+        return ttnn.experimental.tensor.sharded_to_interleaved(x)

--- a/models/demos/t3000/mixtral8x7b/tt/model_config.py
+++ b/models/demos/t3000/mixtral8x7b/tt/model_config.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import ttnn
+from pathlib import Path
+from loguru import logger
+
+
+class TtModelArgs:
+    dim = 4096
+    n_layers = 32
+    head_dim = 128
+    hidden_dim = 14336
+    n_heads = 32
+    n_kv_heads = 8
+    norm_eps = 1e-05
+    sliding_window = 4096
+    vocab_size = 32000
+
+    max_batch_size = 32
+    max_seq_len = 4096
+    moe = True
+    num_experts = 8
+    num_experts_per_tok = 2
+
+    DEFAULT_CKPT_DIR = os.getenv("MIXTRAL_CKPT_DIR", "/proj_sw/user_dev/hf_data/mistral/Mixtral-8x7B-v0.1")
+    DEFAULT_TOKENIZER_PATH = os.getenv("MIXTRAL_TOKENIZER_PATH", "/proj_sw/user_dev/hf_data/mistral/Mixtral-8x7B-v0.1")
+    DEFAULT_CACHE_PATH = os.getenv("MIXTRAL_CACHE_PATH", "/proj_sw/user_dev/hf_data/mistral/Mixtral-8x7B-v0.1")
+
+    OP_KEYS = (
+        # Embedding
+        "EMB_WEIGHTS",
+        # Feed forward
+        "MLP_WEIGHTS",
+        "FF1_OUTPUT",
+        "FF3_OUTPUT",
+        "FF2_OUTPUT",
+        "MLP_W_LAYOUT",
+        # Attention
+        "ATTN_WEIGHTS",
+        "XQKV_MM_OUTPUT",
+        "QKV_HEADS_OUTPUT",
+        "QV_ROT_EMB_OUTPUT",
+        # "KV_UNPAD_OUTPUT",
+        "QK_MM_OUTPUT",
+        "QKV_MM_OUTPUT",
+        "CONCAT_HEADS_OUTPUT",
+        "LM_HEAD_OUTPUT",
+        "ATTN_W_LAYOUT",
+        # RMS norm
+        "NORM_W_LAYOUT",
+        "NORM_WEIGHTS",
+        # MoE
+        "GATE_W_LAYOUT",
+        "GATE_WEIGHTS",
+        "GATE_MM_OUTPUT",
+        # Output
+        "OUTPUT_W_LAYOUT",
+        "OUTPUT_WEIGHTS",
+        "OUTPUT_MM",
+    )
+
+    def __init__(self, device=None, instruct=False):
+        # Assert if all folders and files exist
+        assert os.path.exists(
+            self.DEFAULT_CKPT_DIR
+        ), f"Checkpoint directory {self.DEFAULT_CKPT_DIR} does not exist, please use export MIXTRAL_CKPT_DIR=..."
+        assert os.path.isfile(
+            self.DEFAULT_CKPT_DIR + "/repack_weights.pt"
+        ), f"Repacked weights {self.DEFAULT_CKPT_DIR + '/repack_weights.pt'} does not exist, please use export MIXTRAL_CKPT_DIR=..."
+        assert os.path.isfile(
+            self.DEFAULT_TOKENIZER_PATH + "/tokenizer.model"
+        ), f"Tokenizer file {self.DEFAULT_TOKENIZER_PATH + '/tokenizer.model'} does not exist, please use export MIXTRAL_TOKENIZER_PATH=..."
+        assert os.path.exists(
+            self.DEFAULT_CACHE_PATH
+        ), f"Cache directory {self.DEFAULT_CACHE_PATH} does not exist, please use export MIXTRAL_CACHE_PATH=..."
+
+        logger.info(f"Checkpoint directory: {self.DEFAULT_CKPT_DIR}")
+        logger.info(f"Tokenizer file: {self.DEFAULT_TOKENIZER_PATH + '/tokenizer.model'}")
+        logger.info(f"Cache directory: {self.DEFAULT_CACHE_PATH}")
+
+        self.model_base_path = Path(self.DEFAULT_CKPT_DIR)
+        self.model_cache_path = Path(self.DEFAULT_CACHE_PATH)
+        self.consolidated_weights_path = lambda i: str(self.model_base_path / f"consolidated.{i:02d}.pt")
+        self.tokenizer_path = self.DEFAULT_TOKENIZER_PATH + "/tokenizer.model"
+        self.state_dict_path = str(self.model_base_path / "repack_weights.pt")
+        self.instruct = instruct
+
+        DRAM_MEMCFG = ttnn.DRAM_MEMORY_CONFIG
+        L1_MEMCFG = ttnn.L1_MEMORY_CONFIG
+        self.model_config = {}
+        # Update memory configs (weights->DRAM, activations->L1)
+        self.model_config.update(
+            {f"{key}_MEMCFG": DRAM_MEMCFG if "WEIGHTS" in key else L1_MEMCFG for key in self.OP_KEYS}
+        )
+        # Update memory layouts (Tile, except MLP)
+        self.model_config.update({f"{key}_TILE": ttnn.TILE_LAYOUT for key in self.OP_KEYS if "LAYOUT" in key})
+
+        self.model_config["Q_TRANSPOSE_MEMCFG"] = ttnn.create_sharded_memory_config(
+            shape=(32, 128),
+            core_grid=ttnn.CoreGrid(y=4, x=8),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        self.model_config[
+            "K_CACHE_SLICE_OUTPUT_MEMCFG"
+        ] = lambda padded_layer_past_len: ttnn.create_sharded_memory_config(
+            shape=(128, padded_layer_past_len),
+            core_grid=ttnn.CoreGrid(y=4, x=8),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        self.model_config[
+            "V_CACHE_SLICE_OUTPUT_MEMCFG"
+        ] = lambda padded_layer_past_len: ttnn.create_sharded_memory_config(
+            shape=(padded_layer_past_len, 128),
+            core_grid=ttnn.CoreGrid(y=4, x=8),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        self.model_config[
+            "ATTN_BATCHED_MM_OUTPUT_MEMCFG"
+        ] = lambda padded_layer_past_len: ttnn.create_sharded_memory_config(
+            shape=(32, padded_layer_past_len),
+            core_grid=ttnn.CoreGrid(y=4, x=8),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        self.model_config["SCORES_BATCHED_MM_OUTPUT_MEMCFG"] = ttnn.create_sharded_memory_config(
+            shape=(32, 128),
+            core_grid=ttnn.CoreGrid(y=4, x=8),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        shard_height = 32
+        hidden_size = 4096
+        shard_width_hidden_dim_across_32_cores = hidden_size // 32
+        self.model_config["SHARDED_NORM_INPUT_MEMCFG"] = ttnn.create_sharded_memory_config(
+            shape=(shard_height, shard_width_hidden_dim_across_32_cores),
+            core_grid=ttnn.CoreGrid(y=4, x=8),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        self.model_config["SHARDED_NORM_OUTPUT_MEMCFG"] = self.model_config["SHARDED_NORM_INPUT_MEMCFG"]
+        self.model_config[
+            "SHARDED_NORM_PRGM_CFG"
+        ] = ttnn.experimental.operations.primary.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=[8, 4],
+            subblock_w=4,
+            block_h=shard_height // 32,
+            block_w=shard_width_hidden_dim_across_32_cores // 32,
+            inplace=False,
+        )
+
+        if device is not None:  # Avoid issue with test_mistral_torch.py not having a device
+            grid_size = device.compute_with_storage_grid_size()
+            # TODO Lower max grid size (used by MLP) to avoid hangs
+            self.max_grid_size = ttnn.CoreGrid(y=7, x=6)  # (y,x)  (y=7, x=8)
+            # self.max_grid_size = ttnn.CoreGrid(y=grid_size.y, x=grid_size.x)  # (y,x)  (y=7, x=8)
+            self.core_grid_attention = (
+                ttnn.CoreGrid(y=4, x=8) if (4 <= grid_size.y and 8 <= grid_size.x) else self.max_grid_size
+            )
+
+        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+        self.compute_kernel_attn_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+    def weight_cache_path(self, dtype):
+        # Keep the weight cache separate for generative and instruct weights
+        if self.instruct:
+            return (
+                self.model_cache_path
+                / {
+                    ttnn.bfloat16: "mixtral_tensor_cache_instruct_bf16",
+                    ttnn.bfloat8_b: "mixtral_tensor_cache_instruct_bfp8",
+                    ttnn.bfloat4_b: "mixtral_tensor_cache_instruct_bfp4",
+                }[dtype]
+            )
+        else:
+            return (
+                self.model_cache_path
+                / {
+                    ttnn.bfloat16: "mixtral_tensor_cache_bf16",
+                    ttnn.bfloat8_b: "mixtral_tensor_cache_bfp8",
+                    ttnn.bfloat4_b: "mixtral_tensor_cache_bfp4",
+                }[dtype]
+            )
+
+    def get_model_config(self):
+        return self.model_config
+
+    def get_compute_kernel_config(self):
+        return self.compute_kernel_config
+
+    def get_compute_kernel_attn_config(self):
+        return self.compute_kernel_attn_config

--- a/tests/scripts/multi_chip/run_frequent_regressions_multi_device.sh
+++ b/tests/scripts/multi_chip/run_frequent_regressions_multi_device.sh
@@ -1,3 +1,4 @@
+
 #/bin/bash
 
 set -eo pipefail
@@ -29,3 +30,6 @@ pytest models/demos/t3000/llama2_70b/tests/test_llama_mlp_t3000.py
 pytest models/demos/t3000/llama2_70b/tests/test_llama_attention_t3000.py
 pytest models/demos/t3000/llama2_70b/tests/test_llama_decoder_t3000.py
 pytest models/demos/t3000/llama2_70b/tests/test_llama_model_t3000.py
+
+# Mistral8x7b 8 chip decode full model test (env flags set inside the test)
+pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[10-32-output]

--- a/tests/scripts/multi_chip/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/multi_chip/run_pre_post_commit_regressions_multi_device.sh
@@ -1,3 +1,4 @@
+
 #/bin/bash
 
 set -eo pipefail
@@ -32,6 +33,15 @@ pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_Falcon
 # Falcon40B 8 chip decode tests
 pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips-enable_program_cache]
 pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips-enable_program_cache]
+
+# Mistral8x7b 8 chip decode tests (env flags set inside the tests)
+pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
+pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
+pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[1-1-pcc]
 
 # Falcon40B 8 chip prefill tests; we need 8x8 grid size
 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_prefill.py

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -54,6 +54,9 @@ run_perf_models_llm_javelin_multi_device() {
 
     env pytest models/demos/falcon7b/tests -m $test_marker
 
+    # Mistral8x7b env flags are set inside the tests
+    env pytest models/demos/t3000/mixtral8x7b/tests -m $test_marker
+
     ## Merge all the generated reports
     env python models/perf/merge_perf_results.py
 }


### PR DESCRIPTION
Initial version of Mixtral8x7b running on T3000 (8 chips), including all relevant tests added to multichip CI.

Backup branch with the full commit history: `mixtral8x7b-wh`

FYI:
@yieldthought 
@sraizada-tt 
@xuncaiTT 