### PR TITLE
#6491: Support fp32 dest acc en moreh softmax

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_logsoftmax.py
@@ -9,7 +9,6 @@ import pytest
 from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
 import torch.nn.functional as F
-import ttnn
 from models.utility_functions import is_wormhole_b0
 
 compute_kernel_options = [
@@ -25,16 +24,16 @@ def get_compute_kernel_options(compute_kernel_options):
     if is_wormhole_b0():
         fp32_dest_acc_en = compute_kernel_options
         packer_l1_acc = False
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4,
+        compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
             math_approx_mode=False,
             fp32_dest_acc_en=fp32_dest_acc_en,
             packer_l1_acc=packer_l1_acc,
         )
     else:
         # Grayskull doesn't support fp32 but test passing a GS config is ok
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4,
+        compute_kernel_config = ttl.tensor.GrayskullComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
             math_approx_mode=True,
         )
     return compute_kernel_config

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
@@ -9,6 +9,36 @@ import pytest
 from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
 
+import ttnn
+from models.utility_functions import is_wormhole_b0
+
+compute_kernel_options = [
+    False,  # for grayskull
+]
+compute_kernel_ids = ["fp32_dest_acc_en=False"]
+if is_wormhole_b0:
+    compute_kernel_options.append(True)
+    compute_kernel_ids.append("fp32_dest_acc_en=True")
+
+
+def get_compute_kernel_options(compute_kernel_options):
+    if is_wormhole_b0():
+        fp32_dest_acc_en = compute_kernel_options
+        packer_l1_acc = False
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            packer_l1_acc=packer_l1_acc,
+        )
+    else:
+        # Grayskull doesn't support fp32 but test passing a GS config is ok
+        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=True,
+        )
+    return compute_kernel_config
+
 
 @pytest.mark.parametrize(
     "shape_dim",
@@ -23,18 +53,21 @@ from loguru import logger
         ((10, 20, 32 * 3, 32 * 5), 2),  # multiple tiles per core
     ),
 )
-def test_softmax_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmax_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
 
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     tt_cpu = torch.softmax(x, dim)
-    tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dim)
+    tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
@@ -52,11 +85,14 @@ def test_softmax_for_dim_hw(shape_dim, device):
         ((2, 3, 32 * 4, 32 * 5), 2),
     ),
 )
-def test_softmax_large_algorithm_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmax_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
 
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
@@ -69,7 +105,9 @@ def test_softmax_large_algorithm_for_dim_hw(shape_dim, device):
         if dim == 3
         else ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_H
     )
-    tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dim, None, strategy)
+    tt_npu = ttl.operations.primary.moreh_softmax(
+        dev_x, dim, None, strategy, compute_kernel_config=compute_kernel_config
+    )
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
@@ -89,10 +127,13 @@ def test_softmax_large_algorithm_for_dim_hw(shape_dim, device):
         ((1, 1, 32 * 2 + 10, 32), 2),  # mutiple tile with dim
     ),
 )
-def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
@@ -104,7 +145,7 @@ def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
     )
 
     tt_cpu = torch.softmax(x, dim)
-    tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dim)
+    tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
@@ -127,10 +168,13 @@ def test_softmax_not_multiple_of_32_for_dim_hw(shape_dim, device):
         ((15, 109, 32 * 2, 32 * 2), 0),  # mutiple tiles per cores
     ),
 )
-def test_softmax_for_dim_nc(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmax_for_dim_nc(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
@@ -139,7 +183,7 @@ def test_softmax_for_dim_nc(shape_dim, device):
     )
 
     tt_cpu = torch.softmax(x, dim)
-    tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dim)
+    tt_npu = ttl.operations.primary.moreh_softmax(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
@@ -164,10 +208,13 @@ def test_softmax_for_dim_nc(shape_dim, device):
         ((10, 20, 32 * 3, 32 * 5), 2),  # multiple tiles per core
     ),
 )
-def test_softmax_backward_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmax_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
@@ -178,7 +225,9 @@ def test_softmax_backward_for_dim_hw(shape_dim, device):
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
-    tt_npu = ttl.operations.primary.moreh_softmax_backward(dev_y, dev_dy, dim)
+    tt_npu = ttl.operations.primary.moreh_softmax_backward(
+        dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
+    )
 
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
@@ -196,10 +245,13 @@ def test_softmax_backward_for_dim_hw(shape_dim, device):
         ((2, 3, 32 * 4, 32 * 5), 2),
     ),
 )
-def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
@@ -216,7 +268,9 @@ def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, device):
         if dim == 3
         else ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_H
     )
-    tt_npu = ttl.operations.primary.moreh_softmax_backward(dev_y, dev_dy, dim, None, strategy)
+    tt_npu = ttl.operations.primary.moreh_softmax_backward(
+        dev_y, dev_dy, dim, None, strategy, compute_kernel_config=compute_kernel_config
+    )
 
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
@@ -236,10 +290,13 @@ def test_softmax_backward_large_algorithmfor_dim_hw(shape_dim, device):
         ((1, 1, 32 * 2 + 10, 32), 2),  # mutiple tile with dim
     ),
 )
-def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
@@ -260,7 +317,9 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
     )
 
     y.backward(dy)
-    tt_npu = ttl.operations.primary.moreh_softmax_backward(dev_y, dev_dy, dim)
+    tt_npu = ttl.operations.primary.moreh_softmax_backward(
+        dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
+    )
     tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
@@ -283,10 +342,13 @@ def test_softmax_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
         ((15, 109, 32 * 2, 32 * 2), 0),  # mutiple tiles per cores
     ),
 )
-def test_softmax_backward_for_dim_nc(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmax_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
@@ -297,7 +359,9 @@ def test_softmax_backward_for_dim_nc(shape_dim, device):
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
-    tt_npu = ttl.operations.primary.moreh_softmax_backward(dev_y, dev_dy, dim)
+    tt_npu = ttl.operations.primary.moreh_softmax_backward(
+        dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
+    )
     tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR)
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmax.py
@@ -8,8 +8,6 @@ import tt_lib as ttl
 import pytest
 from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
-
-import ttnn
 from models.utility_functions import is_wormhole_b0
 
 compute_kernel_options = [
@@ -25,16 +23,16 @@ def get_compute_kernel_options(compute_kernel_options):
     if is_wormhole_b0():
         fp32_dest_acc_en = compute_kernel_options
         packer_l1_acc = False
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4,
+        compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
             math_approx_mode=False,
             fp32_dest_acc_en=fp32_dest_acc_en,
             packer_l1_acc=packer_l1_acc,
         )
     else:
         # Grayskull doesn't support fp32 but test passing a GS config is ok
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4,
+        compute_kernel_config = ttl.tensor.GrayskullComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
             math_approx_mode=True,
         )
     return compute_kernel_config

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
@@ -9,8 +9,6 @@ import pytest
 from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
 import torch.nn.functional as F
-
-import ttnn
 from models.utility_functions import is_wormhole_b0
 
 compute_kernel_options = [
@@ -26,16 +24,16 @@ def get_compute_kernel_options(compute_kernel_options):
     if is_wormhole_b0():
         fp32_dest_acc_en = compute_kernel_options
         packer_l1_acc = False
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4,
+        compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
             math_approx_mode=False,
             fp32_dest_acc_en=fp32_dest_acc_en,
             packer_l1_acc=packer_l1_acc,
         )
     else:
         # Grayskull doesn't support fp32 but test passing a GS config is ok
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4,
+        compute_kernel_config = ttl.tensor.GrayskullComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
             math_approx_mode=True,
         )
     return compute_kernel_config

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_softmin.py
@@ -10,6 +10,36 @@ from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
 import torch.nn.functional as F
 
+import ttnn
+from models.utility_functions import is_wormhole_b0
+
+compute_kernel_options = [
+    False,  # for grayskull
+]
+compute_kernel_ids = ["fp32_dest_acc_en=False"]
+if is_wormhole_b0:
+    compute_kernel_options.append(True)
+    compute_kernel_ids.append("fp32_dest_acc_en=True")
+
+
+def get_compute_kernel_options(compute_kernel_options):
+    if is_wormhole_b0():
+        fp32_dest_acc_en = compute_kernel_options
+        packer_l1_acc = False
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            packer_l1_acc=packer_l1_acc,
+        )
+    else:
+        # Grayskull doesn't support fp32 but test passing a GS config is ok
+        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=True,
+        )
+    return compute_kernel_config
+
 
 @pytest.mark.parametrize(
     "shape_dim",
@@ -24,18 +54,21 @@ import torch.nn.functional as F
         ((10, 20, 32 * 3, 32 * 5), 2),  # multiple tiles per core
     ),
 )
-def test_softmin_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
 
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
     dev_x = ttl.tensor.Tensor(x, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     tt_cpu = F.softmin(x, dim)
-    tt_npu = ttl.operations.primary.moreh_softmin(dev_x, dim)
+    tt_npu = ttl.operations.primary.moreh_softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
@@ -53,11 +86,14 @@ def test_softmin_for_dim_hw(shape_dim, device):
         ((2, 3, 32 * 4, 32 * 5), 2),
     ),
 )
-def test_softmin_large_algorithm_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_large_algorithm_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
 
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
@@ -69,7 +105,9 @@ def test_softmin_large_algorithm_for_dim_hw(shape_dim, device):
         if dim == 3
         else ttl.operations.primary.MorehSoftmaxOpParallelizationStrategy.LARGE_H
     )
-    tt_npu = ttl.operations.primary.moreh_softmin(dev_x, dim, None, strategy)
+    tt_npu = ttl.operations.primary.moreh_softmin(
+        dev_x, dim, None, strategy, compute_kernel_config=compute_kernel_config
+    )
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
     tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
@@ -89,10 +127,13 @@ def test_softmin_large_algorithm_for_dim_hw(shape_dim, device):
         ((1, 1, 32 * 2 + 10, 32), 2),  # mutiple tile with dim
     ),
 )
-def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
@@ -104,7 +145,7 @@ def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, device):
     )
 
     tt_cpu = F.softmin(x, dim)
-    tt_npu = ttl.operations.primary.moreh_softmin(dev_x, dim)
+    tt_npu = ttl.operations.primary.moreh_softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
@@ -127,10 +168,13 @@ def test_softmin_not_multiple_of_32_for_dim_hw(shape_dim, device):
         ((15, 109, 32 * 2, 32 * 2), 0),  # mutiple tiles per cores
     ),
 )
-def test_softmin_for_dim_nc(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_for_dim_nc(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16)
 
@@ -139,7 +183,7 @@ def test_softmin_for_dim_nc(shape_dim, device):
     )
 
     tt_cpu = F.softmin(x, dim)
-    tt_npu = ttl.operations.primary.moreh_softmin(dev_x, dim)
+    tt_npu = ttl.operations.primary.moreh_softmin(dev_x, dim, compute_kernel_config=compute_kernel_config)
     tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
@@ -164,10 +208,13 @@ def test_softmin_for_dim_nc(shape_dim, device):
         ((10, 20, 32 * 3, 32 * 5), 2),  # multiple tiles per core
     ),
 )
-def test_softmin_backward_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_backward_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
@@ -178,7 +225,9 @@ def test_softmin_backward_for_dim_hw(shape_dim, device):
     dev_dy = ttl.tensor.Tensor(dy, ttl.tensor.DataType.BFLOAT16).to(ttl.tensor.Layout.TILE).to(device)
 
     y.backward(dy)
-    tt_npu = ttl.operations.primary.moreh_softmin_backward(dev_y, dev_dy, dim)
+    tt_npu = ttl.operations.primary.moreh_softmin_backward(
+        dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
+    )
 
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
@@ -196,10 +245,13 @@ def test_softmin_backward_for_dim_hw(shape_dim, device):
         ((2, 3, 32 * 4, 32 * 5), 2),
     ),
 )
-def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
@@ -215,7 +267,9 @@ def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, device):
         if dim == 3
         else ttl.operations.primary.MorehSoftmaxBackwardOpParallelizationStrategy.LARGE_H
     )
-    tt_npu = ttl.operations.primary.moreh_softmin_backward(dev_y, dev_dy, dim, None, strategy)
+    tt_npu = ttl.operations.primary.moreh_softmin_backward(
+        dev_y, dev_dy, dim, None, strategy, compute_kernel_config=compute_kernel_config
+    )
 
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch().to(torch.bfloat16)
@@ -235,10 +289,13 @@ def test_softmin_backward_large_algorithmfor_dim_hw(shape_dim, device):
         ((1, 1, 32 * 2 + 10, 32), 2),  # mutiple tile with dim
     ),
 )
-def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
@@ -259,7 +316,9 @@ def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
     )
 
     y.backward(dy)
-    tt_npu = ttl.operations.primary.moreh_softmin_backward(dev_y, dev_dy, dim)
+    tt_npu = ttl.operations.primary.moreh_softmin_backward(
+        dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
+    )
     tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
 
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
@@ -282,10 +341,13 @@ def test_softmin_backward_not_multiple_of_32_for_dim_hw(shape_dim, device):
         ((15, 109, 32 * 2, 32 * 2), 0),  # mutiple tiles per cores
     ),
 )
-def test_softmin_backward_for_dim_nc(shape_dim, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_softmin_backward_for_dim_nc(shape_dim, compute_kernel_options, device):
     device.enable_program_cache()
     shape, dim = shape_dim
     torch.manual_seed(0)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     x = torch.randint(low=0, high=4, size=shape).to(torch.bfloat16).requires_grad_(True)
 
@@ -306,7 +368,9 @@ def test_softmin_backward_for_dim_nc(shape_dim, device):
     )
 
     y.backward(dy)
-    tt_npu = ttl.operations.primary.moreh_softmin_backward(dev_y, dev_dy, dim)
+    tt_npu = ttl.operations.primary.moreh_softmin_backward(
+        dev_y, dev_dy, dim, compute_kernel_config=compute_kernel_config
+    )
     tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape)
     assert list(tt_npu.get_legacy_shape()) == list(x.grad.shape)
     tt_dev = tt_npu.cpu().to_torch().to(torch.bfloat16)

--- a/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
@@ -68,13 +68,6 @@ ALWI void mul_tiles_init_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
     mul_tiles_init(icb0, icb1);
 }
 
-ALWI void mask_tile_init_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
-    #if defined FP32_DEST_ACC_EN
-        unpack_reconfig_data_format(icb0, icb1);
-    #endif
-    mask_tile_init();
-}
-
 class ArgFetcher {
    private:
     int arg_idx = 0;
@@ -180,7 +173,7 @@ ALWI void mul_tiles_and_mask_tile_to_cb(
     copy_tile_init_with_dt(maskcb);
     copy_tile(maskcb, mtile, dst_mask);
 
-    mask_tile_init_with_dt(dst0, dst_mask);
+    mask_tile_init();
     mask_tile(dst0, dst_mask);
     tile_regs_commit();
 
@@ -214,7 +207,7 @@ ALWI void mul_tiles_log_to_cb(
     cb_wait_front(icb1, itile1 + 1);
 
     tile_regs_acquire();
-    mul_tiles_init();
+    mul_tiles_init_with_dt(icb0, icb1);
     mul_tiles(icb0, icb1, itile0, itile1, dst0);
 
     log_tile_init();
@@ -222,7 +215,7 @@ ALWI void mul_tiles_log_to_cb(
     tile_regs_commit();
 
     tile_regs_wait();
-    pack_tile(dst0, ocb);
+    pack_tile_with_dt(dst0, ocb);
     tile_regs_release();
 
     if (pop0)
@@ -286,6 +279,9 @@ ALWI void mul_tiles_bcast_rows_log_to_cb(
     cb_wait_front(icb1, itile1 + 1);
 
     tile_regs_acquire();
+    #if defined FP32_DEST_ACC_EN
+        unpack_reconfig_data_format(icb0, icb1);
+    #endif
     mul_bcast_rows_init_short();
     mul_tiles_bcast_rows(icb0, icb1, itile0, itile1, dst0);
 
@@ -294,7 +290,7 @@ ALWI void mul_tiles_bcast_rows_log_to_cb(
     tile_regs_commit();
 
     tile_regs_wait();
-    pack_tile(dst0, ocb);
+    pack_tile_with_dt(dst0, ocb);
     tile_regs_release();
 
     if (pop0)
@@ -358,6 +354,9 @@ ALWI void mul_tiles_bcast_cols_log_to_cb(
     cb_wait_front(icb1, itile1 + 1);
 
     tile_regs_acquire();
+    #if defined FP32_DEST_ACC_EN
+        unpack_reconfig_data_format(icb0, icb1);
+    #endif
     mul_bcast_cols_init_short();
     mul_tiles_bcast_cols(icb0, icb1, itile0, itile1, dst0);
 
@@ -366,7 +365,7 @@ ALWI void mul_tiles_bcast_cols_log_to_cb(
     tile_regs_commit();
 
     tile_regs_wait();
-    pack_tile(dst0, ocb);
+    pack_tile_with_dt(dst0, ocb);
     tile_regs_release();
 
     if (pop0)
@@ -446,7 +445,7 @@ ALWI void mask_tile_to_cb(uint32_t icb, uint32_t maskcb, uint32_t ocb, uint32_t 
     copy_tile_init_with_dt(maskcb);
     copy_tile(maskcb, mtile, dst_mask);
 
-    mask_tile_init_with_dt(icb, maskcb);
+    mask_tile_init();
     mask_tile(dst0, dst_mask);
 
     tile_regs_commit();
@@ -654,7 +653,7 @@ ALWI void rexp_tile_to_cb(uint32_t icb, uint32_t ocb, uint32_t itile = 0, uint32
     tile_regs_commit();
 
     tile_regs_wait();
-    pack_tile(dst, ocb);
+    pack_tile_with_dt(dst, ocb);
     tile_regs_release();
 
     if (pop)
@@ -691,7 +690,7 @@ ALWI void exp_tile_and_mask_tile_to_cb(
     copy_tile_init_with_dt(maskcb);
     copy_tile(maskcb, mtile, dst_mask);
 
-    mask_tile_init_with_dt(dst, dst_mask);
+    mask_tile_init();
     mask_tile(dst, dst_mask);
     tile_regs_commit();
 
@@ -722,7 +721,7 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
     cb_wait_front(maskcb, mtile + 1);
 
     tile_regs_acquire();
-    copy_tile_init();
+    copy_tile_init_with_dt(icb);
     copy_tile(icb, itile, dst);
 
     if (pop)
@@ -734,7 +733,7 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
     exp_tile_init();
     exp_tile(dst);
 
-    copy_tile_init();
+    copy_tile_init_with_dt(maskcb);
     copy_tile(maskcb, mtile, dst_mask);
 
     mask_tile_init();
@@ -745,7 +744,7 @@ ALWI void rexp_tile_and_mask_tile_to_cb(
         cb_pop_front(maskcb, popm);
 
     tile_regs_wait();
-    pack_tile(dst, ocb);
+    pack_tile_with_dt(dst, ocb);
     tile_regs_release();
 
     cb_push_back(ocb, onetile);

--- a/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
@@ -102,6 +102,8 @@ struct CircularBufferArg {
     CircularBufferArg(uint32_t buffer_index, uint32_t num_tiles) : buffer_index(buffer_index), num_tiles(num_tiles) {
         data_format = tt::DataFormat::Invalid;
     }
+    CircularBufferArg(uint32_t buffer_index, uint32_t num_tiles, tt::DataFormat data_format) : buffer_index(buffer_index), num_tiles(num_tiles), data_format(data_format) {
+    }
 };
 
 [[maybe_unused]] std::vector<CBHandle> CreateCircularBuffer(

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/moreh_softmax_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/moreh_softmax_op.cpp
@@ -62,20 +62,20 @@ operation::ProgramWithCallbacks MorehSoftmax::create_program(const std::vector<T
 
     switch (parallelization_strategy) {
         case MorehSoftmaxOpParallelizationStrategy::SMALL_W:
-            return {moreh_softmax_w_small(input, output, this->core_range, this->op)};
+            return {moreh_softmax_w_small(input, output, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxOpParallelizationStrategy::SMALL_H:
-            return {moreh_softmax_h_small(input, output, this->core_range, this->op)};
+            return {moreh_softmax_h_small(input, output, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxOpParallelizationStrategy::LARGE_W:
-            return {moreh_softmax_w_large(input, output, this->core_range, this->op)};
+            return {moreh_softmax_w_large(input, output, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxOpParallelizationStrategy::LARGE_H:
-            return {moreh_softmax_h_large(input, output, this->core_range, this->op)};
+            return {moreh_softmax_h_large(input, output, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxOpParallelizationStrategy::LARGE_C:
-            return {moreh_softmax_c_large(input, output, this->dim, this->core_range, this->op)};
+            return {moreh_softmax_c_large(input, output, this->dim, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxOpParallelizationStrategy::NONE:
         default: break;
     }
 
-    return {moreh_softmax_h_large(input, output, this->core_range, this->op)};
+    return {moreh_softmax_h_large(input, output, this->core_range, this->op, this->compute_kernel_config)};
 }
 
 MorehSoftmaxOpParallelizationStrategy MorehSoftmax::get_parallelization_strategy(
@@ -138,19 +138,22 @@ Tensor moreh_softmax(
     uint32_t dim,
     std::optional<Tensor> output_tensor,
     const MorehSoftmaxOpParallelizationStrategy strategy,
-    const MemoryConfig &output_mem_config) {
+    const MemoryConfig &output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
 
     auto device = input_tensor.device();
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
     output_tensor = operation::run(
                MorehSoftmax{
                    .dim = dim,
                    .core_range = all_cores,
                    .op = MorehSoftmaxOp::SOFTMAX,
                    .strategy = strategy,
-                   .output_mem_config = output_mem_config},
+                   .output_mem_config = output_mem_config,
+                   .compute_kernel_config = kernel_config_val},
                {input_tensor},
                {},
                {output_tensor}).at(0);
@@ -163,19 +166,22 @@ Tensor moreh_softmin(
     uint32_t dim,
     std::optional<Tensor> output_tensor,
     const MorehSoftmaxOpParallelizationStrategy strategy,
-    const MemoryConfig &output_mem_config) {
+    const MemoryConfig &output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
 
     auto device = input_tensor.device();
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
     output_tensor = operation::run(
                MorehSoftmax{
                    .dim = dim,
                    .core_range = all_cores,
                    .op = MorehSoftmaxOp::SOFTMIN,
                    .strategy = strategy,
-                   .output_mem_config = output_mem_config},
+                   .output_mem_config = output_mem_config,
+                   .compute_kernel_config = kernel_config_val},
                {input_tensor},
                {},
                {output_tensor}).at(0);
@@ -188,19 +194,22 @@ Tensor moreh_logsoftmax(
     uint32_t dim,
     std::optional<Tensor> output_tensor,
     const MorehSoftmaxOpParallelizationStrategy strategy,
-    const MemoryConfig &output_mem_config) {
+    const MemoryConfig &output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
 
     auto device = input_tensor.device();
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
     output_tensor = operation::run(
         MorehSoftmax{
             .dim = dim,
             .core_range = all_cores,
             .op = MorehSoftmaxOp::LOGSOFTMAX,
             .strategy = strategy,
-            .output_mem_config = output_mem_config},
+            .output_mem_config = output_mem_config,
+            .compute_kernel_config = kernel_config_val},
         {input_tensor},
         {},
         {output_tensor}).at(0);

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/moreh_softmax_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/moreh_softmax_op.cpp
@@ -145,7 +145,7 @@ Tensor moreh_softmax(
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
-    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
     output_tensor = operation::run(
                MorehSoftmax{
                    .dim = dim,
@@ -173,7 +173,7 @@ Tensor moreh_softmin(
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
-    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
     output_tensor = operation::run(
                MorehSoftmax{
                    .dim = dim,
@@ -201,7 +201,7 @@ Tensor moreh_logsoftmax(
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
-    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
     output_tensor = operation::run(
         MorehSoftmax{
             .dim = dim,

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/moreh_softmax_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/moreh_softmax_op.hpp
@@ -8,6 +8,7 @@
 
 #include "tt_dnn/op_library/operation.hpp"
 #include "tt_eager/tensor/tensor.hpp"
+#include "tt_dnn/op_library/compute_kernel_config.hpp"
 #include <optional>
 
 namespace tt {
@@ -35,15 +36,15 @@ bool is_moreh_softmax_w_small_available(const Tensor &tensor);
 bool is_moreh_softmax_h_small_available(const Tensor &tensor);
 
 operation::ProgramWithCallbacks moreh_softmax_w_small(
-    const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op);
+    const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op, const DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks moreh_softmax_w_large(
-    const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op);
+    const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op, const DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks moreh_softmax_h_small(
-    const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op);
+    const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op, const DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks moreh_softmax_h_large(
-    const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op);
+    const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op, const DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks moreh_softmax_c_large(
-    const Tensor &input, const Tensor &output, uint32_t dim, const CoreRange core_range, const MorehSoftmaxOp op);
+    const Tensor &input, const Tensor &output, uint32_t dim, const CoreRange core_range, const MorehSoftmaxOp op, const DeviceComputeKernelConfig compute_kernel_config);
 
 struct MorehSoftmax {
     const uint32_t dim;
@@ -51,15 +52,16 @@ struct MorehSoftmax {
     const MorehSoftmaxOp op;
     const MorehSoftmaxOpParallelizationStrategy strategy;
     const MemoryConfig output_mem_config;
+    const DeviceComputeKernelConfig compute_kernel_config;
 
     void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     MorehSoftmaxOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
-    static constexpr auto attribute_names = std::make_tuple("dim", "op", "strategy", "output_mem_config");
+    static constexpr auto attribute_names = std::make_tuple("dim", "op", "strategy", "output_mem_config", "compute_kernel_config");
     const auto attribute_values() const {
-        return std::make_tuple(std::cref(this->dim), std::cref(this->op), std::cref(this->strategy), std::cref(this->output_mem_config));
+        return std::make_tuple(std::cref(this->dim), std::cref(this->op), std::cref(this->strategy), std::cref(this->output_mem_config), std::cref(this->compute_kernel_config));
     }
 };
 
@@ -69,21 +71,24 @@ Tensor moreh_softmax(
     uint32_t dim,
     std::optional<Tensor> output_tensor = std::nullopt,
     const MorehSoftmaxOpParallelizationStrategy strategy = MorehSoftmaxOpParallelizationStrategy::NONE,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 Tensor moreh_softmin(
     const Tensor &input_tensor,
     uint32_t dim,
     std::optional<Tensor> output_tensor = std::nullopt,
     const MorehSoftmaxOpParallelizationStrategy strategy = MorehSoftmaxOpParallelizationStrategy::NONE,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 Tensor moreh_logsoftmax(
     const Tensor &input_tensor,
     uint32_t dim,
     std::optional<Tensor> output_tensor = std::nullopt,
     const MorehSoftmaxOpParallelizationStrategy strategy = MorehSoftmaxOpParallelizationStrategy::NONE,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace primary
 }  // namespace operations

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
@@ -18,7 +18,7 @@ namespace tt {
 namespace operations {
 namespace primary {
 
-operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op) {
+operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op, const DeviceComputeKernelConfig compute_kernel_config) {
     log_info(LogTest, "Large tensor algorithm selected");
     // split work
     auto shape = input.get_legacy_shape();
@@ -35,6 +35,9 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
 
+    auto arch = input.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+
     Program program = Program();
 
     // create circular buffers
@@ -48,9 +51,9 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
             {CB::c_in0, 2},        // input
             {CB::c_in1, 1},        // mask
             {CB::c_out0, 2},       // output
-            {CB::c_intermed0, 2},  // exp(x)
-            {CB::c_intermed1, 1},  // reduce
-            {CB::c_intermed2, 1},  // sum
+            {CB::c_intermed0, 2, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // exp(x)
+            {CB::c_intermed1, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // reduce
+            {CB::c_intermed2, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // sum
             {CB::c_in2, 1}         // scaler
         });
 
@@ -74,6 +77,10 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
         compute_defines["LOG"] = "1";
     }
 
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+
     // create compute kernel
     CreateComputeKernel(
         program,
@@ -82,7 +89,10 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
             {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Ht}},
             {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Ht}},
         },
-        compute_defines);
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
 
     // Set Runtime Args
     auto core_x_offset = core_range.start.x;

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
@@ -40,7 +40,7 @@ bool is_moreh_softmax_h_small_available(const Tensor &tensor) {
     return (L1_UNRESERVED_BASE + cb_usage <= L1_512KB);
 }
 
-operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op) {
+operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op, const DeviceComputeKernelConfig compute_kernel_config) {
     log_info(LogTest, "Small tensor algorithm selected");
     // split work
     auto shape = input.get_legacy_shape();
@@ -58,6 +58,9 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
 
+    auto arch = input.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+
     Program program = Program();
 
     // create circular buffers
@@ -71,8 +74,8 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
             {CB::c_in0, 2},         // input
             {CB::c_in1, 1},         // mask
             {CB::c_out0, 2},        // output
-            {CB::c_intermed0, Ht},  // exp(x)
-            {CB::c_intermed1, 1},   // reduce
+            {CB::c_intermed0, Ht, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // exp(x)
+            {CB::c_intermed1, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // reduce
             {CB::c_in2, 1}          // scaler
         });
 
@@ -96,6 +99,10 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
         compute_defines["LOG"] = "1";
     }
 
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+
     // create compute kernel
     CreateComputeKernel(
         program,
@@ -104,7 +111,10 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
             {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Ht}},
             {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Ht}},
         },
-        compute_defines);
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
 
     // Set Runtime Args
     auto core_x_offset = core_range.start.x;

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
@@ -18,7 +18,7 @@ namespace tt {
 namespace operations {
 namespace primary {
 
-operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op) {
+operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op, const DeviceComputeKernelConfig compute_kernel_config) {
     log_info(LogTest, "Large tensor algorithm selected");
     // split work
     auto shape = input.get_legacy_shape();
@@ -36,6 +36,9 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
 
+    auto arch = input.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+
     Program program = Program();
 
     // create circular buffers
@@ -49,9 +52,9 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
             {CB::c_in0, 2},         // input
             {CB::c_in1, 1},         // mask
             {CB::c_out0, 2},        // output
-            {CB::c_intermed0, 2},   // exp(x)
-            {CB::c_intermed1, 1},   // reduce
-            {CB::c_intermed2, 1},   // syn
+            {CB::c_intermed0, 2, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // exp(x)
+            {CB::c_intermed1, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // reduce
+            {CB::c_intermed2, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // syn
             {CB::c_in2, 1}          // scaler
         });
 
@@ -75,6 +78,10 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
         compute_defines["LOG"] = "1";
     }
 
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+
     // create compute kernel
     CreateComputeKernel(
         program,
@@ -83,7 +90,10 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
             {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Wt}},
             {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Wt}},
         },
-        compute_defines);
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
 
     // Set Runtime Args
     auto core_x_offset = core_range.start.x;

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
@@ -40,7 +40,7 @@ bool is_moreh_softmax_w_small_available(const Tensor &tensor) {
     return (L1_UNRESERVED_BASE + cb_usage <= L1_512KB);
 }
 
-operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op) {
+operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const Tensor &output, const CoreRange core_range, const MorehSoftmaxOp op, const DeviceComputeKernelConfig compute_kernel_config) {
     log_info(LogTest, "Small tensor algorithm selected");
     // split work
     auto shape = input.get_legacy_shape();
@@ -58,6 +58,9 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
 
+    auto arch = input.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+
     Program program = Program();
 
     // create circular buffers
@@ -71,8 +74,8 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
             {CB::c_in0, 2},         // input
             {CB::c_in1, 1},         // mask
             {CB::c_out0, 2},        // output
-            {CB::c_intermed0, Wt},  // exp(x)
-            {CB::c_intermed1, 1},   // reduce
+            {CB::c_intermed0, Wt, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // exp(x)
+            {CB::c_intermed1, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // reduce
             {CB::c_in2, 1}          // scaler
         });
 
@@ -96,6 +99,10 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
         compute_defines["LOG"] = "1";
     }
 
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+
     // create compute kernel
     CreateComputeKernel(
         program,
@@ -104,7 +111,10 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
             {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Wt}},
             {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Wt}},
         },
-        compute_defines);
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
 
     // Set Runtime Args
     auto core_x_offset = core_range.start.x;

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
@@ -68,21 +68,21 @@ operation::ProgramWithCallbacks MorehSoftmaxBackward::create_program(
 
     switch (parallelization_strategy) {
         case MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_W:
-            return {moreh_softmax_backward_w_small(output, output_grad, input_grad, this->core_range, this->op)};
+            return {moreh_softmax_backward_w_small(output, output_grad, input_grad, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxBackwardOpParallelizationStrategy::SMALL_H:
-            return {moreh_softmax_backward_h_small(output, output_grad, input_grad, this->core_range, this->op)};
+            return {moreh_softmax_backward_h_small(output, output_grad, input_grad, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_W:
-            return {moreh_softmax_backward_w_large(output, output_grad, input_grad, this->core_range, this->op)};
+            return {moreh_softmax_backward_w_large(output, output_grad, input_grad, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_H:
-            return {moreh_softmax_backward_h_large(output, output_grad, input_grad, this->core_range, this->op)};
+            return {moreh_softmax_backward_h_large(output, output_grad, input_grad, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxBackwardOpParallelizationStrategy::LARGE_C:
             return {
-                moreh_softmax_backward_c_large(output, output_grad, input_grad, this->dim, this->core_range, this->op)};
+                moreh_softmax_backward_c_large(output, output_grad, input_grad, this->dim, this->core_range, this->op, this->compute_kernel_config)};
         case MorehSoftmaxBackwardOpParallelizationStrategy::NONE:
         default: break;
     }
 
-    return {moreh_softmax_backward_h_large(output, output_grad, input_grad, this->core_range, this->op)};
+    return {moreh_softmax_backward_h_large(output, output_grad, input_grad, this->core_range, this->op, this->compute_kernel_config)};
 }
 
 MorehSoftmaxBackwardOpParallelizationStrategy MorehSoftmaxBackward::get_parallelization_strategy(
@@ -144,19 +144,22 @@ Tensor moreh_softmax_backward(
     uint32_t dim,
     std::optional<Tensor> input_grad_tensor,
     const MorehSoftmaxBackwardOpParallelizationStrategy strategy,
-    const MemoryConfig &output_mem_config) {
+    const MemoryConfig &output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
 
     auto device = output_grad_tensor.device();
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
     input_grad_tensor = operation::run(
                MorehSoftmaxBackward{
                    .dim = dim,
                    .core_range = all_cores,
                    .op = MorehSoftmaxBackwardOp::SOFTMAX,
                    .strategy = strategy,
-                   .output_mem_config = output_mem_config},
+                   .output_mem_config = output_mem_config,
+                   .compute_kernel_config = kernel_config_val},
                {output_tensor, output_grad_tensor},
                {},
                {input_grad_tensor}).at(0);
@@ -170,19 +173,22 @@ Tensor moreh_softmin_backward(
     uint32_t dim,
     std::optional<Tensor> input_grad_tensor,
     const MorehSoftmaxBackwardOpParallelizationStrategy strategy,
-    const MemoryConfig &output_mem_config) {
+    const MemoryConfig &output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
 
     auto device = output_grad_tensor.device();
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
     input_grad_tensor = operation::run(
                MorehSoftmaxBackward{
                    .dim = dim,
                    .core_range = all_cores,
                    .op = MorehSoftmaxBackwardOp::SOFTMIN,
                    .strategy = strategy,
-                   .output_mem_config = output_mem_config},
+                   .output_mem_config = output_mem_config,
+                   .compute_kernel_config = kernel_config_val},
                {output_tensor, output_grad_tensor},
                {},
                {input_grad_tensor}).at(0);
@@ -196,19 +202,22 @@ Tensor moreh_logsoftmax_backward(
     uint32_t dim,
     std::optional<Tensor> input_grad_tensor,
     const MorehSoftmaxBackwardOpParallelizationStrategy strategy,
-    const MemoryConfig &output_mem_config) {
+    const MemoryConfig &output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
 
     auto device = output_grad_tensor.device();
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
     input_grad_tensor = operation::run(
                MorehSoftmaxBackward{
                    .dim = dim,
                    .core_range = all_cores,
                    .op = MorehSoftmaxBackwardOp::LOGSOFTMAX,
                    .strategy = strategy,
-                   .output_mem_config = output_mem_config},
+                   .output_mem_config = output_mem_config,
+                   .compute_kernel_config = kernel_config_val},
                {output_tensor, output_grad_tensor},
                {},
                {input_grad_tensor}).at(0);

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.cpp
@@ -151,7 +151,7 @@ Tensor moreh_softmax_backward(
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
-    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
     input_grad_tensor = operation::run(
                MorehSoftmaxBackward{
                    .dim = dim,
@@ -180,7 +180,7 @@ Tensor moreh_softmin_backward(
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
-    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
     input_grad_tensor = operation::run(
                MorehSoftmaxBackward{
                    .dim = dim,
@@ -209,7 +209,7 @@ Tensor moreh_logsoftmax_backward(
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
-    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config);
+    auto kernel_config_val = init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
     input_grad_tensor = operation::run(
                MorehSoftmaxBackward{
                    .dim = dim,

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/moreh_softmax_backward_op.hpp
@@ -8,6 +8,7 @@
 
 #include "tt_dnn/op_library/operation.hpp"
 #include "tt_eager/tensor/tensor.hpp"
+#include "tt_dnn/op_library/compute_kernel_config.hpp"
 
 namespace tt {
 namespace operations {
@@ -38,32 +39,37 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_small(
     const Tensor &output_grad,
     const Tensor &input_grad,
     const CoreRange core_range,
-    const MorehSoftmaxBackwardOp op);
+    const MorehSoftmaxBackwardOp op,
+    const DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks moreh_softmax_backward_w_large(
     const Tensor &output,
     const Tensor &output_grad,
     const Tensor &input_grad,
     const CoreRange core_range,
-    const MorehSoftmaxBackwardOp op);
+    const MorehSoftmaxBackwardOp op,
+    const DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks moreh_softmax_backward_h_small(
     const Tensor &output,
     const Tensor &output_grad,
     const Tensor &input_grad,
     const CoreRange core_range,
-    const MorehSoftmaxBackwardOp op);
+    const MorehSoftmaxBackwardOp op,
+    const DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks moreh_softmax_backward_h_large(
     const Tensor &output,
     const Tensor &output_grad,
     const Tensor &input_grad,
     const CoreRange core_range,
-    const MorehSoftmaxBackwardOp op);
+    const MorehSoftmaxBackwardOp op,
+    const DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks moreh_softmax_backward_c_large(
     const Tensor &output,
     const Tensor &output_grad,
     const Tensor &input_grad,
     uint32_t dim,
     const CoreRange core_range,
-    const MorehSoftmaxBackwardOp op);
+    const MorehSoftmaxBackwardOp op,
+    const DeviceComputeKernelConfig compute_kernel_config);
 
 struct MorehSoftmaxBackward {
     const uint32_t dim;
@@ -71,6 +77,7 @@ struct MorehSoftmaxBackward {
     const MorehSoftmaxBackwardOp op;
     const MorehSoftmaxBackwardOpParallelizationStrategy strategy;
     const MemoryConfig output_mem_config;
+    const DeviceComputeKernelConfig compute_kernel_config;
 
     void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -79,9 +86,9 @@ struct MorehSoftmaxBackward {
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
     MorehSoftmaxBackwardOpParallelizationStrategy get_parallelization_strategy(
         const std::vector<Tensor> &input_tensors) const;
-    static constexpr auto attribute_names = std::make_tuple("dim");
+    static constexpr auto attribute_names = std::make_tuple("dim", "op", "strategy", "output_mem_config", "compute_kernel_config");
     const auto attribute_values() const {
-        return std::make_tuple(std::cref(this->dim));
+        return std::make_tuple(std::cref(this->dim), std::cref(this->op), std::cref(this->strategy), std::cref(this->output_mem_config), std::cref(this->compute_kernel_config));
     }
 };
 
@@ -92,7 +99,8 @@ Tensor moreh_softmax_backward(
     uint32_t dim,
     std::optional<Tensor> input_grad_tensor = std::nullopt,
     const MorehSoftmaxBackwardOpParallelizationStrategy strategy = MorehSoftmaxBackwardOpParallelizationStrategy::NONE,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 Tensor moreh_softmin_backward(
     const Tensor &output_tensor,
@@ -100,7 +108,8 @@ Tensor moreh_softmin_backward(
     uint32_t dim,
     std::optional<Tensor> input_grad_tensor = std::nullopt,
     const MorehSoftmaxBackwardOpParallelizationStrategy strategy = MorehSoftmaxBackwardOpParallelizationStrategy::NONE,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 Tensor moreh_logsoftmax_backward(
     const Tensor &output_tensor,
@@ -108,7 +117,8 @@ Tensor moreh_logsoftmax_backward(
     uint32_t dim,
     std::optional<Tensor> input_grad_tensor = std::nullopt,
     const MorehSoftmaxBackwardOpParallelizationStrategy strategy = MorehSoftmaxBackwardOpParallelizationStrategy::NONE,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace primary
 }  // namespace operations

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -18,7 +18,7 @@ namespace tt {
 namespace operations {
 namespace primary {
 
-operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &output, const Tensor &output_grad, const Tensor &input_grad, uint32_t dim, const CoreRange core_range, const MorehSoftmaxBackwardOp op) {
+operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &output, const Tensor &output_grad, const Tensor &input_grad, uint32_t dim, const CoreRange core_range, const MorehSoftmaxBackwardOp op, const DeviceComputeKernelConfig compute_kernel_config) {
     log_info(LogTest, "Large tensor algorithm selected");
 
     // split work
@@ -36,6 +36,9 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_tiles);
 
+    auto arch = input_grad.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+
     Program program = Program();
 
     // create circular buffers
@@ -49,9 +52,9 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
             {CB::c_in0, 2},        // y
             {CB::c_in1, 2},        // dy
             {CB::c_out0, 2},       // dx
-            {CB::c_intermed0, 1},  // y * dy
-            {CB::c_intermed1, 2},  // sum(y * dy)
-            {CB::c_intermed2, 1},  // dy - sum
+            {CB::c_intermed0, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // y * dy
+            {CB::c_intermed1, 2, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // sum(y * dy)
+            {CB::c_intermed2, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // dy - sum
         });
 
     // create read/wrtie kernel
@@ -71,6 +74,9 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
         reader_defines["LOG"] = 1;
     }
 
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
 
     auto reader_kernel_id = CreateReadKernel(
         program, "tt_eager/tt_dnn/op_library/moreh_softmax_backward/kernels/reader_moreh_softmax_backward_c.cpp", all_cores, {y_is_dram, dy_is_dram}, reader_defines);
@@ -92,7 +98,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
             {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, dim_size}},
             {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, dim_size}},
         },
-        compute_defines);
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
 
     // Set Runtime Args
     auto core_x_offset = core_range.start.x;

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -18,7 +18,7 @@ namespace tt {
 namespace operations {
 namespace primary {
 
-operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &output, const Tensor &output_grad, const Tensor &input_grad, const CoreRange core_range, const MorehSoftmaxBackwardOp op) {
+operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &output, const Tensor &output_grad, const Tensor &input_grad, const CoreRange core_range, const MorehSoftmaxBackwardOp op, const DeviceComputeKernelConfig compute_kernel_config) {
     log_info(LogTest, "Large tensor algorithm selected");
 
     // split work
@@ -37,6 +37,9 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
 
+    auto arch = input_grad.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+
     Program program = Program();
 
     // create circular buffers
@@ -52,10 +55,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
             {CB::c_in2, 1},        // scaler
             {CB::c_in3, 1},        // mask
             {CB::c_out0, 2},       // input_grad
-            {CB::c_intermed0, 1},  // output * output_grad
-            {CB::c_intermed1, 1},  // reduce
-            {CB::c_intermed2, 1},  // dy - sum
-            {CB::c_intermed3, 2},  // add(output * output_grad)
+            {CB::c_intermed0, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // output * output_grad
+            {CB::c_intermed1, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // reduce
+            {CB::c_intermed2, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // dy - sum
+            {CB::c_intermed3, 2, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // add(output * output_grad)
         });
 
     // create read/wrtie kernel
@@ -74,6 +77,9 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
         reader_defines["LOG"] = 1;
     }
 
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
 
     auto reader_kernel_id = CreateReadKernel(
         program, "tt_eager/tt_dnn/op_library/moreh_softmax_backward/kernels/reader_moreh_softmax_backward_h_large.cpp", all_cores, {y_is_dram, dy_is_dram}, reader_defines);
@@ -88,7 +94,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
             {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Ht}},
             {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Ht}},
         },
-        compute_defines);
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
 
     // Set Runtime Args
     auto core_x_offset = core_range.start.x;

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -42,7 +42,7 @@ bool is_moreh_softmax_backward_h_small_available(const Tensor &tensor) {
     return (L1_UNRESERVED_BASE + cb_usage <= L1_512KB);
 }
 
-operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &output, const Tensor &output_grad, const Tensor &input_grad, const CoreRange core_range, const MorehSoftmaxBackwardOp op) {
+operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &output, const Tensor &output_grad, const Tensor &input_grad, const CoreRange core_range, const MorehSoftmaxBackwardOp op, const DeviceComputeKernelConfig compute_kernel_config) {
     log_info(LogTest, "Small tensor algorithm selected");
     // split work
     auto shape = input_grad.get_legacy_shape();
@@ -60,6 +60,9 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
 
+    auto arch = input_grad.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+
     Program program = Program();
 
     // create circular buffers
@@ -75,9 +78,9 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
             {CB::c_in2, 1},         // scaler
             {CB::c_in3, 1},         // mask
             {CB::c_out0, 2},        // input_grad
-            {CB::c_intermed0, Ht},  // output * output_grad
-            {CB::c_intermed1, 1},   // reduce
-            {CB::c_intermed2, 1},   // dy - sum
+            {CB::c_intermed0, Ht, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // output * output_grad
+            {CB::c_intermed1, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // reduce
+            {CB::c_intermed2, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},   // dy - sum
         });
 
     // create read/wrtie kernel
@@ -101,6 +104,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
         compute_defines["LOG"] = 1;
     }
 
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+
     // create compute kernel
     CreateComputeKernel(
         program,
@@ -109,7 +116,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
             {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Ht}},
             {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Ht}},
         },
-        compute_defines);
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
 
     // Set Runtime Args
     auto core_x_offset = core_range.start.x;

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -18,7 +18,7 @@ namespace tt {
 namespace operations {
 namespace primary {
 
-operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &output, const Tensor &output_grad, const Tensor &input_grad, const CoreRange core_range, const MorehSoftmaxBackwardOp op) {
+operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &output, const Tensor &output_grad, const Tensor &input_grad, const CoreRange core_range, const MorehSoftmaxBackwardOp op, const DeviceComputeKernelConfig compute_kernel_config) {
     log_info(LogTest, "Large tensor algorithm selected");
     // split work
     auto shape = input_grad.get_legacy_shape();
@@ -36,6 +36,9 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
 
+    auto arch = input_grad.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(arch, compute_kernel_config);
+
     Program program = Program();
 
     // create circular buffers
@@ -51,10 +54,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
             {CB::c_in2, 1},        // scaler
             {CB::c_in3, 1},        // mask
             {CB::c_out0, 2},       // input_grad
-            {CB::c_intermed0, 1},  // output * output_grad
-            {CB::c_intermed1, 1},  // reduce
-            {CB::c_intermed2, 1},  // dy - sum
-            {CB::c_intermed3, 2},  // add(output * output_grad)
+            {CB::c_intermed0, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // output * output_grad
+            {CB::c_intermed1, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // reduce
+            {CB::c_intermed2, 1, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // dy - sum
+            {CB::c_intermed3, 2, fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format},  // add(output * output_grad)
         });
 
     // create read/wrtie kernel
@@ -73,6 +76,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
         reader_defines["LOG"] = 1;
     }
 
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+
     auto reader_kernel_id = CreateReadKernel(
         program, "tt_eager/tt_dnn/op_library/moreh_softmax_backward/kernels/reader_moreh_softmax_backward_w_large.cpp", all_cores, {y_is_dram, dy_is_dram}, reader_defines);
     auto writer_kernel_id = CreateWriteKernel(
@@ -87,7 +94,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
             {core_group_1, num_tiles_per_core_group_1, {num_tiles_per_core_group_1, Wt}},
             {core_group_2, num_tiles_per_core_group_2, {num_tiles_per_core_group_2, Wt}},
         },
-        compute_defines);
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
 
     // Set Runtime Args
     auto core_x_offset = core_range.start.x;

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -805,6 +805,7 @@ void py_module(py::module& m_primary) {
         py::arg("input_grad_tensor").noconvert() = std::nullopt,
         py::arg("strategy").noconvert() = MorehSoftmaxBackwardOpParallelizationStrategy::NONE,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs a softmax backward operation. Returns an input grad tensor.");
     m_primary.def(
         "moreh_softmin",
@@ -825,6 +826,7 @@ void py_module(py::module& m_primary) {
         py::arg("input_grad_tensor").noconvert() = std::nullopt,
         py::arg("strategy").noconvert() = MorehSoftmaxBackwardOpParallelizationStrategy::NONE,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs a softmin backward operation. Returns an input grad tensor.");
 
     m_primary.def(
@@ -847,6 +849,7 @@ void py_module(py::module& m_primary) {
         py::arg("input_grad_tensor").noconvert() = std::nullopt,
         py::arg("strategy").noconvert() = MorehSoftmaxBackwardOpParallelizationStrategy::NONE,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs a logsoftmax backward operation. Returns an input grad tensor.");
 
     m_primary.def(

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -794,6 +794,7 @@ void py_module(py::module& m_primary) {
         py::arg("output_tensor").noconvert() = std::nullopt,
         py::arg("strategy").noconvert() = MorehSoftmaxOpParallelizationStrategy::NONE,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs a softmax operation. Returns an output tensor.");
     m_primary.def(
         "moreh_softmax_backward",
@@ -813,6 +814,7 @@ void py_module(py::module& m_primary) {
         py::arg("output_tensor").noconvert() = std::nullopt,
         py::arg("strategy").noconvert() = MorehSoftmaxOpParallelizationStrategy::NONE,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs a softmin operation. Returns an output tensor.");
     m_primary.def(
         "moreh_softmin_backward",
@@ -833,6 +835,7 @@ void py_module(py::module& m_primary) {
         py::arg("output_tensor").noconvert() = std::nullopt,
         py::arg("strategy").noconvert() = MorehSoftmaxOpParallelizationStrategy::NONE,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs a logsoftmax operation. Returns an output tensor.");
 
     m_primary.def(


### PR DESCRIPTION
Add DeviceComputeKernelConfig parameter to moreh softmax like ops

```C++
Tensor moreh_softmax(
    const Tensor &input_tensor,
    uint32_t dim,
    std::optional<Tensor> output_tensor = std::nullopt,
    const MorehSoftmaxOpParallelizationStrategy strategy = MorehSoftmaxOpParallelizationStrategy::NONE,
    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
->
Tensor moreh_softmax(
    const Tensor &input_tensor,
    uint32_t dim,
    std::optional<Tensor> output_tensor = std::nullopt,
    const MorehSoftmaxOpParallelizationStrategy strategy = MorehSoftmaxOpParallelizationStrategy::NONE,
    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = nullptr);
```

The only applied configurations in DeviceComputeKernelConfig are `math fidelity` and `fp32_dest_acc_en`.