### PR TITLE
#5044: Add optional output tensor and remove autoformat in eltwise binary ops

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -725,6 +725,71 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_isclose,
         "pytorch_op": pytorch_ops.isclose,
     },
+    # Eltwise binary with optional output
+    "eltwise-ne-optional": {
+        "tt_op": tt_lib_ops.eltwise_ne_optional,
+        "pytorch_op": pytorch_ops.ne,
+    },
+    "eltwise-bias_gelu-optional": {
+        "tt_op": tt_lib_ops.eltwise_bias_gelu_optional,
+        "pytorch_op": pytorch_ops.bias_gelu,
+    },
+    "eltwise-eq-optional": {
+        "tt_op": tt_lib_ops.eltwise_eq_optional,
+        "pytorch_op": pytorch_ops.eq,
+    },
+    "eltwise-lt-optional": {
+        "tt_op": tt_lib_ops.eltwise_lt_optional,
+        "pytorch_op": pytorch_ops.lt,
+    },
+    "eltwise-gt-optional": {
+        "tt_op": tt_lib_ops.eltwise_gt_optional,
+        "pytorch_op": pytorch_ops.gt,
+    },
+    "eltwise-gte-optional": {
+        "tt_op": tt_lib_ops.eltwise_gte_optional,
+        "pytorch_op": pytorch_ops.gte,
+    },
+    "eltwise-lte-optional": {
+        "tt_op": tt_lib_ops.eltwise_lte_optional,
+        "pytorch_op": pytorch_ops.lte,
+    },
+    "eltwise-add-optional": {
+        "tt_op": tt_lib_ops.eltwise_add_optional,
+        "pytorch_op": pytorch_ops.add,
+    },
+    "eltwise-sub-optional": {
+        "tt_op": tt_lib_ops.eltwise_sub_optional,
+        "pytorch_op": pytorch_ops.sub,
+    },
+    "eltwise-mul-optional": {
+        "tt_op": tt_lib_ops.eltwise_mul_optional,
+        "pytorch_op": pytorch_ops.mul,
+    },
+    "eltwise-squared_difference-optional": {
+        "tt_op": tt_lib_ops.eltwise_squared_difference_optional,
+        "pytorch_op": pytorch_ops.squared_difference,
+    },
+    "eltwise-ldexp-optional": {
+        "tt_op": tt_lib_ops.eltwise_ldexp_optional,
+        "pytorch_op": pytorch_ops.ldexp,
+    },
+    "eltwise-logaddexp-optional": {
+        "tt_op": tt_lib_ops.eltwise_logaddexp_optional,
+        "pytorch_op": pytorch_ops.logaddexp,
+    },
+    "eltwise-logaddexp2-optional": {
+        "tt_op": tt_lib_ops.eltwise_logaddexp2_optional,
+        "pytorch_op": pytorch_ops.logaddexp2,
+    },
+    "eltwise-logical_or-optional": {
+        "tt_op": tt_lib_ops.eltwise_logical_or_optional,
+        "pytorch_op": pytorch_ops.logical_or,
+    },
+    "eltwise-logical_and-optional": {
+        "tt_op": tt_lib_ops.eltwise_logical_and_optional,
+        "pytorch_op": pytorch_ops.logical_and,
+    },
     # Eltwise ternary
     "eltwise-arange": {
         "tt_op": tt_lib_ops.arange,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_binary_optional_output.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_binary_optional_output.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from functools import partial
+import tt_lib as ttl
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+from models.utility_functions import is_wormhole_b0
+
+shapes = [
+    [[1, 1, 32, 32], [1, 1, 32, 32], [1, 1, 32, 32]],  # Single core
+    [[1, 1, 32, 32], [32, 1, 32, 32], [32, 1, 32, 32]],  # Single core
+    [[64, 1, 32, 32], [1, 1, 32, 32], [64, 1, 32, 32]],  # Single core
+    [[1, 1, 320, 384], [1, 1, 320, 384], [1, 1, 320, 384]],  # Multi core
+    [[1, 3, 320, 384], [1, 3, 320, 384], [1, 3, 320, 384]],  # Multi core
+]
+
+input_mem_cfgs = generation_funcs.supported_mem_configs
+
+if is_wormhole_b0():
+    shapes = [
+        shapes[0],
+    ]
+    input_mem_cfgs = [
+        input_mem_cfgs[0],
+    ]
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    shapes,
+)
+@pytest.mark.parametrize("input_mem_config", input_mem_cfgs)
+class TestEltwiseBinary:
+    @pytest.mark.parametrize("fn_kind", ["add", "sub", "mul", "squared_difference"])
+    @pytest.mark.parametrize("in0_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+    @pytest.mark.parametrize("in1_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+    @pytest.mark.parametrize("in2_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+    def test_run_eltwise_binary_ops(
+        self,
+        input_shapes,
+        fn_kind,
+        in0_dtype,
+        in1_dtype,
+        in2_dtype,
+        input_mem_config,
+        device,
+        function_level_defaults,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+        ] * (len(input_shapes) - 1)
+        datagen_func.append(
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-10, high=10), torch.bfloat16)
+        )
+        test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+        test_args.update(
+            {
+                "dtype": [in0_dtype, in1_dtype, in2_dtype],
+                "input_mem_config": [input_mem_config, input_mem_config, input_mem_config],
+            }
+        )
+        comparison_func = comparison_funcs.comp_pcc
+        run_single_pytorch_test(
+            f"eltwise-{fn_kind}-optional",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+    @pytest.mark.parametrize(
+        "fn_kind",
+        [
+            "bias_gelu",
+        ],
+    )
+    def test_run_eltwise_binary_bias_ops(
+        self,
+        input_shapes,
+        fn_kind,
+        input_mem_config,
+        device,
+        function_level_defaults,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ] * (len(input_shapes) - 1)
+        datagen_func.append(
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-10, high=10), torch.bfloat16)
+        )
+
+        test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+        test_args.update(
+            {
+                "input_mem_config": [input_mem_config, input_mem_config, input_mem_config],
+            }
+        )
+        comparison_func = comparison_funcs.comp_pcc
+        run_single_pytorch_test(
+            f"eltwise-{fn_kind}-optional",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+    @pytest.mark.parametrize("cmp_kind", ["lt", "gt", "lte", "gte", "ne", "eq"])
+    def test_run_eltwise_binary_cmp_ops(
+        self,
+        input_shapes,
+        input_mem_config,
+        cmp_kind,
+        device,
+        function_level_defaults,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ] * (len(input_shapes) - 1)
+        datagen_func.append(
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-10, high=10), torch.bfloat16)
+        )
+        test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+        test_args.update(
+            {
+                "input_mem_config": [input_mem_config, input_mem_config, input_mem_config],
+            }
+        )
+        comparison_func = comparison_funcs.comp_equal
+        run_single_pytorch_test(
+            f"eltwise-{cmp_kind}-optional",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+    @pytest.mark.parametrize(
+        "log_kind, input_range",
+        (
+            ("logaddexp", {"low": -80, "high": 80}),
+            ("ldexp", {"low": -60, "high": 60}),
+            ("logaddexp2", {"low": -60, "high": 100}),
+        ),
+    )
+    def test_run_eltwise_binary_log_ops(
+        self, input_shapes, input_mem_config, log_kind, input_range, device, function_level_defaults
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, **input_range), torch.bfloat16)
+        ] * (len(input_shapes) - 1)
+        datagen_func.append(
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-10, high=10), torch.bfloat16)
+        )
+        test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+        test_args.update(
+            {
+                "input_mem_config": [input_mem_config, input_mem_config, input_mem_config],
+            }
+        )
+        comparison_func = comparison_funcs.comp_pcc
+        run_single_pytorch_test(
+            f"eltwise-{log_kind}-optional",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+    @pytest.mark.parametrize("logical_kind", ["logical_and", "logical_or"])
+    def test_run_eltwise_binary_logical_ops(
+        self,
+        input_shapes,
+        input_mem_config,
+        logical_kind,
+        device,
+        function_level_defaults,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.int32)
+        ] * (len(input_shapes) - 1)
+        datagen_func.append(
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-10, high=10), torch.bfloat16)
+        )
+        test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+        test_args.update(
+            {
+                "input_mem_config": [input_mem_config, input_mem_config, input_mem_config],
+            }
+        )
+        comparison_func = comparison_funcs.comp_equal
+        run_single_pytorch_test(
+            f"eltwise-{logical_kind}-optional",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+    @pytest.mark.parametrize(
+        "log_kind, input_range",
+        (
+            ("logaddexp", {"low": -80, "high": 80}),
+            ("ldexp", {"low": -60, "high": 60}),
+            ("logaddexp2", {"low": -60, "high": 100}),
+        ),
+    )
+    def test_run_eltwise_binary_log_ops(
+        self, input_shapes, input_mem_config, log_kind, input_range, device, function_level_defaults
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, **input_range), torch.bfloat16)
+        ] * (len(input_shapes) - 1)
+        datagen_func.append(
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-10, high=10), torch.bfloat16)
+        )
+        test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+        test_args.update(
+            {
+                "input_mem_config": [input_mem_config, input_mem_config, input_mem_config],
+            }
+        )
+        comparison_func = comparison_funcs.comp_pcc
+        run_single_pytorch_test(
+            f"eltwise-{log_kind}-optional",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2379,6 +2379,48 @@ eltwise_isnan = make_unary_op(ttl.tensor.isnan)
 eltwise_logical_not_unary = make_unary_op(ttl.tensor.logical_not_unary)
 eltwise_i0 = make_unary_op(ttl.tensor.i0)
 
+
+def make_binary_op_optional_output(ttl_tensor_binop):
+    @setup_host_and_device
+    def binary_op(
+        x,
+        y,
+        z,
+        *args,
+        device,
+        dtype,
+        layout,
+        input_mem_config,
+        **kwargs,
+    ):
+        t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+        t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+        t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+        ttl_tensor_binop(t0, t1, output_tensor=t2)
+
+        return tt2torch_tensor(t2)
+
+    return binary_op
+
+
+eltwise_add_optional = make_binary_op_optional_output(ttl.tensor.add)
+eltwise_sub_optional = make_binary_op_optional_output(ttl.tensor.sub)
+eltwise_mul_optional = make_binary_op_optional_output(ttl.tensor.mul)
+eltwise_bias_gelu_optional = make_binary_op_optional_output(ttl.tensor.bias_gelu)
+eltwise_squared_difference_optional = make_binary_op_optional_output(ttl.tensor.squared_difference)
+eltwise_ne_optional = make_binary_op_optional_output(ttl.tensor.ne)
+eltwise_eq_optional = make_binary_op_optional_output(ttl.tensor.eq)
+eltwise_gt_optional = make_binary_op_optional_output(ttl.tensor.gt)
+eltwise_lt_optional = make_binary_op_optional_output(ttl.tensor.lt)
+eltwise_gte_optional = make_binary_op_optional_output(ttl.tensor.gte)
+eltwise_lte_optional = make_binary_op_optional_output(ttl.tensor.lte)
+eltwise_ldexp_optional = make_binary_op_optional_output(ttl.tensor.ldexp)
+eltwise_logaddexp_optional = make_binary_op_optional_output(ttl.tensor.logaddexp)
+eltwise_logaddexp2_optional = make_binary_op_optional_output(ttl.tensor.logaddexp2)
+eltwise_logical_and_optional = make_binary_op_optional_output(ttl.tensor.logical_and)
+eltwise_logical_or_optional = make_binary_op_optional_output(ttl.tensor.logical_or)
+
+
 ################################################
 #################### Tensor ####################
 ################################################

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_prod.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_prod.py
@@ -38,7 +38,7 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
         (torch.Size([4, 33, 32, 32])),  # 20
         (torch.Size([4, 63, 32, 32])),  # 21
         (torch.Size([4, 64, 32, 32])),  # 22
-        (torch.Size([32, 64, 32, 32])),  # 23
+        (torch.Size([32, 64, 64, 64])),  # 23
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_backward_complex_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_backward_complex_ops.py
@@ -127,14 +127,14 @@ def test_level2_conj_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
     in_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.conj_bw(grad_tensor, input_tensor, memcfg)
     in_data.retain_grad()
@@ -177,14 +177,14 @@ def test_level2_imag_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
     in_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_data = grad_data.imag
     grad_tensor = ttl.tensor.Tensor(
-        ttl.tensor.Tensor(grad_data, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.imag_bw(grad_tensor, input_tensor, memcfg)
     in_data.retain_grad()
@@ -227,14 +227,14 @@ def test_level2_real_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
     in_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_data = grad_data.real
     grad_tensor = ttl.tensor.Tensor(
-        ttl.tensor.Tensor(grad_data, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.real_bw(grad_tensor, input_tensor, memcfg)
     in_data.retain_grad()
@@ -281,18 +281,18 @@ def test_level2_complex_add_bw(bs, hw, alpha, memcfg, dtype, device, function_le
     other_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     other_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_add_bw(grad_tensor, input_tensor, other_tensor, alpha, memcfg)
     in_data.retain_grad()
@@ -341,18 +341,18 @@ def test_level2_complex_sub_bw(bs, hw, alpha, memcfg, dtype, device, function_le
     other_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     other_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_sub_bw(grad_tensor, input_tensor, other_tensor, alpha, memcfg)
     in_data.retain_grad()
@@ -400,18 +400,18 @@ def test_level2_complex_mul_bw(bs, hw, memcfg, dtype, device, function_level_def
     other_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     other_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_mul_bw(grad_tensor, input_tensor, other_tensor, memcfg)
     in_data.retain_grad()
@@ -459,18 +459,18 @@ def test_level2_complex_div_bw(bs, hw, memcfg, dtype, device, function_level_def
     other_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     other_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_div_bw(grad_tensor, input_tensor, other_tensor, memcfg)
     in_data.retain_grad()
@@ -519,18 +519,18 @@ def test_level2_complex_div_bw_other_zero(bs, hw, memcfg, dtype, device, functio
     other_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     other_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_div_bw(grad_tensor, input_tensor, other_tensor, memcfg)
     in_data.retain_grad()
@@ -575,8 +575,8 @@ def test_level2_abs_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
     in_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data, grad_tensor = data_gen_with_range(input_shape, -50, 40, device)
@@ -622,8 +622,8 @@ def test_level2_abs_bw_inp_zero(bs, hw, memcfg, dtype, device, function_level_de
     in_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data, grad_tensor = data_gen_with_range(input_shape, -50, 80, device)
@@ -669,14 +669,14 @@ def test_level2_recip_bw(bs, hw, memcfg, dtype, device, function_level_defaults)
     in_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_recip_bw(grad_tensor, input_tensor, memcfg)
     in_data.retain_grad()
@@ -720,14 +720,14 @@ def test_level2_recip_bw_inp_zero(bs, hw, memcfg, dtype, device, function_level_
     in_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_recip_bw(grad_tensor, input_tensor, memcfg)
     in_data.retain_grad()
@@ -770,8 +770,8 @@ def test_level2_angle_bw(bs, hw, memcfg, dtype, device, function_level_defaults)
     in_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data, grad_tensor = data_gen_with_range(input_shape, -50, 40, device)
@@ -818,14 +818,14 @@ def test_level2_polar_bw(bs, hw, memcfg, dtype, device, function_level_defaults)
     in_data.requires_grad = True
 
     input_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
     grad_tensor = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.polar_bw(grad_tensor, input_tensor, memcfg)
     in_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_complex.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_complex.py
@@ -98,7 +98,7 @@ def test_level1_is_real(memcfg, dtype, device, function_level_defaults):
     # check real
     x = Complex(input_shape)
     x = x.add(x.conj())
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
     tt_dev = ttl.tensor.is_real(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.is_real()
@@ -121,7 +121,7 @@ def test_level1_is_imag(memcfg, dtype, device, function_level_defaults):
     # check imag
     x = Complex(input_shape)
     x = x.sub(x.conj())
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
     tt_dev = ttl.tensor.is_imag(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.is_imag()
@@ -143,7 +143,7 @@ def test_level1_angle(memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([1, 1, 32, 64])
     # check angle
     x = Complex(input_shape)
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
     tt_dev = ttl.tensor.angle(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.angle
@@ -165,7 +165,7 @@ def test_level1_real(memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([1, 1, 32, 64])
     # check real
     x = Complex(input_shape)
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
     tt_dev = ttl.tensor.real(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.real
@@ -183,7 +183,7 @@ def test_level1_real(memcfg, dtype, device, function_level_defaults):
     ids=["out_DRAM", "out_L1"],
 )
 @pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
-@pytest.mark.parametrize("layout", ((ttl.tensor.Layout.ROW_MAJOR,)))
+@pytest.mark.parametrize("layout", ((ttl.tensor.Layout.TILE,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2)))
 def test_level1_imag(bs, memcfg, dtype, device, function_level_defaults, layout):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
@@ -192,7 +192,7 @@ def test_level1_imag(bs, memcfg, dtype, device, function_level_defaults, layout)
     tt_cpu = x.imag
     xtt = ttl.tensor.Tensor(x.metal, dtype).to(layout).to(device, memcfg)
     tt_dev = ttl.tensor.imag(xtt)
-    tt_dev = tt_dev.cpu().to(layout).to_torch()
+    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     passing, output = comp_equal(tt_cpu, tt_dev)
     logger.info(output)
     assert passing
@@ -207,7 +207,7 @@ def test_level1_imag(bs, memcfg, dtype, device, function_level_defaults, layout)
     ids=["out_DRAM", "out_L1"],
 )
 @pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
-@pytest.mark.parametrize("layout", ((ttl.tensor.Layout.ROW_MAJOR,)))
+@pytest.mark.parametrize("layout", ((ttl.tensor.Layout.TILE,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2)))
 def test_level1_abs(bs, memcfg, dtype, device, function_level_defaults, layout):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
@@ -215,7 +215,7 @@ def test_level1_abs(bs, memcfg, dtype, device, function_level_defaults, layout):
     x = Complex(input_shape)
     xtt = ttl.tensor.Tensor(x.metal, dtype).to(layout).to(device, memcfg)
     tt_dev = ttl.tensor.complex_abs(xtt, memcfg)
-    tt_dev = tt_dev.cpu().to(layout).to_torch()
+    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.abs()
     passing, output = comp_pcc(tt_cpu, tt_dev)
     logger.info(output)
@@ -236,7 +236,7 @@ def test_level1_conj(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check conj
     x = Complex(input_shape)
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
     tt_dev = ttl.tensor.conj(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
     tt_cpu = x.conj().metal
@@ -264,8 +264,8 @@ def test_level1_add(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * -0.5
 
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
-    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
+    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
 
     tt_dev = ttl.tensor.add(xtt, ytt)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -293,8 +293,8 @@ def test_level1_sub(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * 0.5
 
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
-    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
+    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
 
     tt_dev = ttl.tensor.sub(xtt, ytt)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -322,8 +322,8 @@ def test_level1_mul_bs(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * 0.75
 
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
-    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
+    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
 
     tt_dev = ttl.tensor.complex_mul(xtt, ytt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -351,8 +351,8 @@ def test_level1_mul(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * 0.75
 
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
-    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
+    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
 
     tt_dev = ttl.tensor.complex_mul(xtt, ytt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -379,8 +379,8 @@ def test_level1_div(memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * 0.75
 
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
-    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
+    ytt = ttl.tensor.Tensor(y.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
 
     tt_dev = ttl.tensor.complex_div(ytt, xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -406,7 +406,7 @@ def test_level1_recip(memcfg, dtype, device, function_level_defaults):
     # check abs
     x = Complex(input_shape)
     x = x.div(x * 0.5)
-    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg)
+    xtt = ttl.tensor.Tensor(x.metal, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg)
 
     tt_dev = ttl.tensor.complex_recip(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -433,8 +433,8 @@ def test_level2_real(bs, memcfg, dtype, device, function_level_defaults):
     # check real
     x = Complex(input_shape)
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.real(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -459,8 +459,8 @@ def test_level2_imag(bs, memcfg, dtype, device, function_level_defaults):
     # check imag
     x = Complex(input_shape)
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.imag(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -485,8 +485,8 @@ def test_level2_abs(bs, memcfg, dtype, device, function_level_defaults):
     # check abs
     x = Complex(input_shape)
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_abs(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -514,8 +514,8 @@ def test_level2_abs(bs, memcfg, dtype, device, function_level_defaults):
     # check abs
     x = Complex(input_shape)
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_abs(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -543,8 +543,8 @@ def test_level2_conj(bs, memcfg, dtype, device, function_level_defaults):
     # check abs
     x = Complex(input_shape)
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.conj(xtt, memcfg)
     tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -575,8 +575,8 @@ def test_level2_recip(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     x = x.div(x * 0.5)
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.complex_recip(xtt, memcfg)
     tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -609,12 +609,12 @@ def test_level2_add(bs, memcfg, dtype, device, function_level_defaults):
     y = Complex(input_shape) * -0.5
 
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     ytt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     tt_dev = ttl.tensor.complex_add(xtt, ytt, memcfg)
@@ -645,12 +645,12 @@ def test_level2_sub(bs, memcfg, dtype, device, function_level_defaults):
     y = Complex(input_shape) * -0.5
 
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     ytt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     tt_dev = ttl.tensor.complex_sub(xtt, ytt, memcfg)
@@ -682,12 +682,12 @@ def test_level2_mul(bs, memcfg, dtype, device, function_level_defaults):
     y = Complex(input_shape) * -0.5
 
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     ytt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     tt_dev = ttl.tensor.complex_mul(xtt, ytt, memcfg)
@@ -719,12 +719,12 @@ def test_level2_div(bs, memcfg, dtype, device, function_level_defaults):
     y = Complex(input_shape) * 1
 
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     ytt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     tt_dev = ttl.tensor.complex_div(xtt, xtt, memcfg)
@@ -754,8 +754,8 @@ def test_level2_is_real(bs, memcfg, dtype, device, function_level_defaults):
     # check abs
     x = Complex(input_shape)
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(0 * x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(0 * x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.is_real(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
@@ -784,8 +784,8 @@ def test_level2_is_imag(bs, memcfg, dtype, device, function_level_defaults):
     # check abs
     x = Complex(input_shape)
     xtt = ttl.tensor.complex_tensor(
-        ttl.tensor.Tensor(0 * x.real, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.ROW_MAJOR).to(device, memcfg),
+        ttl.tensor.Tensor(0 * x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
     tt_dev = ttl.tensor.is_imag(xtt, memcfg)
     tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_lamb_kernel.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_lamb_kernel.py
@@ -49,24 +49,16 @@ def test_lamb_kernel(input_shapes, beta1, beta2, step_size, eps, weight_decay, d
     param_data = torch.Tensor(size=input_shapes).uniform_(1, 100)
     grad_data, exp_avg_data, exp_avg_sq_data = param_data, param_data, param_data
 
-    param = (
-        tt_lib.tensor.Tensor(param_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
-    )
+    param = tt_lib.tensor.Tensor(param_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
 
-    grad = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
-    )
+    grad = tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
 
     exp_avg = (
-        tt_lib.tensor.Tensor(exp_avg_data, tt_lib.tensor.DataType.BFLOAT16)
-        .to(tt_lib.tensor.Layout.ROW_MAJOR)
-        .to(device)
+        tt_lib.tensor.Tensor(exp_avg_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
 
     exp_avg_sq = (
-        tt_lib.tensor.Tensor(exp_avg_sq_data, tt_lib.tensor.DataType.BFLOAT16)
-        .to(tt_lib.tensor.Layout.ROW_MAJOR)
-        .to(device)
+        tt_lib.tensor.Tensor(exp_avg_sq_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
 
     tt_output_tensor_on_device = tt_lib.tensor.lamb_optimizer(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_lamb_optimizer.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_lamb_optimizer.py
@@ -31,24 +31,16 @@ def test_lamb_kernel(input_shapes, beta1, beta2, step_size, eps, weight_decay, d
     exp_avg_data = torch.Tensor(size=input_shapes).uniform_(1, 100)
     exp_avg_sq_data = torch.Tensor(size=input_shapes).uniform_(1, 100)
 
-    param = (
-        tt_lib.tensor.Tensor(param_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
-    )
+    param = tt_lib.tensor.Tensor(param_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
 
-    grad = (
-        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
-    )
+    grad = tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
 
     exp_avg = (
-        tt_lib.tensor.Tensor(exp_avg_data, tt_lib.tensor.DataType.BFLOAT16)
-        .to(tt_lib.tensor.Layout.ROW_MAJOR)
-        .to(device)
+        tt_lib.tensor.Tensor(exp_avg_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
 
     exp_avg_sq = (
-        tt_lib.tensor.Tensor(exp_avg_sq_data, tt_lib.tensor.DataType.BFLOAT16)
-        .to(tt_lib.tensor.Layout.ROW_MAJOR)
-        .to(device)
+        tt_lib.tensor.Tensor(exp_avg_sq_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
     )
 
     tt_output_tensor_on_device = tt_lib.tensor.lamb_optimizer(

--- a/tests/tt_eager/tensors/test_async_tensor_apis.cpp
+++ b/tests/tt_eager/tensors/test_async_tensor_apis.cpp
@@ -113,11 +113,11 @@ TEST_F(CommonFixture, TestAsyncEltwiseBinary) {
     for (int i = 0; i < 5; i++) {
         // Initialize tensors and move them to DRAM
         Tensor input_tensor_a =
-            tt::numpy::full<float>(Shape({1, 1, 1024, 1024}), static_cast<float>(i), DataType::BFLOAT16).to(device);
+            tt::numpy::full<float>(Shape({1, 1, 1024, 1024}), static_cast<float>(i), DataType::BFLOAT16, Layout::TILE).to(device);
         Tensor input_tensor_b =
-            tt::numpy::full<float>(Shape({1, 1, 1024, 1024}), static_cast<float>(i), DataType::BFLOAT16).to(device);
+            tt::numpy::full<float>(Shape({1, 1, 1024, 1024}), static_cast<float>(i), DataType::BFLOAT16, Layout::TILE).to(device);
         Tensor input_tensor_c =
-            tt::numpy::full<float>(Shape({1, 1, 1024, 1024}), static_cast<float>(i), DataType::BFLOAT16).to(device);
+            tt::numpy::full<float>(Shape({1, 1, 1024, 1024}), static_cast<float>(i), DataType::BFLOAT16, Layout::TILE).to(device);
         Tensor output_tensor_device = mul(add(input_tensor_a, input_tensor_b), input_tensor_c);
         Tensor output_tensor_device_2 = neg(sub(output_tensor_device, input_tensor_c));
 
@@ -215,37 +215,37 @@ TEST_F(CommonFixture, TestAsyncRefCountManager) {
     device->set_worker_mode(WorkExecutorMode::SYNCHRONOUS);
 }
 
-TEST_F(CommonFixture, TestAsyncEltwiseBinaryAutoFormat) {
-    // Test usecase where both inputs and outputs are on host and autoformat is used
-    Device* device = this->devices_[0];
-    device->set_worker_mode(WorkExecutorMode::ASYNCHRONOUS);
-    AutoFormat::SetDefaultDevice(device);
+// TEST_F(CommonFixture, TestAsyncEltwiseBinaryAutoFormat) {
+//     // Test usecase where both inputs and outputs are on host and autoformat is used
+//     Device* device = this->devices_[0];
+//     device->set_worker_mode(WorkExecutorMode::ASYNCHRONOUS);
+//     AutoFormat::SetDefaultDevice(device);
 
-    for (int i = 0; i < 5; i++) {
-        // Initialize tensors and keep them on host. Since none of the tensors are divisible by tile dims, the inputs
-        // and outputs are on host.
-        Tensor input_tensor_a =
-            tt::numpy::full<float>(Shape({1, 1, 1023, 1023}), static_cast<float>(i), DataType::BFLOAT16);
-        Tensor input_tensor_b =
-            tt::numpy::full<float>(Shape({1, 1, 1023, 1023}), static_cast<float>(i), DataType::BFLOAT16);
-        Tensor input_tensor_c =
-            tt::numpy::full<float>(Shape({1, 1, 1023, 1023}), static_cast<float>(i), DataType::BFLOAT16);
-        Tensor output_tensor_device = mul(add(input_tensor_a, input_tensor_b), input_tensor_c);
-        Tensor output_tensor_device_2 = neg(sub(output_tensor_device, input_tensor_c));
+//     for (int i = 0; i < 5; i++) {
+//         // Initialize tensors and keep them on host. Since none of the tensors are divisible by tile dims, the inputs
+//         // and outputs are on host.
+//         Tensor input_tensor_a =
+//             tt::numpy::full<float>(Shape({1, 1, 1023, 1023}), static_cast<float>(i), DataType::BFLOAT16);
+//         Tensor input_tensor_b =
+//             tt::numpy::full<float>(Shape({1, 1, 1023, 1023}), static_cast<float>(i), DataType::BFLOAT16);
+//         Tensor input_tensor_c =
+//             tt::numpy::full<float>(Shape({1, 1, 1023, 1023}), static_cast<float>(i), DataType::BFLOAT16);
+//         Tensor output_tensor_device = mul(add(input_tensor_a, input_tensor_b), input_tensor_c);
+//         Tensor output_tensor_device_2 = neg(sub(output_tensor_device, input_tensor_c));
 
-        EXPECT_EQ(output_tensor_device.get_shape(), ttnn::Shape(Shape({1, 1, 1023, 1023})));
-        EXPECT_EQ(output_tensor_device.get_dtype(), DataType::BFLOAT16);
+//         EXPECT_EQ(output_tensor_device.get_shape(), ttnn::Shape(Shape({1, 1, 1023, 1023})));
+//         EXPECT_EQ(output_tensor_device.get_dtype(), DataType::BFLOAT16);
 
-        Tensor output_tensor_host = output_tensor_device_2.cpu();
-        // Verify output data
-        auto& buf =
-            std::get<owned_buffer::Buffer<bfloat16>>(std::get<OwnedStorage>(output_tensor_host.get_storage()).buffer);
-        for (int j = 0; j < 1023 * 1023; j++) {
-            EXPECT_EQ(bfloat16(buf[j]), bfloat16(static_cast<float>(i - 2 * i * i)));
-        }
-    }
-    device->set_worker_mode(WorkExecutorMode::SYNCHRONOUS);
-}
+//         Tensor output_tensor_host = output_tensor_device_2.cpu();
+//         // Verify output data
+//         auto& buf =
+//             std::get<owned_buffer::Buffer<bfloat16>>(std::get<OwnedStorage>(output_tensor_host.get_storage()).buffer);
+//         for (int j = 0; j < 1023 * 1023; j++) {
+//             EXPECT_EQ(bfloat16(buf[j]), bfloat16(static_cast<float>(i - 2 * i * i)));
+//         }
+//     }
+//     device->set_worker_mode(WorkExecutorMode::SYNCHRONOUS);
+// }
 
 TEST_F(CommonFixture, TestTensorAsyncDataMovement) {
     // Test 2 data paths here (resembles async mode):

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -91,7 +91,7 @@ void test_raw_host_memory_pointer() {
             on_destruction_callback},
         shape,
         DataType::BFLOAT16,
-        Layout::ROW_MAJOR);
+        Layout::TILE);
     /* Borrow Data from Numpy End */
 
     /* Sanity Check Start */
@@ -162,7 +162,7 @@ void test_raw_host_memory_pointer() {
             on_destruction_callback},
         shape,
         DataType::BFLOAT16,
-        Layout::ROW_MAJOR);
+        Layout::TILE);
 
     bfloat16 d_value = 8.0f;
     for (auto& element : borrowed_buffer::get_as<bfloat16>(d_cpu)) {

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/add_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/add_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.add(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/bias_gelu_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/bias_gelu_output.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def torch_bias_gelu(x, y, *args, **kwargs):
+    result = torch.nn.functional.gelu(torch.add(x, y))
+    return result
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch_bias_gelu(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.bias_gelu(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/eq_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/eq_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.eq(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.eq(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/ge_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/ge_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.ge(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.gte(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/gt_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/gt_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.gt(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.gt(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/ldexp_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/ldexp_output.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [32, 1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -60
+    high = 60
+
+    torch_input_tensor_a = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.ldexp(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.ldexp(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/le_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/le_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.le(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.lte(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/logaddexp2_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/logaddexp2_output.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [32, 1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -60
+    high = 100
+
+    torch_input_tensor_a = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.logaddexp2(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.logaddexp2(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/logaddexp_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/logaddexp_output.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [32, 384, 1024],
+    "width": [32, 1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    low = -80
+    high = 80
+
+    torch_input_tensor_a = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, low, high, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.logaddexp(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        device=device,
+        layout=input_a_layout,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        device=device,
+        layout=input_b_layout,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.logaddexp(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/logical_and_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/logical_and_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.logical_and(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.logical_and(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/logical_or_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/logical_or_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.logical_or(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.logical_or(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/lt_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/lt_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.lt(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.lt(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/mul_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/mul_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.mul(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.mul(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/ne_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/ne_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.ne(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.ne(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/squared_difference_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/squared_difference_output.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def torch_squared_difference(x, y, *args, **kwargs):
+    return torch.square(torch.sub(x, y))
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -100, 90, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch_squared_difference(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.squared_difference(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/sub_output.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/sub_output.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+parameters = {
+    "batch_sizes": [(1,)],
+    "height": [384, 1024],
+    "width": [1024, 4096],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat16],
+    "input_a_layout": [ttnn.TILE_LAYOUT],
+    "input_b_layout": [ttnn.TILE_LAYOUT],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "out_tensor_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+}
+
+
+def run(
+    batch_sizes,
+    height,
+    width,
+    input_a_dtype,
+    input_b_dtype,
+    input_a_layout,
+    input_b_layout,
+    input_b_memory_config,
+    input_a_memory_config,
+    out_tensor_memory_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    input_shape = (*batch_sizes, height, width)
+
+    torch_input_tensor_a = torch_random(input_shape, -100, 100, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch_random(input_shape, -80, 80, dtype=torch.bfloat16)
+    torch_optional_output = torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensor = torch.sub(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        dtype=input_b_dtype,
+        layout=input_b_layout,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+    output_tensor = ttnn.from_torch(
+        torch_optional_output,
+        dtype=input_a_dtype,
+        layout=input_a_layout,
+        device=device,
+        memory_config=out_tensor_memory_config,
+    )
+
+    ttnn.experimental.tensor.sub(input_tensor_a, input_tensor_b, output_tensor=output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    return check_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1532,12 +1532,27 @@ std::vector<Tensor> binary_gt_bw(const Tensor& grad, const Tensor& input, const 
     return operation::decorate_as_composite(__func__, _binary_gt_bw)(grad, input, output_mem_config);
 }
 
+// Autoformat support
+Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_config) {
+    auto formatted_input_tensor = temp;
+    if(formatted_input_tensor.get_layout()==Layout::ROW_MAJOR){
+        auto a_pad_shape = AutoFormat::pad_to_tile_shape(temp.get_legacy_shape(), false, false, true, true);
+        if (!AutoFormat::check_input_tensor_format(temp, a_pad_shape)) {
+            formatted_input_tensor = AutoFormat::format_input_tensor(temp, temp.device(), a_pad_shape, 1.0, Layout::TILE);
+        }
+    }
+    return formatted_input_tensor;
+}
+
 // Prod
 // along a single dimension --> result: grad_data * (y / input )
 std::vector<Tensor> _prod_bw(
     const Tensor& grad, const Tensor& input, bool all_dimensions, int64_t dim, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor prod_result = prod(input, all_dimensions, dim, output_mem_config);
+    if(prod_result.get_layout()==Layout::ROW_MAJOR && prod_result.storage_type() == StorageType::DEVICE){
+        prod_result = tt::tt_metal::change_layout_to_tile(prod_result, output_mem_config);
+        }
     if (all_dimensions == true) {
         Tensor temp = mul(prod_result, grad, std::nullopt, output_mem_config);  // result is stored in the first position
         Tensor fill_tensor = tt::numpy::fill_first_val_into_tensor<bfloat16>( temp, temp.get_dtype(), temp.get_layout(), temp.device(), output_mem_config);
@@ -1556,6 +1571,14 @@ std::vector<Tensor> _prod_bw(
             Tensor new_unpad_tensor = unpad(required, start_index, end_index);
             after_permute_dims = {0, 2, 3, 1};
             updated_grad = permute(new_unpad_tensor, after_permute_dims, output_mem_config);
+            Tensor pad_updated_grad = updated_grad.pad_to_tile(1.0f);
+            Tensor pad_prod_result = prod_result.pad_to_tile(1.0f);
+            pad_updated_grad = pad_updated_grad.to(Layout::TILE);
+            pad_prod_result = pad_prod_result.to(Layout::TILE);
+            updated_grad = pad_updated_grad.to(input.device());
+            prod_result = pad_prod_result.to(input.device());
+            pad_updated_grad.deallocate();
+            pad_prod_result.deallocate();
         } else if (dim == 2 || dim == -2) {
             std::vector<int64_t> after_permute_dims = {0, 2, 1, 3};
             Tensor required = permute(grad, after_permute_dims, output_mem_config);
@@ -1563,10 +1586,16 @@ std::vector<Tensor> _prod_bw(
             const Shape end_index = { grad.get_legacy_shape()[0] - 1, 0, grad.get_legacy_shape()[1] - 1, grad.get_legacy_shape()[3] - 1};
             Tensor new_unpad_tensor = unpad(required, start_index, end_index);
             updated_grad = permute(new_unpad_tensor, after_permute_dims, output_mem_config);
+            if(updated_grad.get_layout()==Layout::ROW_MAJOR){
+                updated_grad = tt::tt_metal::change_layout_to_tile(updated_grad, output_mem_config);
+            }
         }
     }
     Tensor reciprocal_input = recip(input, output_mem_config);
     Tensor temp = mul(prod_result, (dim == 1 || dim == 0 || dim == -4 || dim == -3) ? grad : updated_grad, std::nullopt, output_mem_config);
+    if(temp.get_layout()==Layout::ROW_MAJOR){
+        temp = tt::tt_metal::change_layout_to_tile(temp, output_mem_config);
+    }
     if (dim == 3 || dim == -1) {
         Tensor grad_result = bcast(reciprocal_input, temp, BcastOpMath::MUL, BcastOpDim::W, output_mem_config);
         grad_tensor.emplace_back(grad_result);

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
@@ -124,7 +124,8 @@ namespace tt {
 
 namespace tt_metal {
 
-void EltwiseBinary::validate(const std::vector<Tensor>& input_tensors) const {
+
+void EltwiseBinary::validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     TT_FATAL(
@@ -144,11 +145,17 @@ void EltwiseBinary::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(
         (input_tensor_a.get_layout() == Layout::TILE && input_tensor_b.get_layout() == Layout::TILE),
         "Inputs to eltwise binary must be tilized");
+    if(!output_tensors.empty() && output_tensors.at(0).has_value()){
+        const auto output_shape_required = this->compute_output_shapes(input_tensors);
+        const auto& out_tensor = output_tensors.at(0).value();
+        TT_FATAL(out_tensor.get_legacy_shape() == output_shape_required.at(0), fmt::format("The input tensors need a shape of {}, however the output tensor is only {}", output_shape_required,  out_tensor.get_legacy_shape()));
+    }
     if (this->in_place) {
         TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
         TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
         TT_FATAL(input_tensor_a.get_dtype() == this->output_dtype);
     }
+    auto out_mem_config = (!output_tensors.empty() && output_tensors.at(0).has_value()) ? output_tensors.at(0).value().memory_config() : this->output_mem_config;
     if (input_tensor_a.memory_config().is_sharded()) {
         if (input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
             // If we aren't height sharded, we require all sharding schemes to match until we add blocked reader/writers
@@ -160,31 +167,31 @@ void EltwiseBinary::validate(const std::vector<Tensor>& input_tensors) const {
             TT_FATAL(input_tensor_a.memory_config().memory_layout == input_tensor_b.memory_config().memory_layout);
             TT_FATAL(input_tensor_a.shard_spec().value() == input_tensor_b.shard_spec().value());
         }
-        if (this->output_mem_config.is_sharded()) {
-            TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+        if (out_mem_config.is_sharded()) {
+            TT_FATAL(input_tensor_a.memory_config().memory_layout == out_mem_config.memory_layout);
         } else {
-            TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(out_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
         }
     } else if (input_tensor_b.memory_config().is_sharded()) {
         TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
         TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        if (this->output_mem_config.is_sharded()) {
-            TT_FATAL(input_tensor_b.memory_config().memory_layout == this->output_mem_config.memory_layout);
+        if (out_mem_config.is_sharded()) {
+            TT_FATAL(input_tensor_b.memory_config().memory_layout == out_mem_config.memory_layout);
         } else {
-            TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(out_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
         }
     } else {
         TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
         TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        if (this->output_mem_config.is_sharded()) {
-            TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        if (out_mem_config.is_sharded()) {
+            TT_FATAL(out_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
             uint32_t num_blocks = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
             auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
             uint32_t num_cores = core_grid.x * core_grid.y;
             TT_FATAL(num_blocks < num_cores || num_blocks % num_cores == 0);
 
         } else {
-            TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(out_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
         }
     }
 }
@@ -194,9 +201,12 @@ std::vector<Shape> EltwiseBinary::compute_output_shapes(const std::vector<Tensor
     return {input_tensor.get_legacy_shape()};
 }
 
-std::vector<Tensor> EltwiseBinary::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+std::vector<Tensor> EltwiseBinary::create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
+    if(!output_tensors.empty() && output_tensors.at(0).has_value()){
+        return {output_tensors.at(0).value()};
+    }
     if (this->in_place) {
         return {};
     }

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -779,6 +779,7 @@ void py_module(py::module& m_primary) {
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_dtype").noconvert() = std::nullopt,
         py::arg("in_place") = false,
+        py::arg("output_tensor").noconvert() = std::nullopt,
         R"doc(Perform an eltwise-binary add (``{0} + {1}``) on two tensors.
 
         Both input tensors must have TILE layout. Output tensor will have TILE layout.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -991,14 +991,14 @@ namespace tt::tt_metal::detail{
 	    py::arg("input_a"), py::arg("input_b"),
             py::arg("output_mem_config").noconvert() = std::nullopt,R"doc(Perform an polar to Cartesian transformation of the input_a (r), input_b(theta) into x + i*y generating a type-2 complex tensor.)doc");
 
-        detail::bind_binary_op<false, true, false>(m_tensor, "logical_xor", &logical_xor, R"doc(Performs eltwise-binary logical_xor (``{0} ^ {1}``) on two tensors.)doc");
-        detail::bind_binary_op<false, true, false>(m_tensor, "max", &tt::tt_metal::max, R"doc(Perform an eltwise-binary max on two tensors.)doc");
-        detail::bind_binary_op<false, true, false>(m_tensor, "min", &tt::tt_metal::min, R"doc(Perform an eltwise-binary min on two tensors.)doc");
-        detail::bind_binary_op<false, true, false>(m_tensor, "hypot", &hypot, R"doc(Returns tensor with the hypot activation on elements of the input tensors ``{0}`` and ``{1}``.)doc");
-        detail::bind_binary_op<false, true, false>(m_tensor, "scatter", &tt::tt_metal::scatter, R"doc(Performs scatter operation on elements of the input tensors ``{0}`` and ``{1}``,specifically to copy channel data.)doc");
-        detail::bind_binary_op<false, true, false>(m_tensor, "xlogy", &xlogy, R"doc(Performs eltwise-binary xlogy (``{0} * log( {1} )``) on two tensors.)doc");
-        detail::bind_binary_op<false, true, false>(m_tensor, "atan2", &atan2, R"doc(Returns tensor with the atan2 activation on elements of the input tensors ``{0}`` and ``{1}``.)doc");
-        detail::bind_binary_op<false, true, false>(m_tensor, "nextafter", &nextafter, R"doc(Returns the next floating-point value after input_a towards input_b of the input tensors ``{0}`` and ``{1}``.)doc");
+        detail::bind_binary_op<false, true, false, false>(m_tensor, "logical_xor", &logical_xor, R"doc(Performs eltwise-binary logical_xor (``{0} ^ {1}``) on two tensors.)doc");
+        detail::bind_binary_op<false, true, false, false>(m_tensor, "max", &tt::tt_metal::max, R"doc(Perform an eltwise-binary max on two tensors.)doc");
+        detail::bind_binary_op<false, true, false, false>(m_tensor, "min", &tt::tt_metal::min, R"doc(Perform an eltwise-binary min on two tensors.)doc");
+        detail::bind_binary_op<false, true, false, false>(m_tensor, "hypot", &hypot, R"doc(Returns tensor with the hypot activation on elements of the input tensors ``{0}`` and ``{1}``.)doc");
+        detail::bind_binary_op<false, true, false, false>(m_tensor, "scatter", &tt::tt_metal::scatter, R"doc(Performs scatter operation on elements of the input tensors ``{0}`` and ``{1}``,specifically to copy channel data.)doc");
+        detail::bind_binary_op<false, true, false, false>(m_tensor, "xlogy", &xlogy, R"doc(Performs eltwise-binary xlogy (``{0} * log( {1} )``) on two tensors.)doc");
+        detail::bind_binary_op<false, true, false, false>(m_tensor, "atan2", &atan2, R"doc(Returns tensor with the atan2 activation on elements of the input tensors ``{0}`` and ``{1}``.)doc");
+        detail::bind_binary_op<false, true, false, false>(m_tensor, "nextafter", &nextafter, R"doc(Returns the next floating-point value after input_a towards input_b of the input tensors ``{0}`` and ``{1}``.)doc");
 
 	    // *** type-2 complex operations in new submodule 'type2_complex' ***
         auto m_type2_cplx = m_tensor.def_submodule("complex", "Complex type2");

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
@@ -51,7 +51,7 @@ namespace tt::tt_metal::detail{
         detail::export_enum<BcastOpDim>(m_tensor);
 
         detail::bind_unary_op<true, true>(m_tensor, "clone", &clone, R"doc(  Returns a new tensor which is a new copy of input tensor ``{0}``.)doc");
-        detail::bind_binary_op<false, false, false>(m_tensor, "copy", &copy, R"doc(  Copies the elements from ``{0}`` into ``{1}``. ``{1}`` is modified in place.)doc");
+        detail::bind_binary_op<false, false, false, false>(m_tensor, "copy", &copy, R"doc(  Copies the elements from ``{0}`` into ``{1}``. ``{1}`` is modified in place.)doc");
         detail::bind_unary_op<true, true>(m_tensor, "assign", py::overload_cast<const Tensor&, const MemoryConfig&, std::optional<const DataType>>(&assign), R"doc(  Returns a new tensor which is a new copy of input tensor ``{0}``.)doc");
 
         // *** tensor manipulation ***


### PR DESCRIPTION
- Add optional output tensor to eltwise binary ops
- Change eltwise_binary ops to use run operation  instead of run_with_autoformat
- Change eltwise_binary ops to use launch_op instead of  launch_with_autoformat

- Primary issue: #5044 

- Related issues: #8731  and  #8962 and #8818

- Add test files for eltwise_binary_ops with optional output tensor.
- Fixes for existing ops and tests that were dependent on autoformat.

CI test:  https://github.com/tenstorrent/tt-metal/actions/runs/9328398084