### PR TITLE
Add missing 2CQ core_desc for galaxy (N300 unharvested) and add N150,N300 multi-queue-single-device-tests to CI

### DIFF
--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -107,7 +107,12 @@ jobs:
       fail-fast: false
       matrix:
         runner-info: [
-          {arch: grayskull, runs-on: ["grayskull"]},
+          # E150
+          {arch: grayskull, runs-on: ["grayskull"], name: E150},
+          # N150
+          {arch: wormhole_b0, runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1"], name: N150},
+          # N300
+          {arch: wormhole_b0, runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2"], name: N300},
         ]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
@@ -23,6 +23,23 @@ galaxy:
     dispatch_core_type:
       "tensix"
 
+  2:
+    l1_bank_size:
+      1376256
+
+    compute_with_storage_grid_range: # Logical only start and end [x, y]
+      start: [0, 0]
+      end: [7, 7]
+
+    storage_cores:
+      []
+
+    dispatch_cores:
+      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+
+    dispatch_core_type:
+      "tensix"
+
 nebula_x1:
   1:
     l1_bank_size:


### PR DESCRIPTION
 Closes #8013
 
     Add missing 2CQ core_desc for galaxy (N300 unharvested)
     
     - And add N150, N300 variants of multi-queue-single-device-tests to CI
       instead of just GS.
     - The tests were hitting segfault, now they pass on unharvested N300