### PR TITLE
#7711: Fix ttnn docs for activation ops

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/sweeps/elu.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/elu.py
@@ -17,15 +17,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "alpha": [-0.5, 0, 0.5],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    alpha,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "BFLOAT8_B is supported in TILE layout"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/hardshrink.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/hardshrink.py
@@ -17,15 +17,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "lambd": [0, 0.5, 1.5],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    lambd,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b:
+        return True, "BFLOAT8_B is not supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/hardsigmoid.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/hardsigmoid.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b:
+        return True, "BFLOAT8_B is not supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/hardswish.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/hardswish.py
@@ -17,14 +17,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b:
+        return True, "BFLOAT8_B is not supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/heaviside.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/heaviside.py
@@ -16,15 +16,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "value": [0.5, 0.6],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    value,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "BFLOAT8_B is supported in TILE layout"
     return False, None
 
 
@@ -65,4 +76,4 @@ def run(
     output_tensor = ttnn.heaviside(input_tensor, value, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/log_sigmoid.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/log_sigmoid.py
@@ -17,14 +17,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "BFLOAT8_B is supported in TILE layout"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/mish.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/mish.py
@@ -17,14 +17,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b:
+        return True, "BFLOAT8_B is not supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/prelu.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/prelu.py
@@ -17,15 +17,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "weight": [-0.5, 0, 0.01, 0.5],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    weight,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "BFLOAT8_B is supported in TILE layout"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/relu6.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/relu6.py
@@ -17,14 +17,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "BFLOAT8_B is supported in TILE layout"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/sigmoid.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/sigmoid.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "BFLOAT8_B is supported in TILE layout"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/sign.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/sign.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "BFLOAT8_B is supported in TILE layout"
     return False, None
 
 
@@ -57,4 +67,4 @@ def run(
     output_tensor = ttnn.sign(input_tensor, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/softshrink.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/softshrink.py
@@ -17,15 +17,26 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
     "lambd": [0, 0.5, 1.5],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+    lambd,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b:
+        return True, "BFLOAT8_B is not supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/softsign.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/softsign.py
@@ -17,14 +17,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b:
+        return True, "BFLOAT8_B is not supported"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/swish.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/swish.py
@@ -17,14 +17,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "BFLOAT8_B is supported in TILE layout"
     return False, None
 
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/tanhshrink.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/tanhshrink.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1,)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "BFLOAT8_B is supported in TILE layout"
     return False, None
 
 


### PR DESCRIPTION
Fix ttnn documentation for activation ops and update sweeps as per validation- unary and with float
Primary issue - #7711 
add sweep tests for recently added ops - celu, sigmoid_accurate.
CI test: https://github.com/tenstorrent/tt-metal/actions/runs/8924536566