### PR TITLE
extend ssm eltwise mul for third case + integrate with mamba

### DIFF
--- a/models/demos/mamba/tests/test_full_model.py
+++ b/models/demos/mamba/tests/test_full_model.py
@@ -39,6 +39,7 @@ class MambaPytorch(torch.nn.Module):
         x = self.lm_head(x)
         return x
 
+
 def run_inference(
     device: ttnn.Device,
     use_program_cache,
@@ -109,7 +110,7 @@ def test_inference(
     iterations: int,
 ):
     run_inference(device, use_program_cache, model_version, batch, pcc, cache_dir, num_layers, iterations)
-    
+
 
 @skip_for_grayskull("Not supported on Grayskull")
 @pytest.mark.parametrize(
@@ -123,7 +124,7 @@ def test_device_perf(
     model_version="state-spaces/mamba-2.8b",
     batch=32,
     pcc=0.97,
-    cache_dir="/tmp",
+    cache_dir=None,
     num_layers=1,
 ):
     run_inference(device, use_program_cache, model_version, batch, pcc, cache_dir, num_layers, iterations)

--- a/models/demos/mamba/tests/test_mamba_perf.py
+++ b/models/demos/mamba/tests/test_mamba_perf.py
@@ -115,7 +115,7 @@ def test_mamba_e2e_perf(
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, warmup, expected_device_fw_duration_ms",
-    ((32, True, 8.02),),
+    ((32, True, 2.81),),
 )
 def test_mamba_perf_device(batch, warmup, expected_device_fw_duration_ms, reset_seeds):
     subdir = "ttnn_mamba"

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_eltwise_mul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_eltwise_mul.cpp
@@ -23,26 +23,33 @@ void MAIN {
     constexpr uint32_t num_rows_in_one_tile = 32;
 
 
-    binary_op_init_common(cb_in0_transposed, cb_in1_bcast_row); // TODO: Is there a specific one for bcast mul?
+    #ifdef REPEAT_INTERLEAVE_IN1
+        binary_op_init_common(cb_in0_transposed, cb_in1_bcast_row); // TODO: Is there a specific one for bcast mul?
+    #else
+        binary_op_init_common(cb_id_in0, cb_id_in1);
+    #endif
 
     #ifdef REPEAT_IN0
         // Transpose in0
         cb_wait_front(cb_id_in0, onetile);
-        tile_regs_acquire();
-        tile_regs_wait();
+        // No need to transpose in0 if in1 is not repeat_interleaved
+        #ifdef REPEAT_INTERLEAVE_IN1
+            tile_regs_acquire();
+            tile_regs_wait();
 
-        transpose_wh_init_short(cb_id_in0);
-        transpose_wh_tile(cb_id_in0, 0, 0);
+            transpose_wh_init_short(cb_id_in0);
+            transpose_wh_tile(cb_id_in0, 0, 0);
 
-        cb_reserve_back(cb_in0_transposed, onetile);
-        pack_tile(0, cb_in0_transposed);
+            cb_reserve_back(cb_in0_transposed, onetile);
+            pack_tile(0, cb_in0_transposed);
 
-        tile_regs_commit();
-        tile_regs_release();
-        cb_push_back(cb_in0_transposed, onetile);
-        cb_pop_front(cb_id_in0, onetile);
+            tile_regs_commit();
+            tile_regs_release();
+            cb_push_back(cb_in0_transposed, onetile);
+            cb_pop_front(cb_id_in0, onetile);
 
-        cb_wait_front(cb_in0_transposed, onetile);
+            cb_wait_front(cb_in0_transposed, onetile);
+        #endif
     #endif
 
     for (uint32_t in1_block = 0; in1_block < in1_num_blocks; in1_block++) {
@@ -51,97 +58,115 @@ void MAIN {
         tile_regs_acquire();
         tile_regs_wait();
 
-        transpose_wh_init_short(cb_id_in1);
-        transpose_wh_tile(cb_id_in1, 0, 0);
+        //If input b is not repeat_interleaved, then no need to transpose, bcast row
+        #ifndef REPEAT_INTERLEAVE_IN1
+            mul_tiles_init(cb_id_in0, cb_id_in1);
+            mul_tiles(cb_id_in0, cb_id_in1, 0, 0, 0);
 
-        cb_reserve_back(cb_in1_transposed, onetile);
-        pack_tile(0, cb_in1_transposed);
+            cb_reserve_back(cb_id_out, onetile);
+            pack_tile(0, cb_id_out);
 
-        tile_regs_commit();
-        tile_regs_release();
-        cb_push_back(cb_in1_transposed, onetile);
-        cb_pop_front(cb_id_in1, onetile);
+            tile_regs_commit();
+            tile_regs_release();
+            cb_push_back(cb_id_out, onetile);
+            cb_pop_front(cb_id_in1, onetile);
+        #else
+            transpose_wh_init_short(cb_id_in1);
+            transpose_wh_tile(cb_id_in1, 0, 0);
 
-        // Receive in1 as single rows to bcast mul with in0
-        for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
-            #ifndef REPEAT_IN0
-                // Transpose in0
-                cb_wait_front(cb_id_in0, onetile);
+            cb_reserve_back(cb_in1_transposed, onetile);
+            pack_tile(0, cb_in1_transposed);
+
+            tile_regs_commit();
+            tile_regs_release();
+            cb_push_back(cb_in1_transposed, onetile);
+            cb_pop_front(cb_id_in1, onetile);
+
+            // Receive in1 as single rows to bcast mul with in0
+            for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
+                #ifndef REPEAT_IN0
+                    // Transpose in0
+                    cb_wait_front(cb_id_in0, onetile);
+                    tile_regs_acquire();
+                    tile_regs_wait();
+
+                    transpose_wh_init_short(cb_id_in0);
+                    transpose_wh_tile(cb_id_in0, 0, 0);
+
+                    cb_reserve_back(cb_in0_transposed, onetile);
+                    pack_tile(0, cb_in0_transposed);
+
+                    tile_regs_commit();
+                    tile_regs_release();
+                    cb_push_back(cb_in0_transposed, onetile);
+                    cb_pop_front(cb_id_in0, onetile);
+
+                    cb_wait_front(cb_in0_transposed, onetile);
+                #endif
+
+                cb_wait_front(cb_in1_bcast_row, onetile);
                 tile_regs_acquire();
                 tile_regs_wait();
 
-                transpose_wh_init_short(cb_id_in0);
-                transpose_wh_tile(cb_id_in0, 0, 0);
+                mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
+                mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
 
-                cb_reserve_back(cb_in0_transposed, onetile);
-                pack_tile(0, cb_in0_transposed);
+                cb_reserve_back(cb_out_transposed, onetile);
+                pack_tile(0, cb_out_transposed);
 
                 tile_regs_commit();
                 tile_regs_release();
-                cb_push_back(cb_in0_transposed, onetile);
-                cb_pop_front(cb_id_in0, onetile);
+                cb_push_back(cb_out_transposed, onetile);
+                #ifndef REPEAT_IN0
+                    cb_pop_front(cb_in0_transposed, onetile);
+                #endif
+                cb_pop_front(cb_in1_bcast_row, onetile);
 
-                cb_wait_front(cb_in0_transposed, onetile);
-            #endif
+                // Transpose output back
+                cb_wait_front(cb_out_transposed, onetile);
+                tile_regs_acquire();
+                tile_regs_wait();
 
-            cb_wait_front(cb_in1_bcast_row, onetile);
-            tile_regs_acquire();
-            tile_regs_wait();
+                transpose_wh_init_short(cb_out_transposed);
+                transpose_wh_tile(cb_out_transposed, 0, 0);
 
-            mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
-            mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
+                cb_reserve_back(cb_id_out, onetile);
+                pack_tile(0, cb_id_out);
 
-            cb_reserve_back(cb_out_transposed, onetile);
-            pack_tile(0, cb_out_transposed);
+                tile_regs_commit();
+                tile_regs_release();
+                cb_push_back(cb_id_out, onetile);
+                cb_pop_front(cb_out_transposed, onetile);
 
-            tile_regs_commit();
-            tile_regs_release();
-            cb_push_back(cb_out_transposed, onetile);
-            #ifndef REPEAT_IN0
-                cb_pop_front(cb_in0_transposed, onetile);
-            #endif
-            cb_pop_front(cb_in1_bcast_row, onetile);
+                /* TODO: Transpose directly on tiles in DST; is something like this possible?
+                cb_reserve_back(cb_id_out, onetile);
 
-            // Transpose output back
-            cb_wait_front(cb_out_transposed, onetile);
-            tile_regs_acquire();
-            tile_regs_wait();
+                tile_regs_acquire();
+                tile_regs_wait();
+                mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
+                mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
 
-            transpose_wh_init_short(cb_out_transposed);
-            transpose_wh_tile(cb_out_transposed, 0, 0);
+                MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(true, true, cb_id_out) ));
+                MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(0) ));
 
-            cb_reserve_back(cb_id_out, onetile);
-            pack_tile(0, cb_id_out);
+                pack_tile(0, cb_id_out);
 
-            tile_regs_commit();
-            tile_regs_release();
-            cb_push_back(cb_id_out, onetile);
-            cb_pop_front(cb_out_transposed, onetile);
+                tile_regs_commit();
+                tile_regs_release();
+                cb_push_back(cb_id_out, onetile);
+                cb_pop_front(cb_in1_bcast_row, onetile);
+                */
+            }
 
-            /* TODO: Transpose directly on tiles in DST; is something like this possible?
-            cb_reserve_back(cb_id_out, onetile);
-
-            tile_regs_acquire();
-            tile_regs_wait();
-            mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
-            mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
-
-            MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(true, true, cb_id_out) ));
-            MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(0) ));
-
-            pack_tile(0, cb_id_out);
-
-            tile_regs_commit();
-            tile_regs_release();
-            cb_push_back(cb_id_out, onetile);
-            cb_pop_front(cb_in1_bcast_row, onetile);
-            */
-        }
-
-        cb_pop_front(cb_in1_transposed, onetile);
+            cb_pop_front(cb_in1_transposed, onetile);
+        #endif
     }
     #ifdef REPEAT_IN0
-        cb_pop_front(cb_in0_transposed, onetile);
+        #ifdef REPEAT_INTERLEAVE_IN1
+            cb_pop_front(cb_in0_transposed, onetile);
+        #else
+            cb_pop_front(cb_id_in0, onetile);
+        #endif
     #endif
 }
 }


### PR DESCRIPTION
Extending ssm_eltwise_mul(input_a, input_b) kernel where
```
shape of input_a : [1, 1, 32, 32]
shape of input_b :  [1, 1, 32, 32*5120]
```
In this case, input_a is repeated 5120 times and multiplied eltwise with input b.

Refer yellow region in the diagram
![image](https://github.com/tenstorrent/tt-metal/assets/132708568/4bdd2599-c7a8-47eb-b330-3144c8174c31).

* All the variants of `ssm_eltwise_mul` is integrated with mamba model. Getting a device perf improvement of around `0.2ms`.
* Device perf target is updated to consider the changes
* Tensor Caching is removed from device perf test.
