### PR TITLE
Improve falcon40b prefill ci test coverage

### DIFF
--- a/.github/workflows/multi-device-build-and-unit-tests.yaml
+++ b/.github/workflows/multi-device-build-and-unit-tests.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Build tt-metal CPP tests
         run: cmake --build build --target tests -- -j`nproc`
       - name: Run pre/post regression tests
-        timeout-minutes: 100
+        timeout-minutes: 120
         run: |
           source build/python_env/bin/activate
           export PYTHONPATH=$TT_METAL_HOME

--- a/.github/workflows/multi-device-end-to-end-demos.yaml
+++ b/.github/workflows/multi-device-end-to-end-demos.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Build tt-metal CPP tests
         run: cmake --build build --target tests -- -j`nproc`
       - name: Run pre/post regression tests
-        timeout-minutes: 60
+        timeout-minutes: 180
         run: |
           source build/python_env/bin/activate
           export PYTHONPATH=$TT_METAL_HOME

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
@@ -17,45 +17,80 @@ from models.utility_functions import (
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
+        ("prefill", 1, 32, 0),
+        ("prefill", 2, 32, 0),
         ("prefill", 1, 128, 0),
         ("prefill", 1, 2048, 0),
+        ("decode", 32, 1, 128),
     ),
     ids=[
+        "prefill_seq32",
+        "prefill_seq32_batch2",
         "prefill_seq128",
         "prefill_seq2048",
+        "decode_batch32",
     ],
 )
 @pytest.mark.parametrize(
-    "num_layers, out_pcc, cache_pcc, token_pcc",
-    ((1, 0.99, 0.99, 0.99),),
-    ids=["layers_1"],
+    "num_layers",
+    (1,),
+    ids=[
+        "layers_1",
+    ],
 )
 @pytest.mark.parametrize(
     "model_version",
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
-@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-DRAM", "BFLOAT16-DRAM"))
-def test_FalconCausalLM_prefill_end_to_end_t3000_ci(
+@pytest.mark.parametrize(
+    "data_type, memcfg",
+    (
+        (
+            "BFLOAT8_B",
+            "SHARDED",
+        ),
+        (
+            "BFLOAT8_B",
+            "DRAM",
+        ),
+        (
+            "BFLOAT16",
+            "DRAM",
+        ),
+    ),
+)
+def test_FalconCausalLM_end_to_end_with_program_cache(
+    num_devices,
     model_version,
     llm_mode,
     batch,
     seq_len,
     kv_cache_len,
     num_layers,
-    out_pcc,
-    cache_pcc,
-    token_pcc,
-    model_config_str,
+    request,
+    data_type,
+    memcfg,
     model_location_generator,
     get_tt_cache_path,
     all_devices,
     use_program_cache,
 ):
-    num_devices = 8
+    model_config_str = f"{data_type}-{memcfg}"
+    if llm_mode == "prefill" and memcfg != "DRAM" or num_devices != 8:
+        pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
+    if llm_mode == "decode" and memcfg != "SHARDED":
+        pytest.skip("Decode is only supported for SHARDED memory config!")
+
+    out_pcc = 0.99
+    k_cache_pcc = 0.99
+    v_cache_pcc = 0.99
+    token_pcc = 0.99
+
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
     devices = get_devices_for_t3000(all_devices, num_devices)
@@ -79,9 +114,11 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci(
         kv_cache_len,
         num_layers,
         out_pcc,
-        cache_pcc,
+        k_cache_pcc,
+        v_cache_pcc,
         token_pcc,
         model_config,
+        1,
         tt_cache_path,
         model_location_generator,
     )

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_5_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_5_loops.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from models.demos.t3000.falcon40b.demo.demo import run_falcon_demo_kv
+from models.demos.t3000.falcon40b.tt.model_config import get_model_config, model_config_entries
+from models.utility_functions import (
+    disable_compilation_reports,
+    get_devices_for_t3000,
+    skip_for_grayskull,
+)
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.timeout(3600)
+@pytest.mark.parametrize(
+    "num_loops",
+    (5,),
+    ids=[
+        "loops_5",
+    ],
+)
+@pytest.mark.parametrize("perf_mode", (False,))  # Option to measure perf using max seq length (with invalid outputs)
+@pytest.mark.parametrize("greedy_sampling", (False,))
+@pytest.mark.parametrize("max_seq_len", (128,))
+def test_demo(
+    num_loops,
+    perf_mode,
+    greedy_sampling,
+    max_seq_len,
+    model_location_generator,
+    get_tt_cache_path,
+    all_devices,
+    use_program_cache,
+):
+    num_devices = 8
+    devices = get_devices_for_t3000(all_devices, num_devices)
+
+    # disable_persistent_kernel_cache()
+    disable_compilation_reports()
+
+    user_inputs = [
+        ["Tell me a joke."],
+        ["What is the capital of Serbia?"],
+        ["Why to cows muh?"],
+        ["Count from 1 to 100."],
+        ["Who is Jim Keller?"],
+        ["Is Tenstorrent the coolest company to work for or what?"],
+        ["Why do all my tests hang?"],
+        ["How many days does a year have?"],
+        ["Can you tell me a story please?"],
+        ["How do I get better at piano?"],
+    ]
+
+    for i in range(num_loops):
+        input_idx = i % len(user_inputs)
+        print(f"Running demo prompt: {user_inputs[input_idx]}")
+        run_falcon_demo_kv(
+            user_input=user_inputs[input_idx],
+            model_version=model_config_entries["_name_or_path"],
+            model_config_str_for_decode="BFLOAT8_B-SHARDED",  # Decode model config
+            model_config_str_for_prefill="BFLOAT16-DRAM",  # Prefill model config
+            batch_size=32,
+            num_layers=model_config_entries["num_hidden_layers"],
+            max_seq_len=max_seq_len,
+            model_location_generator=model_location_generator,
+            get_tt_cache_path=get_tt_cache_path,
+            devices=devices,
+            prefill_on_host=False,
+            perf_mode=perf_mode,
+            greedy_sampling=greedy_sampling,
+        )

--- a/models/demos/t3000/falcon40b/tests/scripts/run_all_falcon40b_tests.sh
+++ b/models/demos/t3000/falcon40b/tests/scripts/run_all_falcon40b_tests.sh
@@ -15,6 +15,9 @@ fi
 cd $TT_METAL_HOME
 export PYTHONPATH=$TT_METAL_HOME
 
+# prefill required 8x8 core grids
+export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+
 # Run all component tests
 pytest models/demos/t3000/falcon40b/tests/test_falcon_mlp.py -k test_FalconMLP_inference
 pytest models/demos/t3000/falcon40b/tests/test_falcon_attention.py -k test_FalconAttention_inference

--- a/models/demos/t3000/falcon40b/tests/scripts/run_representative_falcon40b_tests.sh
+++ b/models/demos/t3000/falcon40b/tests/scripts/run_representative_falcon40b_tests.sh
@@ -15,13 +15,16 @@ fi
 cd $TT_METAL_HOME
 export PYTHONPATH=$TT_METAL_HOME
 
+# prefill required 8x8 core grids
+export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+
 # Run one of each component tests for prefill
 pytest models/demos/t3000/falcon40b/tests/test_falcon_mlp.py::test_FalconMLP_inference[BFLOAT8_B-DRAM-falcon_40b-prefill_seq128-8chips]
 pytest models/demos/t3000/falcon40b/tests/test_falcon_attention.py::test_FalconAttention_inference[BFLOAT8_B-DRAM-falcon_40b-prefill_seq128-8chips]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-DRAM-falcon_40b-layer_0-prefill_seq128-8chips-disable_program_cache]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-DRAM-falcon_40b-layer_0-prefill_seq128-8chips]
 pytest models/demos/t3000/falcon40b/tests/test_falcon_model.py::test_FalconModel_inference[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips]
 pytest models/demos/t3000/falcon40b/tests/test_falcon_causallm.py::test_FalconCausalLM_inference[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips-disable_program_cache]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips]
 
 # Run prefill perf tests
 pytest models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py::test_perf_bare_metal[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq128-8chips]
@@ -31,24 +34,21 @@ pytest models/demos/t3000/falcon40b/tests/test_perf_falcon.py::test_perf_bare_me
 # Run one of each component tests for decode
 pytest models/demos/t3000/falcon40b/tests/test_falcon_mlp.py::test_FalconMLP_inference[BFLOAT8_B-SHARDED-falcon_40b-decode_batch32-8chips]
 pytest models/demos/t3000/falcon40b/tests/test_falcon_attention.py::test_FalconAttention_inference[BFLOAT8_B-SHARDED-falcon_40b-decode_batch32-8chips]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips-disable_program_cache]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips]
 pytest models/demos/t3000/falcon40b/tests/test_falcon_model.py::test_FalconModel_inference[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips]
 pytest models/demos/t3000/falcon40b/tests/test_falcon_causallm.py::test_FalconCausalLM_inference[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips-disable_program_cache]
-
-# Run a 4 chip test for decode
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-4chips-disable_program_cache]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips]
 
 # Run prefill with sequence lengths = {32, 64, 128 (done above), 256, 512, 1024, 2048}
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq32-8chips-disable_program_cache]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq64-8chips-disable_program_cache]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq256-8chips-disable_program_cache]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq512-8chips-disable_program_cache]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq1024-8chips-disable_program_cache]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq2048-8chips-disable_program_cache]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq32-8chips]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq64-8chips]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq256-8chips]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq512-8chips]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq1024-8chips]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_1-prefill_seq2048-8chips]
 
 # Run prefill S=128 with 60L
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_60-prefill_seq128-8chips-disable_program_cache]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_60-prefill_seq128-8chips]
 
 # Run prefill S=2048 with 60L
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_60-prefill_seq2048-8chips-disable_program_cache]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-DRAM-falcon_40b-layers_60-prefill_seq2048-8chips]

--- a/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
@@ -320,7 +320,7 @@ def run_test_FalconAttention_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
@@ -360,7 +360,7 @@ def test_FalconAttention_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
+    use_program_cache,
 ):
     if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")

--- a/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
@@ -295,7 +295,7 @@ def run_test_FalconCausalLM_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
@@ -342,7 +342,7 @@ def test_FalconCausalLM_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
+    use_program_cache,
 ):
     if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")

--- a/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
@@ -332,8 +332,7 @@ def run_test_FalconDecoder_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("enable_program_cache", (True, False), ids=["enable_program_cache", "disable_program_cache"])
-@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
@@ -381,19 +380,15 @@ def test_FalconDecoder_inference(
     cache_pcc,
     token_pcc,
     model_config_str,
-    enable_program_cache,
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
+    use_program_cache,
 ):
     if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
     if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED", "BFLOAT16-SHARDED"]:
         pytest.skip("Decode is only supported for SHARDED memory config!")
-
-    if llm_mode == "decode" and num_devices == 4:
-        pytest.skip("#7842: Possible hangs in t3k")
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
@@ -405,10 +400,6 @@ def test_FalconDecoder_inference(
     tt_cache_path = get_tt_cache_path(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
     )
-
-    if enable_program_cache:
-        for device in devices:
-            device.enable_program_cache()
 
     run_test_FalconDecoder_inference(
         devices,
@@ -425,7 +416,3 @@ def test_FalconDecoder_inference(
         tt_cache_path,
         model_location_generator,
     )
-
-    if enable_program_cache:
-        for device in devices:
-            device.disable_and_clear_program_cache()

--- a/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
@@ -98,7 +98,7 @@ def run_test_FalconMLP_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len",
     (
@@ -140,7 +140,7 @@ def test_FalconMLP_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
+    use_program_cache,
 ):
     if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -292,7 +292,7 @@ def run_test_FalconModel_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
@@ -339,7 +339,7 @@ def test_FalconModel_inference(
     model_location_generator,
     get_tt_cache_path,
     all_devices,
-    # use_program_cache, # TODO: remove workaround when low PCC issue 7159 is fixed
+    use_program_cache,
 ):
     if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")

--- a/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
@@ -366,7 +366,7 @@ def run_test_FalconCausalLM_end_to_end(
 
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len, expected_compile_time, expected_inference_time, inference_iterations",
     (

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -401,7 +401,7 @@ def run_test_FalconCausalLM_end_to_end(
 
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize("num_devices", (4, 8), ids=["4chips", "8chips"])
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len, expected_compile_time, expected_inference_time, inference_iterations",
     (

--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -249,8 +249,11 @@ class TtFalconAttention:
         # self.scalar = pad_by_zero(torch.Tensor([1 / math.sqrt(self.head_dim)]), self.device)[0]
         self.scalar = 1 / math.sqrt(self.head_dim)
 
+        self.preprocessing(self.model_config["LLM_MODE"], self.model_config["BATCH_SIZE"], self.model_config["SEQ_LEN"])
+
     def set_model_config(self, model_config):
         self.model_config = model_config
+        self.preprocessing(self.model_config["LLM_MODE"], self.model_config["BATCH_SIZE"], self.model_config["SEQ_LEN"])
 
     def preprocessing(self, llm_mode, batch_size, sequence_size):
         if llm_mode == "prefill":

--- a/models/demos/t3000/falcon40b/tt/model_config.py
+++ b/models/demos/t3000/falcon40b/tt/model_config.py
@@ -138,19 +138,23 @@ def pretty_print_model_config(model_config):
 def get_model_config(model_config_str, llm_mode, input_shape, num_devices):
     assert llm_mode in ("prefill", "decode")
     assert len(input_shape) == 2
-    assert num_devices in (4, 8)
-
+    assert num_devices == 8, "Currently only supporting 8 devices"
     if llm_mode == "prefill":
-        return get_prefill_model_config(model_config_str, input_shape, num_devices)
+        model_config = get_prefill_model_config(model_config_str, input_shape, num_devices)
     elif llm_mode == "decode":
-        return get_decode_model_config(model_config_str, input_shape, num_devices)
-    assert False
+        model_config = get_decode_model_config(model_config_str, input_shape, num_devices)
+    else:
+        assert False
+
+    model_config["LLM_MODE"] = llm_mode
+
+    return model_config
 
 
 def get_decode_model_config(model_config_str, input_shape, num_devices):
     assert model_config_str in ACCEPTABLE_DECODE_MODEL_CONFIG_STRS
     assert len(input_shape) == 2
-    assert num_devices in (4, 8)
+    assert num_devices == 8, "Decode is currently only supported on 8 devicess"
 
     DRAM_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     L1_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
@@ -179,7 +183,7 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
         "MOVE_DECODER_OUTPUT_BOOL": False,
         "NUM_DEVICES": num_devices,
         "MAX_GRID_SIZE": (8, 4),
-        "ALL_GATHER_NUM_LINKS": 2 if num_devices == 4 else 1,
+        "ALL_GATHER_NUM_LINKS": 1,
         "DEFAULT_CACHE_PATH": Path(f"models/demos/t3000/falcon40b/datasets/"),
         "COMPUTE_KERNEL_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
             math_fidelity=ttl.tensor.MathFidelity.LoFi,
@@ -226,6 +230,8 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
     assert batch == 32
     row_height = batch
     model_config["row_height"] = row_height
+    model_config["BATCH_SIZE"] = batch
+    model_config["SEQ_LEN"] = seq_len
 
     if model_config_str in ("BFLOAT16-L1",):
         model_config["ROTARY_EMBEDDING_OUTPUT_MEMCFG"] = L1_MEMCFG
@@ -430,30 +436,17 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
                 False,
             ),
         )
-        if num_devices == 4:
-            model_config["QKV_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 1),
-                in0_block_w=32,  # TODO: Can this be larger
-                out_subblock_h=1,  # TODO: Can this be larger
-                out_subblock_w=3,
-                per_core_M=row_height // 32,
-                per_core_N=9,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            )
-        else:
-            model_config["QKV_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 1),
-                in0_block_w=32,  # TODO: Can this be larger
-                out_subblock_h=1,  # TODO: Can this be larger
-                out_subblock_w=1,
-                per_core_M=row_height // 32,
-                per_core_N=5,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            )
+        model_config["QKV_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(8, 1),
+            in0_block_w=32,  # TODO: Can this be larger
+            out_subblock_h=1,  # TODO: Can this be larger
+            out_subblock_w=1,
+            per_core_M=row_height // 32,
+            per_core_N=5,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=True,
+        )
         model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
             ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
             ttl.tensor.BufferType.L1,
@@ -467,90 +460,46 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
                 False,
             ),
         )
-        if num_devices == 4:
-            model_config["CREATE_QKV_HEADS_INPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-                ttl.tensor.BufferType.L1,
-                ttl.tensor.ShardSpec(
-                    shard_spec_2_cores_grid,
-                    [
-                        row_height,
-                        total_width_per_group_of_qkv_heads,  # Must always be minimum a full group
-                    ],
-                    ttl.tensor.ShardOrientation.ROW_MAJOR,
-                    False,
-                ),
-            )
-        elif num_devices == 8:
-            model_config["CREATE_QKV_HEADS_INPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-                ttl.tensor.BufferType.L1,
-                ttl.tensor.ShardSpec(
-                    shard_spec_1_cores_grid,
-                    [
-                        row_height,
-                        total_width_per_group_of_qkv_heads,  # Must always be minimum a full group
-                    ],
-                    ttl.tensor.ShardOrientation.ROW_MAJOR,
-                    False,
-                ),
-            )
+        model_config["CREATE_QKV_HEADS_INPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+            ttl.tensor.BufferType.L1,
+            ttl.tensor.ShardSpec(
+                shard_spec_1_cores_grid,
+                [
+                    row_height,
+                    total_width_per_group_of_qkv_heads,  # Must always be minimum a full group
+                ],
+                ttl.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
         model_config["CREATE_QKV_HEADS_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
-        # TODO: Remove this once nlp_create_qkv_heads supports HEIGHT > 32 for sharded
-        if num_devices == 4:
-            model_config["CREATE_Q_HEADS_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttl.tensor.BufferType.L1,
-                ttl.tensor.ShardSpec(
-                    shard_spec_32_cores_grid,
-                    [
-                        row_height,
-                        head_dim,
-                    ],
-                    ttl.tensor.ShardOrientation.ROW_MAJOR,
-                    False,
-                ),
-            )
-            model_config["CREATE_KV_HEADS_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttl.tensor.BufferType.L1,
-                ttl.tensor.ShardSpec(
-                    shard_spec_2_cores_grid,
-                    [
-                        row_height,
-                        head_dim,
-                    ],
-                    ttl.tensor.ShardOrientation.ROW_MAJOR,
-                    False,
-                ),
-            )
-        elif num_devices == 8:
-            model_config["CREATE_Q_HEADS_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttl.tensor.BufferType.L1,
-                ttl.tensor.ShardSpec(
-                    shard_spec_16_cores_grid,
-                    [
-                        row_height,
-                        head_dim,
-                    ],
-                    ttl.tensor.ShardOrientation.ROW_MAJOR,
-                    False,
-                ),
-            )
-            model_config["CREATE_KV_HEADS_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttl.tensor.BufferType.L1,
-                ttl.tensor.ShardSpec(
-                    shard_spec_1_cores_grid,
-                    [
-                        row_height,
-                        head_dim,
-                    ],
-                    ttl.tensor.ShardOrientation.ROW_MAJOR,
-                    False,
-                ),
-            )
+        model_config["CREATE_Q_HEADS_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.BufferType.L1,
+            ttl.tensor.ShardSpec(
+                shard_spec_16_cores_grid,
+                [
+                    row_height,
+                    head_dim,
+                ],
+                ttl.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
+        model_config["CREATE_KV_HEADS_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.BufferType.L1,
+            ttl.tensor.ShardSpec(
+                shard_spec_1_cores_grid,
+                [
+                    row_height,
+                    head_dim,
+                ],
+                ttl.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
         model_config["ROTARY_EMBEDDING_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
         model_config["KV_CACHE_SLICE_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
             ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
@@ -567,20 +516,12 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
         )
         model_config["K_TRANSPOSED_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
         model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
-        if num_devices == 4:
-            model_config["SOFTMAX_PROGCFG"] = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
-                compute_with_storage_grid_size=(8, 4),
-                subblock_w=1,
-                block_h=row_height // 32,
-                block_w=1,  # Dynamic
-            )
-        elif num_devices == 8:
-            model_config["SOFTMAX_PROGCFG"] = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
-                compute_with_storage_grid_size=(8, 2),
-                subblock_w=1,
-                block_h=row_height // 32,
-                block_w=1,  # Dynamic
-            )
+        model_config["SOFTMAX_PROGCFG"] = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=(8, 2),
+            subblock_w=1,
+            block_h=row_height // 32,
+            block_w=1,  # Dynamic
+        )
         model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
         model_config["CONCAT_HEADS_OUTPUT_MEMCFG"] = WIDTH_SHARDED_MEMCFG
         model_config["ATTN_ALL_GATHER_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
@@ -612,84 +553,40 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
             ),
         )
         model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"] = WIDTH_SHARDED_MEMCFG
-        if num_devices == 4:
-            model_config["SELFOUT_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 4),
-                in0_block_w=8,  # TODO: Can this be larger
-                out_subblock_h=1,  # TODO: Can this be larger
-                out_subblock_w=2,
-                per_core_M=row_height // 32,
-                per_core_N=2,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            )
-            # MLP
-            model_config[
-                "DENSE_H_TO_4H_MM_PROGCFG"
-            ] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 4),
-                in0_block_w=8,  # TODO: Can this be larger
-                out_subblock_h=1,  # TODO: Can this be larger
-                out_subblock_w=4,
-                per_core_M=row_height // 32,
-                per_core_N=8,
-                fuse_batch=True,
-                fused_activation=[ttl.tensor.FusibleActivation.GELU, True],
-                mcast_in0=True,
-            )
-            model_config[
-                "DENSE_4H_TO_H_MM_PROGCFG"
-            ] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 4),
-                in0_block_w=32,  # TODO: Can this be larger
-                out_subblock_h=1,  # TODO: Can this be larger
-                out_subblock_w=2,
-                per_core_M=row_height // 32,
-                per_core_N=2,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            )
-        elif num_devices == 8:
-            model_config["SELFOUT_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 4),
-                in0_block_w=8,  # TODO: Can this be larger
-                out_subblock_h=1,  # TODO: Can this be larger
-                out_subblock_w=1,
-                per_core_M=row_height // 32,
-                per_core_N=1,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            )
-            # MLP
-            model_config[
-                "DENSE_H_TO_4H_MM_PROGCFG"
-            ] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 4),
-                in0_block_w=8,  # TODO: Can this be larger
-                out_subblock_h=1,  # TODO: Can this be larger
-                out_subblock_w=4,
-                per_core_M=row_height // 32,
-                per_core_N=4,
-                fuse_batch=True,
-                fused_activation=[ttl.tensor.FusibleActivation.GELU, True],
-                mcast_in0=True,
-            )
-            model_config[
-                "DENSE_4H_TO_H_MM_PROGCFG"
-            ] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 4),
-                in0_block_w=32,  # TODO: Can this be larger
-                out_subblock_h=1,  # TODO: Can this be larger
-                out_subblock_w=1,
-                per_core_M=row_height // 32,
-                per_core_N=1,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            )
+        model_config["SELFOUT_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(8, 4),
+            in0_block_w=8,  # TODO: Can this be larger
+            out_subblock_h=1,  # TODO: Can this be larger
+            out_subblock_w=1,
+            per_core_M=row_height // 32,
+            per_core_N=1,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=True,
+        )
+        # MLP
+        model_config["DENSE_H_TO_4H_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(8, 4),
+            in0_block_w=8,  # TODO: Can this be larger
+            out_subblock_h=1,  # TODO: Can this be larger
+            out_subblock_w=4,
+            per_core_M=row_height // 32,
+            per_core_N=4,
+            fuse_batch=True,
+            fused_activation=[ttl.tensor.FusibleActivation.GELU, True],
+            mcast_in0=True,
+        )
+        model_config["DENSE_4H_TO_H_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(8, 4),
+            in0_block_w=32,  # TODO: Can this be larger
+            out_subblock_h=1,  # TODO: Can this be larger
+            out_subblock_w=1,
+            per_core_M=row_height // 32,
+            per_core_N=1,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=True,
+        )
 
         model_config["FINAL_ALL_GATHER_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
             ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
@@ -727,30 +624,17 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
 
         # LM Head
         model_config["LM_HEAD_MM_OUTPUT_MEMCFG"] = WIDTH_SHARDED_MEMCFG
-        if num_devices == 4:
-            model_config["LM_HEAD_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 4),
-                in0_block_w=8,
-                out_subblock_h=1,
-                out_subblock_w=4,
-                per_core_M=row_height // 32,
-                per_core_N=16,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            )
-        elif num_devices == 8:
-            model_config["LM_HEAD_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 4),
-                in0_block_w=8,
-                out_subblock_h=1,
-                out_subblock_w=4,
-                per_core_M=row_height // 32,
-                per_core_N=8,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            )
+        model_config["LM_HEAD_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(8, 4),
+            in0_block_w=8,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=row_height // 32,
+            per_core_N=8,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=True,
+        )
 
     # uncomment if need to see all the configs
     # logger.debug(f"Falcon model config: \n{pretty_print_model_config(model_config)}")
@@ -761,7 +645,7 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
 def get_prefill_model_config(model_config_str, input_shape, num_devices):
     assert model_config_str in ACCEPTABLE_PREFILL_MODEL_CONFIG_STRS
     assert len(input_shape) == 2
-    assert num_devices == 8, "Prefill is only supported on 8 devicess"
+    assert num_devices == 8, "Prefill is currently only supported on 8 devicess"
 
     DRAM_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     L1_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
@@ -833,8 +717,11 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
     num_attention_heads = model_config_entries["num_attention_heads"]
     num_kv_heads = model_config_entries["num_kv_heads"]
 
-    row_height = input_shape[1]
+    batch_size, seq_len = input_shape[0], input_shape[1]
+    row_height = seq_len
     model_config["row_height"] = row_height
+    model_config["BATCH_SIZE"] = batch_size
+    model_config["SEQ_LEN"] = seq_len
 
     # Layernorm is an exception that are sharded also here, because the interleaved OP does not fit in L1 for 40b hidden size
     layernorm_num_cores_x = 8

--- a/tests/scripts/multi_chip/run_end_to_end_demos.sh
+++ b/tests/scripts/multi_chip/run_end_to_end_demos.sh
@@ -16,4 +16,8 @@ fi
 cd $TT_METAL_HOME
 export PYTHONPATH=$TT_METAL_HOME
 
-# Your tests go here!
+# Falcon40B prefill 60 layer end to end with 10 loops; we need 8x8 grid size
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+
+# Falcon40B end to end demo (prefill + decode)
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_5_loops.py

--- a/tests/scripts/multi_chip/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/multi_chip/run_pre_post_commit_regressions_multi_device.sh
@@ -23,12 +23,15 @@ TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_fast_dispatch --g
 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="DPrintFixture.*:WatcherFixture.*"
 pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k post_commit
 
-# Falcon40B 8 chip decode tests
-pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips-enable_program_cache]
-pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips-enable_program_cache]
-
 # ttnn multi-chip apis unit tests
 pytest tests/ttnn/unit_tests/test_multi_device.py
+
+# Falcon40b unit tests; prefill required 8x8 grids
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_falcon_attention.py
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
 
 # Mistral8x7b 8 chip decode tests (env flags set inside the tests)
 pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -39,12 +42,7 @@ pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
 pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
 pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[1-1-pcc]
 
-# Falcon40B 8 chip prefill tests; we need 8x8 grid size
-WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_prefill.py
-
-pytest tests/ttnn/unit_tests/test_multi_device_async.py
-TT_METAL_THREADCOUNT=1 pytest tests/ttnn/unit_tests/test_multi_device_async.py::test_multi_device_unary_binary_op_chain
-
+# Falcon7B data parallel tests
 pytest models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py
 pytest models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_attention.py
 pytest models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py

--- a/tt_eager/tt_lib/_internal/comparison_funcs.py
+++ b/tt_eager/tt_lib/_internal/comparison_funcs.py
@@ -144,6 +144,16 @@ def comp_pcc(golden, calculated, pcc=0.99):
     return passing, output_str
 
 
+def comp_and_get_pcc(golden, calculated, pcc=0.99):
+    if golden.dtype != calculated.dtype:
+        calculated = calculated.type(golden.dtype)
+    _, _, cal_pcc, output_str = get_atol_rtol_pcc(golden, calculated)
+    passing = cal_pcc >= pcc
+    if not passing:
+        output_str += f", PCC check failed (target: {pcc})"
+    return passing, output_str, cal_pcc
+
+
 def comp_pcc_list(golden, calculated, pcc=0.99):
     total_str = ""
     min_pcc = 1


### PR DESCRIPTION
Contains a couple of changes to extend test coverage and test cleanup:
- Add option to run tests for a specific number of loops
- Add 1 layer component tests to multi chip unit tests pipeline
- Add 60 layer prefill tests with pcc checks running for 10 iterations to the end to end demo pipeline: aim is to check for PCC as well as hangs
- Add a test to run the falcon40b end to end demo for 5 different prompts; tests for hangs and functionality but not for accuracy
- Various clean up changes including the removal of 4 chip configs that are not used anymore, argument cleanup,...
- Updated exact PCC targets for different layers and data format configs

Multi chip pipeline:
https://github.com/tenstorrent/tt-metal/actions/runs/9078779984
https://github.com/tenstorrent/tt-metal/actions/runs/9081041361