### PR TITLE
 #7817: Add Slack notification on failure for Performance Models

### DIFF
--- a/.github/actions/slack-report/action.yaml
+++ b/.github/actions/slack-report/action.yaml
@@ -1,0 +1,21 @@
+name: "Report Workflow Status to Slack"
+description: "Report the workflow status to Slack to help identify breakages faster."
+inputs:
+  owner:
+    description: "The Slack ID of the person to be tagged."
+    default: "U014XCQ9CF8" # @Raymond Kim
+  slack_webhook_url: 
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Report Github Pipeline Status Slack Action 
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        payload: |
+          {
+            "text": "just so you know `${{ github.event.sender.login }}` broke ${{ github.workflow }} with https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }}",
+            "owner": "${{ inputs.owner }}"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}

--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -51,10 +51,15 @@ jobs:
         run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run performance regressions
+        id: performance_tests
         timeout-minutes: 60
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type ${{ matrix.model-type }}_models_performance_${{ matrix.runner-info.machine-type }}
+      - uses: ./.github/actions/slack-report
+        if: ${{ steps.performance_tests.outcome != 'success' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
       - name: Check perf report exists
         id: check-perf-report
         if: ${{ !cancelled() }}


### PR DESCRIPTION
 - Create a new Github action that allows to send a slack notificaton
 - Add reporting to Nightly pipelines
 - Create a concept of owner that can be specified and for now use @tt-rkim as a default maintainer

This creates a structure for adding a lot more notifications and identifying specific owners for different sections of the pipelines.

Follow up: https://github.com/tenstorrent/tt-metal/issues/8304