### PR TITLE
#8404: Async mode support for concat and prefill softmax.

### DIFF
--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -475,18 +475,20 @@ def test_falcon7b_attnention_sliced(
 @pytest.mark.parametrize("seq_len", [128, 1024, 2048], ids=["seq_len_128", "seq_len_1024", "seq_len_2048"])
 @pytest.mark.parametrize("num_cores", [64])
 @skip_for_wormhole_b0("non-determinstic hang, see issue #5882")
+@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_falcon7b_attention_softmax_sequence(
     device,
     seq_len,
     num_cores,
+    async_mode,
     use_program_cache,
     function_level_defaults,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    device.enable_async(async_mode)
     grid_size = (8, 8)
-
     num_heads = 64
 
     if seq_len == 1024:

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -461,6 +461,7 @@ def test_sharded_matmul_1d_in1(
 @pytest.mark.parametrize(
     "output_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B], ids=["out_BFLOAT16", "out_BFLOAT8_B"]
 )
+@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_sharded_partial_op(
     device,
     H,
@@ -468,11 +469,13 @@ def test_sharded_partial_op(
     num_slices,
     activations_dtype,
     output_dtype,
+    async_mode,
     function_level_defaults,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    device.enable_async(async_mode)
     grid_size = (8, 8)
     in0_shape = [1, 1, H, 64]
     W = in0_shape[-1]
@@ -533,12 +536,14 @@ def test_sharded_partial_op(
 @pytest.mark.parametrize(
     "output_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B], ids=["out_BFLOAT16", "out_BFLOAT8_B"]
 )
+@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_block_sharded_partial_op(
-    device, H, W, num_cores, activations_dtype, output_dtype, function_level_defaults, use_program_cache
+    device, H, W, num_cores, activations_dtype, output_dtype, async_mode, function_level_defaults, use_program_cache
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    device.enable_async(async_mode)
     grid_size = (8, 8)
     in0_shape = [1, 1, H, W]
     W = in0_shape[-1]
@@ -689,6 +694,7 @@ def test_bcast_hw(device, num_cores, in0_height_sharded, out_height_sharded, in_
 @pytest.mark.parametrize(
     "output_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B], ids=["out_BFLOAT16", "out_BFLOAT8_B"]
 )
+@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_width_sharded_partial_op(
     device,
     H,
@@ -697,11 +703,13 @@ def test_width_sharded_partial_op(
     num_slices,
     activations_dtype,
     output_dtype,
+    async_mode,
     function_level_defaults,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    device.enable_async(async_mode)
     grid_size = (8, 8)
     in0_shape = [1, 1, H, W]
 
@@ -761,6 +769,7 @@ def test_width_sharded_partial_op(
 @pytest.mark.parametrize(
     "output_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B], ids=["out_BFLOAT16", "out_BFLOAT8_B"]
 )
+@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_partial_sharded_op_binary(
     device,
     in0_sharded,
@@ -771,11 +780,13 @@ def test_partial_sharded_op_binary(
     num_slices,
     activations_dtype,
     output_dtype,
+    async_mode,
     function_level_defaults,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    device.enable_async(async_mode)
     grid_size = (8, 8)
     in0_shape = [1, 1, H, 96]
     in1_shape = in0_shape

--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -14,7 +14,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("height", [20, 32])
 @pytest.mark.parametrize("width", [4, 32])
 @pytest.mark.parametrize("dim", [0, 1])
-def test_concat(device, height, width, dim):
+@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
+def test_concat(device, height, width, dim, async_mode):
+    device.enable_async(async_mode)
     torch_input_tensor_a = torch.rand((height, width), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((height, width), dtype=torch.bfloat16)
     torch_output_tensor = torch.concat([torch_input_tensor_a, torch_input_tensor_b], dim=dim)
@@ -75,9 +77,11 @@ def test_concat(device, height, width, dim):
         ),
     ),
 )
+@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_sharded_concat(
-    device, input_shape_a, shard_shape_a, input_shape_b, shard_shape_b, output_shard_shape, shard_grid
+    device, input_shape_a, shard_shape_a, input_shape_b, shard_shape_b, output_shard_shape, shard_grid, async_mode
 ):
+    device.enable_async(async_mode)
     input_a_sharded_memory_config = ttnn.create_sharded_memory_config(
         shard_shape_a,
         core_grid=shard_grid,


### PR DESCRIPTION
Add async mode for concat and softmax variant used in prefills.
Tested locally that optimised version of Falcon7b prefill passes on single device, and on T3000.