### PR TITLE
Disable Falcon7b async perf tests due to fd2 hang, re-enable sync tests

### DIFF
--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -554,8 +554,8 @@ class TestParametrized:
         use_program_cache,
         async_mode,
     ):
-        pytest.skip(f"#7947")
         if async_mode:
+            pytest.skip(f"Skipping due to Issue #8133, async is hanging with FD2")  # TODO: Remove when #8133 is fixed
             if llm_mode == "prefill" and seq_len == 128:
                 pytest.skip(
                     f"Skipping {llm_mode} with {seq_len} in async mode. Config is supported but provides redundant testing."


### PR DESCRIPTION
- Re-enable Falcon7b sync tests due to #7947 being fixed
- Disable Falcon7b async tests due to FD2 hang #8133 