### PR TITLE
Mistral demo improvement

### DIFF
--- a/models/demos/wormhole/mistral7b/demo/demo.py
+++ b/models/demos/wormhole/mistral7b/demo/demo.py
@@ -12,6 +12,7 @@ from models.demos.wormhole.mistral7b.tt.mistral_common import (
     sample,
     precompute_freqs,
     freqs_to_rotation_matrix,
+    cache_attention,
 )
 from models.demos.wormhole.mistral7b.tt.mistral_model import TtTransformer
 from models.demos.wormhole.mistral7b.tt.mistral_embedding import TtMistralEmbedding
@@ -125,6 +126,10 @@ def run_mistral_demo(user_input, batch_size, device):
     tt_decode_input, pt_encoded_input, input_mask, rot_emb_matrix_list = preprocess_inputs(
         input_prompts, tokenizer, model_args, dtype, embd, instruct_mode, device
     )
+
+    logger.info("Caching attention ops..")
+    cache_attention(device, state_dict, model_args, rot_emb_matrix_list, dtype)
+    logger.info("Cached attention ops.")
 
     if instruct_mode:
         tokenizer._model.pad_id = tokenizer._model.eos_id

--- a/models/demos/wormhole/mistral7b/demo/demo.py
+++ b/models/demos/wormhole/mistral7b/demo/demo.py
@@ -127,9 +127,8 @@ def run_mistral_demo(user_input, batch_size, device):
         input_prompts, tokenizer, model_args, dtype, embd, instruct_mode, device
     )
 
-    logger.info("Caching attention ops..")
+    logger.info("Caching attention ops...")
     cache_attention(device, state_dict, model_args, rot_emb_matrix_list, dtype)
-    logger.info("Cached attention ops.")
 
     if instruct_mode:
         tokenizer._model.pad_id = tokenizer._model.eos_id

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_perf.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_perf.py
@@ -32,13 +32,12 @@ class Emb(torch.nn.Module):
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.skip(reason="Issue #7540: Hanging")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "kv_cache_len, expected_compile_time, expected_inference_time",
     (
-        (32, 15, 0.16),
-        (128, 15, 0.40),
+        (32, 15, 0.11),
+        (128, 15, 0.14),
     ),
 )
 def test_mistral_model_perf(

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py
@@ -34,6 +34,7 @@ def test_mistral_rms_norm_inference(device, use_program_cache, reset_seeds):
         dtype=dtype,
         layer_num=0,
         weight_key="attention_norm",
+        model_config=model_args.get_model_config(),
     )
     input = torch.rand(1, 32, 4096)
     reference_output = reference_model(input)

--- a/models/demos/wormhole/mistral7b/tt/mistral_attention.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_attention.py
@@ -44,9 +44,7 @@ class TtMistralAttention(nn.Module):
         self.dtype = dtype
 
         self.kv_seq_len = configuration.kv_seq_len
-        self.sliding_window = (
-            configuration.kv_seq_len
-        )  # TODO Change sliding window back to configuration.sliding_window
+        self.sliding_window = configuration.kv_seq_len
         self.grid_size = configuration.max_grid_size
 
         self.model_config = configuration.get_model_config()
@@ -148,7 +146,7 @@ class TtMistralAttention(nn.Module):
                 * (self.head_dim**-0.5),  # [seqlen, n_heads, bsz, head_dim] [1,32,32,128]
                 device=self.devices[i],
                 layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
+                dtype=ttnn.bfloat8_b,
             )
             for i in range(self.num_devices)
         ]
@@ -185,6 +183,76 @@ class TtMistralAttention(nn.Module):
             transpose_mcast=False,
             fused_activation=None,
         )
+        expand_D_8D_torch = torch.eye(128, 128).repeat(1, 1, 1, 8)
+        self.expand_D_8D = [
+            ttnn.from_torch(
+                expand_D_8D_torch,
+                device=self.devices[i],
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,
+            )
+            for i in range(len(devices))
+        ]
+
+        reduce_8D_D_torch = torch.eye(128, 128).repeat(1, 1, 8, 1)
+        self.reduce_8D_D = [
+            ttnn.from_torch(
+                reduce_8D_D_torch,
+                device=self.devices[i],
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,
+            )
+            for i in range(len(devices))
+        ]
+
+        mask_Q_8D_torch = torch.zeros(1, 32, 32, 8 * 128)
+        for j in range(8):
+            mask_Q_8D_torch[:, :, j * 4 : (j + 1) * 4, j * 128 : (j + 1) * 128] = 1
+        self.mask_Q_8D = [
+            ttnn.from_torch(
+                mask_Q_8D_torch,
+                device=self.devices[i],
+                layout=ttnn.TILE_LAYOUT,
+                dtype=ttnn.bfloat8_b,
+            )
+            for i in range(len(devices))
+        ]
+        self.expand_program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            in0_block_w=4,
+            out_subblock_h=2,
+            out_subblock_w=2,
+            per_core_M=4,
+            per_core_N=4,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
+        self.reduce_program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            in0_block_w=4,
+            out_subblock_h=4,
+            out_subblock_w=1,
+            per_core_M=4,
+            per_core_N=1,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+
+        self.attn_program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(8, 4),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=1,
+            per_core_N=32,
+        )
+        self.compute_kernel_config_attn = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+        self.attention_grid = ttnn.experimental.tensor.CoreCoord(8, 4)
 
     def forward(
         self,
@@ -213,6 +281,9 @@ class TtMistralAttention(nn.Module):
             wo = self.wo_list[i]
             layer_past = self.layer_past_list[i]
             head_dim = self.head_dims[i]
+            expand_D_8D = self.expand_D_8D[i]
+            reduce_8D_D = self.reduce_8D_D[i]
+            mask_Q_8D = self.mask_Q_8D[i]
 
             ###
             # QKV matmuls
@@ -226,12 +297,14 @@ class TtMistralAttention(nn.Module):
                 dtype=self.dtype,
             )
 
+            # ttnn.deallocate(x)
+
             ###
             # Reshape and rotary embeddings
             ###
             (
-                q_heads,  # [seqlen, n_heads, bsz, head_dim]
-                k_heads,  # [seqlen, n_kv_heads, bsz, head_dim]
+                q_heads_pre_rot,  # [seqlen, n_heads, bsz, head_dim]
+                k_heads_pre_rot,  # [seqlen, n_kv_heads, bsz, head_dim]
                 v_heads,  # [seqlen, n_kv_heads, bsz, head_dim]
             ) = ttnn.experimental.tensor.nlp_create_qkv_heads(
                 xqkv_fused,
@@ -241,24 +314,31 @@ class TtMistralAttention(nn.Module):
                 output_mem_config=self.model_config["QKV_HEADS_OUTPUT_MEMCFG"],
             )
 
+            ttnn.deallocate(xqkv_fused)
+
             # Update rotary matrix on device
             rotary_mat = self.rot_mat[current_pos]
 
             q_heads = ttnn.linear(
-                q_heads,
+                q_heads_pre_rot,
                 rotary_mat,
                 program_config=self.q_heads_program_config,
                 memory_config=self.model_config["QV_ROT_EMB_OUTPUT_MEMCFG"],
                 compute_kernel_config=self.compute_kernel_config,
+                dtype=self.dtype,
             )
 
             k_heads = ttnn.linear(
-                k_heads,
+                k_heads_pre_rot,
                 rotary_mat,
                 program_config=self.k_heads_program_config,
                 memory_config=self.model_config["QV_ROT_EMB_OUTPUT_MEMCFG"],
                 compute_kernel_config=self.compute_kernel_config,
+                dtype=self.dtype,
             )
+
+            ttnn.deallocate(q_heads_pre_rot)
+            ttnn.deallocate(k_heads_pre_rot)
 
             ###
             # KV update
@@ -273,90 +353,151 @@ class TtMistralAttention(nn.Module):
             ttnn.experimental.tensor.update_cache(values, v_heads, current_pos)  # self.current)
             self.layer_past_list[i] = [keys, values]
 
-            keys = keys[:, :, :padded_layer_past_len, :]
-            keys = ttnn.permute(keys, (0, 1, 3, 2))  #  [batch, num_kv_heads, dhead, cache_len + seqlen]
-            values = values[:, :, :layer_slice, :]
+            ttnn.deallocate(k_heads)
+            ttnn.deallocate(v_heads)
 
             ###
             # Attention
             ###
-            """
-            q_heads = ttnn.to_memory_config(
-                q_heads,
-                memory_config=ttnn.create_sharded_memory_config(
-                    (32, 128),
-                    ttnn.CoreGrid(8, 4),
-                    ttnn.ShardStrategy.HEIGHT,
-                    ttnn.ShardOrientation.ROW_MAJOR,
-                    use_height_and_width_as_shard_shape=True,
-                ),
-            )  # [seqlen, n_heads, bsz, head_dim]
+            # splitting attention implementation into 2 parts because for token id>575 we run out of memory for group_attn_matmul op
+            if self.start_pos < 575:
+                keys_sliced = keys[:, :, :padded_layer_past_len, :]
+                keys_sliced_T = ttnn.permute(
+                    keys_sliced, (0, 1, 3, 2)
+                )  #  [batch, num_kv_heads, dhead, cache_len + seqlen]
+                ttnn.deallocate(keys_sliced)
+                q_heads = q_heads * head_dim  # Scale q_heads instead of QK before softmax
 
-            # dynamic sharding
-            keys = ttnn.to_memory_config(
-                keys,
-                memory_config=ttnn.create_sharded_memory_config(
-                    (8 * 1 * 128, padded_layer_past_len),
-                    ttnn.CoreGrid(8, 4),
-                    ttnn.ShardStrategy.HEIGHT,
-                    ttnn.ShardOrientation.ROW_MAJOR,
-                    False,
-                    use_height_and_width_as_shard_shape=True,
-                ),
-            )
-            """
-            q_heads = q_heads * head_dim  # Scale q_heads instead of QK before softmax
+                attn = ttnn.experimental.operations.primary.transformers.group_attn_matmul(
+                    q_heads,
+                    keys_sliced_T,
+                    compute_with_storage_grid_size=self.attention_grid,
+                    output_mem_config=self.model_config["QK_MM_OUTPUT_MEMCFG"],
+                    output_dtype=ttnn.bfloat16,  # Force bfloat16 for higher accuracy
+                )  # seqlen, n_heads, batch, cache_len + seqlen
 
-            attn = ttnn.experimental.operations.primary.transformers.group_attn_matmul(
-                q_heads,
-                keys,
-                compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
-                output_mem_config=self.model_config["QK_MM_OUTPUT_MEMCFG"],
-                output_dtype=ttnn.bfloat16,  # Force bfloat16 for higher accuracy
-            )  # seqlen, n_heads, batch, cache_len + seqlen
+                ttnn.deallocate(keys_sliced_T)
+                ttnn.deallocate(q_heads)
 
-            attn = attn[:, :, :, :layer_slice]
-            attn = ttnn.softmax(attn, dim=-1)  # (attn * (self.head_dim**-0.5))
-            """
-            attn = ttnn.to_memory_config(attn, memory_config=ttnn.create_sharded_memory_config(
-                (32, padded_layer_past_len),
-                ttnn.CoreGrid(8, 4),
-                ttnn.ShardStrategy.HEIGHT,
-                ttnn.ShardOrientation.ROW_MAJOR,
-                use_height_and_width_as_shard_shape=True,
-            ))
+                attn_sliced = attn[:, :, :, :layer_slice]
+                attn_sliced = ttnn.softmax(
+                    attn_sliced,
+                    dim=-1,
+                )
 
-            values = ttnn.to_memory_config(values, memory_config=ttnn.create_sharded_memory_config(
-                (1 * 8 * padded_layer_past_len, 128),
-                ttnn.CoreGrid(8, 4),
-                ttnn.ShardStrategy.HEIGHT,
-                ttnn.ShardOrientation.ROW_MAJOR,
-                False,
-                use_height_and_width_as_shard_shape=True,
-            ))
-            """
+                values_sliced = values[:, :, :layer_slice, :]
 
-            attn_output = ttnn.experimental.operations.primary.transformers.group_attn_matmul(
-                attn,
-                values,
-                compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
-                output_mem_config=self.model_config["QKV_MM_OUTPUT_MEMCFG"],
-                output_dtype=ttnn.bfloat16,  # Force bfloat16 for higher accuracy
-            )  # seqlen, n_heads, batch, dhead
+                attn_output = ttnn.experimental.operations.primary.transformers.group_attn_matmul(
+                    attn_sliced,
+                    values_sliced,
+                    compute_with_storage_grid_size=self.attention_grid,
+                    output_mem_config=self.model_config["QKV_MM_OUTPUT_MEMCFG"],
+                    output_dtype=ttnn.bfloat8_b,  # Force bfloat16 for higher accuracy
+                )  # seqlen, n_heads, batch, dhead
 
-            attn_output = ttnn.transformer.concatenate_heads(
-                attn_output, memory_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"]
-            )
-            # seqlen, 1, batch, hidden_size
+                ttnn.deallocate(attn_sliced)
+                ttnn.deallocate(values_sliced)
+
+                attn_output_cat = ttnn.transformer.concatenate_heads(
+                    attn_output, memory_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"]
+                )
+                # seqlen, 1, batch, hidden_size
+
+                ttnn.deallocate(attn_output)
+
+            else:
+                # reshape keys
+                keys_BKPD = keys[:, :, :padded_layer_past_len, :]
+                keys_1B_P_8D = ttnn.unsqueeze_to_4D(ttnn.transformer.concatenate_heads(keys_BKPD))
+                keys_1B_P_8D = ttnn.clone(
+                    keys_1B_P_8D, dtype=ttnn.bfloat16, memory_config=self.model_config["KV_UNPAD_OUTPUT_MEMCFG"]
+                )
+                keys_1B_8D_P_preshard = ttnn.permute(keys_1B_P_8D, (0, 1, 3, 2))
+
+                keys_BKPD.deallocate()
+                keys_1B_P_8D.deallocate()
+
+                # reshape values
+                values_BKPD = values[:, :, :padded_layer_past_len, :]
+                values_B1_P_8D = ttnn.transformer.concatenate_heads(values_BKPD)
+                values_1B_P_8D_preshard = ttnn.unsqueeze_to_4D(values_B1_P_8D)  # [:, :, :layer_slice, :]
+                values_BKPD.deallocate()
+
+                # reshape queries
+                q_heads_1QBD = q_heads * head_dim  # Scale q_heads instead of QK before softmax
+                q_heads_1QBD = ttnn.clone(
+                    q_heads_1QBD, dtype=ttnn.bfloat16, memory_config=self.model_config["KV_UNPAD_OUTPUT_MEMCFG"]
+                )
+                q_heads_1BQD = ttnn.permute(q_heads_1QBD, (0, 2, 1, 3))
+                q_heads_1QBD.deallocate()
+                q_heads_1B_Q_8D_preshard = (
+                    ttnn.matmul(
+                        q_heads_1BQD,
+                        expand_D_8D,
+                        program_config=self.expand_program_config,
+                        compute_kernel_config=self.compute_kernel_config,
+                        memory_config=self.model_config["KV_UNPAD_OUTPUT_MEMCFG"],
+                    )
+                    * mask_Q_8D
+                )
+                q_heads_1BQD.deallocate()
+
+                # scores matmul
+                attn_1BQP = ttnn.matmul(
+                    q_heads_1B_Q_8D_preshard,
+                    keys_1B_8D_P_preshard,
+                    core_grid=ttnn.CoreGrid(y=4, x=8),
+                    compute_kernel_config=self.compute_kernel_config_attn,
+                    dtype=ttnn.bfloat16,
+                    memory_config=self.model_config["KV_UNPAD_OUTPUT_MEMCFG"],
+                )
+                keys_1B_8D_P_preshard.deallocate()
+                q_heads_1B_Q_8D_preshard.deallocate()
+
+                # scores softmax
+                attn_1BQP_presoftmax = attn_1BQP[:, :, :, :layer_slice]
+                attn_1BQP = ttnn.softmax(attn_1BQP_presoftmax, dim=-1)
+                attn_1BQP = ttnn.pad(attn_1BQP, ((0, 0), (0, 0), (0, 0), (0, 0)), value=0.0)
+
+                # attention matmul
+                attn_output_1B_Q_8D = ttnn.matmul(
+                    attn_1BQP,
+                    values_1B_P_8D_preshard,
+                    program_config=self.attn_program_config,
+                    memory_config=self.model_config["QKV_MM_OUTPUT_MEMCFG"],
+                    dtype=ttnn.bfloat16,
+                    compute_kernel_config=self.compute_kernel_config_attn,
+                )
+
+                attn_1BQP.deallocate()
+
+                # reduce and reshape
+                attn_output_1BQD = ttnn.matmul(
+                    attn_output_1B_Q_8D * mask_Q_8D,
+                    reduce_8D_D,
+                    compute_kernel_config=self.compute_kernel_config,
+                    program_config=self.reduce_program_config,
+                    memory_config=self.model_config["QKV_MM_OUTPUT_MEMCFG"],
+                )
+                attn_output_1QBD = ttnn.permute(attn_output_1BQD, (0, 2, 1, 3))
+
+                attn_output_1BQD.deallocate()
+                attn_output_1B_Q_8D.deallocate()
+
+                attn_output_cat = ttnn.transformer.concatenate_heads(
+                    attn_output_1QBD, memory_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"]
+                )
+                attn_output_1QBD.deallocate()
 
             dense_out = ttnn.linear(
-                attn_output,
+                attn_output_cat,
                 wo,
                 program_config=self.dense_program_config,
                 memory_config=self.model_config["LM_HEAD_OUTPUT_MEMCFG"],
                 compute_kernel_config=self.compute_kernel_config,
             )  # seqlen, 1, batch, hidden_size
 
+            ttnn.deallocate(attn_output_cat)
             dense_outputs.append(dense_out)
 
         # return the sum of the outputs

--- a/models/demos/wormhole/mistral7b/tt/mistral_common.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_common.py
@@ -201,8 +201,6 @@ def cache_attention(device, state_dict, model_args, rot_emb_matrix_list, dtype):
             [attention_input],
             pos,
         )
-        # ttnn.deallocate(tt_out[0])
-        print("Cached iter", iter)
 
     ttnn.deallocate(tt_model.wqkv_list[0])
     ttnn.deallocate(tt_model.wo_list[0])

--- a/models/demos/wormhole/mistral7b/tt/mistral_common.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_common.py
@@ -172,3 +172,44 @@ def sample(logits: torch.Tensor, temperature: float, top_p: float):
         next_token = torch.argmax(logits, dim=-1)
 
     return next_token
+
+
+from models.demos.wormhole.mistral7b.tt.mistral_attention import TtMistralAttention
+
+
+def cache_attention(device, state_dict, model_args, rot_emb_matrix_list, dtype):
+    attention_input = ttnn.from_torch(
+        torch.randn(1, 1, 32, 4096),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    tt_model = TtMistralAttention(
+        [device],
+        state_dict,
+        weight_cache_path=model_args.weight_cache_path(dtype),
+        layer_num=0,
+        dtype=dtype,
+        configuration=model_args,
+        rot_mat=rot_emb_matrix_list,
+        start_pos=0,
+    )
+    for iter in range(1024):
+        pos = iter
+        tt_out = tt_model(
+            [attention_input],
+            pos,
+        )
+        # ttnn.deallocate(tt_out[0])
+        print("Cached iter", iter)
+
+    ttnn.deallocate(tt_model.wqkv_list[0])
+    ttnn.deallocate(tt_model.wo_list[0])
+    ttnn.deallocate(tt_model.layer_past_list[0][0])
+    ttnn.deallocate(tt_model.layer_past_list[0][1])
+    ttnn.deallocate(tt_model.head_dims[0])
+    ttnn.deallocate(tt_model.expand_D_8D[0])
+    ttnn.deallocate(tt_model.reduce_8D_D[0])
+    ttnn.deallocate(tt_model.mask_Q_8D[0])
+    ttnn.deallocate(attention_input)

--- a/models/demos/wormhole/mistral7b/tt/mistral_decoder.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_decoder.py
@@ -60,6 +60,7 @@ class TtTransformerBlock(torch.nn.Module):
             dtype=dtype,
             layer_num=layer_num,
             weight_key="attention_norm",
+            model_config=self.args.get_model_config(),
         )
         self.ffn_norm = TtRMSNorm(
             device=device,
@@ -68,6 +69,7 @@ class TtTransformerBlock(torch.nn.Module):
             dtype=dtype,
             layer_num=layer_num,
             weight_key="ffn_norm",
+            model_config=self.args.get_model_config(),
         )
 
     def forward(

--- a/models/demos/wormhole/mistral7b/tt/mistral_mlp.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_mlp.py
@@ -27,18 +27,18 @@ class TtMistralMLP(torch.nn.Module):
         base_name = f"layers.{layer_num}.feed_forward"
         torch_weight = lambda name: torch.transpose(self.state_dict[f"{base_name}.{name}.weight"], -2, -1)
         cache_name = lambda name: weight_cache_path / (base_name + f".{name}")
-        as_tensor = lambda name: ttnn.as_tensor(
+        as_tensor = lambda name, type: ttnn.as_tensor(
             torch_weight(name),
-            dtype=dtype,
+            dtype=type,
             device=self.device,
             layout=self.model_config["MLP_W_LAYOUT_TILE"],
             memory_config=self.model_config["MLP_WEIGHTS_MEMCFG"],
             cache_file_name=cache_name(name),
         )
 
-        self.w1 = as_tensor("w1")
-        self.w2 = as_tensor("w2")
-        self.w3 = as_tensor("w3")
+        self.w1 = as_tensor("w1", ttnn.bfloat4_b)
+        self.w2 = as_tensor("w2", ttnn.bfloat8_b)
+        self.w3 = as_tensor("w3", ttnn.bfloat4_b)
 
         x_shape = ttnn.Shape([1, 1, args.max_batch_size, args.dim])
         h_shape = ttnn.Shape([1, 1, args.max_batch_size, args.hidden_dim])

--- a/models/demos/wormhole/mistral7b/tt/mistral_model.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_model.py
@@ -53,6 +53,7 @@ class TtTransformer(nn.Module):
             dtype=dtype,
             layer_num=None,
             weight_key="norm",
+            model_config=self.args.get_model_config(),
         )
         self.state_dict = state_dict
 

--- a/models/demos/wormhole/mistral7b/tt/model_config.py
+++ b/models/demos/wormhole/mistral7b/tt/model_config.py
@@ -88,6 +88,26 @@ class TtModelArgs:
             self.model_config["FF1_OUTPUT_MEMCFG"] = mlp_shard_config
             self.model_config["FF3_OUTPUT_MEMCFG"] = mlp_shard_config
 
+            shard_height = 32
+            hidden_size = 4096
+            shard_width_hidden_dim_across_32_cores = hidden_size // 32
+            self.model_config["SHARDED_NORM_INPUT_MEMCFG"] = ttnn.create_sharded_memory_config(
+                shape=(shard_height, shard_width_hidden_dim_across_32_cores),
+                core_grid=ttnn.CoreGrid(y=4, x=8),
+                strategy=ttnn.ShardStrategy.WIDTH,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            self.model_config["SHARDED_NORM_OUTPUT_MEMCFG"] = self.model_config["SHARDED_NORM_INPUT_MEMCFG"]
+            self.model_config[
+                "SHARDED_NORM_PRGM_CFG"
+            ] = ttnn.experimental.operations.primary.LayerNormShardedMultiCoreProgramConfig(
+                compute_with_storage_grid_size=[8, 4],
+                subblock_w=4,
+                block_h=shard_height // 32,
+                block_w=shard_width_hidden_dim_across_32_cores // 32,
+                inplace=False,
+            )
             # Compute kernel shared by attention and MLP. FP32 acc is needed for accuracy
             self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
                 math_fidelity=ttnn.MathFidelity.HiFi4,


### PR DESCRIPTION
Added support for:
- Longer seq len (1024 tokens)
- bf4 MLP weights
- sharded rm norm 
- attention caching

fyi @mtairum @yieldthought 