### PR TITLE
#7678: Re-enable mistral decoder test to CI

### DIFF
--- a/models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py
@@ -21,7 +21,6 @@ from models.utility_functions import skip_for_grayskull
 
 
 @skip_for_grayskull("Requires wormhole_b0 to run")
-@pytest.mark.skip(reason="#7678: Non-det hang")
 @pytest.mark.parametrize(
     "iterations",
     ((1),),

--- a/models/demos/wormhole/mistral7b/tt/model_config.py
+++ b/models/demos/wormhole/mistral7b/tt/model_config.py
@@ -45,6 +45,8 @@ class TtModelArgs:
         "CONCAT_HEADS_OUTPUT",
         "LM_HEAD_OUTPUT",
         "ATTN_W_LAYOUT",
+        # Decoder
+        "DEC_SKIP_OUTPUT",
     )
 
     def __init__(self, device, model_base_path="/mnt/MLPerf/ttnn/models/demos/mistral7b", instruct=False):


### PR DESCRIPTION
Re-enable `test_mistral_decoder.py` in CI.

Ongoing pipelines:
- https://github.com/tenstorrent/tt-metal/actions/runs/9005653990
- https://github.com/tenstorrent/tt-metal/actions/runs/9005647032