### PR TITLE
#7516: launch C++ ttnn ops in async mode generically. Updated to_memory_config to be a ttnn C++ op

### DIFF
--- a/tests/ttnn/unit_tests/test_async.py
+++ b/tests/ttnn/unit_tests/test_async.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize("scalar", [3])
+@pytest.mark.parametrize("size", [64])
+def test_add_1D_tensor_and_scalar(device, scalar, size):
+    device.enable_async(True)
+
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((size,), dtype=torch.bfloat16)
+    torch_output_tensor = torch_input_tensor + scalar
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = input_tensor + scalar
+    output_tensor = ttnn.to_torch(output_tensor, torch_rank=1)
+
+    assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99988
+    assert output_tensor.shape == (size,)
+
+
+@pytest.mark.parametrize("h", [32])
+@pytest.mark.parametrize("w", [64])
+def test_add_2D_tensors(device, h, w):
+    device.enable_async(True)
+
+    torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, device=device)
+
+    input_tensor_a = ttnn.to_layout(input_tensor_a, ttnn.TILE_LAYOUT)
+    input_tensor_b = ttnn.to_layout(input_tensor_b, ttnn.TILE_LAYOUT)
+
+    input_tensor_a = ttnn.to_memory_config(input_tensor_a, ttnn.L1_MEMORY_CONFIG)
+    input_tensor_b = ttnn.to_memory_config(input_tensor_b, ttnn.L1_MEMORY_CONFIG)
+
+    output = ttnn.add(input_tensor_a, input_tensor_b)
+    output = ttnn.to_torch(output)
+
+    assert_with_pcc(torch_output_tensor, output, 0.9999)

--- a/tt_eager/tt_dnn/op_library/operation.hpp
+++ b/tt_eager/tt_dnn/op_library/operation.hpp
@@ -85,6 +85,9 @@ struct function_traits<fn<TReturn, TArgs...> T::*> {
 template <class FnPtr>
 using last_arg_of_function_t = typename function_traits<FnPtr>::last_arg_t;
 
+template <class FnPtr>
+using return_arg_of_function_t = typename function_traits<FnPtr>::return_t;
+
 template<typename, typename = std::void_t<>>
 struct has_create_program : std::false_type {};
 

--- a/tt_eager/tt_dnn/op_library/run_operation.hpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.hpp
@@ -43,6 +43,7 @@ auto generic_create_output_tensors(
 
 namespace run_operation_state {
 namespace detail {
+
 struct RunOperationState {
 
     RunOperationState() {}
@@ -96,6 +97,7 @@ inline const auto& get_composite_parent_names() {
 
 
 namespace detail {
+
 template<typename ReturnType, typename... Args>
 struct CompositeOperation {
 
@@ -392,7 +394,8 @@ void launch_op(
     const Tensors input_tensors,
     Tensors& output_tensors,
     const OptionalConstTensors optional_input_tensors = {},
-    const OptionalTensors optional_output_tensors = {}
+    const OptionalTensors optional_output_tensors = {},
+    bool enable_autoformat_device = true
 );
 
 void launch_with_autoformat(
@@ -403,7 +406,14 @@ void launch_with_autoformat(
     const OptionalTensors optional_output_tensors = {}
 );
 
-std::vector<Device*> get_workers_for_op_output(const std::vector<Tensor>&& inputs, const std::vector<std::optional<const Tensor>>&& optional_inputs = {});
+std::vector<Device*> get_workers_for_op_output(
+    const std::vector<Tensor>&& inputs,
+    const std::vector<std::optional<const Tensor>>&& optional_inputs = {},
+    bool enable_autoformat_device = true);
+
+namespace detail{
+    Device* get_device(const Tensors& input_tensors, const OptionalConstTensors& optional_input_tensors = {});
+}
 
 } //namespace operation
 

--- a/ttnn/cpp/pybind11/core.hpp
+++ b/ttnn/cpp/pybind11/core.hpp
@@ -33,6 +33,7 @@ void py_module(py::module& module) {
 
     module.def("get_memory_config", &ttnn::get_memory_config);
     module.def("set_printoptions", &ttnn::set_printoptions, py::kw_only(), py::arg("profile"));
+    module.def("dump_stack_trace_on_segfault", &ttnn::core::dump_stack_trace_on_segfault);
 }
 
 }  // namespace core

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -87,12 +87,35 @@ void py_module(py::module& module) {
 
     module.def("deallocate", &ttnn::operations::core::deallocate, py::arg("tensor"), py::arg("force") = true);
 
-    module.def(
-        "to_memory_config",
-        &ttnn::operations::core::to_memory_config,
-        py::arg("tensor"),
-        py::arg("memory_config"),
-        py::arg("dtype") = std::nullopt);
+    bind_registered_operation(
+        module,
+        ttnn::to_memory_config,
+        R"doc(to_memory_config(tensor: ttnn.Tensor, memory_config: MemoryConfig, dtype: Optional[DataType] = None) -> ttnn.Tensor
+
+            Converts a tensor to the desired mem_config, used for converting tensors to sharded tensors or interleaved, and to convert DRAM to L1 and vice versa
+
+
+            Args:
+                * :attr:`tensor`: the ttnn.Tensor
+                * :attr:`memory_config`: the desired MemoryConfig
+                * :attr:`dtype`: the optional `ttnn` data type.
+
+            Example::
+                >>> device_id = 0
+                >>> device = ttnn.open_device(device_id=device_id)
+                >>> tensor = ttnn.to_device(ttnn.from_torch(torch.randn((10, 64, 32), dtype=torch.bfloat16)), device)
+                >>> tensor = ttnn.to_memory_config(tensor, memory_config)
+        )doc",
+        ttnn::pybind_overload_t{
+            [](const std::decay_t<decltype(ttnn::to_memory_config)> self,
+               const ttnn::Tensor& tensor,
+               const ttnn::MemoryConfig& memory_config,
+               const std::optional<ttnn::DataType>& dtype) -> ttnn::Tensor {
+                return self(tensor, memory_config, dtype);
+               },
+               py::arg("tensor"),
+               py::arg("memory_config"),
+               py::arg("dtype") = std::nullopt});
 
     module.def(
         "reallocate",
@@ -158,7 +181,7 @@ Args:
                py::arg("dtype") = std::nullopt,
                py::arg("memory_config") = std::nullopt,
                py::arg("device") = std::nullopt});
-    
+
 }
 
 }  // namespace core

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -3,15 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <csignal>
 #include <optional>
 
 #include "third_party/magic_enum/magic_enum.hpp"
 #include "tt_eager/tensor/tensor.hpp"
 #include "tt_eager/tensor/tensor_impl.hpp"  // TTNN_TENSOR_PRINT_PROFILE
 #include "tt_eager/tensor/types.hpp"
+#include "tt_eager/tt_dnn/op_library/operation.hpp"
 #include "ttnn/types.hpp"
 
 namespace ttnn {
+
+using tt::tt_metal::operation::OptionalConstTensors;
+using tt::tt_metal::operation::OptionalTensors;
+using tt::tt_metal::operation::Tensors;
+
 using tt::tt_metal::any_tensor_on_multi_device;
 using tt::tt_metal::is_tensor_on_device;
 using tt::tt_metal::is_tensor_on_device_or_multidevice;
@@ -95,6 +102,18 @@ inline void set_printoptions(const std::string& profile) {
         magic_enum::enum_cast<tt::tt_metal::tensor_impl::TensorPrintProfile>(profile, [](char lhs, char rhs) {
             return std::tolower(lhs) == std::tolower(rhs);
         }).value();
+}
+
+inline void segfault_handler(int sig) {
+    std::cerr << tt::assert::backtrace_to_string() << std::endl;
+    exit(EXIT_FAILURE);
+}
+
+inline void dump_stack_trace_on_segfault() {
+    if (std::signal(SIGSEGV, segfault_handler) == SIG_ERR) {
+        std::cerr << "Error: cannot handle SIGSEGV" << std::endl;
+        exit(EXIT_FAILURE);
+    }
 }
 
 }  // namespace core

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -4,12 +4,153 @@
 
 #pragma once
 
+#include "tt_dnn/op_library/run_operation.hpp"
 #include "tt_eager/tensor/tensor.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 #include "ttnn/validation.hpp"
 
 namespace ttnn {
 namespace decorators {
+
+template <typename T, typename = void>
+struct has_validate_api_arguments : std::false_type {};
+template <typename T>
+struct has_validate_api_arguments<T, std::void_t<decltype(T::validate_api_arguments)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_create_async_output_tensors : std::false_type {};
+template <typename T>
+struct has_create_async_output_tensors<T, std::void_t<decltype(T::create_async_output_tensors)>> : std::true_type {};
+
+template <typename, typename T, typename... Args>
+struct has_map_launch_op_args_to_execute : std::false_type {};
+
+template <typename T, typename... Args>
+struct has_map_launch_op_args_to_execute<
+    decltype((void)(T::map_launch_op_args_to_execute(
+        std::declval<const Tensors&>(), std::declval<const OptionalConstTensors&>(), std::declval<Args>()...))),
+    T,
+    Args...> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_map_execute_return_to_vector : std::false_type {};
+template <typename T>
+struct has_map_execute_return_to_vector<T, std::void_t<decltype(T::map_execute_return_to_vector)>> : std::true_type {};
+
+template <class T, class... Args>
+using execute_return_t = decltype(T::execute(std::declval<Args>()...));
+
+template <class T, class... Args>
+constexpr bool has_execute() {
+    return std::experimental::is_detected_v<execute_return_t, T, Args&&...>;
+}
+
+template <class T, class... Args>
+using execute_async_return_t = decltype(T::execute_async(std::declval<Args>()...));
+
+template <class T, class... Args>
+constexpr bool has_execute_async() {
+    return std::experimental::is_detected_v<execute_async_return_t, T, Args&&...>;
+}
+
+// TODO: come back here and use this to automate map_launch_op_args_to_execute when this method is not implemented
+template <typename... Args1, typename... Args2>
+inline constexpr auto rearrange_tuples_to_match_argument_order(
+    const std::tuple<Args1...>& order, const std::tuple<Args2...>& to_rearrange) {
+    return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        return std::make_tuple(std::get<Is>(to_rearrange)...);
+    }(std::index_sequence<std::tuple_size_v<std::tuple<Args2...>>>{});
+}
+
+template <typename Include, typename... Args>
+auto extract_args_to_vector(Args&&... args) {
+    std::vector<Include> result;
+    result.reserve(sizeof...(Args));
+
+    auto process_arg = [&](auto&& arg) {
+        using ArgType = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<ArgType, Include>) {
+            result.push_back(arg);
+        }
+    };
+    (process_arg(std::forward<Args>(args)), ...);
+    return result;
+}
+
+template <typename T, typename... Excludes>
+constexpr bool is_any_of = (... || std::is_same_v<std::decay_t<T>, Excludes>);
+
+template <typename T, typename... Exclude>
+constexpr auto conditional_tuple(T&& arg) {
+    if constexpr (is_any_of<T, Exclude...>) {
+        return std::tuple<>();
+    } else {
+        return std::tuple<std::decay_t<T>>{std::forward<T>(arg)};
+    }
+}
+
+template <typename... Exclude, typename... Args>
+constexpr auto extract_args_excluding_types_by_value(Args&&... args) {
+    return std::tuple_cat(conditional_tuple<Args, Exclude...>(std::forward<Args>(args))...);
+}
+
+template <typename concrete_operation_t, typename... Args>
+inline Tensors create_async_output_tensors(
+    const Tensors&& inputs, const OptionalConstTensors&& optional_inputs, Args&&... args) {
+    if constexpr (has_create_async_output_tensors<concrete_operation_t>::value) {
+        return concrete_operation_t::create_async_output_tensors(std::forward<Args>(args)...);
+    } else {
+        bool enable_autoformat_device = false;
+        return {Tensor(operation::get_workers_for_op_output(
+            std::move(inputs), std::move(optional_inputs), enable_autoformat_device))};
+    }
+}
+
+template <typename T, typename Return, typename... Args>
+constexpr auto resolve_execute_method(Return (*launch)(Args...)) {
+    return [](const T& self, Args... args) { return self(std::forward<Args>(args)...); };
+}
+
+namespace detail {
+template <typename concrete_operation_t, typename... Args>
+constexpr auto validate(const char* cpp_fully_qualified_name, Args&&... args) {
+    if (ttnn::CONFIG.enable_fast_runtime_mode) {
+        return;
+    }
+    auto tensors_to_validate = concrete_operation_t::input_tensors_to_validate(std::forward<Args>(args)...);
+    static_assert(
+        std::tuple_size_v<decltype(tensors_to_validate)> ==
+            std::tuple_size_v<decltype(concrete_operation_t::input_tensor_schemas())>,
+        "Number of tensors to validate must match the number of input tensors schemas");
+    [cpp_fully_qualified_name, &tensors_to_validate]<auto... Ns>(std::index_sequence<Ns...>) {
+        (ttnn::validate_input_tensor(
+             cpp_fully_qualified_name,
+             std::get<Ns>(tensors_to_validate),
+             concrete_operation_t::input_tensor_schemas().at(Ns)),
+         ...);
+    }(std::make_index_sequence<std::tuple_size_v<decltype(tensors_to_validate)>>{});
+
+    if constexpr (has_validate_api_arguments<concrete_operation_t>::value) {
+        concrete_operation_t::validate_api_arguments(std::forward<Args>(args)...);
+    }
+}
+
+template <typename concrete_operation_t, typename T>
+constexpr auto map_execute_return_to_vector(const T&& value) -> Tensors {
+    if constexpr (has_map_execute_return_to_vector<concrete_operation_t>::value) {
+        return concrete_operation_t::map_execute_return_to_vector(std::forward<decltype(value)>(value));
+    } else if constexpr (std::is_same_v<std::decay_t<decltype(value)>, Tensors>) {
+        return value;
+    } else if constexpr (std::is_same_v<std::decay_t<decltype(value)>, Tensor>) {
+        return {value};
+    } else {
+        static_assert(
+            tt::stl::concepts::always_false_v<concrete_operation_t>,
+            "Operation must return either a single Tensor or a vector of Tensors or implement "
+            "map_execute_return_to_vector.");
+    }
+}
+}  // namespace detail
 
 template <auto id, typename concrete_operation_t>
 struct operation_t {
@@ -18,27 +159,78 @@ struct operation_t {
     template <typename... Args>
     auto operator()(Args&&... args) const {
         ZoneScopedN("ttnn::decorators::operation_t::operator()");
-        tt::log_debug(tt::LogOp, "Started  C++ ttnn operation: {}", this->cpp_fully_qualified_name);
+        tt::log_debug(tt::LogOp, "Started   C++ ttnn operation: {}", this->cpp_fully_qualified_name);
 
-        if (not ttnn::CONFIG.enable_fast_runtime_mode) {
-            auto tensors_to_validate = concrete_operation_t::input_tensors_to_validate(std::forward<Args>(args)...);
-            static_assert(
-                std::tuple_size_v<decltype(tensors_to_validate)> ==
-                    std::tuple_size_v<decltype(concrete_operation_t::input_tensor_schemas())>,
-                "Number of tensors to validate must match the number of input tensors schemas");
-            [this, &tensors_to_validate]<auto... Ns>(std::index_sequence<Ns...>) {
-                (ttnn::validate_input_tensor(
-                     this->cpp_fully_qualified_name,
-                     std::get<Ns>(tensors_to_validate),
-                     concrete_operation_t::input_tensor_schemas().at(Ns)),
-                 ...);
-            }(std::make_index_sequence<std::tuple_size_v<decltype(tensors_to_validate)>>{});
+        static_assert(
+            has_execute<concrete_operation_t, Args&&...>() xor has_execute_async<concrete_operation_t, Args&&...>(),
+            "Operation must either implement execute or execute_async.");
+
+        if constexpr (has_execute<concrete_operation_t, Args&&...>()) {
+            using return_type_of_execute = execute_return_t<concrete_operation_t, Args&&...>;
+            const Tensors input_tensors = extract_args_to_vector<ttnn::Tensor>(std::forward<Args>(args)...);
+            const OptionalConstTensors optional_input_tensors =
+                extract_args_to_vector<std::optional<const ttnn::Tensor>>(std::forward<Args>(args)...);
+
+            auto output_tensors = create_async_output_tensors<concrete_operation_t>(
+                std::move(input_tensors), std::move(optional_input_tensors), std::forward<Args>(args)...);
+
+            auto remaining_args =
+                extract_args_excluding_types_by_value<ttnn::Tensor, std::optional<const ttnn::Tensor>>(
+                    std::forward<Args>(args)...);
+
+            // TODO: add support for optional_output_tensors
+            // auto optional_output_tensors = extract_args_to_vector(std::forward<Args>(args)...,
+            // std::optional<ttnn::Tensor>);
+
+            bool enable_autoformat = false;
+            operation::launch_op(
+                [cpp_fully_qualified_name = this->cpp_fully_qualified_name, remaining_args](
+                    const Tensors& input_tensors,
+                    const OptionalConstTensors& optional_input_tensors,
+                    const OptionalTensors&) mutable -> Tensors {
+                    tt::log_debug(tt::LogOp, "Launching C++ ttnn operation in async: {}", cpp_fully_qualified_name);
+
+                    return std::apply(
+                        [cpp_fully_qualified_name, &input_tensors, &optional_input_tensors](auto&&... args) -> Tensors {
+                            auto args_execute_tuple = concrete_operation_t::map_launch_op_args_to_execute(
+                                input_tensors, optional_input_tensors, std::forward<decltype(args)>(args)...);
+                            return std::apply(
+                                [cpp_fully_qualified_name](auto&&... args) -> Tensors {
+                                    detail::validate<concrete_operation_t>(
+                                        cpp_fully_qualified_name, std::forward<decltype(args)>(args)...);
+                                    return detail::map_execute_return_to_vector<concrete_operation_t>(
+                                        concrete_operation_t::execute(std::forward<decltype(args)>(args)...));
+                                },
+                                args_execute_tuple);
+                        },
+                        remaining_args);
+                },
+                input_tensors,
+                output_tensors,
+                optional_input_tensors,
+                {},
+                enable_autoformat);
+
+            tt::log_debug(tt::LogOp, "Finished  C++ ttnn operation: {}", this->cpp_fully_qualified_name);
+
+            if constexpr (std::is_same_v<std::decay_t<return_type_of_execute>, Tensors>) {
+                return output_tensors;
+            } else if constexpr (std::is_same_v<std::decay_t<return_type_of_execute>, Tensor>) {
+                return output_tensors.at(0);
+            } else {
+                static_assert(
+                    tt::stl::concepts::always_false_v<concrete_operation_t>,
+                    "Operation is expecting the execute method to return either a single Tensor or a vector of "
+                    "Tensor(s).");
+            }
+
+        } else {
+            detail::validate<concrete_operation_t>(cpp_fully_qualified_name, std::forward<decltype(args)>(args)...);
+            tt::log_debug(tt::LogOp, "Launching C++ ttnn operation in async: {}", cpp_fully_qualified_name);
+            auto output = concrete_operation_t::execute_async(std::forward<decltype(args)>(args)...);
+            tt::log_debug(tt::LogOp, "Finished  C++ ttnn operation: {}", this->cpp_fully_qualified_name);
+            return output;
         }
-
-        auto output = concrete_operation_t::execute(std::forward<Args>(args)...);
-
-        tt::log_debug(tt::LogOp, "Finished C++ ttnn operation: {}", this->cpp_fully_qualified_name);
-        return output;
     }
 
     // Get "add" from "ttnn::add"
@@ -49,19 +241,19 @@ struct operation_t {
     }
 
     // Convert "ttnn::add" to "ttnn_add_t"
-    const std::string class_name() const {
-        return this->name() + "_t";
-    }
+    const std::string class_name() const { return this->name() + "_t"; }
 
     // Convert "ttnn::add" to "ttnn.add"
     const std::string python_fully_qualified_name() const {
         auto replace = [](const std::string& input, const std::string& from, const std::string& to) {
-            if(from.empty()) { return input; }
+            if (from.empty()) {
+                return input;
+            }
             auto output = input;
             size_t start = 0;
-            while((start = output.find(from, start)) != std::string::npos) {
+            while ((start = output.find(from, start)) != std::string::npos) {
                 output.replace(start, from.length(), to);
-                start += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+                start += to.length();  // In case 'to' contains 'from', like replacing 'x' with 'yx'
             };
             return output;
         };

--- a/ttnn/cpp/ttnn/op_library/to_layout/to_layout_op.hpp
+++ b/ttnn/cpp/ttnn/op_library/to_layout/to_layout_op.hpp
@@ -42,6 +42,15 @@ struct ToLayout {
         return std::make_tuple(tensor_arg);
     }
 
+
+    template <typename... Args>
+    static auto map_launch_op_args_to_execute(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        Args&&... args) {
+            return std::make_tuple(input_tensors.at(0), std::forward<Args>(args)...);
+    }
+
     static Tensor execute(
         const ttnn::Tensor& tensor_arg,
         const ttnn::Layout layout,

--- a/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <optional>
+
+#include "tensor/tensor.hpp"
+// #include "third_party/magic_enum/magic_enum.hpp"
+// #include "tt_eager/tensor/owned_buffer_functions.hpp"
+// #include "tt_eager/tensor/tensor_utils.hpp"
+#include "tt_eager/tt_dnn/op_library/compute_kernel_config.hpp"
+#include "tt_eager/tt_dnn/op_library/copy/copy_op.hpp"
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
+#include "tt_eager/tt_dnn/op_library/sharded/sharded_op.hpp"
+// #include "tt_metal/host_api.hpp"
+// #include "tt_metal/impl/dispatch/command_queue.hpp"
+// #include "ttnn/core.hpp"
+#include "ttnn/operations/core.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn {
+
+namespace operations {
+
+namespace core {
+
+struct ToMemoryConfig {
+    static inline const std::array<TensorSchema, 1> input_tensor_schemas() {
+        return {ttnn::TensorSchema{
+            1,
+            4,
+            {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b, ttnn::float32, ttnn::uint16, ttnn::uint32, ttnn::int32},
+            {ttnn::ROW_MAJOR_LAYOUT, ttnn::TILE_LAYOUT},
+            true,
+            true,
+            false,
+            false}};
+    }
+
+    template <typename... Args>
+    static auto input_tensors_to_validate(const Tensor& tensor_arg, Args&&... args) {
+        return std::make_tuple(tensor_arg);
+    };
+
+    template <typename... Args>
+    static Tensor create_async_output_tensors(const ttnn::Tensor& tensor_arg, Args&&... args) {
+        return {{Tensor(operation::get_workers_for_op_output({tensor_arg}))}};
+    }
+
+    template <typename... Args>
+    static auto map_launch_op_args_to_execute(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        Args&&... args) {
+        return std::make_tuple(input_tensors.at(0), std::forward<Args>(args)...);
+    }
+
+    // TODO: Move to cpp once we merge with tt_eager
+    static Tensor execute(
+        const ttnn::Tensor tensor,
+        const ttnn::MemoryConfig& memory_config,
+        std::optional<ttnn::DataType> dtype) {
+        // Temporary until we see why buffer data not being populated
+        const auto original_shape = tensor.get_shape();
+
+        const auto original_memory_config = ttnn::get_memory_config(tensor);
+        if (original_memory_config.has_value() && original_memory_config.value() == memory_config) {
+            return tensor;
+        }
+
+        if (memory_config.is_sharded()) {
+            // to_sharded path
+            if (tensor.is_sharded()) {
+                // reshard
+                const auto input_memory_config = ttnn::get_memory_config(tensor);
+                const auto input_shard_spec = input_memory_config.value().shard_spec.value();
+                const auto output_shard_spec = memory_config.shard_spec.value();
+                if (tensor.get_layout() == ttnn::TILE_LAYOUT ||
+                    input_shard_spec.shape[1] == output_shard_spec.shape[1]) {
+                    if (dtype.has_value()) {
+                        throw runtime_error(
+                            "dtype cannot be specified when converting sharded tensor to sharded tensor");
+                    }
+                    TT_FATAL(tensor.shard_spec().has_value());
+                    TT_FATAL(memory_config.is_sharded());
+                    return operation::run(
+                               Reshard{
+                                   .output_mem_config = memory_config,
+                               },
+                               {tensor})
+                        .at(0);
+                } else {
+                    // for row-major tensors where shard-spec[1] is different for input shard and output shard
+
+                    TT_FATAL(memory_config.is_sharded());
+                    Tensor temp = operation::run(
+                                      Sharded{
+                                          .grid_size = tensor.device()->compute_with_storage_grid_size(),
+                                          .shard_spec = input_shard_spec,
+                                          .sharded_op_type = ShardedOpType::ShardedToInterleaved,
+                                          .output_mem_config = ttnn::DRAM_MEMORY_CONFIG,
+                                          .output_dtype = dtype.value_or(tensor.get_dtype())},
+                                      {tensor})
+                                      .at(0);
+                    return operation::run(
+                               Sharded{
+                                   .grid_size = temp.device()->compute_with_storage_grid_size(),
+                                   .shard_spec = output_shard_spec,
+                                   .sharded_op_type = ShardedOpType::InterleavedToSharded,
+                                   .output_mem_config = memory_config,
+                                   .output_dtype = dtype.value_or(temp.get_dtype())},
+                               {temp})
+                        .at(0);
+                }
+            } else {
+                TT_FATAL(memory_config.is_sharded());
+                auto bbox = memory_config.shard_spec.value().grid.bounding_box();
+                CoreCoord grid_size(bbox.end.x + 1, bbox.end.y + 1);
+                return operation::run(
+                           Sharded{
+                               .grid_size = grid_size,
+                               .shard_spec = memory_config.shard_spec.value(),
+                               .sharded_op_type = ShardedOpType::InterleavedToSharded,
+                               .output_mem_config = memory_config,
+                               .output_dtype = dtype.value_or(tensor.get_dtype())},
+                           {tensor})
+                    .at(0);
+            }
+        } else {
+            // to_interleaved path
+            if (tensor.is_sharded()) {
+                TT_FATAL(tensor.shard_spec().has_value());
+                auto shard_spec = tensor.shard_spec().value();
+                return operation::run(
+                           Sharded{
+                               .grid_size = tensor.device()->compute_with_storage_grid_size(),
+                               .shard_spec = shard_spec,
+                               .sharded_op_type = ShardedOpType::ShardedToInterleaved,
+                               .output_mem_config = memory_config,
+                               .output_dtype = dtype.value_or(tensor.get_dtype())},
+                           {tensor})
+                    .at(0);
+            } else {
+                // L1 to DRAM or DRAM to L1
+                return operation::run(Copy{memory_config, dtype.value_or(tensor.get_dtype())}, {tensor}).at(0);
+            }
+        }
+
+        return tensor;
+    }
+};
+
+}  // namespace core
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl.hpp
@@ -29,7 +29,15 @@ struct AllGather {
         return std::make_tuple(input_tensor);
     }
 
-    static ttnn::Tensor execute(
+    template <typename... Args>
+    static auto map_launch_op_args_to_execute(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        Args&&... args) {
+        return std::make_tuple(input_tensors.at(0), std::forward<Args>(args)...);
+    }
+
+    static ttnn::Tensor execute_async(
         const ttnn::Tensor& input_tensor,
         const uint32_t dim,
         const uint32_t num_links = 1,

--- a/ttnn/cpp/ttnn/operations/normalization.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization.hpp
@@ -24,6 +24,15 @@ struct Softmax {
         return std::make_tuple(input_tensor);
     }
 
+
+    template <typename... Args>
+    static auto map_launch_op_args_to_execute(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        Args&&... args) {
+            return std::make_tuple(input_tensors.at(0), std::forward<Args>(args)...);
+    }
+
     static ttnn::Tensor execute(
         const ttnn::Tensor& input_tensor,
         const int dim_arg,
@@ -102,6 +111,16 @@ struct LayerNorm : tt::operations::primary::LayerNorm {
         return std::make_tuple(input_tensor, weight, bias, residual_input_tensor);
     }
 
+
+    template <typename... Args>
+    static auto map_launch_op_args_to_execute(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        float epsilon = 1e-12,
+        Args&&... args) {
+            return std::make_tuple(input_tensors.at(0),epsilon,optional_input_tensors.at(0), optional_input_tensors.at(1), optional_input_tensors.at(2), std::forward<Args>(args)...);
+    }
+
     static inline ttnn::Tensor execute(
         const ttnn::Tensor& input_tensor,
         float epsilon = 1e-12,
@@ -149,6 +168,15 @@ struct RMSNorm : tt::operations::primary::LayerNorm {
     template <typename... Args>
     static auto input_tensors_to_validate(const Tensor& input_tensor, const Tensor& weight, Args&&... args) {
         return std::make_tuple(input_tensor, weight);
+    }
+
+
+    template <typename... Args>
+    static auto map_launch_op_args_to_execute(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        Args&&... args) {
+            return std::make_tuple(input_tensors.at(0), input_tensors.at(1), std::forward<Args>(args)...);
     }
 
     static inline ttnn::Tensor execute(

--- a/ttnn/cpp/ttnn/operations/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/unary.hpp
@@ -40,24 +40,13 @@ inline Tensor execute(
     const Tensor& input_tensor,
     const std::vector<tt::tt_metal::UnaryWithParam>& op_chain,
     const std::optional<MemoryConfig>& memory_config = std::nullopt) {
-    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    operation::launch_op(
-        [op_chain, memory_config](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            const auto& input_tensor = input_tensors.at(0);
-            bool fp32_dest_acc_en =
-                input_tensor.get_dtype() == DataType::UINT32 or
-                input_tensor.get_dtype() == DataType::INT32;  // MT: Currently only uint32/int32 is moved to DST
-                                                              // directly, fp32 is converted to fp16b
-            return operation::run(
-                EltwiseUnary{op_chain, memory_config.value_or(input_tensor.memory_config()), fp32_dest_acc_en},
-                {input_tensor});
-        },
-        {input_tensor},
-        output_tensors);
-    return output_tensors.at(0);
+    bool fp32_dest_acc_en = input_tensor.get_dtype() == DataType::UINT32 or
+                            input_tensor.get_dtype() == DataType::INT32;  // MT: Currently only uint32/int32 is moved to
+                                                                          // DST directly, fp32 is converted to fp16b
+    return operation::run(
+               EltwiseUnary{op_chain, memory_config.value_or(input_tensor.memory_config()), fp32_dest_acc_en},
+               {input_tensor})
+        .at(0);
 }
 }  // namespace detail
 
@@ -69,6 +58,15 @@ struct Unary : public EltwiseUnary {
     static auto input_tensors_to_validate(const Tensor& input_tensor, Args&&... args) {
         return detail::input_tensors_to_validate(input_tensor, std::forward<Args>(args)...);
     };
+
+
+    template <typename... Args>
+    static auto map_launch_op_args_to_execute(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        Args&&... args) {
+            return std::make_tuple(input_tensors.at(0), std::forward<Args>(args)...);
+    }
 
     static Tensor execute(const Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config = std::nullopt) {
         return detail::execute(
@@ -83,6 +81,15 @@ struct Exp : public EltwiseUnary {
     static auto input_tensors_to_validate(const Tensor& input_tensor, Args&&... args) {
         return detail::input_tensors_to_validate(input_tensor, std::forward<Args>(args)...);
     };
+
+
+    template <typename... Args>
+    static auto map_launch_op_args_to_execute(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        Args&&... args) {
+            return std::make_tuple(input_tensors.at(0), std::forward<Args>(args)...);
+    }
 
     static Tensor execute(
         const Tensor& input_tensor,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -226,6 +226,7 @@ from ttnn.core import (
     create_sharded_memory_config,
     dump_memory_config,
     load_memory_config,
+    dump_stack_trace_on_segfault,
 )
 
 import ttnn.reflection

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -43,6 +43,13 @@ def has_tile_padding(tensor):
     return False
 
 
+def dump_stack_trace_on_segfault():
+    """
+    Registers a handler to allow a stack trace to be logged to the console should the program fail because of a segfault.
+    """
+    ttnn._ttnn.core.dump_stack_trace_on_segfault()
+
+
 def create_sharded_memory_config(
     shape: Union[ttnn.Shape, Tuple[int, ...], List[int]],
     core_grid: Union[ttnn.CoreGrid, ttnn.CoreRange],

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -479,25 +479,7 @@ def _golden_function(tensor, *args, **kwargs):
     return tensor
 
 
-doc = r"""
-    to_memory_config(tensor: ttnn.Tensor, memory_config: MemoryConfig, dtype: Optional[DataType] = None) -> ttnn.Tensor
-
-    Converts a tensor to the desired mem_config, used for converting tensors to sharded tensors or interleaved, and to convert DRAM to L1 and vice versa
-
-
-    Args:
-        * :attr:`tensor`: the ttnn.Tensor
-        * :attr:`memory_config`: the desired MemoryConfig
-        * :attr:`dtype`: the optional `ttnn` data type.
-
-    Example::
-        >>> device_id = 0
-        >>> device = ttnn.open_device(device_id=device_id)
-        >>> tensor = ttnn.to_device(ttnn.from_torch(torch.randn((10, 64, 32), dtype=torch.bfloat16)), device)
-        >>> tensor = ttnn.to_memory_config(tensor, memory_config)
-    """
-
-to_memory_config = ttnn.register_operation(name="ttnn.to_memory_config", golden_function=_golden_function, doc=doc)(
+to_memory_config = ttnn.register_operation(golden_function=_golden_function)(
     ttnn._ttnn.operations.core.to_memory_config
 )
 


### PR DESCRIPTION
Updated C++ ttnn op registration to call `launch_op` automatically

Before this change, `launch_op` had to be specified manually which is time-consuming and could be error-prone. Now we wrap all of the APIs using `launch_op` in a common path. 

New method `map_launch_op_args_to_execute` was added to all registered ops for mapping vectors of tensors back into original args. This is a temporary method as we can delete once we update `launch_op` to not use vectors