### PR TITLE
Add ninja as a metal dependency

### DIFF
--- a/.github/actions/install-metal-dev-deps/dependencies.json
+++ b/.github/actions/install-metal-dev-deps/dependencies.json
@@ -7,7 +7,8 @@
     "pandoc",
     "libtbb-dev",
     "libcapstone-dev",
-    "pkg-config"
+    "pkg-config",
+    "ninja-build"
   ],
   "ubuntu-22.04": [
     "git",
@@ -15,6 +16,7 @@
     "pandoc",
     "libtbb-dev",
     "libcapstone-dev",
-    "pkg-config"
+    "pkg-config",
+    "ninja-build"
   ]
 }

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -119,7 +119,7 @@ Please follow the next additional steps if you want to contribute to the codebas
 1. Install dependencies
 
 ```sh
-sudo apt install clang-6.0=1:6.0.1-14 git git-lfs cmake=3.16.3-1ubuntu1.20.04.1 pandoc libtbb-dev libcapstone-dev pkg-config
+sudo apt install clang-6.0=1:6.0.1-14 git git-lfs cmake=3.16.3-1ubuntu1.20.04.1 pandoc libtbb-dev libcapstone-dev pkg-config ninja-build
 ```
 
 2. Download and install [Doxygen](https://www.doxygen.nl/download.html), (v1.9 or higher, but less than v1.10)

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -18,8 +18,8 @@ else
 fi
 
 echo "Building tt-metal"
-cmake -B build
-cmake --build build -- -j`nproc`
+cmake -B build -G Ninja
+cmake --build build
 cmake --build build --target metal-install
 
 echo "Creating virtual env in: $PYTHON_ENV_DIR"


### PR DESCRIPTION
CMake + make should still work, but ninja is better 

CMake + ninja is about 15% faster than CMake + make on my BM

On a VM, CMake + ninja is about 5% faster.