### PR TITLE
#8199: Div_no_nan implementation

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -305,6 +305,8 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.div
 
+.. autofunction:: tt_lib.tensor.div_no_nan
+
 .. autofunction:: tt_lib.tensor.add_unary
 
 .. autofunction:: tt_lib.tensor.sub_unary

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -306,6 +306,10 @@ op_map = {
         "tt_lib_op": tt_lib_ops.eltwise_div,
         "pytorch_op": pytorch_ops.div,
     },
+    "eltwise-div_no_nan": {
+        "tt_lib_op": tt_lib_ops.eltwise_div_no_nan,
+        "pytorch_op": pytorch_ops.div_no_nan,
+    },
     "eltwise-square": {
         "tt_lib_op": tt_lib_ops.eltwise_square,
         "pytorch_op": pytorch_ops.square,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div_no_nan.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div_no_nan.py
@@ -23,7 +23,6 @@ mem_configs = [
 ]
 
 
-@pytest.mark.parametrize("accurate_mode", [False, True])
 @pytest.mark.parametrize(
     "input_shapes",
     [
@@ -36,41 +35,22 @@ mem_configs = [
     "dst_mem_config",
     mem_configs,
 )
-class TestDiv:
-    def test_run_div(
+class TestDiv_No_Nan:
+    def test_run_div_no_nan(
         self,
-        accurate_mode,
         input_shapes,
         dst_mem_config,
         device,
     ):
-        if accurate_mode == False:  # If input_b is non-zero tensor
-            datagen_func = [
-                generation_funcs.gen_func_with_cast(
-                    partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-                )
-            ] + [
-                generation_funcs.gen_func_with_cast(
-                    partial(generation_funcs.gen_rand, low=-100, high=-1), torch.bfloat16
-                )
-            ]
-        else:
-            datagen_func = [
-                generation_funcs.gen_func_with_cast(
-                    partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16
-                )
-            ] * 2
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ] + [generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=-1), torch.bfloat16)]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
-        test_args.update(
-            {
-                "accurate_mode": accurate_mode,
-            }
-        )
         test_args.update({"output_mem_config": dst_mem_config})
         comparison_func = comparison_funcs.comp_pcc
 
         run_single_pytorch_test(
-            "eltwise-div",
+            "eltwise-div_no_nan",
             input_shapes,
             datagen_func,
             comparison_func,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -691,6 +691,11 @@ def div(x, y, *args, accurate_mode, **kwargs):
     return result
 
 
+def div_no_nan(x, y, *args, **kwargs):
+    result = torch.where(y == 0, 0, x / y)
+    return result
+
+
 def div_unary(x, *args, scalar, **kwargs):
     result = torch.div(x, scalar)
     return result

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1047,6 +1047,25 @@ def eltwise_div(
 
 
 @setup_host_and_device
+def eltwise_div_no_nan(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = ttl.tensor.div_no_nan(t0, t1, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t2)
+
+
+@setup_host_and_device
 def lamb_optimizer(
     x,
     y,

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -864,6 +864,20 @@ Tensor div(
     return operation::decorate_as_composite(__func__, _div)(input_a, input_b, accurate_mode, output_mem_config);
 }
 
+Tensor _div_no_nan(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const MemoryConfig& output_mem_config) {
+    Tensor div_result =div(input_a, input_b);
+    return where(eqz(input_b, output_mem_config), 0, div_result);
+}
+Tensor div_no_nan(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const MemoryConfig& output_mem_config) {
+    return operation::decorate_as_composite(__func__, _div_no_nan)(input_a, input_b, output_mem_config);
+}
+
 // logit(input, eps)=log(input / 1 - input)
 Tensor _logit(const Tensor& input_a, float eps, const MemoryConfig& output_mem_config) {
     Tensor t_eps = full_like(input_a, eps, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -171,6 +171,11 @@ Tensor div(
     bool accurate_mode = false,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+Tensor div_no_nan(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 // xlogy(x,y))=x*log(y)
 Tensor xlogy(
     const Tensor& input_a,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -826,6 +826,22 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+         m_tensor.def("div_no_nan", &div_no_nan,
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs the element-wise div_no_nan on ``input_a`` and ``input_b``, which returns 0 if ``input_b`` (denominator) is zero.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input_a", "Numerator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input_b", "Denominator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
         m_tensor.def("mac", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&mac),
             py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Returns tensor with the multiply and accumulation of all of elements of the input tensors ``input, tensor1, tensor2``.


### PR DESCRIPTION
Issue #8199 - Div_no_nan forward op implementation

- Reference : [Link](https://github.com/tenstorrent/tt-metal/issues/8199#issue-2282820033)
- All post-commit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/8983723515) - PASSED
- Test results : `tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div_no_nan.py`
<img width="1006" alt="Screenshot 2024-05-07 at 4 01 50 PM" src="https://github.com/tenstorrent/tt-metal/assets/138196495/d4f2e81d-c396-4d78-a12c-ef32f5de519a">
