### PR TITLE
#8194: pch for metal, tt_lib, ttnn and updated install destinations

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           cmake -B build -G Ninja
           cmake --build build --target tests -- -j`nproc`
-          cmake --build build --target metal-install
+          cmake --build build --target install -- -j`nproc`
       - name: 'Tar files'
         run: tar -cvf ttm_${{ matrix.arch }}.tar build/hw build/lib tt_eager/tt_lib/*.so ttnn/ttnn/*.so build/programming_examples build/test build/tools
       - name: 'Upload Artifact'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,13 @@ else()
 endif()
 message(STATUS "Build shared libs: ${BUILD_SHARED_LIBS}")
 
+include(GNUInstallDirs)
+set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}")
+set(CMAKE_INSTALL_LIBDIR "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_INSTALL_BINDIR "${CMAKE_BINARY_DIR}/tmp/bin")
+set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_BINARY_DIR}/tmp/include")
+set(CMAKE_INSTALL_DATAROOTDIR "${CMAKE_BINARY_DIR}/tmp/share")
+
 ############################################
 # Constructing interface libs for common compiler flags, header directories, and libraries
 #   These interface libs are linked with PUBLIC scope at lowest common target (tt_metal/common) and at tt_metal_libs level
@@ -104,6 +111,14 @@ else()
     )
 endif()
 
+# Can't use the `REUSE_FROM` option bc tt_lib and ttnn have different build flags :(
+add_library(pch_pybinds INTERFACE)
+target_precompile_headers(pch_pybinds INTERFACE
+    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/operators.h
+    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/pybind11.h
+    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/stl.h
+)
+
 ############################################
 # Build subdirectories
 ############################################
@@ -129,26 +144,26 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests EXCLUDE_FROM_ALL)
 ############################################
 # Install for build artifacts that will upload build/lib
 install(TARGETS tt_metal
-    ARCHIVE DESTINATION ${CMAKE_BINARY_DIR}/lib
-    LIBRARY DESTINATION ${CMAKE_BINARY_DIR}/lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT tt_build_artifacts
 )
 install(TARGETS tt_eager
-    ARCHIVE DESTINATION ${CMAKE_BINARY_DIR}/lib
-    LIBRARY DESTINATION ${CMAKE_BINARY_DIR}/lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT tt_build_artifacts
 )
 install(TARGETS tt_lib
-    LIBRARY DESTINATION ${CMAKE_BINARY_DIR}/lib
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT tt_build_artifacts
 )
 install(TARGETS ttnn_lib
-    LIBRARY DESTINATION ${CMAKE_BINARY_DIR}/lib
-    ARCHIVE DESTINATION ${CMAKE_BINARY_DIR}/lib
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT tt_build_artifacts
 )
 install(TARGETS ttnn
-    LIBRARY DESTINATION ${CMAKE_BINARY_DIR}/lib
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT tt_build_artifacts
 )
 
@@ -160,11 +175,4 @@ install(FILES ${CMAKE_BINARY_DIR}/lib/_ttnn.so
 install(FILES ${CMAKE_BINARY_DIR}/lib/_C.so
     DESTINATION ${CMAKE_SOURCE_DIR}/tt_eager/tt_lib
     COMPONENT tt_pybinds
-)
-
-# Top level install target, used by pip install
-add_custom_target(metal-install
-    COMMAND ${CMAKE_COMMAND} --install . --component tt_build_artifacts
-    COMMAND ${CMAKE_COMMAND} --install . --component tt_pybinds
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -19,8 +19,7 @@ fi
 
 echo "Building tt-metal"
 cmake -B build -G Ninja
-cmake --build build
-cmake --build build --target metal-install
+cmake --build build --target install
 
 echo "Creating virtual env in: $PYTHON_ENV_DIR"
 python3 -m venv $PYTHON_ENV_DIR

--- a/scripts/build_scripts/build_with_profiler_opt.sh
+++ b/scripts/build_scripts/build_with_profiler_opt.sh
@@ -13,6 +13,6 @@ fi
 
 remove_default_log_locations
 
-# rm -rf build
+cmake -B build && cmake --build build --target clean && rm -rf build
 PYTHON_ENV_DIR=$(pwd)/build/python_env ENABLE_TRACY=1 ENABLE_PROFILER=1 ./build_metal.sh
 cmake --build build --target programming_examples -- -j`nproc`

--- a/setup.py
+++ b/setup.py
@@ -135,8 +135,9 @@ class CMakeBuild(build_ext):
         build_args = [f"-j{nproc}"]
 
         subprocess.check_call(["cmake", source_dir, *cmake_args], cwd=build_dir, env=build_env)
-        subprocess.check_call(["cmake", "--build", ".", *build_args], cwd=build_dir, env=build_env)
-        subprocess.check_call(["cmake", "--build", ".", "--target", "metal-install"], cwd=build_dir)
+        subprocess.check_call(
+            ["cmake", "--build", ".", "--target", "install", *build_args], cwd=build_dir, env=build_env
+        )
 
         subprocess.check_call(["ls", "-hal"], cwd=source_dir, env=build_env)
         subprocess.check_call(["ls", "-hal", "build/lib"], cwd=source_dir, env=build_env)

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -224,3 +224,13 @@ target_include_directories(tt_dnn PUBLIC
     ${CMAKE_SOURCE_DIR}/ttnn/cpp
     ${CMAKE_SOURCE_DIR}/tt_metal/third_party/fmt
 )
+
+target_precompile_headers(tt_dnn PUBLIC
+    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
+    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/tracy/public/tracy/Tracy.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/auto_format.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/compute_kernel_config.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/operation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/run_operation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/work_split.hpp
+)

--- a/tt_eager/tt_lib/CMakeLists.txt
+++ b/tt_eager/tt_lib/CMakeLists.txt
@@ -13,7 +13,7 @@ set(TT_LIB_SRCS
 # TODO: should be using pybind11_add_module, but right now it introduces many build problems
 # pybinds will always be built as a shared library
 add_library(tt_lib SHARED ${TT_LIB_SRCS})
-target_link_libraries(tt_lib PUBLIC compiler_flags linker_flags tt_eager tt_metal)  # linker_flags = -rdynamic if tracy enabled
+target_link_libraries(tt_lib PUBLIC compiler_flags linker_flags tt_eager tt_metal pch_pybinds)  # linker_flags = -rdynamic if tracy enabled
 target_include_directories(tt_lib PUBLIC
     ${UMD_HOME}
     ${CMAKE_SOURCE_DIR}
@@ -29,6 +29,7 @@ target_link_directories(tt_lib PUBLIC
     ${CMAKE_BINARY_DIR}/tt_metal
     ${Python3_LIBRARIES}
 )
+
 # Make sure library built is _C.so and that it can find all it's linked libraries
 # tt_lib breaks if -fvisibility=hidden, so CXX_VISIBILITY_PRESET set to default
 set_target_properties(tt_lib PROPERTIES

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -15,13 +15,16 @@ target_include_directories(ttnn_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
     ${CMAKE_SOURCE_DIR}/tt_metal/third_party/fmt
 )
+target_precompile_headers(ttnn_lib PRIVATE
+    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
+)
 
 
 # TODO: should be using pybind11_add_module, but right now it introduces many build problems
 # pybinds will always be built as a shared library
 add_library(ttnn SHARED ${CMAKE_SOURCE_DIR}/ttnn/cpp/pybind11/__init__.cpp $<TARGET_OBJECTS:ttnn_lib>)
-target_compile_options(ttnn PUBLIC -MP -Wno-int-to-pointer-cast -fno-var-tracking)
-target_link_libraries(ttnn PUBLIC compiler_flags linker_flags tt_eager)     # linker_flags = -rdynamic if tracy enabled
+target_compile_options(ttnn PUBLIC -Wno-int-to-pointer-cast -fno-var-tracking)
+target_link_libraries(ttnn PUBLIC compiler_flags linker_flags tt_eager pch_pybinds)     # linker_flags = -rdynamic if tracy enabled
 target_include_directories(ttnn PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
     ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include


### PR DESCRIPTION
PCH for third party header files, saves ~10-20 seconds on CI build artifacts.

Install destination update, users can now run `make/ninja install -C build` to build and install metal.

https://github.com/tenstorrent/tt-metal/actions/runs/9084565327