### PR TITLE
#7512: streamline matmul methods

### DIFF
--- a/tests/tt_eager/integration_tests/test_bert.cpp
+++ b/tests/tt_eager/integration_tests/test_bert.cpp
@@ -59,7 +59,7 @@ Tensor encoder(Tensor&& hidden_states, const Tensor& attention_mask, const Param
         .per_core_M = 12,
         .per_core_N = 12,
     };
-    auto pre_softmax_bmm_matmul = tt::operations::primary::matmul(query, key, pre_softmax_bmm_program_config, dram_memory_config);
+    auto pre_softmax_bmm_matmul = tt::operations::primary::matmul(query, key, std::nullopt /*bias*/, pre_softmax_bmm_program_config, dram_memory_config);
     query.deallocate();
     key.deallocate();
 
@@ -75,7 +75,7 @@ Tensor encoder(Tensor&& hidden_states, const Tensor& attention_mask, const Param
         .per_core_M = 12,
         .per_core_N = 2,
     };
-    auto post_softmax_bmm_output = tt::operations::primary::matmul(pre_softmax_bmm_matmul, value, post_softmax_bmm_program_config, l1_memory_config);
+    auto post_softmax_bmm_output = tt::operations::primary::matmul(pre_softmax_bmm_matmul, value, std::nullopt /*bias*/, post_softmax_bmm_program_config, l1_memory_config);
     pre_softmax_bmm_matmul.deallocate();
     value.deallocate();
 
@@ -172,7 +172,7 @@ Tensor encoder(Tensor&& hidden_states, const Tensor& attention_mask, const Param
 
 Tensor qa_head(Tensor&& hidden_states, const Parameters& parameters) {
 
-    auto output = matmul(hidden_states, parameters.at("qa_head_weight"));
+    auto output = tt::operations::primary::matmul(hidden_states, parameters.at("qa_head_weight"));
     hidden_states.deallocate();
 
 

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -50,8 +50,8 @@ int main(int argc, char **argv) {
         Tensor b = tt::numpy::zeros(shapeb, DataType::BFLOAT16).to(Layout::TILE).to(device);
         Tensor b1 = tt::numpy::zeros(shapeb1, DataType::BFLOAT16).to(Layout::TILE).to(device);
 
-        Tensor mm = bmm(a, b).cpu();
-        Tensor mm1 = matmul(a, b1).cpu();
+        Tensor mm = tt::operations::primary::matmul(a, b, std::nullopt, MatmulDefaultProgramConfig{}, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::nullopt, std::nullopt, false, std::nullopt, true).cpu();
+        Tensor mm1 = tt::operations::primary::matmul(a, b1).cpu();
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         Tensor b = tt::numpy::zeros(shapeb, DataType::BFLOAT16).to(Layout::TILE).to(device);
         Tensor b1 = tt::numpy::zeros(shapeb1, DataType::BFLOAT16).to(Layout::TILE).to(device);
 
-        Tensor mm = tt::operations::primary::matmul(a, b, std::nullopt, MatmulDefaultProgramConfig{}, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::nullopt, std::nullopt, false, std::nullopt, true).cpu();
+        Tensor mm = tt::operations::primary::matmul(a, b, std::nullopt, tt::operations::primary::MatmulDefaultProgramConfig{}, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::nullopt, std::nullopt, false, std::nullopt, true).cpu();
         Tensor mm1 = tt::operations::primary::matmul(a, b1).cpu();
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
@@ -388,7 +388,8 @@ inline Tensor matmul(
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     bool untilize_out = false,
     std::optional<const CoreCoord> user_core_coord = std::nullopt,
-    std::optional<const bool> input_b_is_batched = std::nullopt) {
+    std::optional<const bool> input_b_is_batched = std::nullopt,
+    const bool needs_autoformat = false) {
     std::vector<std::optional<const Tensor>> optional_input_tensors = {};
     std::vector<Tensor> output_tensors;
     if (bias) {
@@ -399,8 +400,9 @@ inline Tensor matmul(
         output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
     }
 
-    operation::launch_op(
-        [program_config, mem_config, output_dtype, compute_kernel_config, untilize_out, user_core_coord, input_b_is_batched] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+    if (!needs_autoformat) {
+	operation::launch_op(
+		[program_config, mem_config, output_dtype, compute_kernel_config, untilize_out, user_core_coord, input_b_is_batched] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor_a = input_tensors.at(0);
             const auto& input_tensor_b = input_tensors.at(1);
             auto arch = input_tensor_a.device()->arch();
@@ -413,7 +415,19 @@ inline Tensor matmul(
 	    }
             return operation::run(Matmul{matmul_program_config, broadcast_batch, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val, untilize_out}, {input_tensor_a, input_tensor_b}, optional_input_tensors);
         },
-    {input_tensor_a, input_tensor_b}, output_tensors, optional_input_tensors);
+	{input_tensor_a, input_tensor_b}, output_tensors, optional_input_tensors);
+    } else {
+	operation::launch_with_autoformat(
+		[program_config, mem_config, output_dtype, compute_kernel_config, untilize_out, user_core_coord, input_b_is_batched] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor_a = input_tensors.at(0);
+            const auto& input_tensor_b = input_tensors.at(1);
+	    auto arch = input_tensor_a.storage_type() == StorageType::DEVICE ? input_tensor_a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
+            auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
+            bool broadcast_batch = get_broadcast_batch(input_tensor_a, input_tensor_b, program_config);
+            return operation::run_with_autoformat(Matmul{program_config, broadcast_batch, mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val, untilize_out}, {input_tensor_a, input_tensor_b}, optional_input_tensors);
+        },
+	{input_tensor_a, input_tensor_b}, output_tensors, optional_input_tensors);
+    }
     return output_tensors.at(0);
 }
 

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -1351,7 +1351,7 @@ Tensor _outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
         b_slim = reshape(b, 1, 1, 1, b.volume(), output_mem_config);
     }
 
-    return matmul(a_slim, b_slim, output_mem_config);
+    return tt::operations::primary::matmul(a_slim, b_slim, std::nullopt, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config);
 }
 Tensor outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _outer)(a, b, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -1351,7 +1351,7 @@ Tensor _outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
         b_slim = reshape(b, 1, 1, 1, b.volume(), output_mem_config);
     }
 
-    return tt::operations::primary::matmul(a_slim, b_slim, std::nullopt, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config);
+    return tt::operations::primary::matmul(a_slim, b_slim, std::nullopt, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config, std::nullopt /*output_dtype*/, std::nullopt /*compute_kernel_config*/, false /*untilize_out*/, std::nullopt /*user_core_coord*/, std::nullopt /*input_b_is_batched*/, true /*needs_autoformat*/);
 }
 Tensor outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _outer)(a, b, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/fully_connected/fully_connected_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fully_connected/fully_connected_op.cpp
@@ -13,7 +13,7 @@ namespace tt {
 namespace tt_metal {
 
 Tensor fully_connected_(const Tensor& act, const Tensor& weights, std::optional<std::reference_wrapper<const Tensor>> bias, const MemoryConfig& output_mem_config) {
-    Tensor mm_output = matmul(act, weights, output_mem_config);
+    Tensor mm_output = tt::operations::primary::matmul(act, weights, std::nullopt, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config);
     if (bias) {
         return bcast(mm_output, bias.value(), BcastOpMath::ADD, BcastOpDim::H, output_mem_config);
     }

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -132,7 +132,8 @@ void py_module(py::module& m_primary) {
         py::arg("fused_activation") = std::nullopt,
         py::arg("mcast_in0").noconvert() = true,
         py::arg("out_sharded").noconvert() = false,
-        py::arg("compute_with_storage_grid_size") = std::nullopt);
+        py::arg("compute_with_storage_grid_size") = std::nullopt,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt);
 
     // TODO(arakhmati):
     // delete
@@ -161,7 +162,7 @@ void py_module(py::module& m_primary) {
            std::optional<DeviceComputeKernelConfig> compute_kernel_config,
            const bool untilize_out
            ) {
-            return matmul(input_tensor_a, input_tensor_b, program_config, out_mem_config, output_dtype, compute_kernel_config, untilize_out);
+            return matmul(input_tensor_a, input_tensor_b, std::nullopt /*bias*/, program_config, out_mem_config, output_dtype, compute_kernel_config, untilize_out);
         },
         py::arg("input_tensor_a").noconvert(),
         py::arg("input_tensor_b").noconvert(),
@@ -194,7 +195,7 @@ void py_module(py::module& m_primary) {
            std::optional<DeviceComputeKernelConfig> compute_kernel_config,
            const bool untilize_out
            ) {
-            return matmul(input_tensor_a, input_tensor_b, program_config, out_mem_config, output_dtype, compute_kernel_config, untilize_out);
+            return matmul(input_tensor_a, input_tensor_b, std::nullopt /*bias*/, program_config, out_mem_config, output_dtype, compute_kernel_config, untilize_out);
         },
         py::arg("input_tensor_a").noconvert(),
         py::arg("input_tensor_b").noconvert(),

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -47,8 +47,8 @@ namespace tt::tt_metal::detail
             +-------------------------------+-------------------------------------------------------+-----------+-------------+----------+
         )doc");
         // *** matrix multiplication ***
-        m_tensor.def("matmul", &matmul,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false, R"doc(
+        m_tensor.def("matmul", &tt::operations::primary::matmul,
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("bias").noconvert() = std::nullopt, py::arg("program_config"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false, py::arg("core_coord").noconvert() = std::nullopt, py::arg("input_b_is_batched").noconvert() = false, R"doc(
             Perform a non-batched matrix multiplication ``arg0 x arg1`` with two tensors.
 
             Both input tensors must have BFLOAT16 data type.
@@ -63,8 +63,8 @@ namespace tt::tt_metal::detail
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("bmm", &bmm,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false,  R"doc(
+        m_tensor.def("bmm", &tt::operations::primary::matmul,
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("bias").noconvert() = std::nullopt, py::arg("program_config"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false, py::arg("core_coord").noconvert() = std::nullopt, py::arg("input_b_is_batched").noconvert() = true, R"doc(
             Perform a batched matmul ``arg0 x arg1`` with two tensors, where batch dims match.
 
             Both input tensors must have BFLOAT16 data type.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -47,8 +47,16 @@ namespace tt::tt_metal::detail
             +-------------------------------+-------------------------------------------------------+-----------+-------------+----------+
         )doc");
         // *** matrix multiplication ***
-        m_tensor.def("matmul", &tt::operations::primary::matmul,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("bias").noconvert() = std::nullopt, py::arg("program_config"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false, py::arg("core_coord").noconvert() = std::nullopt, py::arg("input_b_is_batched").noconvert() = false, R"doc(
+        m_tensor.def(
+		"matmul",
+        [](const Tensor& input_a,
+           const Tensor& input_b,
+           const MemoryConfig& output_mem_config,
+           std::optional<const DeviceComputeKernelConfig> kernel_config,
+           const bool untilize_out) {
+		return tt::operations::primary::matmul(input_a, input_b, std::nullopt /*bias*/, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config, std::nullopt /*output_dtype*/, kernel_config, untilize_out);
+		},
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false, R"doc(
             Perform a non-batched matrix multiplication ``arg0 x arg1`` with two tensors.
 
             Both input tensors must have BFLOAT16 data type.
@@ -63,8 +71,15 @@ namespace tt::tt_metal::detail
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("bmm", &tt::operations::primary::matmul,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("bias").noconvert() = std::nullopt, py::arg("program_config"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false, py::arg("core_coord").noconvert() = std::nullopt, py::arg("input_b_is_batched").noconvert() = true, R"doc(
+        m_tensor.def("bmm",
+        [](const Tensor& input_a,
+           const Tensor& input_b,
+           const MemoryConfig& output_mem_config,
+           std::optional<const DeviceComputeKernelConfig> kernel_config,
+           const bool untilize_out) {
+		return tt::operations::primary::matmul(input_a, input_b, std::nullopt /*bias*/, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config, std::nullopt /*output_dtype*/, kernel_config, untilize_out, std::nullopt /*user_core_coord*/, true /*input_b_is_batched*/);
+		},
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false,  R"doc(
             Perform a batched matmul ``arg0 x arg1`` with two tensors, where batch dims match.
 
             Both input tensors must have BFLOAT16 data type.

--- a/ttnn/cpp/pybind11/operations/matmul.hpp
+++ b/ttnn/cpp/pybind11/operations/matmul.hpp
@@ -25,7 +25,7 @@ void py_module(py::module& module) {
            const std::optional<const DataType> dtype = std::nullopt,
            const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::matmul::matmul(
-                input_tensor_a, input_tensor_b, memory_config, dtype, compute_kernel_config);
+                input_tensor_a, input_tensor_b, MatmulDefaultProgramConfig{}, memory_config, dtype, compute_kernel_config);
         },
         py::arg("input_tensor_a"),
         py::arg("input_tensor_b"),
@@ -71,6 +71,7 @@ void py_module(py::module& module) {
                 input_tensor_a,
                 input_tensor_b,
                 bias,
+                ttnn::MatmulDefaultProgramConfig{},
                 memory_config,
                 dtype,
                 activation,
@@ -101,7 +102,9 @@ void py_module(py::module& module) {
                 program_config,
                 memory_config,
                 dtype,
-                compute_kernel_config);
+		std::nullopt /*activation*/,
+                compute_kernel_config,
+		std::nullopt);
         },
         py::arg("input_tensor_a"),
         py::arg("input_tensor_b"),


### PR DESCRIPTION
Streamlines matmul methods

Had to keep an autoformat path for tt_eager/tt_dnn/op_library/composite/composite_ops.cpp outer(). The reason is that this path takes tensors of shapes [1,1,m,1] and [1,1,1,n], which require special off-device handling.

Testing:
Before outer() related change, not using outer():
https://github.com/tenstorrent/tt-metal/actions/runs/8953087050 Model perf regressions and output report
https://github.com/tenstorrent/tt-metal/actions/runs/8951164513 Device perf regressions and output report
https://github.com/tenstorrent/tt-metal/actions/runs/8951165958 metal - Run microbenchmarks
Includes outer() related change: 
https://github.com/tenstorrent/tt-metal/actions/runs/8970323165 All post-commit tests
python tests/ttnn/sweep_tests/run_sweeps.py --include matmul_default
python tests/ttnn/sweep_tests/run_sweeps.py --include matmul_default_sharded
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py
