### PR TITLE
#8098: Remove temp buffer copying when reading from hugepage to host buffer

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -23,7 +23,7 @@ jobs:
             { name: "Common models N300 WH B0", arch: wormhole_b0, cmd: tests/scripts/nightly/run_common_models.sh, timeout: 40 },
             { name: "GS-only ttnn nightly", arch: grayskull, cmd: tests/scripts/nightly/run_ttnn.sh, timeout: 40 },
             { name: "GS-only models", arch: grayskull, cmd: tests/scripts/nightly/run_gs_only.sh, timeout: 40 },
-            { name: "N300 WH-only models", arch: wormhole_b0, cmd: tests/scripts/nightly/run_wh_b0_only.sh, timeout: 30 },
+            { name: "N300 WH-only models", arch: wormhole_b0, cmd: tests/scripts/nightly/run_wh_b0_only.sh, timeout: 60 },
             { name: "API tests GS", arch: grayskull, cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast, timeout: 40 },
             { name: "API tests N300 WH B0", arch: wormhole_b0, cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast, timeout: 40 },
           ]

--- a/models/demos/mamba/tests/test_mamba_demo.py
+++ b/models/demos/mamba/tests/test_mamba_demo.py
@@ -10,6 +10,5 @@ import pytest
     "user_input, max_gen_len",
     ((["Hello World"], 2),),
 )
-@pytest.mark.skip(reason="#8146 ND Hang")
 def test_demo(user_input, device, use_program_cache, max_gen_len):
     return run_mamba_demo(prompts=user_input, device=device, generated_sequence_length=max_gen_len, display=False)


### PR DESCRIPTION
TODO: Currently we only release pages after processing all of them Should update to release as we go along to unblock device