### PR TITLE
#5389: updated ttnn::layer_norm and ttnn::rms_norm to use register_operation

### DIFF
--- a/ttnn/cpp/pybind11/operations/normalization.hpp
+++ b/ttnn/cpp/pybind11/operations/normalization.hpp
@@ -6,6 +6,8 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+
+#include "../decorators.hpp"
 #include "ttnn/operations/normalization.hpp"
 
 namespace py = pybind11;
@@ -18,28 +20,34 @@ namespace ttnn {
 namespace operations {
 namespace normalization {
 void py_module(py::module& module) {
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::layer_norm,
+        R"doc(rms_norm(input_tensor: ttnn.Tensor, epsilon: float = 1e-12, weight: ttnn.Tensor, bias: ttnn.Tensor, residual_input_tensor: ttnn.Tensor, memory_config: ttnn.MemoryConfig, program_config: ttnn.LayerNormProgramConfig) -> ttnn.Tensor
+            Compute layer_norm over :attr:`input_tensor`.
+        )doc",
+        ttnn::pybind_arguments_t{
+            py::arg("input_tensor"),
+            py::kw_only(),
+            py::arg("epsilon") = 1e-12,
+            py::arg("weight") = std::nullopt,
+            py::arg("bias") = std::nullopt,
+            py::arg("residual_input_tensor") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("program_config") = std::nullopt});
 
-    module.def("layer_norm", &layer_norm,
-        py::arg("input_tensor"),
-        py::kw_only(),
-        py::arg("epsilon") = 1e-12,
-        py::arg("weight") = std::nullopt,
-        py::arg("bias") = std::nullopt,
-        py::arg("residual_input_tensor") = std::nullopt,
-        py::arg("memory_config") = ::dram_memory_config,
-        py::arg("program_config") = std::nullopt,
-        R"doc(
-Compute layer_norm over :attr:`input_tensor`.
-    )doc");
-
-    module.def("rms_norm", &rms_norm,
-        py::arg("input_tensor"),
-        py::arg("weight"),
-        py::kw_only(),
-        py::arg("epsilon") = 1e-12,
-        R"doc(
-Compute rms_norm over :attr:`input_tensor`.
-    )doc");
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::rms_norm,
+        R"doc(rms_norm(input_tensor: ttnn.Tensor, weight: ttnn.Tensor, *, epsilon: float = 1e-12, memory_config: ttnn.MemoryConfig) -> ttnn.Tensor
+            Compute rms_norm over :attr:`input_tensor`.
+        )doc",
+        ttnn::pybind_arguments_t{
+            py::arg("input_tensor"),
+            py::arg("weight"),
+            py::kw_only(),
+            py::arg("epsilon") = 1e-12,
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace normalization

--- a/ttnn/cpp/ttnn/operations/normalization.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization.hpp
@@ -10,36 +10,120 @@ namespace ttnn {
 namespace operations {
 namespace normalization {
 
-
-inline ttnn::Tensor layer_norm(
-    const ttnn::Tensor& input_tensor,
-    float epsilon,
-    std::optional<const ttnn::Tensor> & weight,
-    std::optional<const ttnn::Tensor>& bias,
-    std::optional<const ttnn::Tensor>& residual_input_tensor,
-    const MemoryConfig& memory_config,
-    std::optional<const LayerNormProgramConfig>& program_config
-) {
-
-    const LayerNormProgramConfig&  actual_program_config = program_config.value_or(LayerNormDefaultProgramConfig{});
-
-    if (residual_input_tensor.has_value()) {
-        return tt::operations::primary::add_layernorm(input_tensor, residual_input_tensor.value(), epsilon, weight, bias, memory_config, actual_program_config);
+struct LayerNorm : tt::operations::primary::LayerNorm {
+    static inline const std::array<ttnn::TensorSchema, 4> input_tensor_schemas() {
+        return {
+            ttnn::TensorSchema{
+                2,
+                4,
+                {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b},
+                {ttnn::TILE_LAYOUT},
+                true,
+                false,
+                false,
+                false},
+            ttnn::TensorSchema{
+                1,
+                4,
+                {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b},
+                {ttnn::TILE_LAYOUT, ttnn::ROW_MAJOR_LAYOUT},
+                true,
+                false,
+                false,
+                true},
+            ttnn::TensorSchema{
+                1,
+                4,
+                {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b},
+                {ttnn::TILE_LAYOUT, ttnn::ROW_MAJOR_LAYOUT},
+                true,
+                false,
+                false,
+                true},
+            ttnn::TensorSchema{
+                1,
+                4,
+                {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b},
+                {ttnn::TILE_LAYOUT, ttnn::ROW_MAJOR_LAYOUT},
+                true,
+                false,
+                false,
+                true}};
     }
-    else {
-        return tt::operations::primary::layernorm(input_tensor, epsilon, weight, bias, memory_config, actual_program_config);
-    }
-}
 
-inline ttnn::Tensor rms_norm(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& weight,
-    float epsilon = 1e-6
-) {
-    const MemoryConfig & dram_memory_config = tt::tt_metal::MemoryConfig{.memory_layout=tt::tt_metal::TensorMemoryLayout::INTERLEAVED,.buffer_type=tt::tt_metal::BufferType::DRAM};
-    return tt::operations::primary::rmsnorm(input_tensor, epsilon, std::optional<const ttnn::Tensor>(weight), std::nullopt, dram_memory_config);
-}
+    template <typename... Args>
+    static auto input_tensors_to_validate(
+        const Tensor& input_tensor,
+        float epsilon = 1e-12,
+        const std::optional<const ttnn::Tensor>& weight = std::nullopt,
+        const std::optional<const ttnn::Tensor>& bias = std::nullopt,
+        const std::optional<const ttnn::Tensor>& residual_input_tensor = std::nullopt,
+        Args&&... args) {
+        return std::make_tuple(input_tensor, weight, bias, residual_input_tensor);
+    };
+
+    static inline ttnn::Tensor execute(
+        const ttnn::Tensor& input_tensor,
+        float epsilon = 1e-12,
+        const std::optional<const ttnn::Tensor>& weight = std::nullopt,
+        const std::optional<const ttnn::Tensor>& bias = std::nullopt,
+        const std::optional<const ttnn::Tensor>& residual_input_tensor = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+        const std::optional<const LayerNormProgramConfig>& program_config_arg = std::nullopt) {
+        const LayerNormProgramConfig& program_config = program_config_arg.value_or(LayerNormDefaultProgramConfig{});
+
+        auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
+        if (residual_input_tensor.has_value()) {
+            return tt::operations::primary::add_layernorm(
+                input_tensor, residual_input_tensor.value(), epsilon, weight, bias, memory_config, program_config);
+        } else {
+            return tt::operations::primary::layernorm(
+                input_tensor, epsilon, weight, bias, memory_config, program_config);
+        }
+    }
+};
+
+struct RMSNorm : tt::operations::primary::LayerNorm {
+    static inline const std::array<ttnn::TensorSchema, 2> input_tensor_schemas() {
+        return {
+            ttnn::TensorSchema{
+                2,
+                4,
+                {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b},
+                {ttnn::TILE_LAYOUT},
+                true,
+                false,
+                false,
+                false},
+            ttnn::TensorSchema{
+                1,
+                4,
+                {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b},
+                {ttnn::TILE_LAYOUT, ttnn::ROW_MAJOR_LAYOUT},
+                true,
+                false,
+                false,
+                false}};
+    }
+
+    template <typename... Args>
+    static auto input_tensors_to_validate(const Tensor& input_tensor, const Tensor& weight, Args&&... args) {
+        return std::make_tuple(input_tensor, weight);
+    };
+
+    static inline ttnn::Tensor execute(
+        const ttnn::Tensor& input_tensor,
+        const ttnn::Tensor& weight,
+        float epsilon = 1e-12,
+        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt) {
+        auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
+        return tt::operations::primary::rmsnorm(input_tensor, epsilon, weight, std::nullopt, memory_config);
+    }
+};
 
 } // namespace normalization
 } // namespace operations
+
+constexpr auto layer_norm = ttnn::register_operation<ttnn::operations::normalization::LayerNorm>("ttnn::layer_norm");
+constexpr auto rms_norm = ttnn::register_operation<ttnn::operations::normalization::RMSNorm>("ttnn::rms_norm");
 } // namespace ttnn

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -95,9 +95,7 @@ def _golden_function(
     return torch.nn.functional.layer_norm(input_tensor, (input_tensor.shape[-1],), weight, bias, eps=epsilon)
 
 
-layer_norm = ttnn.register_operation(name="ttnn.layer_norm", golden_function=_golden_function)(
-    ttnn._ttnn.operations.normalization.layer_norm
-)
+layer_norm = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.normalization.layer_norm)
 
 
 def _golden_function(input_tensor: ttnn.Tensor, weight=None, *, epsilon=1e-12, **_):
@@ -112,31 +110,7 @@ def _golden_function(input_tensor: ttnn.Tensor, weight=None, *, epsilon=1e-12, *
     return weight * input_tensor
 
 
-def _golden_function(input_tensor: ttnn.Tensor, weight=None, *, epsilon=1e-12, **_):
-    import torch
-
-    variance = input_tensor.to(torch.float32).pow(2).mean(-1, keepdim=True)
-    input_tensor = input_tensor * torch.rsqrt(variance + epsilon)
-
-    if weight.dtype in [torch.float16, torch.bfloat16]:
-        input_tensor = input_tensor.to(weight.dtype)
-
-    return weight * input_tensor
-
-
-rms_norm = ttnn.register_operation(name="ttnn.rms_norm", golden_function=_golden_function)(
-    ttnn._ttnn.operations.normalization.rms_norm
-)
-
-
-def _rms_norm(input_tensor: ttnn.Tensor, weight: ttnn.Tensor, *, epsilon: float = 1e-6) -> ttnn.Tensor:
-    r"""
-    rms_norm(input_tensor: ttnn.Tensor, weight: ttnn.Tensor, *, epsilon: float = 1e-6) -> ttnn.Tensor
-
-    Compute rms_norm over :attr:`input_tensor`.
-
-    """
-    return ttl.tensor.rmsnorm(input_tensor, epsilon, weight)
+rms_norm = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.normalization.rms_norm)
 
 
 # group norm helper function


### PR DESCRIPTION
Update layer_norm and rms_norm to use register_operation. (Use this PR as an example because all the previous PRs were massive)