### PR TITLE
#5592: Enable optimized prefill for Falcon7b

### DIFF
--- a/models/demos/falcon7b/tests/test_falcon_attention.py
+++ b/models/demos/falcon7b/tests/test_falcon_attention.py
@@ -78,7 +78,16 @@ def run_test_FalconAttention_inference(
         tt_layer_past,
         kv_len,
     ) = get_rand_falcon_inputs(
-        llm_mode, seq_len, batch, kv_cache_len, devices, global_batch, head_dim, max_position_embeddings, configuration
+        llm_mode,
+        seq_len,
+        batch,
+        kv_cache_len,
+        devices,
+        global_batch,
+        head_dim,
+        max_position_embeddings,
+        configuration,
+        model_config,
     )
     if layer_past is not None:
         layer_past = layer_past[0]

--- a/models/demos/falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon7b/tests/test_falcon_causallm.py
@@ -94,6 +94,7 @@ def run_test_FalconCausalLM_inference(
         head_dim,
         max_position_embeddings,
         configuration,
+        model_config,
         num_layers=num_layers,
         generate_attention_inputs=False,
     )

--- a/models/demos/falcon7b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon7b/tests/test_falcon_decoder.py
@@ -78,7 +78,16 @@ def run_test_FalconDecoder_inference(
         tt_layer_past,
         kv_len,
     ) = get_rand_falcon_inputs(
-        llm_mode, seq_len, batch, kv_cache_len, devices, global_batch, head_dim, max_position_embeddings, configuration
+        llm_mode,
+        seq_len,
+        batch,
+        kv_cache_len,
+        devices,
+        global_batch,
+        head_dim,
+        max_position_embeddings,
+        configuration,
+        model_config,
     )
     if layer_past is not None:
         layer_past = layer_past[0]

--- a/models/demos/falcon7b/tests/test_falcon_model.py
+++ b/models/demos/falcon7b/tests/test_falcon_model.py
@@ -88,6 +88,7 @@ def run_test_FalconModel_inference(
         head_dim,
         max_position_embeddings,
         configuration,
+        model_config,
         num_layers=num_layers,
         generate_attention_inputs=False,
     )
@@ -220,7 +221,7 @@ def test_FalconModel_inference(
 ):
     devices = get_devices_for_t3000(all_devices, num_devices)
 
-    model_config = get_model_config(model_config_str)
+    model_config = get_model_config(model_config_str, seq_len)
     tt_cache_path = get_tt_cache_path(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
     )

--- a/models/demos/falcon7b/tests/test_utils.py
+++ b/models/demos/falcon7b/tests/test_utils.py
@@ -48,9 +48,9 @@ def get_rand_falcon_inputs(
     head_dim,
     max_position_embeddings,
     configuration,
+    model_config,
     num_layers=1,
     generate_attention_inputs=True,
-    optimized=False,
 ):
     # Generate input, attention_mask, and kv_cache --------------------------------------
     # TODO: Generate attention_mask on device
@@ -76,7 +76,7 @@ def get_rand_falcon_inputs(
                     attention_input_i = attention_input[batch * i : batch * (i + 1)]
                     attention_mask_bool_i = attention_mask_bool[batch * i : batch * (i + 1)]
                     tt_attention_input.append(torch2tt_tensor(attention_input_i.unsqueeze(1), device))
-                    if seq_len in [2048, 128, 1024] and optimized:
+                    if model_config["PREFILL_OPTIMIZED_MODE"] and seq_len in [2048, 128, 1024]:
                         attn_masks = create_prefill_attn_mask_for_sharded_softmax(
                             (attention_mask_bool_i * -1e5),
                             configuration.num_attention_heads,

--- a/models/demos/falcon7b/tt/falcon_model.py
+++ b/models/demos/falcon7b/tt/falcon_model.py
@@ -94,7 +94,7 @@ class TtFalconModelShared(torch.nn.Module):
 
         self.layernorm_eps = config.layer_norm_epsilon
 
-    def model_preprocessing(self, llm_mode, input_ids, kv_cache_len, num_input_tokens, optimized_mode=False):
+    def model_preprocessing(self, llm_mode, input_ids, kv_cache_len, num_input_tokens):
         assert input_ids.dim() == 2
         global_batch_size, sequence_size = input_ids.shape
         batch_size = global_batch_size // self.num_devices
@@ -117,7 +117,11 @@ class TtFalconModelShared(torch.nn.Module):
                 dim=-1,
             )
 
-            if num_input_tokens in [128, 1024, 2048] and optimized_mode:
+            if (
+                self.model_config["PREFILL_OPTIMIZED_MODE"]
+                and self.model_config["PREFILL_ATTENTION_OPTIMIZED_MODE"]
+                and num_input_tokens in [128, 1024, 2048]
+            ):
                 attention_mask_ = create_prefill_attn_mask_for_sharded_softmax(
                     attention_mask_bool_padded * -1e5,
                     self.config.num_attention_heads,

--- a/models/demos/falcon7b/tt/model_config.py
+++ b/models/demos/falcon7b/tt/model_config.py
@@ -5,7 +5,7 @@
 import tt_lib as ttl
 from loguru import logger
 from pathlib import Path
-from models.utility_functions import is_wormhole_b0
+from models.utility_functions import is_grayskull, is_wormhole_b0
 
 OP_KEYS = (
     # Inputs
@@ -92,7 +92,7 @@ def pretty_print_model_config(model_config):
     return "\n".join(print_str)
 
 
-def get_model_config(model_config_str, prefill_seq_len=0, optimized=False):
+def get_model_config(model_config_str, prefill_seq_len=0):
     assert model_config_str in ACCEPTABLE_MODEL_CONFIG_STRS
     DRAM_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
     L1_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
@@ -193,8 +193,9 @@ def get_model_config(model_config_str, prefill_seq_len=0, optimized=False):
     return model_config
 
 
-def set_prefill_config(model_config, seq_len, dram_memcfg, optimized=False):
-    model_config["OPTIMIZED_MODE"] = optimized
+def set_prefill_config(model_config, seq_len, dram_memcfg):
+    model_config["PREFILL_OPTIMIZED_MODE"] = not is_grayskull()
+    model_config["PREFILL_ATTENTION_OPTIMIZED_MODE"] = False  # enable when #8349 is fixed
     model_config["MLP_SEQ_LEN"] = seq_len
     model_config["MLP_PADDING_VALUE"] = 4608
     model_config["MLP_GRID_SIZE"] = (8, 8)

--- a/models/demos/t3000/falcon7b/README.md
+++ b/models/demos/t3000/falcon7b/README.md
@@ -1,5 +1,9 @@
 # Falcon7B Demo (T3000)
 
+Falcon7b prefill uses 8x8 core grid size, so the following environment variable needs to be set on N300 setup:
+
+`export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml`
+
 ## How to Run
 
 To run the demo using prewritten prompts for a batch of 256 users split evenly on 8 devices run (currently only supports same token-length inputs):

--- a/models/demos/wormhole/falcon7b/README.md
+++ b/models/demos/wormhole/falcon7b/README.md
@@ -1,5 +1,9 @@
 # Falcon7B Demo (Wormhole)
 
+Falcon7b prefill uses 8x8 core grid size, so the following environment variable needs to be set on N300 setup:
+
+`export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml`
+
 ## How to Run
 
 To run the model for a single user you can use the command line input:

--- a/tests/scripts/nightly/run_common_models.sh
+++ b/tests/scripts/nightly/run_common_models.sh
@@ -12,8 +12,6 @@ echo "Running common models for archs"
 env pytest models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
 env pytest models/demos/metal_BERT_large_11/tests/test_demo.py
 
-env pytest models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
-
 env pytest models/demos/ttnn_falcon7b/tests/test_falcon_mlp.py
 env pytest models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py
 env pytest models/demos/ttnn_falcon7b/tests/test_falcon_attention.py

--- a/tests/scripts/nightly/run_wh_b0_only.sh
+++ b/tests/scripts/nightly/run_wh_b0_only.sh
@@ -12,6 +12,8 @@ echo "Running nightly tests for WH B0 only"
 env pytest tests/ttnn/integration_tests/unet                # -> failing: issue #7556
 SLOW_MATMULS=1 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml env pytest tests/ttnn/integration_tests/stable_diffusion
 
+env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests/ci/test_falcon_end_to_end_prefill.py
+
 env pytest models/demos/mamba/tests/test_mamba_ssm.py
 env pytest models/demos/mamba/tests/test_mamba_block.py
 env pytest models/demos/mamba/tests/test_residual_block.py

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -31,13 +31,26 @@ run_perf_models_llm_javelin() {
     local tt_arch=$1
     local test_marker=$2
 
-    env pytest models/demos/falcon7b/tests -m $test_marker
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests -m $test_marker
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
         env pytest models/demos/mamba/tests -m $test_marker
     fi
 
     env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mistral7b/tests -m $test_marker  # -> hanging: issue #7540
+
+    ## Merge all the generated reports
+    env python models/perf/merge_perf_results.py
+}
+
+run_perf_models_llm_javelin_multi_device() {
+    local tt_arch=$1
+    local test_marker=$2
+
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests -m $test_marker
+
+    # Mistral8x7b env flags are set inside the tests
+    env pytest models/demos/t3000/mixtral8x7b/tests -m $test_marker
 
     ## Merge all the generated reports
     env python models/perf/merge_perf_results.py

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -43,19 +43,6 @@ run_perf_models_llm_javelin() {
     env python models/perf/merge_perf_results.py
 }
 
-run_perf_models_llm_javelin_multi_device() {
-    local tt_arch=$1
-    local test_marker=$2
-
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests -m $test_marker
-
-    # Mistral8x7b env flags are set inside the tests
-    env pytest models/demos/t3000/mixtral8x7b/tests -m $test_marker
-
-    ## Merge all the generated reports
-    env python models/perf/merge_perf_results.py
-}
-
 run_perf_models_cnn_javelin() {
     local tt_arch=$1
     local test_marker=$2

--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -8,7 +8,7 @@ run_t3000_falcon7b_tests() {
 
   echo "LOG_METAL: Running run_t3000_falcon7b_tests"
 
-  env pytest models/demos/falcon7b/tests -m "model_perf_t3000"
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests -m "model_perf_t3000"
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
Enable optimized prefill for 128, 1024 and 2048 seq len by default on wormhole B0 (GS is kept as is).

Previously it has been disabled by default since there was some e2e perf degradations for 128 seq len. This PR resolves this issues, enables optimized prefill by default and bumps up matmul subblocks now that the matmul hangs have been resolved (https://github.com/tenstorrent/tt-metal/issues/7066).

The remaining cleanup/fixes is listed in https://github.com/tenstorrent/tt-metal/issues/8349 and will be tackled next.

- Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/9031161202