### PR TITLE
#753: Syncing device host times for tracy profiler

### DIFF
--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -48,6 +48,7 @@ RunTimeOptions::RunTimeOptions() {
 
     profiler_enabled = false;
     profile_dispatch_cores = false;
+    profiler_sync_enabled = false;
 #if defined(PROFILER)
     const char *profiler_enabled_str = std::getenv("TT_METAL_DEVICE_PROFILER");
     if (profiler_enabled_str != nullptr && profiler_enabled_str[0] == '1') {
@@ -55,6 +56,10 @@ RunTimeOptions::RunTimeOptions() {
         const char *profile_dispatch_str = std::getenv("TT_METAL_DEVICE_PROFILER_DISPATCH");
         if (profile_dispatch_str != nullptr && profile_dispatch_str[0] == '1') {
             profile_dispatch_cores = true;
+        }
+        const char *profiler_sync_enabled_str = std::getenv("TT_METAL_PROFILER_SYNC");
+        if (profiler_enabled && profiler_sync_enabled_str != nullptr && profiler_sync_enabled_str[0] == '1') {
+            profiler_sync_enabled = true;
         }
     }
 #endif

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -87,6 +87,7 @@ class RunTimeOptions {
 
     bool profiler_enabled = false;
     bool profile_dispatch_cores = false;
+    bool profiler_sync_enabled = false;
 
     bool null_kernels = false;
 
@@ -220,6 +221,7 @@ class RunTimeOptions {
 
     inline bool get_profiler_enabled() { return profiler_enabled; }
     inline bool get_profiler_do_dispatch_cores() { return profile_dispatch_cores; }
+    inline bool get_profiler_sync_enabled() { return profiler_sync_enabled; }
 
     inline void set_kernels_nullified(bool v) { null_kernels = v; }
     inline bool get_kernels_nullified() { return null_kernels; }

--- a/tt_metal/tools/profiler/common.py
+++ b/tt_metal/tools/profiler/common.py
@@ -16,6 +16,7 @@ else:
 
 PROFILER_DEVICE_SIDE_LOG = "profile_log_device.csv"
 PROFILER_HOST_SIDE_LOG = "profile_log_host.csv"
+PROFILER_HOST_DEVICE_SYNC_INFO = "sync_device_info.csv"
 
 PROFILER_SCRIPTS_ROOT = TT_METAL_HOME / "tt_metal/tools/profiler"
 PROFILER_ARTIFACTS_DIR = TT_METAL_HOME / "generated/profiler"

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 
 #include "tt_metal/impl/buffers/buffer.hpp"
+#include "tt_metal/impl/program/program.hpp"
 #include "llrt/llrt.hpp"
 #include "tools/profiler/profiler_state.hpp"
 #include "tools/profiler/common.hpp"
@@ -101,6 +102,7 @@ class DeviceProfiler {
 
         //DRAM buffer for device side results
         std::shared_ptr<tt::tt_metal::Buffer> output_dram_buffer = nullptr;
+        std::shared_ptr<tt::tt_metal::Program> sync_program = nullptr;
 
         // Device-core Syncdata
         std::map<CoreCoord, std::tuple<double,double,double>> device_core_sync_info;

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -50,7 +50,7 @@ class DeviceProfiler {
         // Device-Core tracy context
         std::map<std::pair<uint16_t,CoreCoord>, TracyTTCtx> device_tracy_contexts;
 
-        // Device-Core tracy context
+        // Device events
         std::set<tracy::TTDeviceEvent> device_events;
 
         // Hash to zone source locations
@@ -102,6 +102,8 @@ class DeviceProfiler {
         //DRAM buffer for device side results
         std::shared_ptr<tt::tt_metal::Buffer> output_dram_buffer = nullptr;
 
+        // Device-core Syncdata
+        std::map<CoreCoord, std::tuple<double,double,double>> device_core_sync_info;
 
         //Set the device side file flag
         void setNewLogFlag(bool new_log_flag);

--- a/tt_metal/tools/profiler/sync/sync_kernel.cpp
+++ b/tt_metal/tools/profiler/sync/sync_kernel.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+void kernel_main() {
+    DeviceZoneScopedMainN("SYNC-MAIN");
+    volatile tt_reg_ptr uint32_t *p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t *> (RISCV_DEBUG_REG_WALL_CLOCK_L);
+    volatile tt_l1_ptr uint32_t *profiler_control_buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_CONTROL);
+    volatile tt_l1_ptr uint32_t *briscBuffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_BR + kernel_profiler::CUSTOM_MARKERS * sizeof(uint32_t));
+
+    uint32_t syncTimeBufferIndex = 0;
+
+    constexpr int FIRST_READ_COUNT = 2;
+
+
+    while ( syncTimeBufferIndex < FIRST_READ_COUNT) {
+        uint32_t deviceTime = p_reg[kernel_profiler::WALL_CLOCK_LOW_INDEX];
+
+        uint32_t hostTime = profiler_control_buffer[kernel_profiler::FW_RESET_L];
+        if (hostTime > 0)
+        {
+            briscBuffer[syncTimeBufferIndex++] = p_reg[kernel_profiler::WALL_CLOCK_HIGH_INDEX];
+            briscBuffer[syncTimeBufferIndex++] = deviceTime;
+            briscBuffer[syncTimeBufferIndex++] = deviceTime;
+            briscBuffer[syncTimeBufferIndex++] = hostTime;
+            profiler_control_buffer[kernel_profiler::FW_RESET_L] = 0;
+        }
+    }
+
+    {
+        DeviceZoneScopedMainChildN("SYNC-LOOP");
+        while ( syncTimeBufferIndex < ((SAMPLE_COUNT + 1) * 2) ) {
+            uint32_t deviceTime = p_reg[kernel_profiler::WALL_CLOCK_LOW_INDEX];
+
+            uint32_t hostTime = profiler_control_buffer[kernel_profiler::FW_RESET_L];
+            if (hostTime > 0)
+            {
+                briscBuffer[syncTimeBufferIndex++] = deviceTime;
+                briscBuffer[syncTimeBufferIndex++] = hostTime;
+                profiler_control_buffer[kernel_profiler::FW_RESET_L] = 0;
+            }
+        }
+    }
+}

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-
-#include <thread>
 #include <chrono>
+#include <thread>
+#include <cmath>
 
 #include "tt_metal/host_api.hpp"
 #include "impl/debug/dprint_server.hpp"
@@ -37,19 +37,197 @@ namespace detail {
 
 std::map <uint32_t, DeviceProfiler> tt_metal_device_profiler_map;
 
+std::unordered_map <uint32_t, std::vector <std::pair<uint64_t,uint64_t>>> deviceHostTimePair;
+std::unordered_map <uint32_t, uint64_t> smallestHostime;
+
+
+constexpr CoreCoord SYNC_CORE = {0,0};
+
+void syncDeviceHost(Device *device, CoreCoord logical_core, bool doHeader)
+{
+    if (!tt::llrt::OptionsG.get_profiler_sync_enabled()) return;
+    ZoneScopedC(tracy::Color::Tomato3);
+    auto core = device->worker_core_from_logical_core(logical_core);
+    auto device_id = device->id();
+
+    deviceHostTimePair.emplace(device_id, (std::vector <std::pair<uint64_t,uint64_t>>){});
+    smallestHostime.emplace(device_id, 0);
+
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    constexpr uint16_t sampleCount = 249;
+    std::map<string, string> kernel_defines = {
+        {"SAMPLE_COUNT", std::to_string(sampleCount)},
+    };
+
+    tt_metal::KernelHandle brisc_kernel = tt_metal::CreateKernel(
+        program, "tt_metal/tools/profiler/sync/sync_kernel.cpp",
+        logical_core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .defines = kernel_defines}
+        );
+
+    EnqueueProgram(device->command_queue(), program, false);
+
+    std::filesystem::path output_dir = std::filesystem::path(string(PROFILER_RUNTIME_ROOT_DIR) + string(PROFILER_LOGS_DIR_NAME));
+    std::filesystem::path log_path = output_dir / "sync_device_info.csv";
+    std::ofstream log_file;
+
+    int64_t writeSum = 0;
+
+    constexpr int millisecond_wait = 4;
+
+    const double tracyToSecRatio = TracyGetTimerMul();
+    const int64_t tracyBaseTime = TracyGetBaseTime();
+    const int64_t hostStartTime = TracyGetCpuTime();
+    std::vector<int64_t> writeTimes(sampleCount);
+
+    for (int i = 0; i < sampleCount; i++)
+    {
+        ZoneScopedC(tracy::Color::Tomato2);
+        std::this_thread::sleep_for(std::chrono::milliseconds(millisecond_wait));
+        int64_t writeStart = TracyGetCpuTime();
+        uint32_t sinceStart = writeStart - hostStartTime;
+        tt::Cluster::instance().write_reg(&sinceStart, tt_cxy_pair(device_id, core) , PROFILER_L1_BUFFER_CONTROL + kernel_profiler::FW_RESET_L * sizeof(uint32_t));
+        writeTimes[i] = (TracyGetCpuTime() - writeStart);
+    }
+
+    Finish(device->command_queue());
+
+    log_info ("SYNC PROGRAM FINISH IS DONE ON {}",device_id);
+    if ((smallestHostime[device_id] == 0) || (smallestHostime[device_id] > hostStartTime))
+    {
+        smallestHostime[device_id] = hostStartTime;
+    }
+
+    for (auto writeTime : writeTimes)
+    {
+        writeSum += writeTime;
+    }
+    double writeOverhead = (double)writeSum / sampleCount;
+    vector<std::uint32_t> sync_times = tt::llrt::read_hex_vec_from_core(
+            device_id,
+            core,
+            PROFILER_L1_BUFFER_BR + kernel_profiler::CUSTOM_MARKERS * sizeof(uint32_t),
+            (sampleCount + 1) * 2 * sizeof(uint32_t));
+
+    uint32_t preDeviceTime = 0;
+    uint32_t preHostTime = 0;
+    bool firstSample = true;
+
+    uint64_t deviceStartTime = (uint64_t(sync_times[0] & 0xFFF) << 32) | sync_times[1];
+    uint32_t deviceStartTime_H = sync_times[0] & 0xFFF;
+    uint32_t deviceStartTime_L = sync_times[1];
+    preDeviceTime = deviceStartTime_L;
+
+    uint32_t hostStartTime_H = 0;
+
+    uint64_t preDeviceTimeLarge = 0;
+    uint64_t preHostTimeLarge = 0;
+    uint64_t firstDeviceTimeLarge = 0;
+    uint64_t firstHostTimeLarge = 0;
+
+    for (int i = 2; i < 2 * (sampleCount + 1); i += 2)
+    {
+
+        uint32_t deviceTime = sync_times[i];
+        if (deviceTime < preDeviceTime) deviceStartTime_H ++;
+        preDeviceTime = deviceTime;
+        uint64_t deviceTimeLarge = (uint64_t(deviceStartTime_H) << 32) | deviceTime;
+
+        uint32_t hostTime = sync_times[i + 1] + writeTimes[i/2 - 1];
+        if (hostTime < preHostTime) hostStartTime_H ++;
+        preHostTime = hostTime;
+        uint64_t hostTimeLarge = hostStartTime - smallestHostime[device_id] + ((uint64_t(hostStartTime_H) << 32) | hostTime);
+
+        deviceHostTimePair[device_id].push_back(std::pair<uint64_t,uint64_t> {deviceTimeLarge,hostTimeLarge});
+
+        if (firstSample)
+        {
+            firstDeviceTimeLarge = deviceTimeLarge;
+            firstHostTimeLarge = hostTimeLarge;
+            firstSample = false;
+        }
+
+        preDeviceTimeLarge = deviceTimeLarge;
+        preHostTimeLarge = hostTimeLarge;
+    }
+
+    double hostSum = 0;
+    double deviceSum = 0;
+    double hostSquaredSum = 0;
+    double hostDeviceProductSum = 0;
+
+    for (auto& deviceHostTime : deviceHostTimePair[device_id])
+    {
+        double deviceTime = deviceHostTime.first;
+        double hostTime = deviceHostTime.second;
+
+        deviceSum += deviceTime;
+        hostSum += hostTime;
+        hostSquaredSum += (hostTime * hostTime);
+        hostDeviceProductSum += (hostTime * deviceTime);
+    }
+
+    uint16_t accumulateSampleCount = deviceHostTimePair[device_id].size();
+
+    double frequencyFit = (hostDeviceProductSum * accumulateSampleCount - hostSum * deviceSum)  / ((hostSquaredSum * accumulateSampleCount - hostSum * hostSum) * tracyToSecRatio);
+
+    double delay = (deviceSum - frequencyFit * hostSum * tracyToSecRatio) / accumulateSampleCount;
+
+    log_file.open(log_path, std::ios_base::app);
+    if (doHeader)
+    {
+        log_file << fmt::format("device id,core_x, core_y,device,host_tracy,host_real,write_overhead,host_start,delay,frequency,tracy_ratio,tracy_base_time") << std::endl;
+    }
+    int init = deviceHostTimePair[device_id].size() - sampleCount;
+    for (int i = init ;i < deviceHostTimePair[device_id].size(); i++)
+    {
+        log_file << fmt::format(
+                "{:5},{:5},{:5},{:20},{:20},{:20.2f},{:20},{:20},{:20.2f},{:20.15f},{:20.15f},{:20}",
+                device_id,
+                core.x,
+                core.y,
+                deviceHostTimePair[device_id][i].first,
+                deviceHostTimePair[device_id][i].second,
+                (double) deviceHostTimePair[device_id][i].second  * tracyToSecRatio,
+                writeTimes[i - init],
+                smallestHostime[device_id],
+                delay,
+                frequencyFit,
+                tracyToSecRatio,
+                tracyBaseTime
+                )
+            << std::endl;
+    }
+
+    log_info("Sync data for device: {}, c:{}, d:{}, f:{}",device_id, smallestHostime[device_id], delay, frequencyFit);
+
+    tt_metal_device_profiler_map.at(device_id).device_core_sync_info.emplace(core, std::make_tuple(smallestHostime[device_id], delay, frequencyFit));
+    tt_metal_device_profiler_map.at(device_id).device_core_sync_info[core] = std::make_tuple(smallestHostime[device_id], delay, frequencyFit);
+}
+
+
 void InitDeviceProfiler(Device *device){
 #if defined(PROFILER)
     ZoneScoped;
 
-    TracySetCpuTime();
+    TracySetCpuTime (TracyGetCpuTime());
+
+    bool doSync = false;
     auto device_id = device->id();
     if (getDeviceProfilerState())
     {
         static std::atomic<bool> firstInit = true;
+        bool doHeader = firstInit;
 
         auto device_id = device->id();
+
         if (tt_metal_device_profiler_map.find(device_id) == tt_metal_device_profiler_map.end())
         {
+            doSync = true;
             if (firstInit.exchange(false))
             {
                 tt_metal_device_profiler_map.emplace(device_id, DeviceProfiler(true));
@@ -59,6 +237,7 @@ void InitDeviceProfiler(Device *device){
                 tt_metal_device_profiler_map.emplace(device_id, DeviceProfiler(false));
             }
         }
+
         uint32_t dramBankCount = tt::Cluster::instance().get_soc_desc(device_id).get_num_dram_channels();
         uint32_t coreCountPerDram = tt::Cluster::instance().get_soc_desc(device_id).profiler_ceiled_core_count_perf_dram_bank;
 
@@ -79,6 +258,7 @@ void InitDeviceProfiler(Device *device){
 
         std::vector<uint32_t> control_buffer(PROFILER_L1_CONTROL_VECTOR_SIZE, 0);
         control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS] = tt_metal_device_profiler_map.at(device_id).output_dram_buffer->address();
+
 
         const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device_id);
         auto ethCores = soc_d.get_physical_ethernet_cores() ;
@@ -105,6 +285,10 @@ void InitDeviceProfiler(Device *device){
 
         std::vector<uint32_t> inputs_DRAM(tt_metal_device_profiler_map.at(device_id).output_dram_buffer->size()/sizeof(uint32_t), 0);
         tt_metal::detail::WriteToBuffer(tt_metal_device_profiler_map.at(device_id).output_dram_buffer, inputs_DRAM);
+        if (doSync)
+        {
+            syncDeviceHost (device, SYNC_CORE, doHeader);
+        }
     }
 #endif
 }
@@ -220,6 +404,10 @@ void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cor
         auto device_id = device->id();
         if (tt_metal_device_profiler_map.find(device_id) != tt_metal_device_profiler_map.end())
         {
+            if (!lastDump)
+            {
+                syncDeviceHost (device, SYNC_CORE, false);
+            }
             tt_metal_device_profiler_map.at(device_id).setDeviceArchitecture(device->arch());
             tt_metal_device_profiler_map.at(device_id).dumpResults(device, worker_cores);
             if (lastDump)

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -304,6 +304,9 @@ std::map<chip_id_t, Device *> CreateDevices(
     }
     // TODO: need to only enable routing for used mmio chips
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+    for (auto &active_device: active_devices){
+        detail::InitDeviceProfiler(active_device.second);
+    }
     return active_devices;
 }
 


### PR DESCRIPTION
This is the PR for syncing device and host time for tracy. 

The data is only used by tracy GUI. A tt_metal sync program is created that loads the sync kernel to device. 

With the kernel running and waiting, host writes it time to a L1 location and device reads and tags the time with its own wall clock time. This happens for 249 iterations which is driven by profiler L1 buffer size. 

Each sync program takes ~ 1s. i.e. 249 x 4ms (Sleep time between host time stamps) ~= 1s.

Multiple of these sync programs can happen per device. By default, at least 2 will happen per device, on at init_device and one at dump. 

Host then post processes all the paired host-device timestamps and calculates the delay and frequency of the device.

Syncing is off by default and can be turned on by `TT_METAL_PROFILER_SYNC=1`

Best way to evaluate the precision is to note that I am roughly getting 5 if not 6 significant digits on my frequency calculation. Separate runs are producing frequencies that are equal up to 6 significant digits. That can be seen as microsecond precision on the sync. Certainly sub 10us. 

Below shows FD1 dispatch core end to the host finish call end. We can see the diff of `2.46us`. Part of this delay is real, it is the time for the message to travel. This is showing ~1us accuracy. 

<img width="585" alt="Screenshot 2024-05-03 at 1 10 27 PM" src="https://github.com/tenstorrent/tt-metal/assets/109363418/d2c0c904-90bf-42b0-81a3-6218364ac3d2">

### Green CI 🟢 
Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/9388576940
Profiler with latest rebase: https://github.com/tenstorrent/tt-metal/actions/runs/9421179535
Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/9389438009
T3K profiler: https://github.com/tenstorrent/tt-metal/actions/runs/9421174522
uBenchmark: https://github.com/tenstorrent/tt-metal/actions/runs/9401574470
 
