### PR TITLE
#0: Refactor unpad tile to modify rt args in place and remove dynamic…

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -11,6 +11,10 @@ Runtime Arguments
 
 .. doxygenfunction:: UpdateRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const CoreCoord &core_coord, std::vector<uint32_t> &update_idx, std::shared_ptr<RuntimeArgs> runtime_args)
 
-.. doxygenfunction:: GetRuntimeArgs
+.. doxygenfunction:: GetRuntimeArgs(const Program &program, KernelHandle kernel_id, const CoreCoord &logical_core)
+
+.. doxygenfunction:: GetRuntimeArgs(const Program &program, KernelHandle kernel_id)
 
 .. doxygenfunction:: SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args)
+
+.. doxygenfunction:: GetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_unpad.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_unpad.py
@@ -45,9 +45,6 @@ params += [
 
 @pytest.mark.parametrize("input_shapes, unpad_args", params)
 def test_run_unpad_test(input_shapes, unpad_args, device):
-    if is_wormhole_b0():
-        if input_shapes == [[5, 5, 64, 96]]:
-            pytest.skip("skip this shape for Wormhole B0")
     datagen_func = [
         generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
     ]

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_HostAsyncCQ.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_HostAsyncCQ.cpp
@@ -372,7 +372,7 @@ TEST_F(CommandQueueFixture, TestAsyncCBAllocation) {
     CircularBufferConfig config1 = CircularBufferConfig(page_size, {{buffer_indices[0], data_format}, {buffer_indices[1], data_format}}, *l1_buffer)
         .set_page_size(buffer_indices[0], page_size)
         .set_page_size(buffer_indices[1], page_size);
-    // Asyncrhonously assign the L1 Buffer to the CB
+    // Asynchronously assign the L1 Buffer to the CB
     auto multi_core_cb = CreateCircularBuffer(program, cr_set, config1);
     auto cb_ptr = detail::GetCircularBuffer(program, multi_core_cb);
     Finish(this->device_->command_queue());
@@ -407,7 +407,7 @@ TEST_F(CommandQueueFixture, TestAsyncAssertForDeprecatedAPI) {
         SetRuntimeArgs(program, dummy_kernel, core, runtime_args);
     }
     catch (std::runtime_error &e) {
-        std::string expected = "This variant of SetRuntimeArgs can only be called when Asyncrhonous SW Command Queues are disabled for Fast Dispatch.";
+        std::string expected = "This variant of SetRuntimeArgs can only be called when Asynchronous SW Command Queues are disabled for Fast Dispatch.";
         const string error = string(e.what());
         EXPECT_TRUE(error.find(expected) != std::string::npos);
     }

--- a/tt_eager/tt_dnn/op_library/unpad/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/unpad/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id.cpp
@@ -7,21 +7,22 @@
 
 void kernel_main() {
 
-    const uint32_t src_addr                 = get_arg_val<uint32_t>(0);
-    const uint32_t num_dims                 = get_arg_val<uint32_t>(1);
-    const uint32_t start_id                 = get_arg_val<uint32_t>(2);
-    const uint32_t num_tiles                = get_arg_val<uint32_t>(3);
+    constexpr uint32_t cb_id_in0            =  get_compile_time_arg_val(0);
+    constexpr uint32_t num_dims             =  get_compile_time_arg_val(1);
+    const uint32_t src_addr                 = get_common_arg_val<uint32_t>(0);
 
-    volatile tt_l1_ptr uint32_t * num_unpadded_tiles = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(4));
+    volatile tt_l1_ptr uint32_t * num_unpadded_tiles = (volatile tt_l1_ptr uint32_t*)(get_common_arg_addr(1));
     volatile tt_l1_ptr uint32_t * num_padded_tiles = num_unpadded_tiles + num_dims;
-    volatile tt_l1_ptr uint32_t * id_per_dim = num_padded_tiles + num_dims;
 
-    constexpr uint32_t cb_id_in0 = 0;
+    const uint32_t start_id                 = get_arg_val<uint32_t>(0);
+    const uint32_t num_tiles                = get_arg_val<uint32_t>(1);
 
-    const uint32_t tile_size = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
+    volatile tt_l1_ptr uint32_t * id_per_dim = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(2));
 
-    constexpr bool src0_is_dram                           = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t tile_size = get_tile_size(cb_id_in0);
+    constexpr DataFormat data_format = get_dataformat(cb_id_in0);
+
+    constexpr bool src0_is_dram                           = get_compile_time_arg_val(2) == 1;
     // In and out are assumed to be same dataformat
     const InterleavedAddrGenFast<src0_is_dram> s0 = {
         .bank_base_address = src_addr,
@@ -31,7 +32,7 @@ void kernel_main() {
 
     uint32_t src_tile_id = start_id;
 
-    for(uint32_t i = 0; i < num_tiles; i++) {
+    for(uint32_t i = 0; i < num_tiles; ++i) {
         // Copy Input
         cb_reserve_back(cb_id_in0, 1);
         uint32_t src_buffer_l1_addr = get_write_ptr(cb_id_in0);
@@ -39,7 +40,7 @@ void kernel_main() {
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, 1);
         src_tile_id++;
-        for(uint32_t j = 0; j < num_dims; j++) {
+        for(uint32_t j = 0; j < num_dims; ++j) {
             id_per_dim[j]++;
             if (id_per_dim[j] == num_unpadded_tiles[j]) {
                 id_per_dim[j] = 0;

--- a/tt_eager/tt_dnn/op_library/unpad/multi_core/unpad_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/unpad/multi_core/unpad_op_multi_core.cpp
@@ -2,14 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_dnn/op_library/unpad/unpad_op.hpp"
+#include "optional"
 #include "tt_dnn/op_library/math.hpp"
+#include "tt_dnn/op_library/unpad/unpad_op.hpp"
 #include "tt_dnn/op_library/work_split.hpp"
-
-#include "tt_metal/host_api.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
-#include "optional"
+#include "tt_metal/host_api.hpp"
 
 using namespace tt::constants;
 
@@ -17,21 +16,18 @@ namespace tt {
 
 namespace tt_metal {
 
-
-std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_unpad_runtime_args_rm(
-                                                                                const Tensor &input_tensor,
-                                                                                Tensor& output_tensor,
-                                                                                const Shape &output_tensor_start,
-                                                                                uint32_t num_cores_total,
-                                                                                uint32_t num_cores,
-                                                                                uint32_t num_cores_y,
-                                                                                CoreRangeSet core_group_1,
-                                                                                CoreRangeSet core_group_2,
-                                                                                uint32_t num_sticks_per_core_group_1,
-                                                                                uint32_t num_sticks_per_core_group_2
-                                                                                ){
-
-    tt_metal::Device *device = input_tensor.device();
+inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_unpad_runtime_args_rm(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const Shape& output_tensor_start,
+    uint32_t num_cores_total,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    CoreRangeSet core_group_1,
+    CoreRangeSet core_group_2,
+    uint32_t num_sticks_per_core_group_1,
+    uint32_t num_sticks_per_core_group_2) {
+    tt_metal::Device* device = input_tensor.device();
 
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
@@ -54,7 +50,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_unpad
     num_padded_sticks_per_dim[0] = 0;
     accumulated_total_per_dim[0] = 1;
 
-    for(int32_t i = 1; i < num_dims; i++) {
+    for (int32_t i = 1; i < num_dims; i++) {
         uint32_t num_unpadded_dim = output_shape[-(i + 1)];
         uint32_t num_total_dim = input_shape[-(i + 1)];
         uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
@@ -69,16 +65,16 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_unpad
         unpadded_row_size_bytes,
         num_dims,
         0,
-        0
-    };
-    common_reader_kernel_args.insert(common_reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
-    common_reader_kernel_args.insert(common_reader_kernel_args.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
+        0};
+    common_reader_kernel_args.insert(
+        common_reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
+    common_reader_kernel_args.insert(
+        common_reader_kernel_args.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
 
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > ret_val (num_cores_total);
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_total);
 
     uint32_t start_offset = get_rm_start_offset(input_tensor, output_tensor_start);
-    for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_total; i++){
-
+    for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_sticks_per_core;
         if (core_group_1.core_coord_in_core_ranges(core)) {
@@ -86,7 +82,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_unpad
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
             num_sticks_per_core = num_sticks_per_core_group_2;
         } else {
-            //no-op
+            // no-op
             num_sticks_per_core = 0;
         }
 
@@ -94,42 +90,35 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_unpad
         uint32_t unpadded_written = num_sticks_written / num_unpadded_sticks_per_dim[0];
         uint32_t start_id = id_per_dim[0] + start_offset;
 
-        for(uint32_t j = 1; j < num_dims; j++) {
+        for (uint32_t j = 1; j < num_dims; j++) {
             id_per_dim[j] = unpadded_written % num_unpadded_sticks_per_dim[j];
             unpadded_written = unpadded_written / num_unpadded_sticks_per_dim[j];
             start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
         }
         vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
         //
-        uint32_t addr_offset = 4; //input buffer addr, padded_row_size_bytes, unpadded_row_size_bytes, num_dims
+        uint32_t addr_offset = 4;  // input buffer addr, padded_row_size_bytes, unpadded_row_size_bytes, num_dims
         reader_kernel_args[addr_offset++] = start_id;
         reader_kernel_args[addr_offset] = num_sticks_per_core;
         reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
 
         vector<uint32_t> writer_kernel_args = {
-            output_buffer->address(),
-            unpadded_row_size_bytes,
-            num_sticks_per_core,
-            num_sticks_written,
-            0
-        };
-        num_sticks_written+=num_sticks_per_core;
+            output_buffer->address(), unpadded_row_size_bytes, num_sticks_per_core, num_sticks_written, 0};
+        num_sticks_written += num_sticks_per_core;
         ret_val[i] = {reader_kernel_args, writer_kernel_args};
     }
 
     return ret_val;
 }
 
-
-
-operation::ProgramWithCallbacks unpad_rm_multi_core(const Tensor &a, Tensor& output, const Shape &output_tensor_start, const Shape &output_tensor_end) {
-
+operation::ProgramWithCallbacks unpad_rm_multi_core(
+    const Tensor& a, Tensor& output, const Shape& output_tensor_start, const Shape& output_tensor_end) {
     const Shape output_shape = output.get_legacy_shape();
 
     tt_metal::Program program = tt_metal::CreateProgram();
 
     // This should allocate a DRAM buffer on the device
-    tt_metal::Device *device = a.device();
+    tt_metal::Device* device = a.device();
 
     uint32_t num_unpadded_sticks = output.volume() / output.get_legacy_shape()[-1];
 
@@ -137,18 +126,19 @@ operation::ProgramWithCallbacks unpad_rm_multi_core(const Tensor &a, Tensor& out
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
-    CoreRange total_cores({0, 0}, {num_cores_x-1, num_cores_y-1});
-    uint32_t num_cores_total = num_cores_x*num_cores_y;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
 
-    tt_metal::Buffer *src0_buffer = a.buffer();
+    tt_metal::Buffer* src0_buffer = a.buffer();
 
     tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
     uint32_t padded_row_size_bytes = a.get_legacy_shape()[-1] * a.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * a.element_size();
 
-    tt_metal::Buffer *dst_buffer = output.buffer();
+    tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t src_stick_size = padded_row_size_bytes;
@@ -158,22 +148,16 @@ operation::ProgramWithCallbacks unpad_rm_multi_core(const Tensor &a, Tensor& out
     uint32_t num_input_pages = 2;
 
     uint32_t cb_page_size = round_up(unpadded_row_size_bytes, TILE_WIDTH);
-    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(num_input_pages * cb_page_size, {{src0_cb_index, cb_data_format}})
-		.set_page_size(src0_cb_index, cb_page_size);
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(num_input_pages * cb_page_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, cb_page_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
 
-
     bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
-    std::vector<uint32_t> reader_compile_time_args_vec = {
-        (std::uint32_t) src0_is_dram
-    };
+    std::vector<uint32_t> reader_compile_time_args_vec = {(std::uint32_t)src0_is_dram};
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
 
-
-    std::vector<uint32_t> writer_compile_time_args_vec = {
-        (std::uint32_t) src0_cb_index,
-        (std::uint32_t) dst_is_dram
-    };
+    std::vector<uint32_t> writer_compile_time_args_vec = {(std::uint32_t)src0_cb_index, (std::uint32_t)dst_is_dram};
 
     tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
         program,
@@ -187,96 +171,94 @@ operation::ProgramWithCallbacks unpad_rm_multi_core(const Tensor &a, Tensor& out
         total_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args_vec));
 
-    auto all_runtime_args = get_unpad_runtime_args_rm(a, output, output_tensor_start,
-                                                    num_cores_total, num_cores, num_cores_y, core_group_1, core_group_2,
-                                                    num_sticks_per_core_group_1, num_sticks_per_core_group_2);
+    auto all_runtime_args = get_unpad_runtime_args_rm(
+        a,
+        output,
+        output_tensor_start,
+        num_cores_total,
+        num_cores,
+        num_cores_y,
+        core_group_1,
+        core_group_2,
+        num_sticks_per_core_group_1,
+        num_sticks_per_core_group_2);
 
-    for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_total; i++){
+    for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        tt_metal::SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
-            core,
-            all_runtime_args[i].first
-        );
+        tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
 
-        tt_metal::SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
-            core,
-            all_runtime_args[i].second
-        );
+        tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
     }
 
-    auto override_runtime_args_callback = [
-            unary_reader_kernel_id,
-            unary_writer_kernel_id,
-            compute_with_storage_grid_size
-        ]
-    (
-        const void* operation,
-        const Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>&,
-        const std::vector<Tensor>& output_tensors
-    ) {
-        auto src_tensor = input_tensors.at(0);
-        auto dst_tensor = output_tensors.at(0);
-        uint32_t num_cores_x = compute_with_storage_grid_size.x;
-        uint32_t num_cores_y = compute_with_storage_grid_size.y;
-        uint32_t num_cores_total = num_cores_x*num_cores_y;
-        uint32_t num_unpadded_sticks = dst_tensor.volume() / dst_tensor.get_legacy_shape()[-1];
-        auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+    auto override_runtime_args_callback =
+        [unary_reader_kernel_id, unary_writer_kernel_id, compute_with_storage_grid_size](
+            const void* operation,
+            const Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<Tensor>& output_tensors) {
+            auto src_tensor = input_tensors.at(0);
+            auto dst_tensor = output_tensors.at(0);
+            uint32_t num_cores_x = compute_with_storage_grid_size.x;
+            uint32_t num_cores_y = compute_with_storage_grid_size.y;
+            uint32_t num_cores_total = num_cores_x * num_cores_y;
+            uint32_t num_unpadded_sticks = dst_tensor.volume() / dst_tensor.get_legacy_shape()[-1];
+            auto
+                [num_cores,
+                 all_cores,
+                 core_group_1,
+                 core_group_2,
+                 num_sticks_per_core_group_1,
+                 num_sticks_per_core_group_2] =
+                    split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
 
-        const auto tensor_start = static_cast<const Unpad*>(operation)->output_tensor_start;
-        auto all_runtime_args = get_unpad_runtime_args_rm(src_tensor, dst_tensor, tensor_start,
-                                             num_cores_total, num_cores, num_cores_y, core_group_1, core_group_2,
-                                             num_sticks_per_core_group_1, num_sticks_per_core_group_2);
+            const auto tensor_start = static_cast<const Unpad*>(operation)->output_tensor_start;
+            auto all_runtime_args = get_unpad_runtime_args_rm(
+                src_tensor,
+                dst_tensor,
+                tensor_start,
+                num_cores_total,
+                num_cores,
+                num_cores_y,
+                core_group_1,
+                core_group_2,
+                num_sticks_per_core_group_1,
+                num_sticks_per_core_group_2);
 
+            for (uint32_t i = 0, num_tiles_written = 0; i < num_cores_total; i++) {
+                CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
-        for (uint32_t i = 0, num_tiles_written = 0; i < num_cores_total; i++){
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+                { SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first); }
 
-            {
-                SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
+                { SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second); }
             }
+        };
 
-            {
-                SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
-            }
-        }
-    };
-
-    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_args_callback};
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
-
-// Each element of outer vector corresponds to a core
-// Each core has a pair of std::vector<uint32_t>
-// First of pair is reader args
-// Second of pair is writer args
-std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_unpad_runtime_args_tile(const Tensor &input_tensor,
-                                                                                Tensor& output_tensor,
-                                                                                const Shape &output_tensor_start,
-                                                                                uint32_t num_cores_total,
-                                                                                uint32_t num_cores,
-                                                                                uint32_t num_cores_y,
-                                                                                CoreRangeSet core_group_1,
-                                                                                CoreRangeSet core_group_2,
-                                                                                uint32_t num_tiles_per_core_group_1,
-                                                                                uint32_t num_tiles_per_core_group_2
-                                                                                ){
-    auto input_buffer = input_tensor.buffer();
-    auto output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
+template <bool initialize_args>
+inline __attribute__((always_inline)) void set_unpad_runtime_args_tile(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const Shape& output_tensor_start,
+    const uint32_t& num_cores_total,
+    const uint32_t& num_cores,
+    const std::vector<CoreCoord>& cores,
+    const uint32_t& num_cores_group_1,
+    const uint32_t& num_cores_group_2,
+    const uint32_t& num_tiles_per_core_group_1,
+    const uint32_t& num_tiles_per_core_group_2,
+    const Program& program,
+    const tt_metal::KernelHandle& unary_reader_kernel_id,
+    const tt_metal::KernelHandle& unary_writer_kernel_id,
+    std::vector<uint32_t>& accumulated_total_per_dim) {
+    const auto input_buffer = input_tensor.buffer();
+    const auto output_buffer = output_tensor.buffer();
+    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& output_shape = output_tensor.get_legacy_shape();
 
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
-    std::vector<uint32_t> num_unpadded_tiles_per_dim(num_dims);
-    std::vector<uint32_t> num_padded_tiles_per_dim(num_dims);
-    std::vector<uint32_t> id_per_dim(num_dims);
-
-    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
 
     uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
     uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
@@ -285,97 +267,145 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_unpad
     uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
     uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
 
-    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
-    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
-    num_padded_tiles_per_dim[0] = num_padded_Xt;
-    num_padded_tiles_per_dim[1] = num_padded_Yt;
-    accumulated_total_per_dim[0] = num_total_Xt;
-    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
-
-    for(int32_t i = 2; i < num_dims; i++) {
-        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
-        uint32_t num_total_dim = input_shape[-(i + 1)];
-        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
-        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
-        num_padded_tiles_per_dim[i] = num_padded_dim;
-        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
-    }
-
-
-    vector<uint32_t> common_reader_kernel_args = {
-        input_buffer->address(),
-        num_dims,
-        0, 0
+    const auto set_common_reader_args = [&](
+        std::vector<uint32_t> & reader_common_args,
+        uint32_t * num_unpadded_tiles_per_dim,
+        uint32_t * num_padded_tiles_per_dim) __attribute__((always_inline)) {
+        reader_common_args[0] = input_buffer->address();
+        num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+        num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+        num_padded_tiles_per_dim[0] = num_padded_Xt;
+        num_padded_tiles_per_dim[1] = num_padded_Yt;
+        accumulated_total_per_dim[0] = num_total_Xt;
+        accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+        for (int32_t i = 2; i < num_dims; ++i) {
+            uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+            uint32_t num_total_dim = input_shape[-(i + 1)];
+            uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+            num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+            num_padded_tiles_per_dim[i] = num_padded_dim;
+            accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+        }
     };
-    common_reader_kernel_args.insert(common_reader_kernel_args.end(), num_unpadded_tiles_per_dim.begin(), num_unpadded_tiles_per_dim.end());
-    common_reader_kernel_args.insert(common_reader_kernel_args.end(), num_padded_tiles_per_dim.begin(), num_padded_tiles_per_dim.end());
 
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > ret_val (num_cores_total);
+    const auto set_reader_rt_args = [&](
+        std::vector<uint32_t> & reader_rt_args,
+        const uint32_t* num_unpadded_tiles_per_dim,
+        const uint32_t* num_padded_tiles_per_dim,
+        const uint32_t& num_tiles_per_core,
+        const uint32_t& start_offset,
+        const uint32_t& num_tiles_written) __attribute__((always_inline)) {
+        reader_rt_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = reader_rt_args[2] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            reader_rt_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += reader_rt_args[2 + j] * accumulated_total_per_dim[j - 1];
+        }
+        reader_rt_args[0] = start_id;
+        reader_rt_args[1] = num_tiles_per_core;
+    };
+
+    if constexpr (initialize_args) {
+        std::vector<uint32_t> reader_common_args(1 + num_dims * 2);
+        uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
+        uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+        set_common_reader_args(reader_common_args, num_unpadded_tiles_per_dim, num_padded_tiles_per_dim);
+        SetCommonRuntimeArgs(program, unary_reader_kernel_id, reader_common_args);
+    }
+    auto& reader_common_args = GetCommonRuntimeArgs(program, unary_reader_kernel_id);
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
+    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+    if constexpr (!initialize_args) {
+        set_common_reader_args(reader_common_args, num_unpadded_tiles_per_dim, num_padded_tiles_per_dim);
+    }
 
     uint32_t start_offset = get_tiled_start_offset(input_tensor, output_tensor_start);
 
-    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores_total; i++){
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+    auto& reader_kernel_args_by_core = GetRuntimeArgs(program, unary_reader_kernel_id);
+    auto& writer_kernel_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
+    const uint32_t num_used_cores = num_cores_group_1 + num_cores_group_2;
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores_total; ++i) {
+        const CoreCoord& core = cores[i];
         uint32_t num_tiles_per_core;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
+        if (i < num_cores_group_1) {
             num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+        } else if (i < num_used_cores) {
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
-            //no-op
-            num_tiles_per_core = 0;
+            // no-op
+            if constexpr (initialize_args) {
+                std::vector<uint32_t> reader_kernel_args(2 + num_dims, 0);
+                std::vector<uint32_t> writer_kernel_args(3, 0);
+                tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_kernel_args);
+                tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_kernel_args);
+            } else {
+                auto& reader_kernel_args = reader_kernel_args_by_core[core.x][core.y];
+                reader_kernel_args[1] = 0;
+                auto& writer_kernel_args = writer_kernel_args_by_core[core.x][core.y];
+                writer_kernel_args[1] = 0;
+            }
+            continue;
         }
 
-        id_per_dim[0] = num_tiles_written % num_unpadded_tiles_per_dim[0];
-        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
-        uint32_t start_id = id_per_dim[0] + start_offset;
-
-        for(uint32_t j = 1; j < num_dims; j++) {
-            id_per_dim[j] = unpadded_written % num_unpadded_tiles_per_dim[j];
-            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
-            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        if constexpr (initialize_args) {
+            std::vector<uint32_t> reader_kernel_args(2 + num_dims);
+            set_reader_rt_args(
+                reader_kernel_args,
+                num_unpadded_tiles_per_dim,
+                num_padded_tiles_per_dim,
+                num_tiles_per_core,
+                start_offset,
+                num_tiles_written);
+            SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_kernel_args);
+        } else {
+            auto& reader_kernel_args = reader_kernel_args_by_core[core.x][core.y];
+            set_reader_rt_args(
+                reader_kernel_args,
+                num_unpadded_tiles_per_dim,
+                num_padded_tiles_per_dim,
+                num_tiles_per_core,
+                start_offset,
+                num_tiles_written);
         }
-        vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
-        uint32_t addr_offset = 2; //input buffer addr, num_dims
-        reader_kernel_args[addr_offset++] = start_id;
-        reader_kernel_args[addr_offset] = num_tiles_per_core;
-        reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
 
-        vector<uint32_t> writer_kernel_args = {
-            output_buffer->address(),
-            num_tiles_per_core,
-            num_tiles_written,
-            0
-        };
-        num_tiles_written+=num_tiles_per_core;
-        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+        if constexpr (initialize_args) {
+            vector<uint32_t> writer_kernel_args = {output_buffer->address(), num_tiles_per_core, num_tiles_written};
+            tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_kernel_args);
+        } else {
+            auto& writer_kernel_args = writer_kernel_args_by_core[core.x][core.y];
+            writer_kernel_args[0] = output_buffer->address();
+            writer_kernel_args[1] = num_tiles_per_core;
+            writer_kernel_args[2] = num_tiles_written;
+        }
+        num_tiles_written += num_tiles_per_core;
     }
-
-    return ret_val;
 }
 
-operation::ProgramWithCallbacks unpad_tile_multi_core(const Tensor &a, Tensor& output, const Shape &output_tensor_start, const Shape &output_tensor_end) {
-
+operation::ProgramWithCallbacks unpad_tile_multi_core(
+    const Tensor& a, Tensor& output, const Shape& output_tensor_start, const Shape& output_tensor_end) {
     const Shape output_shape = output.get_legacy_shape();
 
     tt_metal::Program program = tt_metal::CreateProgram();
 
     // This should allocate a DRAM buffer on the device
-    tt_metal::Device *device = a.device();
+    tt_metal::Device* device = a.device();
 
     uint32_t num_unpadded_tiles = output.volume() / TILE_HW;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto num_cores_total = num_cores_x*num_cores_y;
-    CoreRange total_cores({0, 0}, {num_cores_x-1, num_cores_y-1});
+    auto num_cores_total = num_cores_x * num_cores_y;
+    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
 
-    tt_metal::Buffer *src0_buffer = a.buffer();
+    tt_metal::Buffer* src0_buffer = a.buffer();
 
-    tt_metal::Buffer *dst_buffer = output.buffer();
+    tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
@@ -383,26 +413,24 @@ operation::ProgramWithCallbacks unpad_tile_multi_core(const Tensor &a, Tensor& o
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;
-    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-		.set_page_size(src0_cb_index, single_tile_size);
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, single_tile_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, total_cores, cb_src0_config);
 
-
-
+    std::uint32_t num_dims = static_cast<std::uint32_t>(a.get_legacy_shape().rank());
 
     // Reader compile-time args
     // Data is 32 byte aligned
     bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> reader_compile_time_args = {
-        // interleaved accessor args
-        (std::uint32_t) src0_is_dram
+        static_cast<uint32_t>(src0_cb_index),
+        static_cast<uint32_t>(num_dims),
+        static_cast<uint32_t>(src0_is_dram),
     };
     std::vector<uint32_t> writer_compile_time_args = {
-        // interleaved accessor args
-        (std::uint32_t) src0_cb_index,
-        (std::uint32_t) dst_is_dram
-    };
+        static_cast<uint32_t>(src0_cb_index), static_cast<uint32_t>(dst_is_dram)};
 
     // Tilized reader
     tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
@@ -417,78 +445,74 @@ operation::ProgramWithCallbacks unpad_tile_multi_core(const Tensor &a, Tensor& o
         total_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
+    const auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, false);
 
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    set_unpad_runtime_args_tile<true>(
+        a,
+        output,
+        output_tensor_start,
+        num_cores_total,
+        num_cores,
+        cores,
+        core_group_1.num_cores(),
+        core_group_2.num_cores(),
+        num_tiles_per_core_group_1,
+        num_tiles_per_core_group_2,
+        program,
+        unary_reader_kernel_id,
+        unary_writer_kernel_id,
+        accumulated_total_per_dim);
 
-    auto all_runtime_args = get_unpad_runtime_args_tile(a, output, output_tensor_start, num_cores_total, num_cores, num_cores_y, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2);
-
-
-
-    for (uint32_t i = 0; i < num_cores_total; i++){
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        tt_metal::SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
-            core,
-            all_runtime_args[i].first
-        );
-
-        tt_metal::SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
-            core,
-            all_runtime_args[i].second
-        );
-    }
-
-    auto override_runtime_args_callback = [
-            unary_reader_kernel_id,
-            unary_writer_kernel_id,
-            compute_with_storage_grid_size
-        ]
-    (
-        const void* operation,
-        const Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>> & ,
-        const std::vector<Tensor>& output_tensors
-    ) {
-        auto src_tensor = input_tensors.at(0);
-        auto dst_tensor = output_tensors.at(0);
+    auto override_runtime_args_callback = [unary_reader_kernel_id,
+                                           unary_writer_kernel_id,
+                                           compute_with_storage_grid_size,
+                                           cores,
+                                           accumulated_total_per_dim](
+                                              const void* operation,
+                                              const Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>&,
+                                              const std::vector<Tensor>& output_tensors) mutable {
+        const Tensor& src_tensor = input_tensors[0];
+        const Tensor& dst_tensor = output_tensors[0];
         uint32_t num_unpadded_tiles = dst_tensor.volume() / TILE_HW;
 
         uint32_t num_cores_x = compute_with_storage_grid_size.x;
         uint32_t num_cores_y = compute_with_storage_grid_size.y;
-        auto num_cores_total = num_cores_x*num_cores_y;
+        uint32_t num_cores_total = cores.size();
 
-        auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+        auto
+            [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+                split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
 
-        const auto tensor_start = static_cast<const Unpad*>(operation)->output_tensor_start;
-        auto all_runtime_args = get_unpad_runtime_args_tile(src_tensor, dst_tensor, tensor_start, num_cores_total,  num_cores, num_cores_y, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2);
-
-
-        for (uint32_t i = 0; i < num_cores_total; i++){
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
-            {
-                SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args[i].first);
-            }
-            {
-                SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args[i].second);
-            }
-        }
+        const auto& tensor_start = static_cast<const Unpad*>(operation)->output_tensor_start;
+        set_unpad_runtime_args_tile<false>(
+            src_tensor,
+            dst_tensor,
+            tensor_start,
+            num_cores_total,
+            num_cores,
+            cores,
+            core_group_1.num_cores(),
+            core_group_2.num_cores(),
+            num_tiles_per_core_group_1,
+            num_tiles_per_core_group_2,
+            program,
+            unary_reader_kernel_id,
+            unary_writer_kernel_id,
+            accumulated_total_per_dim);
     };
 
-    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_args_callback};
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
-operation::ProgramWithCallbacks unpad_multi_core(const Tensor &a, Tensor& output, const Shape &output_tensor_start, const Shape &output_tensor_end) {
+operation::ProgramWithCallbacks unpad_multi_core(
+    const Tensor& a, Tensor& output, const Shape& output_tensor_start, const Shape& output_tensor_end) {
     switch (a.get_layout()) {
-        case Layout::ROW_MAJOR:
-            return unpad_rm_multi_core(a, output, output_tensor_start, output_tensor_end);
-        case Layout::TILE:
-            return unpad_tile_multi_core(a, output, output_tensor_start, output_tensor_end);
-        default:
-            TT_ASSERT(false, "Unsupported Layout");
+        case Layout::ROW_MAJOR: return unpad_rm_multi_core(a, output, output_tensor_start, output_tensor_end);
+        case Layout::TILE: return unpad_tile_multi_core(a, output, output_tensor_start, output_tensor_end);
+        default: TT_ASSERT(false, "Unsupported Layout");
     }
     return {};
 }

--- a/tt_eager/tt_dnn/op_library/unpad/single_core/unpad_op_single_core.cpp
+++ b/tt_eager/tt_dnn/op_library/unpad/single_core/unpad_op_single_core.cpp
@@ -2,12 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_dnn/op_library/unpad/unpad_op.hpp"
 #include "tt_dnn/op_library/math.hpp"
-
-#include "tt_metal/host_api.hpp"
+#include "tt_dnn/op_library/unpad/unpad_op.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
 
 using namespace tt::constants;
 
@@ -15,12 +14,8 @@ namespace tt {
 
 namespace tt_metal {
 
-
-std::pair<std::vector<uint32_t>, std::vector<uint32_t> >   get_unpad_runtime_args_rm(const Tensor &input_tensor,
-                                                                                Tensor& output_tensor,
-                                                                                const Shape &output_tensor_start
-                                                                                ){
-
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>> get_unpad_runtime_args_rm(
+    const Tensor& input_tensor, Tensor& output_tensor, const Shape& output_tensor_start) {
     auto input_shape = input_tensor.get_legacy_shape();
     auto output_shape = output_tensor.get_legacy_shape();
     uint32_t num_dims = input_shape.rank();
@@ -39,7 +34,7 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t> >   get_unpad_runtime_arg
     num_padded_sticks_per_dim[0] = 0;
     accumulated_total_per_dim[0] = 1;
 
-    for(int32_t i = 1; i < num_dims; i++) {
+    for (int32_t i = 1; i < num_dims; i++) {
         uint32_t num_unpadded_dim = output_shape[-(i + 1)];
         uint32_t num_total_dim = input_shape[-(i + 1)];
         uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
@@ -57,24 +52,25 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t> >   get_unpad_runtime_arg
         unpadded_row_size_bytes,
         num_dims,
         start_offset,
-        num_unpadded_sticks
-    };
-    reader_kernel_args.insert(reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
-    reader_kernel_args.insert(reader_kernel_args.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
+        num_unpadded_sticks};
+    reader_kernel_args.insert(
+        reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
+    reader_kernel_args.insert(
+        reader_kernel_args.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
     reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
 
     vector<uint32_t> writer_kernel_args = {
         output_tensor.buffer()->address(),
         unpadded_row_size_bytes,
-        num_unpadded_sticks, 0,
+        num_unpadded_sticks,
+        0,
     };
 
     return {reader_kernel_args, writer_kernel_args};
-
 }
 
-operation::ProgramWithCallbacks unpad_rm_single_core(const Tensor &a, Tensor& output, const Shape &output_tensor_start, const Shape &output_tensor_end) {
-
+operation::ProgramWithCallbacks unpad_rm_single_core(
+    const Tensor& a, Tensor& output, const Shape& output_tensor_start, const Shape& output_tensor_end) {
     const Shape output_shape = output.get_legacy_shape();
 
     tt_metal::Program program = tt_metal::CreateProgram();
@@ -82,16 +78,16 @@ operation::ProgramWithCallbacks unpad_rm_single_core(const Tensor &a, Tensor& ou
     CoreRange core({0, 0}, {0, 0});
 
     // This should allocate a DRAM buffer on the device
-    tt_metal::Device *device = a.device();
+    tt_metal::Device* device = a.device();
 
-    tt_metal::Buffer *src0_buffer = a.buffer();
+    tt_metal::Buffer* src0_buffer = a.buffer();
 
     tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
 
     uint32_t padded_row_size_bytes = a.get_legacy_shape()[-1] * a.element_size();
     uint32_t unpadded_row_size_bytes = output_shape[-1] * a.element_size();
 
-    tt_metal::Buffer *dst_buffer = output.buffer();
+    tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t src_stick_size = padded_row_size_bytes;
@@ -102,8 +98,9 @@ operation::ProgramWithCallbacks unpad_rm_single_core(const Tensor &a, Tensor& ou
 
     uint32_t cb_page_size = round_up(unpadded_row_size_bytes, TILE_WIDTH);
 
-    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(num_input_pages * cb_page_size, {{src0_cb_index, cb_data_format}})
-		.set_page_size(src0_cb_index, cb_page_size);
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(num_input_pages * cb_page_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, cb_page_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     auto all_runtime_args = get_unpad_runtime_args_rm(a, output, output_tensor_start);
@@ -111,20 +108,17 @@ operation::ProgramWithCallbacks unpad_rm_single_core(const Tensor &a, Tensor& ou
     bool src_stick_size_is_power_of_two = is_power_of_two_at_least_32(src_stick_size);
     uint32_t src_log2_stick_size = src_stick_size_is_power_of_two ? (std::uint32_t)log2(src_stick_size) : 0;
     std::vector<uint32_t> reader_compile_time_args_vec = {
-        (std::uint32_t) src0_is_dram,
-        (std::uint32_t) src_stick_size_is_power_of_two,
-        (std::uint32_t) src_log2_stick_size
-    };
+        (std::uint32_t)src0_is_dram, (std::uint32_t)src_stick_size_is_power_of_two, (std::uint32_t)src_log2_stick_size};
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool dst_stick_size_is_power_of_two = is_power_of_two_at_least_32(dst_stick_size);
     uint32_t dst_log2_stick_size = dst_stick_size_is_power_of_two ? (std::uint32_t)log2(dst_stick_size) : 0;
     std::vector<uint32_t> writer_compile_time_args_vec = {
-        (std::uint32_t) src0_cb_index,
-        (std::uint32_t) dst_is_dram,
-        (std::uint32_t) src_stick_size_is_power_of_two,
-        (std::uint32_t) src_log2_stick_size,
-        (std::uint32_t) dst_stick_size_is_power_of_two,
-        (std::uint32_t) dst_log2_stick_size,
+        (std::uint32_t)src0_cb_index,
+        (std::uint32_t)dst_is_dram,
+        (std::uint32_t)src_stick_size_is_power_of_two,
+        (std::uint32_t)src_log2_stick_size,
+        (std::uint32_t)dst_stick_size_is_power_of_two,
+        (std::uint32_t)dst_log2_stick_size,
     };
 
     // Tilized reader
@@ -140,29 +134,16 @@ operation::ProgramWithCallbacks unpad_rm_single_core(const Tensor &a, Tensor& ou
         core,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args_vec));
 
+    tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args.first);
 
-    tt_metal::SetRuntimeArgs(
-        program,
-        unary_reader_kernel_id,
-        core,
-        all_runtime_args.first
-    );
-
-    tt_metal::SetRuntimeArgs(
-        program,
-        unary_writer_kernel_id,
-        core,
-        all_runtime_args.second
-    );
+    tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args.second);
 
     auto override_runtime_args_callback = [unary_reader_kernel_id, unary_writer_kernel_id](
-        const void* operation,
-        const Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>&,
-        const std::vector<Tensor>& output_tensors
-    ) {
-
+                                              const void* operation,
+                                              const Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>&,
+                                              const std::vector<Tensor>& output_tensors) {
         auto src_tensor = input_tensors.at(0);
         auto dst_tensor = output_tensors.at(0);
 
@@ -170,32 +151,31 @@ operation::ProgramWithCallbacks unpad_rm_single_core(const Tensor &a, Tensor& ou
         const auto tensor_start = static_cast<const Unpad*>(operation)->output_tensor_start;
         auto all_runtime_args = get_unpad_runtime_args_rm(src_tensor, dst_tensor, tensor_start);
 
-        {
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args.first);
-        }
+        { SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args.first); }
 
-        {
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args.second);
-        }
+        { SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args.second); }
     };
 
-    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_args_callback};
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
-std::pair<std::vector<uint32_t>, std::vector<uint32_t> >   get_unpad_runtime_args_tile(const Tensor &input_tensor,
-                                                                                Tensor& output_tensor,
-                                                                                const Shape &output_tensor_start
-                                                                                ){
+template <bool initialize_args>
+inline __attribute__((always_inline)) void set_unpad_runtime_args_tile(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const Shape& output_tensor_start,
+    const CoreCoord& core,
+    const Program& program,
+    const tt_metal::KernelHandle& unary_reader_kernel_id,
+    const tt_metal::KernelHandle& unary_writer_kernel_id,
+    std::vector<uint32_t>& accumulated_total_per_dim) {
+    const auto input_buffer = input_tensor.buffer();
+    const auto output_buffer = output_tensor.buffer();
+    const auto& input_shape = input_tensor.get_legacy_shape();
+    const auto& output_shape = output_tensor.get_legacy_shape();
 
-    auto input_shape = input_tensor.get_legacy_shape();
-    auto output_shape = output_tensor.get_legacy_shape();
-    uint32_t num_dims = input_shape.rank();
-
-    std::vector<uint32_t> num_unpadded_tiles_per_dim(num_dims);
-    std::vector<uint32_t> num_padded_tiles_per_dim(num_dims);
-    std::vector<uint32_t> id_per_dim(num_dims, 0);
-
-    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    uint32_t num_unpadded_tiles = output_tensor.volume() / TILE_HW;
 
     uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
     uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
@@ -204,48 +184,95 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t> >   get_unpad_runtime_arg
     uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
     uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
 
-    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
-    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
-    num_padded_tiles_per_dim[0] = num_padded_Xt;
-    num_padded_tiles_per_dim[1] = num_padded_Yt;
-    accumulated_total_per_dim[0] = num_total_Xt;
-    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+    const auto set_common_reader_args = [&](
+        std::vector<uint32_t> & reader_common_args,
+        uint32_t * num_unpadded_tiles_per_dim,
+        uint32_t * num_padded_tiles_per_dim) __attribute__((always_inline)) {
+        reader_common_args[0] = input_buffer->address();
+        num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+        num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+        num_padded_tiles_per_dim[0] = num_padded_Xt;
+        num_padded_tiles_per_dim[1] = num_padded_Yt;
+        accumulated_total_per_dim[0] = num_total_Xt;
+        accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+        for (int32_t i = 2; i < num_dims; ++i) {
+            uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+            uint32_t num_total_dim = input_shape[-(i + 1)];
+            uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+            num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+            num_padded_tiles_per_dim[i] = num_padded_dim;
+            accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+        }
+    };
 
-    for(int32_t i = 2; i < num_dims; i++) {
-        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
-        uint32_t num_total_dim = input_shape[-(i + 1)];
-        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
-        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
-        num_padded_tiles_per_dim[i] = num_padded_dim;
-        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    const auto set_reader_rt_args = [&](
+        std::vector<uint32_t> & reader_rt_args,
+        const uint32_t* num_unpadded_tiles_per_dim,
+        const uint32_t* num_padded_tiles_per_dim,
+        const uint32_t& num_tiles_per_core,
+        const uint32_t& start_offset,
+        const uint32_t& num_tiles_written) __attribute__((always_inline)) {
+        reader_rt_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = reader_rt_args[2] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            reader_rt_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += reader_rt_args[2 + j] * accumulated_total_per_dim[j - 1];
+        }
+        reader_rt_args[0] = start_id;
+        reader_rt_args[1] = num_tiles_per_core;
+    };
+
+    if constexpr (initialize_args) {
+        std::vector<uint32_t> reader_common_args(1 + num_dims * 2);
+        uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
+        uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+        set_common_reader_args(reader_common_args, num_unpadded_tiles_per_dim, num_padded_tiles_per_dim);
+        SetCommonRuntimeArgs(program, unary_reader_kernel_id, reader_common_args);
+    }
+    auto& reader_common_args = GetCommonRuntimeArgs(program, unary_reader_kernel_id);
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
+    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+    if constexpr (!initialize_args) {
+        set_common_reader_args(reader_common_args, num_unpadded_tiles_per_dim, num_padded_tiles_per_dim);
     }
 
-    uint32_t num_unpadded_tiles = output_tensor.volume() / TILE_HW;
     uint32_t start_offset = get_tiled_start_offset(input_tensor, output_tensor_start);
 
-    vector<uint32_t> reader_kernel_args = {
-        input_tensor.buffer()->address(),
-        num_dims,
-        start_offset,
-        num_unpadded_tiles
-    };
-    reader_kernel_args.insert(reader_kernel_args.end(), num_unpadded_tiles_per_dim.begin(), num_unpadded_tiles_per_dim.end());
-    reader_kernel_args.insert(reader_kernel_args.end(), num_padded_tiles_per_dim.begin(), num_padded_tiles_per_dim.end());
-    reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
+    if constexpr (initialize_args) {
+        std::vector<uint32_t> reader_kernel_args(2 + num_dims);
+        set_reader_rt_args(
+            reader_kernel_args,
+            num_unpadded_tiles_per_dim,
+            num_padded_tiles_per_dim,
+            num_unpadded_tiles,
+            start_offset,
+            0);
+        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_kernel_args);
+    } else {
+        auto& reader_kernel_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+        set_reader_rt_args(
+            reader_kernel_args,
+            num_unpadded_tiles_per_dim,
+            num_padded_tiles_per_dim,
+            num_unpadded_tiles,
+            start_offset,
+            0);
+    }
 
-    vector<uint32_t> writer_kernel_args = {
-        output_tensor.buffer()->address(),
-        num_unpadded_tiles, 0,
-    };
-
-    return {reader_kernel_args, writer_kernel_args};
-
-
+    if constexpr (initialize_args) {
+        vector<uint32_t> writer_kernel_args = {output_buffer->address(), num_unpadded_tiles, 0};
+        tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_kernel_args);
+    } else {
+        auto& writer_kernel_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+        writer_kernel_args[0] = output_buffer->address();
+        writer_kernel_args[1] = num_unpadded_tiles;
+    }
 }
 
-operation::ProgramWithCallbacks unpad_tile_single_core(const Tensor &a, Tensor& output, const Shape &output_tensor_start, const Shape &output_tensor_end) {
-
-
+operation::ProgramWithCallbacks unpad_tile_single_core(
+    const Tensor& a, Tensor& output, const Shape& output_tensor_start, const Shape& output_tensor_end) {
     const Shape output_shape = output.get_legacy_shape();
 
     tt_metal::Program program = tt_metal::CreateProgram();
@@ -253,11 +280,11 @@ operation::ProgramWithCallbacks unpad_tile_single_core(const Tensor &a, Tensor& 
     CoreRange core({0, 0}, {0, 0});
 
     // This should allocate a DRAM buffer on the device
-    tt_metal::Device *device = a.device();
+    tt_metal::Device* device = a.device();
 
-    tt_metal::Buffer *src0_buffer = a.buffer();
+    tt_metal::Buffer* src0_buffer = a.buffer();
 
-    tt_metal::Buffer *dst_buffer = output.buffer();
+    tt_metal::Buffer* dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
@@ -266,24 +293,24 @@ operation::ProgramWithCallbacks unpad_tile_single_core(const Tensor &a, Tensor& 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;
 
-    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-		.set_page_size(src0_cb_index, single_tile_size);
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, single_tile_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
+    std::uint32_t num_dims = static_cast<std::uint32_t>(a.get_legacy_shape().rank());
 
     // Reader compile-time args
     // Data is 32 byte aligned
     bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> reader_compile_time_args = {
-        // interleaved accessor args
-        (std::uint32_t) src0_is_dram
+        static_cast<uint32_t>(src0_cb_index),
+        static_cast<uint32_t>(num_dims),
+        static_cast<uint32_t>(src0_is_dram),
     };
     std::vector<uint32_t> writer_compile_time_args = {
-        // interleaved accessor args
-        (std::uint32_t) src0_cb_index,
-        (std::uint32_t) dst_is_dram
-    };
+        static_cast<uint32_t>(src0_cb_index), static_cast<uint32_t>(dst_is_dram)};
 
     // Tilized reader
     tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
@@ -298,60 +325,49 @@ operation::ProgramWithCallbacks unpad_tile_single_core(const Tensor &a, Tensor& 
         core,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
-
-
-    auto all_runtime_args = get_unpad_runtime_args_tile(a, output, output_tensor_start);
-
-    tt_metal::SetRuntimeArgs(
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    set_unpad_runtime_args_tile<true>(
+        a,
+        output,
+        output_tensor_start,
+        core.start,
         program,
         unary_reader_kernel_id,
-        core,
-        all_runtime_args.first
-    );
-
-    tt_metal::SetRuntimeArgs(
-        program,
         unary_writer_kernel_id,
-        core,
-        all_runtime_args.second
-    );
+        accumulated_total_per_dim);
 
-    auto override_runtime_args_callback = [unary_reader_kernel_id, unary_writer_kernel_id](
-        const void* operation,
-        const Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>&,
-        const std::vector<Tensor>& output_tensors
-    ) {
+    auto override_runtime_args_callback =
+        [unary_reader_kernel_id, unary_writer_kernel_id, core, accumulated_total_per_dim](
+            const void* operation,
+            const Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<Tensor>& output_tensors) mutable {
+            const Tensor& src_tensor = input_tensors[0];
 
-        auto src_tensor = input_tensors.at(0);
+            const Tensor& dst_tensor = output_tensors[0];
 
-        auto dst_tensor = output_tensors.at(0);
+            const auto& tensor_start = static_cast<const Unpad*>(operation)->output_tensor_start;
+            set_unpad_runtime_args_tile<false>(
+                src_tensor,
+                dst_tensor,
+                tensor_start,
+                core.start,
+                program,
+                unary_reader_kernel_id,
+                unary_writer_kernel_id,
+                accumulated_total_per_dim);
+        };
 
-        CoreCoord core = {0, 0};
-        const auto tensor_start = static_cast<const Unpad*>(operation)->output_tensor_start;
-        auto all_runtime_args = get_unpad_runtime_args_tile(src_tensor, dst_tensor, tensor_start);
-
-        {
-            SetRuntimeArgs(program, unary_reader_kernel_id, core, all_runtime_args.first);
-        }
-
-        {
-            SetRuntimeArgs(program, unary_writer_kernel_id, core, all_runtime_args.second);
-        }
-    };
-
-    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_args_callback};
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
-operation::ProgramWithCallbacks unpad_single_core(const Tensor &a, Tensor& output, const Shape &output_tensor_start, const Shape &output_tensor_end) {
+operation::ProgramWithCallbacks unpad_single_core(
+    const Tensor& a, Tensor& output, const Shape& output_tensor_start, const Shape& output_tensor_end) {
     switch (a.get_layout()) {
-        case Layout::ROW_MAJOR:
-            return unpad_rm_single_core(a, output, output_tensor_start, output_tensor_end);
-        case Layout::TILE:
-            return unpad_tile_single_core(a, output, output_tensor_start, output_tensor_end);
-        default:
-            TT_ASSERT(false, "Unsupported Layout");
+        case Layout::ROW_MAJOR: return unpad_rm_single_core(a, output, output_tensor_start, output_tensor_end);
+        case Layout::TILE: return unpad_tile_single_core(a, output, output_tensor_start, output_tensor_end);
+        default: TT_ASSERT(false, "Unsupported Layout");
     }
     return {};
 }

--- a/tt_eager/tt_dnn/op_library/unpad/unpad_op.cpp
+++ b/tt_eager/tt_dnn/op_library/unpad/unpad_op.cpp
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_dnn/op_library/unpad/unpad_op.hpp"
+
+#include "tensor/tensor_utils.hpp"
 #include "tt_dnn/op_library/copy/copy_op.hpp"
 #include "tt_dnn/op_library/math.hpp"
-#include "tensor/tensor_utils.hpp"
-
-#include "tt_metal/host_api.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
-#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/host_api.hpp"
 
 using namespace tt::constants;
 
@@ -18,73 +18,54 @@ namespace tt {
 
 namespace tt_metal {
 
-
-uint32_t get_upper_dims_compressed(const Tensor & tensor) {
-
-    uint32_t upper_dims_compressed = 1;
-
-    for(uint32_t dim=0; dim<tensor.get_legacy_shape().rank() - 2; dim++) {
-        upper_dims_compressed *= tensor.get_legacy_shape()[dim];
-    }
-
-    return upper_dims_compressed;
+inline __attribute__((always_inline)) uint32_t get_upper_dims_compressed(const Shape& shape) {
+    return std::accumulate(shape.begin(), shape.end() - 2, 1, std::multiplies<uint32_t>{});
 }
 
-uint32_t get_upper_start_offset(const Tensor & tensor, const Shape & output_tensor_start) {
-
+inline __attribute__((always_inline)) uint32_t get_upper_start_offset(const Tensor &tensor, const Shape &output_tensor_start) {
     // offset for every dim except last 2
     uint32_t start_offset = 0;
+    const auto& shape = tensor.get_legacy_shape();
 
     uint32_t num_pages = tensor.volume();
-    if(tensor.get_layout() == Layout::TILE) {
-        num_pages /= (TILE_HW);
-    }
-    else {
-        uint32_t page_width = tensor.get_legacy_shape()[-1];
+    if (tensor.get_layout() == Layout::TILE) {
+        num_pages /= TILE_HW;
+    } else {
+        uint32_t page_width = shape[-1];
         num_pages /= page_width;
     }
 
-    for(uint32_t dim_outer=0; dim_outer<tensor.get_legacy_shape().rank() - 2; dim_outer++) {
+    for (uint32_t dim_outer = 0; dim_outer < shape.rank() - 2; dim_outer++) {
         uint32_t compressed_dims = 1;
-        for(uint32_t dim_inner = 0; dim_inner <= dim_outer; dim_inner++) {
-            compressed_dims*=tensor.get_legacy_shape()[dim_inner];
+        for (uint32_t dim_inner = 0; dim_inner <= dim_outer; dim_inner++) {
+            compressed_dims *= shape[dim_inner];
         }
-        start_offset += (num_pages/compressed_dims) * output_tensor_start[dim_outer];
+        start_offset += (num_pages / compressed_dims) * output_tensor_start[dim_outer];
     }
     return start_offset;
-
 }
 
-
-
-uint32_t get_tiled_start_offset(const Tensor &input_tensor,
-                        const Shape &output_tensor_start
- ) {
+uint32_t get_tiled_start_offset(const Tensor &input_tensor, const Shape &output_tensor_start) {
     uint32_t num_input_pages = input_tensor.volume() / (TILE_HW);
-
-    uint32_t upper_dims_compressed = get_upper_dims_compressed(input_tensor);
-    uint32_t num_pages_width = num_input_pages / (upper_dims_compressed * (input_tensor.get_legacy_shape()[-2]/TILE_HEIGHT));
-
+    const auto& shape = input_tensor.get_legacy_shape();
+    uint32_t upper_dims_compressed = get_upper_dims_compressed(shape);
+    uint32_t num_pages_width =
+        num_input_pages / (upper_dims_compressed * (shape[-2] / TILE_HEIGHT));
 
     // offset for every dim except last 2
     uint32_t start_offset = get_upper_start_offset(input_tensor, output_tensor_start);
 
-    start_offset += output_tensor_start[-2]/TILE_HEIGHT*num_pages_width
-                                + output_tensor_start[-1]/TILE_WIDTH;
+    start_offset += output_tensor_start[-2] / TILE_HEIGHT * num_pages_width + output_tensor_start[-1] / TILE_WIDTH;
     return start_offset;
-
 }
 
-uint32_t get_rm_start_offset(
-                        const Tensor &tensor,
-                        const Shape &output_tensor_start
- ) {
-
+uint32_t get_rm_start_offset(const Tensor &tensor, const Shape &output_tensor_start) {
     uint32_t start_offset = 0;
 
     if (tensor.get_legacy_shape().rank() >= 2) {
-        uint32_t num_pages = tensor.volume() / tensor.get_legacy_shape()[-1];
-        uint32_t upper_dims_compressed = get_upper_dims_compressed(tensor);
+        const auto& shape = tensor.get_legacy_shape();
+        uint32_t num_pages = tensor.volume() / shape[-1];
+        uint32_t upper_dims_compressed = get_upper_dims_compressed(shape);
         start_offset = get_upper_start_offset(tensor, output_tensor_start);
         start_offset += output_tensor_start[-2];
     }
@@ -92,11 +73,10 @@ uint32_t get_rm_start_offset(
     return start_offset;
 }
 
-
 void Unpad::validate(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
+    const auto &input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
-    TT_FATAL(input_tensor_a.buffer() != nullptr , "Operands to unpad need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE || input_tensor_a.get_layout() == Layout::ROW_MAJOR);
 
     for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
@@ -111,16 +91,17 @@ void Unpad::validate(const std::vector<Tensor> &input_tensors) const {
 
     if (input_tensor_a.get_layout() == Layout::TILE) {
         TT_FATAL(input_tensor_a.volume() % TILE_HW == 0);
-        TT_FATAL((output_tensor_shape[-2] % TILE_HEIGHT == 0) &&
-                 (this->output_tensor_start[-2] % TILE_HEIGHT == 0),
-                "Can only unpad tilized tensor with full tiles");
-        TT_FATAL((output_tensor_shape[-1] % TILE_WIDTH == 0) &&
-                 (this->output_tensor_start[-1] % TILE_WIDTH == 0),
-                "Can only unpad tilized tensor with full tiles");
+        TT_FATAL(
+            (output_tensor_shape[-2] % TILE_HEIGHT == 0) && (this->output_tensor_start[-2] % TILE_HEIGHT == 0),
+            "Can only unpad tilized tensor with full tiles");
+        TT_FATAL(
+            (output_tensor_shape[-1] % TILE_WIDTH == 0) && (this->output_tensor_start[-1] % TILE_WIDTH == 0),
+            "Can only unpad tilized tensor with full tiles");
     } else if (input_tensor_a.get_layout() == Layout::ROW_MAJOR) {
-        TT_FATAL(( output_tensor_shape[-1] * input_tensor_a.element_size() % sizeof(uint32_t) == 0) &&
-                  (this->output_tensor_start[-1] * input_tensor_a.element_size() % sizeof(uint32_t) == 0)
-                    ,"RM unpadding requires output X size to be packable");
+        TT_FATAL(
+            (output_tensor_shape[-1] * input_tensor_a.element_size() % sizeof(uint32_t) == 0) &&
+                (this->output_tensor_start[-1] * input_tensor_a.element_size() % sizeof(uint32_t) == 0),
+            "RM unpadding requires output X size to be packable");
     }
 }
 std::vector<Shape> Unpad::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
@@ -134,26 +115,27 @@ std::vector<Shape> Unpad::compute_output_shapes(const std::vector<Tensor> &input
     return {output_tensor_shape};
 }
 std::vector<Tensor> Unpad::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    return operation::generic_create_output_tensors(*this, input_tensors, input_tensor_a.get_dtype(), input_tensor_a.get_layout(), this->output_mem_config);
+    const auto &input_tensor_a = input_tensors.at(0);
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, input_tensor_a.get_dtype(), input_tensor_a.get_layout(), this->output_mem_config);
 }
 
 // TODO: If unpad is called on a tile and output is not tile, we could untilize then unpad, and output is RM
 // Currently calling unpad on a tile requires the output unpad shape to be tile
-operation::ProgramWithCallbacks Unpad::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
-    auto& output_tensor = output_tensors.at(0);
-    switch(this->get_parallelization_strategy(input_tensors)) {
+operation::ProgramWithCallbacks Unpad::create_program(
+    const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto &input_tensor_a = input_tensors.at(0);
+    auto &output_tensor = output_tensors.at(0);
+    switch (this->get_parallelization_strategy(input_tensors)) {
         case UnpadOpParallelizationStrategy::MULTI_CORE:
             return unpad_multi_core(input_tensor_a, output_tensor, output_tensor_start, output_tensor_end);
         case UnpadOpParallelizationStrategy::SINGLE_CORE:
-        default:
-            return unpad_single_core(input_tensor_a, output_tensor, output_tensor_start, output_tensor_end);
+        default: return unpad_single_core(input_tensor_a, output_tensor, output_tensor_start, output_tensor_end);
     };
 }
 
 UnpadOpParallelizationStrategy Unpad::get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor_a = input_tensors.at(0);
+    const auto &input_tensor_a = input_tensors.at(0);
     uint32_t num_units;
     auto shape = this->compute_output_shapes(input_tensors).at(0);
     if (input_tensor_a.get_layout() == Layout::TILE) {
@@ -176,17 +158,15 @@ tt::stl::reflection::Attributes Unpad::attributes() const {
     };
 }
 
-const operation::Hash Unpad::compute_program_hash (
-    const std::vector<Tensor> &input_tensors) const {
+const operation::Hash Unpad::compute_program_hash(const std::vector<Tensor> &input_tensors) const {
     auto input_tensor = input_tensors.at(0);
     auto input_mem_config = input_tensor.memory_config();
     auto output_mem_config = this->output_mem_config;
     auto dtype = input_tensor.get_dtype();
     auto num_dims = input_tensor.get_legacy_shape().rank();
 
-
     std::string rm_width = "TILE";
-    if(input_tensor.get_layout() == Layout::ROW_MAJOR){
+    if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
         rm_width = fmt::format("{}", input_tensor.get_legacy_shape()[3]);
     }
 
@@ -203,34 +183,43 @@ const operation::Hash Unpad::compute_program_hash (
 
     );
     return str;
-
 }
 
-Tensor unpad(const Tensor &input_tensor_a, const Shape &output_tensor_start, const Shape &output_tensor_end, const MemoryConfig& output_mem_config) {
+Tensor unpad(
+    const Tensor &input_tensor_a,
+    const Shape &output_tensor_start,
+    const Shape &output_tensor_end,
+    const MemoryConfig &output_mem_config) {
     // No-op (Will do a tensor copy)
     // TODO: We need to run asserts before this
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a}))};
     operation::launch_op(
-        [output_tensor_start, output_tensor_end, output_mem_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) mutable -> std::vector<Tensor> {
-                auto& input_tensor_a = input_tensors.at(0);
-                auto input_tensor_shape = input_tensor_a.get_legacy_shape();
-                const Shape output_tensor_shape = {
-                    output_tensor_end[0] - output_tensor_start[0] + 1,
-                    output_tensor_end[1] - output_tensor_start[1] + 1,
-                    output_tensor_end[2] - output_tensor_start[2] + 1,
-                    output_tensor_end[3] - output_tensor_start[3] + 1,
-                };
-                if (input_tensor_a.get_legacy_shape() == output_tensor_shape) {
-                    return {AutoFormat::move_tensor_to_mem_config(input_tensor_a, output_mem_config)};
-                }
-                return operation::run(Unpad{output_tensor_start, output_tensor_end, output_mem_config, output_tensor_shape, input_tensor_shape}, {input_tensor_a});
+        [output_tensor_start, output_tensor_end, output_mem_config](
+            const std::vector<Tensor> &input_tensors,
+            const std::vector<std::optional<const Tensor>> &optional_input_tensors) mutable -> std::vector<Tensor> {
+            auto &input_tensor_a = input_tensors.at(0);
+            auto input_tensor_shape = input_tensor_a.get_legacy_shape();
+            const Shape output_tensor_shape = {
+                output_tensor_end[0] - output_tensor_start[0] + 1,
+                output_tensor_end[1] - output_tensor_start[1] + 1,
+                output_tensor_end[2] - output_tensor_start[2] + 1,
+                output_tensor_end[3] - output_tensor_start[3] + 1,
+            };
+            if (input_tensor_a.get_legacy_shape() == output_tensor_shape) {
+                return {AutoFormat::move_tensor_to_mem_config(input_tensor_a, output_mem_config)};
+            }
+            return operation::run(
+                Unpad{
+                    output_tensor_start, output_tensor_end, output_mem_config, output_tensor_shape, input_tensor_shape},
+                {input_tensor_a});
         },
-    {input_tensor_a}, output_tensors);
+        {input_tensor_a},
+        output_tensors);
     return output_tensors.at(0);
 }
 
 void UnpadOnHost::validate(const std::vector<Tensor> &input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
+    const auto &input_tensor = input_tensors.at(0);
     TT_FATAL(input_tensor.storage_type() != StorageType::DEVICE);
     TT_FATAL(input_tensor.get_layout() == Layout::ROW_MAJOR);
 
@@ -258,8 +247,8 @@ std::vector<Shape> UnpadOnHost::compute_output_shapes(const std::vector<Tensor> 
     };
     return {output_tensor_shape};
 }
-std::vector<Tensor> UnpadOnHost::compute_output_tensors(const std::vector<Tensor>& input_tensors) const {
-    const auto& input_tensor = input_tensors.at(0);
+std::vector<Tensor> UnpadOnHost::compute_output_tensors(const std::vector<Tensor> &input_tensors) const {
+    const auto &input_tensor = input_tensors.at(0);
     if (input_tensor.get_legacy_shape() == UnpadOnHost::compute_output_shapes(input_tensors).at(0)) {
         return {input_tensor};
     } else {
@@ -274,7 +263,11 @@ tt::stl::reflection::Attributes UnpadOnHost::attributes() const {
     };
 }
 
-Tensor unpad_on_host(const Tensor &input_tensor, const Shape &output_tensor_start, const Shape &output_tensor_end, const MemoryConfig& mem_config) {
+Tensor unpad_on_host(
+    const Tensor &input_tensor,
+    const Shape &output_tensor_start,
+    const Shape &output_tensor_end,
+    const MemoryConfig &mem_config) {
     return operation::run(UnpadOnHost{output_tensor_start, output_tensor_end}, {input_tensor}).at(0);
 }
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -345,6 +345,30 @@ void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const 
 std::vector<uint32_t>& GetRuntimeArgs(const Program &program, KernelHandle kernel_id, const CoreCoord &logical_core);
 
 /**
+ * Get the runtime args for a kernel.
+ *
+ * Return value: std::vector< std::vector< std::vector<uint32_t>> > &
+ *
+ * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | program      | The program containing kernels, circular buffers, semaphores           | const Program &               |                                    | Yes      |
+ * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)       |                                    | Yes      |
+ */
+std::vector< std::vector< std::vector<uint32_t>> > & GetRuntimeArgs(const Program &program, KernelHandle kernel_id);
+
+/**
+ * Get the common runtime args for a kernel.
+ *
+ * Return value: std::vector<uint32_t> &
+ *
+ * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | program      | The program containing kernels, circular buffers, semaphores           | const Program &               |                                    | Yes      |
+ * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)       |                                    | Yes      |
+ */
+std::vector<uint32_t>& GetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id);
+
+/**
  * Update specific entries of the runtime args vector for a kernel using the command queue. This API must be used when Asynchronous Command Queue Mode is enabled.
  *
  * Return Value: void

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -157,6 +157,10 @@ std::vector<uint32_t>& Kernel::runtime_args(const CoreCoord &logical_core) {
     return this->core_to_runtime_args_[logical_core.x][logical_core.y];
 }
 
+std::vector< std::vector< std::vector<uint32_t>> > & Kernel::runtime_args() {
+    return this->core_to_runtime_args_;
+}
+
 std::vector<uint32_t>& Kernel::common_runtime_args() {
     return this->common_runtime_args_;
 }

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -50,6 +50,7 @@ class Kernel : public JitBuildSettings {
     void update_runtime_arg( const CoreCoord &logical_core, size_t idx, uint32_t value);
 
     std::vector<uint32_t> & runtime_args(const CoreCoord &logical_core);
+    std::vector< std::vector< std::vector<uint32_t>> > & runtime_args();
     std::vector<uint32_t> & common_runtime_args();
 
     std::map<std::string, std::string> defines() const { return defines_; }


### PR DESCRIPTION
… allocs when generating new rt args

Update unpad tile to use common runtime args
Add new GetRuntimeArgs api to return mapping of rt args  by core. This allows us to only call the get api once and avoid doing lookups/asserts per core