### PR TITLE
#7145: Fix ttnn arange

### DIFF
--- a/tests/ttnn/python_api_testing/non_working_unit_tests/grayskull/test_arange.py
+++ b/tests/ttnn/python_api_testing/non_working_unit_tests/grayskull/test_arange.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 import traceback
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, divup
 from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
 
 
@@ -37,6 +37,8 @@ def run_arange_tests(
         tt_result = ttnn.arange(start, end, step, device)
 
         tt_result = ttnn_ops.ttnn_tensor_to_torch(tt_result, output_mem_config)
+        if divup((end - start), step) % 2 != 0:
+            tt_result = tt_result.view(-1)[:-1]
 
     except Exception as e:
         logger.warning(f"Test execution crashed: {e}")

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/arange.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/arange.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc
-from models.utility_functions import torch_random
+from models.utility_functions import torch_random, divup
 
 
 parameters = {
@@ -62,5 +62,7 @@ def run(
     )
     output_tensor = ttnn.to_torch(output_tensor)
     output_tensor = output_tensor[-1, -1, -1, :]
+    if divup((end - start), step) % 2 != 0:
+        output_tensor = output_tensor.view(-1)[:-1]
 
     return check_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import ttnn
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_pcc, divup
 
 
 @pytest.mark.parametrize(
@@ -148,7 +148,7 @@ def test_full(device, input_shape, fill_value):
 )
 @pytest.mark.parametrize(
     "step",
-    [1, 2],
+    [1, 2, 3, 4, 5],
 )
 def test_arange(device, start, end, step):
     torch_input_tensor = torch.rand((start, end, step), dtype=torch.bfloat16)
@@ -162,6 +162,8 @@ def test_arange(device, start, end, step):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
     output_tensor = output_tensor[-1, -1, -1, :]
+    if divup((end - start), step) % 2 != 0:
+        output_tensor = output_tensor[:-1]
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 

--- a/tt_eager/tt_numpy/functions.hpp
+++ b/tt_eager/tt_numpy/functions.hpp
@@ -180,6 +180,9 @@ static Tensor arange(
     TT_ASSERT(step > 0, "Step must be greater than 0");
     TT_ASSERT(start < stop, "Start must be less than step");
     auto size = div_up((stop - start), step);
+    if (size%2 != 0){
+        size++;
+    }
     auto owned_buffer = tt_metal::owned_buffer::create<T>(size);
 
     auto index = 0;


### PR DESCRIPTION
Fix Issue #7145 

Broken Unit Test : `pytest tests/ttnn/python_api_testing/non_working_unit_tests/grayskull/test_arange.py`

Sweep Test Result : 
[arange.csv](https://github.com/tenstorrent/tt-metal/files/15243765/arange.csv)

Unit Test Result : 
<img width="1512" alt="Screenshot 2024-05-08 at 9 45 33 AM" src="https://github.com/tenstorrent/tt-metal/assets/156493059/2b0fea3c-ff9b-41c9-8724-b86263f73860">

All post commit test : https://github.com/tenstorrent/tt-metal/actions/runs/8996228953