### PR TITLE
#8258: Correct op name format

### DIFF
--- a/tt_metal/tools/profiler/op_profiler.hpp
+++ b/tt_metal/tools/profiler/op_profiler.hpp
@@ -208,6 +208,7 @@ namespace op_profiler {
             }
         }
 
+        std::replace( opName.begin(), opName.end(), ',', ';');
         j["op_code"] = opName;
 
         json attributesObj;

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -91,7 +91,7 @@ def import_tracy_op_logs():
             if "TT_DNN" in opDataStr:
                 tmpStrs = opDataStr.split(" ->\n", 1)
                 opData = {}
-                if len(tmpStrs) > 1:
+                if len(tmpStrs) > 1:  # uncached device op, host op, or fallback op
                     jsonStr = tmpStrs[-1]
                     opData = json.loads(jsonStr)
                     if "op_hash" in opData.keys():
@@ -103,7 +103,7 @@ def import_tracy_op_logs():
                         else:
                             cached_ops[deviceID] = {opHash: opData.copy()}
                         del cached_ops[deviceID][opHash]["global_call_count"]
-                else:
+                else:  # cached device op
                     opDataList = opDataStr.split(":", 1)[-1].split(",")
                     assert len(opDataList) > 3, "Wrong cached op info format"
                     opCode = opDataList[0].strip()


### PR DESCRIPTION
All other fields in the csv are padded with our qoutechar which is  "`". 

Name field is used in one more place other than the original ops data csv where it uses comma as a delimiter, this is why op_name can't have commas.

New profiler test infra with #516 needs to come in to properly test requirements like this.