### PR TITLE
Watcher/hang dump tool

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -29,7 +29,7 @@ jobs:
           cmake --build build --target tests -- -j`nproc`
           cmake --build build --target metal-install
       - name: 'Tar files'
-        run: tar -cvf ttm_${{ matrix.arch }}.tar build/hw build/lib tt_eager/tt_lib/*.so ttnn/ttnn/*.so build/programming_examples build/test
+        run: tar -cvf ttm_${{ matrix.arch }}.tar build/hw build/lib tt_eager/tt_lib/*.so ttnn/ttnn/*.so build/programming_examples build/test build/tools
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v4
         with:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,4 +5,4 @@ target_link_libraries(test_common_libs INTERFACE pthread stdc++fs GTest::GTest G
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/tt_metal)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager)
 
-add_custom_target(tests DEPENDS metal_tests eager_tests ttnn tt_lib)
+add_custom_target(tests DEPENDS metal_tests eager_tests ttnn tt_lib watcher_dump)

--- a/tests/scripts/run_cpp_unit_tests.sh
+++ b/tests/scripts/run_cpp_unit_tests.sh
@@ -19,3 +19,6 @@ else
     env python tests/scripts/run_tt_eager.py --dispatch-mode fast
     env python tests/scripts/run_tt_metal.py --dispatch-mode fast
 fi
+
+# Tool tests use C++ unit tests so include them here.
+./tests/scripts/run_tools_tests.sh

--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -1,0 +1,33 @@
+#/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$TT_METAL_HOME" ]]; then
+    echo "Must provide TT_METAL_HOME in environment" 1>&2
+    exit 1
+fi
+
+# For now, only test watcher dump tool here.
+if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
+    # Run a test that populates basic fields but not watcher fields
+    ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter=*PrintHanging
+
+    # Run dump tool w/ minimum data - no error expected.
+    ./build/tools/watcher_dump -d=0
+
+    # Verify the kernel we ran shows up in the log.
+    grep "tests/tt_metal/tt_metal/test_kernels/misc/print_hang.cpp" generated/watcher/watcher.log > /dev/null || { echo "Error: couldn't find expected string in watcher log after dump." ; exit 1; }
+    echo "Watcher dump minimal test - Pass"
+
+    # Now run with all watcher features, expect it to throw.
+    ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter=*WatcherAssertBrisc
+    ./build/tools/watcher_dump -d=0 &> tmp.log || { echo "Above failure is expected."; }
+
+    # Verify the error we expect showed up in the program output.
+    grep "brisc tripped an assert" tmp.log > /dev/null || { echo "Error: couldn't find expected string in command output:" ; cat tmp.log; exit 1; }
+    echo "Watcher dump all data test - Pass"
+
+    # Remove created files.
+    rm tmp.log
+    rm generated/watcher/watcher.log
+fi

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -70,6 +70,18 @@ Device *CreateDevice(
     const std::vector<uint32_t> &l1_bank_remap = {});
 
 /**
+ * Instantiates a device with minimal setup, used to attach to a device in a bad state.
+ *
+ * Return value: Device *
+ *
+ * | Argument   | Description                | Type            | Valid Range                       | Required |
+ * |------------|----------------------------|-----------------|-----------------------------------|----------|
+ * | device_id  | ID of the device to target| chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
+ * */
+Device *CreateDeviceMinimal(
+    chip_id_t device_id);
+
+/**
  * Resets device and closes device
  *
  * Return value: bool

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -132,12 +132,18 @@ struct debug_pause_msg_t {
     volatile uint8_t pad[8 - DebugNumUniqueRiscs];
 };
 
+enum watcher_enable_msg_t {
+    WatcherDisabled = 2,
+    WatcherEnabled = 3,
+};
+
 constexpr int num_riscv_per_core = 5;
 struct mailboxes_t {
     struct ncrisc_halt_msg_t ncrisc_halt;
     volatile uint32_t l1_barrier;
     struct launch_msg_t launch;
     struct slave_sync_msg_t slave_sync;
+    volatile uint32_t watcher_enable;
     struct debug_status_msg_t debug_status[num_riscv_per_core];
     struct debug_sanitize_noc_addr_msg_t sanitize_noc[NUM_NOCS];
     struct debug_assert_msg_t assert_status;

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -17,6 +17,10 @@ void watcher_sanitize_host_noc_write(const metal_SocDescriptor &soc_d, CoreCoord
 
 int watcher_register_kernel(const string& name);
 
+// Helper functions for manually dumping watcher contents.
+void watcher_dump();
+void watcher_read_kernel_ids_from_file();
+
 // Check whether the watcher server has been killed due to an error detected, and a function to set
 // that flag. Used in test mode only.
 bool watcher_server_killed_due_to_error();

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -75,7 +75,8 @@ class Device {
         chip_id_t device_id,
         const uint8_t num_hw_cqs,
         std::size_t l1_small_size,
-        const std::vector<uint32_t> &l1_bank_remap = {});
+        const std::vector<uint32_t> &l1_bank_remap = {},
+        bool minimal = false);
 
     ~Device();
 
@@ -207,7 +208,7 @@ class Device {
 
     // Checks that the given arch is on the given pci_slot and that it's responding
     // Puts device into reset
-    bool initialize(size_t l1_small_size, const std::vector<uint32_t> &l1_bank_remap = {});
+    bool initialize(size_t l1_small_size, const std::vector<uint32_t> &l1_bank_remap = {}, bool minimal = false);
     void initialize_cluster();
     void initialize_allocator(size_t l1_small_size, const std::vector<uint32_t> &l1_bank_remap = {});
     void initialize_build();

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -137,6 +137,7 @@ class RunTimeOptions {
     inline bool get_kernels_nullified() { return null_kernels; }
 
     inline bool get_clear_l1() { return clear_l1; }
+    inline void set_clear_l1(bool clear) { clear_l1 = clear; }
 
 private:
     // Helper functions to parse DPrint-specific environment vaiables.

--- a/tt_metal/tools/CMakeLists.txt
+++ b/tt_metal/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/profiler)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/watcher_dump)
 
 set(TOOLS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/memset.cpp)

--- a/tt_metal/tools/module.mk
+++ b/tt_metal/tools/module.mk
@@ -2,6 +2,7 @@
 
 # include $(TT_METAL_HOME)/tt_metal/tools/tt_gdb/module.mk # needs to compiled after llrt and tt_metal
 include $(TT_METAL_HOME)/tt_metal/tools/profiler/module.mk
+include $(TT_METAL_HOME)/tt_metal/tools/watcher_dump/module.mk
 
 TOOLS = \
 	tools/memset
@@ -16,7 +17,7 @@ TOOLS_DEPS = $(addprefix $(OBJDIR)/, $(TOOLS_SRCS:.cpp=.d))
 -include $(TOOLS_DEPS)
 
 # Each module has a top level target as the entrypoint which must match the subdir name
-tools: $(OBJDIR)/tt_metal/tools/memset tools/profiler #tools/tt_gdb
+tools: $(OBJDIR)/tt_metal/tools/memset tools/profiler tools/watcher_dump #tools/tt_gdb
 
 .PRECIOUS: $(OBJDIR)/tools/%
 $(OBJDIR)/tt_metal/tools/memset: $(OBJDIR)/tt_metal/tools/memset.o $(COMMON_OBJS) $(LLRT_OBJS) $(DEVICE_OBJS)

--- a/tt_metal/tools/watcher_dump/CMakeLists.txt
+++ b/tt_metal/tools/watcher_dump/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+add_executable(watcher_dump ${CMAKE_CURRENT_SOURCE_DIR}/watcher_dump.cpp)
+target_link_libraries(watcher_dump PUBLIC test_metal_common_libs)
+target_include_directories(watcher_dump PRIVATE
+    ${UMD_HOME}
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tt_metal
+    ${CMAKE_SOURCE_DIR}/tt_metal/common
+    ${CMAKE_SOURCE_DIR}/tests
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_target_properties(watcher_dump PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tools)

--- a/tt_metal/tools/watcher_dump/module.mk
+++ b/tt_metal/tools/watcher_dump/module.mk
@@ -1,0 +1,21 @@
+# Every variable in subdir must be prefixed with subdir (emulating a namespace)
+WATCHER_DUMP_INCLUDES = $(COMMON_INCLUDES) -Itools/watcher_dump
+WATCHER_DUMP_DEFINES =
+WATCHER_DUMP_LDFLAGS = $(LDFLAGS) -ltt_metal -lyaml-cpp
+
+WATCHER_DUMP_SRCS += \
+	$(wildcard tt_metal/tools/watcher_dump/*.cpp)
+WATCHER_DUMP_OBJS = $(addprefix $(OBJDIR)/, $(WATCHER_DUMP_SRCS:.cpp=.o))
+WATCHER_DUMP_DEPS = $(addprefix $(OBJDIR)/, $(WATCHER_DUMP_SRCS:.cpp=.d))
+
+-include $(WATCHER_DUMP_DEPS)
+# Each module has a top level target as the entrypoint which must match the subdir name
+tools/watcher_dump: $(WATCHER_DUMP_OBJS) $(OUT)/tools/watcher_dump
+
+$(OBJDIR)/tt_metal/tools/watcher_dump/%.o: tt_metal/tools/watcher_dump/%.cpp
+	@mkdir -p $(@D)
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(STATIC_LIB_FLAGS) $(WATCHER_DUMP_INCLUDES) $(WATCHER_DUMP_DEFINES) -c -o $@ $<
+
+$(OUT)/tools/watcher_dump: $(WATCHER_DUMP_OBJS) $(OUT)/lib/libtt_metal.so
+	@mkdir -p $(@D)
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(WATCHER_DUMP_INCLUDES) $(WATCHER_DUMP_DEFINES) -o $@ $^ $(WATCHER_DUMP_LDFLAGS)

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <iostream>
+#include "tt_metal/host_api.hpp"
+#include "impl/debug/watcher_server.hpp"
+
+using namespace tt;
+using std::vector;
+using std::string;
+using std::cout, std::endl;
+
+void dump_data(vector<unsigned>& device_ids) {
+    // Don't clear L1, this way we can dump the state.
+    llrt::OptionsG.set_clear_l1(false);
+
+    // Only look at user-specified devices
+    for (unsigned id : device_ids) {
+        // Minimal setup, since we'll be attaching to a potentially hanging chip.
+        auto* device = tt::tt_metal::CreateDeviceMinimal(id);
+        // Watcher attach wthout watcher init - to avoid clearing mailboxes.
+        watcher_attach(device);
+    }
+
+    // Watcher doesn't have kernel ids since we didn't create them here, need to read from file.
+    watcher_read_kernel_ids_from_file();
+    watcher_dump();
+}
+
+void print_usage(const char* exec_name) {
+    cout << "Usage: " << exec_name << " [OPTION]" << endl;
+    cout << "\t-d=LIST, --devices=LIST: Device IDs of chips to dump, LIST is comma separated list (\"0,2,3\") or \"all\"." << endl;
+    cout << "\t-h, --help: Display this message." << endl;
+}
+
+int main(int argc, char *argv[]) {
+    cout << "Running watcher dump tool..." << endl;
+    // Default devices is all of them.
+    vector<unsigned> device_ids;
+    auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    for (unsigned id = 0; id < num_devices; id++) {
+        device_ids.push_back(id);
+    }
+
+    // Go through user args, handle accordingly.
+    for (int idx = 1; idx < argc; idx++) {
+        string s(argv[idx]);
+        if (s == "-h" || s == "--help") {
+            print_usage(argv[0]);
+            return 0;
+        } else if ((s.rfind("-d=", 0) == 0) || (s.rfind("--devices=", 0) == 0)) {
+            string list = s.substr(s.find("=")+1);
+            // "all" is acceptable, and the same as the default.
+            if (list == "all")
+                continue;
+
+            // Otherwise, parse comma-separated list.
+            device_ids.clear();
+            std::istringstream iss(list);
+            string item;
+            while (std::getline(iss, item, ',')) {
+                if (stoi(item) >= num_devices) {
+                    cout << "Error: illegal device (" << stoi(item) << "), allowed range is [0, " << num_devices << ")" << endl;
+                    print_usage(argv[0]);
+                    return 1;
+                }
+                device_ids.push_back(stoi(item));
+            }
+        } else {
+            cout << "Error: unrecognized command line argument: " << s << endl;
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    // Call dump function with user config.
+    dump_data(device_ids);
+    cout << "Watcher dump tool finished." << endl;
+}

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -765,6 +765,14 @@ Device *CreateDevice(
     return dev;
 }
 
+Device *CreateDeviceMinimal(
+    chip_id_t device_id) {
+    ZoneScoped;
+    Device *dev = new Device(device_id, 1, DEFAULT_L1_SMALL_SIZE, {}, true);
+    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+    return dev;
+}
+
 bool CloseDevice(Device *device) {
     ZoneScoped;
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);


### PR DESCRIPTION
Spun it up pretty quickly, let me know if you see any glaring issues.

```
davidma@e04cs04:~/tt-metal$ ./build/tools/watcher_dump --help
Running watcher dump tool...
Usage: ./build/tools/watcher_dump [OPTION]
        -a, --all-data: If specified, dump all watcher data. Will only work if original program was run with watcher enabled.
        -d=LIST, --devices=LIST: Device IDs of chips to dump, LIST is comma separated list ("0,2,3") or "all".
        -h, --help: Display this message.
```

CI passing here: https://github.com/tenstorrent/tt-metal/actions/runs/8994870970