### PR TITLE
#0: Use generic python3 for pre commit black directive instead of 20.04-specific 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,4 @@ repos:
   rev: 23.10.1
   hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3


### PR DESCRIPTION
…