### PR TITLE
#7511: remove create matmul program configs from python

### DIFF
--- a/models/demos/ttnn_falcon7b/tests/test_perf_device_falcon.py
+++ b/models/demos/ttnn_falcon7b/tests/test_perf_device_falcon.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [1, "BFLOAT16-L1-falcon_7b-layers_32-prefill_seq256", 3.49],
+        [1, "BFLOAT16-L1-falcon_7b-layers_32-prefill_seq256", 3.44],
         [32, "BFLOAT16-L1-falcon_7b-layers_32-decode_batch32", 139],
     ],
 )

--- a/models/demos/wormhole/mistral7b/tt/mistral_mlp.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_mlp.py
@@ -42,25 +42,6 @@ class TtMistralMLP(torch.nn.Module):
 
         x_shape = ttnn.Shape([1, 1, args.max_batch_size, args.dim])
         h_shape = ttnn.Shape([1, 1, args.max_batch_size, args.hidden_dim])
-        self.w1_program_config = ttnn.operations.matmul.create_matmul_1d_systolic_array_program_config(
-            input_shape_a=x_shape,
-            input_shape_b=self.w1.shape,
-            core_grid=self.args.max_grid_size,
-            activation="silu",
-            fp32_dst=self.args.get_compute_kernel_config().fp32_dest_acc_en,
-        )
-        self.w2_program_config = ttnn.operations.matmul.create_matmul_1d_systolic_array_program_config(
-            input_shape_a=h_shape,
-            input_shape_b=self.w2.shape,
-            core_grid=self.args.max_grid_size,
-            fp32_dst=self.args.get_compute_kernel_config().fp32_dest_acc_en,
-        )
-        self.w3_program_config = ttnn.operations.matmul.create_matmul_1d_systolic_array_program_config(
-            input_shape_a=x_shape,
-            input_shape_b=self.w3.shape,
-            core_grid=self.args.max_grid_size,
-            fp32_dst=self.args.get_compute_kernel_config().fp32_dest_acc_en,
-        )
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         """
@@ -74,15 +55,15 @@ class TtMistralMLP(torch.nn.Module):
             self.w1,
             activation="silu",
             memory_config=self.model_config["FF1_OUTPUT_MEMCFG"],
-            program_config=self.w1_program_config,
             compute_kernel_config=self.args.get_compute_kernel_config(),
+            core_grid=self.args.max_grid_size,
         )
         w3_out = ttnn.linear(
             x,
             self.w3,
             memory_config=self.model_config["FF3_OUTPUT_MEMCFG"],
-            program_config=self.w3_program_config,
             compute_kernel_config=self.args.get_compute_kernel_config(),
+            core_grid=self.args.max_grid_size,
         )
         w2_in = ttnn.mul(
             w1_out,
@@ -93,8 +74,8 @@ class TtMistralMLP(torch.nn.Module):
             w2_in,
             self.w2,
             memory_config=self.model_config["FF2_OUTPUT_MEMCFG"],
-            program_config=self.w2_program_config,
             compute_kernel_config=self.args.get_compute_kernel_config(),
+            core_grid=self.args.max_grid_size,
         )
 
         return w2_out

--- a/models/demos/wormhole/mistral7b/tt/mistral_model.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_model.py
@@ -65,12 +65,6 @@ class TtTransformer(nn.Module):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             cache_file_name=weight_cache_path / "output.weight",
         )
-        self.output_program_config = ttnn.operations.matmul.create_matmul_1d_systolic_array_program_config(
-            input_shape_a=ttnn.Shape([1, 1, args.max_batch_size, args.dim]),
-            input_shape_b=self.output_weight.shape,
-            core_grid=args.max_grid_size,
-            fp32_dst=args.get_compute_kernel_config().fp32_dest_acc_en,
-        )
 
     def forward(
         self,
@@ -85,7 +79,7 @@ class TtTransformer(nn.Module):
         output = ttnn.linear(
             x,
             self.output_weight,
-            program_config=self.output_program_config,
             compute_kernel_config=self.args.get_compute_kernel_config(),
+            core_grid=self.args.max_grid_size,
         )
         return output

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         Tensor b = tt::numpy::zeros(shapeb, DataType::BFLOAT16).to(Layout::TILE).to(device);
         Tensor b1 = tt::numpy::zeros(shapeb1, DataType::BFLOAT16).to(Layout::TILE).to(device);
 
-        Tensor mm = tt::operations::primary::matmul(a, b, std::nullopt, tt::operations::primary::MatmulDefaultProgramConfig{}, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::nullopt, std::nullopt, false, std::nullopt, true).cpu();
+        Tensor mm = tt::operations::primary::matmul(a, b, /*bias=*/std::nullopt, tt::operations::primary::MatmulDefaultProgramConfig{}, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, /*output_dtype=*/std::nullopt, /*compute_kernel_config=*/std::nullopt, /*untilize_out=*/false, /*user_core_coord=*/std::nullopt, /*user_fused_activation=*/std::nullopt, /*input_b_is_batched=*/true).cpu();
         Tensor mm1 = tt::operations::primary::matmul(a, b1).cpu();
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/ttnn/unit_tests/operations/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/test_linear.py
@@ -188,17 +188,11 @@ def test_linear_by_passing_in_1D_systolic_array_program_config(device, batch_siz
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    program_config = ttnn.create_matmul_1d_systolic_array_program_config(
-        input_shape_a=input_tensor_a.shape,
-        input_shape_b=input_tensor_b.shape,
-        core_grid=device.core_grid,
-        activation=activation,
-    )
-
     output_tensor = ttnn.linear(
         input_tensor_a,
         input_tensor_b,
-        program_config=program_config,
+        activation=activation,
+        core_grid=device.core_grid,
     )
 
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -482,16 +482,10 @@ def test_matmul_by_passing_in_1D_systolic_array_program_config(device, batch_siz
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    program_config = ttnn.create_matmul_1d_systolic_array_program_config(
-        input_shape_a=input_tensor_a.shape.with_tile_padding(),
-        input_shape_b=input_tensor_b.shape.with_tile_padding(),
-        core_grid=input_tensor_a.device().core_grid,
-    )
-
     output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
-        program_config=program_config,
+        core_grid=input_tensor_a.device().core_grid,
     )
 
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -1388,7 +1388,7 @@ Tensor _outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
         b_slim = reshape(b, 1, 1, 1, b.volume(), output_mem_config);
     }
 
-    return tt::operations::primary::matmul(a_slim, b_slim, std::nullopt, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config, std::nullopt /*output_dtype*/, std::nullopt /*compute_kernel_config*/, false /*untilize_out*/, std::nullopt /*user_core_coord*/, std::nullopt /*input_b_is_batched*/, true /*needs_autoformat*/);
+    return tt::operations::primary::matmul(a_slim, b_slim, std::nullopt, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config, std::nullopt /*output_dtype*/, std::nullopt /*compute_kernel_config*/, false /*untilize_out*/, std::nullopt /*user_core_coord*/, std::nullopt /*fused_activation*/, std::nullopt /*input_b_is_batched*/, true /*needs_autoformat*/);
 }
 Tensor outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _outer)(a, b, output_mem_config);

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_custom_bmm_ops.cpp
@@ -77,7 +77,7 @@ namespace tt::tt_metal::detail
            const MemoryConfig& output_mem_config,
            std::optional<const DeviceComputeKernelConfig> kernel_config,
            const bool untilize_out) {
-		return tt::operations::primary::matmul(input_a, input_b, std::nullopt /*bias*/, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config, std::nullopt /*output_dtype*/, kernel_config, untilize_out, std::nullopt /*user_core_coord*/, true /*input_b_is_batched*/);
+		return tt::operations::primary::matmul(input_a, input_b, std::nullopt /*bias*/, tt::operations::primary::MatmulDefaultProgramConfig{}, output_mem_config, std::nullopt /*output_dtype*/, kernel_config, untilize_out, std::nullopt /*user_core_coord*/, std::nullopt /*user_fused_activation*/, true /*input_b_is_batched*/);
 		},
             py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("kernel_config").noconvert() = std::nullopt, py::arg("untilize_out").noconvert() = false,  R"doc(
             Perform a batched matmul ``arg0 x arg1`` with two tensors, where batch dims match.

--- a/ttnn/cpp/pybind11/operations/matmul.hpp
+++ b/ttnn/cpp/pybind11/operations/matmul.hpp
@@ -23,16 +23,18 @@ void py_module(py::module& module) {
            const ttnn::Tensor& input_tensor_b,
            const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
            const std::optional<const DataType> dtype = std::nullopt,
-           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) -> ttnn::Tensor {
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+	   const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::matmul::matmul(
-                input_tensor_a, input_tensor_b, MatmulDefaultProgramConfig{}, memory_config, dtype, compute_kernel_config);
+                input_tensor_a, input_tensor_b, MatmulDefaultProgramConfig{}, memory_config, dtype, compute_kernel_config, core_grid);
         },
         py::arg("input_tensor_a"),
         py::arg("input_tensor_b"),
         py::kw_only(),
         py::arg("memory_config") = DRAM_MEMORY_CONFIG,
         py::arg("dtype") = std::nullopt,
-        py::arg("compute_kernel_config") = std::nullopt);
+        py::arg("compute_kernel_config") = std::nullopt,
+	py::arg("core_grid") = std::nullopt);
 
     module.def(
         "matmul",
@@ -66,7 +68,8 @@ void py_module(py::module& module) {
            const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
            const std::optional<const DataType> dtype = std::nullopt,
            const std::optional<const std::string>& activation = std::nullopt,
-           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) -> ttnn::Tensor {
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+	   const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::matmul::linear(
                 input_tensor_a,
                 input_tensor_b,
@@ -75,7 +78,8 @@ void py_module(py::module& module) {
                 memory_config,
                 dtype,
                 activation,
-                compute_kernel_config);
+                compute_kernel_config,
+		core_grid);
         },
         py::arg("input_tensor_a"),
         py::arg("input_tensor_b"),
@@ -84,7 +88,8 @@ void py_module(py::module& module) {
         py::arg("memory_config") = DRAM_MEMORY_CONFIG,
         py::arg("dtype") = std::nullopt,
         py::arg("activation") = std::nullopt,
-        py::arg("compute_kernel_config") = std::nullopt);
+        py::arg("compute_kernel_config") = std::nullopt,
+	py::arg("core_grid") = std::nullopt);
 
     module.def(
         "linear",
@@ -114,6 +119,7 @@ void py_module(py::module& module) {
         py::arg("memory_config") = DRAM_MEMORY_CONFIG,
         py::arg("dtype") = std::nullopt,
         py::arg("compute_kernel_config") = std::nullopt);
+
 }
 
 }  // namespace matmul

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -265,8 +265,6 @@ from ttnn.operations.core import (
 from ttnn.operations.matmul import (
     matmul,
     linear,
-    create_matmul_program_config,
-    create_matmul_1d_systolic_array_program_config,
 )
 
 from ttnn.operations.embedding import (

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -7,258 +7,7 @@ from typing import Optional, Tuple
 
 import ttnn
 
-MatmulDefaultProgramConfig = ttnn.experimental.operations.primary.MatmulDefaultProgramConfig
-MatmulMultiCoreReuseProgramConfig = ttnn.experimental.operations.primary.MatmulMultiCoreReuseProgramConfig
-MatmulMultiCoreReuseMultiCastProgramConfig = (
-    ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig
-)
-MatmulMultiCoreReuseMultiCast1DProgramConfig = (
-    ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig
-)
-
-# MatmulProgramConfig is the Union of the above types
 MatmulProgramConfig = ttnn.experimental.operations.primary.MatmulProgramConfig
-
-
-_DST_SUB_BLOCKS = [
-    (2, 4),
-    (4, 2),
-    (1, 8),
-    (8, 1),
-    (1, 7),
-    (7, 1),
-    (2, 3),
-    (3, 2),
-    (1, 6),
-    (6, 1),
-    (1, 5),
-    (5, 1),
-    (2, 2),
-    (1, 4),
-    (4, 1),
-    (1, 3),
-    (3, 1),
-    (1, 2),
-    (2, 1),
-    (1, 1),
-]
-
-_FP32_DST_SUB_BLOCKS = [x for x in _DST_SUB_BLOCKS if x[0] * x[1] <= 4]
-
-
-def _get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, fp32_dst):
-    candidate_sub_blocks = _FP32_DST_SUB_BLOCKS if fp32_dst else _DST_SUB_BLOCKS
-    for m_subblock_size, n_subblock_size in candidate_sub_blocks:
-        if m_tiles_per_core % m_subblock_size == 0 and n_tiles_per_core % n_subblock_size == 0:
-            return m_subblock_size, n_subblock_size
-    raise RuntimeError(
-        f"Unable to find subblock sizes for m_size={m_tiles_per_core} and n_size={n_tiles_per_core} (fp32_dst={fp32_dst})"
-    )
-
-
-def get_fused_activation(activation):
-    if activation is None:
-        return None
-    return ttnn._tt_lib.tensor.string_to_unary_with_param(activation)
-
-
-def create_matmul_1d_systolic_array_program_config(
-    *,
-    input_shape_a: Tuple[int, ...],
-    input_shape_b: Tuple[int, ...],
-    core_grid: Optional[ttnn.CoreGrid] = None,
-    activation: Optional[str] = None,
-    fp32_dst: Optional[bool] = False,
-):
-    """
-
-    Create a MatmulMultiCoreReuseMultiCast1DProgramConfig for a 1D systolic array.
-
-
-    Args:
-        * :attr:`input_shape_a` (Tuple[int, ...]): the shape of the first tensor
-        * :attr:`input_shape_b` (Tuple[int, ...]): the shape of the second tensor
-        * :attr:`core_grid` (ttnn.CoreGrid): the maximum core grid to use
-        * :attr:`activation` (Optional[str]): the activation function to use. Defaults to None
-
-    """
-
-    if core_grid is None:
-        raise RuntimeError(f"core_grid must be a valid CoreGrid object")
-
-    if core_grid is not None and not isinstance(core_grid, ttnn.CoreGrid):
-        raise RuntimeError(f"core_grid must be a valid CoreGrid object")
-
-    *batch_shape_a, m_size, k_size = input_shape_a.with_tile_padding()
-    *batch_shape_b, _, n_size = input_shape_b.with_tile_padding()
-    if math.prod(batch_shape_b) != 1:
-        raise RuntimeError("Second input cannot be currently batched when running matmul using 1d systolic array")
-
-    batch_size = math.prod(batch_shape_a)
-    input_b_is_batched = math.prod(batch_shape_b) > 1
-
-    if input_b_is_batched:
-        raise RuntimeError(f"Input b shouldn't be batched")
-
-    if (batch_size * m_size) % ttnn.TILE_SIZE != 0 or k_size % ttnn.TILE_SIZE != 0 or n_size % ttnn.TILE_SIZE != 0:
-        raise RuntimeError(
-            f"The last two dimensions of the first tensor and the last dimension of the second tensor must be a multiple of {ttnn.TILE_SIZE}"
-        )
-
-    batch_and_m_tiles = (batch_size * m_size) // ttnn.TILE_SIZE
-    k_tiles = k_size // ttnn.TILE_SIZE
-    n_tiles = n_size // ttnn.TILE_SIZE
-
-    is_tall = batch_and_m_tiles > n_tiles
-    is_wide = not is_tall
-    # Tall output
-    if is_tall:
-        batch_and_m_tiles_per_core = int(math.ceil(batch_and_m_tiles / core_grid.num_cores))
-        k_tiles_per_core = int(math.ceil(k_tiles / core_grid.num_cores))
-        n_tiles_per_core = n_tiles
-
-    # Wide output
-    else:
-        batch_and_m_tiles_per_core = batch_and_m_tiles
-        k_tiles_per_core = int(math.ceil(k_tiles / core_grid.num_cores))
-        n_tiles_per_core = int(math.ceil(n_tiles / core_grid.num_cores))
-
-    while k_tiles % k_tiles_per_core != 0:
-        k_tiles_per_core -= 1
-
-    m_subblock_size, n_subblock_size = _get_subblock_sizes(batch_and_m_tiles_per_core, n_tiles_per_core, fp32_dst)
-
-    return MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=(core_grid.x, core_grid.y),
-        in0_block_w=k_tiles_per_core,
-        out_subblock_h=m_subblock_size,
-        out_subblock_w=n_subblock_size,
-        per_core_M=batch_and_m_tiles_per_core,
-        per_core_N=n_tiles_per_core,
-        fuse_batch=True,
-        fused_activation=get_fused_activation(activation=activation),
-        mcast_in0=is_wide,
-    )
-
-
-def create_matmul_program_config(
-    *, input_tensor_a, input_tensor_b, core_grid, activation, use_1d_systolic_array, compute_kernel_config
-):
-    *batch_shape_a, m_size, k_size = input_tensor_a.shape.with_tile_padding()
-    *batch_shape_b, _, n_size = input_tensor_b.shape.with_tile_padding()
-    *_, intended_k_size_of_a = input_tensor_a.shape
-    *_, intended_k_size_of_b, _ = input_tensor_b.shape
-
-    if intended_k_size_of_a != intended_k_size_of_b:
-        raise RuntimeError(f"The k dimension does not match between tensors")
-
-    batch_size = math.prod(batch_shape_a)
-    input_b_is_batched = math.prod(batch_shape_b) > 1
-
-    input_tensor_a_memory_config = ttnn.get_memory_config(input_tensor_a)
-    input_tensor_b_memory_config = ttnn.get_memory_config(input_tensor_b)
-
-    # Determine how many subblock tiles we can use based on dest register data format
-    fp32_dst = (
-        compute_kernel_config
-        and isinstance(compute_kernel_config, ttnn.WormholeComputeKernelConfig)
-        and compute_kernel_config.fp32_dest_acc_en
-    )
-
-    if use_1d_systolic_array is None and not input_b_is_batched:
-        # Infer use_1d_systolic_array based on how rectangular the output matrix
-        height_width_ratio = (math.prod(batch_shape_a) * m_size) / n_size
-        if height_width_ratio < 1:
-            height_width_ratio = 1 / height_width_ratio
-
-        # 8 is an arbitrary choice. It should probably be inferred based on the device core grid
-        threshold_of_being_rectangular = 8
-        is_more_rectangular_than_square = height_width_ratio > threshold_of_being_rectangular
-        use_1d_systolic_array = is_more_rectangular_than_square
-
-    if use_1d_systolic_array:
-        return create_matmul_1d_systolic_array_program_config(
-            input_shape_a=input_tensor_a.shape,
-            input_shape_b=input_tensor_b.shape,
-            core_grid=core_grid,
-            activation=activation,
-            fp32_dst=fp32_dst,
-        )
-
-    # TODO: clean up the code below by mvoing it to separate create_*_config functions
-
-    if (batch_size * m_size) % ttnn.TILE_SIZE != 0 or k_size % ttnn.TILE_SIZE != 0 or n_size % ttnn.TILE_SIZE != 0:
-        raise RuntimeError(
-            f"The last two dimensions of the first tensor and the last dimension of the second tensor must be a multiple of {ttnn.TILE_SIZE}"
-        )
-
-    if input_b_is_batched:
-        if activation is not None:
-            raise RuntimeError(f"Cannot use activation with batched input b")
-        if (not ttnn.is_sharded(input_tensor_a)) and (not ttnn.is_sharded(input_tensor_b)):
-            m_tiles_per_core = int(math.ceil((m_size / ttnn.TILE_SIZE)))
-            n_tiles_per_core = int(math.ceil((n_size / ttnn.TILE_SIZE)))
-            k_tiles_per_core = 1  # TODO(arakhmati): Can it be more than 1 without running out of memory?
-        elif ttnn.is_sharded(input_tensor_a):
-            if input_tensor_a_memory_config.memory_layout == ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED:
-                raise RuntimeError(f"MatmulMultiCoreReuseProgramConfig: Cannot be width sharded")
-            shard_shape = input_tensor_a_memory_config.shard_spec.shape
-            N = input_tensor_b.shape[-1] // ttnn.TILE_SIZE
-            m_tiles_per_core = shard_shape[0] // ttnn.TILE_SIZE
-            n_tiles_per_core = N
-            k_tiles_per_core = shard_shape[1] // ttnn.TILE_SIZE
-        elif ttnn.is_sharded(input_tensor_b):
-            if input_tensor_b_memory_config.memory_layout == ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED:
-                raise RuntimeError(f"MatmulMultiCoreReuseProgramConfig: Cannot be width sharded")
-            shard_shape = input_tensor_b_memory_config.shard_spec.shape
-            m_tiles_per_core = int(math.ceil((m_size / ttnn.TILE_SIZE)))
-            n_tiles_per_core = shard_shape[1] // ttnn.TILE_SIZE
-            k_tiles_per_core = 1
-
-        m_subblock_size, n_subblock_size = _get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, fp32_dst)
-
-        program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseProgramConfig(
-            compute_with_storage_grid_size=(core_grid.x, core_grid.y),
-            per_core_M=m_tiles_per_core,
-            per_core_N=n_tiles_per_core,
-            in0_block_w=k_tiles_per_core,
-            out_subblock_h=m_subblock_size,
-            out_subblock_w=n_subblock_size,
-        )
-    else:
-        if not ttnn.is_sharded(input_tensor_a):
-            m_tiles_per_core = int(math.ceil(((batch_size * m_size) / ttnn.TILE_SIZE) / core_grid.y))
-            n_tiles_per_core = int(math.ceil(n_size / ttnn.TILE_SIZE / core_grid.x))
-            k_tiles_per_core = 4  # TODO(arakhmati): What is a good starting point?
-            while (k_size // ttnn.TILE_SIZE) % k_tiles_per_core != 0:
-                k_tiles_per_core -= 1
-        else:
-            if (
-                not input_tensor_a_memory_config.memory_layout
-                == ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED
-            ):
-                raise RuntimeError(f"MatmulMultiCoreReuseMultiCastProgramConfig: Must be block sharded")
-            K = input_tensor_a.shape[-1] // ttnn.TILE_SIZE
-            N = input_tensor_b.shape[-1] // ttnn.TILE_SIZE
-            shard_shape = input_tensor_a_memory_config.shard_spec.shape
-            m_tiles_per_core = shard_shape[0] // ttnn.TILE_SIZE
-            n_tiles_per_core = (N * shard_shape[1]) // (K * ttnn.TILE_SIZE)
-            k_tiles_per_core = shard_shape[1] // ttnn.TILE_SIZE
-
-        m_subblock_size, n_subblock_size = _get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, fp32_dst)
-
-        program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=(core_grid.x, core_grid.y),
-            per_core_M=m_tiles_per_core,
-            per_core_N=n_tiles_per_core,
-            in0_block_w=k_tiles_per_core,
-            out_subblock_h=m_subblock_size,
-            out_subblock_w=n_subblock_size,
-            transpose_mcast=False,
-            fused_activation=get_fused_activation(activation=activation),
-        )
-
-    return program_config
 
 
 def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -363,14 +112,7 @@ def matmul(
     if use_1d_systolic_array is not None or core_grid is not None:
         if program_config is not None:
             raise RuntimeError(f"Cannot use program_config with use_1d_systolic_array or core_grid")
-        program_config = create_matmul_program_config(
-            input_tensor_a=input_tensor_a,
-            input_tensor_b=input_tensor_b,
-            core_grid=core_grid or input_tensor_a.device().core_grid,
-            activation=None,
-            use_1d_systolic_array=use_1d_systolic_array,
-            compute_kernel_config=compute_kernel_config,
-        )
+        core_grid = core_grid or input_tensor_a.device().core_grid
 
     if program_config is not None:
         return ttnn._ttnn.operations.matmul.matmul(
@@ -388,6 +130,7 @@ def matmul(
         memory_config=memory_config,
         dtype=dtype,
         compute_kernel_config=compute_kernel_config,
+        core_grid=core_grid,
     )
 
 
@@ -463,14 +206,7 @@ def linear(
     if use_1d_systolic_array is not None or core_grid is not None:
         if program_config is not None:
             raise RuntimeError(f"Cannot use program_config with use_1d_systolic_array or core_grid")
-        program_config = create_matmul_program_config(
-            input_tensor_a=input_tensor_a,
-            input_tensor_b=input_tensor_b,
-            core_grid=core_grid or input_tensor_a.device().core_grid,
-            activation=activation,
-            use_1d_systolic_array=use_1d_systolic_array,
-            compute_kernel_config=compute_kernel_config,
-        )
+        core_grid = core_grid or input_tensor_a.device().core_grid
 
     if program_config is not None:
         return ttnn._ttnn.operations.matmul.linear(
@@ -492,6 +228,7 @@ def linear(
         dtype=dtype,
         activation=activation,
         compute_kernel_config=compute_kernel_config,
+        core_grid=core_grid,
     )
 
 


### PR DESCRIPTION
Moves create_matmul_1d_systolic_array_program_config and create_matmul_program_config from Python to C++

Removes all references to create_matmul_1d_systolic_array_program_config and create_matmul_program_config from Python

This requires properly passing through the core grid and activation (for linear) to C++.

Notes:
- models/demos/ttnn_falcon7b/tests/test_perf_device_falcon.py got slightly faster.
- the order of sub-block indices used by the moved code is reverse of what it is in the C++ code, and that can affect PCC.
- shapes that have one dimension be one tile large can only be handled by the 1d choice in create_matmul_program_config and therefore that is used. 

Testing:
- pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py passed
- python tests/ttnn/sweep_tests/run_sweeps.py --include matmul_user_program_config passed
- pytest ./tests/ttnn/unit_tests/operations/test_linear.py passed

Passed Workflows:
- https://github.com/tenstorrent/tt-metal/actions/runs/9066490454 Nightly fast dispatch tests
- https://github.com/tenstorrent/tt-metal/actions/runs/9066578924/job/24909784925 Device perf regressions and output report
- https://github.com/tenstorrent/tt-metal/actions/runs/9066183829 metal - Run microbenchmarks 
- https://github.com/tenstorrent/tt-metal/actions/runs/9066616102/job/24910065396 Model perf regressions and output report
- https://github.com/tenstorrent/tt-metal/actions/runs/9066187519 [post-commit] ttnn unit tests
- https://github.com/tenstorrent/tt-metal/actions/runs/9066189467 ttnn - Run sweeps