### PR TITLE
#7980: Make global perf structures thread safe

### DIFF
--- a/scripts/tools_setup_common.sh
+++ b/scripts/tools_setup_common.sh
@@ -17,6 +17,25 @@ remove_default_log_locations(){
     echo "Removed all profiler artifacts"
 }
 
+verify_perf_line_count_floor(){
+    csvLog=$1
+    LINE_COUNT=$2
+
+    lineCount=$(cat $csvLog | wc | awk  'NR == 1 { print $1 }')
+
+    if [[ ! $lineCount =~ ^[0-9]+$ ]]; then
+        echo "Value for line count was $lineCount, not a number !" 1>&2
+        exit 1
+    fi
+
+    if (( lineCount < LINE_COUNT )); then
+        echo "Value for line count was $lineCount, not higher than $LINE_COUNT" 1>&2
+        exit 1
+    fi
+
+    echo "Value for line count was in correct range" 1>&2
+}
+
 verify_perf_line_count(){
     csvLog=$1
     LINE_COUNT=$2

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -31,7 +31,14 @@ run_async_mode_T3000_test(){
     if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
     then
         echo "No verification as test was skipped"
+    else
+        echo "Verifying test results"
+        runDate=$(ls $PROFILER_OUTPUT_DIR/)
+        LINE_COUNT=1000 # Smoke test to see at least 1000 ops are reported
+        res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
+        echo $res
     fi
+    cat $PROFILER_ARTIFACTS_DIR/test_out.log
 }
 
 run_profiling_test(){

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -23,6 +23,17 @@ run_additional_T3000_test(){
     cat $PROFILER_ARTIFACTS_DIR/test_out.log
 }
 
+run_async_mode_T3000_test(){
+    remove_default_log_locations
+    mkdir -p $PROFILER_ARTIFACTS_DIR
+
+    ./tt_metal/tools/profiler/profile_this.py -c "pytest -svv models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py::test_falcon_causal_lm[wormhole_b0-True-True-20-2-BFLOAT16-L1-falcon_7b-layers_2-decode_batch32]" > $PROFILER_ARTIFACTS_DIR/test_out.log
+    if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
+    then
+        echo "No verification as test was skipped"
+    fi
+}
+
 run_profiling_test(){
     if [[ -z "$ARCH_NAME" ]]; then
       echo "Must provide ARCH_NAME in environment" 1>&2
@@ -35,6 +46,8 @@ run_profiling_test(){
     export PYTHONPATH=$TT_METAL_HOME
 
     run_additional_T3000_test
+
+    run_async_mode_T3000_test
 
     TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py::test_custom_cycle_count -vvv
     TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py::test_full_buffer -vvv


### PR DESCRIPTION
 - Add async falcon MLP test running with profiler enabled to CI
 - This workload was exposing segfaults due to non-thread safe perf structures