### PR TITLE
#8250: Add unary div_no_nan

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -310,6 +310,10 @@ op_map = {
         "tt_lib_op": tt_lib_ops.eltwise_div_no_nan,
         "pytorch_op": pytorch_ops.div_no_nan,
     },
+    "eltwise-unary_div_no_nan": {
+        "tt_lib_op": tt_lib_ops.eltwise_unary_div_no_nan,
+        "pytorch_op": pytorch_ops.unary_div_no_nan,
+    },
     "eltwise-square": {
         "tt_lib_op": tt_lib_ops.eltwise_square,
         "pytorch_op": pytorch_ops.square,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_unary_div_no_nan.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_unary_div_no_nan.py
@@ -1,14 +1,10 @@
 # SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
-
 # SPDX-License-Identifier: Apache-2.0
-
 import pytest
 import torch
 import random
 from functools import partial
 import tt_lib as ttl
-
-
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
     generation_funcs,
@@ -32,27 +28,30 @@ mem_configs = [
     ],
 )
 @pytest.mark.parametrize(
+    "value",
+    [-5.1, 0.0, 10.9],
+)
+@pytest.mark.parametrize(
     "dst_mem_config",
     mem_configs,
 )
-class TestDiv_No_Nan:
-    def test_run_div_no_nan(
+class TestUnary_Div_No_Nan:
+    def test_run_unary_div_no_nan(
         self,
         input_shapes,
+        value,
         dst_mem_config,
         device,
     ):
         datagen_func = [
             generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
-        ] + [
-            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update({"value": value})
         test_args.update({"output_mem_config": dst_mem_config})
         comparison_func = comparison_funcs.comp_pcc
-
         run_single_pytorch_test(
-            "eltwise-div_no_nan",
+            "eltwise-unary_div_no_nan",
             input_shapes,
             datagen_func,
             comparison_func,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -696,6 +696,15 @@ def div_no_nan(x, y, *args, **kwargs):
     return result
 
 
+def unary_div_no_nan(x, *args, **kwargs):
+    value = kwargs.pop("value")
+    if value == 0:
+        result = torch.zeros_like(x)
+    else:
+        result = x / value
+    return result
+
+
 def div_unary(x, *args, scalar, **kwargs):
     result = torch.div(x, scalar)
     return result

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1066,6 +1066,24 @@ def eltwise_div_no_nan(
 
 
 @setup_host_and_device
+def eltwise_unary_div_no_nan(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.div_no_nan(t0, value, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
 def lamb_optimizer(
     x,
     y,

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -884,6 +884,22 @@ Tensor div_no_nan(
     return operation::decorate_as_composite(__func__, _div_no_nan)(input_a, input_b, output_mem_config);
 }
 
+Tensor _div_no_nan_overload(
+    const Tensor& input_a,
+    float value,
+    const MemoryConfig& output_mem_config) {
+    if(value == 0)
+        return full_like(input_a, 0.0f, output_mem_config);
+    else
+        return div_unary(input_a, value);
+}
+Tensor div_no_nan(
+    const Tensor& input_a,
+    float value,
+    const MemoryConfig& output_mem_config) {
+    return operation::decorate_as_composite(__func__, _div_no_nan_overload)(input_a, value, output_mem_config);
+}
+
 // logit(input, eps)=log(input / 1 - input)
 Tensor _logit(const Tensor& input_a, float eps, const MemoryConfig& output_mem_config) {
     Tensor t_eps = full_like(input_a, eps, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -176,6 +176,11 @@ Tensor div_no_nan(
     const Tensor& input_b,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+Tensor div_no_nan(
+    const Tensor& input_a,
+    float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 // xlogy(x,y))=x*log(y)
 Tensor xlogy(
     const Tensor& input_a,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -826,9 +826,9 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-         m_tensor.def("div_no_nan", &div_no_nan,
+        m_tensor.def("div_no_nan", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&div_no_nan),
             py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs the element-wise div_no_nan on ``input_a`` and ``input_b``, which returns 0 if ``input_b`` (denominator) is zero.
+            Performs the element-wise div_no_nan on two tensors ``input_a`` and ``input_b``, which returns 0 if ``input_b`` (denominator) is zero.
 
             Input tensor must have BFLOAT16 data type.
 
@@ -839,6 +839,22 @@ namespace tt::tt_metal::detail{
 
                 "input_a", "Numerator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "input_b", "Denominator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+        m_tensor.def("div_no_nan", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&div_no_nan),
+            py::arg("input_a").noconvert(), py::arg("value").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs the element-wise div_no_nan on  a tensor ``input_a`` and  a scalar ``value``, which returns 0 if ``value`` (denominator) is zero.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input_a", "Numerator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "value", "Denominator value", "float", "", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 


### PR DESCRIPTION
Issue #8250 
Reference : [Link](https://github.com/tenstorrent/tt-metal/issues/8250#issue-2285550073)

Add unary div_no_nan forward op

All Post Commit Test : https://github.com/tenstorrent/tt-metal/actions/runs/9002733735

Test result:
- File : `tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div_no_nan.py`
<img width="1442" alt="Screenshot 2024-05-09 at 2 49 57 PM" src="https://github.com/tenstorrent/tt-metal/assets/156493059/a8f61262-6cb5-47dd-ad25-5e010ce50cee">

- File : `tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_unary_div_no_nan.py`
<img width="1442" alt="Screenshot 2024-05-09 at 2 49 24 PM" src="https://github.com/tenstorrent/tt-metal/assets/156493059/00405731-2f22-4c11-b0d6-df7ec47a7643">

Doc:
<img width="1512" alt="Screenshot 2024-05-09 at 2 56 47 PM" src="https://github.com/tenstorrent/tt-metal/assets/156493059/704e2799-9b07-42ac-9b27-4ebb6e0b2361">


