### PR TITLE
Async Engine Runtime Optimizations

### DIFF
--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -114,18 +114,16 @@ void Tensor::deallocate(bool force) {
                             uint32_t ref_count_to_use = (this->workers.at(0)->get_worker_mode() == WorkExecutorMode::SYNCHRONOUS or not this->tensor_attributes->main_thread_tensor) ? this->tensor_attributes.use_count() : this->tensor_attributes->main_thread_ref_count;
                             if ((force or ref_count_to_use == 1) and not this->tensor_attributes->deallocated) {
                                 this->tensor_attributes->deallocated = true;
-                                // Record ref count before sending to worker
-                                uint32_t device_tensor_ref_count = this->tensor_attributes->record_main_thread_ref_count();
-                                this->workers.at(0)->push_work([force, *this] () mutable {
+                                this->workers.at(0)->push_work(std::make_shared<std::function<void()>>([force, attr = this->tensor_attributes] () mutable {
                                     // Cross worker synchronization: If the tensor being deallocated is shared across workers (ex: all_gather op),
                                     // wait until all workers are done with this tensor before deallocating.
-                                    bool num_threads_sharing_tensor = this->tensor_attributes->num_sibling_workers_sharing_tensor;
+                                    bool num_threads_sharing_tensor = attr->num_sibling_workers_sharing_tensor;
                                     if (num_threads_sharing_tensor) {
                                         while (num_threads_sharing_tensor) {
-                                           num_threads_sharing_tensor = this->tensor_attributes->num_sibling_workers_sharing_tensor;;
+                                           num_threads_sharing_tensor = attr->num_sibling_workers_sharing_tensor;;
                                         }
                                     }
-                                    std::visit([force, this] (auto&& s) {
+                                    std::visit([force, attr] (auto&& s) {
                                         using type = std::decay_t<decltype(s)>;
                                         if constexpr (std::is_same_v<type, DeviceStorage>) {
                                             if (force or s.buffer.use_count() == 1) {
@@ -138,13 +136,11 @@ void Tensor::deallocate(bool force) {
                                         } else if  constexpr(std::is_same_v<type, OwnedStorage>) {
                                             // Manage Dynamic Storage (due to autoformat in async mode): Main thread sees this tensor as a device tensor, since worker has not updated
                                             // storage time. When the worker executes the dealloc request, the storage type has been appropriately updated to Owned.
-                                            TT_ASSERT(this->tensor_attributes->dynamic_storage, "Tensor storage type changed during runtime (device -> host), but dynamic storage was not marked.");
+                                            TT_ASSERT(attr->dynamic_storage, "Tensor storage type changed during runtime (device -> host), but dynamic storage was not marked.");
                                             std::visit([] (auto&& buffer) { buffer.reset(); }, s.buffer);
                                         }
-                                    }, this->tensor_attributes->storage);
-                                });
-                                // Update ref count after sending to worker
-                                this->tensor_attributes->update_main_thread_ref_count(this->workers.at(0), device_tensor_ref_count);
+                                    }, attr->storage);
+                                }));
                             }
                         } else {
                             TT_FATAL(this->deallocate_through_destructor, "Device tensors created in the main thread cannot be explictly deallocated in worker threads.");
@@ -155,32 +151,26 @@ void Tensor::deallocate(bool force) {
                         }
                     } else if constexpr (std::is_same_v<T, MultiDeviceStorage>) {
                         if (this->workers.at(0)->in_main_thread() or not this->tensor_attributes->main_thread_tensor) {
-                            if (not this->tensor_attributes->main_thread_tensor) {
-                                TT_ASSERT(not this->tensor_attributes->main_thread_ref_count, "main_thread_ref_count for tensors created inside a worker thread must be 0");
-                            }
                             // If owned by the main thread, deallocate this tensor only from the main thread. If owned by worker thread, allow deallocation in worker and use shared_ptr ref count, since this is a thread_local tensor
                             uint32_t ref_count_to_use = (this->workers.at(0)->get_worker_mode() == WorkExecutorMode::SYNCHRONOUS or not this->tensor_attributes->main_thread_tensor) ? this->tensor_attributes.use_count() : this->tensor_attributes->main_thread_ref_count;
                             if ((force or ref_count_to_use == 1) and not this->tensor_attributes->deallocated) {
                                 this->tensor_attributes->deallocated = true;
-                                // Record ref count before sending to workers
-                                uint32_t device_tensor_ref_count = this->tensor_attributes->record_main_thread_ref_count();
+                                auto dealloc_lambda = std::make_shared<std::function<void(Device*)>>([force, attr = this->tensor_attributes] (Device* worker) mutable {
+                                    ZoneScopedN("ShardDeallocate");
+                                    auto& s = std::get<MultiDeviceStorage>(attr->storage);
+                                    if (s.buffers.find(worker->id()) != s.buffers.end()) {
+                                        if ((force or s.buffers.at(worker->id()).use_count() == 1)) {
+                                            DeallocateBuffer(*(s.buffers.at(worker->id())));
+                                        }
+                                        s.buffers.at(worker->id()).reset();
+                                    }
+                                });
+
                                 for (auto worker : this->workers) {
-                                    worker->push_work([force, *this, worker] () mutable {
-                                        std::visit([force, worker] (auto&& s) {
-                                            using type = std::decay_t<decltype(s)>;
-                                            if constexpr (std::is_same_v<type, MultiDeviceStorage>) {
-                                                if (s.buffers.find(worker->id()) != s.buffers.end()) {
-                                                    if (force or s.buffers.at(worker->id()).use_count() == 1) {
-                                                        DeallocateBuffer(*(s.buffers.at(worker->id())));
-                                                    }
-                                                    s.buffers.at(worker->id()).reset();
-                                                }
-                                            }
-                                        }, this->tensor_attributes->storage);
-                                    });
+                                    worker->push_work(std::make_shared<std::function<void()>>([worker, dealloc_lambda] () mutable {
+                                        (*dealloc_lambda)(worker);
+                                    }));
                                 }
-                                // Update ref count after sending to workers
-                                this->tensor_attributes->update_main_thread_ref_count(this->workers.at(0), device_tensor_ref_count);
                             }
                         } else {
                             TT_FATAL(this->deallocate_through_destructor, "Device tensors created in the main thread cannot be explictly deallocated in worker threads.");

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -654,6 +654,7 @@ void launch_op(
     // Assert to ensure that worker threads are specified.
     ZoneScopedN("LaunchOp");
     auto& workers = output_tensors.at(0).workers;
+    std::size_t workers_size = workers.size();
     if (not enable_autoformat_device and workers.empty()) {
         // Run on the host
         output_tensors = op_func(input_tensors, optional_input_tensors, optional_output_tensors);
@@ -665,47 +666,47 @@ void launch_op(
     }
     validate_worker_modes(workers);
     // Record ref counts for all tensors before pushing to worker queue.
-    std::vector<uint32_t> input_tensor_ref_count = {};
-    std::vector<uint32_t> optional_input_tensor_ref_count = {};
-    std::vector<uint32_t> output_tensor_ref_count = {};
-    std::vector<uint32_t> optional_output_tensor_ref_count = {};
+    std::vector<uint32_t> input_tensor_ref_count = std::vector<uint32_t>(input_tensors.size());
+    std::vector<uint32_t> optional_input_tensor_ref_count = std::vector<uint32_t>(optional_input_tensors.size());
+    std::vector<uint32_t> output_tensor_ref_count = std::vector<uint32_t>(output_tensors.size());
+    std::vector<uint32_t> optional_output_tensor_ref_count = std::vector<uint32_t>(optional_output_tensors.size());;
 
-    std::vector<Tensor> async_safe_input_tensors = {};
+    std::vector<Tensor> async_safe_input_tensors = std::vector<Tensor>(input_tensors.size());
     std::vector<std::optional<const Tensor>> async_safe_optional_input_tensors = {};
     std::unordered_set<uint32_t> cross_worker_input_tensor_idx = {};
     std::unordered_set<uint32_t> cross_worker_optional_input_tensor_idx = {};
     // When running on a single device, input tensors can be using borrowed storage. If so, when running in async mode,
     // copy borrowed tensors to owned storage.
     for (int i = 0; i < input_tensors.size(); i++) {
-        async_safe_input_tensors.push_back(copy_borrowed_tensor_in_async_mode(workers.at(0), input_tensors.at(i)));
-        input_tensor_ref_count.push_back(async_safe_input_tensors[i].tensor_attributes->record_main_thread_ref_count());
+        async_safe_input_tensors[i] = copy_borrowed_tensor_in_async_mode(workers.at(0), input_tensors.at(i));
+        input_tensor_ref_count[i] = async_safe_input_tensors[i].tensor_attributes->record_main_thread_ref_count();
     }
     for (int i = 0; i < optional_input_tensors.size(); i++) {
         if (optional_input_tensors[i].has_value()) {
             async_safe_optional_input_tensors.push_back(copy_borrowed_tensor_in_async_mode(workers.at(0), optional_input_tensors[i].value()));
-            optional_input_tensor_ref_count.push_back(async_safe_optional_input_tensors[i].value().tensor_attributes->record_main_thread_ref_count());
+            optional_input_tensor_ref_count[i] = async_safe_optional_input_tensors[i].value().tensor_attributes->record_main_thread_ref_count();
         }
         else {
             async_safe_optional_input_tensors.push_back(std::nullopt);
-            optional_input_tensor_ref_count.push_back(0);
+            optional_input_tensor_ref_count[i] = 0;
         }
     }
     for (int i = 0; i < output_tensors.size(); i++) {
-        output_tensor_ref_count.push_back(output_tensors[i].tensor_attributes->record_main_thread_ref_count());
+        output_tensor_ref_count[i] = output_tensors[i].tensor_attributes->record_main_thread_ref_count();
     }
     for (int i = 0; i < optional_output_tensors.size(); i++) {
         if (optional_output_tensors[i].has_value()) {
-            optional_output_tensor_ref_count.push_back(optional_output_tensors[i].value().tensor_attributes->record_main_thread_ref_count());
+            optional_output_tensor_ref_count[i] = optional_output_tensors[i].value().tensor_attributes->record_main_thread_ref_count();
         }
         else {
-            optional_output_tensor_ref_count.push_back(0);
+            optional_output_tensor_ref_count[i] = 0;
         }
     }
     // Check if this op dispatch step relies on tensors from other workers.
     // If so, mark them in use by current worker. Tensors shared across workers
     // are only supported when each tensor is tied to a single device/worker
     // (example all-gather).
-    if (workers.size() == 1) {
+    if (workers_size == 1) {
         // Single worker per tensor and.
         for (int i = 0; i < async_safe_input_tensors.size(); i++) {
             if (async_safe_input_tensors.at(i).get_workers().size() and async_safe_input_tensors.at(i).get_workers().at(0) != workers.at(0)) {
@@ -724,17 +725,19 @@ void launch_op(
 
     {
         ZoneScopedN("PushOpToWorkers");
-        for (auto target_device : workers) {
-            target_device->push_work([target_device, workers, op_func, optional_output_tensors, async_safe_optional_input_tensors, inputs = async_safe_input_tensors, outputs = output_tensors, shared_input_idx = cross_worker_input_tensor_idx, shared_optional_input_idx = cross_worker_optional_input_tensor_idx] () mutable {
+        auto work_lambda = std::make_shared<std::function<void(Device*)>>([workers_size, op_func, optional_output_tensors, async_safe_optional_input_tensors, inputs = async_safe_input_tensors, outputs = output_tensors, shared_input_idx = cross_worker_input_tensor_idx, shared_optional_input_idx = cross_worker_optional_input_tensor_idx] (Device* target_device) mutable {
+            std::vector<Tensor> input_shards = std::vector<Tensor>(inputs.size(), Tensor());
+            std::vector<std::optional<const Tensor>> optional_input_shards = {};
+            std::vector<std::optional<Tensor>> optional_output_shards = {};
+            // Initialize all optional_outputs to std::nullopt
+            optional_output_shards.resize(optional_output_tensors.size());
 
-                std::vector<Tensor> input_shards = {};
-                std::vector<std::optional<const Tensor>> optional_input_shards = {};
-                std::vector<std::optional<Tensor>> optional_output_shards = {};
-                // Initialize all optional_outputs to std::nullopt
-                optional_output_shards.resize(optional_output_tensors.size());
-                for (const auto& input : inputs) {
-                    input_shards.push_back(get_shard_for_device(input, target_device));
+            {
+                ZoneScopedN("CreateShards");
+                for (int i = 0; i < input_shards.size(); i++) {
+                    input_shards[i] = get_shard_for_device(inputs[i], target_device);
                 }
+
                 for (auto& input : async_safe_optional_input_tensors) {
                     if (input.has_value()) {
                         optional_input_shards.push_back(get_shard_for_device(input.value(), target_device));
@@ -743,24 +746,31 @@ void launch_op(
                         optional_input_shards.push_back(std::nullopt);
                     }
                 }
+
                 for (std::size_t optional_output_idx = 0; optional_output_idx < optional_output_tensors.size(); optional_output_idx++) {
                     if (optional_output_tensors[optional_output_idx].has_value()) {
                         optional_output_shards[optional_output_idx] = get_shard_for_device(optional_output_tensors[optional_output_idx].value(), target_device);
                     }
                 }
-                auto local_tensors = op_func(input_shards, optional_input_shards, optional_output_shards);
+            }
+
+            auto local_tensors = op_func(input_shards, optional_input_shards, optional_output_shards);
+
+            {
+                ZoneScopedN("OpPostProcess");
                 // Release shared ownership of tensors belonging to other workers.
                 // If the workers for this tensor are stalled to deallocate
                 for (auto& shared_input : shared_input_idx) {
                     inputs.at(shared_input).tensor_attributes->num_sibling_workers_sharing_tensor--;
                 }
+
                 for (auto& shared_optional_input : shared_optional_input_idx) {
                     async_safe_optional_input_tensors.at(shared_optional_input).value().tensor_attributes->num_sibling_workers_sharing_tensor--;
                 }
+
                 for (int i = 0; i < local_tensors.size(); i++) {
                     if (local_tensors.at(i).storage_type() == StorageType::OWNED) {
                         TT_ASSERT(outputs.at(i).tensor_attributes->dynamic_storage, "launch_with_autoformat must be used if output tensor for op can be placed on host.");
-                        TT_ASSERT(std::holds_alternative<DeviceStorage>(outputs.at(i).tensor_attributes->storage), "All inputs and outputs to an op must be on device for multi-device tensors.");
                         // Make this a host side tensor - Set storage = Owned and clear workers
                         outputs.at(i).tensor_attributes->storage = OwnedStorage();
                         outputs.at(i).workers = {};
@@ -769,19 +779,25 @@ void launch_op(
                         outputs.at(i).tensor_attributes->dynamic_storage = false;
                     }
                     insert_buffer_and_shape_for_device(target_device, local_tensors.at(i), outputs.at(i));
-                    if (not target_device->id() or workers.size() == 1) {
+                    if (not target_device->id() or workers_size == 1) {
                         outputs.at(i).set_shape(local_tensors.at(i).get_shape());
                         outputs.at(i).set_dtype(local_tensors.at(i).get_dtype());
                         outputs.at(i).set_layout(local_tensors.at(i).get_layout());
                     }
-                    if (workers.size() == 1) {
+                    if (workers_size == 1) {
                         outputs.at(i).set_populated();
                     }
                     else {
                         outputs.at(i).set_populated(target_device);
                     }
                 }
-            });
+            }
+        });
+
+        for (auto target_device : workers) {
+            target_device->push_work(std::make_shared<std::function<void()>>([target_device, work_lambda] () mutable {
+                (*work_lambda)(target_device);
+            }));
         }
     }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1859,6 +1859,10 @@ void Device::push_work(std::function<void()>&& work, bool blocking) {
     this->work_executor.push_work(work, blocking);
 }
 
+void Device::push_work(std::shared_ptr<std::function<void()>> work, bool blocking) {
+    this->work_executor.push_work(work, blocking);
+}
+
 void Device::synchronize() {
     this->work_executor.synchronize();
 }

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -230,6 +230,7 @@ class Device {
 
     // APIs to access this device's work executor
     void push_work(std::function<void()>&& work, bool blocking = false);
+    void push_work(std::shared_ptr<std::function<void()>> work, bool blocking = false);
     void synchronize();
     void set_worker_mode(const WorkExecutorMode& mode);
     void enable_async(bool enable);

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <memory>
 #include <thread>
 #include <utility>
@@ -494,6 +495,9 @@ class HWCommandQueue {
 
     Device* device;
 
+    std::condition_variable reader_thread_cv;
+    std::mutex reader_thread_cv_mutex;
+
     CoreType get_dispatch_core_type();
 
     void copy_into_user_space(const detail::ReadBufferDescriptor &read_buffer_descriptor, chip_id_t mmio_device_id, uint16_t channel);
@@ -512,6 +516,8 @@ class HWCommandQueue {
     void enqueue_trace(const uint32_t trace_id, bool blocking);
     void finish();
     void terminate();
+    void increment_num_entries_in_completion_q();
+    void set_exit_condition();
     friend void EnqueueTraceImpl(CommandQueue& cq, uint32_t trace_id, bool blocking);
     friend void EnqueueProgramImpl(CommandQueue& cq, std::variant < std::reference_wrapper<Program>, std::shared_ptr<Program> > program, bool blocking);
     friend void EnqueueReadBufferImpl(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void* dst, bool blocking);

--- a/tt_metal/impl/dispatch/lock_free_queue.hpp
+++ b/tt_metal/impl/dispatch/lock_free_queue.hpp
@@ -23,7 +23,7 @@ class LockFreeQueue {
         std::atomic<Node*> head;
         std::atomic<Node*> tail;
 
-        Node* pop_head() {
+        inline Node* pop_head() {
             Node* oldHead = head.load();
             if (oldHead == tail.load()) {
                 return nullptr; // Queue is empty
@@ -31,33 +31,67 @@ class LockFreeQueue {
             head.store(oldHead->next);
             return oldHead;
         }
+        // Statically allocated ring buffer containing
+        // node objects, which contain handles to data
+        // and another node object to traverse ring buffer.
+        const static uint32_t ring_buffer_size = 8192;
+        Node ring_buffer[ring_buffer_size];
 
     public:
         // Optional - Set these if the worker and parent thread state needs to be tracked
         std::atomic<uint64_t> worker_thread_id = 0;
         std::atomic<uint64_t> parent_thread_id = 0;
-        LockFreeQueue() : head(new Node), tail(head.load()) {}
+        LockFreeQueue()
+        {
+            // Initialize ring buffer for traversal. Each node points to the subsequent node, except for the last one, which points to the head.
+            for (int node_idx = 0; node_idx < ring_buffer_size; node_idx++) {
+                (node_idx < ring_buffer_size - 1) ? ring_buffer[node_idx].next = (&ring_buffer[node_idx + 1]) : ring_buffer[node_idx].next = &(ring_buffer[0]);
+            }
+            // Initialize head and tail ptrs to start of ring buffer.
+            this->head = ring_buffer;
+            this->tail = ring_buffer;
+        }
+
         LockFreeQueue(LockFreeQueue&& other) {
+            Node ring_buffer = other.ring_buffer;
             head.store(other.head.load());
             tail.store(other.tail.load());
             worker_thread_id.store(other.worker_thread_id.load());
             parent_thread_id.store(other.parent_thread_id.load());
         }
-        void push(const T& value) {
-            std::shared_ptr<T> newData(std::make_shared<T>(value));
-            Node* newNode = new Node;
-            tail.load()->data = newData;
-            tail.load()->next = newNode;
-            tail.store(newNode);
+
+        inline void push(const T& value) {
+            // Legacy Push API allowing copy by value
+            // for object T.
+
+            // Stall condition: this push will update the tail (wptr)
+            // to match the location of head (rptr). The current push can
+            // thus overwrite data that's being read. Stall until head
+            // has progressed (data has been read).
+            while(tail.load()->next == head.load()) {};
+            tail.load()->data = std::make_shared<T>(value);
+            tail.store(tail.load()->next);
         }
 
-        std::shared_ptr<T> pop() {
+        inline void push(std::shared_ptr<T> value) {
+            // Latest Push API, passing ptrs around.
+            // Usually faster, since no data-copies.
+
+            // Stall condition: this push will update the tail (wptr)
+            // to match the location of head (rptr). The current push can
+            // thus overwrite data that's being read. Stall until head
+            // has progressed (data has been read).
+            while(tail.load()->next == head.load()) {};
+            tail.load()->data = value;
+            tail.store(tail.load()->next);
+        }
+
+        inline std::shared_ptr<T> pop() {
             Node* oldHead = pop_head();
-            if (!oldHead) {
-                TT_THROW("Queue is empty");
-            }
             std::shared_ptr<T> result(oldHead->data);
-            delete oldHead;
+            // Does not actually delete oldHead->data.
+            // Just mark is to null to mark prev node as empty.
+            (oldHead->data).reset();
             return result;
         }
 


### PR DESCRIPTION
- Lock Free Queue is now based on a statically allocated ring buffer data structure. This removes overhead associated with initializing and deleting memory each time a unit of work is pushed to async.
- `push_work` now accepts a `shared_ptr<std::function<void()>>` bypassing additional memcpy when function is pushed to worker
- Stolen from @cglagovichTT: in multi-device case, initialize function outside for loop
- Deallocate optimizations: avoid tensor copy
- Move type checking to compile time
- Set process priority to 0 during host-initialization to ensure that OS doesn't keep rescheduling workload
- Pin CQ Reader thread and use condition vars to toggle