### PR TITLE
[Falcon40b demo cleanup] Add back inference runs, fix perf measurements, compile with single layer, perf mode, top-k/top-p sampling, update input json

### DIFF
--- a/models/demos/t3000/falcon40b/demo/input_data.json
+++ b/models/demos/t3000/falcon40b/demo/input_data.json
@@ -1,27 +1,27 @@
 [
     {
-"question": "write a short poem about London in English"
+"question": "List the first 5 prime numbers "
             },
          {
-"question": "write a short poem about Madrid in Spanish"
+"question": "Give a brief history of the internet "
             },
          {
-"question": "write a short poem about Madrid in English"
+"question": "Describe to me some good coding practices "
             },
          {
 "question": "write a short poem about Paris in English"
             },
          {
-"question": "write a short poem about Paris in French"
+"question": "Who is the inventor of the telephone?"
             },
          {
 "question": "write a short poem about Istanbul in English"
             },
          {
-"question": "write a short poem about Shanghai in English"
+"question": "What are the tourist attractions in Paris?"
             },
          {
-"question": "write a short poem about Lagos in English"
+"question": "How many countries are in Africa? "
             },
          {
 "question": "what is the capital of USA? "

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -5,6 +5,7 @@
 import torch
 from abc import abstractmethod
 from typing import Optional, Tuple
+from tqdm import tqdm
 
 import tt_lib
 import ttnn
@@ -81,7 +82,7 @@ class TtFalconModelShared:
                 tt_cache_path=tt_cache_path,
                 global_cos_sin_cache=global_cos_sin_cache,
             )
-            for layer_num in range(num_layers)
+            for layer_num in tqdm(range(num_layers), desc="Loading decoder layers")
         ]
 
         layer_name = f"{base_url}"


### PR DESCRIPTION
Apply all of the recent optimizations and fixes which were done on the Falcon7b demo to the Falcon40b demo
- Add back inference runs and perf measurements, while retaining the prefill_on_host option
- Fix perf measurement errors and logging
- Change compile runs to use a single layer of the model
- Change decode compile run to iterate per 32 kvcache sizes to avoid unnecessary compiles
- Add option for performance measurement mode (disabled by default)
- Add top-k/top-p sampling and disable greedy decoding by default
- Add progress bar for loading model layers
- Minor cleanup of logging in Falcon7b demo

FYI @uaydonat @johanna-rock-tt @s-jovic 