### PR TITLE
Add support for multiple parameters in `EltwiseUnary`

### DIFF
--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -103,7 +103,7 @@ void test_operation_infrastructure() {
     auto input_tensor = tt::numpy::random::uniform(bfloat16(0), bfloat16(1), shape).to(Layout::TILE).to(device);
 
     auto op = operation::DeviceOperation(EltwiseUnary{
-        {tt::tt_metal::UnaryWithParam{tt::tt_metal::UnaryOpType::SQRT, std::nullopt}},
+        {tt::tt_metal::UnaryWithParam{tt::tt_metal::UnaryOpType::SQRT}},
         MemoryConfig{.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}});
 
     auto program_hash = op.compute_program_hash({input_tensor}, {});
@@ -139,7 +139,7 @@ void test_shape_padding() {
     auto output_tensor =
         tt::tt_metal::operation::run(
             tt::tt_metal::EltwiseUnary{
-                {tt::tt_metal::UnaryWithParam{tt::tt_metal::UnaryOpType::SQRT, std::nullopt}},
+                {tt::tt_metal::UnaryWithParam{tt::tt_metal::UnaryOpType::SQRT}},
                 tt::tt_metal::MemoryConfig{.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}},
             {padded_input_tensor})
             .at(0);

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -42,7 +42,7 @@ void update_sfpu_op_to_hlk_op()
                 sfpu_op_to_hlk_op_name[sfpu_op_name]  = eltwise_unary_op_utils::get_block_defines({tt::tt_metal::UnaryWithParam{unary_op_type, 0.5}});
             }
         } else {
-            sfpu_op_to_hlk_op_name[sfpu_op_name]  = eltwise_unary_op_utils::get_block_defines({tt::tt_metal::UnaryWithParam{unary_op_type, std::nullopt}});
+            sfpu_op_to_hlk_op_name[sfpu_op_name]  = eltwise_unary_op_utils::get_block_defines({tt::tt_metal::UnaryWithParam{unary_op_type}});
         }
     }
 }

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -259,7 +259,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
         if (fused_activation.value().op_type == UnaryOpType::RELU) {
             mm_kernel_defines["PACK_RELU"] = "1";
         } else {
-            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(fused_activation.value().op_type, fused_activation.value().param, "ACTIVATION", "i"));
+            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
         }
     }
     if (packer_l1_acc_en) {
@@ -836,7 +836,7 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
         if (fused_activation.value().op_type == UnaryOpType::RELU) {
             mm_kernel_defines["PACK_RELU"] = "1";
         } else {
-            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(fused_activation.value().op_type, fused_activation.value().param, "ACTIVATION", "i"));
+            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
         }
     }
     if (packer_l1_acc_en) {

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -347,7 +347,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         if (fused_activation.value().op_type == UnaryOpType::RELU) {
             mm_kernel_defines["PACK_RELU"] = "1";
         } else {
-            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(fused_activation.value().op_type, fused_activation.value().param, "ACTIVATION", "i"));
+            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
         }
     }
     if (packer_l1_acc_en) {

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -972,10 +972,10 @@ Tensor xlogy(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& o
 // torch.where(x > 0, x, alpha * (torch.exp(x / alpha) - 1))
 Tensor _celu(const Tensor& input_a, float alpha, const MemoryConfig& output_mem_config) {
     float recip_val = 1.0f / alpha;
-    std::vector<UnaryWithParam> ops_chain = {UnaryWithParam{.op_type = UnaryOpType::MUL_UNARY_SFPU, recip_val},
-                                             UnaryWithParam{.op_type = UnaryOpType::EXP, 1.0f},
-                                             UnaryWithParam{.op_type = UnaryOpType::SUB_UNARY_SFPU, 1.0f},
-                                             UnaryWithParam{.op_type = UnaryOpType::MUL_UNARY_SFPU, alpha}};
+    std::vector<UnaryWithParam> ops_chain = {UnaryWithParam{UnaryOpType::MUL_UNARY_SFPU, recip_val},
+                                             UnaryWithParam{UnaryOpType::EXP, 1.0f},
+                                             UnaryWithParam{UnaryOpType::SUB_UNARY_SFPU, 1.0f},
+                                             UnaryWithParam{UnaryOpType::MUL_UNARY_SFPU, alpha}};
     Tensor result = unary_chain(input_a, ops_chain, output_mem_config);
     result = where(gtz(input_a, output_mem_config), input_a, result, output_mem_config);
     return result;

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
@@ -52,13 +52,13 @@ std::map<string, string> get_defines(BinaryOpType op_type, const std::optional<s
         case BinaryOpType::BIAS_GELU:
             op_name = "add_tiles";
             op_code = "0";
-            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::GELU, 0, "0", idst));
+            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::GELU, std::vector<float>{0}, "0", idst));
             break;
         case BinaryOpType::LOGADDEXP:
             // PRE_IN0_0 ===> Applies prescaling for first input
             // PRE_IN1_0 ====> Applies prescaling for second input
-            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::EXP, false, "PRE_IN0_0"));
-            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::EXP, false, "PRE_IN1_0"));
+            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
+            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
             op_name = "add_tiles";
             op_code = "0";
             defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::LOG, std::nullopt, "0", idst));
@@ -253,8 +253,8 @@ const operation::Hash EltwiseBinary::compute_program_hash(
     if (this->fused_activations.has_value()) {
         for (const auto& unary_with_param_op : this->fused_activations.value()) {
             hash = tt::stl::hash::hash_objects(hash, static_cast<uint16_t>(unary_with_param_op.op_type));
-            if (unary_with_param_op.param.has_value()) {
-                hash = tt::stl::hash::hash_objects(hash, static_cast<uint16_t>(unary_with_param_op.param.value()));
+            if (unary_with_param_op.has_parameter()) {
+                hash = tt::stl::hash::hash_objects(hash, unary_with_param_op.params);
             }
         }
     }

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -3,98 +3,66 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
-#include "tt_metal/tools/profiler/op_profiler.hpp"
 
-#include "tt_metal/host_api.hpp"
-#include "tt_metal/common/constants.hpp"
+#include "third_party/magic_enum/magic_enum.hpp"
 #include "tt_dnn/op_library/bcast/bcast_op.hpp"
 #include "tt_dnn/op_library/composite/composite_ops.hpp"
 #include "tt_eager/tensor/tensor_utils.hpp"
-
-#include "third_party/magic_enum/magic_enum.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/tools/profiler/op_profiler.hpp"
 
 using namespace tt::constants;
 
 namespace eltwise_unary_op_utils {
 using namespace tt::tt_metal;
 
-
 union Converter {
-public:
-  float f;
-  uint32_t u;
+   public:
+    float f;
+    uint32_t u;
 
-  Converter(float f_) : f(f_) {};
+    Converter(float f_) : f(f_){};
 
-  static
-  std::string to_hex(float f_) {
-    Converter obj(f_);
-    std::stringstream ss;
-    ss << "0x" << std::hex << obj.u;
-    return ss.str();
-  }
+    static std::string to_hex(float f_) {
+        Converter obj(f_);
+        std::stringstream ss;
+        ss << "0x" << std::hex << obj.u;
+        return ss.str();
+    }
 };
 
-
 // update split eltwise ops include macros
-void update_macro_defines(UnaryOpType op_type, std::map<std::string,std::string>& defines) {
-    switch( op_type) {
-        case UnaryOpType::EXP:
-            defines["SFPU_OP_EXP_INCLUDE"] = "1";
-            break;
-        case UnaryOpType::GELU:
-            defines["SFPU_OP_GELU_INCLUDE"] = "1";
-            break;
-        case UnaryOpType::RECIP:
-            defines["SFPU_OP_RECIP_INCLUDE"] = "1";
-            break;
-        case UnaryOpType::SQRT:
-            defines["SFPU_OP_SQRT_INCLUDE"] = "1";
-            break;
-        case UnaryOpType::ERFINV:
-            defines["SFPU_OP_ERFINV_INCLUDE"] = "1";
-            break;
+void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string>& defines) {
+    switch (op_type) {
+        case UnaryOpType::EXP: defines["SFPU_OP_EXP_INCLUDE"] = "1"; break;
+        case UnaryOpType::GELU: defines["SFPU_OP_GELU_INCLUDE"] = "1"; break;
+        case UnaryOpType::RECIP: defines["SFPU_OP_RECIP_INCLUDE"] = "1"; break;
+        case UnaryOpType::SQRT: defines["SFPU_OP_SQRT_INCLUDE"] = "1"; break;
+        case UnaryOpType::ERFINV: defines["SFPU_OP_ERFINV_INCLUDE"] = "1"; break;
         case UnaryOpType::ERFC:
-        case UnaryOpType::ERF:
-            defines["SFPU_OP_ERF_ERFC_INCLUDE"] = "1";
-            break;
-        case UnaryOpType::ELU:
-            defines["SFPU_OP_ELU_INCLUDE"] = "1";
-            break;
+        case UnaryOpType::ERF: defines["SFPU_OP_ERF_ERFC_INCLUDE"] = "1"; break;
+        case UnaryOpType::ELU: defines["SFPU_OP_ELU_INCLUDE"] = "1"; break;
         case UnaryOpType::RELU:
         case UnaryOpType::RELU6:
         case UnaryOpType::RELU_MAX:
         case UnaryOpType::RELU_MIN:
-        case UnaryOpType::LEAKY_RELU:
-            defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1";
-            break;
+        case UnaryOpType::LEAKY_RELU: defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1"; break;
         case UnaryOpType::ADD_UNARY_SFPU:
         case UnaryOpType::SUB_UNARY_SFPU:
         case UnaryOpType::MUL_UNARY_SFPU:
-        case UnaryOpType::DIV_UNARY_SFPU:
-            defines["SFPU_OP_BINOP_WITH_SCALAR_INCLUDE"] = "1";
-            break;
+        case UnaryOpType::DIV_UNARY_SFPU: defines["SFPU_OP_BINOP_WITH_SCALAR_INCLUDE"] = "1"; break;
         case UnaryOpType::IDENTITY:
-        case UnaryOpType::IDENTITY_UINT32:
-            defines["SFPU_OP_IDENTITY_INCLUDE"] = "1";
-            break;
-        case UnaryOpType::RDIV:
-            break;
-        case UnaryOpType::RSUB:
-            defines["SFPU_OP_REVERSE_FAMILY_INCLUDE"] = "1";
+        case UnaryOpType::IDENTITY_UINT32: defines["SFPU_OP_IDENTITY_INCLUDE"] = "1"; break;
+        case UnaryOpType::RDIV: break;
+        case UnaryOpType::RSUB: defines["SFPU_OP_REVERSE_FAMILY_INCLUDE"] = "1";
         case UnaryOpType::ISINF:
         case UnaryOpType::ISNAN:
         case UnaryOpType::ISNEGINF:
         case UnaryOpType::ISPOSINF:
-        case UnaryOpType::ISFINITE:
-            defines["SFPU_OP_ISINF_ISNAN_INCLUDE"]="1";
-            break;
-        case UnaryOpType::LOGICAL_NOT_UNARY:
-            defines["SFPU_OP_LOGICAL_NOT_NOTI_INCLUDE"]="1";
-            break;
-        case UnaryOpType::I0:
-            defines["SFPU_OP_I0_INCLUDE"]="1";
-            break;
+        case UnaryOpType::ISFINITE: defines["SFPU_OP_ISINF_ISNAN_INCLUDE"] = "1"; break;
+        case UnaryOpType::LOGICAL_NOT_UNARY: defines["SFPU_OP_LOGICAL_NOT_NOTI_INCLUDE"] = "1"; break;
+        case UnaryOpType::I0: defines["SFPU_OP_I0_INCLUDE"] = "1"; break;
         case UnaryOpType::COS:
         case UnaryOpType::SIN:
         case UnaryOpType::TAN:
@@ -109,22 +77,60 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string,std::string>
     };
 }
 
-std::pair<string, string> get_op_init_and_func_parameterized(UnaryOpType op_type, float param0, string idst) {
+std::pair<string, string> get_op_init_and_func_parameterized(
+    UnaryOpType op_type, std::vector<float> params, string idst) {
     std::pair<string, string> op_init_and_name;
-    TT_FATAL( is_parametrized_type(op_type) && "operator should support one parameter" );
-
+    TT_FATAL(is_parametrized_type(op_type) && "operator should support one parameter");
+    float param0 = params[0];
     switch (op_type) {
-        case UnaryOpType::RELU_MAX: op_init_and_name = {"relu_max_tile_init();", fmt::format("relu_max_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
-        case UnaryOpType::RELU_MIN: op_init_and_name = {"relu_min_tile_init();", fmt::format("relu_min_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
-        case UnaryOpType::POWER: op_init_and_name = {"power_tile_init();", fmt::format("power_tile({}, {}u);", idst, std::to_string((uint32_t)param0))}; break;
-        case UnaryOpType::LEAKY_RELU: op_init_and_name = {"leaky_relu_tile_init();", fmt::format("leaky_relu_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
-        case UnaryOpType::ELU: op_init_and_name = {"elu_tile_init();", fmt::format("elu_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
-        case UnaryOpType::GELU: op_init_and_name = {fmt::format("gelu_tile_init<{}u>();", std::to_string((uint32_t)param0)), fmt::format("gelu_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))}; break;
-        case UnaryOpType::RSQRT: op_init_and_name = {fmt::format("rsqrt_tile_init<{}u>();", std::to_string((uint32_t)param0)),  fmt::format("rsqrt_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))}; break;
-        case UnaryOpType::HEAVISIDE: op_init_and_name = {"heaviside_tile_init();", fmt::format("heaviside_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
-        case UnaryOpType::EXP: op_init_and_name = {fmt::format("exp_tile_init<{}u>();", std::to_string((uint32_t)param0)), fmt::format("exp_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))}; break;
-        case UnaryOpType::ERF: op_init_and_name = {fmt::format("erf_tile_init<{}u>();", std::to_string((uint32_t)param0)), fmt::format("erf_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))}; break;
-        case UnaryOpType::ERFC: op_init_and_name = {fmt::format("erfc_tile_init<{}u>();", std::to_string((uint32_t)param0)), fmt::format("erfc_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))}; break;
+        case UnaryOpType::RELU_MAX:
+            op_init_and_name = {
+                "relu_max_tile_init();", fmt::format("relu_max_tile({}, {}u);", idst, Converter::to_hex(param0))};
+            break;
+        case UnaryOpType::RELU_MIN:
+            op_init_and_name = {
+                "relu_min_tile_init();", fmt::format("relu_min_tile({}, {}u);", idst, Converter::to_hex(param0))};
+            break;
+        case UnaryOpType::POWER:
+            op_init_and_name = {
+                "power_tile_init();", fmt::format("power_tile({}, {}u);", idst, std::to_string((uint32_t)param0))};
+            break;
+        case UnaryOpType::LEAKY_RELU:
+            op_init_and_name = {
+                "leaky_relu_tile_init();", fmt::format("leaky_relu_tile({}, {}u);", idst, Converter::to_hex(param0))};
+            break;
+        case UnaryOpType::ELU:
+            op_init_and_name = {"elu_tile_init();", fmt::format("elu_tile({}, {}u);", idst, Converter::to_hex(param0))};
+            break;
+        case UnaryOpType::GELU:
+            op_init_and_name = {
+                fmt::format("gelu_tile_init<{}u>();", std::to_string((uint32_t)param0)),
+                fmt::format("gelu_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))};
+            break;
+        case UnaryOpType::RSQRT:
+            op_init_and_name = {
+                fmt::format("rsqrt_tile_init<{}u>();", std::to_string((uint32_t)param0)),
+                fmt::format("rsqrt_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))};
+            break;
+        case UnaryOpType::HEAVISIDE:
+            op_init_and_name = {
+                "heaviside_tile_init();", fmt::format("heaviside_tile({}, {}u);", idst, Converter::to_hex(param0))};
+            break;
+        case UnaryOpType::EXP:
+            op_init_and_name = {
+                fmt::format("exp_tile_init<{}u>();", std::to_string((uint32_t)param0)),
+                fmt::format("exp_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))};
+            break;
+        case UnaryOpType::ERF:
+            op_init_and_name = {
+                fmt::format("erf_tile_init<{}u>();", std::to_string((uint32_t)param0)),
+                fmt::format("erf_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))};
+            break;
+        case UnaryOpType::ERFC:
+            op_init_and_name = {
+                fmt::format("erfc_tile_init<{}u>();", std::to_string((uint32_t)param0)),
+                fmt::format("erfc_tile<{1}u>({0});", idst, std::to_string((uint32_t)param0))};
+            break;
         case UnaryOpType::RDIV: op_init_and_name = {}; break;
         case UnaryOpType::RSUB: op_init_and_name = {"rsub_tile_init();", fmt::format("rsub_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
         case UnaryOpType::SUB_UNARY_SFPU: op_init_and_name = {"binop_with_scalar_tile_init();", fmt::format("sub_unary_tile({}, {}u);", idst, Converter::to_hex(param0))}; break;
@@ -146,68 +152,76 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, stri
         case UnaryOpType::RECIP: op_init_and_name = {"recip_tile_init();", fmt::format("recip_tile({});", idst)}; break;
         case UnaryOpType::RELU: op_init_and_name = {"relu_tile_init();", fmt::format("relu_tile({});", idst)}; break;
         case UnaryOpType::SQRT: op_init_and_name = {"sqrt_tile_init();", fmt::format("sqrt_tile({});", idst)}; break;
-        case UnaryOpType::SIGMOID: op_init_and_name = {"sigmoid_tile_init();", fmt::format("sigmoid_tile({});", idst)}; break;
+        case UnaryOpType::SIGMOID:
+            op_init_and_name = {"sigmoid_tile_init();", fmt::format("sigmoid_tile({});", idst)};
+            break;
         case UnaryOpType::LOG: op_init_and_name = {"log_tile_init();", fmt::format("log_tile({});", idst)}; break;
         case UnaryOpType::TANH: op_init_and_name = {"tanh_tile_init();", fmt::format("tanh_tile({});", idst)}; break;
-        case UnaryOpType::SIGNBIT: op_init_and_name = {"signbit_tile_init();", fmt::format("signbit_tile({});", idst)}; break;
+        case UnaryOpType::SIGNBIT:
+            op_init_and_name = {"signbit_tile_init();", fmt::format("signbit_tile({});", idst)};
+            break;
         case UnaryOpType::SIN: op_init_and_name = {"sin_tile_init();", fmt::format("sin_tile({});", idst)}; break;
         case UnaryOpType::COS: op_init_and_name = {"cos_tile_init();", fmt::format("cos_tile({});", idst)}; break;
-        case UnaryOpType::ISFINITE: op_init_and_name = {"isfinite_tile_init();", fmt::format("isfinite_tile({});", idst)}; break;
+        case UnaryOpType::ISFINITE:
+            op_init_and_name = {"isfinite_tile_init();", fmt::format("isfinite_tile({});", idst)};
+            break;
         case UnaryOpType::ISINF: op_init_and_name = {"isinf_tile_init();", fmt::format("isinf_tile({});", idst)}; break;
-        case UnaryOpType::ISPOSINF: op_init_and_name = {"isposinf_tile_init();", fmt::format("isposinf_tile({});", idst)}; break;
-        case UnaryOpType::ISNEGINF: op_init_and_name = {"isneginf_tile_init();", fmt::format("isneginf_tile({});", idst)}; break;
+        case UnaryOpType::ISPOSINF:
+            op_init_and_name = {"isposinf_tile_init();", fmt::format("isposinf_tile({});", idst)};
+            break;
+        case UnaryOpType::ISNEGINF:
+            op_init_and_name = {"isneginf_tile_init();", fmt::format("isneginf_tile({});", idst)};
+            break;
         case UnaryOpType::ISNAN: op_init_and_name = {"isnan_tile_init();", fmt::format("isnan_tile({});", idst)}; break;
-        case UnaryOpType::LOGICAL_NOT_UNARY: op_init_and_name = {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile({});", idst)}; break;
+        case UnaryOpType::LOGICAL_NOT_UNARY:
+            op_init_and_name = {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile({});", idst)};
+            break;
         case UnaryOpType::I0: op_init_and_name = {"i0_tile_init();", fmt::format("i0_tile({});", idst)}; break;
-        case UnaryOpType::ERFINV: op_init_and_name = {"erfinv_tile_init();", fmt::format("erfinv_tile({});", idst)}; break;
+        case UnaryOpType::ERFINV:
+            op_init_and_name = {"erfinv_tile_init();", fmt::format("erfinv_tile({});", idst)};
+            break;
         case UnaryOpType::LOG10:
             // log10[x] = log[x]/log[10] = log[x]*0.4342944819032518; FP32@U32 0x3ede5bd9; FP16@U16 0x36f3;
-            op_init_and_name = {"log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x36f3u);", idst)}; break;
+            op_init_and_name = {"log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x36f3u);", idst)};
+            break;
             break;
         case UnaryOpType::LOG2:  // log2[x] = log[x]*1.4426950408889634f; FP32@U32 0x3fb8aa3b; FP16@U16 0x3dc5;
-            op_init_and_name = {"log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x3dc5u);", idst)}; break;
+            op_init_and_name = {"log_with_base_tile_init();", fmt::format("log_with_base_tile({}, 0x3dc5u);", idst)};
             break;
-        case UnaryOpType::ABS:
-            op_init_and_name = {"abs_tile_init();", fmt::format("abs_tile({});", idst)}; break;
-        case UnaryOpType::SIGN:
-            op_init_and_name = {"sign_tile_init();", fmt::format("sign_tile({});", idst)}; break;
+            break;
+        case UnaryOpType::ABS: op_init_and_name = {"abs_tile_init();", fmt::format("abs_tile({});", idst)}; break;
+        case UnaryOpType::SIGN: op_init_and_name = {"sign_tile_init();", fmt::format("sign_tile({});", idst)}; break;
         case UnaryOpType::SQUARE:
-            op_init_and_name = {"square_tile_init();", fmt::format("square_tile({});", idst)}; break;
+            op_init_and_name = {"square_tile_init();", fmt::format("square_tile({});", idst)};
+            break;
         case UnaryOpType::TILED_PROD:
-            op_init_and_name = {"tiled_prod_tile_init();", fmt::format("tiled_prod_tile({});", idst)}; break;
-        case UnaryOpType::EQZ:
-            op_init_and_name = {"eqz_tile_init();", fmt::format("eqz_tile({});", idst)}; break;
-        case UnaryOpType::NEZ:
-            op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile({});", idst)}; break;
-        case UnaryOpType::LTZ:
-            op_init_and_name = {"ltz_tile_init();", fmt::format("ltz_tile({});", idst)}; break;
-        case UnaryOpType::GTZ:
-            op_init_and_name = {"gtz_tile_init();", fmt::format("gtz_tile({});", idst)}; break;
-        case UnaryOpType::LEZ:
-            op_init_and_name = {"lez_tile_init();", fmt::format("lez_tile({});", idst)}; break;
-        case UnaryOpType::GEZ:
-            op_init_and_name = {"gez_tile_init();", fmt::format("gez_tile({});", idst)}; break;
-        case UnaryOpType::EXP2:
-            op_init_and_name = {"exp2_tile_init();", fmt::format("exp2_tile({});", idst)}; break;
-        case UnaryOpType::EXPM1:
-            op_init_and_name = {"expm1_tile_init();", fmt::format("expm1_tile({});", idst)}; break;
-        case UnaryOpType::ASIN:
-            op_init_and_name = {"asin_tile_init();", fmt::format("asin_tile({});", idst)}; break;
-        case UnaryOpType::ACOS:
-            op_init_and_name = {"acos_tile_init();", fmt::format("acos_tile({});", idst)}; break;
-        case UnaryOpType::ATAN:
-            op_init_and_name = {"atan_tile_init();", fmt::format("atan_tile({});", idst)}; break;
-        case UnaryOpType::TAN:
-            op_init_and_name = {"tan_tile_init();", fmt::format("tan_tile({});", idst)}; break;
-        case UnaryOpType::SILU:
-            op_init_and_name = {"silu_tile_init();", fmt::format("silu_tile({});", idst)}; break;
+            op_init_and_name = {"tiled_prod_tile_init();", fmt::format("tiled_prod_tile({});", idst)};
+            break;
+        case UnaryOpType::EQZ: op_init_and_name = {"eqz_tile_init();", fmt::format("eqz_tile({});", idst)}; break;
+        case UnaryOpType::NEZ: op_init_and_name = {"nez_tile_init();", fmt::format("nez_tile({});", idst)}; break;
+        case UnaryOpType::LTZ: op_init_and_name = {"ltz_tile_init();", fmt::format("ltz_tile({});", idst)}; break;
+        case UnaryOpType::GTZ: op_init_and_name = {"gtz_tile_init();", fmt::format("gtz_tile({});", idst)}; break;
+        case UnaryOpType::LEZ: op_init_and_name = {"lez_tile_init();", fmt::format("lez_tile({});", idst)}; break;
+        case UnaryOpType::GEZ: op_init_and_name = {"gez_tile_init();", fmt::format("gez_tile({});", idst)}; break;
+        case UnaryOpType::EXP2: op_init_and_name = {"exp2_tile_init();", fmt::format("exp2_tile({});", idst)}; break;
+        case UnaryOpType::EXPM1: op_init_and_name = {"expm1_tile_init();", fmt::format("expm1_tile({});", idst)}; break;
+        case UnaryOpType::ASIN: op_init_and_name = {"asin_tile_init();", fmt::format("asin_tile({});", idst)}; break;
+        case UnaryOpType::ACOS: op_init_and_name = {"acos_tile_init();", fmt::format("acos_tile({});", idst)}; break;
+        case UnaryOpType::ATAN: op_init_and_name = {"atan_tile_init();", fmt::format("atan_tile({});", idst)}; break;
+        case UnaryOpType::TAN: op_init_and_name = {"tan_tile_init();", fmt::format("tan_tile({});", idst)}; break;
+        case UnaryOpType::SILU: op_init_and_name = {"silu_tile_init();", fmt::format("silu_tile({});", idst)}; break;
         case UnaryOpType::IDENTITY:
-            op_init_and_name = {"identity_tile_init();", fmt::format("identity_tile({});", idst)}; break;
+            op_init_and_name = {"identity_tile_init();", fmt::format("identity_tile({});", idst)};
+            break;
         case UnaryOpType::IDENTITY_UINT32:
-            op_init_and_name = {"identity_tile_init();", fmt::format("identity_tile_uint32({});", idst)}; break;
+            op_init_and_name = {"identity_tile_init();", fmt::format("identity_tile_uint32({});", idst)};
+            break;
         case UnaryOpType::RELU6:
-            op_init_and_name = {"relu_max_tile_init();", fmt::format("relu_max_tile({}, 0x40c00000u);", idst)}; break;
-        case UnaryOpType::NEG: op_init_and_name = {"negative_tile_init();", fmt::format("negative_tile({});", idst)}; break;
+            op_init_and_name = {"relu_max_tile_init();", fmt::format("relu_max_tile({}, 0x40c00000u);", idst)};
+            break;
+        case UnaryOpType::NEG:
+            op_init_and_name = {"negative_tile_init();", fmt::format("negative_tile({});", idst)};
+            break;
         default: TT_ASSERT(false && "Undefined non-parametrized op type");
     }
     return op_init_and_name;
@@ -215,30 +229,28 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, stri
 
 bool get_op_approx_mode(UnaryOpType op_type) {
     switch (op_type) {
-        default:
-            return false;
+        default: return false;
     }
 }
 
-std::map<string, string> get_defines_impl(UnaryOpType op_type, std::optional<float> param0, std::string idst, std::string init_def, std::string func_def) {
-    std::pair<string, string> op_init_and_name = get_op_init_and_func(op_type, param0, idst);
-    std::map<string, string> defines = {
-        {init_def, op_init_and_name.first},
-        {func_def, op_init_and_name.second}
-    };
+std::map<string, string> get_defines_impl(
+    UnaryOpType op_type, const std::vector<float> &params, std::string idst, std::string init_def, std::string func_def) {
+    std::pair<string, string> op_init_and_name = get_op_init_and_func(op_type, params, idst);
+    std::map<string, string> defines = {{init_def, op_init_and_name.first}, {func_def, op_init_and_name.second}};
     update_macro_defines(op_type, defines);
     return defines;
 }
 
-std::map<string, string> get_defines(UnaryOpType op_type, std::optional<float> param0, std::string id, std::string idst) {
+std::map<string, string> get_defines(
+    UnaryOpType op_type, std::optional<std::vector<float>> params, std::string id, std::string idst) {
     std::string init_def = fmt::format("SFPU_OP_INIT_{}", id);
     std::string func_def = fmt::format("SFPU_OP_FUNC_{}", id);
-    return get_defines_impl(op_type, param0, idst, init_def, func_def);
+    return get_defines_impl(op_type, params.has_value() ? params.value() : std::vector<float>{}, idst, init_def, func_def);
 }
 
-
-std::pair<string, string> get_op_init_and_func(UnaryOpType op_type, std::optional<float> param0, std::string idst) {
-   return param0.has_value() ? get_op_init_and_func_parameterized(op_type, param0.value(), idst) : get_op_init_and_func_default(op_type, idst);
+std::pair<string, string> get_op_init_and_func(UnaryOpType op_type, std::vector<float> params, std::string idst) {
+    return params.size() > 0 ? get_op_init_and_func_parameterized(op_type, params, idst)
+                             : get_op_init_and_func_default(op_type, idst);
 }
 
 std::map<string, string> get_block_defines(
@@ -246,53 +258,65 @@ std::map<string, string> get_block_defines(
     std::vector<std::pair<string, string>> op_init_and_name;
     std::map<string, string> block_defines;
     std::string block_define = "";
-    for (uint32_t i = 0; i<op_chain.size(); i++) {
+    for (uint32_t i = 0; i < op_chain.size(); i++) {
         std::string init_def = fmt::format("SFPU_OP_CHAIN_{}_INIT_{}", block_id, i);
         std::string func_def = fmt::format("SFPU_OP_CHAIN_{}_FUNC_{}", block_id, i);
         block_define += init_def + " " + func_def + " ";
-        block_defines.merge(get_defines_impl(op_chain[i].op_type, op_chain[i].param, idst, init_def, func_def));
+        block_defines.merge(get_defines_impl(op_chain[i].op_type, op_chain[i].params, idst, init_def, func_def));
     }
     block_defines[fmt::format("SFPU_OP_CHAIN_{}", block_id)] = block_define;
     return block_defines;
 }
 
-} // namespace eltwise_unary_op_utils
+}  // namespace eltwise_unary_op_utils
 
 namespace tt {
 
 namespace tt_metal {
 
-void EltwiseUnary::validate(const std::vector<Tensor> &input_tensors) const {
+void EltwiseUnary::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to eltwise unary need to be on device!");
-    TT_FATAL(input_tensor_a.buffer() != nullptr , "Operands to eltwise unary need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout , "Input and output memory layout must match");
-    if(!input_tensor_a.is_sharded()){
+    TT_FATAL(
+        input_tensor_a.buffer() != nullptr, "Operands to eltwise unary need to be allocated in buffers on device!");
+    TT_FATAL(
+        input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout,
+        "Input and output memory layout must match");
+    if (!input_tensor_a.is_sharded()) {
         TT_FATAL((input_tensor_a.get_layout() == Layout::TILE), "Inputs to eltwise unary must be tilized");
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Interleaved memory layout supported");
+        TT_FATAL(
+            input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "Interleaved memory layout supported");
     }
 }
 
-std::vector<Shape> EltwiseUnary::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+std::vector<Shape> EltwiseUnary::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     return {input_tensor.get_legacy_shape()};
 }
 
-std::vector<Tensor> EltwiseUnary::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
+std::vector<Tensor> EltwiseUnary::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    if(this->output_mem_config.is_sharded()){
-            Shape output_shape = compute_output_shapes(input_tensors).at(0);
-            return {create_sharded_device_tensor(output_shape, input_tensor.get_dtype(), input_tensor.get_layout(), input_tensor.device(), this->output_mem_config)};
+    if (this->output_mem_config.is_sharded()) {
+        Shape output_shape = compute_output_shapes(input_tensors).at(0);
+        return {create_sharded_device_tensor(
+            output_shape,
+            input_tensor.get_dtype(),
+            input_tensor.get_layout(),
+            input_tensor.device(),
+            this->output_mem_config)};
     }
-    return operation::generic_create_output_tensors(*this, input_tensors, input_tensor.get_dtype(), Layout::TILE, this->output_mem_config);
-    }
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, input_tensor.get_dtype(), Layout::TILE, this->output_mem_config);
+}
 
-operation::ProgramWithCallbacks EltwiseUnary::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
+operation::ProgramWithCallbacks EltwiseUnary::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
 
     auto parallelization_strategy = this->get_parallelization_strategy(input_tensors);
-    switch (parallelization_strategy){
+    switch (parallelization_strategy) {
         case UnaryOpParallelizationStrategy::SHARDED_MULTI_CORE:
             return eltwise_unary_sharded(input_tensor, output_tensor, this->op_chain, this->fp32_dest_acc_en);
             break;
@@ -300,21 +324,19 @@ operation::ProgramWithCallbacks EltwiseUnary::create_program(const std::vector<T
             return eltwise_unary_multi_core(input_tensor, output_tensor, this->op_chain, this->fp32_dest_acc_en);
             break;
         case UnaryOpParallelizationStrategy::SINGLE_CORE:
-        default:
-            return eltwise_unary_single_core(input_tensor, output_tensor, this->op_chain, this->fp32_dest_acc_en);
+        default: return eltwise_unary_single_core(input_tensor, output_tensor, this->op_chain, this->fp32_dest_acc_en);
     }
 }
 
-
-UnaryOpParallelizationStrategy EltwiseUnary::get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const {
+UnaryOpParallelizationStrategy EltwiseUnary::get_parallelization_strategy(
+    const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     uint32_t num_tiles = input_tensor.volume() / TILE_HW;
-    if(input_tensor.is_sharded())
+    if (input_tensor.is_sharded())
         return UnaryOpParallelizationStrategy::SHARDED_MULTI_CORE;
     else if (num_tiles > 1) {
         return UnaryOpParallelizationStrategy::MULTI_CORE;
-    }
-    else{
+    } else {
         return UnaryOpParallelizationStrategy::SINGLE_CORE;
     }
 }
@@ -332,87 +354,67 @@ const operation::Hash EltwiseUnary::compute_program_hash(const std::vector<Tenso
 
     for (const auto& unary_with_param_op : this->op_chain) {
         hash = tt::stl::hash::hash_objects(hash, unary_with_param_op.op_type);
-        if (unary_with_param_op.param.has_value()) {
-            hash = tt::stl::hash::hash_objects(hash, unary_with_param_op.param.value());
+        if (unary_with_param_op.has_parameter()) {
+            hash = tt::stl::hash::hash_objects(hash, unary_with_param_op.params);
         }
     }
     return hash;
 }
 
-//unary op version tie
-template<BcastOpMath OP>
+// unary op version tie
+template <BcastOpMath OP>
 Tensor tie_binop_to_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
-  Tensor t_value = mk_tiled_scalar(value);
-  return bcast(input_tensor, t_value, OP, BcastOpDim::HW);
+    Tensor t_value = mk_tiled_scalar(value);
+    return bcast(input_tensor, t_value, OP, BcastOpDim::HW);
 }
 
-Tensor lte_unary(
-    const Tensor& input_tensor,
-    float value,
-    const MemoryConfig& output_mem_config)  {
-    return lez(sub_unary_sfpu(input_tensor,value,output_mem_config),output_mem_config);
+Tensor lte_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
+    return lez(sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config);
 }
-Tensor lte_unary(
-    float value,
-    const Tensor& input_tensor,
-    const MemoryConfig& output_mem_config)  {
-    return lez(sub_unary_sfpu(value,input_tensor,output_mem_config),output_mem_config);
+Tensor lte_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
+    return lez(sub_unary_sfpu(value, input_tensor, output_mem_config), output_mem_config);
 }
-Tensor gte_unary(
-    const Tensor& input_tensor,
-    float value,
-    const MemoryConfig& output_mem_config) {
-    return gez(sub_unary_sfpu(input_tensor,value,output_mem_config),output_mem_config);
+Tensor gte_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
+    return gez(sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config);
 }
-Tensor gte_unary(
-    float value,
-    const Tensor& input_tensor,
-    const MemoryConfig& output_mem_config) {
-    return gez(sub_unary_sfpu(value,input_tensor,output_mem_config),output_mem_config);
+Tensor gte_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
+    return gez(sub_unary_sfpu(value, input_tensor, output_mem_config), output_mem_config);
 }
-Tensor eq_unary(
-    const Tensor& input_tensor,
-    float value,
-    const MemoryConfig& output_mem_config) {
-    return eqz(sub_unary_sfpu(input_tensor,value,output_mem_config),output_mem_config);
+Tensor eq_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
+    return eqz(sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config);
 }
 
-Tensor eq_unary(
-    float value,
-    const Tensor& input_tensor,
-    const MemoryConfig& output_mem_config) {
-        return eq_unary(input_tensor,value,output_mem_config);
+Tensor eq_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
+    return eq_unary(input_tensor, value, output_mem_config);
 }
 
 Tensor div_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
-    return tie_binop_to_unary<BcastOpMath::MUL>(input_tensor, 1.0f/value, output_mem_config);
+    return tie_binop_to_unary<BcastOpMath::MUL>(input_tensor, 1.0f / value, output_mem_config);
 }
 
-Tensor div_unary(float value,const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-    Tensor inv = recip(input_tensor,output_mem_config);
+Tensor div_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
+    Tensor inv = recip(input_tensor, output_mem_config);
     return tie_binop_to_unary<BcastOpMath::MUL>(inv, value, output_mem_config);
 }
 
-//same as div_unary(value,tensor)
-Tensor rdiv(const Tensor& input_tensor,float value, const MemoryConfig& output_mem_config) {
+// same as div_unary(value,tensor)
+Tensor rdiv(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
     float t_inf = std::numeric_limits<float>::infinity();
     Tensor result = div_unary(value, input_tensor, output_mem_config);
     result = where(eqz(input_tensor, output_mem_config), t_inf, result, output_mem_config);
     return result;
 }
 
-
-
 Tensor mul_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
     return tie_binop_to_unary<BcastOpMath::MUL>(input_tensor, value, output_mem_config);
 }
 
-Tensor sub_unary(const Tensor& input_tensor,float value, const MemoryConfig& output_mem_config) {
+Tensor sub_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
     return tie_binop_to_unary<BcastOpMath::SUB>(input_tensor, value, output_mem_config);
 }
 
 Tensor sub_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-  return add_unary(value, neg(input_tensor, output_mem_config), output_mem_config);
+    return add_unary(value, neg(input_tensor, output_mem_config), output_mem_config);
 }
 
 Tensor add_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -117,49 +117,55 @@ bool is_parametrized_type(T val) {
 
 struct UnaryWithParam {
     UnaryOpType op_type;
-    std::optional<float> param = std::nullopt;
+    std::vector<float> params;
+
+    UnaryWithParam(UnaryOpType op_type, const std::vector<float>& params) : op_type{op_type}, params{params} {}
+    UnaryWithParam(UnaryOpType op_type, float param) : op_type{op_type}, params{param} {}
+    UnaryWithParam(UnaryOpType op_type) : op_type{op_type} {}
+
+    bool has_parameter() const { return params.size() > 0; }
 
     static constexpr auto attribute_names = std::make_tuple("op_type", "param");
-    const auto attribute_values() const { return std::make_tuple(std::cref(this->op_type), std::cref(this->param)); }
+    const auto attribute_values() const { return std::make_tuple(std::cref(this->op_type), std::cref(this->params)); }
 };
 
 inline UnaryWithParam string_to_unary_with_param(const std::string& name) {
     if (name == "relu")
-        return UnaryWithParam{.op_type = UnaryOpType::RELU};
+        return UnaryWithParam(UnaryOpType::RELU);
     else if (name == "gelu")
-        return UnaryWithParam{.op_type = UnaryOpType::GELU, .param = static_cast<float>(true)};
+        return UnaryWithParam(UnaryOpType::GELU, static_cast<float>(true));
     else if (name == "silu")
-        return UnaryWithParam{.op_type = UnaryOpType::SILU};
+        return UnaryWithParam(UnaryOpType::SILU);
     else if (name == "sigmoid")
-        return UnaryWithParam{.op_type = UnaryOpType::SIGMOID};
+        return UnaryWithParam(UnaryOpType::SIGMOID);
     else if (name == "sqrt")
-        return UnaryWithParam{.op_type = UnaryOpType::SQRT};
+        return UnaryWithParam(UnaryOpType::SQRT);
     else if (name == "exp")
-        return UnaryWithParam{.op_type = UnaryOpType::EXP, .param = static_cast<float>(true)};
+        return UnaryWithParam(UnaryOpType::EXP, static_cast<float>(true));
     else if (name == "recip")
-        return UnaryWithParam{.op_type = UnaryOpType::RECIP};
+        return UnaryWithParam(UnaryOpType::RECIP);
     else if (name == "log")
-        return UnaryWithParam{.op_type = UnaryOpType::LOG};
+        return UnaryWithParam(UnaryOpType::LOG);
     else if (name == "tanh")
-        return UnaryWithParam{.op_type = UnaryOpType::TANH};
+        return UnaryWithParam(UnaryOpType::TANH);
     else if (name == "log2")
-        return UnaryWithParam{.op_type = UnaryOpType::LOG2};
+        return UnaryWithParam(UnaryOpType::LOG2);
     else if (name == "log10")
-        return UnaryWithParam{.op_type = UnaryOpType::LOG10};
+        return UnaryWithParam(UnaryOpType::LOG10);
     else if (name == "sin")
-        return UnaryWithParam{.op_type = UnaryOpType::SIN};
+        return UnaryWithParam(UnaryOpType::SIN);
     else if (name == "cos")
-        return UnaryWithParam{.op_type = UnaryOpType::COS};
+        return UnaryWithParam(UnaryOpType::COS);
     else if (name == "abs")
-        return UnaryWithParam{.op_type = UnaryOpType::ABS};
+        return UnaryWithParam(UnaryOpType::ABS);
     else if (name == "sign")
-        return UnaryWithParam{.op_type = UnaryOpType::SIGN};
+        return UnaryWithParam(UnaryOpType::SIGN);
     else if (name == "square")
-        return UnaryWithParam{.op_type = UnaryOpType::SQUARE};
+        return UnaryWithParam(UnaryOpType::SQUARE);
     TT_THROW("Unknown unary op: " + name);
 }
 
-enum class UnaryOpParallelizationStrategy { SINGLE_CORE = 0, MULTI_CORE = 1, SHARDED_MULTI_CORE=2 };
+enum class UnaryOpParallelizationStrategy { SINGLE_CORE = 0, MULTI_CORE = 1, SHARDED_MULTI_CORE = 2 };
 
 struct EltwiseUnary {
     const std::vector<UnaryWithParam> op_chain;
@@ -193,24 +199,40 @@ inline Tensor run_eltwise_unary(
     const std::vector<UnaryWithParam>& ops_chain,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     TT_FATAL(ops_chain.size() > 0, "At least 1 unary op must be specified");
-    bool fp32_dest_acc_en = input_tensor.get_dtype() == DataType::UINT32 or input_tensor.get_dtype() == DataType::INT32;       // MT: Currently only uint32/int32 is moved to DST directly, fp32 is converted to fp16b
+    bool fp32_dest_acc_en =
+        input_tensor.get_dtype() == DataType::UINT32 or
+        input_tensor.get_dtype() ==
+            DataType::INT32;  // MT: Currently only uint32/int32 is moved to DST directly, fp32 is converted to fp16b
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    if(output_mem_config.is_sharded()){
+    if (output_mem_config.is_sharded()) {
         operation::launch_op(
-            [ops_chain, output_mem_config, fp32_dest_acc_en] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            [ops_chain, output_mem_config, fp32_dest_acc_en](
+                const std::vector<Tensor>& input_tensors,
+                const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+                const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
                 return operation::run_without_autoformat(
                     EltwiseUnary{ops_chain, output_mem_config, fp32_dest_acc_en}, input_tensors);
-            }, {input_tensor}, output_tensors);
-    }
-    else {
+            },
+            {input_tensor},
+            output_tensors);
+    } else {
         operation::launch_with_autoformat(
-            [ops_chain, output_mem_config,fp32_dest_acc_en] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            [ops_chain, output_mem_config, fp32_dest_acc_en](
+                const std::vector<Tensor>& input_tensors,
+                const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+                const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
                 Tensor input_tensor = input_tensors.at(0);
                 Shape pad_shape = AutoFormat::pad_to_tile_shape(input_tensor.get_legacy_shape());
-                FormatParams input_format_params = {.pad_shape = pad_shape, .pad_value = 0.0, .target_layout = Layout::TILE};
+                FormatParams input_format_params = {
+                    .pad_shape = pad_shape, .pad_value = 0.0, .target_layout = Layout::TILE};
                 return operation::run_with_autoformat(
-                        EltwiseUnary{ops_chain, output_mem_config, fp32_dest_acc_en}, {input_tensor}, {input_format_params}, {Layout::TILE});
-            }, {input_tensor}, output_tensors);
+                    EltwiseUnary{ops_chain, output_mem_config, fp32_dest_acc_en},
+                    {input_tensor},
+                    {input_format_params},
+                    {Layout::TILE});
+            },
+            {input_tensor},
+            output_tensors);
     }
     return output_tensors.at(0);
 }
@@ -221,7 +243,10 @@ inline Tensor run_eltwise_unary(
     const std::vector<UnaryWithParam>& ops_chain,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     TT_FATAL(ops_chain.size() > 0, "At least 1 unary op must be specified");
-    bool fp32_dest_acc_en = input_tensor.get_dtype() == DataType::UINT32 or input_tensor.get_dtype() == DataType::INT32;       // MT: Currently only uint32/int32 is moved to DST directly, fp32 is converted to fp16b
+    bool fp32_dest_acc_en =
+        input_tensor.get_dtype() == DataType::UINT32 or
+        input_tensor.get_dtype() ==
+            DataType::INT32;  // MT: Currently only uint32/int32 is moved to DST directly, fp32 is converted to fp16b
     return operation::run(
                queue,
                tt::tt_metal::operation::DeviceOperation(EltwiseUnary{ops_chain, output_mem_config, fp32_dest_acc_en}),
@@ -236,9 +261,7 @@ struct make_eltwise_unary_with_param {
         T param,
         const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) const {
         return run_eltwise_unary(
-            input_tensor,
-            {UnaryWithParam{.op_type = unary_op_type, .param = static_cast<float>(param)}},
-            output_mem_config);
+            input_tensor, {UnaryWithParam(unary_op_type, static_cast<float>(param))}, output_mem_config);
     }
 };
 
@@ -247,7 +270,7 @@ struct make_eltwise_unary {
     Tensor operator()(
         const Tensor& input_tensor,
         const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) const {
-        return run_eltwise_unary(input_tensor, {UnaryWithParam{.op_type = unary_op_type}}, output_mem_config);
+        return run_eltwise_unary(input_tensor, {UnaryWithParam(unary_op_type)}, output_mem_config);
     }
 };
 
@@ -258,18 +281,14 @@ struct make_eltwise_symmetric_binop_unary_with_param {
         T param,
         const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) const {
         return run_eltwise_unary(
-            input_tensor,
-            {UnaryWithParam{.op_type = unary_op_type, .param = static_cast<float>(param)}},
-            output_mem_config);
+            input_tensor, {UnaryWithParam(unary_op_type, static_cast<float>(param))}, output_mem_config);
     }
     Tensor operator()(
         T param,
         const Tensor& input_tensor,
         const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) const {
         return run_eltwise_unary(
-            input_tensor,
-            {UnaryWithParam{.op_type = unary_op_type, .param = static_cast<float>(param)}},
-            output_mem_config);
+            input_tensor, {UnaryWithParam(unary_op_type, static_cast<float>(param))}, output_mem_config);
     }
 };
 
@@ -280,31 +299,27 @@ struct make_eltwise_asymmetric_binop_unary_with_param {
         T param,
         const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) const {
         return run_eltwise_unary(
-            input_tensor,
-            {UnaryWithParam{.op_type = unary_op_type, .param = static_cast<float>(param)}},
-            output_mem_config);
+            input_tensor, {UnaryWithParam(unary_op_type, static_cast<float>(param))}, output_mem_config);
     }
     Tensor operator()(
         T param,
         const Tensor& input_tensor,
         const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) const {
         return run_eltwise_unary(
-            input_tensor,
-            {UnaryWithParam{.op_type = unary_op_rev_type, .param = static_cast<float>(param)}},
-            output_mem_config);
+            input_tensor, {UnaryWithParam(unary_op_rev_type, static_cast<float>(param))}, output_mem_config);
     }
 };
 
 inline Tensor sqrt(
     const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
-    return run_eltwise_unary(input_tensor, {UnaryWithParam{.op_type = UnaryOpType::SQRT}}, output_mem_config);
+    return run_eltwise_unary(input_tensor, {UnaryWithParam(UnaryOpType::SQRT)}, output_mem_config);
 }
 
 inline Tensor sqrt(
     CommandQueue& queue,
     const Tensor& input_tensor,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
-    return run_eltwise_unary(queue, input_tensor, {UnaryWithParam{.op_type = UnaryOpType::SQRT}}, output_mem_config);
+    return run_eltwise_unary(queue, input_tensor, {UnaryWithParam(UnaryOpType::SQRT)}, output_mem_config);
 }
 
 constexpr auto recip = make_eltwise_unary<UnaryOpType::RECIP>{};
@@ -404,16 +419,17 @@ inline Tensor rsqrt(
 inline Tensor log_sigmoid(
     const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     return run_eltwise_unary(
-        input_tensor,
-        {UnaryWithParam{.op_type = UnaryOpType::SIGMOID}, UnaryWithParam{.op_type = UnaryOpType::LOG}},
-        output_mem_config);
+        input_tensor, {UnaryWithParam(UnaryOpType::SIGMOID), UnaryWithParam(UnaryOpType::LOG)}, output_mem_config);
 }
 
 inline Tensor sigmoid_accurate(
     const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     return run_eltwise_unary(
         input_tensor,
-        {UnaryWithParam{.op_type = UnaryOpType::NEG}, UnaryWithParam{.op_type = UnaryOpType::EXP, .param = 1.0f}, UnaryWithParam{.op_type = UnaryOpType::ADD_UNARY_SFPU, .param = 1.0f}, UnaryWithParam{.op_type = UnaryOpType::RECIP}},
+        {UnaryWithParam(UnaryOpType::NEG),
+         UnaryWithParam(UnaryOpType::EXP, 1.0f),
+         UnaryWithParam(UnaryOpType::ADD_UNARY_SFPU, 1.0f),
+         UnaryWithParam(UnaryOpType::RECIP)},
         output_mem_config);
 }
 
@@ -519,13 +535,19 @@ inline Tensor relu(
     const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     operation::launch_op(
-        [output_mem_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+        [output_mem_config](
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor = input_tensors.at(0);
-            bool fp32_dest_acc_en = input_tensor.get_dtype() == DataType::UINT32 or input_tensor.get_dtype() == DataType::INT32;       // MT: Currently only uint32/int32 is moved to DST directly, fp32 is converted to fp16b
-            return operation::run(
-               EltwiseUnary{{UnaryWithParam{.op_type = UnaryOpType::RELU}}, output_mem_config}, {input_tensor});
+            bool fp32_dest_acc_en =
+                input_tensor.get_dtype() == DataType::UINT32 or
+                input_tensor.get_dtype() == DataType::INT32;  // MT: Currently only uint32/int32 is moved to DST
+                                                              // directly, fp32 is converted to fp16b
+            return operation::run(EltwiseUnary{{UnaryWithParam(UnaryOpType::RELU)}, output_mem_config}, {input_tensor});
         },
-    {input_tensor}, output_tensors);
+        {input_tensor},
+        output_tensors);
     return output_tensors.at(0);
 }
 
@@ -539,9 +561,9 @@ namespace eltwise_unary_op_utils {
 using namespace tt::tt_metal;
 
 bool get_op_approx_mode(UnaryOpType op_type);
-std::pair<string, string> get_op_init_and_func(UnaryOpType op_type, std::optional<float> param = {}, string idst = "0");
+std::pair<string, string> get_op_init_and_func(UnaryOpType op_type, std::vector<float> params = {}, string idst = "0");
 std::map<string, string> get_defines(
-    UnaryOpType op_type, std::optional<float> param = {}, string id = "0", string idst = "0");
+    UnaryOpType op_type, std::optional<std::vector<float>> params = std::nullopt, string id = "0", string idst = "0");
 std::map<string, string> get_block_defines(
     const std::vector<UnaryWithParam>& op_chain, string block_id = "0", string idst = "0");
 }  // namespace eltwise_unary_op_utils

--- a/tt_eager/tt_dnn/op_library/loss/loss_op.cpp
+++ b/tt_eager/tt_dnn/op_library/loss/loss_op.cpp
@@ -28,11 +28,11 @@ Tensor lossfunction(
     std::vector<UnaryWithParam> fused_ops;
     switch(loss_kind) {
         case LossFunction::MAE:
-            fused_ops = {UnaryWithParam{.op_type=UnaryOpType::ABS}};
+            fused_ops = {UnaryWithParam{UnaryOpType::ABS}};
             result = sub(ref,prediction, fused_ops);
             break;
         case LossFunction::MSE:
-            fused_ops = {UnaryWithParam{.op_type=UnaryOpType::SQUARE}};
+            fused_ops = {UnaryWithParam{UnaryOpType::SQUARE}};
             result = sub(ref,prediction, fused_ops);
             break;
         default:

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -117,7 +117,7 @@ void TensorModule(py::module &m_tensor) {
         .def(py::init<UnaryOpType, float>())
         .def(py::init<>(
             [](std::pair<UnaryOpType, float> arg) {
-                return UnaryWithParam{.op_type=arg.first, .param=arg.second};
+                return UnaryWithParam{arg.first, arg.second};
             }
         ))
         .def_readonly("op_type", &UnaryWithParam::op_type);

--- a/ttnn/cpp/ttnn/operations/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/unary.hpp
@@ -63,7 +63,7 @@ struct Unary : public EltwiseUnary {
 
     static Tensor execute(const Tensor& input_tensor, const std::optional<MemoryConfig>& memory_config = std::nullopt) {
         return detail::execute(
-            input_tensor, {UnaryWithParam{.op_type = unary_op_type, .param = std::nullopt}}, memory_config);
+            input_tensor, {UnaryWithParam{unary_op_type}}, memory_config);
     }
 };
 
@@ -82,7 +82,7 @@ struct Exp : public EltwiseUnary {
         return detail::execute(
             input_tensor,
             {UnaryWithParam{
-                .op_type = ttnn::operations::unary::UnaryOpType::EXP, .param = static_cast<float>(parameter)}},
+                ttnn::operations::unary::UnaryOpType::EXP, static_cast<float>(parameter)}},
             memory_config);
     }
 };


### PR DESCRIPTION
This PR adds support for multiple parameters in `EltwiseUnary` ops. Previously, we only supported 0 or 1 parameters per unary op in the unary chain. Multiple parameters are required for ops like `Softplus`, which I am currently converting to a single op from a composite for performance reasons (see https://github.com/tenstorrent/tt-metal/pull/8249).

The core change is to convert `UnaryParam` from:

```cpp
struct UnaryWithParam {
    UnaryOpType op_type;
    std::optional<float> param = std::nullopt;

    static constexpr auto attribute_names = std::make_tuple("op_type", "param");
    const auto attribute_values() const { return std::make_tuple(std::cref(this->op_type), std::cref(this->param)); }
};
```

to:

```cpp
struct UnaryWithParam {
    UnaryOpType op_type;
    std::vector<float> params;

    UnaryWithParam(UnaryOpType op_type, const std::vector<float>& params) : op_type{op_type}, params{params} {}
    UnaryWithParam(UnaryOpType op_type, float param) : op_type{op_type}, params{param} {}
    UnaryWithParam(UnaryOpType op_type) : op_type{op_type} {}

    bool has_parameter() const { return params.size() > 0; }

    static constexpr auto attribute_names = std::make_tuple("op_type", "param");
    const auto attribute_values() const { return std::make_tuple(std::cref(this->op_type), std::cref(this->params)); }
};
```

I didn't bother tackling it here, but I think we should probably move away from using `float` as the underlying storage for all parameters to keep things type safe.