### PR TITLE
Disable tensor cache in Mamba performance tests

### DIFF
--- a/models/demos/mamba/demo/demo.py
+++ b/models/demos/mamba/demo/demo.py
@@ -82,7 +82,7 @@ def run_mamba_demo(
     model_version: MambaPretrainedModelName = "state-spaces/mamba-2.8b-slimpj",
     batch_size: int = 32,
     generated_sequence_length: int = 50,
-    cache_dir: Optional[str] = "/tmp",
+    cache_dir: Optional[str] = None,
     display: bool = True,
 ):
     if len(prompts) == 1:

--- a/models/demos/mamba/tests/test_mamba_perf.py
+++ b/models/demos/mamba/tests/test_mamba_perf.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch
 import pytest
-from loguru import logger
-import ttnn
 import time
 import json
 
@@ -12,7 +10,6 @@ from models.demos.mamba.demo.demo import (
     get_tokenizer,
     get_cpu_reference_model,
     get_tt_metal_model,
-    apply_repetition_penalty_,
     display_tokens,
 )
 
@@ -48,7 +45,7 @@ def test_mamba_e2e_perf(
     profiler.end("pytorch_ref_model_setup")
 
     profiler.start("tt_model_setup")
-    tt_model = get_tt_metal_model(model_version, device, cache_dir="/tmp", batch_size=batch)
+    tt_model = get_tt_metal_model(model_version, device, cache_dir=None, batch_size=batch)
     profiler.end("tt_model_setup")
 
     sequences: torch.Tensor = tokenizer(prompts, return_tensors="pt", padding=True).input_ids


### PR DESCRIPTION
This fixes an issue where CI uses the tensor cache from a previous version of the Mamba model which causes these tests to fail. 

This should resolve the current pipeline failure: https://github.com/tenstorrent/tt-metal/actions/runs/8991531946/job/24699559736.