### PR TITLE
#8080: Re-enable tests

### DIFF
--- a/tests/scripts/multi_chip/run_pre_post_commit_regressions_multi_device.sh
+++ b/tests/scripts/multi_chip/run_pre_post_commit_regressions_multi_device.sh
@@ -23,13 +23,12 @@ TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_fast_dispatch --g
 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="DPrintFixture.*:WatcherFixture.*"
 pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k post_commit
 
+# Falcon40B 8 chip decode tests
+pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-8chips-enable_program_cache]
+pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips-enable_program_cache]
+
 # ttnn multi-chip apis unit tests
 pytest tests/ttnn/unit_tests/test_multi_device.py
-
-# Falcon40B 4 chip decode tests
-# #8080
-# pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py::test_FalconDecoder_inference[BFLOAT8_B-SHARDED-falcon_40b-layer_0-decode_batch32-4chips-enable_program_cache]
-# pytest models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py::test_FalconCausalLM_end_to_end_with_program_cache[BFLOAT8_B-SHARDED-falcon_40b-layers_1-decode_batch32-8chips-enable_program_cache]
 
 # Mistral8x7b 8 chip decode tests (env flags set inside the tests)
 pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py


### PR DESCRIPTION
Was failing on FD2 branch pre-merge, but should be fixed now.

Running CI: 
https://github.com/tenstorrent/tt-metal/actions/runs/8972002345
https://github.com/tenstorrent/tt-metal/actions/runs/8971998370