### PR TITLE
#5389: added ZoneScopeN inside of ttnn::decorators::operation_t::operator() and document input tensors

### DIFF
--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -768,6 +768,30 @@ struct TensorSchema {
     const bool can_be_on_cpu;
     const bool can_be_scalar;
     const bool is_optional;
+
+    static constexpr auto attribute_names() {
+        return std::make_tuple(
+            "min_rank",
+            "max_rank",
+            "dtypes",
+            "layouts",
+            "can_be_on_device",
+            "can_be_on_cpu",
+            "can_be_scalar",
+            "is_optional");
+    }
+
+    const auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->min_rank),
+            std::cref(this->max_rank),
+            std::cref(this->dtypes),
+            std::cref(this->layouts),
+            std::cref(this->can_be_on_device),
+            std::cref(this->can_be_on_cpu),
+            std::cref(this->can_be_scalar),
+            std::cref(this->is_optional));
+    }
 };
 
 }  // namespace types

--- a/ttnn/cpp/pybind11/operations/unary.hpp
+++ b/ttnn/cpp/pybind11/operations/unary.hpp
@@ -41,7 +41,7 @@ void bind_unary(py::module& module, const unary_operation_t& operation) {
             >>> output = {1}(tensor)
     )doc",
         operation.name(),
-        operation.python_name());
+        operation.python_fully_qualified_name());
 
     bind_registered_operation(
         module,
@@ -73,7 +73,7 @@ void bind_unary_with_bool_parameter_set_to_false_by_default(py::module& module, 
             >>> output = {1}(tensor, parameter=true)
     )doc",
         operation.name(),
-        operation.python_name());
+        operation.python_fully_qualified_name());
 
     bind_registered_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/transformer.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer.hpp
@@ -268,18 +268,19 @@ struct AttentionSoftmax : public tt::operations::primary::Softmax {
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt;
         auto kernel_config_val = init_device_compute_kernel_config(
             input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
-        operation::run(
-            AttentionSoftmax{
-                head_size.has_value() ? 1.0 / sqrt(head_size.value()) : 1.0,
-                true,
-                memory_config.value_or(input_tensor.memory_config()),
-                program_config,
-                causal_mask.value(),
-                kernel_config_val,
-                false},
-            {input_tensor},
-            {attention_mask});
-        return input_tensor;
+        auto output_tensor = operation::run(
+                                 AttentionSoftmax{
+                                     head_size.has_value() ? 1.0 / sqrt(head_size.value()) : 1.0,
+                                     in_place,
+                                     memory_config.value_or(input_tensor.memory_config()),
+                                     program_config,
+                                     causal_mask.value(),
+                                     kernel_config_val,
+                                     false},
+                                 {input_tensor},
+                                 {attention_mask})
+                                 .at(0);
+        return output_tensor;
     }
 };
 

--- a/ttnn/ttnn/database.py
+++ b/ttnn/ttnn/database.py
@@ -264,7 +264,7 @@ def insert_operation(report_path, operation_id, operation, duration):
 
     cursor.execute(
         f"""INSERT INTO operations VALUES (
-            {operation_id}, '{operation.fully_qualified_name}', {optional_value(duration)}
+            {operation_id}, '{operation.python_fully_qualified_name}', {optional_value(duration)}
             )
         ON CONFLICT (operation_id)
         DO UPDATE

--- a/ttnn/ttnn/experimental/operations/primary/__init__.py
+++ b/ttnn/ttnn/experimental/operations/primary/__init__.py
@@ -21,7 +21,7 @@ for attribute_name in dir(ttl.operations.primary):
         "tt_lib.tensor.Tensor" in attribute.__doc__ or "tt::tt_metal::Tensor" in attribute.__doc__
     ):
         attribute = ttnn.decorators.register_ttl_operation_as_ttnn_operation(
-            fully_qualified_name=f"ttnn.experimental.operations.primary.{attribute_name}", function=attribute
+            python_fully_qualified_name=f"ttnn.experimental.operations.primary.{attribute_name}", function=attribute
         )
     setattr(THIS_MODULE, attribute_name, attribute)
     __all__.append(attribute_name)

--- a/ttnn/ttnn/experimental/operations/primary/transformers/__init__.py
+++ b/ttnn/ttnn/experimental/operations/primary/transformers/__init__.py
@@ -20,7 +20,7 @@ for attribute_name in dir(ttl.operations.primary.transformers):
         "tt_lib.tensor.Tensor" in attribute.__doc__ or "tt::tt_metal::Tensor" in attribute.__doc__
     ):
         attribute = ttnn.decorators.register_ttl_operation_as_ttnn_operation(
-            fully_qualified_name=f"ttnn.experimental.operations.primary.transformers.{attribute_name}",
+            python_fully_qualified_name=f"ttnn.experimental.operations.primary.transformers.{attribute_name}",
             function=attribute,
         )
     setattr(THIS_MODULE, attribute_name, attribute)

--- a/ttnn/ttnn/experimental/tensor/__init__.py
+++ b/ttnn/ttnn/experimental/tensor/__init__.py
@@ -24,7 +24,7 @@ for attribute_name in dir(ttl.tensor):
         "tt_lib.tensor.Tensor" in attribute.__doc__ or "tt::tt_metal::Tensor" in attribute.__doc__
     ):
         attribute = ttnn.decorators.register_ttl_operation_as_ttnn_operation(
-            fully_qualified_name=f"ttnn.experimental.tensor.{attribute_name}", function=attribute
+            python_fully_qualified_name=f"ttnn.experimental.tensor.{attribute_name}", function=attribute
         )
     setattr(THIS_MODULE, attribute_name, attribute)
     __all__.append(attribute_name)

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -360,7 +360,10 @@ def to_torch(
             if tensor.shape[0] != 1:
                 raise RuntimeError("ttnn: Unable to squeeze to desired rank!")
             tensor = tensor.squeeze()
-    return TorchTensor(tensor)
+
+    if not ttnn.CONFIG.enable_fast_runtime_mode:
+        tensor = TorchTensor(tensor)
+    return tensor
 
 
 def _to_device_validate_input_tensors(operation_name, tensor, *args, **kwargs):

--- a/ttnn/visualizer/app.py
+++ b/ttnn/visualizer/app.py
@@ -130,7 +130,7 @@ def root():
 def apis():
     @dataclasses.dataclass
     class Api:
-        fully_qualified_name: str
+        python_fully_qualified_name: str
         is_experimental: bool
         is_cpp_function: bool
         golden_function: callable
@@ -139,7 +139,7 @@ def apis():
         @classmethod
         def from_registered_operation(cls, operation):
             return cls(
-                fully_qualified_name=operation.fully_qualified_name,
+                python_fully_qualified_name=operation.python_fully_qualified_name,
                 is_experimental=operation.is_experimental,
                 is_cpp_function=operation.is_cpp_function,
                 golden_function=operation.golden_function,
@@ -149,7 +149,7 @@ def apis():
     apis = [Api.from_registered_operation(api) for api in ttnn.query_registered_operations(include_experimental=True)]
 
     df = pd.DataFrame(apis)
-    df.sort_values(by=["is_experimental", "is_cpp_function", "fully_qualified_name"], inplace=True)
+    df.sort_values(by=["is_experimental", "is_cpp_function", "python_fully_qualified_name"], inplace=True)
     df["has_fallback"] = df["golden_function"].apply(lambda golden_function: golden_function is not None)
     df["will_fallback"] = df[["has_fallback", "allow_to_fallback_to_golden_function_on_failure"]].apply(
         lambda row: row.has_fallback and row.allow_to_fallback_to_golden_function_on_failure, axis=1
@@ -159,7 +159,13 @@ def apis():
         apis=df.to_html(
             index=False,
             justify="center",
-            columns=["fully_qualified_name", "is_cpp_function", "is_experimental", "has_fallback", "will_fallback"],
+            columns=[
+                "python_fully_qualified_name",
+                "is_cpp_function",
+                "is_experimental",
+                "has_fallback",
+                "will_fallback",
+            ],
         ),
     )
 


### PR DESCRIPTION
- Added ZoneScopedN in `ttnn::decorators::operation_t::operator()`
- Renamed `fully_qualified_name` to `cpp_ fully_qualified_name` and `python_fully_qualified_name`
- Disabled `decorate_external_operation` on the return of `ttnn.to_torch` when in fast runtime mode
- Document schemas of input tensors