### PR TITLE
Fix logaddexp low pcc 

### DIFF
--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_bfloat8_eltwise_logaddexp.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_bfloat8_eltwise_logaddexp.py
@@ -58,7 +58,7 @@ test_sweep_args = [
         [ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.BFLOAT8_B],
         [ttl.tensor.Layout.TILE, ttl.tensor.Layout.TILE],
         [
-            "SYSTEM_MEMORY",
+            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
             ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
         ],
         ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/multi_core/eltwise_binary_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/multi_core/eltwise_binary_op_multi_core.cpp
@@ -256,6 +256,14 @@ operation::ProgramWithCallbacks eltwise_binary_multi_core(const Tensor &a, const
     tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
     uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
 
+    tt::DataFormat interim_cb_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    if (op_type == BinaryOpType::LOGADDEXP || op_type == BinaryOpType::LOGICAL_AND ||
+        op_type == BinaryOpType::LOGICAL_OR || op_type == BinaryOpType::LDEXP ||
+        op_type == BinaryOpType::LOGADDEXP2){
+        interim_cb_format = tt::DataFormat::Float16_b;
+    }
+    uint32_t interim_single_tile_size = tt_metal::detail::TileSize(interim_cb_format);
+
     tt_metal::Buffer *src0_buffer = a.buffer();
     tt_metal::Buffer *src1_buffer = b.buffer();
 
@@ -315,13 +323,13 @@ operation::ProgramWithCallbacks eltwise_binary_multi_core(const Tensor &a, const
     std::map<string, string> eltwise_defines = eltwise_binary_op_utils::get_defines(op_type, output.get_dtype(), fused_activations);
 
     if (eltwise_defines.find("SFPU_OP_INIT_PRE_IN0_0") != eltwise_defines.end()) {
-        tt_metal::CircularBufferConfig cb_interm_config = tt_metal::CircularBufferConfig(1 * src0_single_tile_size, {{CB::c_intermed0, src0_cb_data_format}})
-		    .set_page_size(CB::c_intermed0, src0_single_tile_size);
+        tt_metal::CircularBufferConfig cb_interm_config = tt_metal::CircularBufferConfig(1 * interim_single_tile_size, {{CB::c_intermed0, interim_cb_format}})
+		    .set_page_size(CB::c_intermed0, interim_single_tile_size);
         auto cb_interm = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_interm_config);
     }
     if (eltwise_defines.find("SFPU_OP_INIT_PRE_IN1_0") != eltwise_defines.end()) {
-        tt_metal::CircularBufferConfig cb_interm2_config = tt_metal::CircularBufferConfig(1 * src1_single_tile_size, {{CB::c_intermed1, src1_cb_data_format}})
-		    .set_page_size(CB::c_intermed1, src1_single_tile_size);
+        tt_metal::CircularBufferConfig cb_interm2_config = tt_metal::CircularBufferConfig(1 * interim_single_tile_size, {{CB::c_intermed1, interim_cb_format}})
+		    .set_page_size(CB::c_intermed1, interim_single_tile_size);
         auto cb_interm2 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_interm2_config);
     }
 


### PR DESCRIPTION
Fix low pcc issue for logaddexp problems
@tt-aho @eyonland For logaddexp, logaddexp2 we are getting low pcc issue when one of the datatype is bf8, for this issue updated the
- interim buffer format to bf16
- output tensor dtype to bf16 (hardcoded it to bf16 , instead of getting if from input tensors)

Kindly review and share the comments