### PR TITLE
#7956: Fix addc like ttnn ops doc

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/addcdiv.py
+++ b/tests/ttnn/sweep_tests/sweeps/addcdiv.py
@@ -16,15 +16,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "value": [5.5, 15.8],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    value,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b:
+        return True, "Skipped as BFLOAT8_B not supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/addcmul.py
+++ b/tests/ttnn/sweep_tests/sweeps/addcmul.py
@@ -16,15 +16,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "value": [5.5, 15.8],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    value,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b:
+        return True, "Skipped as BFLOAT8_B not supported"
     return False, None
 
 

--- a/ttnn/ttnn/operations/ternary.py
+++ b/ttnn/ttnn/operations/ternary.py
@@ -154,7 +154,7 @@ def register_ttl_ternary_function_with_float(name, ttl_ternary_function, op_name
             input_tensor,
             ranks=(2, 3, 4),
             dtypes=(ttnn.bfloat16,),
-            layouts=(ttnn.TILE_LAYOUT,),
+            layouts=(ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
             can_be_on_device=True,
             can_be_on_cpu=False,
         )
@@ -163,7 +163,7 @@ def register_ttl_ternary_function_with_float(name, ttl_ternary_function, op_name
             input_tensor1,
             ranks=(2, 3, 4),
             dtypes=(ttnn.bfloat16,),
-            layouts=(ttnn.TILE_LAYOUT,),
+            layouts=(ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
             can_be_on_device=True,
             can_be_on_cpu=False,
         )
@@ -172,7 +172,7 @@ def register_ttl_ternary_function_with_float(name, ttl_ternary_function, op_name
             input_tensor2,
             ranks=(2, 3, 4),
             dtypes=(ttnn.bfloat16,),
-            layouts=(ttnn.TILE_LAYOUT,),
+            layouts=(ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
             can_be_on_device=True,
             can_be_on_cpu=False,
         )
@@ -240,6 +240,8 @@ def register_ttl_ternary_function_with_float(name, ttl_ternary_function, op_name
                 >>> tensor1 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
                 >>> tensor2 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
                 >>> output = ttnn.{(name)}(tensor, tensor1, tensor2, {param})
+
+            {ternary_function.__doc__}
 
             """
     setattr(THIS_MODULE, name, ternary_function)


### PR DESCRIPTION
Fix issue #7956 

- Add supported dtypes and layouts and skipped that are unsupported
- Reflect the same in documentation

Sweep Test Results:
[addcdiv.csv](https://github.com/tenstorrent/tt-metal/files/15186670/addcdiv.csv)
[addcmul.csv](https://github.com/tenstorrent/tt-metal/files/15186671/addcmul.csv)

All post commit test : https://github.com/tenstorrent/tt-metal/actions/runs/8922478405
