### PR TITLE
Watcher inlining to match non-watcher

### DIFF
--- a/docs/source/tt-metalium/tools/watcher.rst
+++ b/docs/source/tt-metalium/tools/watcher.rst
@@ -43,6 +43,9 @@ Watcher features can be disabled individually using the following environment va
    export TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=1
    export TT_METAL_WATCHER_DISABLE_STATUS=1
 
+   # In certain cases enabling watcher can cause the binary to be too large. In this case, disable inlining.
+   export TT_METAL_WATCHER_NOINLINE=1
+
 Details
 -------
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
@@ -21,6 +21,8 @@ set(UNIT_TESTS_COMMON_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dram/test_dram.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_assert.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_noc_sanitize.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_pause.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_ringbuf.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/watcher/test_waypoint.cpp
 )
 add_library(unit_tests_common_o OBJECT ${UNIT_TESTS_COMMON_SRC})

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -20,6 +20,9 @@ public:
     }
 
 protected:
+    // Running with dprint + watcher enabled can make the code size blow up, so let's force watcher
+    // disabled for DPRINT tests.
+    bool watcher_previous_enabled;
     void SetUp() override {
         // The core range (physical) needs to be set >= the set of all cores
         // used by all tests using this fixture, so set dprint enabled for
@@ -31,6 +34,8 @@ protected:
         // Send output to a file so the test can check after program is run.
         tt::llrt::OptionsG.set_dprint_file_name(dprint_file_name);
         tt::llrt::OptionsG.set_test_mode_enabled(true);
+        watcher_previous_enabled = tt::llrt::OptionsG.get_watcher_enabled();
+        tt::llrt::OptionsG.set_watcher_enabled(false);
 
         // By default, exclude dispatch cores from printing
         auto num_cqs_str = getenv("TT_METAL_NUM_HW_CQS");
@@ -67,6 +72,7 @@ protected:
         tt::llrt::OptionsG.set_dprint_all_chips(false);
         tt::llrt::OptionsG.set_dprint_file_name("");
         tt::llrt::OptionsG.set_test_mode_enabled(false);
+        tt::llrt::OptionsG.set_watcher_enabled(watcher_previous_enabled);
     }
 
     void RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_pause.cpp
@@ -132,7 +132,6 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
 }
 
 TEST_F(WatcherFixture, TestWatcherPause) {
-    GTEST_SKIP();
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tt_metal/hw/inc/debug/status.h
+++ b/tt_metal/hw/inc/debug/status.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <utility>
+#include <stddef.h>
 
 #include "dev_msgs.h"
 

--- a/tt_metal/hw/inc/risc_attribs.h
+++ b/tt_metal/hw/inc/risc_attribs.h
@@ -37,10 +37,12 @@ inline __attribute__((always_inline)) uint64_t tt_l1_load(volatile tt_uint64_t *
     return v.v;
 }
 
-#if not defined(WATCHER_ENABLED)
-    #define FORCE_INLINE inline __attribute__((always_inline))
-#else
+// In certain cases enabling watcher can cause the code size to be too large. Give an option to
+// disable inlining if we need to.
+#if defined(WATCHER_NOINLINE)
     #define FORCE_INLINE
+#else
+    #define FORCE_INLINE inline __attribute__((always_inline))
 #endif
 
 #endif // _RISC_ATTRIBS_H_

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -96,6 +96,9 @@ void JitBuildEnv::init(uint32_t device_id, tt::ARCH arch)
     if (tt::llrt::OptionsG.get_watcher_enabled()) {
         this->defines_ += "-DWATCHER_ENABLED ";
     }
+    if (tt::llrt::OptionsG.get_watcher_noinline()) {
+        this->defines_ += "-DWATCHER_NOINLINE ";
+    }
     for (auto &feature : tt::llrt::OptionsG.get_watcher_disabled_features()) {
         this->defines_ += "-DWATCHER_DISABLE_" + feature + " ";
     }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -80,6 +80,9 @@ void RunTimeOptions::ParseWatcherEnv() {
     const char *watcher_append_str = getenv("TT_METAL_WATCHER_APPEND");
     watcher_append = (watcher_append_str != nullptr);
 
+    const char *watcher_noinline_str = getenv("TT_METAL_WATCHER_NOINLINE");
+    watcher_noinline = (watcher_noinline_str != nullptr);
+
     // Auto unpause is for testing only, no env var.
     watcher_auto_unpause = false;
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -30,6 +30,7 @@ class RunTimeOptions {
     bool watcher_dump_all = false;
     bool watcher_append = false;
     bool watcher_auto_unpause = false;
+    bool watcher_noinline = false;
 
     std::map<CoreType, std::vector<CoreCoord>> dprint_cores;
     std::map<CoreType, bool> dprint_all_cores;
@@ -67,6 +68,8 @@ class RunTimeOptions {
     inline void set_watcher_append(bool append)       { watcher_append = append; }
     inline int get_watcher_auto_unpause()             { return watcher_auto_unpause; }
     inline void set_watcher_auto_unpause(bool auto_unpause) { watcher_auto_unpause = auto_unpause; }
+    inline int get_watcher_noinline()             { return watcher_noinline; }
+    inline void set_watcher_noinline(bool noinline) { watcher_noinline = noinline; }
     inline std::set<std::string>& get_watcher_disabled_features() { return watcher_disabled_features; }
     inline bool watcher_status_disabled() { return watcher_feature_disabled(watcher_status_str); }
     inline bool watcher_noc_sanitize_disabled() { return watcher_feature_disabled(watcher_noc_sanitize_str); }


### PR DESCRIPTION
Enable FORCE_INLINE when watcher is enabled. Get around the code size issue by (1) disabling watcher on DPRINT tests, and (2) give a env var `TT_METAL_WATCHER_NOINLINE` you can use to go back to old noinline behaviour in case DPRINT + watcher is needed.

Also, some watcher tests were never re-enabled from FD2 merge, re-enable them.

Passing CI:
https://github.com/tenstorrent/tt-metal/actions/runs/9010093237