### PR TITLE
Add Falcon7b prefill 32 layer test to nightly CI

### DIFF
--- a/models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
+++ b/models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from models.demos.falcon7b.tests.test_falcon_end_to_end import run_test_FalconCausalLM_end_to_end
+from models.demos.falcon7b.tt.model_config import get_model_config
+from models.utility_functions import disable_compilation_reports, disable_persistent_kernel_cache
+
+
+@pytest.mark.parametrize(
+    "llm_mode, batch, seq_len, kv_cache_len",
+    (
+        ("prefill", 1, 32, 0),
+        ("prefill", 1, 128, 0),
+    ),
+    ids=["prefill_seq32", "prefill_seq128"],
+)
+@pytest.mark.parametrize(
+    "num_layers, out_pcc, cache_pcc",
+    ((32, 0.97, 0.95),),
+    ids=["layers_32"],
+)
+@pytest.mark.parametrize(
+    "model_version",
+    ("tiiuae/falcon-7b-instruct",),
+    ids=["falcon_7b"],
+)
+@pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
+def test_FalconCausalLM_end_to_end_with_program_cache(
+    device,
+    use_program_cache,
+    model_version,
+    llm_mode,
+    batch,
+    seq_len,
+    kv_cache_len,
+    num_layers,
+    out_pcc,
+    cache_pcc,
+    model_config_str,
+    model_location_generator,
+    get_tt_cache_path,
+):
+    model_config = get_model_config(model_config_str, seq_len)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
+
+    disable_persistent_kernel_cache()
+    disable_compilation_reports()
+
+    run_test_FalconCausalLM_end_to_end(
+        [device],
+        model_version,
+        llm_mode,
+        batch,
+        seq_len,
+        kv_cache_len,
+        num_layers,
+        out_pcc,
+        cache_pcc,
+        model_config,
+        tt_cache_path,
+        model_location_generator,
+    )

--- a/models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
+++ b/models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
@@ -6,7 +6,7 @@ import pytest
 
 from models.demos.falcon7b.tests.test_falcon_end_to_end import run_test_FalconCausalLM_end_to_end
 from models.demos.falcon7b.tt.model_config import get_model_config
-from models.utility_functions import disable_compilation_reports, disable_persistent_kernel_cache
+from models.utility_functions import disable_compilation_reports, disable_persistent_kernel_cache, skip_for_grayskull
 
 
 @pytest.mark.parametrize(
@@ -28,6 +28,7 @@ from models.utility_functions import disable_compilation_reports, disable_persis
     ids=["falcon_7b"],
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
+@skip_for_grayskull()
 def test_FalconCausalLM_end_to_end_with_program_cache(
     device,
     use_program_cache,

--- a/models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
+++ b/models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+import tt_lib
+
 from models.demos.falcon7b.tests.test_falcon_end_to_end import run_test_FalconCausalLM_end_to_end
 from models.demos.falcon7b.tt.model_config import get_model_config
 from models.utility_functions import disable_compilation_reports, disable_persistent_kernel_cache, skip_for_grayskull
@@ -44,6 +46,11 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     model_location_generator,
     get_tt_cache_path,
 ):
+    is_grayskull = device.arch() == tt_lib.device.Arch.GRAYSKULL
+    if is_grayskull:
+        out_pcc = 0.86
+        cache_pcc = 0.86
+
     model_config = get_model_config(model_config_str, seq_len)
     tt_cache_path = get_tt_cache_path(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]

--- a/models/demos/falcon7b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon7b/tests/test_falcon_end_to_end.py
@@ -20,8 +20,6 @@ from models.utility_functions import (
     enable_persistent_kernel_cache,
     is_e75,
     profiler,
-    skip_for_wormhole_b0,
-    torch2tt_tensor,
     tt2torch_tensor,
 )
 from sklearn.metrics import top_k_accuracy_score
@@ -316,7 +314,6 @@ def run_test_FalconCausalLM_end_to_end(
     ids=["falcon_7b"],
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
-@skip_for_wormhole_b0(reason_str="Hangs way too often, issue #4425")
 def test_FalconCausalLM_end_to_end_with_program_cache(
     device,
     use_program_cache,

--- a/models/demos/falcon7b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon7b/tests/test_falcon_end_to_end.py
@@ -316,6 +316,7 @@ def run_test_FalconCausalLM_end_to_end(
     ids=["falcon_7b"],
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
+@skip_for_wormhole_b0(reason_str="Hangs way too often, issue #4425")
 def test_FalconCausalLM_end_to_end_with_program_cache(
     device,
     use_program_cache,

--- a/tests/scripts/nightly/run_common_models.sh
+++ b/tests/scripts/nightly/run_common_models.sh
@@ -12,7 +12,6 @@ echo "Running common models for archs"
 env pytest models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
 env pytest models/demos/metal_BERT_large_11/tests/test_demo.py
 
-env pytest models/demos/falcon7b/tests/test_falcon_end_to_end.py
 env pytest models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
 
 env pytest models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py

--- a/tests/scripts/nightly/run_common_models.sh
+++ b/tests/scripts/nightly/run_common_models.sh
@@ -12,6 +12,7 @@ echo "Running common models for archs"
 env pytest models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
 env pytest models/demos/metal_BERT_large_11/tests/test_demo.py
 
+env pytest models/demos/falcon7b/tests/test_falcon_end_to_end.py
 env pytest models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
 
 env pytest models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py

--- a/tests/scripts/nightly/run_common_models.sh
+++ b/tests/scripts/nightly/run_common_models.sh
@@ -12,7 +12,7 @@ echo "Running common models for archs"
 env pytest models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
 env pytest models/demos/metal_BERT_large_11/tests/test_demo.py
 
-env pytest models/demos/falcon7b/tests/test_falcon_end_to_end.py
+env pytest models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
 
 env pytest models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py
 env pytest models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py


### PR DESCRIPTION
Add prefill tests for e2e pcc.

The command that was already in the nightly ci:
`env pytest models/demos/falcon7b/tests/test_falcon_end_to_end.py`
skips wormhole due to some hangs (possibly in decode, this should be investigated additionally, we wanted to put some 32layer tests for prefill asap). 

I ran all the test combinations I added (4 of them) in loops of 100 iterations on a single-chip machine with the new firmware.

Nightly CI: https://github.com/tenstorrent/tt-metal/actions/runs/8998163709