### PR TITLE
#8042: Fix ttnn multi-device all_gather for 8-devices

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -338,7 +338,7 @@ def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
 
     device_mesh = ttnn.open_device_mesh(ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested])
 
-    logger.info(f"multidevice with {device_mesh.get_num_devices()} devices is created")
+    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
     yield device_mesh
 
     ttnn.close_device_mesh(device_mesh)
@@ -362,7 +362,31 @@ def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
         ttnn.DeviceGrid(1, num_pcie_devices_requested), device_ids[:num_pcie_devices_requested]
     )
 
-    logger.info(f"multidevice with {device_mesh.get_num_devices()} devices is created")
+    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
+    yield device_mesh
+
+    ttnn.close_device_mesh(device_mesh)
+    del device_mesh
+
+
+@pytest.fixture(scope="function")
+def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
+    import ttnn
+
+    if ttnn.get_num_devices() < 8:
+        pytest.skip()
+    device_ids = [0, 7, 6, 1, 2, 5, 4, 3]
+    try:
+        num_devices_requested = min(request.param, len(device_ids))
+    except (ValueError, AttributeError):
+        num_devices_requested = len(device_ids)
+
+    if num_devices_requested <= 1:
+        pytest.skip("Requires multiple devices to run")
+
+    device_mesh = ttnn.open_device_mesh(ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested])
+
+    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
     yield device_mesh
 
     ttnn.close_device_mesh(device_mesh)

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -50,8 +50,9 @@ Tensor::Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, L
                 this->tensor_attributes->tensor_populated = {true};
             } else if constexpr (std::is_same_v<StorageType, MultiDeviceStorage>) {
                 workers.reserve(storage.buffers.size());
-                for (const auto& device_buf_pair : storage.buffers) {
-                    auto [device_id, buffer] = device_buf_pair;
+                for (int i = 0; i < storage.ordered_device_ids.size(); i++) {
+                    auto device_id = storage.ordered_device_ids[i];
+                    auto buffer = storage.buffers.at(device_id);
                     TT_ASSERT(buffer->device() != nullptr);
                     TT_ASSERT(buffer->device()->id() == device_id);
                     tensor_impl::validate_on_device_dtype_and_layout(buffer->device(), shape.value(), dtype, layout);
@@ -301,9 +302,9 @@ std::vector<Device*> Tensor::get_workers(bool blocking) const {
                 // Not populated - sync.
                 this->wait_for_tensor_data_populated();
                 workers.reserve(storage.buffers.size());
-                for (auto& device_buf_pair : storage.buffers) {
-                    // Already populated.
-                    workers.push_back(device_buf_pair.second->device());
+                for (int i = 0; i < storage.ordered_device_ids.size(); ++i) {
+                    auto device_id = storage.ordered_device_ids[i];
+                    workers.push_back(storage.buffers[device_id]->device());
                 }
             } else {
                 workers = this->workers;
@@ -414,14 +415,15 @@ Tensor Tensor::to(const std::vector<Device*>& workers, const MemoryConfig &mem_c
     uint32_t device_tensor_ref_count = device_tensor.tensor_attributes->record_main_thread_ref_count();
     uint32_t original_tensor_ref_count = this->tensor_attributes->record_main_thread_ref_count();
     uint32_t num_workers = workers_to_use.size();
-    for (auto& worker : workers_to_use) {
+    for (int worker_index = 0; worker_index < workers_to_use.size(); ++worker_index) {
+        auto& worker = workers_to_use[worker_index];
         worker->push_work(
-            [worker, *this, device_tensor, mem_config, num_workers] () mutable {
-                auto shard = get_shard_for_device(*this, worker);
+            [worker, *this, device_tensor, mem_config, num_workers, worker_index] () mutable {
+                auto shard = get_shard_for_device(*this, worker, worker_index);
                 if (shard.storage_type() == StorageType::OWNED) {
                     shard = tensor_impl::to_device_wrapper(shard, worker, mem_config);
                 }
-                insert_buffer_and_shape_for_device(worker, shard, device_tensor);
+                insert_buffer_and_shape_for_device(worker, shard, device_tensor, worker_index);
                 if (not worker->id()) {
                     device_tensor.set_shape(this->get_shape());
                     device_tensor.set_dtype(this->get_dtype());
@@ -448,12 +450,13 @@ Tensor Tensor::cpu(bool blocking) const {
     TT_FATAL(validate_worker_modes(workers), "All device threads/workers must be running in the same mode (ASYNC or SYNC)");
     Tensor host_tensor({}, workers.size());
     uint32_t original_tensor_ref_count = this->tensor_attributes->record_main_thread_ref_count();
-    for (auto target_device : workers) {
-        target_device->push_work([host_tensor, blocking, target_device, *this, workers] () mutable {
+    for (int worker_index = 0; worker_index < workers.size(); worker_index++) {
+        auto target_device = workers[worker_index];
+        target_device->push_work([host_tensor, blocking, target_device, *this, workers, worker_index] () mutable {
             TT_ASSERT(this->storage_type() == StorageType::DEVICE or this->storage_type() == StorageType::MULTI_DEVICE, "Can only use worker queue for cpu call if tensor is on device.");
             auto shard = get_shard_for_device(*this, target_device);
             shard = tensor_impl::to_host_wrapper(shard, blocking);
-            insert_buffer_and_shape_for_device(target_device, shard, host_tensor);
+            insert_buffer_and_shape_for_device(target_device, shard, host_tensor, worker_index);
             if (not target_device->id() or workers.size() == 1) {
                 host_tensor.set_shape(this->get_shape());
                 host_tensor.set_dtype(this->get_dtype());
@@ -634,8 +637,9 @@ bool Tensor::is_allocated() const {
             }
             else if constexpr (std::is_same_v<T, MultiDeviceStorage>) {
                 bool is_allocated = true;
-                for (const auto& device_buf_pair : storage.buffers) {
-                    auto buffer = device_buf_pair.second;
+                for (int i = 0; i < storage.ordered_device_ids.size(); ++i) {
+                    auto device_id = storage.ordered_device_ids[i];
+                    const auto& buffer = storage.buffers.at(device_id);
                     is_allocated &= bool(buffer) and buffer->size() > 0;
                 }
                 return is_allocated;

--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -123,6 +123,9 @@ struct Tensor {
                 this->tensor_attributes->storage = DeviceStorage();
             } else if (workers.size() > 1) {
                 this->tensor_attributes->storage = MultiDeviceStorage();
+                std::transform(workers.cbegin(), workers.cend(),
+                    std::back_inserter(std::get<MultiDeviceStorage>(this->tensor_attributes->storage).ordered_device_ids),
+                    [](const Device* worker) { return worker->id(); });
             }
             this->tensor_attributes->tensor_populated = std::vector<bool>(workers.size(), false);
         } else if (num_buffers) {

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -386,13 +386,14 @@ inline Tensor to_host(const Tensor& tensor, bool blocking = true) {
     } else if (tensor.storage_type() == StorageType::MULTI_DEVICE) {
         auto devices = get_devices(tensor);
         Tensor host_tensor({}, devices.size());
-        for (const auto& device : devices) {
+        for (int device_index = 0; device_index < devices.size(); ++device_index) {
+            const auto& device = devices[device_index];
             auto shard = get_shard_for_device(tensor, device);
             shard = to_host_helper<T>(shard, blocking);
             host_tensor.set_shape(tensor.get_shape());
             host_tensor.set_dtype(tensor.get_dtype());
             host_tensor.set_layout(tensor.get_layout());
-            insert_buffer_and_shape_for_device(device, shard, host_tensor);
+            insert_buffer_and_shape_for_device(device, shard, host_tensor, device_index);
             host_tensor.set_populated(device);
         }
         return host_tensor;

--- a/tt_eager/tensor/tensor_utils.hpp
+++ b/tt_eager/tensor/tensor_utils.hpp
@@ -78,9 +78,9 @@ std::vector<Device*> get_devices(const Tensor& multi_device_tensor);
 
 uint32_t num_buffers_in_tensor(const Tensor& tensor);
 
-Tensor get_shard_for_device(const Tensor& tensor, Device* target_device);
+Tensor get_shard_for_device(const Tensor& tensor, Device* target_device, std::optional<int> buffer_index = std::nullopt);
 
-void insert_buffer_and_shape_for_device(Device* target_device, const Tensor& shard, Tensor& tensor_to_modify);
+void insert_buffer_and_shape_for_device(Device* target_device, const Tensor& shard, Tensor& tensor_to_modify, std::optional<int> buffer_index = std::nullopt);
 
 Tensor copy_borrowed_tensor_in_async_mode(Device* worker, const Tensor& tensor);
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -198,6 +198,7 @@ from ttnn.multi_device import (
     open_device_mesh,
     close_device_mesh,
     get_num_pcie_devices,
+    get_num_devices,
     get_pcie_device_ids,
     get_device_ids,
     create_device_mesh,

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -263,8 +263,7 @@ def from_torch(
             raise RuntimeError("device must be specified when memory_config is specified")
 
     if mesh_mapper:
-        device_id_to_shard_ranges = mesh_mapper.map(tensor)
-        shards = list(device_id_to_shard_ranges.values())
+        shards = mesh_mapper.map(tensor)
         tensor = ttl.tensor.Tensor(shards, dtype, mesh_mapper.config())
     else:
         tensor = ttl.tensor.Tensor(tensor, dtype)


### PR DESCRIPTION
- fix "Device 5 is not connected to device 6" device-connectivity
- fix non-deterministic traversal of multi-device storage buffers
- add ttnn.all_gather for 8-devices to multi-chip unit test