### PR TITLE
#8031: Shallow Unet bringup for 512x512 and 1024x1024

### DIFF
--- a/tests/ttnn/integration_tests/unet/test_ttnn_shallow_unet.py
+++ b/tests/ttnn/integration_tests/unet/test_ttnn_shallow_unet.py
@@ -26,11 +26,595 @@ import ttnn
 
 
 @pytest.mark.skip(reason="#9417: Various failures preventing model from running")
+def update_ttnn_module_args(ttnn_module_args):
+    ttnn_module_args["use_1d_systolic_array"] = ttnn_module_args.in_channels < 256
+
+
+def create_custom_preprocessor(device, groups=1, act_block_n=1):
+    def custom_preprocessor(model, name, ttnn_module_args):
+        parameters = {}
+        if isinstance(model, UNet):
+            print("\n\n\n")
+            print("model output weights: ", type(model.output_layer.weight))
+            print("model output weights: ", list(model.output_layer.weight))
+
+            ttnn_module_args.p1["deallocate_activation"] = False
+            ttnn_module_args.p2["deallocate_activation"] = False
+            ttnn_module_args.p3["deallocate_activation"] = False
+            ttnn_module_args.p4["deallocate_activation"] = False
+
+            ttnn_module_args.c1["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c1["padded_input_channels"] = None if device.arch() == ttl.device.Arch.WORMHOLE_B0 else 16
+            ttnn_module_args.c1["use_shallow_conv_variant"] = (
+                False if device.arch() == ttl.device.Arch.WORMHOLE_B0 else True
+            )
+            ttnn_module_args.c1_2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c1_2["use_shallow_conv_variant"] = (
+                False if device.arch() == ttl.device.Arch.WORMHOLE_B0 else True
+            )
+            ttnn_module_args.c1["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c1_2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c1["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c1_2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c1["activation"] = "relu"  # Fuse relu with conv1
+            ttnn_module_args.c1_2["activation"] = "relu"  # Fuse relu with conv1
+            ttnn_module_args.c1["deallocate_activation"] = True
+            ttnn_module_args.c1_2["deallocate_activation"] = True
+            ttnn_module_args.c1["conv_blocking_and_parallelization_config_override"] = (
+                {"act_block_h": 32}
+                if groups > 1
+                else (
+                    {"act_block_h": act_block_n * 32}
+                    if device.arch() == ttl.device.Arch.WORMHOLE_B0
+                    else {"act_block_h": 64}
+                )
+            )
+            ttnn_module_args.c1_2["conv_blocking_and_parallelization_config_override"] = (
+                {"act_block_h": 32}
+                if groups > 1
+                else (
+                    {"act_block_h": act_block_n * 32}
+                    if device.arch() == ttl.device.Arch.WORMHOLE_B0
+                    else {"act_block_h": 64}
+                )
+            )
+
+            ttnn_module_args.c2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c2_2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c2_2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c2_2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c2["activation"] = "relu"  # Fuse relu with conv2
+            ttnn_module_args.c2_2["activation"] = "relu"  # Fuse relu with conv2
+            ttnn_module_args.c2["deallocate_activation"] = True
+            ttnn_module_args.c2_2["deallocate_activation"] = True
+            ttnn_module_args.c2["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.c2_2["conv_blocking_and_parallelization_config_override"] = None
+
+            ttnn_module_args.c3["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c3["use_shallow_conv_variant"] = False
+            ttnn_module_args.c3_2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c3_2["use_shallow_conv_variant"] = False
+            ttnn_module_args.c3["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c3_2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c3["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c3_2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c3["activation"] = "relu"  # Fuse relu with conv3
+            ttnn_module_args.c3_2["activation"] = "relu"  # Fuse relu with conv3
+            ttnn_module_args.c3["deallocate_activation"] = True
+            ttnn_module_args.c3_2["deallocate_activation"] = True
+            ttnn_module_args.c3["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.c3_2["conv_blocking_and_parallelization_config_override"] = None
+
+            ttnn_module_args.c4["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c4["use_shallow_conv_variant"] = False
+            ttnn_module_args.c4_2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c4_2["use_shallow_conv_variant"] = False
+            ttnn_module_args.c4["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c4_2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c4["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c4_2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c4["activation"] = "relu"  # Fuse relu with conv4
+            ttnn_module_args.c4_2["activation"] = "relu"  # Fuse relu with conv4
+            ttnn_module_args.c4["deallocate_activation"] = True
+            ttnn_module_args.c4_2["deallocate_activation"] = True
+            ttnn_module_args.c4["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.c4_2["conv_blocking_and_parallelization_config_override"] = None
+
+            ttnn_module_args.bnc["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.bnc_2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.bnc["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.bnc_2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.bnc["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.bnc_2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.bnc["activation"] = "relu"  # Fuse relu with bottle neck conv
+            ttnn_module_args.bnc_2["activation"] = "relu"  # Fuse relu with bottle neck conv
+            ttnn_module_args.bnc["deallocate_activation"] = True
+            ttnn_module_args.bnc_2["deallocate_activation"] = True
+            ttnn_module_args.bnc["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.bnc_2["conv_blocking_and_parallelization_config_override"] = None
+
+            ttnn_module_args.c5["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c5_2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c5_3["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c5["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c5_2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c5_3["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c5["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c5_2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c5_3["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c5["activation"] = "relu"  # Fuse relu with conv5
+            ttnn_module_args.c5_2["activation"] = "relu"  # Fuse relu with conv5
+            ttnn_module_args.c5_3["activation"] = "relu"  # Fuse relu with conv5
+            ttnn_module_args.c5["deallocate_activation"] = True
+            ttnn_module_args.c5_2["deallocate_activation"] = True
+            ttnn_module_args.c5_3["deallocate_activation"] = True
+            ttnn_module_args.c5["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.c5_2["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.c5_3["conv_blocking_and_parallelization_config_override"] = None
+
+            ttnn_module_args.c6["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c6["use_shallow_conv_variant"] = (
+                False if device.arch() == ttl.device.Arch.WORMHOLE_B0 else True
+            )
+            ttnn_module_args.c6_2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c6_2["use_shallow_conv_variant"] = (
+                False if device.arch() == ttl.device.Arch.WORMHOLE_B0 else True
+            )
+            ttnn_module_args.c6_3["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c6["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c6_2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c6_3["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c6["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c6_2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c6_3["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c6["activation"] = "relu"  # Fuse relu with conv6
+            ttnn_module_args.c6_2["activation"] = "relu"  # Fuse relu with conv6
+            ttnn_module_args.c6_3["activation"] = "relu"  # Fuse relu with conv6
+            ttnn_module_args.c6["deallocate_activation"] = True
+            ttnn_module_args.c6_2["deallocate_activation"] = True
+            ttnn_module_args.c6_3["deallocate_activation"] = True
+            ttnn_module_args.c6["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.c6_2["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.c6_3["conv_blocking_and_parallelization_config_override"] = None
+
+            ttnn_module_args.c7["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c7_2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c7_3["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c7["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c7_2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c7_3["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c7["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c7_2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c7_3["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c7["activation"] = "relu"  # Fuse relu with conv7
+            ttnn_module_args.c7_2["activation"] = "relu"  # Fuse relu with conv7
+            ttnn_module_args.c7_3["activation"] = "relu"  # Fuse relu with conv7
+            ttnn_module_args.c7["deallocate_activation"] = True
+            ttnn_module_args.c7_2["deallocate_activation"] = True
+            ttnn_module_args.c7_3["deallocate_activation"] = True
+            ttnn_module_args.c7["padded_input_channels"] = 48 * groups
+            ttnn_module_args.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
+            ttnn_module_args.c7_2["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.c7_3["conv_blocking_and_parallelization_config_override"] = None
+
+            ttnn_module_args.c8["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c8_2["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c8_3["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.c8["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c8_2["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c8_3["dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c8["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c8_2["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c8_3["weights_dtype"] = ttnn.bfloat8_b
+            ttnn_module_args.c8["activation"] = "relu"  # Fuse relu with conv8
+            ttnn_module_args.c8_2["activation"] = "relu"  # Fuse relu with conv8
+            ttnn_module_args.c8_3["activation"] = "relu"  # Fuse relu with conv8
+            ttnn_module_args.c8["deallocate_activation"] = True
+            ttnn_module_args.c8_2["deallocate_activation"] = True
+            ttnn_module_args.c8_3["deallocate_activation"] = True
+            ttnn_module_args.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
+            ttnn_module_args.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
+            ttnn_module_args.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
+
+            ttnn_module_args.output_layer["math_fidelity"] = ttnn.MathFidelity.LoFi
+            ttnn_module_args.output_layer["dtype"] = ttnn.bfloat16
+            ttnn_module_args.output_layer["weights_dtype"] = ttnn.bfloat16
+            ttnn_module_args.output_layer["conv_blocking_and_parallelization_config_override"] = None
+            ttnn_module_args.output_layer["activation"] = None
+            ttnn_module_args.output_layer["deallocate_activation"] = True
+
+            conv1_weight, conv1_bias = fold_batch_norm2d_into_conv2d(model.c1, model.b1)
+            print("model output weights for c1: ", type(conv1_weight))
+            conv1_2_weight, conv1_2_bias = fold_batch_norm2d_into_conv2d(model.c1_2, model.b1_2)
+            conv2_weight, conv2_bias = fold_batch_norm2d_into_conv2d(model.c2, model.b2)
+            conv2_2_weight, conv2_2_bias = fold_batch_norm2d_into_conv2d(model.c2_2, model.b2_2)
+            conv3_weight, conv3_bias = fold_batch_norm2d_into_conv2d(model.c3, model.b3)
+            conv3_2_weight, conv3_2_bias = fold_batch_norm2d_into_conv2d(model.c3_2, model.b3_2)
+            conv4_weight, conv4_bias = fold_batch_norm2d_into_conv2d(model.c4, model.b4)
+            conv4_2_weight, conv4_2_bias = fold_batch_norm2d_into_conv2d(model.c4_2, model.b4_2)
+            convbn_weight, convbn_bias = fold_batch_norm2d_into_conv2d(model.bnc, model.bnb)
+            convbn_2_weight, convbn_2_bias = fold_batch_norm2d_into_conv2d(model.bnc_2, model.bnb_2)
+            conv5_weight, conv5_bias = fold_batch_norm2d_into_conv2d(model.c5, model.b5)
+            conv5_2_weight, conv5_2_bias = fold_batch_norm2d_into_conv2d(model.c5_2, model.b5_2)
+            conv5_3_weight, conv5_3_bias = fold_batch_norm2d_into_conv2d(model.c5_3, model.b5_3)
+            conv6_weight, conv6_bias = fold_batch_norm2d_into_conv2d(model.c6, model.b6)
+            conv6_2_weight, conv6_2_bias = fold_batch_norm2d_into_conv2d(model.c6_2, model.b6_2)
+            conv6_3_weight, conv6_3_bias = fold_batch_norm2d_into_conv2d(model.c6_3, model.b6_3)
+            conv7_weight, conv7_bias = fold_batch_norm2d_into_conv2d(model.c7, model.b7)
+            conv7_2_weight, conv7_2_bias = fold_batch_norm2d_into_conv2d(model.c7_2, model.b7_2)
+            conv7_3_weight, conv7_3_bias = fold_batch_norm2d_into_conv2d(model.c7_3, model.b7_3)
+            conv8_weight, conv8_bias = fold_batch_norm2d_into_conv2d(model.c8, model.b8)
+            conv8_2_weight, conv8_2_bias = fold_batch_norm2d_into_conv2d(model.c8_2, model.b8_2)
+            conv8_3_weight, conv8_3_bias = fold_batch_norm2d_into_conv2d(model.c8_3, model.b8_3)
+
+            update_ttnn_module_args(ttnn_module_args.c1)
+            update_ttnn_module_args(ttnn_module_args.c1_2)
+            update_ttnn_module_args(ttnn_module_args.c2)
+            update_ttnn_module_args(ttnn_module_args.c2_2)
+            update_ttnn_module_args(ttnn_module_args.c3)
+            update_ttnn_module_args(ttnn_module_args.c3_2)
+            update_ttnn_module_args(ttnn_module_args.c4)
+            update_ttnn_module_args(ttnn_module_args.c4_2)
+            update_ttnn_module_args(ttnn_module_args.bnc)
+            update_ttnn_module_args(ttnn_module_args.bnc_2)
+            update_ttnn_module_args(ttnn_module_args.c5)
+            update_ttnn_module_args(ttnn_module_args.c5_2)
+            update_ttnn_module_args(ttnn_module_args.c5_3)
+            update_ttnn_module_args(ttnn_module_args.c6)
+            update_ttnn_module_args(ttnn_module_args.c6_2)
+            update_ttnn_module_args(ttnn_module_args.c6_3)
+            update_ttnn_module_args(ttnn_module_args.c7)
+            update_ttnn_module_args(ttnn_module_args.c7_2)
+            update_ttnn_module_args(ttnn_module_args.c7_3)
+            update_ttnn_module_args(ttnn_module_args.c8)
+            update_ttnn_module_args(ttnn_module_args.c8_2)
+            update_ttnn_module_args(ttnn_module_args.c8_3)
+            update_ttnn_module_args(ttnn_module_args.output_layer)
+
+            parameters["c1"], c1_parallel_config = preprocess_conv2d(
+                conv1_weight, conv1_bias, ttnn_module_args.c1, return_parallel_config=True
+            )
+            parameters["c1_2"] = preprocess_conv2d(conv1_2_weight, conv1_2_bias, ttnn_module_args.c1_2)
+            parameters["p1"] = {}
+            ttnn_module_args.p1["parallel_config_override"] = {
+                "grid_size": (c1_parallel_config.grid_size.x, c1_parallel_config.grid_size.y),
+                "num_cores_nhw": c1_parallel_config.num_cores_nhw,
+            }
+            parameters["c2"], c2_parallel_config = preprocess_conv2d(
+                conv2_weight, conv2_bias, ttnn_module_args.c2, return_parallel_config=True
+            )
+            parameters["c2_2"] = preprocess_conv2d(conv2_2_weight, conv2_2_bias, ttnn_module_args.c2_2)
+            parameters["p2"] = {}
+            ttnn_module_args.p2["parallel_config_override"] = {
+                "grid_size": (c2_parallel_config.grid_size.x, c2_parallel_config.grid_size.y),
+                "num_cores_nhw": c2_parallel_config.num_cores_nhw,
+            }
+            parameters["c3"], c3_parallel_config = preprocess_conv2d(
+                conv3_weight, conv3_bias, ttnn_module_args.c3, return_parallel_config=True
+            )
+            parameters["c3_2"] = preprocess_conv2d(conv3_2_weight, conv3_2_bias, ttnn_module_args.c3_2)
+            parameters["p3"] = {}
+            ttnn_module_args.p3["parallel_config_override"] = {
+                "grid_size": (c3_parallel_config.grid_size.x, c3_parallel_config.grid_size.y),
+                "num_cores_nhw": c3_parallel_config.num_cores_nhw,
+            }
+            parameters["c4"], c4_parallel_config = preprocess_conv2d(
+                conv4_weight, conv4_bias, ttnn_module_args.c4, return_parallel_config=True
+            )
+            parameters["c4_2"] = preprocess_conv2d(conv4_2_weight, conv4_2_bias, ttnn_module_args.c4_2)
+            parameters["p4"] = {}
+            ttnn_module_args.p4["parallel_config_override"] = {
+                "grid_size": (c4_parallel_config.grid_size.x, c4_parallel_config.grid_size.y),
+                "num_cores_nhw": c4_parallel_config.num_cores_nhw,
+            }
+            parameters["bnc"] = preprocess_conv2d(convbn_weight, convbn_bias, ttnn_module_args.bnc)
+            parameters["bnc_2"] = preprocess_conv2d(convbn_2_weight, convbn_2_bias, ttnn_module_args.bnc_2)
+            parameters["c5"] = preprocess_conv2d(conv5_weight, conv5_bias, ttnn_module_args.c5)
+            parameters["c5_2"] = preprocess_conv2d(conv5_2_weight, conv5_2_bias, ttnn_module_args.c5_2)
+            parameters["c5_3"] = preprocess_conv2d(conv5_3_weight, conv5_3_bias, ttnn_module_args.c5_3)
+            parameters["c6"] = preprocess_conv2d(conv6_weight, conv6_bias, ttnn_module_args.c6)
+            parameters["c6_2"] = preprocess_conv2d(conv6_2_weight, conv6_2_bias, ttnn_module_args.c6_2)
+            parameters["c6_3"] = preprocess_conv2d(conv6_3_weight, conv6_3_bias, ttnn_module_args.c6_3)
+            parameters["c7"] = preprocess_conv2d(conv7_weight, conv7_bias, ttnn_module_args.c7)
+            parameters["c7_2"] = preprocess_conv2d(conv7_2_weight, conv7_2_bias, ttnn_module_args.c7_2)
+            parameters["c7_3"] = preprocess_conv2d(conv7_3_weight, conv7_3_bias, ttnn_module_args.c7_3)
+            parameters["c8"] = preprocess_conv2d(conv8_weight, conv8_bias, ttnn_module_args.c8)
+            parameters["c8_2"] = preprocess_conv2d(conv8_2_weight, conv8_2_bias, ttnn_module_args.c8_2)
+            parameters["c8_3"] = preprocess_conv2d(conv8_3_weight, conv8_3_bias, ttnn_module_args.c8_3)
+            parameters["output_layer"] = preprocess_conv2d(
+                model.output_layer.weight, model.output_layer.bias, ttnn_module_args.output_layer
+            )
+
+        return parameters
+
+    return custom_preprocessor
+
+
+class UNet(nn.Module):
+    def __init__(self, groups=1):
+        super(UNet, self).__init__()
+        # Contracting Path
+        self.c1 = nn.Conv2d(4 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b1 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r1 = nn.ReLU(inplace=True)
+        self.c1_2 = nn.Conv2d(16 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b1_2 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r1_2 = nn.ReLU(inplace=True)
+        self.p1 = nn.MaxPool2d(kernel_size=2, stride=2)
+
+        self.c2 = nn.Conv2d(16 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b2 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r2 = nn.ReLU(inplace=True)
+        self.c2_2 = nn.Conv2d(16 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b2_2 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r2_2 = nn.ReLU(inplace=True)
+        self.p2 = nn.MaxPool2d(kernel_size=2, stride=2)
+
+        self.c3 = nn.Conv2d(16 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b3 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r3 = nn.ReLU(inplace=True)
+        self.c3_2 = nn.Conv2d(32 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b3_2 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r3_2 = nn.ReLU(inplace=True)
+        self.p3 = nn.MaxPool2d(kernel_size=2, stride=2)
+
+        self.c4 = nn.Conv2d(32 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b4 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r4 = nn.ReLU(inplace=True)
+        self.c4_2 = nn.Conv2d(32 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b4_2 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r4_2 = nn.ReLU(inplace=True)
+        self.p4 = nn.MaxPool2d(kernel_size=2, stride=2)
+
+        self.bnc = nn.Conv2d(32 * groups, 64 * groups, kernel_size=3, padding=1)
+        self.bnb = nn.BatchNorm2d(64 * groups, momentum=1)
+        self.bnr = nn.ReLU(inplace=True)
+        self.bnc_2 = nn.Conv2d(64 * groups, 64 * groups, kernel_size=3, padding=1)
+        self.bnb_2 = nn.BatchNorm2d(64 * groups, momentum=1)
+        self.bnr_2 = nn.ReLU(inplace=True)
+
+        self.u4 = nn.Upsample(scale_factor=(2, 2), mode="nearest")
+
+        self.c5 = nn.Conv2d(96 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b5 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r5 = nn.ReLU(inplace=True)
+        self.c5_2 = nn.Conv2d(32 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b5_2 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r5_2 = nn.ReLU(inplace=True)
+        self.c5_3 = nn.Conv2d(32 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b5_3 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r5_3 = nn.ReLU(inplace=True)
+        self.u3 = nn.Upsample(scale_factor=(2, 2), mode="nearest")
+
+        self.c6 = nn.Conv2d(64 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b6 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r6 = nn.ReLU(inplace=True)
+        self.c6_2 = nn.Conv2d(32 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b6_2 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r6_2 = nn.ReLU(inplace=True)
+        self.c6_3 = nn.Conv2d(32 * groups, 32 * groups, kernel_size=3, padding=1)
+        self.b6_3 = nn.BatchNorm2d(32 * groups, momentum=1)
+        self.r6_3 = nn.ReLU(inplace=True)
+        self.u2 = nn.Upsample(scale_factor=(2, 2), mode="nearest")
+
+        self.c7 = nn.Conv2d(48 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b7 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r7 = nn.ReLU(inplace=True)
+        self.c7_2 = nn.Conv2d(16 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b7_2 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r7_2 = nn.ReLU(inplace=True)
+        self.c7_3 = nn.Conv2d(16 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b7_3 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r7_3 = nn.ReLU(inplace=True)
+        self.u1 = nn.Upsample(scale_factor=(2, 2), mode="nearest")
+
+        self.c8 = nn.Conv2d(32 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b8 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r8 = nn.ReLU(inplace=True)
+        self.c8_2 = nn.Conv2d(16 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b8_2 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r8_2 = nn.ReLU(inplace=True)
+        self.c8_3 = nn.Conv2d(16 * groups, 16 * groups, kernel_size=3, padding=1)
+        self.b8_3 = nn.BatchNorm2d(16 * groups, momentum=1)
+        self.r8_3 = nn.ReLU(inplace=True)
+
+        # Output layer
+        self.output_layer = nn.Conv2d(16 * groups, 1 * groups, kernel_size=1)
+
+    def forward(self, x):
+        # Contracting Path
+        c1 = self.c1(x)
+        b1 = self.b1(c1)
+        r1 = self.r1(b1)
+        c1_2 = self.c1_2(r1)
+        b1_2 = self.b1_2(c1_2)
+        r1_2 = self.r1_2(b1_2)
+
+        p1 = self.p1(r1_2)
+
+        c2 = self.c2(p1)
+        b2 = self.b2(c2)
+        r2 = self.r2(b2)
+        c2_2 = self.c2_2(r2)
+        b2_2 = self.b2_2(c2_2)
+        r2_2 = self.r2_2(b2_2)
+        p2 = self.p2(r2_2)
+
+        c3 = self.c3(p2)
+        b3 = self.b3(c3)
+        r3 = self.r3(b3)
+        c3_2 = self.c3_2(r3)
+        b3_2 = self.b3_2(c3_2)
+        r3_2 = self.r3_2(b3_2)
+        p3 = self.p3(r3_2)
+
+        c4 = self.c4(p3)
+        b4 = self.b4(c4)
+        r4 = self.r4(b4)
+        c4_2 = self.c4_2(r4)
+        b4_2 = self.b4_2(c4_2)
+        r4_2 = self.r4_2(b4_2)
+        p4 = self.p4(r4_2)
+
+        bnc = self.bnc(p4)
+        bnb = self.bnb(bnc)
+        bnr = self.bnr(bnb)
+        bnc_2 = self.bnc_2(bnr)
+        bnb_2 = self.bnb_2(bnc_2)
+        bnr_2 = self.bnr_2(bnb_2)
+        u4 = self.u4(bnr_2)
+        conc1 = torch.cat([u4, r4_2], dim=1)
+
+        c5 = self.c5(conc1)
+        b5 = self.b5(c5)
+        r5 = self.r5(b5)
+        c5_2 = self.c5_2(r5)
+        b5_2 = self.b5_2(c5_2)
+        r5_2 = self.r5_2(b5_2)
+        c5_3 = self.c5_3(r5_2)
+        b5_3 = self.b5_3(c5_3)
+        r5_3 = self.r5_3(b5_3)
+        u3 = self.u3(r5_3)
+        conc2 = torch.cat([u3, r3_2], dim=1)
+
+        c6 = self.c6(conc2)
+        b6 = self.b6(c6)
+        r6 = self.r6(b6)
+        c6_2 = self.c6_2(r6)
+        b6_2 = self.b6_2(c6_2)
+        r6_2 = self.r6_2(b6_2)
+        c6_3 = self.c6_3(r6_2)
+        b6_3 = self.b6_3(c6_3)
+        r6_3 = self.r6_3(b6_3)
+        u2 = self.u2(r6_3)
+
+        conc3 = torch.cat([u2, r2_2], dim=1)
+
+        c7 = self.c7(conc3)
+        b7 = self.b7(c7)
+        r7 = self.r7(b7)
+        c7_2 = self.c7_2(r7)
+        b7_2 = self.b7_2(c7_2)
+        r7_2 = self.r7_2(b7_2)
+        c7_3 = self.c7_3(r7_2)
+        b7_3 = self.b7_3(c7_3)
+        r7_3 = self.r7_3(b7_3)
+
+        u1 = self.u1(r7_3)
+        conc4 = torch.cat([u1, r1_2], dim=1)
+
+        c8 = self.c8(conc4)
+        b8 = self.b8(c8)
+        r8 = self.r8(b8)
+        c8_2 = self.c8_2(r8)
+        b8_2 = self.b8_2(c8_2)
+        r8_2 = self.r8_2(b8_2)
+        c8_3 = self.c8_3(r8_2)
+        b8_3 = self.b8_3(c8_3)
+        r8_3 = self.r8_3(b8_3)
+
+        # Output layer
+        output = self.output_layer(r8_3)
+
+        return output
+
+
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("loop", [0])
 @pytest.mark.parametrize("perf_mode, groups", [(False, 1), (True, 1), (True, 2)])  # , (True, 4)])
 def test_unet(device, loop, perf_mode, groups):
+    if perf_mode and device.arch() == ttl.device.Arch.GRAYSKULL:
+        pytest.skip("Perf mode is not supported on Grayskull")
+    if is_x2_harvested(device):
+        pytest.skip("x2 harvested chip is not supported")
+    with torch.no_grad():
+        torch.manual_seed(0)
+        torch_model = UNet(groups=groups)
+        torch_model.eval()
+        new_state_dict = {}
+        for name, parameter in torch_model.state_dict().items():
+            if isinstance(parameter, torch.FloatTensor):
+                if "b1" or "b2" or "b3" or "b4" or "bnb" in name:
+                    new_state_dict[name] = parameter
+                else:
+                    new_state_dict[name] = parameter + 1000
+        torch_model.load_state_dict(new_state_dict)
+        batch = 1 if groups > 1 else 2
+        torch_input_tensor = torch.randn(
+            batch, 4 * groups, 1056, 160
+        )  # Batch size of 2, 3 channels (RGB), 1056x160 input
+        original_shape = list(torch_input_tensor.shape)
+        torch_output_tensor = torch_model(torch_input_tensor)
+        reader_patterns_cache = {}
+        parameters = preprocess_model(
+            initialize_model=lambda: torch_model,
+            run_model=lambda model: model(torch_input_tensor),
+            custom_preprocessor=create_custom_preprocessor(device, groups=groups, act_block_n=5),
+            reader_patterns_cache=reader_patterns_cache,
+            device=device,
+        )
+
+        ttnn_model = unet_shallow_ttnn.UNet(parameters)
+
+        #
+        # Tensor Preprocessing
+        #
+        input_shape = torch_input_tensor.shape
+        input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
+
+        # Pad to 16 if grayskull run and 32 for wormhole
+        input_tensor = input_tensor.reshape(
+            input_tensor.shape[0], 1, input_tensor.shape[1] * input_tensor.shape[2], input_tensor.shape[3]
+        )
+        pad = 32 if device.arch() == ttl.device.Arch.WORMHOLE_B0 else 16
+        hpad = 0  # 96*32*64
+        if input_tensor.shape[-1] < pad or input_tensor.shape[-2] < hpad:
+            input_tensor = torch.nn.functional.pad(
+                input_tensor, (0, max(0, pad - input_tensor.shape[-1]), 0, max(0, hpad - input_tensor.shape[-2]))
+            )
+        input_tensor = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat16)
+
+        warmup = 1
+        start = None
+        for i in range(loop + warmup):
+            if i == warmup:
+                start = time.perf_counter()
+            profiler.tracy_frame()
+            output_tensor = ttnn_model(device, input_tensor, original_shape, perf_mode=perf_mode)
+        if start is not None:
+            stop = time.perf_counter()
+            total_time = stop - start
+            batch = input_shape[0]
+            total_frame_count = batch * loop
+            print(f"Elapsed host time (sec): {total_time}")
+            print(f"Frames processed: {total_frame_count}")
+            print(f"Host perf (fps): {total_frame_count / total_time}")
+
+        #
+        # Tensor Postprocessing
+        #
+        output_tensor = ttnn.to_torch(output_tensor)
+        output_tensor = output_tensor[:, :, :, :groups]
+        output_tensor = output_tensor.reshape(input_shape[0], input_shape[2], input_shape[3], -1)
+        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+        output_tensor = output_tensor.to(torch_input_tensor.dtype)
+
+        if perf_mode:
+            pass  # skip PCC checks if perf_mode is set
+        elif device.arch() == ttl.device.Arch.WORMHOLE_B0:
+            assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+        else:
+            assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.97)
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("device_l1_small_size", [32768], indirect=True)
+@pytest.mark.parametrize("loop", [0])
+@pytest.mark.parametrize("perf_mode, groups", [(False, 1), (True, 1)])  # , (True, 2)])
+def test_unet_512x512(device, loop, perf_mode, groups):
     if perf_mode and device.arch() == ttl.device.Arch.GRAYSKULL:
         pytest.skip("Perf mode is not supported on Grayskull")
 
@@ -52,10 +636,10 @@ def test_unet(device, loop, perf_mode, groups):
 
         torch_model.load_state_dict(new_state_dict)
 
-        batch = 1 if groups > 1 else 2
+        batch = 1
         torch_input_tensor = torch.randn(
-            batch, 4 * groups, 1056, 160
-        )  # Batch size of 2, 3 channels (RGB), 1056x160 input
+            batch, 4 * groups, 512, 512
+        )  # Batch size of 1, 3 channels (RGB), 512x512 input
         original_shape = list(torch_input_tensor.shape)
         torch_output_tensor = torch_model(torch_input_tensor)
 
@@ -63,7 +647,102 @@ def test_unet(device, loop, perf_mode, groups):
         parameters = preprocess_model(
             initialize_model=lambda: torch_model,
             run_model=lambda model: model(torch_input_tensor),
-            custom_preprocessor=create_custom_preprocessor(device, groups=groups),
+            custom_preprocessor=create_custom_preprocessor(device, groups=groups, act_block_n=16),
+            reader_patterns_cache=reader_patterns_cache,
+            device=device,
+        )
+
+        ttnn_model = unet_shallow_ttnn.UNet(parameters)
+
+        #
+        # Tensor Preprocessing
+        #
+        input_shape = torch_input_tensor.shape
+        input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
+
+        # Pad to 16 if grayskull run and 32 for wormhole
+        input_tensor = input_tensor.reshape(
+            input_tensor.shape[0], 1, input_tensor.shape[1] * input_tensor.shape[2], input_tensor.shape[3]
+        )
+        pad = 32 if device.arch() == ttl.device.Arch.WORMHOLE_B0 else 16
+        hpad = 0  # 96*32*64
+        if input_tensor.shape[-1] < pad or input_tensor.shape[-2] < hpad:
+            input_tensor = torch.nn.functional.pad(
+                input_tensor, (0, max(0, pad - input_tensor.shape[-1]), 0, max(0, hpad - input_tensor.shape[-2]))
+            )
+        input_tensor = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat16)
+
+        warmup = 1
+        start = None
+        for i in range(loop + warmup):
+            if i == warmup:
+                start = time.perf_counter()
+            profiler.tracy_frame()
+            output_tensor = ttnn_model(device, input_tensor, original_shape, perf_mode=perf_mode)
+        if start is not None:
+            stop = time.perf_counter()
+            total_time = stop - start
+            batch = input_shape[0]
+            total_frame_count = batch * loop
+            print(f"Elapsed host time (sec): {total_time}")
+            print(f"Frames processed: {total_frame_count}")
+            print(f"Host perf (fps): {total_frame_count / total_time}")
+
+        #
+        # Tensor Postprocessing
+        #
+        output_tensor = ttnn.to_torch(output_tensor)
+        output_tensor = output_tensor[:, :, :, :groups]
+        output_tensor = output_tensor.reshape(input_shape[0], input_shape[2], input_shape[3], -1)
+        output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+        output_tensor = output_tensor.to(torch_input_tensor.dtype)
+
+        if perf_mode:
+            pass  # skip PCC checks if perf_mode is set
+        elif device.arch() == ttl.device.Arch.WORMHOLE_B0:
+            assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+        else:
+            assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.97)
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("device_l1_small_size", [32768], indirect=True)
+@pytest.mark.parametrize("loop", [0])
+@pytest.mark.parametrize("perf_mode, groups", [(False, 1), (True, 1)])  # , (True, 2)])
+def test_unet_1024x1024(device, loop, perf_mode, groups):
+    if perf_mode and device.arch() == ttl.device.Arch.GRAYSKULL:
+        pytest.skip("Perf mode is not supported on Grayskull")
+
+    if is_x2_harvested(device):
+        pytest.skip("x2 harvested chip is not supported")
+
+    with torch.no_grad():
+        torch.manual_seed(0)
+        torch_model = UNet(groups=groups)
+        torch_model.eval()
+
+        new_state_dict = {}
+        for name, parameter in torch_model.state_dict().items():
+            if isinstance(parameter, torch.FloatTensor):
+                if "b1" or "b2" or "b3" or "b4" or "bnb" in name:
+                    new_state_dict[name] = parameter
+                else:
+                    new_state_dict[name] = parameter + 1000
+
+        torch_model.load_state_dict(new_state_dict)
+
+        batch = 1
+        torch_input_tensor = torch.randn(batch, 4 * groups, 1024, 1024)  # Batch size of 1, 3 channels (RGB), 1024 input
+        original_shape = list(torch_input_tensor.shape)
+        torch_output_tensor = torch_model(torch_input_tensor)
+
+        reader_patterns_cache = {}
+        parameters = preprocess_model(
+            initialize_model=lambda: torch_model,
+            run_model=lambda model: model(torch_input_tensor),
+            custom_preprocessor=create_custom_preprocessor(
+                device, groups=groups, act_block_n=32
+            ),  # act_block_n = input_width/32
             reader_patterns_cache=reader_patterns_cache,
             device=device,
         )
@@ -131,4 +810,6 @@ if __name__ == "__main__":
     device_id = 0
     device = ttnn.open_device(device_id=device_id)
     test_unet(device, args.loop, args.perf_mode, args.groups)
+    test_unet_512x512(device, args.loop, args.perf_mode, args.groups)
+    test_unet_1024x1024(device, args.loop, args.perf_mode, args.groups)
     ttnn.close_device(device)


### PR DESCRIPTION
512x512 is working for the dimension (1, 4, 512, 512), but fails with out of memory issue (L1) for the 
dimension (2, 4, 512, 512), [This can be tested by changing or increasing batch_size in the code.

For 1024x1024, both (1, 4, 1024, 1024) and (2, 4, 1024, 1024) fail with out of memory issue (L1)

Summary:
1. (1,4,512,512) - passes, however, batch>1, tests fail with OOM.
2. 1024x1024 - fails for any input batch_size, with OOM