### PR TITLE
#8068: Remove spurious docs jobs / workflows / executions

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -6,6 +6,12 @@ on:
   push:
     branches: ["main", "fd-2/main"]
 
+permissions:
+  actions: read
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   static-checks:
     uses: ./.github/workflows/all-static-checks.yaml
@@ -26,6 +32,10 @@ jobs:
     secrets: inherit
   eager-package-main:
     uses: ./.github/workflows/eager-package-main.yaml
+    secrets: inherit
+  build-docs:
+    needs: build-artifact
+    uses: ./.github/workflows/docs-latest-public.yaml
     secrets: inherit
   build:
     uses: ./.github/workflows/build.yaml

--- a/.github/workflows/docs-latest-public-wrapper.yaml
+++ b/.github/workflows/docs-latest-public-wrapper.yaml
@@ -1,0 +1,13 @@
+name: post-commit - Docs Build latest docs and deploy to GitHub pages on main
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+  build-docs:
+    needs: build-artifact
+    uses: ./.github/workflows/docs-latest-public.yaml
+    secrets: inherit

--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -1,15 +1,7 @@
-name: Docs - Build latest docs and deploy to GitHub pages on main
+name: Internal - Docs Build latest docs and deploy to GitHub pages on main
 
 on:
-  push:
-    branches: ["main"]
-  workflow_dispatch:
-
-permissions:
-  actions: read
-  contents: read
-  pages: write
-  id-token: write
+  workflow_call:
 
 concurrency:
   # Note that people may spam the post-commit pipeline on their branch, and
@@ -31,32 +23,34 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       DOCS_VERSION: latest
       ARCH_NAME: ${{ matrix.arch }}
+      LOGURU_LEVEL: INFO
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.arch }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
-      - uses: ./.github/actions/install-metal-deps
-        with:
-          os: ubuntu-20.04
-      - uses: ./.github/actions/install-metal-dev-deps
-        with:
-          os: ubuntu-20.04
-      - name: Build tt-metal
+      - name: Set up dynamic env vars for build
         run: |
-          export TT_METAL_HOME=$(pwd)
-          make build
-      - name: Activate docs environment and build docs
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
+      - name: Build Docs
+        timeout-minutes: 15
         run: |
-          export PYTHONPATH=$(pwd)
-          source build/python_env/bin/activate
-          cd docs/
-          make html
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
+          ./tests/scripts/run_build_docs.sh
       - name: Build additional ttnn sweeps docs
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           export PYTHONPATH=$(pwd)
-          source build/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           cd docs/
           make ttnn_sweeps/check_directory
           make ttnn_sweeps

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -62,45 +62,6 @@ jobs:
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}
-  build-docs:
-    strategy:
-      # Do not fail-fast because we need to ensure all tests go to completion
-      # so we try not to get hanging machines
-      fail-fast: false
-      matrix:
-        runner-info: [
-          # E150
-          {arch: grayskull, runs-on: ["grayskull"]},
-          # N150
-          {arch: wormhole_b0, runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1"]},
-          # N300
-          {arch: wormhole_b0, runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2"]},
-        ]
-    env:
-      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
-      ARCH_NAME: ${{ matrix.runner-info.arch }}
-      LOGURU_LEVEL: INFO
-      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: ${{ matrix.runner-info.runs-on }}
-    steps:
-      - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
-      - name: Set up dynamic env vars for build
-        run: |
-          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - uses: actions/download-artifact@v4
-        with:
-          name: TTMetal_build_${{ matrix.runner-info.arch }}
-      - name: Extract files
-        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
-      - uses: ./.github/actions/install-python-deps
-      - name: Build Docs
-        timeout-minutes: 15
-        run: |
-          source ${{ github.workspace }}/python_env/bin/activate
-          cd $TT_METAL_HOME
-          export PYTHONPATH=$TT_METAL_HOME
-          ./tests/scripts/run_build_docs.sh
-
   multi-queue-single-device-tests:
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion

--- a/tests/scripts/run_pre_post_commit_regressions_fast_dispatch.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_fast_dispatch.sh
@@ -24,5 +24,3 @@ export PYTHONPATH=$TT_METAL_HOME
 
 ./tests/scripts/run_cpp_unit_tests.sh
 
-# build docs
-./tests/scripts/run_build_docs.sh

--- a/tests/scripts/run_pre_post_commit_regressions_slow_dispatch.sh
+++ b/tests/scripts/run_pre_post_commit_regressions_slow_dispatch.sh
@@ -24,10 +24,3 @@ export PYTHONPATH=$TT_METAL_HOME
 ./tests/scripts/run_cpp_fd2_tests.sh
 
 ./tests/scripts/run_cpp_unit_tests.sh
-
-echo "Checking docs build..."
-
-cd $TT_METAL_HOME/docs
-python -m pip install -r requirements-docs.txt
-make clean
-make html


### PR DESCRIPTION
Resolve #8068 
Resolve #8097 

@TT-billteng also pushed me to get this https://github.com/tenstorrent/tt-metal/issues/8097 over the line :) 

Moved `docs-latest-public.yaml` into `all-post-commit-workflows.yaml`'

Removed the doc step from `fast-dispatch-build-and-unit-tests.yaml` and also from the secret steps hidden within `slow and fast dispatch tests (`run_pre_post_commit_regressions_fast_dispatch.sh` and `run_pre_post_commit_regressions_slow_dispatch.sh` )