### PR TITLE
[llama] implement nlp_create_heads_decode and nlp_concat_heads_decode

### DIFF
--- a/models/experimental/llama2_70b/tests/unit_tests/test_nlp_concat_head.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_nlp_concat_head.py
@@ -187,21 +187,16 @@ def test_concat_head2(
     batch,
     seq_len,
     all_devices,
-    # use_program_cache,
+    use_program_cache,
 ):
     n_devices = 8
     devices = get_devices_for_t3000(all_devices, num_devices=1)
     torch.manual_seed(0)
 
-    run_test_concat_head2(
-        devices,
-        batch,
-        seq_len,
-    )
-
-    # for i in range(3):
-    #     run_test_concat_head2(
-    #         devices,
-    #         batch,
-    #         seq_len,
-    #     )
+    for i in range(3):
+        # multiple loops to test program caching
+        run_test_concat_head2(
+            devices,
+            batch,
+            seq_len,
+        )

--- a/models/experimental/llama2_70b/tests/unit_tests/test_nlp_concat_head.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_nlp_concat_head.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+from loguru import logger
+import torch
+from torch import nn
+import tt_lib as ttl
+import ttnn
+
+from models.experimental.llama2_70b.reference.llama.llama import Llama
+from models.experimental.llama2_70b.reference.llama.llama.model import precompute_freqs_cis, apply_rotary_emb
+from models.experimental.llama2_70b.tt.model_config import (
+    get_model_config,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_allclose,
+    comp_pcc,
+)
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor, skip_for_grayskull, get_devices_for_t3000
+from models.experimental.llama2_70b.tt.llama_common import (
+    get_llama_path,
+    extract_pcc_from_log,
+    MAX_SEQ_LEN,
+    BASE_URL,
+    UNIT_TEST_N_LAYER,
+    UNIT_TEST_LAYER_NUM,
+    UNIT_TEST_START_POS,
+    UNIT_TEST_GENERATION_LENGTH,
+)
+from models.experimental.llama2_70b.tt.llama_common import (
+    tt_all_gather_torch,
+    precompute_freqs,
+    freqs_to_rotation_matrix,
+    gather_rotary_emb,
+    get_weight_cache_path,
+)
+
+
+def run_test_concat_head1(
+    devices,
+    batch,
+    seq_len,
+):
+    ## Split Heads
+    n_local_heads = 8
+    n_local_kv_heads = 1
+    head_dim = 128
+    # Prepare input
+    concat_head_input = torch.rand(1, n_local_heads, batch, head_dim)
+
+    shard_spec_8_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(7, 0),
+            ),
+        }
+    )
+
+    SCORES_TRANSPOSED_OUTPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_8_cores_grid,  # Volume must match # of attn heads
+            [
+                32,  # Each core has 32 users
+                head_dim,  # head dim
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    WIDTH_SHARDED_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED, ttl.tensor.BufferType.L1
+    )
+
+    # Prepare tt input
+    concat_head_input_tt = torch2tt_tensor(concat_head_input, tt_device=None).to(
+        device=devices[0], mem_config=SCORES_TRANSPOSED_OUTPUT_MEMCFG
+    )
+
+    concat_head_output = ttl.tensor.nlp_concat_heads(
+        concat_head_input_tt, output_mem_config=WIDTH_SHARDED_MEMCFG
+    )  # seqlen, 1, batch, hidden_size
+
+    logger.info(f"concat_head_output: {concat_head_output.memory_config()}")
+
+    concat_head_output_torch = concat_head_input.permute(0, 2, 1, 3).reshape(1, 1, batch, head_dim * 8)
+
+    # compare
+    concat_head_output_tt_cpu = tt2torch_tensor(concat_head_output)
+    out_pass_q, output_pcc_q = comp_pcc(concat_head_output_tt_cpu, concat_head_output_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+    assert out_pass_q
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "batch, seq_len",
+    ((32, 1),),
+)
+def test_concat_head1(
+    batch,
+    seq_len,
+    all_devices,
+):
+    n_devices = 8
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    run_test_concat_head1(
+        devices,
+        batch,
+        seq_len,
+    )
+
+
+def run_test_concat_head2(
+    devices,
+    batch,
+    seq_len,
+):
+    ## Split Heads
+    n_local_heads = 8
+    padded_local_heads = 32
+    head_dim = 128
+    # Prepare input
+    concat_head_input = torch.rand(1, batch, padded_local_heads, head_dim)
+
+    shard_spec_32_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(7, 3),
+            ),
+        }
+    )
+    SCORES_BATCHED_MM_OUTPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_32_cores_grid,
+            [
+                batch,  # Each core has 32 users
+                head_dim,  # head dim
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    WIDTH_SHARDED_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED, ttl.tensor.BufferType.L1
+    )
+
+    # Prepare tt input
+    concat_head_input_tt = torch2tt_tensor(concat_head_input, tt_device=None).to(
+        device=devices[0], mem_config=SCORES_BATCHED_MM_OUTPUT_MEMCFG
+    )
+
+    concat_head_output = ttl.tensor.nlp_concat_heads_decode(
+        concat_head_input_tt,
+        num_heads=n_local_heads,
+    )  # seqlen, 1, batch, hidden_size
+
+    logger.info(f"concat_head_output: {concat_head_output.memory_config()}")
+
+    # Input: (1, 32, 32(8), 128)
+    # Output: (1, 1, 32, 1024)
+    concat_head_output_torch = concat_head_input[:, :, :n_local_heads].reshape(1, 1, batch, head_dim * n_local_heads)
+
+    # compare
+    concat_head_output_tt_cpu = tt2torch_tensor(concat_head_output)
+    out_pass_q, output_pcc_q = comp_pcc(concat_head_output_tt_cpu, concat_head_output_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+    assert out_pass_q
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "batch, seq_len",
+    ((32, 1),),
+)
+def test_concat_head2(
+    batch,
+    seq_len,
+    all_devices,
+):
+    n_devices = 8
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    run_test_concat_head2(
+        devices,
+        batch,
+        seq_len,
+    )

--- a/models/experimental/llama2_70b/tests/unit_tests/test_nlp_concat_head.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_nlp_concat_head.py
@@ -187,6 +187,7 @@ def test_concat_head2(
     batch,
     seq_len,
     all_devices,
+    # use_program_cache,
 ):
     n_devices = 8
     devices = get_devices_for_t3000(all_devices, num_devices=1)
@@ -197,3 +198,10 @@ def test_concat_head2(
         batch,
         seq_len,
     )
+
+    # for i in range(3):
+    #     run_test_concat_head2(
+    #         devices,
+    #         batch,
+    #         seq_len,
+    #     )

--- a/models/experimental/llama2_70b/tests/unit_tests/test_nlp_create_head.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_nlp_create_head.py
@@ -392,6 +392,7 @@ def test_create_head3(
     torch.manual_seed(0)
 
     for i in range(3):
+        # multiple loops to test program caching
         run_test_create_head3(
             devices,
             batch,

--- a/models/experimental/llama2_70b/tests/unit_tests/test_nlp_create_head.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_nlp_create_head.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+from loguru import logger
+import torch
+from torch import nn
+import tt_lib as ttl
+import ttnn
+
+from models.experimental.llama2_70b.reference.llama.llama import Llama
+from models.experimental.llama2_70b.reference.llama.llama.model import precompute_freqs_cis, apply_rotary_emb
+from models.experimental.llama2_70b.tt.model_config import (
+    get_model_config,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_allclose,
+    comp_pcc,
+)
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor, skip_for_grayskull, get_devices_for_t3000
+from models.experimental.llama2_70b.tt.llama_common import (
+    get_llama_path,
+    extract_pcc_from_log,
+    MAX_SEQ_LEN,
+    BASE_URL,
+    UNIT_TEST_N_LAYER,
+    UNIT_TEST_LAYER_NUM,
+    UNIT_TEST_START_POS,
+    UNIT_TEST_GENERATION_LENGTH,
+)
+from models.experimental.llama2_70b.tt.llama_common import (
+    tt_all_gather_torch,
+    precompute_freqs,
+    freqs_to_rotation_matrix,
+    gather_rotary_emb,
+    get_weight_cache_path,
+)
+
+
+def run_test_create_head1(
+    devices,
+    batch,
+    seq_len,
+):
+    ## Split Heads
+    n_local_heads = 8
+    n_local_kv_heads = 1
+    head_dim = 128
+    # Prepare input
+    proj_output = torch.rand(1, seq_len, batch, head_dim * 10)
+
+    # TT configs
+    shard_spec_1_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(0, 0),
+            ),
+        }
+    )
+    CREATE_HEAD_INPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_1_cores_grid,
+            [
+                32,
+                1280,
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    HEIGHT_SHARDED_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1
+    )
+
+    # Prepare tt input
+    proj_output_tt = torch2tt_tensor(proj_output, tt_device=None).to(
+        device=devices[0], mem_config=CREATE_HEAD_INPUT_MEMCFG
+    )
+
+    # tt operation
+    (
+        q_heads_tt,  # [seqlen, n_local_heads, bsz, head_dim]
+        k_heads_tt,  # [seqlen, n_local_kv_heads, bsz, head_dim]
+        v_heads_tt,  # [seqlen, n_local_kv_heads, bsz, head_dim]
+    ) = ttl.tensor.nlp_create_qkv_heads(
+        proj_output_tt,
+        num_heads=n_local_heads,
+        num_kv_heads=n_local_kv_heads,
+        transpose_k_heads=False,
+        output_mem_config=HEIGHT_SHARDED_MEMCFG,
+    )
+    logger.info(f"q_heads_tt: {q_heads_tt.memory_config()}")
+    logger.info(f"k_heads_tt: {k_heads_tt.memory_config()}")
+    logger.info(f"v_heads_tt: {v_heads_tt.memory_config()}")
+
+    # torch operation
+    q_heads_torch = (
+        proj_output[:, :, :, : head_dim * n_local_heads]
+        .view(seq_len, batch, n_local_heads, head_dim)
+        .permute(0, 2, 1, 3)
+    )
+    k_heads_torch = (
+        proj_output[:, :, :, head_dim * n_local_heads : head_dim * (n_local_heads + n_local_kv_heads)]
+        .view(seq_len, batch, n_local_kv_heads, head_dim)
+        .permute(0, 2, 1, 3)
+    )
+    v_heads_torch = (
+        proj_output[:, :, :, head_dim * (n_local_heads + n_local_kv_heads) :]
+        .view(seq_len, batch, n_local_kv_heads, head_dim)
+        .permute(0, 2, 1, 3)
+    )
+
+    # compare
+    q_heads_tt_cpu = tt2torch_tensor(q_heads_tt)
+    out_pass_q, output_pcc_q = comp_pcc(q_heads_tt_cpu, q_heads_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+    assert out_pass_q
+
+    k_heads_tt_cpu = tt2torch_tensor(k_heads_tt)
+    out_pass_k, output_pcc_k = comp_pcc(k_heads_tt_cpu, k_heads_torch)
+    logger.info(f"PCC value: {output_pcc_k}")
+    assert out_pass_k
+
+    v_heads_tt_cpu = tt2torch_tensor(v_heads_tt)
+    out_pass_v, output_pcc_v = comp_pcc(v_heads_tt_cpu, v_heads_torch)
+    logger.info(f"PCC value: {output_pcc_v}")
+    assert out_pass_v
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "batch, seq_len",
+    ((32, 1),),
+)
+def test_create_head1(
+    batch,
+    seq_len,
+    all_devices,
+):
+    n_devices = 8
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    run_test_create_head1(
+        devices,
+        batch,
+        seq_len,
+    )
+
+
+def run_test_create_head2(
+    devices,
+    batch,
+    seq_len,
+):
+    ## Split Heads
+    n_local_heads = 8
+    n_local_kv_heads = 1
+    head_dim = 128
+    # Prepare input
+    proj_output = torch.rand(1, seq_len, batch, head_dim * 10)
+
+    # TT configs
+    shard_spec_1_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(0, 0),
+            ),
+        }
+    )
+    CREATE_HEAD_INPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_1_cores_grid,
+            [
+                32,
+                1280,
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    HEIGHT_SHARDED_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1
+    )
+
+    # Prepare tt input
+    proj_output_tt = torch2tt_tensor(proj_output, tt_device=None).to(
+        device=devices[0], mem_config=CREATE_HEAD_INPUT_MEMCFG
+    )
+
+    # tt operation
+    (
+        q_heads_tt,  # [seqlen, n_local_heads, bsz, head_dim]
+        k_heads_tt,  # [seqlen, n_local_kv_heads, bsz, head_dim]
+        v_heads_tt,  # [seqlen, n_local_kv_heads, bsz, head_dim]
+    ) = ttl.tensor.nlp_create_qkv_heads_decode(
+        proj_output_tt,
+        num_heads=n_local_heads,
+        num_kv_heads=n_local_kv_heads,
+        output_mem_config=HEIGHT_SHARDED_MEMCFG,
+    )
+    logger.info(f"q_heads_tt: {q_heads_tt.memory_config()}")
+    logger.info(f"k_heads_tt: {k_heads_tt.memory_config()}")
+    logger.info(f"v_heads_tt: {v_heads_tt.memory_config()}")
+
+    # torch operation
+    q_heads_torch = torch.cat(
+        [
+            proj_output[:, :, :, : head_dim * n_local_heads].view(seq_len, batch, n_local_heads, head_dim),
+            torch.zeros(seq_len, batch, 32 - n_local_heads, head_dim),
+        ],
+        dim=-2,
+    )
+    k_heads_torch = torch.cat(
+        [
+            proj_output[:, :, :, head_dim * n_local_heads : head_dim * (n_local_heads + n_local_kv_heads)].view(
+                seq_len, batch, n_local_kv_heads, head_dim
+            ),
+            torch.zeros(seq_len, batch, 32 - n_local_kv_heads, head_dim),
+        ],
+        dim=-2,
+    )
+    v_heads_torch = torch.cat(
+        [
+            proj_output[:, :, :, head_dim * (n_local_heads + n_local_kv_heads) :].view(
+                seq_len, batch, n_local_kv_heads, head_dim
+            ),
+            torch.zeros(seq_len, batch, 32 - n_local_kv_heads, head_dim),
+        ],
+        dim=-2,
+    )
+
+    # compare
+    q_heads_tt_cpu = tt2torch_tensor(q_heads_tt)
+    out_pass_q, output_pcc_q = comp_pcc(q_heads_tt_cpu, q_heads_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+    assert out_pass_q
+
+    k_heads_tt_cpu = tt2torch_tensor(k_heads_tt)
+    out_pass_k, output_pcc_k = comp_pcc(k_heads_tt_cpu, k_heads_torch)
+    logger.info(f"PCC value: {output_pcc_k}")
+    assert out_pass_k
+
+    v_heads_tt_cpu = tt2torch_tensor(v_heads_tt)
+    out_pass_v, output_pcc_v = comp_pcc(v_heads_tt_cpu, v_heads_torch)
+    logger.info(f"PCC value: {output_pcc_v}")
+    assert out_pass_v
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "batch, seq_len",
+    ((32, 1),),
+)
+def test_create_head2(
+    batch,
+    seq_len,
+    all_devices,
+):
+    n_devices = 8
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    run_test_create_head2(
+        devices,
+        batch,
+        seq_len,
+    )

--- a/models/experimental/llama2_70b/tests/unit_tests/test_nlp_create_head.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_nlp_create_head.py
@@ -385,13 +385,15 @@ def test_create_head3(
     batch,
     seq_len,
     all_devices,
+    use_program_cache,
 ):
     n_devices = 8
     devices = get_devices_for_t3000(all_devices, num_devices=1)
     torch.manual_seed(0)
 
-    run_test_create_head3(
-        devices,
-        batch,
-        seq_len,
-    )
+    for i in range(3):
+        run_test_create_head3(
+            devices,
+            batch,
+            seq_len,
+        )

--- a/models/experimental/llama2_70b/tests/unit_tests/test_nlp_create_head.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_nlp_create_head.py
@@ -242,17 +242,16 @@ def run_test_create_head2(
     q_heads_tt_cpu = tt2torch_tensor(q_heads_tt)
     out_pass_q, output_pcc_q = comp_pcc(q_heads_tt_cpu, q_heads_torch)
     logger.info(f"PCC value: {output_pcc_q}")
-    assert out_pass_q
 
     k_heads_tt_cpu = tt2torch_tensor(k_heads_tt)
     out_pass_k, output_pcc_k = comp_pcc(k_heads_tt_cpu, k_heads_torch)
     logger.info(f"PCC value: {output_pcc_k}")
-    assert out_pass_k
 
     v_heads_tt_cpu = tt2torch_tensor(v_heads_tt)
     out_pass_v, output_pcc_v = comp_pcc(v_heads_tt_cpu, v_heads_torch)
     logger.info(f"PCC value: {output_pcc_v}")
-    assert out_pass_v
+
+    assert out_pass_q and out_pass_k and out_pass_v
 
 
 @skip_for_grayskull("Requires eth connected devices to run")

--- a/models/experimental/llama2_70b/tests/unit_tests/test_rotary_matmul.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_rotary_matmul.py
@@ -1,0 +1,499 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+from loguru import logger
+import torch
+from torch import nn
+import tt_lib as ttl
+import ttnn
+
+from models.experimental.llama2_70b.reference.llama.llama import Llama
+from models.experimental.llama2_70b.reference.llama.llama.model import precompute_freqs_cis, apply_rotary_emb
+from models.experimental.llama2_70b.tt.model_config import (
+    get_model_config,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_allclose,
+    comp_pcc,
+)
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor, skip_for_grayskull, get_devices_for_t3000
+from models.experimental.llama2_70b.tt.llama_common import (
+    get_llama_path,
+    extract_pcc_from_log,
+    MAX_SEQ_LEN,
+    BASE_URL,
+    UNIT_TEST_N_LAYER,
+    UNIT_TEST_LAYER_NUM,
+    UNIT_TEST_START_POS,
+    UNIT_TEST_GENERATION_LENGTH,
+)
+from models.experimental.llama2_70b.tt.llama_common import (
+    tt_all_gather_torch,
+    precompute_freqs,
+    freqs_to_rotation_matrix,
+    gather_rotary_emb,
+    get_weight_cache_path,
+)
+
+
+def run_test_rotary_matmul1(
+    devices,
+    batch,
+    seq_len,
+):
+    # Prepare input
+    head_dim = 128
+    n_head = 8
+    query_torch = torch.rand(seq_len, n_head, batch, head_dim)
+    key_torch = torch.rand(seq_len, 1, batch, head_dim)
+    rotary_mat = torch.rand(1, 1, head_dim, head_dim)
+
+    # memory configs
+    shard_spec_8_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(7, 0),
+            ),
+        }
+    )
+
+    ROT_MAT_Q_MM_OUTPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_8_cores_grid,
+            [
+                32,
+                head_dim,  # head dim
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    L1_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+
+    ROT_MAT_Q_MM_PROGCFG = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(8, 1),
+        in0_block_w=4,
+        out_subblock_h=1,
+        out_subblock_w=4,
+        per_core_M=1,
+        per_core_N=4,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+    )
+
+    ROT_MAT_COMPUTE_KERNEL_CONFIG = ttl.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttl.tensor.MathFidelity.HiFi4,  # Highest fidelity
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    # Prepare tt input
+    query_tt = torch2tt_tensor(query_torch, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_Q_MM_OUTPUT_MEMCFG)
+    key_tt = torch2tt_tensor(key_torch, devices[0])
+    rotary_mat_tt = torch2tt_tensor(rotary_mat, devices[0])
+
+    # tt operation
+    query_tt = ttl.operations.primary.matmul(
+        query_tt,
+        rotary_mat_tt,
+        program_config=ROT_MAT_Q_MM_PROGCFG,
+        output_mem_config=ROT_MAT_Q_MM_OUTPUT_MEMCFG,
+        compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
+        # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
+    )
+    key_tt = ttl.operations.primary.matmul(
+        key_tt,
+        rotary_mat_tt,
+        output_mem_config=L1_MEMCFG,
+        compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
+        # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
+    )
+
+    # torch operation
+    query_torch = query_torch @ rotary_mat
+    key_torch = key_torch @ rotary_mat
+
+    # compare
+    query_tt_cpu = tt2torch_tensor(query_tt)
+    key_tt_cpu = tt2torch_tensor(key_tt)
+    out_pass_q, output_pcc_q = comp_pcc(query_tt_cpu, query_torch)
+    out_pass_k, output_pcc_k = comp_pcc(key_tt_cpu, key_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+    logger.info(f"PCC value: {output_pcc_k}")
+    assert out_pass_q and out_pass_k
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "batch, seq_len",
+    ((32, 1),),
+)
+def test_rotray_matmul1(
+    batch,
+    seq_len,
+    all_devices,
+):
+    n_devices = 8
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    run_test_rotary_matmul1(
+        devices,
+        batch,
+        seq_len,
+    )
+
+
+def run_test_rotary_matmul2(
+    devices,
+    batch,
+    seq_len,
+):
+    # Prepare input
+    head_dim = 128
+    n_head = 8
+    query_torch = torch.rand(seq_len, batch, max(n_head, 32), head_dim)
+    key_torch = torch.rand(seq_len, batch, max(1, 32), head_dim)
+    rotary_mat = torch.rand(1, 1, head_dim, head_dim)
+
+    # memory configs
+    shard_spec_32_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(7, 3),
+            ),
+        }
+    )
+
+    ROT_MAT_MM_OUTPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_32_cores_grid,
+            [
+                32,
+                head_dim,  # head dim
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    L1_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+
+    ROT_MAT_MM_PROGCFG = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(8, 4),
+        in0_block_w=4,
+        out_subblock_h=1,
+        out_subblock_w=4,
+        per_core_M=1,
+        per_core_N=4,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+    )
+
+    ROT_MAT_COMPUTE_KERNEL_CONFIG = ttl.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttl.tensor.MathFidelity.HiFi4,  # Highest fidelity
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    # Prepare tt input
+    query_tt = torch2tt_tensor(query_torch, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_MM_OUTPUT_MEMCFG)
+    key_tt = torch2tt_tensor(key_torch, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_MM_OUTPUT_MEMCFG)
+    rotary_mat_tt = torch2tt_tensor(rotary_mat, devices[0])
+
+    # tt operation
+    query_tt = ttl.operations.primary.matmul(
+        query_tt,
+        rotary_mat_tt,
+        program_config=ROT_MAT_MM_PROGCFG,
+        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
+        # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
+    )
+    key_tt = ttl.operations.primary.matmul(
+        key_tt,
+        rotary_mat_tt,
+        program_config=ROT_MAT_MM_PROGCFG,
+        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
+        # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
+    )
+
+    # torch operation
+    query_torch = query_torch @ rotary_mat
+    key_torch = key_torch @ rotary_mat
+
+    # compare
+    query_tt_cpu = tt2torch_tensor(query_tt)
+    key_tt_cpu = tt2torch_tensor(key_tt)
+    out_pass_q, output_pcc_q = comp_pcc(query_tt_cpu, query_torch)
+    out_pass_k, output_pcc_k = comp_pcc(key_tt_cpu, key_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+    logger.info(f"PCC value: {output_pcc_k}")
+    assert out_pass_q and out_pass_k
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "batch, seq_len",
+    ((32, 1),),
+)
+def test_rotray_matmul2(
+    batch,
+    seq_len,
+    all_devices,
+):
+    n_devices = 8
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    run_test_rotary_matmul2(
+        devices,
+        batch,
+        seq_len,
+    )
+
+
+def run_test_rotary_matmul3(
+    devices,
+    batch,
+    seq_len,
+):
+    # Prepare input
+    head_dim = 128
+    n_head = 8
+    query_torch = torch.rand(seq_len, batch, max(n_head, 32), head_dim)
+    key_torch = torch.rand(seq_len, batch, max(1, 32), head_dim)
+    rotary_mat = torch.rand(1, batch, head_dim, head_dim)
+
+    # memory configs
+    shard_spec_32_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(7, 3),
+            ),
+        }
+    )
+
+    ROT_MAT_MM_OUTPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_32_cores_grid,
+            [
+                32,
+                head_dim,  # head dim
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    L1_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+
+    ROT_MAT_MM_PROGCFG = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+        compute_with_storage_grid_size=[8, 4],
+        in0_block_w=4,  # 128 // TILE_SIZE (dynamic)
+        out_subblock_h=1,
+        out_subblock_w=4,
+        per_core_M=1,
+        per_core_N=4,
+    )
+
+    ROT_MAT_COMPUTE_KERNEL_CONFIG = ttl.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttl.tensor.MathFidelity.HiFi4,  # Highest fidelity
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    # Prepare tt input
+    query_tt = torch2tt_tensor(query_torch, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_MM_OUTPUT_MEMCFG)
+    key_tt = torch2tt_tensor(key_torch, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_MM_OUTPUT_MEMCFG)
+    rotary_mat_tt = torch2tt_tensor(rotary_mat, devices[0])
+
+    # tt operation
+    query_tt = ttl.operations.primary.matmul(
+        query_tt,
+        rotary_mat_tt,
+        program_config=ROT_MAT_MM_PROGCFG,
+        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
+        # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
+    )
+    key_tt = ttl.operations.primary.matmul(
+        key_tt,
+        rotary_mat_tt,
+        program_config=ROT_MAT_MM_PROGCFG,
+        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
+        # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
+    )
+
+    # torch operation
+    query_torch = torch.bmm(torch.squeeze(query_torch), torch.squeeze(rotary_mat)).unsqueeze(0)
+    key_torch = torch.bmm(torch.squeeze(key_torch), torch.squeeze(rotary_mat)).unsqueeze(0)
+
+    # compare
+    query_tt_cpu = tt2torch_tensor(query_tt)
+    key_tt_cpu = tt2torch_tensor(key_tt)
+    out_pass_q, output_pcc_q = comp_pcc(query_tt_cpu, query_torch)
+    out_pass_k, output_pcc_k = comp_pcc(key_tt_cpu, key_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+    logger.info(f"PCC value: {output_pcc_k}")
+    assert out_pass_q and out_pass_k
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "batch, seq_len",
+    ((32, 1),),
+)
+def test_rotray_matmul3(
+    batch,
+    seq_len,
+    all_devices,
+):
+    n_devices = 8
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    run_test_rotary_matmul3(
+        devices,
+        batch,
+        seq_len,
+    )
+
+
+def run_test_rotary_matmul4(
+    devices,
+    batch,
+    seq_len,
+):
+    # Prepare input
+    head_dim = 128
+    n_head = 8
+    query_torch = torch.rand(seq_len, batch, max(n_head, 32), head_dim)
+    key_torch = torch.rand(seq_len, batch, max(1, 32), head_dim)
+    rotary_mat = torch.rand(1, batch, head_dim, head_dim)
+
+    # memory configs
+    shard_spec_32_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(7, 3),
+            ),
+        }
+    )
+
+    ROT_MAT_MM_OUTPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_32_cores_grid,
+            [
+                32,
+                head_dim,  # head dim
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    ROT_MAT_MM_IN1_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_32_cores_grid,
+            [
+                head_dim,
+                head_dim,  # head dim
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    ROT_MAT_MM_PROGCFG = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+        compute_with_storage_grid_size=[8, 4],
+        in0_block_w=4,  # 128 // TILE_SIZE (dynamic)
+        out_subblock_h=1,
+        out_subblock_w=4,
+        per_core_M=1,
+        per_core_N=4,
+    )
+
+    ROT_MAT_COMPUTE_KERNEL_CONFIG = ttl.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttl.tensor.MathFidelity.HiFi4,  # Highest fidelity
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    # Prepare tt input
+    query_tt = torch2tt_tensor(query_torch, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_MM_OUTPUT_MEMCFG)
+    key_tt = torch2tt_tensor(key_torch, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_MM_OUTPUT_MEMCFG)
+    rotary_mat_tt = torch2tt_tensor(rotary_mat, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_MM_IN1_MEMCFG)
+
+    # tt operation
+    query_tt = ttl.operations.primary.matmul(
+        query_tt,
+        rotary_mat_tt,
+        program_config=ROT_MAT_MM_PROGCFG,
+        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
+        # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
+    )
+    key_tt = ttl.operations.primary.matmul(
+        key_tt,
+        rotary_mat_tt,
+        program_config=ROT_MAT_MM_PROGCFG,
+        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
+        # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
+    )
+
+    # torch operation
+    query_torch = torch.bmm(torch.squeeze(query_torch), torch.squeeze(rotary_mat)).unsqueeze(0)
+    key_torch = torch.bmm(torch.squeeze(key_torch), torch.squeeze(rotary_mat)).unsqueeze(0)
+
+    # compare
+    query_tt_cpu = tt2torch_tensor(query_tt)
+    key_tt_cpu = tt2torch_tensor(key_tt)
+    out_pass_q, output_pcc_q = comp_pcc(query_tt_cpu, query_torch)
+    out_pass_k, output_pcc_k = comp_pcc(key_tt_cpu, key_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+    logger.info(f"PCC value: {output_pcc_k}")
+    assert out_pass_q and out_pass_k
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "batch, seq_len",
+    ((32, 1),),
+)
+def test_rotray_matmul4(
+    batch,
+    seq_len,
+    all_devices,
+):
+    n_devices = 8
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    run_test_rotary_matmul4(
+        devices,
+        batch,
+        seq_len,
+    )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
@@ -7,7 +7,6 @@ from loguru import logger
 import torch
 from torch import nn
 import tt_lib as ttl
-import ttnn
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_concat_heads_decode.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from loguru import logger
+import torch
+from torch import nn
+import tt_lib as ttl
+import ttnn
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_allclose,
+    comp_pcc,
+)
+
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor, skip_for_grayskull, get_devices_for_t3000
+
+
+def run_test_concat_head(
+    devices,
+    n_local_heads,
+    padded_local_heads,
+    head_dim,
+):
+    ## Split Heads
+    batch = 32
+    seq_len = 1
+
+    # Prepare input
+    concat_head_input = torch.rand(1, batch, padded_local_heads, head_dim)
+
+    shard_spec_32_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(7, 3),
+            ),
+        }
+    )
+    SCORES_BATCHED_MM_OUTPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_32_cores_grid,
+            [
+                batch,  # Each core has padded_local_heads
+                head_dim,  # head dim
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    WIDTH_SHARDED_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED, ttl.tensor.BufferType.L1
+    )
+
+    # Prepare tt input
+    concat_head_input_tt = torch2tt_tensor(concat_head_input, tt_device=None).to(
+        device=devices[0], mem_config=SCORES_BATCHED_MM_OUTPUT_MEMCFG
+    )
+
+    concat_head_output = ttl.tensor.nlp_concat_heads_decode(
+        concat_head_input_tt,
+        num_heads=n_local_heads,
+    )  # seqlen, 1, batch, hidden_size
+
+    logger.info(f"concat_head_output: {concat_head_output.memory_config()}")
+
+    # Input: (1, 32, 32(8), 128)
+    # Output: (1, 1, 32, 1024)
+    concat_head_output_torch = concat_head_input[:, :, :n_local_heads].reshape(1, 1, batch, head_dim * n_local_heads)
+
+    # compare
+    concat_head_output_tt_cpu = tt2torch_tensor(concat_head_output)
+    out_pass_q, output_pcc_q = comp_pcc(concat_head_output_tt_cpu, concat_head_output_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+    assert out_pass_q
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "n_local_heads, padded_local_heads, head_dim",
+    ((8, 32, 128), (17, 32, 96), (32, 32, 64)),
+)
+def test_concat_head(
+    n_local_heads,
+    padded_local_heads,
+    head_dim,
+    all_devices,
+    use_program_cache,
+):
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    for i in range(3):
+        # multiple loops to test program caching
+        run_test_concat_head(
+            devices,
+            n_local_heads,
+            padded_local_heads,
+            head_dim,
+        )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from loguru import logger
+import torch
+from torch import nn
+import tt_lib as ttl
+import ttnn
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_allclose,
+    comp_pcc,
+)
+
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor, skip_for_grayskull, get_devices_for_t3000
+
+
+def run_test_create_head_max_width_shard(
+    devices,
+    n_local_heads,
+    n_local_kv_heads,
+    head_dim,
+):
+    ## Split Heads
+    batch = 32
+    seq_len = 1
+    total_heads = n_local_heads + n_local_kv_heads * 2
+    # Prepare input
+    proj_output = torch.rand(1, seq_len, batch, head_dim * total_heads)
+
+    # TT configs
+    shard_spec_1_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(0, 0),
+            ),
+        }
+    )
+    CREATE_HEAD_INPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_1_cores_grid,
+            [
+                batch,
+                head_dim * total_heads,
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    HEIGHT_SHARDED_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1
+    )
+
+    # Prepare tt input
+    proj_output_tt = torch2tt_tensor(proj_output, tt_device=None).to(
+        device=devices[0], mem_config=CREATE_HEAD_INPUT_MEMCFG
+    )
+
+    # tt operation
+    (
+        q_heads_tt,  # [seqlen, n_local_heads, bsz, head_dim]
+        k_heads_tt,  # [seqlen, n_local_kv_heads, bsz, head_dim]
+        v_heads_tt,  # [seqlen, n_local_kv_heads, bsz, head_dim]
+    ) = ttl.tensor.nlp_create_qkv_heads_decode(
+        proj_output_tt,
+        num_heads=n_local_heads,
+        num_kv_heads=n_local_kv_heads,
+        output_mem_config=HEIGHT_SHARDED_MEMCFG,
+    )
+    logger.info(f"q_heads_tt: {q_heads_tt.memory_config()}")
+    logger.info(f"k_heads_tt: {k_heads_tt.memory_config()}")
+    logger.info(f"v_heads_tt: {v_heads_tt.memory_config()}")
+
+    # torch operation
+    q_heads_torch = torch.cat(
+        [
+            proj_output[:, :, :, : head_dim * n_local_heads].view(seq_len, batch, n_local_heads, head_dim),
+            torch.zeros(seq_len, batch, 32 - n_local_heads, head_dim),
+        ],
+        dim=-2,
+    )
+    k_heads_torch = torch.cat(
+        [
+            proj_output[:, :, :, head_dim * n_local_heads : head_dim * (n_local_heads + n_local_kv_heads)].view(
+                seq_len, batch, n_local_kv_heads, head_dim
+            ),
+            torch.zeros(seq_len, batch, 32 - n_local_kv_heads, head_dim),
+        ],
+        dim=-2,
+    )
+    v_heads_torch = torch.cat(
+        [
+            proj_output[:, :, :, head_dim * (n_local_heads + n_local_kv_heads) :].view(
+                seq_len, batch, n_local_kv_heads, head_dim
+            ),
+            torch.zeros(seq_len, batch, 32 - n_local_kv_heads, head_dim),
+        ],
+        dim=-2,
+    )
+
+    # compare
+    q_heads_tt_cpu = tt2torch_tensor(q_heads_tt)
+    out_pass_q, output_pcc_q = comp_pcc(q_heads_tt_cpu, q_heads_torch, pcc=0.9999)
+    logger.info(f"PCC value: {output_pcc_q}")
+
+    k_heads_tt_cpu = tt2torch_tensor(k_heads_tt)
+    out_pass_k, output_pcc_k = comp_pcc(k_heads_tt_cpu, k_heads_torch, pcc=0.9999)
+    logger.info(f"PCC value: {output_pcc_k}")
+
+    v_heads_tt_cpu = tt2torch_tensor(v_heads_tt)
+    out_pass_v, output_pcc_v = comp_pcc(v_heads_tt_cpu, v_heads_torch, pcc=0.9999)
+    logger.info(f"PCC value: {output_pcc_v}")
+
+    assert out_pass_q and out_pass_k and out_pass_v
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "n_local_heads, n_local_kv_heads, head_dim",
+    ((8, 1, 128), (8, 4, 96), (16, 2, 64)),
+)
+def test_create_head_max_width_shard(
+    n_local_heads,
+    n_local_kv_heads,
+    head_dim,
+    all_devices,
+    use_program_cache,
+):
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    for i in range(3):
+        # multiple loops to test program caching
+        run_test_create_head_max_width_shard(
+            devices,
+            n_local_heads,
+            n_local_kv_heads,
+            head_dim,
+        )
+
+
+def run_test_create_min_width_shard(
+    devices,
+    n_local_heads,
+    n_local_kv_heads,
+    head_dim,
+):
+    ## Split Heads
+    batch = 32
+    seq_len = 1
+    total_heads = n_local_heads + n_local_kv_heads * 2
+    total_cores = total_heads * head_dim // 32
+    core_x = min(total_cores, 8)
+    core_y = max(1, total_cores // core_x)
+    # Prepare input
+    proj_output = torch.rand(1, seq_len, batch, head_dim * total_heads)
+
+    # TT configs
+    shard_spec_n_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(core_x - 1, core_y - 1),
+            ),
+        }
+    )
+    CREATE_HEAD_INPUT_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_n_cores_grid,
+            [
+                32,
+                32,
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    HEIGHT_SHARDED_MEMCFG = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1
+    )
+
+    # Prepare tt input
+    proj_output_tt = torch2tt_tensor(proj_output, tt_device=None).to(
+        device=devices[0], mem_config=CREATE_HEAD_INPUT_MEMCFG
+    )
+
+    # tt operation
+    (
+        q_heads_tt,  # [seqlen, n_local_heads, bsz, head_dim]
+        k_heads_tt,  # [seqlen, n_local_kv_heads, bsz, head_dim]
+        v_heads_tt,  # [seqlen, n_local_kv_heads, bsz, head_dim]
+    ) = ttl.tensor.nlp_create_qkv_heads_decode(
+        proj_output_tt,
+        num_heads=n_local_heads,
+        num_kv_heads=n_local_kv_heads,
+        output_mem_config=HEIGHT_SHARDED_MEMCFG,
+    )
+    logger.info(f"q_heads_tt: {q_heads_tt.memory_config()}")
+    logger.info(f"k_heads_tt: {k_heads_tt.memory_config()}")
+    logger.info(f"v_heads_tt: {v_heads_tt.memory_config()}")
+
+    # torch operation
+    q_heads_torch = torch.cat(
+        [
+            proj_output[:, :, :, : head_dim * n_local_heads].view(seq_len, batch, n_local_heads, head_dim),
+            torch.zeros(seq_len, batch, 32 - n_local_heads, head_dim),
+        ],
+        dim=-2,
+    )
+    k_heads_torch = torch.cat(
+        [
+            proj_output[:, :, :, head_dim * n_local_heads : head_dim * (n_local_heads + n_local_kv_heads)].view(
+                seq_len, batch, n_local_kv_heads, head_dim
+            ),
+            torch.zeros(seq_len, batch, 32 - n_local_kv_heads, head_dim),
+        ],
+        dim=-2,
+    )
+    v_heads_torch = torch.cat(
+        [
+            proj_output[:, :, :, head_dim * (n_local_heads + n_local_kv_heads) :].view(
+                seq_len, batch, n_local_kv_heads, head_dim
+            ),
+            torch.zeros(seq_len, batch, 32 - n_local_kv_heads, head_dim),
+        ],
+        dim=-2,
+    )
+
+    # compare
+    q_heads_tt_cpu = tt2torch_tensor(q_heads_tt)
+    out_pass_q, output_pcc_q = comp_pcc(q_heads_tt_cpu, q_heads_torch)
+    logger.info(f"PCC value: {output_pcc_q}")
+
+    k_heads_tt_cpu = tt2torch_tensor(k_heads_tt)
+    out_pass_k, output_pcc_k = comp_pcc(k_heads_tt_cpu, k_heads_torch)
+    logger.info(f"PCC value: {output_pcc_k}")
+
+    v_heads_tt_cpu = tt2torch_tensor(v_heads_tt)
+    out_pass_v, output_pcc_v = comp_pcc(v_heads_tt_cpu, v_heads_torch)
+    logger.info(f"PCC value: {output_pcc_v}")
+
+    assert out_pass_q and out_pass_k and out_pass_v
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "n_local_heads, n_local_kv_heads, head_dim",
+    ((8, 1, 128), (8, 4, 96), (16, 2, 64)),
+)
+def test_create_min_width_shard(
+    n_local_heads,
+    n_local_kv_heads,
+    head_dim,
+    all_devices,
+    use_program_cache,
+):
+    devices = get_devices_for_t3000(all_devices, num_devices=1)
+    torch.manual_seed(0)
+
+    for i in range(3):
+        # multiple loops to test program caching
+        run_test_create_min_width_shard(
+            devices,
+            n_local_heads,
+            n_local_kv_heads,
+            head_dim,
+        )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
@@ -7,7 +7,6 @@ from loguru import logger
 import torch
 from torch import nn
 import tt_lib as ttl
-import ttnn
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -186,6 +186,7 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads.cpp \
+	tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp \
 	tt_eager/tt_dnn/op_library/rotate_half/single_core/rotate_half_op_single_core.cpp \

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -183,6 +183,7 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/repeat/repeat_op.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_falcon7b.cpp \
+	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads.cpp \
 	tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp \

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -186,7 +186,9 @@ set(TT_DNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/nlp_tms/nlp_tms.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/nlp_tms/nlp_create_qkv_heads_falcon7b.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/nlp_tms/nlp_create_qkv_heads.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/nlp_tms/nlp_create_qkv_heads_decode.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/nlp_tms/nlp_concat_heads.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/nlp_tms/nlp_concat_heads_decode.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rotate_half/single_core/rotate_half_op_single_core.cpp

--- a/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode.cpp
@@ -31,44 +31,16 @@ void kernel_main() {
     uint32_t total_input_cores = num_x * num_y;
     uint32_t num_tiles_per_core = (head_size_num_tiles * batch) / total_input_cores;
 
-    // // debug for loop
-    // DPRINT << "[mikevin DPRINT] NOC coordinates:" << ENDL();
-    // DPRINT << "     total_input_cores: " << total_input_cores << ENDL();
-    // DPRINT << "     num_tiles_per_core: " << num_tiles_per_core << ENDL();
-    // for (uint32_t i = 0; i < num_x; i++){
-    //     for (uint32_t j = 0; j < num_y; j++){
-    //         DPRINT << "         " << in0_mcast_noc_x[i] << ", " << in0_mcast_noc_y[j] << ENDL();
-    //     }
-    // }
-
-
     uint64_t qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_head;
     uint32_t num_tiles_read_cur_core = 0;
     uint32_t q_write_addr = 0;
     uint32_t tile_size = head_size/head_size_num_tiles;
     const uint32_t cb_write_ptr_base = get_write_ptr(cb_id_q_out);
 
-    // DPRINT << "[xuncai DPRINT] head_size = " << head_size << ENDL();
-    // DPRINT << "[xuncai DPRINT] head_size_num_tiles = " << head_size_num_tiles << ENDL();
-    // DPRINT << "[xuncai DPRINT] ELEMENT_SIZE = " << ELEMENT_SIZE << ENDL();
-    // DPRINT << "[xuncai DPRINT] SUBTILE_LINE_BYTES = " << SUBTILE_LINE_BYTES << ENDL();
-    // DPRINT << "[xuncai DPRINT] tile_size = " << tile_size << ENDL();
-    // DPRINT << "[xuncai DPRINT] batch = " << batch << ENDL();
-    // DPRINT << "[xuncai DPRINT] num_kv_heads = " << num_kv_heads << ENDL();
-    // DPRINT << "[xuncai DPRINT] in_tile_offset_by_head = " << in_tile_offset_by_head << ENDL();
-
-    // Read 2 phases per tile, where there are batch * q_num_tiles tiles
-    // DPRINT << "[xuncai DPRINT] Q read:" << ENDL();
-    // DPRINT << "         qkv_read_addr = " << qkv_read_addr << ENDL();
-    // DPRINT << "         q_write_addr = " << q_write_addr << ENDL();
     for (uint32_t q = 0; q < batch; ++q) {
-        // DPRINT << "[xuncai DPRINT] q = " << q << ENDL();
         uint32_t wptr_offset = q < 16 ? q * SUBTILE_LINE_BYTES : (q - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
         uint32_t q_write_addr = cb_write_ptr_base + wptr_offset;
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
-            // DPRINT << "[xuncai DPRINT] i = " << i << ENDL();
-            // DPRINT << "         qkv_read_addr = " << qkv_read_addr << ENDL();
-            // DPRINT << "         q_write_addr = " << q_write_addr << ENDL();
             // Read first phase
             if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
                 noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);

--- a/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+// #include "debug/dprint.h"  // required in all kernels using DPRINT
+
+void kernel_main() {
+
+    uint32_t head_size                     = get_arg_val<uint32_t>(0);
+    uint32_t batch                         = get_arg_val<uint32_t>(1);
+    uint32_t head_size_num_tiles           = get_arg_val<uint32_t>(2);
+    uint32_t in_tile_offset_by_head        = get_arg_val<uint32_t>(3);
+    uint32_t start_qkv_x                   = get_arg_val<uint32_t>(4);
+    uint32_t start_qkv_y                   = get_arg_val<uint32_t>(5);
+    uint32_t q_start_addr                  = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t ELEMENT_SIZE        = get_compile_time_arg_val(0);
+    constexpr uint32_t SUBTILE_LINE_BYTES  = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_q_out         = get_compile_time_arg_val(2);
+
+    uint32_t num_x                         = get_arg_val<uint32_t>(7);
+    uint32_t num_y                         = get_arg_val<uint32_t>(8);
+    volatile tt_l1_ptr uint32_t * in0_mcast_noc_x          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(9));
+    volatile tt_l1_ptr uint32_t * in0_mcast_noc_y          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(9 + num_x));
+
+    // Q
+    uint32_t qkv_x = start_qkv_x;
+    uint32_t qkv_y = start_qkv_y;
+    uint32_t total_input_cores = num_x * num_y;
+    uint32_t num_tiles_per_core = (head_size_num_tiles * batch) / total_input_cores;
+
+    // // debug for loop
+    // DPRINT << "[mikevin DPRINT] NOC coordinates:" << ENDL();
+    // DPRINT << "     total_input_cores: " << total_input_cores << ENDL();
+    // DPRINT << "     num_tiles_per_core: " << num_tiles_per_core << ENDL();
+    // for (uint32_t i = 0; i < num_x; i++){
+    //     for (uint32_t j = 0; j < num_y; j++){
+    //         DPRINT << "         " << in0_mcast_noc_x[i] << ", " << in0_mcast_noc_y[j] << ENDL();
+    //     }
+    // }
+
+
+    uint64_t qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_head;
+    uint32_t num_tiles_read_cur_core = 0;
+    uint32_t q_write_addr = 0;
+    uint32_t tile_size = head_size/head_size_num_tiles;
+
+    // DPRINT << "[xuncai DPRINT] head_size = " << head_size << ENDL();
+    // DPRINT << "[xuncai DPRINT] head_size_num_tiles = " << head_size_num_tiles << ENDL();
+    // DPRINT << "[xuncai DPRINT] ELEMENT_SIZE = " << ELEMENT_SIZE << ENDL();
+    // DPRINT << "[xuncai DPRINT] SUBTILE_LINE_BYTES = " << SUBTILE_LINE_BYTES << ENDL();
+    // DPRINT << "[xuncai DPRINT] tile_size = " << tile_size << ENDL();
+    // DPRINT << "[xuncai DPRINT] batch = " << batch << ENDL();
+    // DPRINT << "[xuncai DPRINT] num_kv_heads = " << num_kv_heads << ENDL();
+    // DPRINT << "[xuncai DPRINT] in_tile_offset_by_head = " << in_tile_offset_by_head << ENDL();
+
+    // Read 2 phases per tile, where there are batch * q_num_tiles tiles
+    // DPRINT << "[xuncai DPRINT] Q read:" << ENDL();
+    // DPRINT << "         qkv_read_addr = " << qkv_read_addr << ENDL();
+    // DPRINT << "         q_write_addr = " << q_write_addr << ENDL();
+    for (uint32_t q = 0; q < batch; ++q) {
+        // DPRINT << "[xuncai DPRINT] q = " << q << ENDL();
+        uint32_t wptr_offset = q < 16 ? q * SUBTILE_LINE_BYTES : (q - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
+        uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            // DPRINT << "[xuncai DPRINT] i = " << i << ENDL();
+            // DPRINT << "         qkv_read_addr = " << qkv_read_addr << ENDL();
+            // DPRINT << "         q_write_addr = " << q_write_addr << ENDL();
+            // Read first phase
+            noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
+            //noc_async_read_barrier();
+            // Read second phase
+            noc_async_read(qkv_read_addr+256*ELEMENT_SIZE, q_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+            //noc_async_read_barrier();
+
+            qkv_read_addr += tile_size;
+            q_write_addr += tile_size;
+            num_tiles_read_cur_core++;
+
+            if (num_tiles_read_cur_core == num_tiles_per_core) {
+                qkv_x++;
+                if (qkv_x == num_x) {
+                    qkv_x = 0;
+                    qkv_y++;
+                }
+                qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_head;
+                num_tiles_read_cur_core = 0;
+            }
+        }
+    }
+
+    noc_async_read_barrier();
+}

--- a/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 
+// #include "debug/dprint.h"  // required in all kernels using DPRINT
+
 void kernel_main() {
 
     uint32_t head_size                     = get_arg_val<uint32_t>(0);
@@ -25,27 +27,44 @@ void kernel_main() {
     constexpr uint32_t cb_id_v_out         = get_compile_time_arg_val(4);
 
     uint32_t num_x                         = get_arg_val<uint32_t>(10);
-    volatile tt_l1_ptr uint32_t * in0_mcast_noc_x          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(8));
-    volatile tt_l1_ptr uint32_t * in0_mcast_noc_y          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(8 + num_x));
+    volatile tt_l1_ptr uint32_t * in0_mcast_noc_x          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(11));
+    volatile tt_l1_ptr uint32_t * in0_mcast_noc_y          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(11 + num_x));
 
     // Q
     uint32_t q_x = start_q_x;
     uint32_t q_y = start_q_y;
+    // DPRINT << "[xuncai DPRINT] NOC coordinates: " << in0_mcast_noc_x[q_x] << ", " << in0_mcast_noc_y[q_y] << ENDL();
     uint64_t q_read_addr = get_noc_addr(in0_mcast_noc_x[q_x], in0_mcast_noc_y[q_y], q_start_addr) + in_tile_offset_by_batch;
     uint32_t q_write_addr = 0;
     uint32_t tile_size = head_size/head_size_num_tiles;
 
+    // DPRINT << "[xuncai DPRINT] head_size = " << head_size << ENDL();
+    // DPRINT << "[xuncai DPRINT] head_size_num_tiles = " << head_size_num_tiles << ENDL();
+    // DPRINT << "[xuncai DPRINT] ELEMENT_SIZE = " << ELEMENT_SIZE << ENDL();
+    // DPRINT << "[xuncai DPRINT] SUBTILE_LINE_BYTES = " << SUBTILE_LINE_BYTES << ENDL();
+    // DPRINT << "[xuncai DPRINT] tile_size = " << tile_size << ENDL();
+    // DPRINT << "[xuncai DPRINT] num_q_heads = " << num_q_heads << ENDL();
+    // DPRINT << "[xuncai DPRINT] num_kv_heads = " << num_kv_heads << ENDL();
+    // DPRINT << "[xuncai DPRINT] in_tile_offset_by_batch = " << in_tile_offset_by_batch << ENDL();
+
     // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+    // DPRINT << "[xuncai DPRINT] Q read:" << ENDL();
+    // DPRINT << "         q_read_addr = " << q_read_addr << ENDL();
+    // DPRINT << "         q_write_addr = " << q_write_addr << ENDL();
     for (uint32_t q = 0; q < num_q_heads; ++q) {
+        // DPRINT << "[xuncai DPRINT] q = " << q << ENDL();
         uint32_t wptr_offset = q < 16 ? q * SUBTILE_LINE_BYTES : (q - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
         uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            // DPRINT << "[xuncai DPRINT] i = " << i << ENDL();
+            // DPRINT << "         q_read_addr = " << q_read_addr << ENDL();
+            // DPRINT << "         q_write_addr = " << q_write_addr << ENDL();
             // Read first phase
             noc_async_read(q_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
-            noc_async_read_barrier();
+            //noc_async_read_barrier();
             // Read second phase
             noc_async_read(q_read_addr+256*ELEMENT_SIZE, q_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
-            noc_async_read_barrier();
+            //noc_async_read_barrier();
 
             q_read_addr += tile_size;
             q_write_addr += tile_size;
@@ -65,10 +84,10 @@ void kernel_main() {
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
             // Read first phase
             noc_async_read(k_read_addr, k_write_addr, SUBTILE_LINE_BYTES);
-            noc_async_read_barrier();
+            //noc_async_read_barrier();
             // Read second phase
             noc_async_read(k_read_addr+256*ELEMENT_SIZE, k_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
-            noc_async_read_barrier();
+            //noc_async_read_barrier();
 
             k_read_addr += tile_size;
             k_write_addr += tile_size;
@@ -88,13 +107,15 @@ void kernel_main() {
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
             // Read first phase
             noc_async_read(v_read_addr, v_write_addr, SUBTILE_LINE_BYTES);
-            noc_async_read_barrier();
+            //noc_async_read_barrier();
             // Read second phase
             noc_async_read(v_read_addr+256*ELEMENT_SIZE, v_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
-            noc_async_read_barrier();
+            //noc_async_read_barrier();
 
             v_read_addr += tile_size;
             v_write_addr += tile_size;
         }
     }
+
+    noc_async_read_barrier();
 }

--- a/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+
+    uint32_t head_size                     = get_arg_val<uint32_t>(0);
+    uint32_t num_q_heads                   = get_arg_val<uint32_t>(1);
+    uint32_t num_kv_heads                   = get_arg_val<uint32_t>(2);
+    uint32_t head_size_num_tiles           = get_arg_val<uint32_t>(3);
+    uint32_t in_tile_offset_by_batch       = get_arg_val<uint32_t>(4);
+    uint32_t start_q_x                     = get_arg_val<uint32_t>(5);
+    uint32_t start_q_y                     = get_arg_val<uint32_t>(6);
+    uint32_t q_start_addr                  = get_arg_val<uint32_t>(7);
+    uint32_t k_start_addr                  = get_arg_val<uint32_t>(8);
+    uint32_t v_start_addr                  = get_arg_val<uint32_t>(9);
+
+    constexpr uint32_t ELEMENT_SIZE        = get_compile_time_arg_val(0);
+    constexpr uint32_t SUBTILE_LINE_BYTES  = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_q_out         = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_id_k_out         = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_id_v_out         = get_compile_time_arg_val(4);
+
+    uint32_t num_x                         = get_arg_val<uint32_t>(10);
+    volatile tt_l1_ptr uint32_t * in0_mcast_noc_x          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(8));
+    volatile tt_l1_ptr uint32_t * in0_mcast_noc_y          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(8 + num_x));
+
+    // Q
+    uint32_t q_x = start_q_x;
+    uint32_t q_y = start_q_y;
+    uint64_t q_read_addr = get_noc_addr(in0_mcast_noc_x[q_x], in0_mcast_noc_y[q_y], q_start_addr) + in_tile_offset_by_batch;
+    uint32_t q_write_addr = 0;
+    uint32_t tile_size = head_size/head_size_num_tiles;
+
+    // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+    for (uint32_t q = 0; q < num_q_heads; ++q) {
+        uint32_t wptr_offset = q < 16 ? q * SUBTILE_LINE_BYTES : (q - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
+        uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            // Read first phase
+            noc_async_read(q_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
+            noc_async_read_barrier();
+            // Read second phase
+            noc_async_read(q_read_addr+256*ELEMENT_SIZE, q_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+            noc_async_read_barrier();
+
+            q_read_addr += tile_size;
+            q_write_addr += tile_size;
+        }
+    }
+
+    // K
+    uint32_t k_x = start_q_x;
+    uint32_t k_y = start_q_y;
+    uint64_t k_read_addr = get_noc_addr(in0_mcast_noc_x[k_x], in0_mcast_noc_y[k_y], k_start_addr) + in_tile_offset_by_batch;
+    uint32_t k_write_addr = 0;
+
+    // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+    for (uint32_t k = 0; k < num_kv_heads; ++k) {
+        uint32_t wptr_offset = k < 16 ? k * SUBTILE_LINE_BYTES : (k - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
+        uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            // Read first phase
+            noc_async_read(k_read_addr, k_write_addr, SUBTILE_LINE_BYTES);
+            noc_async_read_barrier();
+            // Read second phase
+            noc_async_read(k_read_addr+256*ELEMENT_SIZE, k_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+            noc_async_read_barrier();
+
+            k_read_addr += tile_size;
+            k_write_addr += tile_size;
+        }
+    }
+
+    // v
+    uint32_t v_x = start_q_x;
+    uint32_t v_y = start_q_y;
+    uint64_t v_read_addr = get_noc_addr(in0_mcast_noc_x[v_x], in0_mcast_noc_y[v_y], v_start_addr) + in_tile_offset_by_batch;
+    uint32_t v_write_addr = 0;
+
+    // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+    for (uint32_t v = 0; v < num_kv_heads; ++v) {
+        uint32_t wptr_offset = v < 16 ? v * SUBTILE_LINE_BYTES : (v - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
+        uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            // Read first phase
+            noc_async_read(v_read_addr, v_write_addr, SUBTILE_LINE_BYTES);
+            noc_async_read_barrier();
+            // Read second phase
+            noc_async_read(v_read_addr+256*ELEMENT_SIZE, v_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+            noc_async_read_barrier();
+
+            v_read_addr += tile_size;
+            v_write_addr += tile_size;
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -33,43 +33,15 @@ void kernel_main() {
     uint32_t total_input_cores = num_x * num_y;
     uint32_t num_tiles_per_core = head_size_num_tiles * (num_q_heads + 2 * num_kv_heads) / total_input_cores;
 
-    // // debug for loop
-    // DPRINT << "[mikevin DPRINT] NOC coordinates:" << ENDL();
-    // DPRINT << "     total_input_cores: " << total_input_cores << ENDL();
-    // DPRINT << "     num_tiles_per_core: " << num_tiles_per_core << ENDL();
-    // for (uint32_t i = 0; i < num_x; i++){
-    //     for (uint32_t j = 0; j < num_y; j++){
-    //         DPRINT << "         " << in0_mcast_noc_x[i] << ", " << in0_mcast_noc_y[j] << ENDL();
-    //     }
-    // }
-
-
     uint64_t qkv_read_addr = get_noc_addr(in0_mcast_noc_x[qkv_x], in0_mcast_noc_y[qkv_y], q_start_addr) + in_tile_offset_by_batch;
     uint32_t num_tiles_read_cur_core = 0;
     uint32_t q_write_addr = 0;
     uint32_t tile_size = head_size/head_size_num_tiles;
 
-    // DPRINT << "[xuncai DPRINT] head_size = " << head_size << ENDL();
-    // DPRINT << "[xuncai DPRINT] head_size_num_tiles = " << head_size_num_tiles << ENDL();
-    // DPRINT << "[xuncai DPRINT] ELEMENT_SIZE = " << ELEMENT_SIZE << ENDL();
-    // DPRINT << "[xuncai DPRINT] SUBTILE_LINE_BYTES = " << SUBTILE_LINE_BYTES << ENDL();
-    // DPRINT << "[xuncai DPRINT] tile_size = " << tile_size << ENDL();
-    // DPRINT << "[xuncai DPRINT] num_q_heads = " << num_q_heads << ENDL();
-    // DPRINT << "[xuncai DPRINT] num_kv_heads = " << num_kv_heads << ENDL();
-    // DPRINT << "[xuncai DPRINT] in_tile_offset_by_batch = " << in_tile_offset_by_batch << ENDL();
-
-    // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
-    // DPRINT << "[xuncai DPRINT] Q read:" << ENDL();
-    // DPRINT << "         qkv_read_addr = " << qkv_read_addr << ENDL();
-    // DPRINT << "         q_write_addr = " << q_write_addr << ENDL();
     for (uint32_t q = 0; q < num_q_heads; ++q) {
-        // DPRINT << "[xuncai DPRINT] q = " << q << ENDL();
         uint32_t wptr_offset = q < 16 ? q * SUBTILE_LINE_BYTES : (q - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
         uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
         for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
-            // DPRINT << "[xuncai DPRINT] i = " << i << ENDL();
-            // DPRINT << "         qkv_read_addr = " << qkv_read_addr << ENDL();
-            // DPRINT << "         q_write_addr = " << q_write_addr << ENDL();
             // Read first phase
             if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
                 noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);

--- a/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -17,8 +17,6 @@ void kernel_main() {
     uint32_t start_qkv_x                     = get_arg_val<uint32_t>(5);
     uint32_t start_qkv_y                     = get_arg_val<uint32_t>(6);
     uint32_t q_start_addr                  = get_arg_val<uint32_t>(7);
-    uint32_t k_start_addr                  = get_arg_val<uint32_t>(8);
-    uint32_t v_start_addr                  = get_arg_val<uint32_t>(9);
 
     constexpr uint32_t ELEMENT_SIZE        = get_compile_time_arg_val(0);
     constexpr uint32_t SUBTILE_LINE_BYTES  = get_compile_time_arg_val(1);
@@ -26,10 +24,10 @@ void kernel_main() {
     constexpr uint32_t cb_id_k_out         = get_compile_time_arg_val(3);
     constexpr uint32_t cb_id_v_out         = get_compile_time_arg_val(4);
 
-    uint32_t num_x                         = get_arg_val<uint32_t>(10);
-    uint32_t num_y                         = get_arg_val<uint32_t>(11);
-    volatile tt_l1_ptr uint32_t * in0_mcast_noc_x          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(12));
-    volatile tt_l1_ptr uint32_t * in0_mcast_noc_y          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(12 + num_x));
+    uint32_t num_x                         = get_arg_val<uint32_t>(8);
+    uint32_t num_y                         = get_arg_val<uint32_t>(9);
+    volatile tt_l1_ptr uint32_t * in0_mcast_noc_x          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(10));
+    volatile tt_l1_ptr uint32_t * in0_mcast_noc_y          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(10 + num_x));
 
     // Q
     uint32_t qkv_x = start_qkv_x;

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
@@ -41,18 +41,6 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor 
     auto in_cores = in_shard_spec.grid;
     auto in_num_tiles = in_shard_spec.shape[0] * in_shard_spec.shape[1] / TILE_HW;
 
-    log_debug("[xuncai] head_tiles: {}", head_tiles);
-    log_debug("[xuncai] head_size: {}", head_size);
-    log_debug("[xuncai] element_size: {}", element_size);
-    log_debug("[xuncai] sub_tile_line_bytes: {}", sub_tile_line_bytes);
-    log_debug("[xuncai] in_shard_spec: {}", in_shard_spec);
-    log_debug("[xuncai] in_cores: {}", in_cores);
-    log_debug("[xuncai] in_num_tiles: {}", in_num_tiles);
-
-    log_debug("[xuncai] q_shard_spec: {}", q_shard_spec);
-    log_debug("[xuncai] q_cores: {}", q_cores);
-    log_debug("[xuncai] q_num_tiles: {}", q_num_tiles);
-
     uint32_t q_output_cb_index = CB::c_out0;
     tt_metal::CircularBufferConfig cb_q_output_config =
         tt_metal::CircularBufferConfig(
@@ -77,13 +65,11 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor 
     noc_x_coords.reserve(in_num_cores_x);
     for (uint32_t x = 0; x < in_num_cores_x; ++x) {
         noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
-        log_debug("[xuncai] noc_x_coords[{}]: {}", x, noc_x_coords[x]);
     }
     std::vector<uint32_t> noc_y_coords;
     noc_y_coords.reserve(in_num_cores_y);
     for (uint32_t y = 0; y < in_num_cores_y; ++y) {
         noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
-        log_debug("[xuncai] noc_y_coords[{}]: {}", y, noc_y_coords[y]);
     }
 
     // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a tile respectively)

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
@@ -41,17 +41,17 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor 
     auto in_cores = in_shard_spec.grid;
     auto in_num_tiles = in_shard_spec.shape[0] * in_shard_spec.shape[1] / TILE_HW;
 
-    log_info("[xuncai] head_tiles: {}", head_tiles);
-    log_info("[xuncai] head_size: {}", head_size);
-    log_info("[xuncai] element_size: {}", element_size);
-    log_info("[xuncai] sub_tile_line_bytes: {}", sub_tile_line_bytes);
-    log_info("[xuncai] in_shard_spec: {}", in_shard_spec);
-    log_info("[xuncai] in_cores: {}", in_cores);
-    log_info("[xuncai] in_num_tiles: {}", in_num_tiles);
+    log_debug("[xuncai] head_tiles: {}", head_tiles);
+    log_debug("[xuncai] head_size: {}", head_size);
+    log_debug("[xuncai] element_size: {}", element_size);
+    log_debug("[xuncai] sub_tile_line_bytes: {}", sub_tile_line_bytes);
+    log_debug("[xuncai] in_shard_spec: {}", in_shard_spec);
+    log_debug("[xuncai] in_cores: {}", in_cores);
+    log_debug("[xuncai] in_num_tiles: {}", in_num_tiles);
 
-    log_info("[xuncai] q_shard_spec: {}", q_shard_spec);
-    log_info("[xuncai] q_cores: {}", q_cores);
-    log_info("[xuncai] q_num_tiles: {}", q_num_tiles);
+    log_debug("[xuncai] q_shard_spec: {}", q_shard_spec);
+    log_debug("[xuncai] q_cores: {}", q_cores);
+    log_debug("[xuncai] q_num_tiles: {}", q_num_tiles);
 
     uint32_t q_output_cb_index = CB::c_out0;
     tt_metal::CircularBufferConfig cb_q_output_config =
@@ -77,13 +77,13 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor 
     noc_x_coords.reserve(in_num_cores_x);
     for (uint32_t x = 0; x < in_num_cores_x; ++x) {
         noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
-        log_info("[xuncai] noc_x_coords[{}]: {}", x, noc_x_coords[x]);
+        log_debug("[xuncai] noc_x_coords[{}]: {}", x, noc_x_coords[x]);
     }
     std::vector<uint32_t> noc_y_coords;
     noc_y_coords.reserve(in_num_cores_y);
     for (uint32_t y = 0; y < in_num_cores_y; ++y) {
         noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
-        log_info("[xuncai] noc_y_coords[{}]: {}", y, noc_y_coords[y]);
+        log_debug("[xuncai] noc_y_coords[{}]: {}", y, noc_y_coords[y]);
     }
 
     // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a tile respectively)

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/nlp_tms/nlp_tms.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+
+using namespace tt::constants;
+using namespace tt;
+
+namespace tt {
+
+namespace tt_metal {
+
+operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor &a, Tensor& output, CoreCoord compute_with_storage_grid_size) {
+
+    const auto& ashape = a.get_legacy_shape();
+
+    tt_metal::Device *device = a.device();
+
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+
+    uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
+    tt_metal::Buffer *in0_buffer = a.buffer();
+    bool in_sharded = a.is_sharded();
+    bool out_sharded = output.is_sharded();
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      TM Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t per_tensor_tiles = ashape[1] * ashape[3] / TILE_WIDTH; // 142
+
+    // Per output tensor args
+    // Output shape is: [B, 1, s, 4544]
+    uint32_t in0_h_tiles = ashape[2] / TILE_HEIGHT;
+    uint32_t in0_w_tiles = ashape[3] / TILE_WIDTH; // head_dim
+    uint32_t in0_c = per_tensor_tiles / in0_w_tiles; // num_heads
+    uint32_t in0_HtWt = in0_h_tiles * in0_w_tiles;
+    uint32_t in0_CHtWt = in0_c * in0_HtWt;
+
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    // Block is a unit of work; ie. num of per_tensor_tiles per core
+    uint32_t num_blocks = ashape[0] * ashape[2] / TILE_HEIGHT;
+    uint32_t num_cores = 0, num_blocks_per_core_group_1 = 0, num_blocks_per_core_group_2 = 0;
+    CoreRangeSet all_cores = CoreRangeSet({}), core_group_1 = CoreRangeSet({}), core_group_2 = CoreRangeSet({});
+    bool row_major = false;
+    if (in_sharded) {
+        all_cores = a.shard_spec().value().grid;
+        num_cores = all_cores.num_cores();
+        core_group_1 = all_cores;
+        num_blocks_per_core_group_1 = a.shard_spec().value().shape[0] / a.get_legacy_shape()[-2];
+        per_tensor_tiles = a.shard_spec().value().shape[0] * a.shard_spec().value().shape[1] / TILE_HW;
+        row_major = a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
+    } else {
+        std::tie(num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2) = split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+    }
+    uint32_t g1_numcores = core_group_1.num_cores();
+    uint32_t g2_numcores = core_group_2.num_cores();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Grayskull Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Buffer *out_buffer = output.buffer();
+    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program program = tt_metal::CreateProgram();
+    uint32_t src0_cb_index = 0, out_cb_index = 16;
+
+    bool in0_is_dram = in0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    bool out_is_dram = out_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+
+    KernelHandle reader_kernel_id = 0, writer_kernel_id = 0;
+    if (in_sharded) {
+        std::vector<uint32_t>compile_time_args = {
+            (std::uint32_t) src0_cb_index,
+            (std::uint32_t) out_cb_index,
+            (std::uint32_t) in0_h_tiles,
+            (std::uint32_t) in0_w_tiles * single_tile_size,
+            (std::uint32_t) num_blocks_per_core_group_1 * in0_w_tiles * single_tile_size,
+            (std::uint32_t) num_blocks_per_core_group_1 * in0_HtWt,
+        };
+        reader_kernel_id = tt_metal::CreateKernel(
+            program,
+            "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp",
+            all_cores,
+            tt_metal::ReaderDataMovementConfig(compile_time_args));
+        writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp",
+            all_cores,
+            tt_metal::WriterDataMovementConfig(compile_time_args));
+    } else {
+        std::vector<uint32_t> reader_compile_time_args = {
+            // interleaved accessor args
+            (std::uint32_t) in0_is_dram,
+            (std::uint32_t) in0_h_tiles,
+            (std::uint32_t) in0_w_tiles,
+            (std::uint32_t) in0_c,
+            (std::uint32_t) in0_HtWt,
+        };
+        std::vector<uint32_t> writer_compile_time_args = {
+            // interleaved accessor args
+            (std::uint32_t) src0_cb_index,
+            (std::uint32_t) out_is_dram,
+        };
+        reader_kernel_id = tt_metal::CreateKernel(
+            program,
+            "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp",
+            all_cores,
+            tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+        writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            "tt_eager/tt_dnn/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+            all_cores,
+            tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    }
+
+
+    // Create circular buffers
+    CBHandle cb_src0 = 0, cb_out = 0;
+    uint32_t cb_src0_num_tiles = per_tensor_tiles;
+    if (!in_sharded) {
+        cb_src0_num_tiles *= 2; // double buffer
+    }
+    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(cb_src0_num_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+		.set_page_size(src0_cb_index, single_tile_size);
+    if (in_sharded) {
+        cb_src0_config = cb_src0_config.set_globally_allocated_address(*in0_buffer);
+    }
+    cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    if (out_sharded) {
+        uint32_t cb_out_num_tiles = per_tensor_tiles;
+        tt_metal::CircularBufferConfig cb_out_config = tt_metal::CircularBufferConfig(cb_out_num_tiles * single_tile_size, {{out_cb_index, cb_data_format}})
+            .set_page_size(out_cb_index, single_tile_size);
+        cb_out_config = cb_out_config.set_globally_allocated_address(*out_buffer);
+        cb_out = tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
+    }
+
+    const auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+    if (in_sharded) {
+        uint32_t nheads_first_risc = div_up(num_blocks_per_core_group_1, 2);
+        uint32_t nheads_second_risc = num_blocks_per_core_group_1 - nheads_first_risc;
+        std::vector<uint32_t> reader_runtime_args = {
+            (std::uint32_t) nheads_first_risc,
+            0,
+            0,
+        };
+        tt_metal::SetRuntimeArgs(program, reader_kernel_id, all_cores, reader_runtime_args);
+        std::vector<uint32_t> writer_runtime_args = {
+            (std::uint32_t) nheads_second_risc,
+            (std::uint32_t) nheads_first_risc * in0_HtWt * single_tile_size,
+            (std::uint32_t) nheads_first_risc * in0_w_tiles * single_tile_size,
+        };
+        tt_metal::SetRuntimeArgs(program, writer_kernel_id, all_cores, writer_runtime_args);
+
+    } else {
+        for (uint32_t i = 0, num_blocks_written = 0; i < cores.size(); ++i){
+            const CoreCoord &core = cores[i];
+            uint32_t num_blocks_per_core = i < g1_numcores ? num_blocks_per_core_group_1  : num_blocks_per_core_group_2;
+
+            uint32_t in0_h_dim = num_blocks_written % in0_h_tiles;
+            uint32_t in0_tensor_tile_id = num_blocks_written / in0_h_tiles * in0_CHtWt + in0_h_dim * in0_w_tiles;
+
+            std::vector<uint32_t> reader_runtime_args = {
+                (std::uint32_t) in0_buffer->address(),
+                num_blocks_per_core, // num_blocks
+                in0_h_dim, // in0_h_dim
+                in0_tensor_tile_id, // in0_tensor_tile_id
+            };
+
+            std::vector<uint32_t> writer_runtime_args = {
+                (std::uint32_t) out_buffer->address(), // out_tensor_addr
+                num_blocks_per_core * per_tensor_tiles,
+                num_blocks_written * per_tensor_tiles,
+            };
+
+            tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+            tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+            num_blocks_written += num_blocks_per_core;
+        }
+    }
+
+    auto override_runtime_arguments_callback = [
+            reader_kernel_id,
+            writer_kernel_id,
+            cb_src0,
+            cb_out,
+            cores
+        ]
+    (
+        const void* operation,
+        Program& program,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>&,
+        const std::vector<Tensor>& output_tensors
+    ) {
+
+        const auto src_buffer = input_tensors.at(0).buffer();
+        const auto dst_buffer = output_tensors.at(0).buffer();
+        const bool in_sharded = input_tensors.at(0).is_sharded();
+        const bool out_sharded = output_tensors.at(0).is_sharded();
+        if (in_sharded) {
+            UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
+        } else {
+            for (const auto& core : cores) {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = src_buffer->address();
+            }
+        }
+
+        if (out_sharded) {
+            UpdateDynamicCircularBufferAddress(program, cb_out, *dst_buffer);
+        } else {
+            for (const auto& core : cores) {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = dst_buffer->address();
+            }
+        }
+    };
+    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
+}
+
+} // namespace tt_metal
+
+} // namespace tt

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
@@ -15,219 +15,152 @@ namespace tt {
 
 namespace tt_metal {
 
-operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor &a, Tensor& output, CoreCoord compute_with_storage_grid_size) {
+operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor &input_tensor, Tensor& output, CoreCoord compute_with_storage_grid_size) {
 
-    const auto& ashape = a.get_legacy_shape();
+    tt_metal::Program program = tt_metal::CreateProgram();
 
-    tt_metal::Device *device = a.device();
+    const auto& input_shape = input_tensor.get_legacy_shape();
+    const uint32_t head_dim = input_shape[-1];
+    const uint32_t batch = input_shape[1];
 
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    tt_metal::Device *device = input_tensor.device();
+
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
 
     uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
-    tt_metal::Buffer *in0_buffer = a.buffer();
-    bool in_sharded = a.is_sharded();
-    bool out_sharded = output.is_sharded();
 
+    uint32_t head_tiles = head_dim / TILE_WIDTH;
+    uint32_t head_size = head_tiles * single_tile_size;
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      TM Parameters Setup
-    ////////////////////////////////////////////////////////////////////////////
-    uint32_t per_tensor_tiles = ashape[1] * ashape[3] / TILE_WIDTH; // 142
+    uint32_t element_size = input_tensor.element_size();
+    uint32_t sub_tile_line_bytes = 16 * element_size;
+    auto q_shard_spec = output.shard_spec().value();
+    auto q_cores = q_shard_spec.grid;
+    auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
+    auto in_shard_spec = input_tensor.shard_spec().value();
+    auto in_cores = in_shard_spec.grid;
+    auto in_num_tiles = in_shard_spec.shape[0] * in_shard_spec.shape[1] / TILE_HW;
 
-    // Per output tensor args
-    // Output shape is: [B, 1, s, 4544]
-    uint32_t in0_h_tiles = ashape[2] / TILE_HEIGHT;
-    uint32_t in0_w_tiles = ashape[3] / TILE_WIDTH; // head_dim
-    uint32_t in0_c = per_tensor_tiles / in0_w_tiles; // num_heads
-    uint32_t in0_HtWt = in0_h_tiles * in0_w_tiles;
-    uint32_t in0_CHtWt = in0_c * in0_HtWt;
+    log_info("[xuncai] head_tiles: {}", head_tiles);
+    log_info("[xuncai] head_size: {}", head_size);
+    log_info("[xuncai] element_size: {}", element_size);
+    log_info("[xuncai] sub_tile_line_bytes: {}", sub_tile_line_bytes);
+    log_info("[xuncai] in_shard_spec: {}", in_shard_spec);
+    log_info("[xuncai] in_cores: {}", in_cores);
+    log_info("[xuncai] in_num_tiles: {}", in_num_tiles);
 
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    // Block is a unit of work; ie. num of per_tensor_tiles per core
-    uint32_t num_blocks = ashape[0] * ashape[2] / TILE_HEIGHT;
-    uint32_t num_cores = 0, num_blocks_per_core_group_1 = 0, num_blocks_per_core_group_2 = 0;
-    CoreRangeSet all_cores = CoreRangeSet({}), core_group_1 = CoreRangeSet({}), core_group_2 = CoreRangeSet({});
-    bool row_major = false;
-    if (in_sharded) {
-        all_cores = a.shard_spec().value().grid;
-        num_cores = all_cores.num_cores();
-        core_group_1 = all_cores;
-        num_blocks_per_core_group_1 = a.shard_spec().value().shape[0] / a.get_legacy_shape()[-2];
-        per_tensor_tiles = a.shard_spec().value().shape[0] * a.shard_spec().value().shape[1] / TILE_HW;
-        row_major = a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR;
-    } else {
-        std::tie(num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2) = split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+    log_info("[xuncai] q_shard_spec: {}", q_shard_spec);
+    log_info("[xuncai] q_cores: {}", q_cores);
+    log_info("[xuncai] q_num_tiles: {}", q_num_tiles);
+
+    uint32_t q_output_cb_index = CB::c_out0;
+    tt_metal::CircularBufferConfig cb_q_output_config =
+        tt_metal::CircularBufferConfig(
+            q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
+            .set_page_size(q_output_cb_index, single_tile_size).set_globally_allocated_address(*output.buffer());
+    auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+
+    uint32_t q_base_addr = input_tensor.buffer()->address();
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t) element_size,
+        (std::uint32_t) sub_tile_line_bytes,
+        q_output_cb_index,
+    };
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_decode.cpp",
+        q_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    // cores to read and write to output
+    uint32_t num_cores = q_cores.num_cores(); // number of cores of the output
+    auto core_grid = q_cores.bounding_box();
+    uint32_t num_cores_x = core_grid.end.x + 1, num_cores_y = core_grid.end.y + 1;
+    const auto &cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
+
+    // cores for input
+    uint32_t in_num_cores = in_cores.num_cores(); // number of cores of the input
+    auto in_core_grid = in_cores.bounding_box();
+    uint32_t in_num_cores_x = in_core_grid.end.x + 1, in_num_cores_y = in_core_grid.end.y + 1;
+
+    std::vector<uint32_t> noc_x_coords;
+    noc_x_coords.reserve(in_num_cores_x);
+    for (uint32_t x = 0; x < in_num_cores_x; ++x) {
+        noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
+        log_info("[xuncai] noc_x_coords[{}]: {}", x, noc_x_coords[x]);
     }
-    uint32_t g1_numcores = core_group_1.num_cores();
-    uint32_t g2_numcores = core_group_2.num_cores();
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Grayskull Device Setup
-    ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer *out_buffer = output.buffer();
-    TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
-
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Application Setup
-    ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Program program = tt_metal::CreateProgram();
-    uint32_t src0_cb_index = 0, out_cb_index = 16;
-
-    bool in0_is_dram = in0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
-    bool out_is_dram = out_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
-
-    KernelHandle reader_kernel_id = 0, writer_kernel_id = 0;
-    if (in_sharded) {
-        std::vector<uint32_t>compile_time_args = {
-            (std::uint32_t) src0_cb_index,
-            (std::uint32_t) out_cb_index,
-            (std::uint32_t) in0_h_tiles,
-            (std::uint32_t) in0_w_tiles * single_tile_size,
-            (std::uint32_t) num_blocks_per_core_group_1 * in0_w_tiles * single_tile_size,
-            (std::uint32_t) num_blocks_per_core_group_1 * in0_HtWt,
-        };
-        reader_kernel_id = tt_metal::CreateKernel(
-            program,
-            "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp",
-            all_cores,
-            tt_metal::ReaderDataMovementConfig(compile_time_args));
-        writer_kernel_id = tt_metal::CreateKernel(
-            program,
-            "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads_sharded.cpp",
-            all_cores,
-            tt_metal::WriterDataMovementConfig(compile_time_args));
-    } else {
-        std::vector<uint32_t> reader_compile_time_args = {
-            // interleaved accessor args
-            (std::uint32_t) in0_is_dram,
-            (std::uint32_t) in0_h_tiles,
-            (std::uint32_t) in0_w_tiles,
-            (std::uint32_t) in0_c,
-            (std::uint32_t) in0_HtWt,
-        };
-        std::vector<uint32_t> writer_compile_time_args = {
-            // interleaved accessor args
-            (std::uint32_t) src0_cb_index,
-            (std::uint32_t) out_is_dram,
-        };
-        reader_kernel_id = tt_metal::CreateKernel(
-            program,
-            "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_concat_heads.cpp",
-            all_cores,
-            tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
-
-        writer_kernel_id = tt_metal::CreateKernel(
-            program,
-            "tt_eager/tt_dnn/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-            all_cores,
-            tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    std::vector<uint32_t> noc_y_coords;
+    noc_y_coords.reserve(in_num_cores_y);
+    for (uint32_t y = 0; y < in_num_cores_y; ++y) {
+        noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
+        log_info("[xuncai] noc_y_coords[{}]: {}", y, noc_y_coords[y]);
     }
 
+    uint32_t q_start_addr = q_base_addr;
 
-    // Create circular buffers
-    CBHandle cb_src0 = 0, cb_out = 0;
-    uint32_t cb_src0_num_tiles = per_tensor_tiles;
-    if (!in_sharded) {
-        cb_src0_num_tiles *= 2; // double buffer
-    }
-    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(cb_src0_num_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-		.set_page_size(src0_cb_index, single_tile_size);
-    if (in_sharded) {
-        cb_src0_config = cb_src0_config.set_globally_allocated_address(*in0_buffer);
-    }
-    cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        uint32_t in_tile_offset_by_batch = i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512*element_size;
 
-    if (out_sharded) {
-        uint32_t cb_out_num_tiles = per_tensor_tiles;
-        tt_metal::CircularBufferConfig cb_out_config = tt_metal::CircularBufferConfig(cb_out_num_tiles * single_tile_size, {{out_cb_index, cb_data_format}})
-            .set_page_size(out_cb_index, single_tile_size);
-        cb_out_config = cb_out_config.set_globally_allocated_address(*out_buffer);
-        cb_out = tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
-    }
-
-    const auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
-    if (in_sharded) {
-        uint32_t nheads_first_risc = div_up(num_blocks_per_core_group_1, 2);
-        uint32_t nheads_second_risc = num_blocks_per_core_group_1 - nheads_first_risc;
-        std::vector<uint32_t> reader_runtime_args = {
-            (std::uint32_t) nheads_first_risc,
-            0,
-            0,
+        const auto& core = cores[i];
+        std::vector<uint32_t> reader_runtime_args;
+        reader_runtime_args.reserve(8 + in_num_cores_x + in_num_cores_y);
+        reader_runtime_args = {
+            head_size,
+            batch,
+            head_tiles,
+            in_tile_offset_by_batch,
+            0, // start_q_x
+            0, // start_q_y
+            q_start_addr,
+            in_num_cores_x,
+            in_num_cores_y
         };
-        tt_metal::SetRuntimeArgs(program, reader_kernel_id, all_cores, reader_runtime_args);
-        std::vector<uint32_t> writer_runtime_args = {
-            (std::uint32_t) nheads_second_risc,
-            (std::uint32_t) nheads_first_risc * in0_HtWt * single_tile_size,
-            (std::uint32_t) nheads_first_risc * in0_w_tiles * single_tile_size,
-        };
-        tt_metal::SetRuntimeArgs(program, writer_kernel_id, all_cores, writer_runtime_args);
+        reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
+        reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
 
-    } else {
-        for (uint32_t i = 0, num_blocks_written = 0; i < cores.size(); ++i){
-            const CoreCoord &core = cores[i];
-            uint32_t num_blocks_per_core = i < g1_numcores ? num_blocks_per_core_group_1  : num_blocks_per_core_group_2;
-
-            uint32_t in0_h_dim = num_blocks_written % in0_h_tiles;
-            uint32_t in0_tensor_tile_id = num_blocks_written / in0_h_tiles * in0_CHtWt + in0_h_dim * in0_w_tiles;
-
-            std::vector<uint32_t> reader_runtime_args = {
-                (std::uint32_t) in0_buffer->address(),
-                num_blocks_per_core, // num_blocks
-                in0_h_dim, // in0_h_dim
-                in0_tensor_tile_id, // in0_tensor_tile_id
-            };
-
-            std::vector<uint32_t> writer_runtime_args = {
-                (std::uint32_t) out_buffer->address(), // out_tensor_addr
-                num_blocks_per_core * per_tensor_tiles,
-                num_blocks_written * per_tensor_tiles,
-            };
-
-            tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-            tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-            num_blocks_written += num_blocks_per_core;
-        }
+        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
     }
 
     auto override_runtime_arguments_callback = [
             reader_kernel_id,
-            writer_kernel_id,
-            cb_src0,
-            cb_out,
-            cores
-        ]
+            batch,
+            num_cores,
+            cb_q_output,
+            cores,
+            head_size,
+            head_tiles,
+            single_tile_size,
+            element_size,
+            sub_tile_line_bytes
+    ]
     (
         const void* operation,
-        Program& program,
+        Program &program,
         const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>&,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         const std::vector<Tensor>& output_tensors
     ) {
 
-        const auto src_buffer = input_tensors.at(0).buffer();
-        const auto dst_buffer = output_tensors.at(0).buffer();
-        const bool in_sharded = input_tensors.at(0).is_sharded();
-        const bool out_sharded = output_tensors.at(0).is_sharded();
-        if (in_sharded) {
-            UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
-        } else {
-            for (const auto& core : cores) {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_buffer->address();
-            }
-        }
+        auto src_buffer = input_tensors.at(0).buffer();
 
-        if (out_sharded) {
-            UpdateDynamicCircularBufferAddress(program, cb_out, *dst_buffer);
-        } else {
-            for (const auto& core : cores) {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_buffer->address();
-            }
+        auto dst_buffer_query = output_tensors.at(0).buffer();
+
+        UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
+
+        uint32_t q_base_addr = input_tensors[0].buffer()->address();
+
+        uint32_t q_start_addr = q_base_addr;
+
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            uint32_t in_tile_offset_by_batch = i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512*element_size;
+            const auto& core = cores[i];
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[3] = in_tile_offset_by_batch;
+            runtime_args[6] = q_start_addr;
         }
     };
+
     return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
 }
 

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
@@ -120,11 +120,13 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
     noc_x_coords.reserve(in_num_cores_x);
     for (uint32_t x = 0; x < in_num_cores_x; ++x) {
         noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
+        log_info("[xuncai] noc_x_coords[{}]: {}", x, noc_x_coords[x]);
     }
     std::vector<uint32_t> noc_y_coords;
     noc_y_coords.reserve(in_num_cores_y);
     for (uint32_t y = 0; y < in_num_cores_y; ++y) {
         noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
+        log_info("[xuncai] noc_y_coords[{}]: {}", y, noc_y_coords[y]);
     }
 
     uint32_t q_start_addr = q_base_addr;

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
@@ -39,18 +39,6 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
     auto in_cores = in_shard_spec.grid;
     auto in_num_tiles = in_shard_spec.shape[0] * in_shard_spec.shape[1] / TILE_HW;
 
-    log_debug("[xuncai] head_tiles: {}", head_tiles);
-    log_debug("[xuncai] head_size: {}", head_size);
-    log_debug("[xuncai] element_size: {}", element_size);
-    log_debug("[xuncai] sub_tile_line_bytes: {}", sub_tile_line_bytes);
-    log_debug("[xuncai] in_shard_spec: {}", in_shard_spec);
-    log_debug("[xuncai] in_cores: {}", in_cores);
-    log_debug("[xuncai] in_num_tiles: {}", in_num_tiles);
-
-    log_debug("[xuncai] q_shard_spec: {}", q_shard_spec);
-    log_debug("[xuncai] q_cores: {}", q_cores);
-    log_debug("[xuncai] q_num_tiles: {}", q_num_tiles);
-
     uint32_t q_output_cb_index = CB::c_out0;
     tt_metal::CircularBufferConfig cb_q_output_config =
         tt_metal::CircularBufferConfig(
@@ -62,10 +50,6 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
     auto k_cores = k_shard_spec.grid;
     auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
 
-    log_debug("[xuncai] k_shard_spec: {}", k_shard_spec);
-    log_debug("[xuncai] k_cores: {}", k_cores);
-    log_debug("[xuncai] k_num_tiles: {}", k_num_tiles);
-
     uint32_t k_output_cb_index = CB::c_out1;
     tt_metal::CircularBufferConfig cb_k_output_config =
         tt_metal::CircularBufferConfig(
@@ -76,10 +60,6 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
     auto v_shard_spec = output[0].shard_spec().value();
     auto v_cores = q_shard_spec.grid;
     auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
-
-    log_debug("[xuncai] v_shard_spec: {}", k_shard_spec);
-    log_debug("[xuncai] v_cores: {}", k_cores);
-    log_debug("[xuncai] v_num_tiles: {}", k_num_tiles);
 
     uint32_t v_output_cb_index = CB::c_out2;
     tt_metal::CircularBufferConfig cb_v_output_config =
@@ -105,13 +85,11 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
     noc_x_coords.reserve(in_num_cores_x);
     for (uint32_t x = 0; x < in_num_cores_x; ++x) {
         noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
-        log_debug("[xuncai] noc_x_coords[{}]: {}", x, noc_x_coords[x]);
     }
     std::vector<uint32_t> noc_y_coords;
     noc_y_coords.reserve(in_num_cores_y);
     for (uint32_t y = 0; y < in_num_cores_y; ++y) {
         noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
-        log_debug("[xuncai] noc_y_coords[{}]: {}", y, noc_y_coords[y]);
     }
 
     // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a tile respectively)

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
@@ -138,7 +138,7 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
 
         const auto& core = cores[i];
         std::vector<uint32_t> reader_runtime_args;
-        reader_runtime_args.reserve(10 + in_num_cores_x + in_num_cores_y);
+        reader_runtime_args.reserve(11 + in_num_cores_x + in_num_cores_y);
         reader_runtime_args = {
             head_size,
             num_q_heads,
@@ -151,6 +151,7 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
             k_start_addr,
             v_start_addr,
             in_num_cores_x,
+            in_num_cores_y
         };
         reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
         reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
@@ -163,7 +164,6 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
             num_q_heads,
             num_kv_heads,
             num_cores,
-            in_num_cores_y,
             cb_q_output,
             cb_k_output,
             cb_v_output,

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/nlp_tms/nlp_tms.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+
+using namespace tt::constants;
+using namespace tt;
+
+namespace tt {
+
+namespace tt_metal {
+
+operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
+
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    const auto& input_shape = input_tensor.get_legacy_shape();
+
+    tt_metal::Device *device = input_tensor.device();
+
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+
+    uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
+
+    uint32_t head_tiles = head_dim / TILE_WIDTH;
+    uint32_t head_size = head_tiles * single_tile_size;
+
+    auto q_shard_spec = output[0].shard_spec().value();
+    auto q_cores = q_shard_spec.grid;
+    auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
+
+    uint32_t per_core_out_q_heads = num_q_heads / q_cores.num_cores();
+    uint32_t per_risc0_out_q_heads = div_up(per_core_out_q_heads, 2);
+    uint32_t per_risc1_out_q_heads = per_core_out_q_heads / 2;
+    uint32_t per_core_in_q_heads = num_q_heads / input_tensor.shard_spec().value().num_cores();
+
+    uint32_t q_output_cb_index = CB::c_out0;
+    tt_metal::CircularBufferConfig cb_q_output_config =
+        tt_metal::CircularBufferConfig(
+            q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
+            .set_page_size(q_output_cb_index, single_tile_size).set_globally_allocated_address(*output[0].buffer());
+    auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+
+    auto k_shard_spec = output[1].shard_spec().value();
+    auto k_cores = k_shard_spec.grid;
+    auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
+
+    uint32_t k_output_cb_index = CB::c_out1;
+    tt_metal::CircularBufferConfig cb_k_output_config =
+        tt_metal::CircularBufferConfig(
+            k_num_tiles * single_tile_size, {{k_output_cb_index, cb_data_format}})
+            .set_page_size(k_output_cb_index, single_tile_size).set_globally_allocated_address(*output[1].buffer());
+    auto cb_k_output = tt_metal::CreateCircularBuffer(program, k_cores, cb_k_output_config);
+
+    auto v_shard_spec = output[0].shard_spec().value();
+    auto v_cores = q_shard_spec.grid;
+    auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
+
+    uint32_t v_output_cb_index = CB::c_out2;
+    tt_metal::CircularBufferConfig cb_v_output_config =
+        tt_metal::CircularBufferConfig(
+            v_num_tiles * single_tile_size, {{v_output_cb_index, cb_data_format}})
+            .set_page_size(v_output_cb_index, single_tile_size).set_globally_allocated_address(*output[2].buffer());
+    auto cb_v_output = tt_metal::CreateCircularBuffer(program, v_cores, cb_v_output_config);
+
+    uint32_t per_core_out_kv_heads = num_kv_heads / k_cores.num_cores();
+    uint32_t per_core_in_kv_heads = num_kv_heads / input_tensor.shard_spec().value().num_cores();
+
+    uint32_t q_base_addr = input_tensor.buffer()->address();
+    uint32_t k_base_addr = q_base_addr + per_core_in_q_heads * head_tiles * single_tile_size;
+    uint32_t v_base_addr = k_base_addr + per_core_in_kv_heads * head_tiles * single_tile_size;
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        q_output_cb_index,
+        k_output_cb_index
+    };
+    std::vector<uint32_t> writer_compile_time_args = {
+        q_output_cb_index,
+        v_output_cb_index
+    };
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp",
+        q_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+    auto writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/nlp_tms/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads_sharded.cpp",
+        q_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    uint32_t num_cores = std::max(q_cores.num_cores(), k_cores.num_cores());
+
+    auto core_grid = q_cores.bounding_box();
+    uint32_t num_cores_x = core_grid.end.x + 1, num_cores_y = core_grid.end.y + 1;
+    uint32_t num_kv_cores = k_cores.num_cores();
+
+    const auto &cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
+
+    std::vector<uint32_t> noc_x_coords;
+    noc_x_coords.reserve(num_cores_x);
+    for (uint32_t x = 0; x < num_cores_x; ++x) {
+        noc_x_coords.push_back(device->worker_core_from_logical_core({x, 0}).x);
+    }
+    std::vector<uint32_t> noc_y_coords;
+    noc_y_coords.reserve(num_cores_y);
+    for (uint32_t y = 0; y < num_cores_y; ++y) {
+        noc_y_coords.push_back(device->worker_core_from_logical_core({0, y}).y);
+    }
+
+    uint32_t remote_q_head_start_idx = 0;
+    uint32_t remote_kv_head_start_idx = 0;
+    uint32_t q_x = 0, q_y = 0, kv_x = 0, kv_y = 0;
+    uint32_t q_start_addr = q_base_addr;
+    uint32_t k_start_addr = k_base_addr;
+    uint32_t v_start_addr = v_base_addr;
+
+    uint32_t remote_q_read = 0;
+    uint32_t remote_kv_read = 0;
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const auto& core = cores[i];
+        bool read_kv_heads = i < k_cores.num_cores();
+        std::vector<uint32_t> reader_runtime_args;
+        reader_runtime_args.reserve(18 + num_cores_x + num_cores_y);
+        reader_runtime_args = {
+            head_size,
+            per_risc0_out_q_heads,
+            per_core_in_q_heads,
+            remote_q_head_start_idx,
+            q_x,
+            q_y,
+            q_base_addr,
+            q_start_addr,
+            0,
+            read_kv_heads,
+            per_core_out_kv_heads,
+            per_core_in_kv_heads,
+            remote_kv_head_start_idx,
+            kv_x,
+            kv_y,
+            k_base_addr,
+            k_start_addr,
+            k_num_tiles,
+            num_cores_x,
+        };
+        reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
+        reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+
+        remote_q_read += per_risc0_out_q_heads;
+        q_y = (remote_q_read / per_core_in_q_heads) / num_cores_x;
+        q_x = (remote_q_read / per_core_in_q_heads) % num_cores_x;
+        remote_q_head_start_idx = (remote_q_head_start_idx + per_risc0_out_q_heads) % per_core_in_q_heads;
+        q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
+
+        tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+
+        reader_runtime_args[1] = per_risc1_out_q_heads;
+        reader_runtime_args[3] = remote_q_head_start_idx;
+        reader_runtime_args[4] = q_x;
+        reader_runtime_args[5] = q_y;
+        reader_runtime_args[7] = q_start_addr;
+        reader_runtime_args[8] = per_risc0_out_q_heads * head_size;
+
+        if (per_risc1_out_q_heads > 0) {
+            remote_q_read += per_risc1_out_q_heads;
+            q_y = (remote_q_read / per_core_in_q_heads) / num_cores_x;
+            q_x = (remote_q_read / per_core_in_q_heads) % num_cores_x;
+            remote_q_head_start_idx = (per_risc1_out_q_heads + remote_q_head_start_idx) % per_core_in_q_heads;
+            q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
+        }
+
+        if (read_kv_heads) {
+            reader_runtime_args[15] = v_base_addr;
+            reader_runtime_args[16] = v_start_addr;
+            remote_kv_read += per_core_out_kv_heads;
+            kv_y = (remote_kv_read / per_core_in_kv_heads) / num_cores_x;
+            kv_x = (remote_kv_read / per_core_in_kv_heads) % num_cores_x;
+            remote_kv_head_start_idx = (remote_kv_head_start_idx + per_core_out_kv_heads) % per_core_in_kv_heads;
+            k_start_addr = k_base_addr + remote_kv_head_start_idx * head_size;
+            v_start_addr = v_base_addr + remote_kv_head_start_idx * head_size;
+        }
+
+        tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);
+    }
+
+    auto override_runtime_arguments_callback = [
+            reader_kernel_id,
+            writer_kernel_id,
+            num_cores,
+            num_cores_y,
+            cb_q_output,
+            cb_k_output,
+            cb_v_output,
+            cores,
+            head_size,
+            per_risc0_out_q_heads,
+            per_risc1_out_q_heads,
+            per_core_in_q_heads,
+            per_core_out_kv_heads,
+            per_core_in_kv_heads,
+            head_tiles,
+            num_kv_cores,
+            single_tile_size
+        ]
+    (
+        const void* operation,
+        Program &program,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        const std::vector<Tensor>& output_tensors
+    ) {
+
+        auto src_buffer = input_tensors.at(0).buffer();
+
+        uint32_t src_kv_buffer_addr = 0;
+
+        auto dst_buffer_query = output_tensors.at(0).buffer();
+        auto dst_buffer_key = output_tensors.at(1).buffer();
+        auto dst_buffer_value = output_tensors.at(2).buffer();
+
+        UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
+        UpdateDynamicCircularBufferAddress(program, cb_k_output, *dst_buffer_key);
+        UpdateDynamicCircularBufferAddress(program, cb_v_output, *dst_buffer_value);
+
+        uint32_t q_base_addr = input_tensors[0].buffer()->address();
+        uint32_t k_base_addr = q_base_addr + per_core_in_q_heads * head_tiles * single_tile_size;
+        uint32_t v_base_addr = k_base_addr + per_core_in_kv_heads * head_tiles * single_tile_size;
+
+        uint32_t remote_q_head_start_idx = 0;
+        uint32_t remote_kv_head_start_idx = 0;
+        uint32_t q_start_addr = q_base_addr;
+        uint32_t k_start_addr = k_base_addr;
+        uint32_t v_start_addr = v_base_addr;
+
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            const auto& core = cores[i];
+            bool read_kv_heads = i < num_kv_cores;
+            {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[6] = q_base_addr;
+                runtime_args[7] = q_start_addr;
+                runtime_args[15] = k_base_addr;
+                runtime_args[16] = k_start_addr;
+                remote_q_head_start_idx = (remote_q_head_start_idx + per_risc0_out_q_heads) % per_core_in_q_heads;
+                q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
+            }
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[6] = q_base_addr;
+                runtime_args[15] = v_base_addr;
+                if (per_risc1_out_q_heads > 0) {
+                    runtime_args[7] = q_start_addr;
+                    remote_q_head_start_idx = (remote_q_head_start_idx + per_risc1_out_q_heads) % per_core_in_q_heads;
+                    q_start_addr = q_base_addr + remote_q_head_start_idx * head_size;
+                }
+                if (read_kv_heads) {
+                    runtime_args[16] = v_start_addr;
+                    remote_kv_head_start_idx = (remote_kv_head_start_idx + per_core_out_kv_heads) % per_core_in_kv_heads;
+                    k_start_addr = k_base_addr + remote_kv_head_start_idx * head_size;
+                    v_start_addr = v_base_addr + remote_kv_head_start_idx * head_size;
+                }
+            }
+        }
+    };
+
+    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
+}
+
+} // namespace tt_metal
+
+} // namespace tt

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -73,24 +73,26 @@ void NlpCreateHeadsDecode::validate(const std::vector<Tensor>& input_tensors) co
     TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Unsupported data format");
     TT_FATAL(input_tensor.get_layout() == Layout::TILE);
 
-    TT_FATAL(input_shape[3] % TILE_WIDTH == 0, "Unsupported input shape");
-    TT_FATAL(input_shape[2] == 32, "Unsupported input shape");
+    // input
+    TT_FATAL(input_shape[3] % TILE_WIDTH == 0, "Unsupported input shape");  // head_dim must be multiple of TILE_WIDTH
+    TT_FATAL(input_shape[2] == 32, "Unsupported input shape");  // 32 users
     TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
     TT_FATAL(input_shape[0] == 1, "Unsupported input shape");
     TT_FATAL(input_tensor.is_sharded(), "Input must be sharded");
     TT_FATAL(input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_legacy_shape()[-1]);
-    TT_FATAL(this->output_mem_config.is_sharded() && this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
     TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+    // we either put everything in one shard or split it into minimum tile width accross as many cores as possible
+    TT_FATAL(input_tensor.shard_spec().value().shape[1] == (this->num_q_heads + this->num_kv_heads * 2) * this->head_dim || input_tensor.shard_spec().value().shape[1] == 32);
     auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
+
+    // output
+    TT_FATAL(this->output_mem_config.is_sharded() && this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
     uint32_t num_cores = core_grid.x * core_grid.y;
     // Support maximum 32 heads for now
     TT_FATAL(this->num_q_heads <= 32);
     // 1 User Per Core Max and 32 users for now
     TT_FATAL(num_cores >= 32, "Need at least 32 cores for decode");
     TT_FATAL(this->num_q_heads >= this->num_kv_heads);
-    TT_FATAL(this->num_q_heads % input_tensor.shard_spec().value().num_cores() == 0);
-    TT_FATAL(this->num_kv_heads % input_tensor.shard_spec().value().num_cores() == 0);
-    TT_FATAL(input_tensor.shard_spec().value().shape[1] == (this->num_q_heads / this->num_kv_heads + 2) * this->head_dim);
 }
 
 std::vector<Shape> NlpCreateHeadsDecode::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -70,7 +70,7 @@ void NlpCreateHeadsDecode::validate(const std::vector<Tensor>& input_tensors) co
     // NOTE: Checks for head_dim and shape[3] is done in nlp_create_qkv_heads because it's needed to infer head_dim
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
+    TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Unsupported data format");
     TT_FATAL(input_tensor.get_layout() == Layout::TILE);
 
     TT_FATAL(input_shape[3] % TILE_WIDTH == 0, "Unsupported input shape");
@@ -83,6 +83,8 @@ void NlpCreateHeadsDecode::validate(const std::vector<Tensor>& input_tensors) co
     TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
     auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
     uint32_t num_cores = core_grid.x * core_grid.y;
+    // Support maximum 32 heads for now
+    TT_FATAL(this->num_q_heads <= 32);
     // 1 User Per Core Max and 32 users for now
     TT_FATAL(num_cores >= 32, "Need at least 32 cores for decode");
     TT_FATAL(this->num_q_heads >= this->num_kv_heads);

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -62,6 +62,97 @@ tt::stl::reflection::Attributes NlpCreateHeadsFalcon7B::attributes() const {
 }
 
 
+// Generic NLP CreateHeads op for decode
+void NlpCreateHeadsDecode::validate(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto input_shape = input_tensor.get_legacy_shape();
+    // TODO: Rewrite validation for this decode case
+    // NOTE: Checks for head_dim and shape[3] is done in nlp_create_qkv_heads because it's needed to infer head_dim
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
+    TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+
+    TT_FATAL(input_shape[2] % TILE_HEIGHT == 0, "Unsupported input shape");
+    TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
+    TT_FATAL(input_tensor.is_sharded(), "Input must be sharded");
+    TT_FATAL(input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_legacy_shape()[-1]);
+    TT_FATAL(this->output_mem_config.is_sharded() && this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+    TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+    auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
+    uint32_t num_cores = core_grid.x * core_grid.y;
+    // 1 Head Per Core Max for now
+    TT_FATAL(this->num_q_heads <= num_cores);
+    TT_FATAL(this->num_kv_heads <= num_cores);
+    TT_FATAL(this->num_q_heads >= this->num_kv_heads);
+    TT_FATAL(this->num_q_heads % input_tensor.shard_spec().value().num_cores() == 0);
+    TT_FATAL(this->num_kv_heads % input_tensor.shard_spec().value().num_cores() == 0);
+    TT_FATAL(input_tensor.shard_spec().value().shape[1] == (this->num_q_heads / this->num_kv_heads + 2) * this->head_dim);
+}
+
+std::vector<Shape> NlpCreateHeadsDecode::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    std::vector<Shape> output_shape_vec;
+    const auto& input_tensor = input_tensors.at(0);
+    const auto input_shape = input_tensor.get_legacy_shape();
+
+    auto sequence_length = input_shape[2];
+    auto head_dim = this->head_dim;
+    if (sequence_length % TILE_HEIGHT != 0) {
+        sequence_length = (sequence_length / TILE_HEIGHT + 1) * TILE_HEIGHT;
+    }
+    if (head_dim % TILE_WIDTH != 0) {
+        head_dim = (head_dim / TILE_WIDTH + 1) * TILE_WIDTH;
+    }
+
+    const Shape q_output_shape = {input_shape[0], this->num_q_heads, sequence_length, head_dim};
+    const Shape v_output_shape = {input_shape[0], this->num_kv_heads, sequence_length, head_dim};
+    const Shape k_output_shape = v_output_shape;
+    output_shape_vec = {q_output_shape, k_output_shape, v_output_shape};
+
+    return output_shape_vec;
+}
+
+std::vector<Tensor> NlpCreateHeadsDecode::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    if (this->output_mem_config.is_sharded()) {
+        auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
+        auto q_shard_grid = num_cores_to_corerange_set(this->num_q_heads, core_grid, true);
+        ShardSpec q_shard_spec{q_shard_grid, {TILE_HEIGHT, this->head_dim}};
+        auto q_mem_config = this->output_mem_config;
+        q_mem_config.shard_spec = q_shard_spec;
+        auto kv_shard_grid = num_cores_to_corerange_set(this->num_kv_heads, core_grid, true);
+        ShardSpec kv_shard_spec{kv_shard_grid, {TILE_HEIGHT, this->head_dim}};
+        auto kv_mem_config = this->output_mem_config;
+        kv_mem_config.shard_spec = kv_shard_spec;
+        auto output_shapes = this->compute_output_shapes(input_tensors);
+        return {
+            create_sharded_device_tensor(output_shapes[0], input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), q_mem_config),
+            create_sharded_device_tensor(output_shapes[1], input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), kv_mem_config),
+            create_sharded_device_tensor(output_shapes[2], input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), kv_mem_config)
+        };
+
+    } else {
+        return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.get_dtype(), Layout::TILE, this->output_mem_config);
+    }
+}
+
+operation::ProgramWithCallbacks NlpCreateHeadsDecode::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    auto& output_tensor = output_tensors.at(0);
+
+    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    return  multi_core_nlp_create_qkv_heads_decode(input_tensor, this->num_q_heads, this->num_kv_heads, this->head_dim, output_tensors, compute_with_storage_grid_size);
+}
+
+tt::stl::reflection::Attributes NlpCreateHeadsDecode::attributes() const {
+    return {
+        {"num_q_heads", this->num_q_heads},
+        {"num_kv_heads", this->num_kv_heads},
+        {"output_mem_config", this->output_mem_config},
+    };
+}
+
+
 // Generic NLP CreateHeads op
 void NlpCreateHeads::validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -135,6 +135,10 @@ namespace tt::tt_metal::detail
             py::arg().noconvert(), py::arg("output_mem_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Shuffles [B, num_heads, S, head_dim] tensor into tensor with shape [B, 1, S, num_heads * head_dim].
         )doc");
+        m_tensor.def("nlp_concat_heads_decode", &nlp_concat_heads_decode,
+            py::arg().noconvert(), py::arg("num_heads").noconvert() = std::nullopt, R"doc(
+            Shuffles [S=1, B=32, 32(num_heads), head_dim] tensor into tensor with shape [S=1, 1, B=32, num_heads * head_dim]. num_heads should be specified and be less than 32; the op will assume the input padded num_heads to 32 and will unpad it. The output is default width sharded by num heads.
+        )doc");
 
         // Custom Resnet matmuls
         m_tensor.def("resnet_matmul", &resnet_matmul,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -124,7 +124,7 @@ namespace tt::tt_metal::detail
         )doc");
         m_tensor.def("nlp_create_qkv_heads_decode", &nlp_create_qkv_heads_decode,
             py::arg("input").noconvert(), py::arg("num_heads").noconvert(), py::arg("num_kv_heads").noconvert() = std::nullopt, py::arg("output_mem_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Shuffles [1, S=1, B=32, head_dim * (num_heads + 2*num_kv_heads)] fused qkv matrix into Q, K, and V heads with shape [S, B, num_heads, head_dim] for Q and [S, B, num_kv_heads, head_dim] for K and V, where num_heads and num_kv_heads will be padded to nearest 32. Input must be sharded.
+            Shuffles [1, S=1, B=32, head_dim * (num_heads + 2*num_kv_heads)] fused qkv matrix into Q, K, and V heads with shape [S, B, num_heads, head_dim] for Q and [S, B, num_kv_heads, head_dim] for K and V, where num_heads and num_kv_heads will be padded to nearest 32. Input must be sharded, B=32 and S=1.
         )doc");
         // More general implementation, but perf might be worse since the cbs are very small and writer calls noc_async_write_barrier() a lot
         m_tensor.def("nlp_create_qkv_heads", &nlp_create_qkv_heads,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -122,6 +122,10 @@ namespace tt::tt_metal::detail
             py::arg().noconvert(), py::arg("output_mem_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Shuffles [B, 1, S, 4672] fused qkv matrix into 3 heads with shapes [B, 71, S, 64], [B, 1, S, 64], and [B, 1, S, 64].
         )doc");
+        m_tensor.def("nlp_create_qkv_heads_decode", &nlp_create_qkv_heads_decode,
+            py::arg("input").noconvert(), py::arg("num_heads").noconvert(), py::arg("num_kv_heads").noconvert() = std::nullopt, py::arg("output_mem_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Shuffles [1, S=1, B=32, head_dim * (num_heads + 2*num_kv_heads)] fused qkv matrix into Q, K, and V heads with shape [S, B, num_heads, head_dim] for Q and [S, B, num_kv_heads, head_dim] for K and V, where num_heads and num_kv_heads will be padded to nearest 32. Input must be sharded.
+        )doc");
         // More general implementation, but perf might be worse since the cbs are very small and writer calls noc_async_write_barrier() a lot
         m_tensor.def("nlp_create_qkv_heads", &nlp_create_qkv_heads,
             py::arg("input").noconvert(), py::arg("input_kv").noconvert() = std::nullopt, py::arg("num_heads").noconvert(), py::arg("num_kv_heads").noconvert() = std::nullopt, py::arg("transpose_k_heads").noconvert() = true, py::arg("output_mem_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(


### PR DESCRIPTION
(Copied from #8071):

# Proposed Kernel
- [x] nlp_create_heads_decode : Take in fused_qkv output in [S=1, 1, B=32, head_dim * (n_heads + 2 * n_kv_heads)] and output padded transposed qkv heads separately in this dim: [B=32, 1, padded_q_heads=32, head_dim] to get rid of pad and transpose.
- [x] nlp_concat_heads_decode: Shuffles [S=1, B=32, 32(num_heads), head_dim] tensor into tensor with shape [S=1, 1, B=32, num_heads * head_dim]. num_heads should be specified and be less than 32; the op will assume the input padded num_heads to 32 and will unpad it. The output is default width sharded by num heads.

<img width="791" alt="image" src="https://github.com/tenstorrent/tt-metal/assets/61562234/e96a3f9b-658a-449f-aded-22b9fc702017">

# Implementation
- [x] Implemented as separate kernels under `tt-metal/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.hpp`. Significant perf improvement compared to unfused version with padding/unpadding and transpose.
- [x] nlp_create_heads_decode: 5146 ns for [1,1,32,1280] -> [1,32,32(8),128] and [1,32,32(1),128] x2
- [x] nlp_concat_heads_decode: 8278 ns for [1,32,32,128] -> [1,1,32,1024]

# Overall:
The two new kernel brings significant speed up on data movement ops in llama and mixtral models, and eliminating around 30% ops, which will further improves e2e performance. It would help significantly if the changes can be merged into main asap.
