### PR TITLE
#6041: CCL refactoring and sharded allgather optimization

### DIFF
--- a/.github/workflows/multi-device-build-and-unit-tests.yaml
+++ b/.github/workflows/multi-device-build-and-unit-tests.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Build tt-metal CPP tests
         run: cmake --build build --target tests -- -j`nproc`
       - name: Run pre/post regression tests
-        timeout-minutes: 90
+        timeout-minutes: 100
         run: |
           source build/python_env/bin/activate
           export PYTHONPATH=$TT_METAL_HOME

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -101,6 +101,7 @@ tests/scripts/run_performance.sh @tt-rkim @tapspatel
 tt_eager/tt_dnn/op_library/bmm/ @TT-BrianLiu @bbradelTT
 
 # eager - tensor and op infra
+tt_eager/tt_dnn/op_library/ccl/ @SeanNijjar
 tt_eager/tt_dnn/op_library/operation_history.*pp @arakhmati @eyonland @cfjchu @xanderchin
 tt_eager/tt_dnn/op_library/operation.*pp @arakhmati @eyonland @cfjchu @xanderchin
 tt_eager/tt_dnn/op_library/run_operation.*pp @arakhmati @eyonland @cfjchu @xanderchin

--- a/tests/scripts/run_tt_eager.py
+++ b/tests/scripts/run_tt_eager.py
@@ -28,6 +28,11 @@ from tests.scripts.cmdline_args import (
 )
 
 TT_EAGER_COMMON_TEST_ENTRIES = (
+    TestEntry("tt_eager/tests/ops/ccl/test_all_gather_utils", "ops/ccl/test_all_gather_utils"),
+    TestEntry(
+        "tt_eager/tests/ops/ccl/test_all_gather_sharded_indexing_helpers",
+        "ops/ccl/test_all_gather_sharded_indexing_helpers",
+    ),
     TestEntry("tt_eager/tests/ops/test_eltwise_binary_op", "ops/test_eltwise_binary_op"),
     TestEntry("tt_eager/tests/ops/test_bcast_op", "ops/test_bcast_op"),
     TestEntry("tt_eager/tests/ops/test_reduce_op", "ops/test_reduce_op"),

--- a/tests/tt_eager/CMakeLists.txt
+++ b/tests/tt_eager/CMakeLists.txt
@@ -3,7 +3,8 @@ add_library(test_eager_common_libs INTERFACE)
 target_link_libraries(test_eager_common_libs INTERFACE tt_eager test_common_libs)
 
 set(TT_EAGER_TESTS_OPS
-    # ccl/test_all_gather_utils           # <- not called in run_tt_eager.py
+    ops/ccl/test_all_gather_utils
+    ops/ccl/test_all_gather_sharded_indexing_helpers
     ops/test_average_pool
     ops/test_eltwise_binary_op
     ops/test_eltwise_unary_op

--- a/tests/tt_eager/module.mk
+++ b/tests/tt_eager/module.mk
@@ -1,6 +1,7 @@
 # Every variable in subdir must be prefixed with subdir (emulating a namespace)
 TT_EAGER_TESTS += \
 		 tests/tt_eager/ops/ccl/test_all_gather_utils \
+		 tests/tt_eager/ops/ccl/test_all_gather_sharded_indexing_helpers \
 		 tests/tt_eager/ops/test_average_pool \
 		 tests/tt_eager/ops/test_eltwise_binary_op \
 		 tests/tt_eager/ops/test_eltwise_unary_op \

--- a/tests/tt_eager/ops/ccl/test_all_gather_sharded_indexing_helpers.cpp
+++ b/tests/tt_eager/ops/ccl/test_all_gather_sharded_indexing_helpers.cpp
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+
+
+TEST(AllGatherSharded_WidthShardedIndexing_FullWorkerGridVariant, AdvanceFullTileRow_ClockWise_In3x5_NumShards3) {
+    bool is_clockwise = true;
+    uint16_t const num_shards_x = 3;
+    uint16_t const input_shard_num_tiles_x = 5;
+    uint16_t const input_shard_num_tiles_y = 3;
+    uint16_t const total_num_tiles_x = input_shard_num_tiles_x * num_shards_x;
+    uint16_t const total_num_cores = 3;
+
+    { // Advance to end from start of row
+        uint16_t curr_core_index = 0;
+        uint16_t curr_shard_tile_x = 0;
+        uint16_t curr_shard_tile_y = 0;
+        uint16_t curr_tile_index = (total_num_tiles_x * curr_shard_tile_y) + curr_shard_tile_x;
+        uint16_t curr_shard = 0;
+        uint16_t shard_offset = 0;
+        uint16_t old_curr_shard = curr_shard;
+
+       tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+            curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+        ASSERT_EQ(curr_shard_tile_x, 0);
+        ASSERT_EQ(curr_shard_tile_y, 1);
+        ASSERT_EQ(curr_tile_index, total_num_tiles_x);
+        ASSERT_EQ(curr_shard, old_curr_shard);
+        ASSERT_EQ(curr_core_index, 0);
+    }
+    { // Advance to end from "middle" of row
+        uint16_t curr_core_index = 0;
+        uint16_t curr_shard_tile_x = 3;
+        uint16_t curr_shard_tile_y = 0;
+        uint16_t curr_tile_index = (total_num_tiles_x * curr_shard_tile_y) + curr_shard_tile_x;
+        uint16_t curr_shard = 0;
+        uint16_t old_curr_shard = curr_shard;
+
+        tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+            curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+        ASSERT_EQ(curr_shard_tile_x, 0);
+        ASSERT_EQ(curr_shard_tile_y, 1);
+        ASSERT_EQ(curr_tile_index, total_num_tiles_x);
+        ASSERT_EQ(curr_shard, old_curr_shard);
+        ASSERT_EQ(curr_core_index, 0);
+    }
+
+    { // Advance to end from start of "middle" row
+        uint16_t curr_core_index = 0;
+        uint16_t curr_shard_tile_x = 0;
+        uint16_t curr_shard_tile_y = 1;
+        uint16_t curr_tile_index = (total_num_tiles_x * curr_shard_tile_y) + curr_shard_tile_x;
+        uint16_t curr_shard = 0;
+        uint16_t old_curr_shard = curr_shard;
+        ASSERT_EQ(curr_core_index, 0);
+
+        tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+            curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+        ASSERT_EQ(curr_shard_tile_x, 0);
+        ASSERT_EQ(curr_shard_tile_y, 2);
+        ASSERT_EQ(curr_tile_index, total_num_tiles_x * 2);
+        ASSERT_EQ(curr_shard, old_curr_shard);
+        ASSERT_EQ(curr_core_index, 0);
+    }
+    { // Advance to end from "middle" of "middle" row
+        uint16_t curr_core_index = 0;
+        uint16_t curr_shard_tile_x = 3;
+        uint16_t curr_shard_tile_y = 1;
+        uint16_t curr_tile_index = (total_num_tiles_x * curr_shard_tile_y) + curr_shard_tile_x;
+        uint16_t curr_shard = 0;
+        uint16_t old_curr_shard = curr_shard;
+        ASSERT_EQ(curr_core_index, 0);
+
+        tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+            curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+        ASSERT_EQ(curr_shard_tile_x, 0);
+        ASSERT_EQ(curr_shard_tile_y, 2);
+        ASSERT_EQ(curr_tile_index, total_num_tiles_x * 2);
+        ASSERT_EQ(curr_shard, old_curr_shard);
+        ASSERT_EQ(curr_core_index, 0);
+    }
+
+    { // Advance to end from "start" of row, and from last row
+        uint16_t curr_core_index = 0;
+        uint16_t curr_shard_tile_x = 0;
+        uint16_t curr_shard_tile_y = input_shard_num_tiles_y - 1;
+        uint16_t curr_tile_index = (total_num_tiles_x * curr_shard_tile_y) + curr_shard_tile_x;
+        uint16_t curr_shard = 0;
+        uint16_t old_curr_shard = curr_shard;
+
+
+        tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+            curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+        ASSERT_EQ(curr_shard_tile_x, 0);
+        ASSERT_EQ(curr_shard_tile_y, 0);
+        ASSERT_EQ(curr_tile_index, input_shard_num_tiles_x * old_curr_shard);
+        ASSERT_EQ(curr_shard, old_curr_shard);
+        ASSERT_EQ(curr_core_index, total_num_cores - 1);
+    }
+    { // Advance to end from "middle" of row, and from last row, first shard
+        uint16_t curr_core_index = 0;
+        uint16_t curr_shard_tile_x = 2;
+        uint16_t curr_shard_tile_y = input_shard_num_tiles_y - 1;
+        uint16_t curr_tile_index = (total_num_tiles_x * curr_shard_tile_y) + curr_shard_tile_x;
+        uint16_t curr_shard = 0;
+        uint16_t old_curr_shard = curr_shard;
+
+        tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+            curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+        ASSERT_EQ(curr_shard_tile_x, 0);
+        ASSERT_EQ(curr_shard_tile_y, 0);
+        ASSERT_EQ(curr_tile_index, input_shard_num_tiles_x * old_curr_shard);
+        ASSERT_EQ(curr_shard, old_curr_shard);
+        ASSERT_EQ(curr_core_index, total_num_cores - 1);
+    }
+}
+
+
+static uint16_t advance_core(uint16_t curr_core_index, bool is_clockwise, uint16_t total_num_cores) {
+    return is_clockwise ?
+        (curr_core_index == 0 ? total_num_cores - 1 : curr_core_index - 1) :
+        (curr_core_index == total_num_cores - 1 ? 0 : curr_core_index + 1);
+};
+
+TEST(AllGatherSharded_WidthShardedIndexing_FullWorkerGridVariant, AdvanceFullTileRow_ClockWise_In3x5_NumShards3_Sequence) {
+    bool is_clockwise = true;
+    uint16_t const num_shards_x = 3;
+    uint16_t const input_shard_num_tiles_x = 5;
+    uint16_t const input_shard_num_tiles_y = 3;
+    uint16_t const total_num_tiles_x = input_shard_num_tiles_x * num_shards_x;
+    uint16_t total_num_tiles = total_num_tiles_x * input_shard_num_tiles_y;
+    uint16_t const total_num_cores = 3;
+
+    uint16_t curr_shard_tile_x = 0;
+    uint16_t curr_shard_tile_y = 0;
+    uint16_t curr_tile_index = 0;
+    uint16_t curr_shard = 0;
+    uint16_t old_curr_shard = 0;
+    uint16_t curr_core_index = 0;
+
+    uint16_t num_core_iterations = total_num_cores * 2;
+    uint16_t expected_core_index = curr_core_index;
+    for (uint16_t i = 0; i < num_core_iterations; i++) {
+
+        for (uint16_t tile_row = curr_shard_tile_y; tile_row < input_shard_num_tiles_y; tile_row++) {
+            tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+                curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+            uint16_t next_tile_row = tile_row + 1;
+            if (next_tile_row == input_shard_num_tiles_y) {
+                next_tile_row = 0;
+                expected_core_index = advance_core(expected_core_index, is_clockwise, total_num_cores);
+            }
+            ASSERT_EQ(curr_shard_tile_x, 0);
+            ASSERT_EQ(curr_shard_tile_y, next_tile_row);
+            ASSERT_EQ(curr_tile_index, (next_tile_row * total_num_tiles_x) + (old_curr_shard * input_shard_num_tiles_x));
+            ASSERT_EQ(curr_shard, old_curr_shard);
+            ASSERT_EQ(curr_core_index, expected_core_index);
+        }
+    }
+}
+
+
+TEST(AllGatherSharded_WidthShardedIndexing_FullWorkerGridVariant, AdvanceFullTileRow_CounterClockWise_In3x5_NumShards3_Sequence) {
+    bool is_clockwise = false;
+    uint16_t const num_shards_x = 3;
+    uint16_t const input_shard_num_tiles_x = 5;
+    uint16_t const input_shard_num_tiles_y = 3;
+    uint16_t const total_num_tiles_x = input_shard_num_tiles_x * num_shards_x;
+    uint16_t total_num_tiles = total_num_tiles_x * input_shard_num_tiles_y;
+
+    uint16_t curr_shard_tile_x = 0;
+    uint16_t curr_shard_tile_y = 0;
+    uint16_t curr_tile_index = 0;
+    uint16_t curr_shard = 0;
+    uint16_t old_curr_shard = curr_shard;
+    uint16_t curr_core_index = 0;
+    uint16_t total_num_cores = 0;
+
+    uint16_t num_core_iterations = total_num_cores * 2;
+    uint16_t expected_core_index = curr_core_index;
+    for (uint16_t i = 0; i < num_core_iterations; i++) {
+
+        for (uint16_t tile_row = curr_shard_tile_y; tile_row < input_shard_num_tiles_y; tile_row++) {
+            tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+                curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+                uint16_t next_tile_row = tile_row + 1;
+                if (next_tile_row == input_shard_num_tiles_y) {
+                    next_tile_row = 0;
+                    expected_core_index = advance_core(expected_core_index, is_clockwise, total_num_cores);
+                }
+                ASSERT_EQ(curr_shard_tile_x, 0);
+                ASSERT_EQ(curr_shard_tile_y, next_tile_row);
+                ASSERT_EQ(curr_tile_index, (next_tile_row * total_num_tiles_x) + (old_curr_shard * input_shard_num_tiles_x));
+                ASSERT_EQ(curr_shard, old_curr_shard);
+                ASSERT_EQ(curr_core_index, expected_core_index);
+        }
+    }
+}
+
+
+
+TEST(AllGatherSharded_WidthShardedIndexing_FullWorkerGridVariant, AdvanceSingleTile_ClockWise_In3x5_NumShards3_Sequence) {
+    bool is_clockwise = true;
+    uint16_t const num_shards_x = 3;
+    uint16_t const input_shard_num_tiles_x = 5;
+    uint16_t const input_shard_num_tiles_y = 3;
+    uint16_t const total_num_tiles_x = input_shard_num_tiles_x * num_shards_x;
+    uint16_t total_num_tiles = total_num_tiles_x * input_shard_num_tiles_y;
+
+    uint16_t curr_shard_tile_x = 0;
+    uint16_t curr_shard_tile_y = 0;
+    uint16_t curr_tile_index = 0;
+    uint16_t curr_shard = 0;
+    uint16_t old_curr_shard = curr_shard;
+    uint16_t curr_core_index = 0;
+    uint16_t total_num_cores = 3;
+
+    uint16_t num_core_iterations = total_num_cores * 2;
+    uint16_t expected_core_index = curr_core_index;
+    for (uint16_t i = 0; i < num_core_iterations; i++) {
+
+        for (uint16_t tile_row = curr_shard_tile_y; tile_row < input_shard_num_tiles_y; tile_row++) {
+            for (uint16_t tile_col = curr_shard_tile_x; tile_col < input_shard_num_tiles_x; tile_col++) {
+                tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance (
+                    curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+                uint16_t next_tile_row = tile_row;
+                uint16_t next_tile_col = tile_col + 1;
+                if (next_tile_col == input_shard_num_tiles_x) {
+                    next_tile_col = 0;
+                    next_tile_row = tile_row + 1;
+                    if (next_tile_row == input_shard_num_tiles_y) {
+                        next_tile_row = 0;
+                        expected_core_index = advance_core(expected_core_index, is_clockwise, total_num_cores);
+                    }
+                }
+                ASSERT_EQ(curr_shard_tile_x, next_tile_col);
+                ASSERT_EQ(curr_shard_tile_y, next_tile_row);
+                ASSERT_EQ(curr_tile_index, (next_tile_row * total_num_tiles_x) + (old_curr_shard * input_shard_num_tiles_x) + next_tile_col);
+                ASSERT_EQ(curr_shard, old_curr_shard);
+                ASSERT_EQ(curr_core_index, expected_core_index);
+            }
+        }
+    }
+
+}
+
+TEST(AllGatherSharded_WidthShardedIndexing_FullWorkerGridVariant, AdvanceSingleTile_CounterClockWise_In3x5_NumShards3_Sequence) {
+    bool is_clockwise = false;
+    uint16_t const num_shards_x = 3;
+    uint16_t const input_shard_num_tiles_x = 5;
+    uint16_t const input_shard_num_tiles_y = 3;
+    uint16_t const total_num_tiles_x = input_shard_num_tiles_x * num_shards_x;
+    uint16_t total_num_tiles = total_num_tiles_x * input_shard_num_tiles_y;
+
+    uint16_t curr_shard_tile_x = 0;
+    uint16_t curr_shard_tile_y = 0;
+    uint16_t curr_tile_index = 0;
+    uint16_t curr_shard = 0;
+    uint16_t const old_curr_shard = curr_shard;
+    uint16_t curr_core_index = 0;
+    uint16_t total_num_cores = 3;
+
+    uint16_t num_core_iterations = total_num_cores * 2;
+    uint16_t expected_core_index = curr_core_index;
+    for (uint16_t i = 0; i < num_core_iterations; i++) {
+
+        for (uint16_t tile_row = curr_shard_tile_y; tile_row < input_shard_num_tiles_y; tile_row++) {
+            for (uint16_t tile_col = curr_shard_tile_x; tile_col < input_shard_num_tiles_x; tile_col++) {
+                tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance (
+                    curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, input_shard_num_tiles_y, num_shards_x, curr_shard, is_clockwise);
+                uint16_t next_tile_row = tile_row;
+                uint16_t next_tile_col = tile_col + 1;
+                if (next_tile_col == input_shard_num_tiles_x) {
+                    next_tile_col = 0;
+                    next_tile_row = tile_row + 1;
+                    if (next_tile_row == input_shard_num_tiles_y) {
+                        next_tile_row = 0;
+                        expected_core_index = advance_core(expected_core_index, is_clockwise, total_num_cores);
+                    }
+                }
+                ASSERT_EQ(curr_shard_tile_x, next_tile_col);
+                ASSERT_EQ(curr_shard_tile_y, next_tile_row);
+                ASSERT_EQ(curr_tile_index, (next_tile_row * total_num_tiles_x) + (old_curr_shard * input_shard_num_tiles_x) + next_tile_col);
+                ASSERT_EQ(curr_shard, old_curr_shard);
+                ASSERT_EQ(curr_core_index, expected_core_index);
+            }
+        }
+    }
+}

--- a/tests/tt_eager/ops/ccl/test_all_gather_utils.cpp
+++ b/tests/tt_eager/ops/ccl/test_all_gather_utils.cpp
@@ -6,11 +6,15 @@
 #include "tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "tt_eager/tt_dnn/op_library/all_gather/all_gather_op.hpp"
 
+
+//////////////////////////////////////////////////////
+/// InputTensorShardAddrGenArgGenerator TESTS
+//////////////////////////////////////////////////////
+
 // Col major orientation not supported yet
 TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_GetFirstOutputShardStartingLocation_RowMajorOrientation) {
     // tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
     //     num_workers, input_tensor_shard_grid_size, ring_index, serving_worker_index);
-
     {
         uint32_t ring_size = 8;
         auto const [dest_worker_index, offset_chunk_in_worker] =
@@ -64,7 +68,6 @@ TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_GetFirstOutputShardSta
         uint32_t num_workers = 1;
         auto const [dest_worker_index, offset_chunk_in_worker] =
             tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
-            // num_workers, input_tensor_shard_grid_size, ring_index, ring_size, serving_worker_index);
                 num_workers, 2, 0, ring_size, 0);
         ASSERT_EQ(dest_worker_index, 0);
         ASSERT_EQ(offset_chunk_in_worker, 0);
@@ -74,7 +77,6 @@ TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_GetFirstOutputShardSta
         uint32_t num_workers = 2;
         auto const [dest_worker_index, offset_chunk_in_worker] =
             tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
-            // num_workers, input_tensor_shard_grid_size, ring_index, ring_size, serving_worker_index);
                 num_workers, 2, 0, ring_size, 0);
         ASSERT_EQ(dest_worker_index, 0);
         ASSERT_EQ(offset_chunk_in_worker, 0);
@@ -84,7 +86,6 @@ TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_GetFirstOutputShardSta
         uint32_t num_workers = 2;
         auto const [dest_worker_index, offset_chunk_in_worker] =
             tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
-            // num_workers, input_tensor_shard_grid_size, ring_index, ring_size, serving_worker_index);
                 num_workers, 2, 0, ring_size, 1);
         ASSERT_EQ(dest_worker_index, 0);
         ASSERT_EQ(offset_chunk_in_worker, 1);
@@ -94,236 +95,1273 @@ TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_GetFirstOutputShardSta
         uint32_t num_workers = 2;
         auto const [dest_worker_index, offset_chunk_in_worker] =
             tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
-            // num_workers, input_tensor_shard_grid_size, ring_index, ring_size, serving_worker_index);
                 num_workers, 2, 1, ring_size, 1);
         ASSERT_EQ(dest_worker_index, 0);
         ASSERT_EQ(offset_chunk_in_worker, 3);
+    }
+    {
+        uint32_t ring_size = 8;
+        uint32_t num_workers = 8;
+        auto const [dest_worker_index, offset_chunk_in_worker] =
+            tt::tt_metal::OutputTensorShardAddrGenArgGenerator::get_first_output_shard_starting_location(
+                num_workers, 32, 1, ring_size, 0);
+        ASSERT_EQ(dest_worker_index, 4);
+        ASSERT_EQ(offset_chunk_in_worker, 0);
     }
 }
 
 
 TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_ComputeWorkerDestCores_WidthSharding) {
-    // tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-    //         ccl::ShardType shard_type,
-    //         std::vector<CoreCoord> const& global_shard_dest_cores,
-    //         uint32_t input_num_shards,
-    //         uint32_t output_num_shards,
-    //         uint32_t num_workers,
-    //         uint32_t worker_index,
-    //         bool is_shard_orientation_row_major)
-
     bool is_shard_orientation_row_major = true;
     ccl::ShardType shard_type = ccl::ShardType::Width;
-    {
-        auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-            shard_type, {CoreCoord(0,0)}, 1, 8, 1, 0, is_shard_orientation_row_major);
-        ASSERT_EQ(dest_cores.size(), 1);
-        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-    }
-    {
-        std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0)};
-        uint32_t ring_size = 8;
-        uint32_t num_workers = 1;
-        auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-            shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
-        ASSERT_EQ(dest_cores.size(), 2);
-        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-    }
-    {
-        std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0)};
-        uint32_t ring_size = 8;
-        uint32_t num_workers = 2;
-        auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-            shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
-        ASSERT_EQ(dest_cores.size(), 2);
-        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-        // ASSERT_EQ(dest_cores.size(), 1);
-        // ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-    }
-    {
-        std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0)};
-        uint32_t ring_size = 8;
-        uint32_t num_workers = 2;
-        auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-            shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
-        ASSERT_EQ(dest_cores.size(), 2);
-        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-        // ASSERT_EQ(dest_cores.size(), 1);
-        // ASSERT_EQ(dest_cores.at(0), CoreCoord(1,0));
-    }
 
-    // { // Unsupported For Now
-    //     std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0),CoreCoord(2,0),CoreCoord(3,0)};
-    //     uint32_t ring_size = 8;
-    //     uint32_t num_workers = 2;
-    //     auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-    //         shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
-    //     ASSERT_EQ(dest_cores.size(), 4);
-    //     ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-    //     ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-    //     ASSERT_EQ(dest_cores.at(1), CoreCoord(2,0));
-    //     ASSERT_EQ(dest_cores.at(2), CoreCoord(3,0));
-    // }
-    // { // Unsupported For Now
-    //     std::vector<CoreCoord> global_shard_dest_cores = {CoreCoord(0,0),CoreCoord(1,0),CoreCoord(2,0),CoreCoord(3,0)};
-    //     uint32_t ring_size = 8;
-    //     uint32_t num_workers = 2;
-    //     auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-    //         shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
-    //     ASSERT_EQ(dest_cores.size(), 4);
-    //     ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-    //     ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-    //     ASSERT_EQ(dest_cores.at(1), CoreCoord(2,0));
-    //     ASSERT_EQ(dest_cores.at(2), CoreCoord(3,0));
-    // }
-
-    { // shard grid size = 16, ring size = 8, num_workers = 1
-        std::vector<CoreCoord> global_shard_dest_cores =
-            {CoreCoord(0,0),CoreCoord(1,0)};
-        uint32_t ring_size = 8;
-        uint32_t num_workers = 2;
-        {
-            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 2);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-            ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-        }
-        {
-            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 2);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-            ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-        }
-    }
-    { // shard grid size = 16, ring size = 8, num_workers = 1
-        std::vector<CoreCoord> global_shard_dest_cores =
-            {CoreCoord(0,0),CoreCoord(1,0)};
-        uint32_t ring_size = 8;
-        uint32_t num_workers = 1;
-        {
-            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 2);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-            ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-        }
-    }
-
-    { // shard grid size = 16, ring size = 8, num_workers = 1
-        std::vector<CoreCoord> global_shard_dest_cores =
-            {CoreCoord(0,0),CoreCoord(1,0),CoreCoord(2,0),CoreCoord(3,0),CoreCoord(4,0),CoreCoord(5,0),CoreCoord(6,0),CoreCoord(7,0),
-                CoreCoord(0,1),CoreCoord(1,1),CoreCoord(2,1),CoreCoord(3,1),CoreCoord(4,1),CoreCoord(5,1),CoreCoord(6,1),CoreCoord(7,1)};
-        uint32_t ring_size = 2;
-        uint32_t num_workers = 4;
-        {
-            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 4);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
-            ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-            ASSERT_EQ(dest_cores.at(2), CoreCoord(0,1));
-            ASSERT_EQ(dest_cores.at(3), CoreCoord(1,1));
-        }
-        {
-            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 4);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(2,0));
-            ASSERT_EQ(dest_cores.at(1), CoreCoord(3,0));
-            ASSERT_EQ(dest_cores.at(2), CoreCoord(2,1));
-            ASSERT_EQ(dest_cores.at(3), CoreCoord(3,1));
-        }
-        {
-            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 2, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 4);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(4,0));
-            ASSERT_EQ(dest_cores.at(1), CoreCoord(5,0));
-            ASSERT_EQ(dest_cores.at(2), CoreCoord(4,1));
-            ASSERT_EQ(dest_cores.at(3), CoreCoord(5,1));
-        }
-        {
-            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
-                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 3, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 4);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(6,0));
-            ASSERT_EQ(dest_cores.at(1), CoreCoord(7,0));
-            ASSERT_EQ(dest_cores.at(2), CoreCoord(6,1));
-            ASSERT_EQ(dest_cores.at(3), CoreCoord(7,1));
-        }
-    }
-
-    { // shard grid size = 64, ring size = 8, num_workers = 4
+    { // shard grid size = 32, ring size = 8, num_workers = 8
         std::vector<CoreCoord> global_shard_dest_cores =
             {CoreCoord(0,0),CoreCoord(1,0),CoreCoord(2,0),CoreCoord(3,0),CoreCoord(4,0),CoreCoord(5,0),CoreCoord(6,0),CoreCoord(7,0),
                 CoreCoord(0,1),CoreCoord(1,1),CoreCoord(2,1),CoreCoord(3,1),CoreCoord(4,1),CoreCoord(5,1),CoreCoord(6,1),CoreCoord(7,1),
                 CoreCoord(0,2),CoreCoord(1,2),CoreCoord(2,2),CoreCoord(3,2),CoreCoord(4,2),CoreCoord(5,2),CoreCoord(6,2),CoreCoord(7,2),
-                CoreCoord(0,3),CoreCoord(1,3),CoreCoord(2,3),CoreCoord(3,3),CoreCoord(4,3),CoreCoord(5,3),CoreCoord(6,3),CoreCoord(7,3),
-                CoreCoord(0,4),CoreCoord(1,4),CoreCoord(2,4),CoreCoord(3,4),CoreCoord(4,4),CoreCoord(5,4),CoreCoord(6,4),CoreCoord(7,4),
-                CoreCoord(0,5),CoreCoord(1,5),CoreCoord(2,5),CoreCoord(3,5),CoreCoord(4,5),CoreCoord(5,5),CoreCoord(6,5),CoreCoord(7,5),
-                CoreCoord(0,6),CoreCoord(1,6),CoreCoord(2,6),CoreCoord(3,6),CoreCoord(4,6),CoreCoord(5,6),CoreCoord(6,6),CoreCoord(7,6),
-                CoreCoord(0,7),CoreCoord(1,7),CoreCoord(2,7),CoreCoord(3,7),CoreCoord(4,7),CoreCoord(5,7),CoreCoord(6,7),CoreCoord(7,7)};
-        EXPECT_EQ(global_shard_dest_cores.size(), 64); // otherwise I set it up wrong D:
+                CoreCoord(0,3),CoreCoord(1,3),CoreCoord(2,3),CoreCoord(3,3),CoreCoord(4,3),CoreCoord(5,3),CoreCoord(6,3),CoreCoord(7,3)};
+        EXPECT_EQ(global_shard_dest_cores.size(), 32); // otherwise I set it up wrong
         uint32_t ring_size = 8;
-        uint32_t num_workers = 4;
+        uint32_t num_workers = 8;
         {
+            std::cout << "HERE" << std::endl;
             auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
                 shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 0, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 16);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
-            ASSERT_EQ(dest_cores.at(2), CoreCoord(0,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(1,1));
-            ASSERT_EQ(dest_cores.at(4), CoreCoord(0,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(1,2));
-            ASSERT_EQ(dest_cores.at(6), CoreCoord(0,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(1,3));
-            ASSERT_EQ(dest_cores.at(8), CoreCoord(0,4));   ASSERT_EQ(dest_cores.at(9), CoreCoord(1,4));
-            ASSERT_EQ(dest_cores.at(10), CoreCoord(0,5));  ASSERT_EQ(dest_cores.at(11), CoreCoord(1,5));
-            ASSERT_EQ(dest_cores.at(12), CoreCoord(0,6));  ASSERT_EQ(dest_cores.at(13), CoreCoord(1,6));
-            ASSERT_EQ(dest_cores.at(14), CoreCoord(0,7));  ASSERT_EQ(dest_cores.at(15), CoreCoord(1,7));
+            ASSERT_EQ(dest_cores.size(), 8);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(4,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(0,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(4,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(0,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(4,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(0,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(4,3));
+
         }
         {
             auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
                 shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 1, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 16);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(2,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(3,0));
-            ASSERT_EQ(dest_cores.at(2), CoreCoord(2,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(3,1));
-            ASSERT_EQ(dest_cores.at(4), CoreCoord(2,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(3,2));
-            ASSERT_EQ(dest_cores.at(6), CoreCoord(2,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(3,3));
-            ASSERT_EQ(dest_cores.at(8), CoreCoord(2,4));   ASSERT_EQ(dest_cores.at(9), CoreCoord(3,4));
-            ASSERT_EQ(dest_cores.at(10), CoreCoord(2,5));  ASSERT_EQ(dest_cores.at(11), CoreCoord(3,5));
-            ASSERT_EQ(dest_cores.at(12), CoreCoord(2,6));  ASSERT_EQ(dest_cores.at(13), CoreCoord(3,6));
-            ASSERT_EQ(dest_cores.at(14), CoreCoord(2,7));  ASSERT_EQ(dest_cores.at(15), CoreCoord(3,7));
+            ASSERT_EQ(dest_cores.size(), 8);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(4,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(0,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(4,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(0,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(4,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(0,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(4,3));
+
         }
         {
             auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
                 shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 2, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 16);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(4,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(5,0));
-            ASSERT_EQ(dest_cores.at(2), CoreCoord(4,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(5,1));
-            ASSERT_EQ(dest_cores.at(4), CoreCoord(4,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(5,2));
-            ASSERT_EQ(dest_cores.at(6), CoreCoord(4,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(5,3));
-            ASSERT_EQ(dest_cores.at(8), CoreCoord(4,4));   ASSERT_EQ(dest_cores.at(9), CoreCoord(5,4));
-            ASSERT_EQ(dest_cores.at(10), CoreCoord(4,5));  ASSERT_EQ(dest_cores.at(11), CoreCoord(5,5));
-            ASSERT_EQ(dest_cores.at(12), CoreCoord(4,6));  ASSERT_EQ(dest_cores.at(13), CoreCoord(5,6));
-            ASSERT_EQ(dest_cores.at(14), CoreCoord(4,7));  ASSERT_EQ(dest_cores.at(15), CoreCoord(5,7));
+            ASSERT_EQ(dest_cores.size(), 8);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(1,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(5,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(1,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(5,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(1,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(5,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(1,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(5,3));
+
         }
         {
             auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
                 shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 3, is_shard_orientation_row_major);
-            ASSERT_EQ(dest_cores.size(), 16);
-            ASSERT_EQ(dest_cores.at(0), CoreCoord(6,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(7,0));
-            ASSERT_EQ(dest_cores.at(2), CoreCoord(6,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(7,1));
-            ASSERT_EQ(dest_cores.at(4), CoreCoord(6,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(7,2));
-            ASSERT_EQ(dest_cores.at(6), CoreCoord(6,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(7,3));
-            ASSERT_EQ(dest_cores.at(8), CoreCoord(6,4));   ASSERT_EQ(dest_cores.at(9), CoreCoord(7,4));
-            ASSERT_EQ(dest_cores.at(10), CoreCoord(6,5));  ASSERT_EQ(dest_cores.at(11), CoreCoord(7,5));
-            ASSERT_EQ(dest_cores.at(12), CoreCoord(6,6));  ASSERT_EQ(dest_cores.at(13), CoreCoord(7,6));
-            ASSERT_EQ(dest_cores.at(14), CoreCoord(6,7));  ASSERT_EQ(dest_cores.at(15), CoreCoord(7,7));
+            ASSERT_EQ(dest_cores.size(), 8);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(1,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(5,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(1,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(5,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(1,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(5,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(1,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(5,3));
+
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 4, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 8);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(2,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(6,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(2,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(6,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(2,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(6,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(2,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(6,3));
+
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 5, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 8);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(2,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(6,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(2,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(6,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(2,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(6,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(2,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(6,3));
+
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 6, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 8);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(3,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(7,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(3,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(7,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(3,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(7,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(3,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(7,3));
+
+        }
+        {
+            auto const& dest_cores = tt::tt_metal::OutputTensorShardAddrGenArgGenerator::compute_worker_coord_worker_dest_cores (
+                shard_type, global_shard_dest_cores, global_shard_dest_cores.size(), global_shard_dest_cores.size() * ring_size, num_workers, 7, is_shard_orientation_row_major);
+            ASSERT_EQ(dest_cores.size(), 8);
+            ASSERT_EQ(dest_cores.at(0), CoreCoord(3,0));   ASSERT_EQ(dest_cores.at(1), CoreCoord(7,0));
+            ASSERT_EQ(dest_cores.at(2), CoreCoord(3,1));   ASSERT_EQ(dest_cores.at(3), CoreCoord(7,1));
+            ASSERT_EQ(dest_cores.at(4), CoreCoord(3,2));   ASSERT_EQ(dest_cores.at(5), CoreCoord(7,2));
+            ASSERT_EQ(dest_cores.at(6), CoreCoord(3,3));   ASSERT_EQ(dest_cores.at(7), CoreCoord(7,3));
+
         }
     }
 
+
     // TODO: Add a 64 core, 8 ring size test
+}
+
+
+TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_GetIntraCoreStrideInShards) {
+
+    {
+        uint32_t input_shard_grid_size = 2;
+        uint32_t num_workers = 2;
+        uint32_t ring_size = 8;
+        auto stride = OutputTensorShardAddrGenArgGenerator::get_intra_core_stride_in_shards(input_shard_grid_size,num_workers,ring_size);
+        ASSERT_EQ(stride, 2);
+    }
+    {
+        uint32_t input_shard_grid_size = 4;
+        uint32_t num_workers = 2;
+        uint32_t ring_size = 8;
+        auto stride = OutputTensorShardAddrGenArgGenerator::get_intra_core_stride_in_shards(input_shard_grid_size,num_workers,ring_size);
+        ASSERT_EQ(stride, 3);
+    }
+    {
+        uint32_t input_shard_grid_size = 16;
+        uint32_t num_workers = 4;
+        uint32_t ring_size = 8;
+        auto stride = OutputTensorShardAddrGenArgGenerator::get_intra_core_stride_in_shards(input_shard_grid_size,num_workers,ring_size);
+        // Since we should be striding past the end of the core for this case, we don't care
+        // so either of these values would be valid
+        // the first would be the hypothetical stride if ring_size was bigger
+        // stride = 1 would be equivalent to no special extra stride
+        ASSERT_TRUE(stride == 5);
+    }
+    {
+        uint32_t input_shard_grid_size = 56;
+        uint32_t num_workers = 1;
+        uint32_t ring_size = 8;
+        auto stride = OutputTensorShardAddrGenArgGenerator::get_intra_core_stride_in_shards(input_shard_grid_size,num_workers,ring_size);
+        ASSERT_EQ(stride, 1);
+    }
+
+}
+
+TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_GetContiguousChunkCount) {
+
+    {
+        uint32_t input_shard_grid_size = 1;
+        uint32_t num_workers = 1;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        TT_ASSERT(num_contiguous_shards, 1);
+    }
+    {
+        uint32_t input_shard_grid_size = 2;
+        uint32_t num_workers = 2;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        TT_ASSERT(num_contiguous_shards, 1);
+    }
+    {
+        uint32_t input_shard_grid_size = 4;
+        uint32_t num_workers = 2;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        TT_ASSERT(num_contiguous_shards, 2);
+    }
+    {
+        uint32_t input_shard_grid_size = 16;
+        uint32_t num_workers = 4;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        TT_ASSERT(num_contiguous_shards, 4);
+    }
+    {
+        uint32_t input_shard_grid_size = 56;
+        uint32_t num_workers = 1;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        TT_ASSERT(num_contiguous_shards, 1);
+    }
+    {
+        uint32_t input_shard_grid_size = 32;
+        uint32_t num_workers = 8;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        TT_ASSERT(num_contiguous_shards, 4);
+    }
+}
+
+TEST(AllGatherUtils, OutputTensorShardAddrGenArgGenerator_GetContiguousChunksBeforeStrideAndContiguousChunksBeforeStride) {
+    {
+        uint32_t input_shard_grid_size = 1;
+        uint32_t num_workers = 1;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        auto intra_core_stride_in_chunks = OutputTensorShardAddrGenArgGenerator::get_intra_core_stride_in_shards(input_shard_grid_size, num_workers, ring_size);
+        ASSERT_EQ(num_contiguous_shards, intra_core_stride_in_chunks);
+    }
+    {
+        uint32_t input_shard_grid_size = 2;
+        uint32_t num_workers = 1;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        auto intra_core_stride_in_chunks = OutputTensorShardAddrGenArgGenerator::get_intra_core_stride_in_shards(input_shard_grid_size, num_workers, ring_size);
+        ASSERT_EQ(num_contiguous_shards, 1);
+        ASSERT_EQ(intra_core_stride_in_chunks, 1);
+    }
+    {
+        uint32_t input_shard_grid_size = 16;
+        uint32_t num_workers = 4;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        auto intra_core_stride_in_chunks = OutputTensorShardAddrGenArgGenerator::get_intra_core_stride_in_shards(input_shard_grid_size, num_workers, ring_size);
+        ASSERT_TRUE(num_contiguous_shards == 4 && intra_core_stride_in_chunks == 5);
+    }
+    {
+        uint32_t input_shard_grid_size = 32;
+        uint32_t num_workers = 8;
+        uint32_t ring_size = 8;
+        auto num_contiguous_shards = OutputTensorShardAddrGenArgGenerator::get_contiguous_chunks_before_stride(input_shard_grid_size, num_workers, ring_size);
+        auto intra_core_stride_in_chunks = OutputTensorShardAddrGenArgGenerator::get_intra_core_stride_in_shards(input_shard_grid_size, num_workers, ring_size);
+        ASSERT_TRUE(num_contiguous_shards == 4 && intra_core_stride_in_chunks == 5);
+    }
+}
+
+//////////////////////////////////////////////////////
+/// InputTensorShardAddrGenArgGenerator TESTS
+//////////////////////////////////////////////////////
+
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_2Workers_WorkerIdx0_2Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0)}, CoreCoord(1,0)});
+        uint32_t num_workers = 2;
+        uint32_t worker_index = 0;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            CoreRangeSet(all_shard_cores), worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 1);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_2Workers_WorkerIdx1_2Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(1,0)}});
+        uint32_t num_workers = 2;
+        uint32_t worker_index = 1;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 1);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(1,0));
+    }
+
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_2Workers_WorkerIdx0_4Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(3,0)}});
+        uint32_t num_workers = 2;
+        uint32_t worker_index = 0;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 2);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_2Workers_WorkerIdx1_4Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(3,0)}});
+        uint32_t num_workers = 2;
+        uint32_t worker_index = 1;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 2);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(2,0));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(3,0));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_4Workers_WorkerIdx0_16Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(7,1)}});
+        uint32_t num_workers = 4;
+        uint32_t worker_index = 0;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 4);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+        ASSERT_EQ(dest_cores.at(2), CoreCoord(2,0));
+        ASSERT_EQ(dest_cores.at(3), CoreCoord(3,0));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_4Workers_WorkerIdx1_16Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(7,1)}});
+        uint32_t num_workers = 4;
+        uint32_t worker_index = 1;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 4);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(4,0));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(5,0));
+        ASSERT_EQ(dest_cores.at(2), CoreCoord(6,0));
+        ASSERT_EQ(dest_cores.at(3), CoreCoord(7,0));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_4Workers_WorkerIdx2_16Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(7,1)}});
+        uint32_t num_workers = 4;
+        uint32_t worker_index = 2;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 4);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,1));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,1));
+        ASSERT_EQ(dest_cores.at(2), CoreCoord(2,1));
+        ASSERT_EQ(dest_cores.at(3), CoreCoord(3,1));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_4Workers_WorkerIdx3_16Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(7,1)}});
+        uint32_t num_workers = 4;
+        uint32_t worker_index = 3;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 4);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(4,1));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(5,1));
+        ASSERT_EQ(dest_cores.at(2), CoreCoord(6,1));
+        ASSERT_EQ(dest_cores.at(3), CoreCoord(7,1));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_8Workers_WorkerIdx0_32Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(7,3)}});
+        uint32_t num_workers = 8;
+        uint32_t worker_index = 0;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 4);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,0));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,0));
+        ASSERT_EQ(dest_cores.at(2), CoreCoord(2,0));
+        ASSERT_EQ(dest_cores.at(3), CoreCoord(3,0));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_8Workers_WorkerIdx1_32Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(7,3)}});
+        uint32_t num_workers = 8;
+        uint32_t worker_index = 1;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 4);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(4,0));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(5,0));
+        ASSERT_EQ(dest_cores.at(2), CoreCoord(6,0));
+        ASSERT_EQ(dest_cores.at(3), CoreCoord(7,0));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_8Workers_WorkerIdx2_32Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(7,3)}});
+        uint32_t num_workers = 8;
+        uint32_t worker_index = 2;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        ASSERT_EQ(dest_cores.size(), 4);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(0,1));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(1,1));
+        ASSERT_EQ(dest_cores.at(2), CoreCoord(2,1));
+        ASSERT_EQ(dest_cores.at(3), CoreCoord(3,1));
+    }
+TEST(AllGatherUtils, InputTensorShardAddrGenArgGenerator_CtorGenerateDestCoresWidthSharding_8Workers_WorkerIdx3_32Cores)
+    {
+        CoreRangeSet const& all_shard_cores = CoreRangeSet({CoreRange{CoreCoord(0,0), CoreCoord(7,3)}});
+        uint32_t num_workers = 8;
+        uint32_t worker_index = 3;
+        std::cout << "sup" << std::endl;
+        auto const& dest_cores = InputTensorShardAddrGenArgGenerator::ctor_generate_dest_cores(
+            all_shard_cores, worker_index, num_workers);
+        std::cout << "hey" << std::endl;
+        ASSERT_EQ(dest_cores.size(), 4);
+        ASSERT_EQ(dest_cores.at(0), CoreCoord(4,1));
+        ASSERT_EQ(dest_cores.at(1), CoreCoord(5,1));
+        ASSERT_EQ(dest_cores.at(2), CoreCoord(6,1));
+        ASSERT_EQ(dest_cores.at(3), CoreCoord(7,1));
+    }
+
+
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers2WorkerIndex0ShardGridSize2_ClockWise) {
+    { // ring_size = 8, 2 workers, worker 0, shard grid size = 2
+        bool is_clockwise = true;
+        uint16_t curr_core_chunk_index = 0;
+        uint16_t curr_worker_index = 0;
+        uint16_t contiguous_chunk_count = 1;
+        uint16_t current_core_chunks_visited = 0;
+        const uint16_t total_chunks_per_core = 8; // shared between all workers
+        const uint16_t num_dest_cores = 2;
+        const uint16_t intra_core_stride_in_shards = 2; // skip 1
+        const uint16_t contiguous_chunks_before_stride = 1;
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 6);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 4);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 2);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 0);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        // Should have moved to the next core
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 6);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        // Should have moved to the next core
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 4);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+    }
+}
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers2WorkerIndex0ShardGridSize2_CounterClockWise) {
+    { // ring_size = 8, 2 workers, worker 0, shard grid size = 2
+        bool is_clockwise = false;
+        uint16_t curr_core_chunk_index = 0;
+        uint16_t curr_worker_index = 0;
+        uint16_t contiguous_chunk_count = 1;
+        uint16_t current_core_chunks_visited = 0;
+        const uint16_t total_chunks_per_core = 8; // shared between all workers
+        const uint16_t num_dest_cores = 2;
+        const uint16_t intra_core_stride_in_shards = 2; // skip 1
+        const uint16_t contiguous_chunks_before_stride = 1;
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 2);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 4);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 6);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 0);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        // Should have moved to the next core
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 2);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        // Should have moved to the next core
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 4);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+    }
+}
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers2WorkerIndex1ShardGridSize2_CounterClockWise) {
+     // ring_size = 8, 2 workers, worker 1, shard grid size = 2
+        bool is_clockwise = false;
+        uint16_t curr_core_chunk_index = 1;
+        uint16_t curr_worker_index = 0;
+        uint16_t contiguous_chunk_count = 1;
+        uint16_t current_core_chunks_visited = 0;
+        const uint16_t total_chunks_per_core = 8; // shared between all workers
+        const uint16_t num_dest_cores = 2;
+        const uint16_t intra_core_stride_in_shards = 2; // skip 1
+        const uint16_t contiguous_chunks_before_stride = 1;
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 3);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 5);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 7);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 1);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        // Should have moved to the next core
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 3);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        // Should have moved to the next core
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 5);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex1_NumWorkers2WorkerIndex0ShardGridSize2_CounterClockWise) {
+        // ring_size = 8, 2 workers, worker 0, shard grid size = 2
+        bool is_clockwise = false;
+        uint16_t curr_core_chunk_index = 0;
+        uint16_t curr_worker_index = 1;
+        uint16_t contiguous_chunk_count = 1;
+        const uint16_t total_chunks_per_core = 8; // shared between all workers
+        const uint16_t num_dest_cores = 2;
+        const uint16_t intra_core_stride_in_shards = 2; // skip 1
+        const uint16_t contiguous_chunks_before_stride = 1;
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 2);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 4);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 6);
+        ASSERT_EQ(curr_worker_index, 1);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 0);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        // Should have moved to the next core
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 2);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+
+        // Should have moved to the next core
+        ccl::all_gather::addr_gen_advance_width_sharded(
+            curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        ASSERT_EQ(curr_core_chunk_index, 4);
+        ASSERT_EQ(curr_worker_index, 0);
+        ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex1_NumWorkers2WorkerIndex1ShardGridSize2_CounterClockWise) {
+    // ring_size = 8, 2 workers, worker 1, shard grid size = 2
+    bool is_clockwise = false;
+    uint16_t curr_core_chunk_index = 1;
+    uint16_t curr_worker_index = 1;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 2;
+    const uint16_t intra_core_stride_in_shards = 2; // skip 1
+    const uint16_t contiguous_chunks_before_stride = 1;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 7);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+    // ASSERT_EQ(current_core_chunks_visited, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    // Should have moved to the next core
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    // Should have moved to the next core
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+}
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers4WorkerIndex0ShardGridSize16_CounterClockWise) {
+    bool is_clockwise = false;
+    uint16_t curr_core_chunk_index = 0;
+    uint16_t curr_worker_index = 0;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 16;
+    const uint16_t intra_core_stride_in_shards = 5; // skip 4
+    const uint16_t contiguous_chunks_before_stride = 4;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex1_NumWorkers4WorkerIndex3ShardGridSize16_CounterClockWise) {
+    bool is_clockwise = false;
+    uint16_t curr_core_chunk_index = 4;
+    uint16_t curr_worker_index = 0;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 16;
+    const uint16_t intra_core_stride_in_shards = 5; // skip 1
+    const uint16_t contiguous_chunks_before_stride = 4;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 6);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 7);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 6);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 7);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers8WorkerIndex0ShardGridSize32_CounterClockWise) {
+    bool is_clockwise = false;
+    uint16_t curr_core_chunk_index = 0;
+    uint16_t curr_worker_index = 0;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 8;
+    const uint16_t intra_core_stride_in_shards = 5; // skip 4
+    const uint16_t contiguous_chunks_before_stride = 4;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    // check for wraparound
+    for (uint32_t i = 0; i < num_dest_cores; i++) {
+        for (uint32_t c = 0; c < contiguous_chunks_before_stride; c++) {
+            ccl::all_gather::addr_gen_advance_width_sharded(
+                curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        }
+    }
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers8WorkerIndex1ShardGridSize32_CounterClockWise) {
+    bool is_clockwise = false;
+    uint16_t curr_core_chunk_index = 4;
+    uint16_t curr_worker_index = 0;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 8;
+    const uint16_t intra_core_stride_in_shards = 5; // skip 4
+    const uint16_t contiguous_chunks_before_stride = 4;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index, contiguous_chunk_count, total_chunks_per_core, num_dest_cores, intra_core_stride_in_shards, contiguous_chunks_before_stride, is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 6);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 7);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 6);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 7);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    // check for wraparound
+    for (uint32_t i = 0; i < num_dest_cores; i++) {
+        for (uint32_t c = 0; c < contiguous_chunks_before_stride; c++) {
+            ccl::all_gather::addr_gen_advance_width_sharded(
+                curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        }
+    }
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers8WorkerIndex2ShardGridSize32_CounterClockWise) {
+    bool is_clockwise = false;
+    uint16_t curr_core_chunk_index = 0;
+    uint16_t curr_worker_index = 0;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 8;
+    const uint16_t intra_core_stride_in_shards = 5; // skip 4
+    const uint16_t contiguous_chunks_before_stride = 4;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index, curr_worker_index, contiguous_chunk_count, total_chunks_per_core, num_dest_cores, intra_core_stride_in_shards, contiguous_chunks_before_stride, is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    // check for wraparound
+    for (uint32_t i = 0; i < num_dest_cores; i++) {
+        for (uint32_t c = 0; c < contiguous_chunks_before_stride; c++) {
+            ccl::all_gather::addr_gen_advance_width_sharded(
+                curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        }
+    }
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers8WorkerIndex3ShardGridSize32_CounterClockWise) {
+    bool is_clockwise = false;
+    uint16_t curr_core_chunk_index = 4;
+    uint16_t curr_worker_index = 0;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 8;
+    const uint16_t intra_core_stride_in_shards = 5; // skip 4
+    const uint16_t contiguous_chunks_before_stride = 4;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 6);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 7);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 6);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 7);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    // check for wraparound
+    for (uint32_t i = 0; i < num_dest_cores; i++) {
+        for (uint32_t c = 0; c < contiguous_chunks_before_stride; c++) {
+            ccl::all_gather::addr_gen_advance_width_sharded(
+                curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        }
+    }
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex1_NumWorkers8WorkerIndex2ShardGridSize32_CounterClockWise) {
+    bool is_clockwise = false;
+    uint16_t curr_core_chunk_index = 0;
+    uint16_t curr_worker_index = 1;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 8;
+    const uint16_t intra_core_stride_in_shards = 5; // skip 4
+    const uint16_t contiguous_chunks_before_stride = 4;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 1);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 2);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 3);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    // Check for wraparound
+    for (uint32_t i = 0; i < num_dest_cores; i++) {
+        for (uint32_t c = 0; c < contiguous_chunks_before_stride; c++) {
+            ccl::all_gather::addr_gen_advance_width_sharded(
+                curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        }
+    }
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 3);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers8WorkerIndex0ShardGridSize32_ClockWise) {
+    bool is_clockwise = true;
+    uint16_t curr_core_chunk_index = 0;
+    uint16_t curr_worker_index = 0;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 8;
+    const uint16_t intra_core_stride_in_shards = 5; // skip 4
+    const uint16_t contiguous_chunks_before_stride = 4;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 7);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 1);
+    ASSERT_EQ(curr_worker_index, 7);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 2);
+    ASSERT_EQ(curr_worker_index, 7);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 3);
+    ASSERT_EQ(curr_worker_index, 7);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 6);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    // check for wraparound
+    for (uint32_t i = 0; i < num_dest_cores; i++) {
+        for (uint32_t c = 0; c < contiguous_chunks_before_stride; c++) {
+            ccl::all_gather::addr_gen_advance_width_sharded(
+                curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        }
+    }
+    ASSERT_EQ(curr_core_chunk_index, 0);
+    ASSERT_EQ(curr_worker_index, 6);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+}
+
+TEST(AllGatherUtilsDevice, AddrGenAdvanceWidthSharded_RingSize8RingIndex0_NumWorkers8WorkerIndex1ShardGridSize32_ClockWise) {
+    bool is_clockwise = true;
+    uint16_t curr_core_chunk_index = 4;
+    uint16_t curr_worker_index = 0;
+    uint16_t contiguous_chunk_count = 1;
+    uint16_t current_core_chunks_visited = 0;
+    const uint16_t total_chunks_per_core = 8; // shared between all workers
+    const uint16_t num_dest_cores = 8;
+    const uint16_t intra_core_stride_in_shards = 5; // skip 4
+    const uint16_t contiguous_chunks_before_stride = 4;
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 6);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 7);
+    ASSERT_EQ(curr_worker_index, 0);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 7);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 5);
+    ASSERT_EQ(curr_worker_index, 7);
+    ASSERT_EQ(contiguous_chunk_count, 2);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 6);
+    ASSERT_EQ(curr_worker_index, 7);
+    ASSERT_EQ(contiguous_chunk_count, 3);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 7);
+    ASSERT_EQ(curr_worker_index, 7);
+    ASSERT_EQ(contiguous_chunk_count, 4);
+
+    ccl::all_gather::addr_gen_advance_width_sharded(
+        curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 6);
+    ASSERT_EQ(contiguous_chunk_count, 1);
+
+    // check for wraparound
+    for (uint32_t i = 0; i < num_dest_cores; i++) {
+        for (uint32_t c = 0; c < contiguous_chunks_before_stride; c++) {
+            ccl::all_gather::addr_gen_advance_width_sharded(
+                curr_core_chunk_index,curr_worker_index,contiguous_chunk_count,total_chunks_per_core,num_dest_cores,intra_core_stride_in_shards,contiguous_chunks_before_stride,is_clockwise);
+        }
+    }
+    ASSERT_EQ(curr_core_chunk_index, 4);
+    ASSERT_EQ(curr_worker_index, 6);
+    ASSERT_EQ(contiguous_chunk_count, 1);
 }

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
@@ -157,7 +157,6 @@ def run_all_gather_on_t3000_impl_tight_loop(
 
 
 # Enumerate the post-commit cases explicitly
-@pytest.mark.skip("#7705: Hanging on various configs")
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
@@ -219,7 +218,6 @@ def test_all_gather_on_t3000_post_commit_looping(
 
 
 # Enumerate the post-commit cases explicitly
-@pytest.mark.skip("#7705: Hanging on various configs")
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
@@ -305,7 +303,6 @@ def test_all_gather_on_t3000_post_commit(
 
 # Enumerate the post-commit cases explicitly
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.skip("#7705: Hanging on various configs")
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
@@ -399,7 +396,6 @@ def test_line_all_gather_on_t3000_post_commit(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@pytest.mark.skip("#7705: Hanging on various configs")
 @pytest.mark.parametrize(
     "num_devices, num_links",
     [

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
@@ -86,6 +86,7 @@ bool RunWriteBWTest(
     const CoreCoord& eth_sender_core,
     const CoreCoord& eth_receiver_core,
 
+    const size_t eth_channel_sync_ack_addr,
     const size_t src_eth_l1_byte_address,
     const size_t dst_eth_l1_byte_address,
 
@@ -228,6 +229,7 @@ bool RunWriteBWTest(
         eth_receiver_kernel,
         eth_receiver_core,
         {
+            uint32_t(eth_channel_sync_ack_addr),
             uint32_t(dst_eth_l1_byte_address),
             uint32_t(src_eth_l1_byte_address),
             dram_output_buffer_base_addr,
@@ -317,8 +319,9 @@ int main(int argc, char** argv) {
     const auto& device_0 = test_fixture.devices_.at(0);
     const auto& device_1 = test_fixture.devices_.at(1);
     const size_t precomputed_source_addresses_buffer_address = (size_t)nullptr;
-    const size_t src_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 32;
-    const size_t dst_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 32;
+    const size_t eth_channel_sync_ack_addr = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+    const size_t src_eth_l1_byte_address = eth_channel_sync_ack_addr + 16;
+    const size_t dst_eth_l1_byte_address = eth_channel_sync_ack_addr + 16;
 
     auto const& active_eth_cores = device_0->get_active_ethernet_cores(true);
     assert (active_eth_cores.size() > 0);
@@ -342,6 +345,7 @@ int main(int argc, char** argv) {
             device_1,
             eth_sender_core,
             eth_receiver_core,
+            eth_channel_sync_ack_addr,
             src_eth_l1_byte_address,
             dst_eth_l1_byte_address,
             precomputed_source_addresses_buffer_address,

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_non_blocking_receive_fwd_to_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_non_blocking_receive_fwd_to_dram.cpp
@@ -88,11 +88,12 @@ void kernel_main() {
     // Handshake first before timestamping to make sure we aren't measuring any
     // dispatch/setup times for the kernels on both sides of the link.
 
-    const std::uint32_t local_eth_l1_src_addr = get_arg_val<uint32_t>(0);
-    const std::uint32_t remote_eth_l1_dst_addr = get_arg_val<uint32_t>(1);
-    const std::uint32_t dest_addr = get_arg_val<uint32_t>(2);
-    const std::uint32_t page_size = get_arg_val<uint32_t>(3);
-    const std::uint32_t num_pages = get_arg_val<uint32_t>(4);
+    const std::uint32_t eth_channel_sync_ack_addr = get_arg_val<uint32_t>(0);
+    const std::uint32_t local_eth_l1_src_addr = get_arg_val<uint32_t>(1);
+    const std::uint32_t remote_eth_l1_dst_addr = get_arg_val<uint32_t>(2);
+    const std::uint32_t dest_addr = get_arg_val<uint32_t>(3);
+    const std::uint32_t page_size = get_arg_val<uint32_t>(4);
+    const std::uint32_t num_pages = get_arg_val<uint32_t>(5);
     erisc::datamover::eth_setup_handshake(remote_eth_l1_dst_addr, false);
 
     const InterleavedAddrGen<dest_is_dram> dest_address_generator = {
@@ -134,7 +135,7 @@ void kernel_main() {
             bool did_something = false;
 
             bool received = erisc::datamover::deprecated::receiver_eth_accept_payload_sequence(
-                                noc_writer_buffer_wrptr, noc_writer_buffer_ackptr, eth_receiver_rdptr, eth_receiver_ackptr);
+                                noc_writer_buffer_wrptr, noc_writer_buffer_ackptr, eth_receiver_rdptr, eth_receiver_ackptr, eth_channel_sync_ack_addr);
             num_receives_acked = received ? num_receives_acked + 1 : num_receives_acked;
             did_something = received || did_something;
 

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -4,6 +4,7 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/layout_conversion/layout_conversion_op.cpp \
 	tt_eager/tt_dnn/op_library/all_gather/all_gather_op.cpp \
 	tt_eager/tt_dnn/op_library/all_gather/multi_core/all_gather_op_multi_core.cpp \
+	tt_eager/tt_dnn/op_library/ccl/ccl_common.cpp \
 	tt_eager/tt_dnn/op_library/sharded/sharded_op.cpp \
 	tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp \
 	tt_eager/tt_dnn/op_library/sharded_partial/sharded_op_partial.cpp \

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TT_DNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/layout_conversion/layout_conversion_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/all_gather/all_gather_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/all_gather/multi_core/all_gather_op_multi_core.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ccl/ccl_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sharded/sharded_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sharded/multi_core/sharded_op_multi_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sharded_partial/sharded_op_partial.cpp

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp
@@ -5,23 +5,162 @@
 #include "dataflow_api.h"
 #include "debug/assert.h"
 #include "tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
-#include "tt_eager/tt_dnn/op_library/ccl/ccl_common.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/kernel_common/worker_edm_utils.hpp"
 
-using ccl::ShardType;
+using tt::tt_metal::ccl::ShardType;
+using tt::tt_metal::ccl::WorkerXY;
+using tt::tt_metal::ccl::UNINITIALIZED_VALUE_U32;
+using tt::tt_metal::ccl::UNINITIALIZED_VALUE_U16;
 
-FORCE_INLINE void validate_sane_transaction_counters() {
-    ASSERT (NOC_STATUS_READ_REG(noc_index, NIU_MST_WR_ACK_RECEIVED) != 0);
-    ASSERT (NOC_STATUS_READ_REG(noc_index, NIU_MST_NONPOSTED_WR_REQ_SENT) != 0);
-    ASSERT(noc_nonposted_writes_num_issued[noc_index] != 0);
-    ASSERT(noc_nonposted_writes_acked[noc_index] != 0);
-}
+// Only workers on local worker core, hence no uint64_t noc addresses
+template <ShardType SHARD_TYPE>
+struct FullWorkerGridShardAddrGen {
+    FullWorkerGridShardAddrGen()=default;
+    FORCE_INLINE static void build_with_placement_new(FullWorkerGridShardAddrGen* placement_new_address, const uint32_t arg_index) {
+        tt::tt_metal::ccl::FullWorkerGridShardAddrGenArgs<false> input_args;
 
-FORCE_INLINE void validate_sane_transaction_counters_rw() {
-    ASSERT (NOC_STATUS_READ_REG(noc_index, NIU_MST_WR_ACK_RECEIVED) != 0);
-    ASSERT (NOC_STATUS_READ_REG(noc_index, NIU_MST_NONPOSTED_WR_REQ_SENT) != 0);
-    ASSERT(noc_nonposted_writes_num_issued[noc_index] != 0);
-    ASSERT(noc_nonposted_writes_acked[noc_index] != 0);
-}
+        uint32_t curr_arg_index = arg_index;
+        input_args.tile_size_in_bytes = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.shards_start_address = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.curr_shard_tile_x = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.curr_shard_tile_y = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.curr_tile_index = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.curr_shard = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.input_shard_num_tiles_x = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.input_shard_num_tiles_y = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.total_shards_x = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.is_clockwise = get_arg_val<uint32_t>(curr_arg_index++) != 0;
+        input_args.curr_core_index = static_cast<uint16_t>(get_arg_val<uint32_t>(curr_arg_index++));
+        input_args.total_num_cores = static_cast<uint16_t>(get_arg_val<uint32_t>(curr_arg_index++));
+        input_args.dest_cores = reinterpret_cast<WorkerXY*>(get_arg_addr(curr_arg_index));
+        curr_arg_index += input_args.total_num_cores;
+
+        ASSERT(input_args.tile_size_in_bytes != UNINITIALIZED_VALUE_U32);
+        ASSERT(input_args.shards_start_address != UNINITIALIZED_VALUE_U32);
+        ASSERT(input_args.curr_core_index != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.total_num_cores != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.curr_shard_tile_x != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.curr_shard_tile_y != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.curr_tile_index != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.curr_shard != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.input_shard_num_tiles_x != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.input_shard_num_tiles_y != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.total_shards_x != UNINITIALIZED_VALUE_U16);
+
+        ASSERT(curr_arg_index - arg_index == input_args.get_expected_num_args());
+
+        new (placement_new_address) FullWorkerGridShardAddrGen(curr_arg_index - arg_index, input_args);
+    }
+
+    FullWorkerGridShardAddrGen(
+        uint8_t num_args_consumed,
+        tt::tt_metal::ccl::FullWorkerGridShardAddrGenArgs<false> const& input_args) :
+        dest_cores(input_args.dest_cores),
+        tile_size_in_bytes(input_args.tile_size_in_bytes),
+        shards_start_address(input_args.shards_start_address),
+        curr_core_index(input_args.curr_core_index),
+        total_num_cores(input_args.total_num_cores),
+        curr_shard_tile_x(input_args.curr_shard_tile_x),
+        curr_shard_tile_y(input_args.curr_shard_tile_y),
+        curr_tile_index(input_args.curr_tile_index),
+        curr_shard(input_args.curr_shard),
+        input_shard_num_tiles_x(input_args.input_shard_num_tiles_x),
+        input_shard_num_tiles_y(input_args.input_shard_num_tiles_y),
+        total_shards_x(input_args.total_shards_x),
+        num_args_consumed(num_args_consumed),
+        is_clockwise(input_args.is_clockwise)
+    {
+        ASSERT(input_shard_num_tiles_x > 0);
+        ASSERT(input_shard_num_tiles_y > 0);
+        ASSERT(total_shards_x > 0);
+        ASSERT(total_num_cores > 0);
+        ASSERT(curr_core_index < total_num_cores);
+        if constexpr (SHARD_TYPE == ShardType::Width) {
+            ASSERT(curr_shard < total_shards_x);
+            ASSERT(curr_tile_index = curr_shard_tile_x * input_shard_num_tiles_x + (curr_shard_tile_y * total_shards_x * input_shard_num_tiles_x));
+        } else {
+            ASSERT(false); // Not implemented yet
+        }
+    }
+
+
+    [[nodiscard]] FORCE_INLINE WorkerXY get_next_noc_xy_core() const {
+        ASSERT(this->curr_core_index < this->total_num_cores);
+        return this->dest_cores[this->curr_core_index];
+    }
+
+    [[nodiscard]] FORCE_INLINE uint64_t get_next_noc_addr() const {
+        WorkerXY dest_worker = this->get_next_noc_xy_core();
+        uint32_t curr_address = this->shards_start_address + this->curr_tile_index * this->tile_size_in_bytes;
+        ASSERT(this->shards_start_address <= curr_address);
+        return get_noc_addr(dest_worker.x, dest_worker.y, curr_address);
+    }
+
+    FORCE_INLINE uint16_t get_tiles_left_in_row_in_shard() const {
+        return this->input_shard_num_tiles_x - this->curr_shard_tile_x;
+    }
+
+    FORCE_INLINE void advance() {
+        tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance (
+            this->curr_shard_tile_x,
+            this->curr_shard_tile_y,
+            this->curr_tile_index,
+            this->curr_core_index,
+            this->total_num_cores,
+            this->input_shard_num_tiles_x,
+            this->input_shard_num_tiles_y,
+            this->total_shards_x,
+            this->curr_shard,
+            this->is_clockwise);
+    }
+
+    FORCE_INLINE void advance_to_next_tile_row() {
+        tt::tt_metal::ccl::all_gather::full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+            this->curr_shard_tile_x,
+            this->curr_shard_tile_y,
+            this->curr_tile_index,
+            this->curr_core_index,
+            this->total_num_cores,
+            this->input_shard_num_tiles_x,
+            this->input_shard_num_tiles_y,
+            this->total_shards_x,
+            this->curr_shard,
+            this->is_clockwise);
+    }
+
+    FORCE_INLINE void advance_n_tiles(uint16_t n) {
+        // TODO: optimize
+        for (uint16_t i = 0; i < n; i++) {
+            this->advance();
+        }
+    }
+
+    [[nodiscard]] FORCE_INLINE uint32_t get_tile_size_in_bytes() const {
+        return this->tile_size_in_bytes;
+    }
+
+    [[nodiscard]] FORCE_INLINE uint32_t get_shard_tile_row_size_in_bytes() const {
+        return this->input_shard_num_tiles_x * this->tile_size_in_bytes;
+    }
+
+    [[nodiscard]] FORCE_INLINE uint32_t get_num_args_consumed() const { return this->num_args_consumed; }
+
+    WorkerXY* dest_cores;
+    uint32_t tile_size_in_bytes;
+    uint32_t shards_start_address;
+    uint16_t curr_core_index;
+    uint16_t total_num_cores;
+    uint16_t curr_shard_tile_x;
+    uint16_t curr_shard_tile_y;
+    uint16_t curr_tile_index;
+    uint16_t curr_shard;
+    uint16_t input_shard_num_tiles_x;
+    uint16_t input_shard_num_tiles_y;
+    uint16_t total_shards_x;
+    uint8_t num_args_consumed;
+    bool is_clockwise;
+};
+
 
 
 template <ShardType TYPE>
@@ -29,25 +168,29 @@ struct ShardAddrGen final {
     ShardAddrGen()=default;
 
     FORCE_INLINE static void build_with_placement_new(ShardAddrGen* placement_new_address, const uint32_t arg_index) {
-        ccl::ShardAddrGenArgs<false> input_args;
+        tt::tt_metal::ccl::ShardAddrGenArgs<false> input_args;
 
         uint32_t curr_arg_index = arg_index;
         input_args.is_clockwise = bool(get_arg_val<uint32_t>(curr_arg_index++) == 1);
         input_args.shard_size_in_bytes = get_arg_val<uint32_t>(curr_arg_index++);
-        input_args.chunks_per_core_before_advance = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.total_chunks_per_core = get_arg_val<uint32_t>(curr_arg_index++);
         input_args.shards_start_address = get_arg_val<uint32_t>(curr_arg_index++);
         input_args.starting_core_index = get_arg_val<uint32_t>(curr_arg_index++);
         input_args.starting_chunk_into_shard = get_arg_val<uint32_t>(curr_arg_index++);
+
+        input_args.intra_core_stride_in_shards = get_arg_val<uint32_t>(curr_arg_index++);
+        input_args.contiguous_chunks_before_stride = get_arg_val<uint32_t>(curr_arg_index++);
+
         input_args.num_dest_cores = get_arg_val<uint32_t>(curr_arg_index++);
-        input_args.dest_cores = reinterpret_cast<ccl::WorkerXY*>(get_arg_addr(curr_arg_index));
+        input_args.dest_cores = reinterpret_cast<WorkerXY*>(get_arg_addr(curr_arg_index));
         curr_arg_index += input_args.num_dest_cores;
 
-        ASSERT(input_args.shard_size_in_bytes != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
-        ASSERT(input_args.chunks_per_core_before_advance != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
-        ASSERT(input_args.shards_start_address != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
-        ASSERT(input_args.starting_core_index != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
-        ASSERT(input_args.starting_chunk_into_shard != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
-        ASSERT(input_args.num_dest_cores != ccl::ShardAddrGenArgs<true>::UNINITIALIZED_VALUE);
+        ASSERT(input_args.shard_size_in_bytes != UNINITIALIZED_VALUE_U32);
+        ASSERT(input_args.total_chunks_per_core != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.shards_start_address != UNINITIALIZED_VALUE_U32);
+        ASSERT(input_args.starting_core_index != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.starting_chunk_into_shard != UNINITIALIZED_VALUE_U16);
+        ASSERT(input_args.num_dest_cores != UNINITIALIZED_VALUE_U16);
 
         ASSERT(curr_arg_index - arg_index == input_args.get_expected_num_args());
 
@@ -61,74 +204,67 @@ struct ShardAddrGen final {
     //
     ShardAddrGen(
         uint8_t num_args_consumed,
-        ccl::ShardAddrGenArgs<false> const& input_args) :
+        tt::tt_metal::ccl::ShardAddrGenArgs<false> const& input_args) :
         dest_cores(input_args.dest_cores),
-        num_dest_cores(input_args.num_dest_cores),
         shards_start_address(input_args.shards_start_address),
         shard_size_in_bytes(input_args.shard_size_in_bytes),
-        chunks_per_core_before_advance(input_args.chunks_per_core_before_advance),
+        total_chunks_per_core(input_args.total_chunks_per_core),
         curr_worker_index(input_args.starting_core_index),
         curr_core_chunk_index(input_args.starting_chunk_into_shard),
-        num_args_consumed(num_args_consumed),
-        is_clockwise(input_args.is_clockwise),
-        completed_core_wrap(false){};
 
-    static_assert(
-        TYPE == ShardType::Width || TYPE == ShardType::Height || TYPE == ShardType::Block, "Invalid ShardType");
+        intra_core_stride_in_shards(input_args.intra_core_stride_in_shards),
+        contiguous_chunk_count(1),
+        contiguous_chunks_before_stride(input_args.contiguous_chunks_before_stride),
+        num_dest_cores(input_args.num_dest_cores),
+
+        num_args_consumed(num_args_consumed),
+        is_clockwise(input_args.is_clockwise)
+        {
+            ASSERT(this->contiguous_chunks_before_stride >= 1);
+            ASSERT(this->intra_core_stride_in_shards >= 1);
+            ASSERT(input_args.starting_chunk_into_shard <= this->total_chunks_per_core);
+        };
+
+    static_assert(TYPE == ShardType::Width || TYPE == ShardType::Height || TYPE == ShardType::Block, "Invalid ShardType");
 
     // Clockwise vs counter clockwise only affects worker core traversal order (relative to canonical order). Since the
     // dest core list is a configurable list, we will, for now, require the host side kernel config code to produce the
     // correc order per worker
     FORCE_INLINE void advance() {
         if constexpr (TYPE == ShardType::Width or TYPE == ShardType::Height) {
-            if (this->is_clockwise) {
-                // Read inputs in reverse order too
-                bool do_chunk_wrap = this->curr_core_chunk_index == 0;
-                if (do_chunk_wrap) {
-                    bool do_core_wrap = this->curr_worker_index == 0;
-                    this->curr_core_chunk_index = this->chunks_per_core_before_advance - 1;
-                    if (do_core_wrap) {
-                        completed_core_wrap = true;
-                        this->curr_worker_index = this->num_dest_cores - 1;
-                    } else {
-                        this->curr_worker_index--;
-                    }
-                } else {
-                    this->curr_core_chunk_index--;
-                }
-
-
-            } else {
-                // If I analyzed it properly, then we should never be wrapping back to the first dest core *and* still have
-                // tiles/input shards to move
-                this->curr_core_chunk_index++;
-                bool do_chunk_wrap = this->curr_core_chunk_index == this->chunks_per_core_before_advance;
-                if (do_chunk_wrap) {
-                    this->curr_core_chunk_index = 0;
-                    this->curr_worker_index++;
-                    bool do_core_wrap = this->curr_worker_index == this->num_dest_cores;
-                    if (do_core_wrap) {
-                        this->curr_worker_index = 0;
-                        completed_core_wrap = true;
-                    }
-                }
-            }
+            tt::tt_metal::ccl::all_gather::addr_gen_advance_width_sharded(
+                this->curr_core_chunk_index,
+                this->curr_worker_index,
+                this->contiguous_chunk_count,
+                this->total_chunks_per_core,
+                this->num_dest_cores,
+                this->intra_core_stride_in_shards,
+                this->contiguous_chunks_before_stride,
+                this->is_clockwise
+            );
         } else {
             // Unsupported
             ASSERT(false);
         }
     }
 
-    [[nodiscard]] FORCE_INLINE ccl::WorkerXY get_next_noc_xy_core() const {
+    [[nodiscard]] FORCE_INLINE WorkerXY get_next_noc_xy_core() const {
         ASSERT(this->curr_worker_index < this->num_dest_cores);
         return this->dest_cores[this->curr_worker_index];
     }
 
+    [[nodiscard]] FORCE_INLINE uint64_t get_next_noc_addr() const {
+        WorkerXY dest_worker = this->get_next_noc_xy_core();
+        uint32_t curr_address = this->shards_start_address + this->curr_core_chunk_index * this->shard_size_in_bytes;
+        ASSERT(this->shards_start_address <= curr_address);
+        return get_noc_addr(dest_worker.x, dest_worker.y, curr_address);
+    }
+
     [[nodiscard]] FORCE_INLINE uint64_t get_next_noc_addr_and_advance() {
         if constexpr (TYPE == ShardType::Width) {
-            ccl::WorkerXY dest_worker = this->get_next_noc_xy_core();
+            WorkerXY dest_worker = this->get_next_noc_xy_core();
             uint32_t curr_address = this->shards_start_address + this->curr_core_chunk_index * this->shard_size_in_bytes;
-            ASSERT(curr_address + this->shard_size_in_bytes <= 1499136); // L1 wraparound - oops!
+            ASSERT(this->shards_start_address <= curr_address);
             this->advance();
             return get_noc_addr(dest_worker.x, dest_worker.y, curr_address);
         } else {
@@ -141,80 +277,43 @@ struct ShardAddrGen final {
     [[nodiscard]] FORCE_INLINE uint32_t get_shard_size_in_bytes() const { return this->shard_size_in_bytes; }
 
     [[nodiscard]] FORCE_INLINE uint32_t get_num_dest_cores() const { return this->num_dest_cores; }
-    [[nodiscard]] FORCE_INLINE uint32_t get_chunks_per_core_before_advance() const {
-        return this->chunks_per_core_before_advance;
+    [[nodiscard]] FORCE_INLINE uint32_t get_total_chunks_per_core() const {
+        return this->total_chunks_per_core;
     }
     [[nodiscard]] FORCE_INLINE uint32_t get_num_args_consumed() const { return this->num_args_consumed;}
 
-    ccl::WorkerXY* dest_cores;
-    uint32_t num_dest_cores;
+    WorkerXY* dest_cores;
     uint32_t shards_start_address;
     uint32_t shard_size_in_bytes;
-    uint32_t chunks_per_core_before_advance;
-    uint32_t curr_worker_index;
-    uint32_t curr_core_chunk_index;
+    uint16_t total_chunks_per_core;
+    uint16_t curr_worker_index;
+    uint16_t curr_core_chunk_index;
+    uint16_t intra_core_stride_in_shards;
+    uint16_t contiguous_chunk_count;
+    uint16_t contiguous_chunks_before_stride;
+    uint16_t num_dest_cores;
     uint8_t num_args_consumed;
     bool is_clockwise;
-    bool completed_core_wrap;
 };
-
-FORCE_INLINE void push_filler_pages_to_cb(const uint32_t& cb_id, uint32_t num_pages) {
-    ASSERT(num_pages < cb_interface[cb_id].fifo_num_pages);
-    cb_reserve_back(cb_id, num_pages);
-    cb_push_back(cb_id, num_pages);
-}
-FORCE_INLINE void pop_filler_pages_from_cb(const uint32_t& cb_id, uint32_t num_pages) {
-    ASSERT(num_pages < cb_interface[cb_id].fifo_num_pages);
-    cb_wait_front(cb_id, num_pages);
-    cb_pop_front(cb_id, num_pages);
-}
-
-
-FORCE_INLINE void fetch_chunk(
-    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_read_addr) {
-    cb_reserve_back(cb_id, num_pages);
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
-    noc_async_read(remote_l1_read_addr, l1_write_addr, page_size * num_pages);
-    noc_async_read_barrier();
-    cb_push_back(cb_id, num_pages);
-}
-FORCE_INLINE void fetch_chunk_sharded(
-    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_read_addr) {
-    cb_reserve_back(cb_id, num_pages);
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
-    noc_async_read(remote_l1_read_addr, l1_write_addr, num_pages * page_size);
-    validate_sane_transaction_counters();
-    noc_async_read_barrier();
-    cb_push_back(cb_id, num_pages);
-}
-
-FORCE_INLINE void send_chunk(
-    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr) {
-    cb_wait_front(cb_id, num_pages);
-    uint32_t l1_read_addr = get_read_ptr(cb_id);
-    noc_async_write(l1_read_addr, remote_l1_write_addr, page_size * num_pages);
-    noc_async_write_barrier();
-    cb_pop_front(cb_id, num_pages);
-}
-FORCE_INLINE void send_chunk_sharded(
-    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr) {
-    cb_wait_front(cb_id, num_pages);
-    uint32_t l1_read_addr = get_read_ptr(cb_id);
-    noc_async_write(l1_read_addr, remote_l1_write_addr, page_size * num_pages);
-    validate_sane_transaction_counters();
-    noc_async_write_barrier();
-    cb_pop_front(cb_id, num_pages);
-}
 
 template <ShardType T>
 FORCE_INLINE void write_and_send_chunk_sharded(
-    const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t num_pages, uint64_t remote_eth_l1_write_addr) {
+    const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t const num_pages, uint64_t remote_eth_l1_write_addr, uint64_t eth_l1_sender_semaphore_addr) {
     cb_wait_front(cb_id, num_pages);
     uint32_t l1_read_addr = get_read_ptr(cb_id);
-    uint64_t dest_worker_noc_addr = addr_gen.get_next_noc_addr_and_advance();
-    noc_async_write(l1_read_addr, remote_eth_l1_write_addr, addr_gen.get_shard_size_in_bytes());
-    noc_async_write(l1_read_addr, dest_worker_noc_addr, addr_gen.get_shard_size_in_bytes());
-    validate_sane_transaction_counters();
+    uint32_t num_pages_remaining = num_pages;
+    noc_async_write(l1_read_addr, remote_eth_l1_write_addr, num_pages * addr_gen.get_shard_size_in_bytes());
+    noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
+    while (num_pages_remaining > 0) {
+        uint64_t dest_worker_noc_addr = addr_gen.get_next_noc_addr();
+        uint32_t num_shards_to_write = std::min<uint32_t>(num_pages_remaining, addr_gen.contiguous_chunks_before_stride);
+        noc_async_write(l1_read_addr, dest_worker_noc_addr, num_shards_to_write * addr_gen.get_shard_size_in_bytes());
+        for (uint32_t i = 0; i < num_shards_to_write; i++) {
+            addr_gen.advance();
+        }
+        num_pages_remaining -= num_shards_to_write;
+        l1_read_addr += num_shards_to_write * addr_gen.get_shard_size_in_bytes();
+    }
     noc_async_write_barrier();
     cb_pop_front(cb_id, num_pages);
 }
@@ -256,19 +355,23 @@ FORCE_INLINE void write_and_send_chunk(uint32_t& output_page_idx, uint32_t& col_
 }
 
 template <ShardType T>
-FORCE_INLINE void write_chunk_sharded(const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t num_pages) {
-    for (uint32_t i = 0; i < num_pages; ++i) {
-        cb_wait_front(cb_id, 1);
-        uint32_t l1_read_addr = get_read_ptr(cb_id);
-        uint64_t dest_worker_noc_addr = addr_gen.get_next_noc_addr_and_advance();
-
-        noc_async_write(l1_read_addr, dest_worker_noc_addr, addr_gen.get_shard_size_in_bytes());
-
-        // validate_sane_transaction_counters();
-        validate_sane_transaction_counters_rw();
-        noc_async_write_barrier();
-        cb_pop_front(cb_id, 1);
+FORCE_INLINE void write_chunk_sharded(const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, const uint32_t num_pages) {
+    cb_wait_front(cb_id, num_pages);
+    uint32_t l1_read_addr = get_read_ptr(cb_id);
+    uint32_t num_pages_remaining = num_pages;
+    while (num_pages_remaining > 0) {
+        uint64_t dest_worker_noc_addr = addr_gen.get_next_noc_addr();
+        uint32_t num_contiguous_shards = addr_gen.contiguous_chunks_before_stride;
+        uint32_t num_to_send = std::min(num_pages_remaining, num_contiguous_shards);
+        noc_async_write(l1_read_addr, dest_worker_noc_addr, num_to_send * addr_gen.get_shard_size_in_bytes());
+        for (uint32_t i = 0; i < num_to_send; i++) {
+            addr_gen.advance();
+        }
+        l1_read_addr += num_to_send * addr_gen.get_shard_size_in_bytes();
+        num_pages_remaining -= num_to_send;
     }
+    noc_async_write_barrier();
+    cb_pop_front(cb_id, num_pages);
 }
 template <typename AddrGen>
 FORCE_INLINE void write_chunk(uint32_t& output_page_idx, uint32_t& col_idx, uint32_t& row_idx, const uint32_t& cb_id, const AddrGen& d, const uint32_t& num_cols, const uint32_t& num_rows, const uint32_t& col_offset, const uint32_t& row_offset, const uint32_t& num_pages, const uint32_t& page_size) {
@@ -305,15 +408,17 @@ FORCE_INLINE void write_chunk(uint32_t& output_page_idx, uint32_t& col_idx, uint
 }
 
 template <ShardType T>
-FORCE_INLINE void read_chunk_from_input_tensor_sharded(
-    const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t num_pages) {
-    cb_reserve_back(cb_id, num_pages);
+FORCE_INLINE void read_shard_from_input_tensor_sharded(
+    const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t num_shards) {
+    cb_reserve_back(cb_id, num_shards);
     uint32_t local_l1_read_dest_addr = get_write_ptr(cb_id);
-    uint64_t src_noc_addr = addr_gen.get_next_noc_addr_and_advance();
-    noc_async_read(src_noc_addr, local_l1_read_dest_addr, addr_gen.get_shard_size_in_bytes());
-    validate_sane_transaction_counters();
+    for (uint32_t s = 0; s < num_shards; s++) {
+        uint64_t src_noc_addr = addr_gen.get_next_noc_addr_and_advance();
+        noc_async_read(src_noc_addr, local_l1_read_dest_addr, addr_gen.get_shard_size_in_bytes());
+        local_l1_read_dest_addr += addr_gen.get_shard_size_in_bytes();
+    }
     noc_async_read_barrier();
-    cb_push_back(cb_id, num_pages);
+    cb_push_back(cb_id, num_shards);
 }
 // read chunk from input tensor (local chip)
 template <typename AddrGen>
@@ -337,12 +442,20 @@ FORCE_INLINE void read_chunk_from_input_tensor(uint32_t& input_page_idx, const u
 // Same function - just different address generators? Commonize later
 template <ShardType T>
 FORCE_INLINE void read_chunk_from_output_tensor_sharded(
-    const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t num_pages) {
+    const uint32_t& cb_id, ShardAddrGen<T>& addr_gen, uint32_t const num_pages) {
     cb_reserve_back(cb_id, num_pages);
     uint32_t local_l1_read_dest_addr = get_write_ptr(cb_id);
-    uint64_t src_noc_addr = addr_gen.get_next_noc_addr_and_advance();
-    noc_async_read(src_noc_addr, local_l1_read_dest_addr, addr_gen.get_shard_size_in_bytes());
-    validate_sane_transaction_counters();
+    uint32_t num_pages_remaining = num_pages;
+    while (num_pages_remaining > 0) {
+        uint64_t src_noc_addr = addr_gen.get_next_noc_addr();
+        uint32_t shards_to_read = std::min<uint32_t>(num_pages_remaining, addr_gen.contiguous_chunks_before_stride);
+        noc_async_read(src_noc_addr, local_l1_read_dest_addr, shards_to_read * addr_gen.get_shard_size_in_bytes());
+        local_l1_read_dest_addr += shards_to_read * addr_gen.get_shard_size_in_bytes();
+        for (uint32_t i = 0; i < shards_to_read; i++) {
+            addr_gen.advance();
+        }
+        num_pages_remaining -= shards_to_read;
+    }
     noc_async_read_barrier();
     cb_push_back(cb_id, num_pages);
 }

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_reader.cpp
@@ -9,11 +9,9 @@
 #include "tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_ring_gather_utils.hpp"
 
 void kernel_main() {
-    // Compile Time Arg(s)
-    constexpr ShardType shard_type = static_cast<ShardType>(get_compile_time_arg_val(0));
-
     // TODO: Update the interleaver receive reader kernel invocation to just be able to use this
-    ShardAddrGen<shard_type> output_tensor_shard_writer;
+    constexpr ShardType shard_type = static_cast<ShardType>(get_compile_time_arg_val(0));
+    ShardAddrGen<shard_type> input_tensor_shard_writer;
 
     // Info about the eth receiver eth core (producer of this core)
     // TODO: Make this arch agnostic
@@ -26,11 +24,11 @@ void kernel_main() {
     const uint32_t receiver_read_sem_addr = get_arg_val<uint32_t>(arg_index++);
     const uint32_t input_shards_per_eth_buffer = get_arg_val<uint32_t>(arg_index++);
     const uint32_t num_transfers = get_arg_val<uint32_t>(arg_index++);
+    const uint32_t half_cb_n_pages = get_arg_val<uint32_t>(arg_index++);
 
-    ShardAddrGen<shard_type>::build_with_placement_new(&output_tensor_shard_writer, arg_index);
-    arg_index += output_tensor_shard_writer.get_num_args_consumed();
+    ShardAddrGen<shard_type>::build_with_placement_new(&input_tensor_shard_writer, arg_index);
+    arg_index += input_tensor_shard_writer.get_num_args_consumed();
     ASSERT(eth_receiver_noc_x >= 1 && eth_receiver_noc_x < 12  && (eth_receiver_noc_y == 0 || eth_receiver_noc_y == 6));
-
 
     // Eth receiver will set this semaphore when data is available
     volatile tt_l1_ptr uint32_t* receiver_read_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_read_sem_addr);
@@ -43,28 +41,22 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 
-    // -1 because we are not receiving from our local chip (local chip has num_dest_cores_worth of tiles already handled)
-    uint32_t shards_per_ring_index = output_tensor_shard_writer.get_num_dest_cores();
-
-    uint32_t const shard_size = output_tensor_shard_writer.get_shard_size_in_bytes();
-
+    uint32_t shards_per_ring_index = input_tensor_shard_writer.get_num_dest_cores();
+    uint32_t const shard_size = input_tensor_shard_writer.get_shard_size_in_bytes();
     for (uint32_t t = 0; t < num_transfers; t++) {
         for (uint32_t i = 0; i < shards_per_ring_index; i += input_shards_per_eth_buffer) {
             uint32_t shards_to_send = std::min(input_shards_per_eth_buffer, shards_per_ring_index - i);
-            // `shards_to_send` to CB ... need to make sure we are aware of CB wraparound
             noc_semaphore_wait(receiver_read_semaphore_addr_ptr, 1);
             noc_semaphore_set(receiver_read_semaphore_addr_ptr, 0);
-            for (uint32_t s = 0; s < shards_to_send; ++s) {
-                // Read page by page so that writer can be kicked off instead of being blocked waiting for full
-                // chunk to be read Look into perf/optimizations for this
-                uint64_t source_eth_buffer_noc_addr = eth_receiver_l1_base_noc_addr + s * shard_size;
-                fetch_chunk_sharded(
-                    cb_id_in0,
-                    1,
-                    shard_size,
-                    source_eth_buffer_noc_addr);
-            }
+            fetch_chunk_sharded(
+                cb_id_in0,
+                shards_to_send,
+                shard_size,
+                eth_receiver_l1_base_noc_addr);
             noc_semaphore_inc(eth_receiver_l1_semaphore_noc_addr, 1);
+            if (half_cb_n_pages > shards_to_send) {
+                push_filler_pages_to_cb(cb_id_in0, half_cb_n_pages - shards_to_send);
+            }
         }
     }
 }

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_writer.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_receive_writer.cpp
@@ -17,6 +17,8 @@ void kernel_main() {
     uint32_t const remote_sender_reader_semaphore_addres = get_arg_val<uint32_t>(arg_index++);
     uint32_t const max_shards_per_eth_buffer = get_arg_val<uint32_t>(arg_index++);
     uint32_t const num_transfers = get_arg_val<uint32_t>(arg_index++);
+    uint32_t const shards_per_transfer = get_arg_val<uint32_t>(arg_index++);
+    uint32_t const half_cb_n_shards = get_arg_val<uint32_t>(arg_index++);
     ShardAddrGen<shard_type>::build_with_placement_new(&output_tensor_shard_writer, arg_index);
     arg_index += output_tensor_shard_writer.get_num_args_consumed();
 
@@ -26,17 +28,21 @@ void kernel_main() {
     const uint64_t worker_send_reader_semaphore_noc_addr =
         get_noc_addr(remote_sender_worker_x, remote_sender_worker_y, remote_sender_reader_semaphore_addres);
 
-    uint32_t total_num_shards = output_tensor_shard_writer.get_num_dest_cores() *
-                             (output_tensor_shard_writer.get_chunks_per_core_before_advance() - 1);
+    uint32_t total_num_shards = shards_per_transfer * num_transfers;
 
     for (uint32_t d = 0; d < num_transfers; d++) {
-        uint32_t num_shards_to_send = std::min(max_shards_per_eth_buffer, total_num_shards);
 
-        write_chunk_sharded(cb_id_in0, output_tensor_shard_writer, num_shards_to_send);  // 1 shard = 1 page
+        for (uint32_t s = 0; s <  shards_per_transfer; s += max_shards_per_eth_buffer) {
+            uint32_t num_shards_to_send = std::min(max_shards_per_eth_buffer, shards_per_transfer - s);
 
-        noc_semaphore_inc(worker_send_reader_semaphore_noc_addr, num_shards_to_send);
-        total_num_shards -= num_shards_to_send;
+            write_chunk_sharded(cb_id_in0, output_tensor_shard_writer, num_shards_to_send);
+            noc_semaphore_inc(worker_send_reader_semaphore_noc_addr, num_shards_to_send);
 
-        ASSERT(total_num_shards > 0 || d == num_transfers - 1); // If we are out of shards, make sure we are on the last transfer
+            total_num_shards -= num_shards_to_send;
+            ASSERT(total_num_shards > 0 || d == num_transfers - 1); // If we are out of shards, make sure we are on the last transfer
+            if (half_cb_n_shards > num_shards_to_send) {
+                pop_filler_pages_from_cb(cb_id_in0, half_cb_n_shards - num_shards_to_send);
+            }
+        }
     }
 }

--- a/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/kernels/dataflow/worker_sharded_ring_gather_send_reader.cpp
@@ -16,6 +16,9 @@ void kernel_main() {
 
     uint32_t arg_index = 0;
     volatile tt_l1_ptr uint32_t* local_semaphore_address = get_arg_val<volatile tt_l1_ptr uint32_t*>(arg_index++);
+    uint32_t const num_shards_per_transfer = get_arg_val<uint32_t>(arg_index++);
+    uint32_t const shards_per_eth_l1_buffer = get_arg_val<uint32_t>(arg_index++);
+    uint32_t const half_cb_n_pages = get_arg_val<uint32_t>(arg_index++);
     ShardAddrGen<shard_type>::build_with_placement_new(&input_tensor_shard_reader, arg_index);
     arg_index += input_tensor_shard_reader.get_num_args_consumed();
     ShardAddrGen<shard_type>::build_with_placement_new(&output_tensor_shard_reader, arg_index);
@@ -23,23 +26,27 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 
-    uint32_t num_chunks_per_transfer =
-        input_tensor_shard_reader.get_num_dest_cores() * input_tensor_shard_reader.get_chunks_per_core_before_advance();
-
-    ASSERT(output_tensor_shard_reader.get_num_dest_cores() * output_tensor_shard_reader.get_chunks_per_core_before_advance() ==
-        (num_transfers + 1) * num_chunks_per_transfer);
-
-    for (uint32_t c = 0; c < num_chunks_per_transfer; ++c) {
-        read_chunk_from_input_tensor_sharded(cb_id_in0, input_tensor_shard_reader, 1);
+    for (uint32_t c = 0; c < num_shards_per_transfer; c += shards_per_eth_l1_buffer) {
+        uint32_t num_shards_to_send = std::min(shards_per_eth_l1_buffer, num_shards_per_transfer - c);
+        read_shard_from_input_tensor_sharded(cb_id_in0, input_tensor_shard_reader, num_shards_to_send);
+        ASSERT(half_cb_n_pages >= num_shards_to_send);
+        if (half_cb_n_pages > num_shards_to_send) {
+            push_filler_pages_to_cb(cb_id_in0, half_cb_n_pages - num_shards_to_send);
+        }
     }
 
     uint32_t sem_idx = 1;
 
     for (uint32_t i = 1; i < num_transfers; ++i) {
-        for (uint32_t c = 0; c < num_chunks_per_transfer; ++c) {
+
+        for (uint32_t c = 0; c < num_shards_per_transfer; c += shards_per_eth_l1_buffer) {
+            uint32_t num_shards_to_send = std::min(shards_per_eth_l1_buffer, num_shards_per_transfer - c);
             noc_semaphore_wait_min(local_semaphore_address, sem_idx);
-            sem_idx++;
-            read_chunk_from_output_tensor_sharded(cb_id_in0, output_tensor_shard_reader, 1);  // 1 chunk == 1 page
+            sem_idx += num_shards_to_send;
+            read_chunk_from_output_tensor_sharded(cb_id_in0, output_tensor_shard_reader, num_shards_to_send);  // 1 chunk == 1 shard for now
+            if (half_cb_n_pages > num_shards_to_send) {
+                push_filler_pages_to_cb(cb_id_in0, half_cb_n_pages - num_shards_to_send);
+            }
         }
     }
 

--- a/tt_eager/tt_dnn/op_library/all_gather/multi_core/all_gather_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/all_gather/multi_core/all_gather_op_multi_core.cpp
@@ -10,6 +10,8 @@
 #include "tensor/tensor_impl.hpp"
 #include "tt_dnn/op_library/all_gather/all_gather_op.hpp"
 #include "tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/ccl_host_datastructures.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/ccl_common.hpp"
 #include "tt_dnn/op_library/math.hpp"
 #include "tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/common/constants.hpp"
@@ -111,13 +113,13 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     bool is_linear = topology == all_gather_op::Topology::Linear;
 
     tt_metal::Program program{};
+    const auto& device = input_tensor.device();
     auto const& all_gather_config = AllGatherConfig(input_tensor, output_tensor, dim, ring_size, num_links, topology);
+    auto const& topology_config = ccl::RingTopology(device, topology, sender_device_id, receiver_device_id, num_links, ring_size, ring_index);
 
     auto const& sharding_info = ShardedAllGatherConfig(input_tensor, output_tensor, dim);
     bool enable_print = false; // ring_index == 0
-    if (enable_print) {
-        all_gather_config.print();
-    }
+    all_gather_config.print();
 
     bool is_sharded = input_tensor.is_sharded();
 
@@ -127,16 +129,14 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     const auto output_buffer = output_tensor.buffer();
 
     int32_t shard_size_in_bytes = is_sharded ?
-        (input_buffer->shard_spec().page_shape[0] * input_buffer->shard_spec().page_shape[1] * input_buffer->shard_spec().tensor2d_shape[0] * input_buffer->shard_spec().tensor2d_shape[1] * input_tensor.element_size()) / input_tensor.shard_spec()->num_cores() :
+        (input_buffer->page_size() * input_buffer->shard_spec().tensor2d_shape[0] * input_buffer->shard_spec().tensor2d_shape[1]) / input_tensor.shard_spec()->num_cores() :
         -1;
     uint32_t input_page_size = is_sharded ? shard_size_in_bytes : input_buffer->page_size();
     uint32_t output_page_size = is_sharded ? shard_size_in_bytes : output_buffer->page_size();
     if (is_sharded) {
-        log_trace(tt::LogOp, "input_buffer->shard_spec().page_shape[0]: {}", input_buffer->shard_spec().page_shape[0]);
-        log_trace(tt::LogOp, "input_buffer->shard_spec().page_shape[1]: {}", input_buffer->shard_spec().page_shape[1]);
+        log_trace(tt::LogOp, "input_buffer->page_size: {}", input_buffer->page_size());
         log_trace(tt::LogOp, "input_buffer->shard_spec().tensor2d_shape[0]: {}", input_buffer->shard_spec().tensor2d_shape[0]);
         log_trace(tt::LogOp, "input_buffer->shard_spec().tensor2d_shape[1]: {}", input_buffer->shard_spec().tensor2d_shape[1]);
-        log_trace(tt::LogOp, "input_tensor.element_size(): {}", input_tensor.element_size());
     }
     const uint32_t max_buffer_per_chunk = is_sharded ?
         round_down(all_gather_config.get_eth_buffer_size(), shard_size_in_bytes):
@@ -148,12 +148,11 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     log_trace(tt::LogOp, "input_page_size: {}", input_page_size);
     log_trace(tt::LogOp, "max_buffer_per_chunk: {}", max_buffer_per_chunk);
     log_trace(tt::LogOp, "max_pages_per_chunk: {}", max_pages_per_chunk);
-    const auto& device = input_tensor.device();
-
     bool rm = input_tensor.get_layout() == Layout::ROW_MAJOR;
     bool width = input_tensor.get_legacy_shape().rank() - 1 == dim;
     DataFormat df = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
 
+    uint32_t global_num_workers = all_gather_config.get_num_eth_buffers_per_edm() * num_links;
 
     std::map<string, string> worker_defines;
     if (rm) {
@@ -164,10 +163,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
 
     // number of worker cores is 2x this since there is 1 worker for the sender buffer and 1 worker for the receiver buffer
     uint32_t total_worker_core_pairs_used = num_links * all_gather_config.get_num_eth_buffers_per_edm();
-    std::vector<KernelHandle> eth_sender_kernels;
-    eth_sender_kernels.reserve(num_links);
-    std::vector<KernelHandle> eth_receiver_kernels;
-    eth_receiver_kernels.reserve(num_links);
 
     std::vector<KernelHandle> worker_reader_sender_kernels;
     worker_reader_sender_kernels.reserve(total_worker_core_pairs_used);
@@ -189,8 +184,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     uint32_t min_pages_per_link = num_input_pages / num_links;
 
 
-    auto sender_noc = detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch());
-    auto receiver_noc = detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch());
 
     const uint32_t num_full_send_directions = topology == all_gather_op::Topology::Linear ? 2 : 1;
     constexpr uint32_t max_num_full_send_directions = 2;
@@ -220,14 +213,12 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
         }
 
         clockwise_edm_builders.emplace_back(
-            all_gather_config, edm_sem_addrs_per_link.at(link), edm_buffer_addrs_per_link.at(link));
+            all_gather_config.get_eth_buffer_size(), all_gather_config.get_erisc_handshake_address(), edm_sem_addrs_per_link.at(link), edm_buffer_addrs_per_link.at(link), ccl::EriscDataMoverBufferSharingMode::NOT_SHARED);
         counter_clockwise_edm_builders.emplace_back(
-            all_gather_config, edm_sem_addrs_per_link.at(link), edm_buffer_addrs_per_link.at(link));
+            all_gather_config.get_eth_buffer_size(), all_gather_config.get_erisc_handshake_address(), edm_sem_addrs_per_link.at(link), edm_buffer_addrs_per_link.at(link), ccl::EriscDataMoverBufferSharingMode::NOT_SHARED);
     }
 
-
     for (uint32_t direction = 0; direction < num_full_send_directions; direction++) {
-        uint32_t global_num_workers = all_gather_config.get_num_eth_buffers_per_edm() * num_links;
         // if we're in ring topology, we'll always need to transfer all ring indices (except the last one)
         // but if we are implementing a line topology, the number of transfers will depend on whether we
         // are setting up the forward/clockwise direction or the backward/counter-clockwise direction and also
@@ -274,8 +265,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
             }
         }
 
-
-
         auto is_buffer_in_clockwise_direction = [&all_gather_config,&direction](uint32_t b) {
             TT_ASSERT(direction < max_num_full_send_directions);
             bool in_clockwise_direction = all_gather_config.is_buffer_in_clockwise_ring(b);
@@ -287,46 +276,12 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
             pages_per_link.at(i)++;
         }
 
-        uint32_t num_rows = 0, num_cols = 0, row_offset = 0, col_offset = 0, num_tiles = 0;
-
-        if (rm) {
-            num_cols = input_tensor.get_legacy_shape()[-1];
-            auto input_shape = input_tensor.get_legacy_shape();
-            auto output_shape = output_tensor.get_legacy_shape();
-            num_rows = std::accumulate(input_shape.begin()+dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>());
-            row_offset = std::accumulate(output_shape.begin()+dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) - num_rows;
-        } else {
-            num_cols = input_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
-            auto input_shape = input_tensor.get_legacy_shape();
-            auto output_shape = output_tensor.get_legacy_shape();
-            uint32_t num_output_cols = output_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
-            num_rows = std::accumulate(input_shape.begin()+dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>()) / TILE_HEIGHT;
-            row_offset = (std::accumulate(output_shape.begin()+dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) / TILE_HEIGHT - num_rows) * num_output_cols;
-            col_offset = num_output_cols - num_cols;
-            num_tiles = num_rows * num_cols;
-        }
-
-        uint32_t input_start_page_idx = 0;
-        uint32_t output_addr_offset = 0;
-        uint32_t col_idx = 0;
-        uint32_t row_idx = 0;
-        uint32_t output_page_offset = 0;
-
-        if (rm) {
-            if (width) {
-                output_addr_offset = input_page_size;
-            } else {
-                output_page_offset = num_rows;
-            }
-        } else {
-            if (width) {
-                output_page_offset = num_cols;
-            } else {
-                output_page_offset = num_tiles;
-            }
-        }
-        uint32_t output_start_page_idx = ring_index * output_page_offset;
-        uint32_t output_start_addr_offset = ring_index * output_addr_offset;
+        auto tensor_slicer = ccl::InterleavedRingAllGatherTensorSlicer (
+            input_tensor,
+            output_tensor,
+            dim,
+            ring_index
+        );
 
         ///
         /// (counter clockwise sender) < ----- (this chip) < ----- (counter-clockwise receiver)
@@ -523,8 +478,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                 bool is_clockwise_direction = is_buffer_in_clockwise_direction(b);
 
                 // Not fully sure about these two
-                uint32_t last_output_page_offset = (ring_size - 1) * output_page_offset;
-                uint32_t last_output_addr_offset = (ring_size - 1) * output_addr_offset;
+                uint32_t last_output_page_offset = (ring_size - 1) * tensor_slicer.output_page_offset;
+                uint32_t last_output_addr_offset = (ring_size - 1) * tensor_slicer.output_addr_offset;
 
                 log_trace(tt::LogOp,"\tlast_output_page_offset={}", last_output_page_offset);
                 log_trace(tt::LogOp,"\tlast_output_addr_offset={}", last_output_addr_offset);
@@ -555,19 +510,19 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                                 static_cast<uint32_t>(output_page_size),
                                 static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
                                 static_cast<uint32_t>(rem_pages_per_worker.at(b)),
-                                static_cast<uint32_t>(input_start_page_idx),
-                                static_cast<uint32_t>(output_start_page_idx),
-                                static_cast<uint32_t>(output_start_addr_offset),
-                                static_cast<uint32_t>(row_idx),
-                                static_cast<uint32_t>(col_idx),
-                                static_cast<uint32_t>(row_offset),
-                                static_cast<uint32_t>(col_offset),
-                                static_cast<uint32_t>(num_rows),
-                                static_cast<uint32_t>(num_cols),
+                                static_cast<uint32_t>(tensor_slicer.input_start_page_idx),
+                                static_cast<uint32_t>(tensor_slicer.output_start_page_idx),
+                                static_cast<uint32_t>(tensor_slicer.output_start_addr_offset),
+                                static_cast<uint32_t>(tensor_slicer.row_idx),
+                                static_cast<uint32_t>(tensor_slicer.col_idx),
+                                static_cast<uint32_t>(tensor_slicer.row_offset),
+                                static_cast<uint32_t>(tensor_slicer.col_offset),
+                                static_cast<uint32_t>(tensor_slicer.num_rows),
+                                static_cast<uint32_t>(tensor_slicer.num_cols),
                                 static_cast<uint32_t>(last_output_page_offset),
-                                static_cast<uint32_t>(output_page_offset),
+                                static_cast<uint32_t>(tensor_slicer.output_page_offset),
                                 static_cast<uint32_t>(last_output_addr_offset),
-                                static_cast<uint32_t>(output_addr_offset),
+                                static_cast<uint32_t>(tensor_slicer.output_addr_offset),
                                 static_cast<uint32_t>(ring_index),
                                 static_cast<uint32_t>(sender_worker_reader_semaphore_addr),
                                 static_cast<uint32_t>(is_clockwise_direction ? 1 : 0),
@@ -584,19 +539,19 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
                             log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer.at(b): {}", pages_per_eth_l1_buffer.at(b));
                             log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
-                            log_trace(tt::LogOp, "\tinput_start_page_idx: {}", input_start_page_idx);
-                            log_trace(tt::LogOp, "\toutput_start_page_idx: {}", output_start_page_idx);
-                            log_trace(tt::LogOp, "\toutput_start_addr_offset: {}", output_start_addr_offset);
-                            log_trace(tt::LogOp, "\trow_idx: {}", row_idx);
-                            log_trace(tt::LogOp, "\tcol_idx: {}", col_idx);
-                            log_trace(tt::LogOp, "\trow_offset: {}", row_offset);
-                            log_trace(tt::LogOp, "\tcol_offset: {}", col_offset);
-                            log_trace(tt::LogOp, "\tnum_rows: {}", num_rows);
-                            log_trace(tt::LogOp, "\tnum_cols: {}", num_cols);
+                            log_trace(tt::LogOp, "\tinput_start_page_idx: {}", tensor_slicer.input_start_page_idx);
+                            log_trace(tt::LogOp, "\toutput_start_page_idx: {}", tensor_slicer.output_start_page_idx);
+                            log_trace(tt::LogOp, "\toutput_start_addr_offset: {}", tensor_slicer.output_start_addr_offset);
+                            log_trace(tt::LogOp, "\trow_idx: {}", tensor_slicer.row_idx);
+                            log_trace(tt::LogOp, "\tcol_idx: {}", tensor_slicer.col_idx);
+                            log_trace(tt::LogOp, "\trow_offset: {}", tensor_slicer.row_offset);
+                            log_trace(tt::LogOp, "\tcol_offset: {}", tensor_slicer.col_offset);
+                            log_trace(tt::LogOp, "\tnum_rows: {}", tensor_slicer.num_rows);
+                            log_trace(tt::LogOp, "\tnum_cols: {}", tensor_slicer.num_cols);
                             log_trace(tt::LogOp, "\tlast_output_page_offset: {}", last_output_page_offset);
-                            log_trace(tt::LogOp, "\toutput_page_offset: {}", output_page_offset);
+                            log_trace(tt::LogOp, "\toutput_page_offset: {}", tensor_slicer.output_page_offset);
                             log_trace(tt::LogOp, "\tlast_output_addr_offset: {}", last_output_addr_offset);
-                            log_trace(tt::LogOp, "\toutput_addr_offset: {}", output_addr_offset);
+                            log_trace(tt::LogOp, "\toutput_addr_offset: {}", tensor_slicer.output_addr_offset);
                             log_trace(tt::LogOp, "\tring_index: {}", ring_index);
                             log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_addr: {}", sender_worker_reader_semaphore_addr);
                             log_trace(tt::LogOp, "\tis_clockwise_direction: {}", is_clockwise_direction ? 1 : 0);
@@ -721,15 +676,15 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                                 static_cast<uint32_t>(output_page_size),
                                 static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
                                 static_cast<uint32_t>(rem_pages_per_worker.at(b)),
-                                static_cast<uint32_t>(input_start_page_idx),
-                                static_cast<uint32_t>(output_start_page_idx),
-                                static_cast<uint32_t>(output_start_addr_offset),
-                                static_cast<uint32_t>(row_idx),
-                                static_cast<uint32_t>(col_idx),
-                                static_cast<uint32_t>(row_offset),
-                                static_cast<uint32_t>(col_offset),
-                                static_cast<uint32_t>(num_rows),
-                                static_cast<uint32_t>(num_cols),
+                                static_cast<uint32_t>(tensor_slicer.input_start_page_idx),
+                                static_cast<uint32_t>(tensor_slicer.output_start_page_idx),
+                                static_cast<uint32_t>(tensor_slicer.output_start_addr_offset),
+                                static_cast<uint32_t>(tensor_slicer.row_idx),
+                                static_cast<uint32_t>(tensor_slicer.col_idx),
+                                static_cast<uint32_t>(tensor_slicer.row_offset),
+                                static_cast<uint32_t>(tensor_slicer.col_offset),
+                                static_cast<uint32_t>(tensor_slicer.num_rows),
+                                static_cast<uint32_t>(tensor_slicer.num_cols),
                                 static_cast<uint32_t>(ring_index),
 
                                 // worker local L1 address of semaphore
@@ -746,15 +701,15 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
                             log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer: {}", pages_per_eth_l1_buffer.at(b));
                             log_trace(tt::LogOp, "\trem_pages_per_worker: {}", rem_pages_per_worker.at(b));
-                            log_trace(tt::LogOp, "\tinput_start_page_idx: {}", input_start_page_idx);
-                            log_trace(tt::LogOp, "\toutput_start_page_idx: {}", output_start_page_idx);
-                            log_trace(tt::LogOp, "\toutput_start_addr_offset: {}", output_start_addr_offset);
-                            log_trace(tt::LogOp, "\trow_idx: {}", row_idx);
-                            log_trace(tt::LogOp, "\tcol_idx: {}", col_idx);
-                            log_trace(tt::LogOp, "\trow_offset: {}", row_offset);
-                            log_trace(tt::LogOp, "\tcol_offset: {}", col_offset);
-                            log_trace(tt::LogOp, "\tnum_rows: {}", num_rows);
-                            log_trace(tt::LogOp, "\tnum_cols: {}", num_cols);
+                            log_trace(tt::LogOp, "\tinput_start_page_idx: {}", tensor_slicer.input_start_page_idx);
+                            log_trace(tt::LogOp, "\toutput_start_page_idx: {}", tensor_slicer.output_start_page_idx);
+                            log_trace(tt::LogOp, "\toutput_start_addr_offset: {}", tensor_slicer.output_start_addr_offset);
+                            log_trace(tt::LogOp, "\trow_idx: {}", tensor_slicer.row_idx);
+                            log_trace(tt::LogOp, "\tcol_idx: {}", tensor_slicer.col_idx);
+                            log_trace(tt::LogOp, "\trow_offset: {}", tensor_slicer.row_offset);
+                            log_trace(tt::LogOp, "\tcol_offset: {}", tensor_slicer.col_offset);
+                            log_trace(tt::LogOp, "\tnum_rows: {}", tensor_slicer.num_rows);
+                            log_trace(tt::LogOp, "\tnum_cols: {}", tensor_slicer.num_cols);
                             log_trace(tt::LogOp, "\tring_index: {}", ring_index);
                             log_trace(tt::LogOp, "\tsender_worker_writer_semaphore_addr: {}", sender_worker_writer_semaphore_addr);
                             log_trace(tt::LogOp, "\tethernet_core_x: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).x);
@@ -892,14 +847,14 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             (ring_index == 0 ? ring_size - 1 : ring_index - 1):
                             (ring_index == ring_size - 1 ? 0 : ring_index + 1));
 
-                    uint32_t receiver_output_start_addr_offset = receiver_ring_index * output_addr_offset;
+                    uint32_t receiver_output_start_addr_offset = receiver_ring_index * tensor_slicer.output_addr_offset;
 
-                    uint32_t receiver_output_start_page_idx = output_start_page_idx;
+                    uint32_t receiver_output_start_page_idx = tensor_slicer.output_start_page_idx;
                     if (topology == all_gather_op::Topology::Linear) {
                         if (is_clockwise_direction) {
-                            receiver_output_start_page_idx -= output_page_offset;
+                            receiver_output_start_page_idx -= tensor_slicer.output_page_offset;
                         } else {
-                            receiver_output_start_page_idx += output_page_offset;
+                            receiver_output_start_page_idx += tensor_slicer.output_page_offset;
                         }
                     } else {
                         if (is_clockwise_direction) {
@@ -907,7 +862,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             if (is_wraparound_ring_index) {
                                 receiver_output_start_page_idx += last_output_page_offset;
                             } else {
-                                receiver_output_start_page_idx -= output_page_offset;
+                                receiver_output_start_page_idx -= tensor_slicer.output_page_offset;
                             }
                         } else {
                             // counter clockwise direction
@@ -915,7 +870,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             if (is_wraparound_ring_index) {
                                 receiver_output_start_page_idx -= last_output_page_offset;
                             } else {
-                                receiver_output_start_page_idx += output_page_offset;
+                                receiver_output_start_page_idx += tensor_slicer.output_page_offset;
                             }
                         }
                     }
@@ -1012,7 +967,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(cb_num_pages / 2)); // local_receiver_read_sem_addr
                             std::copy(output_tensor_shard_addr_gen_args.begin(), output_tensor_shard_addr_gen_args.end(), std::back_inserter(worker_reader_receiver_rt_args));
 
-                            log_trace(tt::LogOp, "----worker_receiver_reader_ct_args size={}", worker_receiver_reader_ct_args.size());
+                            log_trace(tt::LogOp, "----worker_receiver_reader_rt_args size={}", worker_reader_receiver_rt_args.size());
                             log_trace(tt::LogOp, "\teth_receiver_noc_x: {}", static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).x));
                             log_trace(tt::LogOp, "\teth_receiver_noc_y: {}", static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).y));
                             log_trace(tt::LogOp, "\teth_receiver_l1_base_addr: {}", receiver_eth_buffer_addrs.at(b));
@@ -1075,16 +1030,16 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                                 static_cast<uint32_t>(rem_pages_per_worker.at(b)),
                                 static_cast<uint32_t>(receiver_output_start_page_idx),
                                 static_cast<uint32_t>(receiver_output_start_addr_offset),
-                                static_cast<uint32_t>(row_idx),
-                                static_cast<uint32_t>(col_idx),
-                                static_cast<uint32_t>(row_offset),
-                                static_cast<uint32_t>(col_offset),
-                                static_cast<uint32_t>(num_rows),
-                                static_cast<uint32_t>(num_cols),
+                                static_cast<uint32_t>(tensor_slicer.row_idx),
+                                static_cast<uint32_t>(tensor_slicer.col_idx),
+                                static_cast<uint32_t>(tensor_slicer.row_offset),
+                                static_cast<uint32_t>(tensor_slicer.col_offset),
+                                static_cast<uint32_t>(tensor_slicer.num_rows),
+                                static_cast<uint32_t>(tensor_slicer.num_cols),
                                 static_cast<uint32_t>(last_output_page_offset),
-                                static_cast<uint32_t>(output_page_offset),
+                                static_cast<uint32_t>(tensor_slicer.output_page_offset),
                                 static_cast<uint32_t>(last_output_addr_offset),
-                                static_cast<uint32_t>(output_addr_offset),
+                                static_cast<uint32_t>(tensor_slicer.output_addr_offset),
                                 static_cast<uint32_t>(receiver_ring_index),
                                 static_cast<uint32_t>(sender_worker_reader_semaphore_addr),
                                 static_cast<uint32_t>(is_clockwise_direction ? 1 : 0),
@@ -1102,16 +1057,16 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
                             log_trace(tt::LogOp, "\treceiver_output_start_page_idx: {}", receiver_output_start_page_idx);
                             log_trace(tt::LogOp, "\treceiver_output_start_addr_offset: {}", receiver_output_start_addr_offset);
-                            log_trace(tt::LogOp, "\trow_idx: {}", row_idx);
-                            log_trace(tt::LogOp, "\tcol_idx: {}", col_idx);
-                            log_trace(tt::LogOp, "\trow_offset: {}", row_offset);
-                            log_trace(tt::LogOp, "\tcol_offset: {}", col_offset);
-                            log_trace(tt::LogOp, "\tnum_rows: {}", num_rows);
-                            log_trace(tt::LogOp, "\tnum_cols: {}", num_cols);
+                            log_trace(tt::LogOp, "\trow_idx: {}", tensor_slicer.row_idx);
+                            log_trace(tt::LogOp, "\tcol_idx: {}", tensor_slicer.col_idx);
+                            log_trace(tt::LogOp, "\trow_offset: {}", tensor_slicer.row_offset);
+                            log_trace(tt::LogOp, "\tcol_offset: {}", tensor_slicer.col_offset);
+                            log_trace(tt::LogOp, "\tnum_rows: {}", tensor_slicer.num_rows);
+                            log_trace(tt::LogOp, "\tnum_cols: {}", tensor_slicer.num_cols);
                             log_trace(tt::LogOp, "\tlast_output_page_offset: {}", last_output_page_offset);
-                            log_trace(tt::LogOp, "\toutput_page_offset: {}", output_page_offset);
+                            log_trace(tt::LogOp, "\toutput_page_offset: {}", tensor_slicer.output_page_offset);
                             log_trace(tt::LogOp, "\tlast_output_addr_offset: {}", last_output_addr_offset);
-                            log_trace(tt::LogOp, "\toutput_addr_offset: {}", output_addr_offset);
+                            log_trace(tt::LogOp, "\toutput_addr_offset: {}", tensor_slicer.output_addr_offset);
                             log_trace(tt::LogOp, "\treceiver_ring_index: {}", receiver_ring_index);
                             log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_addr: {}", sender_worker_reader_semaphore_addr);
                             log_trace(tt::LogOp, "\tis_clockwise_direction ? 1 : 0: {}", is_clockwise_direction ? 1 : 0);
@@ -1209,27 +1164,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                 }
 
                 uint32_t pages_per_worker = num_full_chunks_per_worker.at(b) * pages_per_chunk + rem_pages_per_worker.at(b);
-                if (is_sharded) {
-                    // nothing to do here - is handled by
-                } else {
-                    // Only for interleaved
-                    if (pages_per_worker > 0) {
-                        if (rm) {
-                            uint32_t num_rows_shifted = row_idx + pages_per_worker;
-                            uint32_t num_blocks_shifted = width ? 0 : num_rows_shifted / num_rows;
-                            output_start_page_idx += pages_per_worker + num_blocks_shifted * row_offset;
-                            row_idx = width ? 0 : num_rows_shifted % num_rows;
-                        } else {
-                            uint32_t num_cols_shifted = col_idx + pages_per_worker;
-                            uint32_t num_rows_shifted = num_cols_shifted / num_cols;
-                            uint32_t num_blocks_shifted = width ? 0 : num_rows_shifted / num_rows;
-                            output_start_page_idx += pages_per_worker + num_rows_shifted * col_offset + num_blocks_shifted * row_offset;
-                            col_idx = num_cols_shifted % num_cols;
-                            row_idx = width ? 0 : num_rows_shifted % num_rows;
-                        }
-                    }
-                    input_start_page_idx += pages_per_worker;
-                }
+                tensor_slicer.increment(pages_per_worker);
+
             }
 
 
@@ -1243,95 +1179,14 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
         }
     } // num_full_send_directions
 
-
-    {  // emit EDM kernel configs
-    uint32_t sender_socket_idx = 0;
-    uint32_t receiver_socket_idx = 0;
-    if (receiver_device_id == sender_device_id) {
-        if (ring_index == 0) {
-            receiver_socket_idx = 1;
-        } else {
-            sender_socket_idx = 1;
-        }
-    }
-    for (uint32_t i = 0; i < num_links; ++i) {
-        bool is_clockwise_direction_edm_enabled = !is_linear || ring_index != ring_size - 1;
-        if (is_clockwise_direction_edm_enabled) {
-            log_trace(tt::LogOp, "EDM CLOCKWISE KERNEL RT ARGS: ");
-            clockwise_edm_builders.at(i).dump_to_log();
-
-            auto eth_sender_core = device->get_ethernet_sockets(receiver_device_id.value()).at(sender_socket_idx);
-
-            std::vector<uint32_t> const& edm_clockwise_kernel_rt_args = clockwise_edm_builders.at(i).emit_runtime_args();
-            // Ethernet Kernels
-            std::vector<uint32_t> eth_sender_ct_args = clockwise_edm_builders.at(i).emit_compile_time_args();
-
-            auto eth_sender_kernel = tt_metal::CreateKernel(
-                program,
-                "tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp",
-                eth_sender_core,
-                tt_metal::EthernetConfig{.noc=sender_noc, .compile_args=eth_sender_ct_args});
-
-
-            tt_metal::SetRuntimeArgs(
-                program,
-                eth_sender_kernel,
-                eth_sender_core,
-                edm_clockwise_kernel_rt_args);
-
-            eth_sender_kernels.push_back(eth_sender_kernel);
-            log_trace(tt::LogOp, "RingIndex: {}. Link {}. Clockwise EDM Core (x={},y={})", ring_index, i, eth_sender_core.x, eth_sender_core.y);
-
-            std::stringstream ss;
-            ss << "HOST SENDER EDM ARGS:\n";
-            for (auto const& s : edm_clockwise_kernel_rt_args) {
-                ss << "\t" << s << "\n";
-            }
-            log_trace(tt::LogOp, "{}", ss.str());
-        }
-
-        bool is_counter_clockwise_direction_edm_enabled = !is_linear || ring_index != 0;
-        if (is_counter_clockwise_direction_edm_enabled) {
-            log_trace(tt::LogOp, "EDM COUNTER CLOCKWISE KERNEL RT ARGS: ");
-            counter_clockwise_edm_builders.at(i).dump_to_log();
-            std::vector<uint32_t> const& edm_counter_clockwise_kernel_rt_args = counter_clockwise_edm_builders.at(i).emit_runtime_args();
-
-            auto eth_receiver_core = device->get_ethernet_sockets(sender_device_id.value()).at(receiver_socket_idx);
-            std::vector<uint32_t> eth_receiver_ct_args = counter_clockwise_edm_builders.at(i).emit_compile_time_args();
-
-            auto eth_receiver_kernel = tt_metal::CreateKernel(
-                program,
-                "tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp",
-                eth_receiver_core,
-                tt_metal::EthernetConfig{.noc=receiver_noc, .compile_args=eth_receiver_ct_args});
-
-            eth_receiver_kernels.push_back(eth_receiver_kernel);
-
-            log_trace(tt::LogOp, "RingIndex: {}. Link {}. Counter-clockwise EDM Core (x={},y={})", ring_index, i, eth_receiver_core.x, eth_receiver_core.y);
-
-            std::stringstream ss2;
-            ss2 << "HOST RECEIVER EDM ARGS:\n";
-            for (auto const& s : edm_counter_clockwise_kernel_rt_args) {
-                ss2 << "\t" << s << "\n";
-            }
-            log_trace(tt::LogOp, "{}", ss2.str());
-
-            tt_metal::SetRuntimeArgs(
-                program,
-                eth_receiver_kernel,
-                eth_receiver_core,
-                edm_counter_clockwise_kernel_rt_args);
-        }
-
-        if (receiver_device_id == sender_device_id) {
-            receiver_socket_idx += 2;
-            sender_socket_idx += 2;
-        } else {
-            receiver_socket_idx += 1;
-            sender_socket_idx += 1;
-        }
-    }
-    }
+    ccl::generate_edm_kernels_for_ring_or_linear_topology(
+        program,
+        device,
+        topology_config,
+        clockwise_edm_builders,
+        counter_clockwise_edm_builders,
+        receiver_device_id,
+        sender_device_id);
 
     auto override_runtime_arguments_callback = [num_links, total_worker_core_pairs_used, worker_reader_sender_kernels, worker_writer_sender_kernels, worker_reader_receiver_kernels, worker_writer_receiver_kernels, all_worker_sender_cores, all_worker_receiver_cores] (
         const void* operation,
@@ -1340,17 +1195,43 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         const std::vector<Tensor>& output_tensors
     ) {
+        bool is_sharded = input_tensors.at(0).is_sharded();
         const auto& input = input_tensors.at(0);
         const auto& output = output_tensors.at(0);
         for (uint32_t i = 0; i < total_worker_core_pairs_used; ++i) {
-            auto &worker_reader_sender_runtime_args = GetRuntimeArgs(program, worker_reader_sender_kernels.at(i), all_worker_sender_cores.at(i));
-            worker_reader_sender_runtime_args.at(0) = input.buffer()->address();
-            worker_reader_sender_runtime_args.at(1) = output.buffer()->address();
-            auto &worker_writer_sender_runtime_args = GetRuntimeArgs(program, worker_writer_sender_kernels.at(i), all_worker_sender_cores.at(i));
-            worker_writer_sender_runtime_args.at(0) = output.buffer()->address();
+            if (is_sharded) {
+                auto &worker_reader_sender_runtime_args = GetRuntimeArgs(program, worker_reader_sender_kernels.at(i), all_worker_sender_cores.at(i));
+                worker_reader_sender_runtime_args.at(7) = input.buffer()->address();
+                uint32_t num_dest_cores = worker_reader_sender_runtime_args.at(12);
+                worker_reader_sender_runtime_args.at(12 + num_dest_cores + 4) = output.buffer()->address();
+                log_trace(tt::LogOp, "override worker_reader_sender_runtime_args:");
+                for (uint32_t j = 0; j < worker_reader_sender_runtime_args.size(); ++j) {
+                    log_trace(tt::LogOp, "\tworker_reader_sender_runtime_args[{}]: {}", j, worker_reader_sender_runtime_args.at(j));
+                }
 
-            auto &worker_writer_receiver_runtime_args = GetRuntimeArgs(program, worker_writer_receiver_kernels.at(i), all_worker_receiver_cores.at(i));
-            worker_writer_receiver_runtime_args.at(0) = output.buffer()->address();
+                auto &worker_writer_sender_runtime_args = GetRuntimeArgs(program, worker_writer_sender_kernels.at(i), all_worker_sender_cores.at(i));
+                worker_writer_sender_runtime_args.at(12) = output.buffer()->address();
+                log_trace(tt::LogOp, "override worker_writer_sender_runtime_args:");
+                for (uint32_t j = 0; j < worker_writer_sender_runtime_args.size(); ++j) {
+                    log_trace(tt::LogOp, "\tworker_writer_sender_runtime_args[{}]: {}", j, worker_reader_sender_runtime_args.at(j));
+                }
+
+                auto &worker_writer_receiver_runtime_args = GetRuntimeArgs(program, worker_writer_receiver_kernels.at(i), all_worker_receiver_cores.at(i));
+                worker_writer_receiver_runtime_args.at(10) = output.buffer()->address();
+                log_trace(tt::LogOp, "override worker_writer_receiver_runtime_args:");
+                for (uint32_t j = 0; j < worker_writer_receiver_runtime_args.size(); ++j) {
+                    log_trace(tt::LogOp, "\tworker_writer_receiver_runtime_args[{}]: {}", j, worker_reader_sender_runtime_args.at(j));
+                }
+            } else {
+                auto &worker_reader_sender_runtime_args = GetRuntimeArgs(program, worker_reader_sender_kernels.at(i), all_worker_sender_cores.at(i));
+                worker_reader_sender_runtime_args.at(0) = input.buffer()->address();
+                worker_reader_sender_runtime_args.at(1) = output.buffer()->address();
+                auto &worker_writer_sender_runtime_args = GetRuntimeArgs(program, worker_writer_sender_kernels.at(i), all_worker_sender_cores.at(i));
+                worker_writer_sender_runtime_args.at(0) = output.buffer()->address();
+
+                auto &worker_writer_receiver_runtime_args = GetRuntimeArgs(program, worker_writer_receiver_kernels.at(i), all_worker_receiver_cores.at(i));
+                worker_writer_receiver_runtime_args.at(0) = output.buffer()->address();
+            }
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/ccl/ccl_common.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/ccl_common.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include <cstdint>
+#include "ccl_common.hpp"
+#include "ccl_host_datastructures.hpp"
+
+namespace tt {
+namespace tt_metal {
+namespace ccl {
+
+void generate_edm_kernels_for_ring_or_linear_topology(
+    tt_metal::Program &program,
+    Device const* device,
+    RingTopology const& topology_config,
+    std::vector<ccl::EriscDatamoverBuilder> const& clockwise_edm_builders,
+    std::vector<ccl::EriscDatamoverBuilder> const& counter_clockwise_edm_builders,
+    std::optional<uint32_t> receiver_device_id,
+    std::optional<uint32_t> sender_device_id
+    ) {
+
+    auto sender_noc = detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch());
+    auto receiver_noc = detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch());
+    uint32_t sender_socket_idx = 0;
+    uint32_t receiver_socket_idx = 0;
+    if (receiver_device_id == sender_device_id) {
+        if (topology_config.ring_index == 0) {
+            receiver_socket_idx = 1;
+        } else {
+            sender_socket_idx = 1;
+        }
+    }
+    for (uint32_t i = 0; i < topology_config.num_links; ++i) {
+        bool is_clockwise_direction_edm_enabled = !topology_config.is_linear || topology_config.ring_index != topology_config.ring_size - 1;
+        if (is_clockwise_direction_edm_enabled) {
+            auto eth_sender_core = topology_config.eth_sender_cores.at(i);
+            log_trace(tt::LogOp, "EDM CLOCKWISE KERNEL RT ARGS: ");
+            auto eth_sender_kernel = ccl::generate_edm_kernel(
+                program,
+                device,
+                clockwise_edm_builders.at(i),
+                eth_sender_core,
+                sender_noc);
+            log_trace(tt::LogOp, "RingIndex: {}. Link {}. Clockwise EDM Core (x={},y={})", topology_config.ring_index, i, eth_sender_core.x, eth_sender_core.y);
+        }
+
+        bool is_counter_clockwise_direction_edm_enabled = !topology_config.is_linear || topology_config.ring_index != 0;
+        if (is_counter_clockwise_direction_edm_enabled) {
+            log_trace(tt::LogOp, "EDM COUNTER CLOCKWISE KERNEL RT ARGS: ");
+            auto eth_receiver_core = topology_config.eth_receiver_cores.at(i);
+            auto eth_receiver_kernel = ccl::generate_edm_kernel(
+                program,
+                device,
+                counter_clockwise_edm_builders.at(i),
+                eth_receiver_core,
+                receiver_noc);
+            log_trace(tt::LogOp, "RingIndex: {}. Link {}. Counter-clockwise EDM Core (x={},y={})", topology_config.ring_index, i, eth_receiver_core.x, eth_receiver_core.y);
+        }
+    }
+
+}
+
+KernelHandle generate_edm_kernel(
+    tt_metal::Program &program,
+    Device const* device,
+    ccl::EriscDatamoverBuilder const& edm_builder,
+    CoreCoord const& eth_core,
+    NOC noc_id) {
+    log_trace(tt::LogOp, "EDM CLOCKWISE KERNEL RT ARGS: ");
+    edm_builder.dump_to_log();
+
+    // auto eth_sender_core = device->get_ethernet_sockets(receiver_device_id.value()).at(sender_socket_idx);
+
+    std::vector<uint32_t> const& edm_clockwise_kernel_rt_args = edm_builder.emit_runtime_args();
+    // Ethernet Kernels
+    std::vector<uint32_t> eth_sender_ct_args = edm_builder.emit_compile_time_args();
+
+    auto eth_sender_kernel = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp",
+        eth_core,
+        tt_metal::EthernetConfig{.noc=noc_id, .compile_args=eth_sender_ct_args});
+
+
+    tt_metal::SetRuntimeArgs(
+        program,
+        eth_sender_kernel,
+        eth_core,
+        edm_clockwise_kernel_rt_args);
+
+    // eth_sender_kernels.push_back(eth_sender_kernel);
+    // log_trace(tt::LogOp, "RingIndex: {}. Link {}. Clockwise EDM Core (x={},y={})", ring_index, i, eth_sender_core.x, eth_sender_core.y);
+
+    std::stringstream ss;
+    ss << "EDM ARGS:\n";
+    for (auto const& s : edm_clockwise_kernel_rt_args) {
+        ss << "\t" << s << "\n";
+    }
+    log_trace(tt::LogOp, "{}", ss.str());
+
+    return eth_sender_kernel;
+}
+
+
+ccl::EriscDatamoverBuilder create_erisc_datamover_builder(std::size_t num_channels, uint32_t page_size, ccl::EriscDataMoverBufferSharingMode buffer_sharing_mode) {
+
+    std::vector<uint32_t> edm_sem_addresses(num_channels, 0);
+    std::vector<uint32_t> edm_buffer_addresses(num_channels, 0);
+
+    uint32_t edm_sem_addr = ccl::EriscDatamoverConfig::get_semaphores_base_address(num_channels);
+    uint32_t edm_buffer_addr = ccl::EriscDatamoverConfig::get_buffers_base_address(num_channels);
+    const uint32_t buffer_size = ccl::EriscDatamoverConfig::compute_buffer_size(num_channels, page_size);
+    for (std::size_t c = 0; c < num_channels; ++c) {
+        edm_sem_addresses.push_back(edm_sem_addr);
+        edm_sem_addr += ccl::EriscDatamoverConfig::semaphore_size;
+        edm_buffer_addresses.push_back(edm_buffer_addr);
+        edm_buffer_addr += buffer_size;
+        TT_ASSERT((c == 0) || (edm_buffer_addresses.back() != edm_buffer_addresses.front()));
+        TT_ASSERT((c == 0) || (edm_sem_addresses.back() != edm_sem_addresses.front()));
+    }
+
+    return ccl::EriscDatamoverBuilder(
+        buffer_size, ccl::EriscDatamoverConfig::get_edm_handshake_address(), edm_sem_addresses, edm_buffer_addresses, buffer_sharing_mode);
+}
+
+} // namespace ccl
+} // namespace tt_metal
+} // namespace tt

--- a/tt_eager/tt_dnn/op_library/ccl/ccl_common.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/ccl_common.hpp
@@ -4,33 +4,307 @@
 
 #pragma once
 
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/program/program.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/ccl_host_datastructures.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include <cstdint>
-#include "debug/assert.h"
+#include <numeric>
 
+
+namespace tt {
+namespace tt_metal {
 namespace ccl {
 
-// TODO(snijjar): Clean this up (mainly dependence on device ASSERT)
-// so I can include this from host side as well
-// template <typename ... Args>
-// class ArgListConstructible {
-//    public:
-//    void build_with_placement_new(Args &&... args) = 0;
-//    // do placement new construction with static build methods
-//     ArgListConstructible(uint16_t num_args_consumed) : num_args_consumed(num_args_consumed) {
-//         ASSERT(num_args_consumed >= 0);//, "num_args_consumed not set")
-//     }
+// Eventual home: ccl_topology_descriptors
+struct RingTopology {
+    RingTopology(
+        Device const* device,
+        Topology topology,
+        std::optional<uint32_t> sender_device_id,
+        std::optional<uint32_t> receiver_device_id,
+        uint32_t num_links,
+        uint32_t ring_size,
+        uint32_t ring_index) :
+        num_links(num_links), ring_size(ring_size), ring_index(ring_index), is_linear(topology == Topology::Linear) {
+        eth_sender_cores.reserve(num_links);
+        eth_receiver_cores.reserve(num_links);
 
-//     int16_t get_num_args_consumed() const {
-//         ASSERT(num_args_consumed >= 0);//, "num_args_consumed not set")
-//         return num_args_consumed;
-//     }
+        uint32_t sender_socket_idx = 0;
+        uint32_t receiver_socket_idx = 0;
+        if (receiver_device_id == sender_device_id) {
+            if (ring_index == 0) {
+                receiver_socket_idx = 1;
+            } else {
+                sender_socket_idx = 1;
+            }
+        }
 
-//    protected:
-//     int16_t set_num_args_consumed(uint16_t num_args) {
-//         num_args_consumed = num_args;
-//     }
+        for (uint32_t l = 0; l < num_links; ++l) {
+            // Get the cores for the sender and receiver worker cores
+            if (!is_linear || ring_index != ring_size - 1) {
+                uint32_t receiver_device = receiver_device_id.value();
+                auto const &sockets = device->get_ethernet_sockets(receiver_device);
+                auto eth_sender_core =
+                    sockets.at(sender_socket_idx);
+                eth_sender_cores.push_back(eth_sender_core);
+                log_trace(
+                    tt::LogOp, "\teth_sender_core on link {}: (x={},y={})", l, eth_sender_core.x, eth_sender_core.y);
+            }
+            if (!is_linear || ring_index != 0) {
+                uint32_t sender_device = sender_device_id.value();
+                auto const& sockets = device->get_ethernet_sockets(sender_device);
+                auto eth_receiver_core =
+                    sockets.at(receiver_socket_idx);
+                eth_receiver_cores.push_back(eth_receiver_core);
+                log_trace(
+                    tt::LogOp,
+                    "\teth_receiver_core on link {}: (x={},y={})",
+                    l,
+                    eth_receiver_core.x,
+                    eth_receiver_core.y);
+            }
 
-//     int16_t num_args_consumed;
-// };
+            if (receiver_device_id == sender_device_id) {
+                receiver_socket_idx += 2;
+                sender_socket_idx += 2;
+            } else {
+                receiver_socket_idx += 1;
+                sender_socket_idx += 1;
+            }
+        }
+    }
+
+    std::vector<CoreCoord> eth_sender_cores;
+    std::vector<CoreCoord> eth_receiver_cores;
+
+    uint32_t num_links;
+    uint32_t ring_size;
+    uint32_t ring_index;
+    bool is_linear;
+};
+
+struct CclTensorSlicer {
+    CclTensorSlicer(
+        Shape tensor_shape,
+        Shape dim_slice_factors,
+        // Shape page_shape,
+        std::size_t num_pages,
+        std::size_t elem_size,
+        std::size_t page_size_in_bytes
+    ) :
+        tensor_shape(tensor_shape),
+        dim_slice_factors_per_rank(dim_slice_factors),
+        // page_shape(page_shape),
+        num_pages(num_pages),
+        page_size_in_bytes(page_size_in_bytes),
+        elem_size(elem_size)
+    {
+        TT_ASSERT(tensor_shape.rank() == dim_slice_factors.rank(),
+                  "Tensor shape and dim slice factors must have the same size");
+        TT_ASSERT(std::all_of(dim_slice_factors.begin(), dim_slice_factors.end(), [](uint32_t factor) { return factor > 0; }),
+                  "All factors must be greater than 0");
+        // TT_ASSERT(page_shape.rank() == 2 || page_shape.rank() == tensor_shape.rank(),
+        //           "Page shape must have rank 2 or the same rank as the tensor shape");
+
+        // // TODO(snijjar)
+        // rank_slice_shape
+    }
+
+    std::size_t get_num_pages_per_slice() const {
+        std::size_t n = std::accumulate(dim_slice_factors_per_rank.begin(), dim_slice_factors_per_rank.end(), 1, std::multiplies<uint32_t>());
+        for (uint32_t i = 0; i < (tensor_shape.rank() - dim_slice_factors_per_rank.rank()); ++i) {
+            n *= tensor_shape[i];
+        }
+        return n;
+    }
+
+    Shape const tensor_shape;
+    Shape const dim_slice_factors_per_rank;
+    // Shape const page_shape;
+    std::size_t const num_pages;
+
+    // Shape rank_slice_shape;
+
+    std::size_t const page_size_in_bytes;
+    std::size_t const elem_size;
+};
+
+
+// To be replaced by the CclTensorSlicer class, which should be reusable between sharded and interleaved
+// specs and also provides a simpler interface to reason about
+struct LegacyCclTensorSlicer {
+    LegacyCclTensorSlicer() :
+        input_page_size(0),
+        num_rows(0),
+        num_cols(0),
+        row_offset(0),
+        col_offset(0),
+        num_tiles(0),
+        input_start_page_idx(0),
+        output_addr_offset(0),
+        col_idx(0),
+        row_idx(0),
+        output_page_offset(0),
+        output_start_page_idx(0),
+        output_start_addr_offset(0),
+        row_major(false),
+        slice_dim_is_width(false),
+        is_sharded(false) {}
+
+    LegacyCclTensorSlicer(
+        uint32_t input_page_size,
+        uint32_t num_rows,
+        uint32_t num_cols,
+        uint32_t row_offset,
+        uint32_t col_offset,
+        uint32_t num_tiles,
+        uint32_t input_start_page_idx,
+        uint32_t output_addr_offset,
+        uint32_t col_idx,
+        uint32_t row_idx,
+        uint32_t output_page_offset,
+        uint32_t output_start_page_idx,
+        uint32_t output_start_addr_offset,
+        bool row_major,
+        bool slice_dim_is_width,
+        bool is_sharded) :
+        input_page_size(input_page_size),
+        num_rows(num_rows),
+        num_cols(num_cols),
+        row_offset(row_offset),
+        col_offset(col_offset),
+        num_tiles(num_tiles),
+        input_start_page_idx(input_start_page_idx),
+        output_addr_offset(output_addr_offset),
+        col_idx(col_idx),
+        row_idx(row_idx),
+        output_page_offset(output_page_offset),
+        output_start_page_idx(output_start_page_idx),
+        output_start_addr_offset(output_start_addr_offset),
+        row_major(row_major),
+        slice_dim_is_width(slice_dim_is_width),
+        is_sharded(is_sharded) {}
+
+    virtual void increment(uint32_t num_pages) = 0;
+
+    uint32_t input_page_size;
+    uint32_t num_rows;
+    uint32_t num_cols;
+    uint32_t row_offset;
+    uint32_t col_offset;
+    uint32_t num_tiles;
+    uint32_t input_start_page_idx;
+    uint32_t output_addr_offset;
+    uint32_t col_idx;
+    uint32_t row_idx;
+    uint32_t output_page_offset;
+    uint32_t output_start_page_idx;
+    uint32_t output_start_addr_offset;
+    bool row_major;
+    bool slice_dim_is_width;
+    bool is_sharded;
+};
+
+class InterleavedRingAllGatherTensorSlicer : public LegacyCclTensorSlicer {
+   public:
+    InterleavedRingAllGatherTensorSlicer (
+        Tensor const& input_tensor,
+        Tensor const& output_tensor,
+        int slice_dim,
+        uint32_t slice_idx
+    ) : LegacyCclTensorSlicer() {
+
+        this->row_major = input_tensor.get_layout() == Layout::ROW_MAJOR;
+        this->slice_dim_is_width = input_tensor.get_legacy_shape().rank() - 1 == slice_dim;
+        this->is_sharded = input_tensor.is_sharded();
+
+        int32_t shard_size_in_bytes = is_sharded ?
+            (input_tensor.buffer()->page_size() * input_tensor.buffer()->shard_spec().tensor2d_shape[0] * input_tensor.buffer()->shard_spec().tensor2d_shape[1]) / input_tensor.shard_spec()->num_cores() :
+            -1;
+        this->input_page_size = is_sharded ? shard_size_in_bytes : input_tensor.buffer()->page_size();;
+        if (row_major) {
+            this->num_cols = input_tensor.get_legacy_shape()[-1];
+            auto input_shape = input_tensor.get_legacy_shape();
+            auto output_shape = output_tensor.get_legacy_shape();
+            this->num_rows = std::accumulate(input_shape.begin() + slice_dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>());
+            this->row_offset = std::accumulate(output_shape.begin() + slice_dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) - num_rows;
+        } else {
+            this->num_cols = input_tensor.get_legacy_shape()[-1] / tt::constants::TILE_WIDTH;
+            auto input_shape = input_tensor.get_legacy_shape();
+            auto output_shape = output_tensor.get_legacy_shape();
+            uint32_t num_output_cols = output_tensor.get_legacy_shape()[-1] / tt::constants::TILE_WIDTH;
+            this->num_rows = std::accumulate(input_shape.begin() + slice_dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>()) / tt::constants::TILE_HEIGHT;
+            this->row_offset = (std::accumulate(output_shape.begin() + slice_dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) / tt::constants::TILE_HEIGHT - num_rows) * num_output_cols;
+            this->col_offset = num_output_cols - num_cols;
+            this->num_tiles = num_rows * num_cols;
+        }
+
+        if (row_major) {
+            if (slice_dim_is_width) {
+                this->output_addr_offset = input_page_size;
+            } else {
+                this->output_page_offset = num_rows;
+            }
+        } else {
+            if (slice_dim_is_width) {
+                this->output_page_offset = num_cols;
+            } else {
+                this->output_page_offset = num_tiles;
+            }
+        }
+        this->output_start_page_idx = slice_idx/*ring_index*/ * output_page_offset;
+        this->output_start_addr_offset = slice_idx/*ring_index*/ * output_addr_offset;
+    }
+
+    virtual void increment(uint32_t num_pages) override {
+        // uint32_t pages_per_worker = num_full_chunks_per_worker.at(b) * pages_per_chunk + rem_pages_per_worker.at(b);
+        if (is_sharded) {
+            // nothing to do here - is handled by
+        } else {
+            // Only for interleaved
+            if (num_pages/*pages_per_worker*/ > 0) {
+                if (row_major) {
+                    uint32_t num_rows_shifted = row_idx + num_pages/*pages_per_worker*/;
+                    uint32_t num_blocks_shifted = slice_dim_is_width ? 0 : num_rows_shifted / num_rows;
+                    this->output_start_page_idx += num_pages/*pages_per_worker*/ + num_blocks_shifted * row_offset;
+                    this->row_idx = slice_dim_is_width ? 0 : num_rows_shifted % num_rows;
+                } else {
+                    uint32_t num_cols_shifted = col_idx + num_pages/*pages_per_worker*/;
+                    uint32_t num_rows_shifted = num_cols_shifted / num_cols;
+                    uint32_t num_blocks_shifted = slice_dim_is_width ? 0 : num_rows_shifted / num_rows;
+                    this->output_start_page_idx += num_pages/*pages_per_worker*/ + num_rows_shifted * col_offset + num_blocks_shifted * row_offset;
+                    this->col_idx = num_cols_shifted % num_cols;
+                    this->row_idx = slice_dim_is_width ? 0 : num_rows_shifted % num_rows;
+                }
+            }
+            this->input_start_page_idx += num_pages/*pages_per_worker*/;
+        }
+    }
+};
+
+
+KernelHandle generate_edm_kernel(
+    tt_metal::Program &program,
+    Device const* device,
+    ccl::EriscDatamoverBuilder const& edm_builder,
+    CoreCoord const& eth_core,
+    NOC noc_id);
+
+void generate_edm_kernels_for_ring_or_linear_topology(
+    tt_metal::Program &program,
+    Device const* device,
+    RingTopology const& topology_config,
+    std::vector<ccl::EriscDatamoverBuilder> const& clockwise_edm_builders,
+    std::vector<ccl::EriscDatamoverBuilder> const& counter_clockwise_edm_builders,
+    std::optional<uint32_t> receiver_device_id,
+    std::optional<uint32_t> sender_device_id);
+
+ccl::EriscDatamoverBuilder create_erisc_datamover_builder(
+    std::size_t num_channels,
+    uint32_t page_size,
+    ccl::EriscDataMoverBufferSharingMode buffer_sharing_mode);
 
 } // namespace ccl
+} // namespace tt_metal
+} // namespace tt

--- a/tt_eager/tt_dnn/op_library/ccl/ccl_host_datastructures.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/ccl_host_datastructures.hpp
@@ -1,0 +1,313 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "eth_l1_address_map.h"
+#include "tensor/tensor_impl.hpp"
+#include "tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+
+namespace tt {
+namespace tt_metal {
+namespace ccl {
+
+enum Topology {
+    Ring = 0,
+    Linear = 1,
+    Meash = 2
+};
+
+
+struct EriscDatamoverConfig {
+    static constexpr std::size_t total_l1_buffer_space = eth_l1_mem::address_map::MAX_L1_LOADING_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+    static constexpr std::size_t usable_l1_base_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+
+    static constexpr std::size_t semaphore_size = 4;
+    static constexpr std::size_t handshake_location_size = 16; // ethernet word size
+    static constexpr std::size_t eth_word_size_bytes = 16;
+
+    static uint32_t get_edm_handshake_address() {
+        return usable_l1_base_address;
+    }
+    static uint32_t get_semaphores_base_address(std::size_t num_edm_channels) {
+        return usable_l1_base_address + handshake_location_size;
+    }
+    static uint32_t get_buffers_base_address(std::size_t num_edm_channels) {
+        uint32_t base_address = round_up(get_semaphores_base_address(num_edm_channels) + num_edm_channels * semaphore_size, eth_word_size_bytes);
+        TT_ASSERT(base_address % eth_word_size_bytes == 0);
+        return base_address;
+    }
+    static uint32_t compute_buffer_size(std::size_t num_edm_channels, uint32_t page_size = eth_word_size_bytes) {
+        page_size = std::max<uint32_t>(page_size, eth_word_size_bytes);
+        uint32_t buffer_size = round_down((total_l1_buffer_space - get_buffers_base_address(num_edm_channels)) / (num_edm_channels), page_size);
+        TT_ASSERT(buffer_size > 0 && buffer_size % page_size == 0);
+        return buffer_size;
+    }
+};
+
+
+
+struct CCLOpConfig {
+   public:
+    CCLOpConfig(const std::vector<Tensor>& input_tensors, const std::vector<Tensor>& output_tensors, Topology topology) :
+        input_tensors(&input_tensors),
+        output_tensors(&output_tensors),
+        input_sharded(input_tensors.at(0).is_sharded()),
+        output_sharded(output_tensors.at(0).is_sharded()),
+        page_size(input_tensors.at(0).buffer()->page_size()),
+        input_shard_size_bytes(
+            input_tensors.at(0).is_sharded() ?
+                static_cast<std::optional<uint32_t>>((input_tensors.at(0).buffer()->page_size() * input_tensors.at(0).buffer()->shard_spec().tensor2d_shape[0] * input_tensors.at(0).buffer()->shard_spec().tensor2d_shape[1]) / input_tensors.at(0).shard_spec()->num_cores()) :
+                std::nullopt),
+        output_shard_size_bytes(
+            output_tensors.at(0).is_sharded() ?
+                static_cast<std::optional<uint32_t>>((output_tensors.at(0).buffer()->page_size() * output_tensors.at(0).buffer()->shard_spec().tensor2d_shape[0] * output_tensors.at(0).buffer()->shard_spec().tensor2d_shape[1]) / input_tensors.at(0).shard_spec()->num_cores()) :
+                std::nullopt),
+        shard_grid_size(output_tensors.at(0).is_sharded() ? input_tensors.at(0).shard_spec()->num_cores() : 0),
+        topology(topology)
+    {
+        TT_ASSERT(!this->is_input_sharded() || input_shard_size_bytes.has_value());
+        TT_ASSERT(!this->is_output_sharded() || output_shard_size_bytes.has_value());
+    }
+
+    uint32_t get_input_shard_size_bytes() const {
+        TT_ASSERT(input_shard_size_bytes.has_value());
+        return input_shard_size_bytes.value();
+    }
+    uint32_t get_output_shard_size_bytes() const {
+        TT_ASSERT(output_shard_size_bytes.has_value());
+        return output_shard_size_bytes.value();
+    }
+    uint32_t get_page_size() const {
+        return this->page_size;
+    }
+    Topology get_topology() const {
+        return this->topology;
+    }
+    bool is_input_sharded() const {
+        return this->input_sharded;
+    }
+    bool is_output_sharded() const {
+        return this->output_sharded;
+    }
+    bool get_shard_grid_size() const {
+        return this->shard_grid_size;
+    }
+    Tensor const& get_input_tensor(std::size_t i) const {
+        return input_tensors->at(i);
+    }
+    Tensor const& get_output_tensor(std::size_t i) const {
+        return output_tensors->at(i);
+    }
+
+   private:
+
+
+    std::optional<uint32_t> input_shard_size_bytes; // TODO: split off into CCL op input config ()
+    std::optional<uint32_t> output_shard_size_bytes; // TODO: split off into CCL op input config ()
+    uint32_t page_size;
+    uint32_t shard_grid_size;
+    Topology topology;
+    bool input_sharded;
+    bool output_sharded;
+
+    std::vector<Tensor> const* input_tensors;
+    std::vector<Tensor> const* output_tensors;
+};
+
+class EriscDatamoverBuilder {
+   public:
+    struct ChannelBufferInterface {
+        uint32_t eth_buffer_l1_address;
+        uint32_t eth_semaphore_l1_address;
+    };
+
+    EriscDatamoverBuilder(uint32_t eth_buffer_size, uint32_t handshake_addr, std::vector<uint32_t> const& local_semaphore_addresses, std::vector<uint32_t> const& local_buffer_addresses, ccl::EriscDataMoverBufferSharingMode buffer_sharing_mode) :
+        local_semaphore_addresses(local_semaphore_addresses),
+        local_buffer_addresses(local_buffer_addresses),
+        eth_buffer_size_bytes(eth_buffer_size),
+        handshake_addr(handshake_addr),
+        num_channel_buffers(local_buffer_addresses.size()),
+        buffer_sharing_mode(buffer_sharing_mode),
+        enable_sender(false),
+        enable_receiver(false),
+        num_senders(0),
+        num_receivers(0)
+        {
+            TT_ASSERT(local_buffer_addresses.size() == local_semaphore_addresses.size());
+            active_channels.reserve(num_channel_buffers);
+            TT_ASSERT(eth_buffer_size_bytes < 163000);
+            log_trace(tt::LogOp, "EriscDatamoverBuilder:");
+            for (auto const& addr : local_semaphore_addresses) {
+                log_trace(tt::LogOp, "\tsemaphore_address: {}", addr);
+            }
+            for (auto const& addr : local_buffer_addresses) {
+                log_trace(tt::LogOp, "\tbuffer_address: {}", addr);
+            }
+        }
+
+    // EriscDatamoverBuilder(AllGatherConfig const& all_gather_config, std::vector<uint32_t> const& local_semaphore_addresses, std::vector<uint32_t> const& local_buffer_addresses, ccl::EriscDataMoverBufferSharingMode buffer_sharing_mode) :
+    //     local_semaphore_addresses(local_semaphore_addresses),
+    //     local_buffer_addresses(local_buffer_addresses),
+    //     eth_buffer_size_bytes(all_gather_config.get_eth_buffer_size()),
+    //     handshake_addr(all_gather_config.get_erisc_handshake_address()),
+    //     num_channel_buffers(all_gather_config.get_num_eth_buffers_per_edm()),
+    //     buffer_sharing_mode(buffer_sharing_mode),
+    //     enable_sender(false),
+    //     enable_receiver(false),
+    //     num_senders(0),
+    //     num_receivers(0)
+    //     {
+    //         active_channels.reserve(num_channel_buffers);
+    //         TT_ASSERT(eth_buffer_size_bytes < 163000);
+    //         log_trace(tt::LogOp, "EriscDatamoverBuilder:");
+    //         for (auto const& addr : local_semaphore_addresses) {
+    //             log_trace(tt::LogOp, "\tsemaphore_address: {}", addr);
+    //         }
+    //         for (auto const& addr : local_buffer_addresses) {
+    //             log_trace(tt::LogOp, "\tbuffer_address: {}", addr);
+    //         }
+    //     }
+
+    [[nodiscard]]
+    ChannelBufferInterface add_sender_channel(uint32_t worker_semaphore_address, uint32_t num_eth_messages_to_forward, std::vector<ccl::WorkerXY> const& worker_coords) {
+        this->enable_sender = true;
+        this->num_senders++;
+        auto channel = active_channels.size();
+        active_channels.emplace_back(true, worker_semaphore_address, num_eth_messages_to_forward, channel, worker_coords);
+        log_trace(tt::LogOp, "Adding sender channel:");
+        log_trace(tt::LogOp, "\tworker_semaphore_address: {}", active_channels.back().worker_semaphore_address);
+        log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
+        log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
+        log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
+        log_trace(tt::LogOp, "\tbuffer_address: {}", local_buffer_addresses.at(channel));
+        log_trace(tt::LogOp, "\tsemaphore_address: {}", local_semaphore_addresses.at(channel));
+
+        return ChannelBufferInterface{local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
+    }
+    [[nodiscard]]
+    ChannelBufferInterface add_receiver_channel(uint32_t worker_semaphore_address, uint32_t num_eth_messages_to_forward, std::vector<ccl::WorkerXY> const& worker_coords) {
+        this->enable_receiver = true;
+        this->num_receivers++;
+        auto channel = active_channels.size();
+        active_channels.emplace_back(false, worker_semaphore_address, num_eth_messages_to_forward, channel, worker_coords);
+        log_trace(tt::LogOp, "Adding receiver channel:");
+        log_trace(tt::LogOp, "\tworker_semaphore_address: {}", active_channels.back().worker_semaphore_address);
+        log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
+        log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
+        log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
+        return ChannelBufferInterface{local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
+    }
+
+    [[nodiscard]]
+    std::vector<uint32_t> emit_compile_time_args() const {
+        return std::vector<uint32_t>{
+            static_cast<uint32_t>(this->enable_sender ? 1 : 0),
+            static_cast<uint32_t>(this->enable_receiver ? 1 : 0),
+            this->num_senders,
+            this->num_receivers,
+            this->buffer_sharing_mode};
+    }
+
+    [[nodiscard]]
+    std::vector<uint32_t> emit_runtime_args() const {
+        std::vector<uint32_t> args;
+        uint32_t size = 3 + active_channels.size() * 6;
+        for (auto const& channel : active_channels) {
+            size += channel.worker_coords.size();
+        }
+        args.reserve(size);
+
+        // Handshake address
+        args.push_back(handshake_addr);
+
+        bool senders_below_receivers = active_channels.size() == 0 || this->active_channels.front().is_sender;
+
+        // Sender channel args
+        uint32_t sender_channels_offset = senders_below_receivers ? 0 : this->num_receivers;
+        args.push_back(sender_channels_offset);
+        for (auto const& channel : this->active_channels) {
+            if (!channel.is_sender) {
+                continue;
+            }
+            push_back_channel_args(args, channel);
+        }
+
+        // Receiver channel args
+        uint32_t receiver_channels_offset = senders_below_receivers ? this->num_senders : 0;
+        args.push_back(receiver_channels_offset);
+        for (auto const& channel : this->active_channels) {
+            if (channel.is_sender) {
+                continue;
+            }
+            push_back_channel_args(args, channel);
+        }
+
+        return args;
+    }
+
+    void dump_to_log() const {
+        auto const& rt_args = this->emit_runtime_args();
+        log_trace(tt::LogOp, "EDM RT Args:");
+        for (auto const& arg : rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+    };
+
+    [[nodiscard]]
+    uint32_t get_eth_buffer_size_bytes() const {
+        return this->eth_buffer_size_bytes;
+    }
+
+   private:
+    struct ChannelBufferSpec {
+        ChannelBufferSpec(
+            bool is_sender,
+            uint32_t worker_semaphore_address,
+            uint32_t num_eth_messages_to_forward,
+            uint32_t channel,
+            std::vector<ccl::WorkerXY> const& worker_coords
+        ) :
+            worker_coords(worker_coords),
+            worker_semaphore_address(worker_semaphore_address),
+            num_eth_messages_to_forward(num_eth_messages_to_forward),
+            channel(channel),
+            is_sender(is_sender) {}
+
+        std::vector<ccl::WorkerXY> const worker_coords;
+        uint32_t worker_semaphore_address;
+        uint32_t num_eth_messages_to_forward;
+        uint32_t channel;
+        bool is_sender;
+    };
+
+    void push_back_channel_args (std::vector<uint32_t> &args, ChannelBufferSpec const& channel) const {
+        args.push_back(this->local_buffer_addresses.at(channel.channel));
+        args.push_back(channel.num_eth_messages_to_forward);
+        args.push_back(this->eth_buffer_size_bytes);
+        args.push_back(this->local_semaphore_addresses.at(channel.channel));
+        args.push_back(channel.worker_semaphore_address);
+        args.push_back(channel.worker_coords.size());
+        for (auto const& worker_coord : channel.worker_coords) {
+            args.push_back(worker_coord.to_uint32());
+        }
+    }
+
+    std::vector<ChannelBufferSpec> active_channels;
+    std::vector<uint32_t> const local_semaphore_addresses;
+    std::vector<uint32_t> const local_buffer_addresses;
+    uint32_t eth_buffer_size_bytes;
+    uint32_t handshake_addr;
+    uint32_t const num_channel_buffers;
+    ccl::EriscDataMoverBufferSharingMode const buffer_sharing_mode;
+    uint32_t num_senders;
+    uint32_t num_receivers;
+
+    bool enable_sender;
+    bool enable_receiver;
+};
+
+}; // namespace ccl
+}; // namespace tt_metal
+}; // namespace tt

--- a/tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp
@@ -8,6 +8,7 @@
 #include "dataflow_api.h"
 #include "debug/dprint.h"
 #include "eth_l1_address_map.h"
+#include "tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "tt_eager/tt_dnn/op_library/ccl/edm/erisc_async_datamover.hpp"
 
 // Args Schema:
@@ -42,6 +43,8 @@ FORCE_INLINE void eth_setup_handshake2(std::uint32_t handshake_register_address,
         eth_receiver_channel_done(0);
     }
 }
+
+using tt::tt_metal::ccl::WorkerXY;
 
 template<uint8_t num_senders, uint8_t num_receivers>
 struct sender_receiver_index_t {
@@ -113,8 +116,9 @@ void kernel_main() {
 
     constexpr uint32_t num_senders = get_compile_time_arg_val(2);
     constexpr uint32_t num_receivers = get_compile_time_arg_val(3);
+    constexpr tt::tt_metal::ccl::EriscDataMoverBufferSharingMode edm_buffer_sharing_mode = static_cast<tt::tt_metal::ccl::EriscDataMoverBufferSharingMode>(get_compile_time_arg_val(4));
 
-    std::array<erisc::datamover::ChannelBuffer, eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS> buffer_channels;
+    std::array<erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>, eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS> buffer_channels;
 
     //
     std::array<uint32_t, eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS> printed_receiver_done;
@@ -139,7 +143,7 @@ void kernel_main() {
         const uint32_t sender_num_workers = get_arg_val<uint32_t>(args_offset++);
         const uint32_t workers_xy_list_addr = get_arg_addr(args_offset);
         args_offset += sender_num_workers;
-        new (&buffer_channels[sender_channels_start + channel]) erisc::datamover::ChannelBuffer(
+        new (&buffer_channels[sender_channels_start + channel]) erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>(
             sender_channels_start + channel,
             sender_buffer_address,
             sender_channel_size,
@@ -147,7 +151,7 @@ void kernel_main() {
             sender_num_workers,
             sender_num_messages_to_send,
             (volatile tt_l1_ptr uint32_t *const)sender_semaphores_base_address,
-            (const ccl::WorkerXY *)workers_xy_list_addr,
+            (const WorkerXY *)workers_xy_list_addr,
             true);
         if (sender_num_messages_to_send == 0) {
             num_senders_with_no_work++;
@@ -169,7 +173,7 @@ void kernel_main() {
         uint32_t const receiver_num_workers = get_arg_val<uint32_t>(args_offset++);
         const uint32_t workers_xy_list_addr = get_arg_addr(args_offset);
         args_offset += receiver_num_workers;
-        new (&buffer_channels[receiver_channels_start + channel]) erisc::datamover::ChannelBuffer(
+        new (&buffer_channels[receiver_channels_start + channel]) erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>(
             receiver_channels_start + channel,
             receiver_buffers_base_address,
             receiver_channel_size,
@@ -177,7 +181,7 @@ void kernel_main() {
             receiver_num_workers,
             receiver_num_messages_to_send,
             (volatile tt_l1_ptr uint32_t *const)receiver_semaphores_base_address,
-            (const ccl::WorkerXY *)workers_xy_list_addr,
+            (const WorkerXY *)workers_xy_list_addr,
             false);
 
         if (receiver_num_messages_to_send == 0) {
@@ -211,28 +215,28 @@ void kernel_main() {
         //////////////////////////////////////
         // SENDER
         if constexpr (enable_sender_side) {
-            erisc::datamover::ChannelBuffer &current_sender = buffer_channels[send_recv_index.real_index.sender];
+            erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode> &current_sender = buffer_channels[send_recv_index.real_index.sender];
             switch (current_sender.get_state()) {
-                case erisc::datamover::ChannelBuffer::STATE::WAITING_FOR_WORKER:
+                case erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>::STATE::WAITING_FOR_WORKER:
                 did_something_sender =
                     erisc::datamover::sender_noc_receive_payload_ack_check_sequence(current_sender);
                 break;
 
-                case erisc::datamover::ChannelBuffer::STATE::READY_FOR_ETH_TRANSFER:
+                case erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>::STATE::READY_FOR_ETH_TRANSFER:
                 did_something_sender = erisc::datamover::sender_eth_send_data_sequence(current_sender);
                     break;
 
-                case erisc::datamover::ChannelBuffer::STATE::SIGNALING_WORKER:
+                case erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>::STATE::SIGNALING_WORKER:
                 did_something_sender = erisc::datamover::sender_notify_workers_if_buffer_available_sequence(
                                     current_sender, num_senders_complete);
                 senders_in_progress = senders_in_progress && num_senders_complete != sender_num_channels;
                 break;
 
-                case erisc::datamover::ChannelBuffer::STATE::WAITING_FOR_ETH:
-
+                case erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>::STATE::WAITING_FOR_ETH:
                 did_something_sender =
                     erisc::datamover::sender_eth_check_receiver_ack_sequence(current_sender, num_senders_complete);
                 senders_in_progress = senders_in_progress && num_senders_complete != sender_num_channels;
+                break;
 
                 default:
                 break;
@@ -242,19 +246,19 @@ void kernel_main() {
         //////////////////////////////////////
         // RECEIVER
         if constexpr (enable_receiver_side) {
-            erisc::datamover::ChannelBuffer &current_receiver = buffer_channels[send_recv_index.real_index.receiver];
+            erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode> &current_receiver = buffer_channels[send_recv_index.real_index.receiver];
 
             switch (current_receiver.get_state()) {
-                case erisc::datamover::ChannelBuffer::STATE::WAITING_FOR_ETH:
+                case erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>::STATE::WAITING_FOR_ETH:
                 did_something_receiver = erisc::datamover::receiver_eth_accept_payload_sequence(current_receiver);
                 break;
 
-                case erisc::datamover::ChannelBuffer::STATE::SIGNALING_WORKER:
+                case erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>::STATE::SIGNALING_WORKER:
                 did_something_receiver =
                     erisc::datamover::receiver_eth_notify_workers_payload_available_sequence(current_receiver);
                 break;
 
-                case erisc::datamover::ChannelBuffer::STATE::WAITING_FOR_WORKER:
+                case erisc::datamover::ChannelBuffer<edm_buffer_sharing_mode>::STATE::WAITING_FOR_WORKER:
                 did_something_receiver = erisc::datamover::receiver_noc_read_worker_completion_check_sequence(
                                     current_receiver, num_receivers_complete);
                 receivers_in_progress = receivers_in_progress && num_receivers_complete != receiver_num_channels;
@@ -278,6 +282,5 @@ void kernel_main() {
             }
         }
     }
-
 
 }

--- a/tt_eager/tt_dnn/op_library/ccl/kernel_common/worker_edm_utils.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/kernel_common/worker_edm_utils.hpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "dataflow_api.h"
+#include "debug/assert.h"
+#include "tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+
+using tt::tt_metal::ccl::ShardType;
+using tt::tt_metal::ccl::WorkerXY;
+
+FORCE_INLINE void push_filler_pages_to_cb(const uint32_t& cb_id, uint32_t num_pages) {
+    ASSERT(num_pages < cb_interface[cb_id].fifo_num_pages);
+    cb_reserve_back(cb_id, num_pages);
+    cb_push_back(cb_id, num_pages);
+}
+FORCE_INLINE void pop_filler_pages_from_cb(const uint32_t& cb_id, uint32_t num_pages) {
+    ASSERT(num_pages < cb_interface[cb_id].fifo_num_pages);
+    cb_wait_front(cb_id, num_pages);
+    cb_pop_front(cb_id, num_pages);
+}
+
+
+FORCE_INLINE void fetch_chunk(
+    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_read_addr) {
+    cb_reserve_back(cb_id, num_pages);
+    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    noc_async_read(remote_l1_read_addr, l1_write_addr, page_size * num_pages);
+    noc_async_read_barrier();
+    cb_push_back(cb_id, num_pages);
+}
+FORCE_INLINE void fetch_chunk_sharded(
+    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_read_addr) {
+    cb_reserve_back(cb_id, num_pages);
+    uint32_t l1_write_addr = get_write_ptr(cb_id);
+    noc_async_read(remote_l1_read_addr, l1_write_addr, num_pages * page_size);
+    noc_async_read_barrier();
+    cb_push_back(cb_id, num_pages);
+}
+
+FORCE_INLINE void send_chunk(
+    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr) {
+    cb_wait_front(cb_id, num_pages);
+    uint32_t l1_read_addr = get_read_ptr(cb_id);
+    noc_async_write(l1_read_addr, remote_l1_write_addr, page_size * num_pages);
+    noc_async_write_barrier();
+    cb_pop_front(cb_id, num_pages);
+}
+FORCE_INLINE void send_chunk_sharded(
+    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr, uint64_t eth_l1_sender_semaphore_addr) {
+    cb_wait_front(cb_id, num_pages);
+    uint32_t l1_read_addr = get_read_ptr(cb_id);
+    noc_async_write(l1_read_addr, remote_l1_write_addr, page_size * num_pages);
+    noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
+    noc_async_write_barrier();
+    cb_pop_front(cb_id, num_pages);
+}

--- a/tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -9,8 +9,8 @@
 #include <vector>
 #include <limits>
 
-// #include "tt_dnn/op_library/ccl/ccl_common.hpp"
-
+namespace tt {
+namespace tt_metal {
 namespace ccl {
 
 enum EriscDataMoverBufferSharingMode: uint32_t {
@@ -54,37 +54,231 @@ struct ArchDependentTypes;
 template <>
 struct ArchDependentTypes<true> {
     using workers_list_t = std::vector<ccl::WorkerXY>;
+    static const workers_list_t WORKERS_LIST_UNINITIALIZED_VALUE;
 };
 
 template <>
 struct ArchDependentTypes<false> {
     using workers_list_t = ccl::WorkerXY*;
+    static const workers_list_t WORKERS_LIST_UNINITIALIZED_VALUE;
 };
 
 
 template <bool IS_HOST>
-struct ShardAddrGenArgs final {
-    static constexpr uint32_t UNINITIALIZED_VALUE = std::numeric_limits<uint32_t>::max();
-
-    uint32_t shard_size_in_bytes = UNINITIALIZED_VALUE;
-    uint32_t chunks_per_core_before_advance = UNINITIALIZED_VALUE;
-    uint32_t shards_start_address = UNINITIALIZED_VALUE;
-
-    uint32_t starting_core_index = UNINITIALIZED_VALUE;
-    uint32_t starting_chunk_into_shard = UNINITIALIZED_VALUE;
-
-    uint32_t num_dest_cores = UNINITIALIZED_VALUE;
+struct FullWorkerGridShardAddrGenArgs final {
     typename ArchDependentTypes<IS_HOST>::workers_list_t dest_cores;
+    uint32_t tile_size_in_bytes = UNINITIALIZED_VALUE_U32;
+    uint32_t shards_start_address = UNINITIALIZED_VALUE_U32;
+    uint16_t curr_core_index = UNINITIALIZED_VALUE_U16;
+    uint16_t total_num_cores = UNINITIALIZED_VALUE_U16;
+    uint16_t curr_shard_tile_x = UNINITIALIZED_VALUE_U16;
+    uint16_t curr_shard_tile_y = UNINITIALIZED_VALUE_U16;
+    uint16_t curr_tile_index = UNINITIALIZED_VALUE_U16;
+    uint16_t curr_shard = UNINITIALIZED_VALUE_U16;
+    uint16_t input_shard_num_tiles_x = UNINITIALIZED_VALUE_U16;
+    uint16_t input_shard_num_tiles_y = UNINITIALIZED_VALUE_U16;
+    uint16_t total_shards_x = UNINITIALIZED_VALUE_U16;
     bool is_clockwise = false;
 
-    uint32_t get_expected_num_args() const {
+    inline uint32_t get_expected_num_args() const {
         if constexpr (IS_HOST) {
-            return 7 + dest_cores.size();
+            return 12 + this->total_num_cores;
         } else {
-            return 7 + this->num_dest_cores;
+            return 12 + this->total_num_cores;
         }
     }
 };
 
+template <bool IS_HOST>
+struct ShardAddrGenArgs final {
+
+    uint32_t shards_start_address = UNINITIALIZED_VALUE_U32;
+    uint32_t shard_size_in_bytes = UNINITIALIZED_VALUE_U32;
+    uint16_t total_chunks_per_core = UNINITIALIZED_VALUE_U16;
+
+    uint16_t starting_core_index = UNINITIALIZED_VALUE_U16;
+    uint16_t starting_chunk_into_shard = UNINITIALIZED_VALUE_U16;
+
+    uint16_t intra_core_stride_in_shards = UNINITIALIZED_VALUE_U16;
+    uint16_t contiguous_chunks_before_stride = UNINITIALIZED_VALUE_U16;
+
+    uint16_t num_dest_cores = UNINITIALIZED_VALUE_U16;
+
+    typename ArchDependentTypes<IS_HOST>::workers_list_t dest_cores;
+    bool is_clockwise = false;
+
+    inline uint32_t get_expected_num_args() const {
+        if constexpr (IS_HOST) {
+            return 9 + dest_cores.size();
+        } else {
+            return 9 + this->num_dest_cores;
+        }
+    }
+};
+
+// uint16_t &curr_shard_tile_x,
+// uint16_t &curr_shard_tile_y,
+// uint16_t &curr_tile_index,
+// uint16_t &curr_shard,
+// uint16_t const input_shard_num_tiles_x,
+// uint16_t const input_shard_num_tiles_y,
+// uint16_t const total_shards_x,
+// bool is_clockwise) {
+
+namespace all_gather {
+inline void addr_gen_advance_width_sharded(
+    // uint16_t& curr_core_chunk_index,
+    // uint16_t& curr_worker_index,
+    // uint16_t& contiguous_chunk_count,
+    // // uint16_t& current_core_chunks_visited,
+    // const uint16_t& total_chunks_per_core,
+    // const uint16_t& num_dest_cores,
+    // const uint16_t& intra_core_stride_in_shards,
+    // const uint16_t& contiguous_chunks_before_stride,
+    // bool is_clockwise
+    uint16_t& curr_core_tile_index,
+    uint16_t& curr_worker_index,
+    uint16_t& contiguous_tile_count,
+    // uint16_t& current_core_chunks_visited,
+    const uint16_t& total_chunks_per_core,
+    const uint16_t& num_dest_cores,
+    const uint16_t& intra_core_stride_in_shards,
+    const uint16_t& contiguous_chunks_before_stride,
+    bool is_clockwise
+) {
+    if (is_clockwise) {
+        bool do_stride = contiguous_tile_count == contiguous_chunks_before_stride;
+        bool stride_induced_chunk_wraparound = (do_stride && curr_core_tile_index < (intra_core_stride_in_shards + contiguous_chunks_before_stride - 1));
+        bool do_chunk_wrap = curr_core_tile_index >= total_chunks_per_core || stride_induced_chunk_wraparound;
+
+        // current_core_chunks_visited++;
+        if (do_chunk_wrap) {
+            bool do_core_wrap = curr_worker_index == 0;
+            uint32_t past_end_index = (total_chunks_per_core + curr_core_tile_index + 1 - contiguous_chunks_before_stride);
+            uint32_t backward_step_amount = (intra_core_stride_in_shards + contiguous_chunks_before_stride - 1);
+            // ASSERT(past_end_index >= backward_step_amount);
+            curr_core_tile_index = past_end_index - backward_step_amount;
+            // curr_core_tile_index = (total_chunks_per_core + curr_core_tile_index - contiguous_chunks_before_stride) - (intra_core_stride_in_shards + contiguous_chunks_before_stride);
+            contiguous_tile_count = 1;
+            if (do_core_wrap) {
+                curr_worker_index = num_dest_cores - 1;
+                // current_core_chunks_visited=0;
+            } else {
+                curr_worker_index--;
+            }
+        } else {
+
+            if (do_stride) {
+                contiguous_tile_count = 1;
+                curr_core_tile_index -= (intra_core_stride_in_shards + contiguous_chunks_before_stride - 1);
+            } else {
+                contiguous_tile_count++;
+                curr_core_tile_index++;
+            }
+        }
+
+    } else {
+        // current_core_chunks_visited++;
+        if (contiguous_tile_count == contiguous_chunks_before_stride) {
+            contiguous_tile_count = 1;
+            // TT_ASSERT(curr_core_chunk_index >= intra_core_stride_in_shards);
+            curr_core_tile_index += intra_core_stride_in_shards;
+        } else {
+            contiguous_tile_count++;
+            curr_core_tile_index++;
+        }
+
+        bool do_chunk_wrap = curr_core_tile_index >= total_chunks_per_core;
+        if (do_chunk_wrap) {
+            // current_core_chunks_visited = 0;
+            curr_core_tile_index = curr_core_tile_index - total_chunks_per_core;
+            curr_worker_index++;
+            bool do_core_wrap = curr_worker_index == num_dest_cores;
+            if (do_core_wrap) {
+                curr_worker_index = 0;
+            }
+        }
+    }
+}
+
+inline void full_worker_grid_addr_gen_width_sharded_advance_shard_impl(
+    uint16_t &curr_shard_tile_x,
+    uint16_t &curr_shard_tile_y,
+    uint16_t &curr_tile_index,
+    uint16_t &curr_core_index,
+    uint16_t const total_num_cores,
+    uint16_t const input_shard_num_tiles_x,
+    uint16_t const total_shards_x,
+    uint16_t const shard_offset,
+    bool is_clockwise
+) {
+    bool wrap_around = is_clockwise ? curr_core_index == 0 : curr_core_index == total_num_cores - 1;
+    curr_core_index = wrap_around ?
+        (is_clockwise ? total_num_cores - 1 : 0) :
+        (is_clockwise ? curr_core_index - 1 : curr_core_index + 1);
+    curr_tile_index = input_shard_num_tiles_x * shard_offset;
+    curr_shard_tile_x = 0;
+    curr_shard_tile_y = 0;
+}
+
+// TODO: support cases where the full shard is contiguous (e.g. height sharded)
+inline void full_worker_grid_addr_gen_width_sharded_advance_full_tile_row(
+    uint16_t &curr_shard_tile_x,
+    uint16_t &curr_shard_tile_y,
+    uint16_t &curr_tile_index,
+    uint16_t &curr_core_index,
+    uint16_t const total_num_cores,
+    uint16_t const input_shard_num_tiles_x,
+    uint16_t const input_shard_num_tiles_y,
+    uint16_t const total_shards_x,
+    uint16_t const shard_offset,
+    bool is_clockwise) {
+
+    // Keep it verbose for now. we can reduce to a flat index later
+    bool is_last_row = curr_shard_tile_y == input_shard_num_tiles_y - 1;
+    if (is_last_row) {
+        full_worker_grid_addr_gen_width_sharded_advance_shard_impl(
+            curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, total_shards_x, shard_offset, is_clockwise);
+
+    } else {
+        curr_tile_index += total_shards_x * input_shard_num_tiles_x - curr_shard_tile_x;
+        curr_shard_tile_x = 0;
+        curr_shard_tile_y++;
+    }
+}
+
+inline void full_worker_grid_addr_gen_width_sharded_advance (
+    uint16_t &curr_shard_tile_x,
+    uint16_t &curr_shard_tile_y,
+    uint16_t &curr_tile_index,
+    uint16_t &curr_core_index,
+    uint16_t const total_num_cores,
+    uint16_t const input_shard_num_tiles_x,
+    uint16_t const input_shard_num_tiles_y,
+    uint16_t const total_shards_x,
+    uint16_t const shard_offset,
+    bool is_clockwise) {
+
+    // Keep it verbose for now. we can reduce to a flat index later
+    bool last_tile_in_row = curr_shard_tile_x == input_shard_num_tiles_x - 1;
+    bool last_tile_in_col = curr_shard_tile_y == input_shard_num_tiles_y - 1;
+    if (last_tile_in_row && last_tile_in_col) {
+        full_worker_grid_addr_gen_width_sharded_advance_shard_impl(
+            curr_shard_tile_x, curr_shard_tile_y, curr_tile_index, curr_core_index, total_num_cores, input_shard_num_tiles_x, total_shards_x, shard_offset, is_clockwise);
+
+    } else if (last_tile_in_row) {
+        curr_tile_index += total_shards_x * input_shard_num_tiles_x - curr_shard_tile_x;
+        curr_shard_tile_x = 0;
+        curr_shard_tile_y++;
+    } else {
+        curr_shard_tile_x++;
+        curr_tile_index++;
+    }
+}
+
+
+}; // namespace all_gather
 
 }  // namespace ccl
+}  // namespace tt_metal
+}  // namespace tt


### PR DESCRIPTION
Now that FD2 has dropped, and with it a lot of stability improvements, I'm going through my backlog of CCL changes and starting to merge them into main.

Unfortunately, due to the backlog, some of my changes ended up being intertwined and weren't easily  separable. For that reason, reason this PR needed to include some substantial refactor work in preparation for the reduce scatter op. Those refactors are included alongside some sharded allgather optimizations and bug fixes.

At this point, the sharded allgather supports single-tile-high shards only. Multi-tile-high sharded support are coming in a future change.

@tt-rkim - FYI adding myself as codeowner for new CCL directory
@tt-aho - just FYI and to get another set of eyes