### PR TITLE
#5906: remove same data format assert for output/intermediate operands

### DIFF
--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -102,8 +102,8 @@ DataFormat check_same_format_within_operand(DataFormat data_format[NUM_OPERANDS]
     DataFormat last_valid_format = DataFormat::Invalid;
     for (int i = 0; i < NUM_OPERANDS; i++) {
         if (data_format[i] != DataFormat::Invalid && last_valid_format != DataFormat::Invalid) {
-            TT_FATAL(data_format[i] == last_valid_format,
-                "Not all buffer data-formats within this operand are the same");
+            // TT_FATAL(data_format[i] == last_valid_format,
+            //     "Not all buffer data-formats within this operand are the same");
 
             // dump_data_formats(data_format);
         } else if (data_format[i] != DataFormat::Invalid && last_valid_format == DataFormat::Invalid) {


### PR DESCRIPTION
Enable different op output data formats by removing the assert for all output/intermediate data formats to be the same, as this is a legacy assert.
Now, we can enable different data formats by reconfiguring the packer/unpacker.

Separate issue will be created to review and ensure it is ok for GS and WHB0.

Passing post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/9017957084