### PR TITLE
#7844: Add ability to gather noc xfer data through dprint

### DIFF
--- a/tt_metal/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/dprint_common.h
@@ -30,9 +30,10 @@
     DPRINT_PREFIX(WAIT)              \
     DPRINT_PREFIX(BFLOAT16)          \
     DPRINT_PREFIX(SETPRECISION)      \
-    DPRINT_PREFIX(FIXED) \
+    DPRINT_PREFIX(NOC_LOG_XFER)      \
+    DPRINT_PREFIX(FIXED)             \
     DPRINT_PREFIX(DEFAULTFLOAT)      \
-    DPRINT_PREFIX(HEX)   \
+    DPRINT_PREFIX(HEX)               \
     DPRINT_PREFIX(OCT)               \
     DPRINT_PREFIX(DEC)               \
     DPRINT_PREFIX(TILESLICE)         \

--- a/tt_metal/hw/inc/dataflow_internal.h
+++ b/tt_metal/hw/inc/dataflow_internal.h
@@ -17,7 +17,6 @@ void noc_fast_read_wait_ready() {
 
 FORCE_INLINE
 void noc_fast_read_set_src_xy(uint64_t src_addr) {
-    DEBUG_SANITIZE_NOC_ADDR(src_addr, NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID, src_addr >> 32);
 }
 
@@ -64,7 +63,6 @@ void noc_fast_write_set_cmd_field(uint32_t vc, bool mcast, bool linked) {
 
 FORCE_INLINE
 void noc_fast_write_set_dst_xy(uint64_t dest_addr) {
-    DEBUG_SANITIZE_NOC_ADDR(dest_addr, NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID, dest_addr >> 32);
 }
 

--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -34,10 +34,6 @@
 #include "hostdevcommon/common_runtime_address_map.h"
 
 #include "dprint_buffer.h"
-#if defined(COMPILE_FOR_ERISC)
-#include "ethernet/tunneling.h"
-#endif
-
 #include "status.h"
 
 #define DPRINT DebugPrinter()
@@ -83,6 +79,7 @@ struct HEX  { char tmp; } ATTR_PACK; // Analog of cout << std::hex
 struct OCT  { char tmp; } ATTR_PACK; // Analog of cout << std::oct
 struct DEC  { char tmp; } ATTR_PACK; // Analog of cout << std::dec
 struct SETW { char w; SETW(char w) : w(w) {} } ATTR_PACK; // Analog of cout << std::setw()
+struct NOC_LOG_XFER { uint32_t size; NOC_LOG_XFER(uint32_t sz) : size(sz) {} } ATTR_PACK; // For tracking noc transactions.
 struct U32_ARRAY {
     uint32_t* ptr; uint32_t len;
     U32_ARRAY(uint32_t* ptr, uint32_t len) : ptr(ptr), len(len) {}
@@ -142,6 +139,7 @@ template<> uint8_t DebugPrintTypeToId<RAISE>()         { return DPrintRAISE; }
 template<> uint8_t DebugPrintTypeToId<WAIT>()          { return DPrintWAIT; }
 template<> uint8_t DebugPrintTypeToId<BF16>()          { return DPrintBFLOAT16; }
 template<> uint8_t DebugPrintTypeToId<SETPRECISION>()  { return DPrintSETPRECISION; }
+template<> uint8_t DebugPrintTypeToId<NOC_LOG_XFER>()  { return DPrintNOC_LOG_XFER; }
 template<> uint8_t DebugPrintTypeToId<FIXED>()         { return DPrintFIXED; }
 template<> uint8_t DebugPrintTypeToId<DEFAULTFLOAT>()  { return DPrintDEFAULTFLOAT; }
 template<> uint8_t DebugPrintTypeToId<HEX>()           { return DPrintHEX; }
@@ -213,6 +211,9 @@ void debug_print(DebugPrinter &dp, DebugPrintData data) {
 #if defined(COMPILE_FOR_ERISC)
             internal_::risc_context_switch();
 #endif
+            // If we've closed the device, we've now disabled printing on it, don't hang.
+            if (*dp.wpos() == DEBUG_PRINT_SERVER_DISABLED_MAGIC)
+                return;
             ; // wait for host to catch up to wpos with it's rpos
         }
         DEBUG_STATUS("DPD");
@@ -293,6 +294,7 @@ template DebugPrinter operator<< <HEX>(DebugPrinter, HEX val);
 template DebugPrinter operator<< <OCT>(DebugPrinter, OCT val);
 template DebugPrinter operator<< <DEC>(DebugPrinter, DEC val);
 template DebugPrinter operator<< <SETPRECISION>(DebugPrinter, SETPRECISION val);
+template DebugPrinter operator<< <NOC_LOG_XFER>(DebugPrinter, NOC_LOG_XFER val);
 template DebugPrinter operator<< <BF16>(DebugPrinter, BF16 val);
 template DebugPrinter operator<< <F32>(DebugPrinter, F32 val);
 template DebugPrinter operator<< <U32>(DebugPrinter, U32 val);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -692,7 +692,7 @@ void Device::compile_command_queue_programs() {
                     .eth_mode = Eth::IDLE,
                     .noc = NOC::NOC_0,
                     .compile_args = mux_compile_args,
-                    .defines = {}
+                    .defines = {{"SKIP_NOC_LOGGING", "1"}}
                 }
             );
         } else {
@@ -704,7 +704,7 @@ void Device::compile_command_queue_programs() {
                 .processor = tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = mux_compile_args,
-                .defines = {}
+                .defines = {{"SKIP_NOC_LOGGING", "1"}}
             }
         );
         }
@@ -746,7 +746,10 @@ void Device::compile_command_queue_programs() {
             tunneler_logical_core,
             tt_metal::EthernetConfig{
                 .noc = tt_metal::NOC::NOC_0,
-                .compile_args = tunneler_l_compile_args
+                .compile_args = tunneler_l_compile_args,
+                // Skip noc logging for tunneling cores, since stopping the print server can hang
+                // the chip in this case.
+                .defines = {{"SKIP_NOC_LOGGING", "1"}}
             }
         );
         log_debug(LogDevice, "run tunneler at {}", tunneler_location.str());
@@ -817,7 +820,7 @@ void Device::compile_command_queue_programs() {
                     .eth_mode = Eth::IDLE,
                     .noc = NOC::NOC_0,
                     .compile_args = demux_compile_args,
-                    .defines = {}
+                    .defines = {{"SKIP_NOC_LOGGING", "1"}}
                 }
             );
         } else {
@@ -829,7 +832,7 @@ void Device::compile_command_queue_programs() {
                 .processor = tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = demux_compile_args,
-                .defines = {}
+                .defines = {{"SKIP_NOC_LOGGING", "1"}}
             }
         );
         }
@@ -999,7 +1002,10 @@ void Device::compile_command_queue_programs() {
             r_tunneler_logical_core,
             tt_metal::EthernetConfig{
                 .noc = tt_metal::NOC::NOC_0,
-                .compile_args = tunneler_r_compile_args
+                .compile_args = tunneler_r_compile_args,
+                // Skip noc logging for tunneling cores, since stopping the print server can hang
+                // the chip in this case.
+                .defines = {{"SKIP_NOC_LOGGING", "1"}}
             }
         );
         log_debug(LogDevice, "run tunneler at device {} Core {}", this->id(), r_tunneler_logical_core.str());
@@ -1067,7 +1073,7 @@ void Device::compile_command_queue_programs() {
                     .eth_mode = Eth::IDLE,
                     .noc = NOC::NOC_0,
                     .compile_args = demux_d_compile_args,
-                    .defines = {}
+                    .defines = {{"SKIP_NOC_LOGGING", "1"}}
                 }
             );
         } else {
@@ -1079,7 +1085,7 @@ void Device::compile_command_queue_programs() {
                 .processor = tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = demux_d_compile_args,
-                .defines = {}
+                .defines = {{"SKIP_NOC_LOGGING", "1"}}
             }
         );
         }
@@ -1266,7 +1272,7 @@ void Device::compile_command_queue_programs() {
                     .eth_mode = Eth::IDLE,
                     .noc = NOC::NOC_0,
                     .compile_args = mux_d_compile_args,
-                    .defines = {}
+                    .defines = {{"SKIP_NOC_LOGGING", "1"}}
                 }
             );
         } else {
@@ -1278,7 +1284,7 @@ void Device::compile_command_queue_programs() {
                 .processor = tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = mux_d_compile_args,
-                .defines = {}
+                .defines = {{"SKIP_NOC_LOGGING", "1"}}
             }
         );
         }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -121,6 +121,10 @@ void RunTimeOptions::ParseDPrintEnv() {
     for (auto &core_type_and_cores : dprint_cores)
         if (core_type_and_cores.second.size() > 0)
             dprint_enabled = true;
+
+    const char *print_noc_xfers = std::getenv("TT_METAL_DPRINT_NOC_TRANSFER_DATA");
+    if (print_noc_xfers != nullptr)
+        dprint_noc_transfer_data = true;
 };
 
 void RunTimeOptions::ParseDPrintCoreRange(const char* env_var, CoreType core_type) {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -40,6 +40,7 @@ class RunTimeOptions {
     bool dprint_all_chips = false;
     uint32_t dprint_riscv_mask = 0;
     std::string dprint_file_name;
+    bool dprint_noc_transfer_data = false;
 
     bool test_mode_enabled = false;
 
@@ -127,6 +128,8 @@ class RunTimeOptions {
     inline void set_dprint_file_name(std::string file_name) {
         dprint_file_name = file_name;
     }
+    inline bool get_dprint_noc_transfers() { return dprint_noc_transfer_data; }
+    inline void set_dprint_noc_transfers(bool val) { dprint_noc_transfer_data = val; }
 
     // Used for both watcher and dprint servers, this dev option (no corresponding env var) sets
     // whether to catch exceptions (test mode = true) coming from debug servers or to throw them


### PR DESCRIPTION
Passing CI: https://github.com/tenstorrent/tt-metal/actions/runs/9071514938

Ran into an issue where dprint being killed on mmio chip caused hangs (I'm guessing due to prints stacking up on mmio chip when it's no longer being drained), so add a fix for that here as well