### PR TITLE
#8228: fix issue with loading a sharded multi-device tensor

### DIFF
--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -307,6 +307,37 @@ def test_multi_device_as_tensor_api(device_mesh, layout, memory_config, dtype):
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
+def test_multi_device_as_tensor_api_sharded_tensor(device_mesh, layout, memory_config, dtype):
+    """Multidevice API: Data Parallel on matmul using cached tensor"""
+    input_tensor = torch.rand((device_mesh.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
+
+    with tempfile.NamedTemporaryFile() as temp_file:
+        save_tensor = ttnn.as_tensor(
+            input_tensor,
+            dtype=dtype,
+            layout=layout,
+            device=device_mesh,
+            memory_config=memory_config,
+            cache_file_name=f"{temp_file.name}.weight",
+            mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+        )
+        load_tensor = ttnn.as_tensor(
+            input_tensor,
+            dtype=dtype,
+            layout=layout,
+            device=device_mesh,
+            memory_config=memory_config,
+            cache_file_name=f"{temp_file.name}.weight",
+            mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+        )
+        torch_loaded_tensor = ttnn.to_torch(load_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=0))
+        expected_pcc = 0.98 if dtype == ttnn.bfloat4_b else 0.99
+        assert_with_pcc(input_tensor, torch_loaded_tensor, pcc=expected_pcc)
+
+
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
 def test_multi_device_permute(device_mesh, layout, memory_config, dtype):
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:

--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -370,6 +370,7 @@ struct MultiDeviceHostStorage {
         MultiDeviceHostStorage() = default;
         MultiDeviceHostStorage(DistributedTensorConfig strategy_, std::vector<OwnedBuffer> buffers_, std::vector<Shape> shapes_) : strategy(strategy_), buffers(buffers_), shapes(shapes_) {}
         MultiDeviceHostStorage(MultiDeviceHostStorage &&other) {
+            strategy = other.strategy;
             buffers = other.buffers;
             shapes = other.shapes;
         }


### PR DESCRIPTION
Previously, it seemed like it would default to loading a replicated tensor. The fix was to correct the copy constructor for MultiDeviceHostStorage. Unit test is also added to regress on this behaviour.