### PR TITLE
#6684: Fix ttnn nextafter

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/nextafter.py
+++ b/tests/ttnn/sweep_tests/sweeps/nextafter.py
@@ -16,14 +16,24 @@ parameters = {
     "batch_sizes": [(1, 2)],
     "height": [384, 1024],
     "width": [1024, 4096],
-    "input_dtype": [ttnn.bfloat16],
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
     "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
-    "layout": [ttnn.TILE_LAYOUT],
+    "layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
 }
 
 
-def skip(**_) -> Tuple[bool, Optional[str]]:
+def skip(
+    batch_sizes,
+    height,
+    width,
+    input_dtype,
+    input_memory_config,
+    output_memory_config,
+    layout,
+) -> Tuple[bool, Optional[str]]:
+    if input_dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True, "Skipped as BFLOAT8_B not supported"
     return False, None
 
 

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -763,19 +763,20 @@ Tensor repeat_interleave(const Tensor& input_a, uint32_t repeat, int32_t dim, co
 // nextafter
 Tensor _nextafter(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {
     const float eps = input_a.device()->sfpu_eps();
+    Tensor t_eps = full(input_a.get_legacy_shape(), eps, DataType::BFLOAT16, input_a.get_layout(), input_a.device());
     Tensor result(input_a);
     {
         Tensor eps_gt(input_a);
         {
             eps_gt = where(
                 gt(input_a, input_b, std::nullopt, output_mem_config),
-                add_unary(input_a, eps, output_mem_config),
+                add(input_a, t_eps, std::nullopt, output_mem_config),
                 input_a,
                 output_mem_config);
         }
         result = where(
             lt(input_a, input_b, std::nullopt, output_mem_config),
-            sub_unary(input_a, eps, output_mem_config),
+            sub(input_a, t_eps, std::nullopt, output_mem_config),
             eps_gt,
             output_mem_config);
     }

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -547,7 +547,7 @@ def _nextafter_validate_input_tensors(operation_name, input_tensor_a, input_tens
         input_tensor_a,
         ranks=(4,),
         dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
-        layouts=(ttnn.TILE_LAYOUT,),
+        layouts=(ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
         can_be_on_device=True,
         can_be_on_cpu=False,
     )
@@ -556,7 +556,7 @@ def _nextafter_validate_input_tensors(operation_name, input_tensor_a, input_tens
         input_tensor_b,
         ranks=(4,),
         dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
-        layouts=(ttnn.TILE_LAYOUT,),
+        layouts=(ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
         can_be_on_device=True,
         can_be_on_cpu=False,
         can_be_a_scalar=False,


### PR DESCRIPTION
Fix Issue #6684 

Broken Unit Test : `pytest tests/ttnn/python_api_testing/non_working_unit_tests/grayskull/test_nextafter.py`
Result : 
<img width="1512" alt="Screenshot 2024-05-03 at 10 40 26 AM" src="https://github.com/tenstorrent/tt-metal/assets/156493059/a5485d66-f1f9-4afb-ab03-3dbbc9ec782b">

Sweep Test Result:
[nextafter.csv](https://github.com/tenstorrent/tt-metal/files/15196392/nextafter.csv)

All Post commit test : https://github.com/tenstorrent/tt-metal/actions/runs/8934410810