### PR TITLE
#7955: Update ttnn doc for log, exp alike ops

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/sweeps/ldexp.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/ldexp.py
@@ -16,17 +16,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [32, 384, 1024],
     "width": [32, 1024, 4096],
-    "input_a_dtype": [ttnn.bfloat16],
-    "input_b_dtype": [ttnn.bfloat16],
-    "input_a_layout": [ttnn.TILE_LAYOUT],
-    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+    "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+) -> Tuple[bool, Optional[str]]:
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT or input_dtype == ttnn.bfloat8_b:
+        return True, "Not Supported"
     return False, None
 
 
@@ -38,10 +47,8 @@ def run(
     batch_sizes,
     height,
     width,
-    input_a_dtype,
-    input_b_dtype,
-    input_a_layout,
-    input_b_layout,
+    input_dtype,
+    input_layout,
     input_b_memory_config,
     input_a_memory_config,
     output_memory_config,
@@ -59,16 +66,16 @@ def run(
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
-        dtype=input_a_dtype,
+        dtype=input_dtype,
         device=device,
-        layout=input_a_layout,
+        layout=input_layout,
         memory_config=input_a_memory_config,
     )
     input_tensor_b = ttnn.from_torch(
         torch_input_tensor_b,
-        dtype=input_b_dtype,
+        dtype=input_dtype,
         device=device,
-        layout=input_b_layout,
+        layout=input_layout,
         memory_config=input_b_memory_config,
     )
     output_tensor = ttnn.ldexp(input_tensor_a, input_tensor_b, memory_config=output_memory_config)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/logaddexp.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/logaddexp.py
@@ -16,17 +16,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [32, 384, 1024],
     "width": [32, 1024, 4096],
-    "input_a_dtype": [ttnn.bfloat16],
-    "input_b_dtype": [ttnn.bfloat16],
-    "input_a_layout": [ttnn.TILE_LAYOUT],
-    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+    "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+) -> Tuple[bool, Optional[str]]:
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Not Supported"
     return False, None
 
 
@@ -38,10 +47,8 @@ def run(
     batch_sizes,
     height,
     width,
-    input_a_dtype,
-    input_b_dtype,
-    input_a_layout,
-    input_b_layout,
+    input_dtype,
+    input_layout,
     input_b_memory_config,
     input_a_memory_config,
     output_memory_config,
@@ -59,16 +66,16 @@ def run(
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
-        dtype=input_a_dtype,
+        dtype=input_dtype,
         device=device,
-        layout=input_a_layout,
+        layout=input_layout,
         memory_config=input_a_memory_config,
     )
     input_tensor_b = ttnn.from_torch(
         torch_input_tensor_b,
-        dtype=input_b_dtype,
+        dtype=input_dtype,
         device=device,
-        layout=input_b_layout,
+        layout=input_layout,
         memory_config=input_b_memory_config,
     )
     output_tensor = ttnn.logaddexp(input_tensor_a, input_tensor_b, memory_config=output_memory_config)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/logaddexp2.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/logaddexp2.py
@@ -16,17 +16,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_a_dtype": [ttnn.bfloat16],
-    "input_b_dtype": [ttnn.bfloat16],
-    "input_a_layout": [ttnn.TILE_LAYOUT],
-    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+    "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    output_memory_config,
+) -> Tuple[bool, Optional[str]]:
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Not Supported"
     return False, None
 
 
@@ -38,10 +47,8 @@ def run(
     batch_sizes,
     height,
     width,
-    input_a_dtype,
-    input_b_dtype,
-    input_a_layout,
-    input_b_layout,
+    input_dtype,
+    input_layout,
     input_b_memory_config,
     input_a_memory_config,
     output_memory_config,
@@ -59,16 +66,16 @@ def run(
 
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,
-        dtype=input_a_dtype,
+        dtype=input_dtype,
         device=device,
-        layout=input_a_layout,
+        layout=input_layout,
         memory_config=input_a_memory_config,
     )
     input_tensor_b = ttnn.from_torch(
         torch_input_tensor_b,
-        dtype=input_b_dtype,
+        dtype=input_dtype,
         device=device,
-        layout=input_b_layout,
+        layout=input_layout,
         memory_config=input_b_memory_config,
     )
     output_tensor = ttnn.logaddexp2(input_tensor_a, input_tensor_b, memory_config=output_memory_config)

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -159,11 +159,15 @@ def register_ttl_elt_binary_function(name, ttl_elt_binary_function, op_name):
         return torch_function(input_tensor_a, input_tensor_b)
 
     def _elt_binary_validate_input_tensors(operation_name, input_tensor_a, input_tensor_b, *args, **kwargs):
+        if operation_name == "ttnn.ldexp":
+            supported_dtypes = (ttnn.bfloat16,)
+        else:
+            supported_dtypes = (ttnn.bfloat16, ttnn.bfloat8_b)
         ttnn.validate_input_tensor(
             operation_name,
             input_tensor_a,
             ranks=(2, 3, 4),
-            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            dtypes=supported_dtypes,
             layouts=(ttnn.TILE_LAYOUT,),
             can_be_on_device=True,
             can_be_on_cpu=False,
@@ -172,7 +176,7 @@ def register_ttl_elt_binary_function(name, ttl_elt_binary_function, op_name):
             operation_name,
             input_tensor_b,
             ranks=(2, 3, 4),
-            dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+            dtypes=supported_dtypes,
             layouts=(ttnn.TILE_LAYOUT,),
             can_be_on_device=True,
             can_be_on_cpu=False,
@@ -225,6 +229,9 @@ def register_ttl_elt_binary_function(name, ttl_elt_binary_function, op_name):
                 >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 2], [3, 4]]), dtype=torch.bfloat16)), device)
                 >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 1], [4, 4]]), dtype=torch.bfloat16)), device)
                 >>> output = ttnn.{name}(tensor1, tensor2)
+
+            {elt_binary_function.__doc__}
+
             """
 
     setattr(THIS_MODULE, name, elt_binary_function)


### PR DESCRIPTION
Issue #7955 

**Fix Provided**
- Documentation updated with information regarding supported data type and layout for logaddexp, logaddexp2, ldexp
- Skipped test for unsupported data type and layout
- Since data type ,layout for both inputs needs to be the same, I've modified the code to accept one data type, layout and pass it to both inputs

**Sweep test results :** 
- `tests/ttnn/sweep_tests/sweeps/logaddexp.py` - [logaddexp.csv](https://github.com/tenstorrent/tt-metal/files/15186572/logaddexp.csv)
- `tests/ttnn/sweep_tests/sweeps/logaddexp2.py` - [logaddexp2.csv](https://github.com/tenstorrent/tt-metal/files/15186576/logaddexp2.csv)
- `tests/ttnn/sweep_tests/sweeps/ldexp.py` - [ldexp.csv](https://github.com/tenstorrent/tt-metal/files/15186580/ldexp.csv)

**CI Tests**
- All post-commit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8922000212) - PASSED
- [post-commit] Fast Dispatch unit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8922001067) - PASSED
- [post-commit] Slow Dispatch unit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8922002044) - PASSED