### PR TITLE
#8081: Fix watcher assuming NoC-0 when reporting errors

### DIFF
--- a/tt_metal/hostdevcommon/common_runtime_address_map.h
+++ b/tt_metal/hostdevcommon/common_runtime_address_map.h
@@ -127,3 +127,7 @@ constexpr static std::uint32_t DRAM_BARRIER_BASE = 0;
 constexpr static std::uint32_t DRAM_ALIGNMENT = 32;
 constexpr static std::uint32_t DRAM_BARRIER_SIZE = ((sizeof(uint32_t) + DRAM_ALIGNMENT - 1) / DRAM_ALIGNMENT) * DRAM_ALIGNMENT;
 constexpr static std::uint32_t DRAM_UNRESERVED_BASE = DRAM_BARRIER_BASE + DRAM_BARRIER_SIZE; // Start of unreserved space
+
+// Helper functions to convert NoC coordinates to NoC-0 coordinates, used in metal as "physical" coordinates.
+#define NOC_0_X(noc_index, noc_size_x, x) (noc_index == 0 ? (x) : (noc_size_x-1-(x)))
+#define NOC_0_Y(noc_index, noc_size_y, y) (noc_index == 0 ? (y) : (noc_size_y-1-(y)))

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -17,8 +17,8 @@
 #include "limits.h"
 #include "mod_div_lib.h"
 
-#define NOC_X(x) (noc_index == 0 ? (x) : (noc_size_x-1-(x)))
-#define NOC_Y(y) (noc_index == 0 ? (y) : (noc_size_y-1-(y)))
+#define NOC_X(x) NOC_0_X(noc_index, noc_size_x, (x))
+#define NOC_Y(y) NOC_0_Y(noc_index, noc_size_y, (y))
 
 #define TILE_WORD_2_BIT ((256 + 64 + 32) >> 4)
 #define TILE_WORD_4_BIT ((512 + 64 + 32) >> 4)

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -355,9 +355,6 @@ void jit_build_genfiles_descriptors(const JitBuildEnv& env,
     }
 }
 
-#define NOC_X(noc_index, noc_size_x, x) (noc_index == 0 ? (x) : (noc_size_x-1-(x)))
-#define NOC_Y(noc_index, noc_size_y, y) (noc_index == 0 ? (y) : (noc_size_y-1-(y)))
-
 std::string generate_bank_to_noc_coord_descriptor_string(
     tt_xy_pair grid_size,
     std::vector<CoreCoord>& dram_bank_map,
@@ -427,8 +424,8 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     for (unsigned int noc = 0; noc < 2; noc++) {
         ss << "    {" << "\t// noc=" << noc << endl;
         for (unsigned int bank_id = 0; bank_id < dram_bank_map.size(); bank_id++) {
-            uint16_t noc_x = NOC_X(noc, grid_size.x, dram_bank_map[bank_id].x);
-            uint16_t noc_y = NOC_Y(noc, grid_size.y, dram_bank_map[bank_id].y);
+            uint16_t noc_x = NOC_0_X(noc, grid_size.x, dram_bank_map[bank_id].x);
+            uint16_t noc_y = NOC_0_Y(noc, grid_size.y, dram_bank_map[bank_id].y);
             uint16_t xy = ((noc_y << NOC_ADDR_NODE_ID_BITS) | noc_x) << (NOC_ADDR_LOCAL_BITS - 32);
             ss << "        " << xy << "," << "\t// NOC_X=" << noc_x << " NOC_Y=" << noc_y << endl;
         }
@@ -482,8 +479,8 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     for (unsigned int noc = 0; noc < 2; noc++) {
         ss << "    {" << "\t// noc=" << noc << endl;
         for (unsigned int bank_id = 0; bank_id < l1_bank_map.size(); bank_id++) {
-            uint16_t noc_x = NOC_X(noc, grid_size.x, l1_bank_map[bank_id].x);
-            uint16_t noc_y = NOC_Y(noc, grid_size.y, l1_bank_map[bank_id].y);
+            uint16_t noc_x = NOC_0_X(noc, grid_size.x, l1_bank_map[bank_id].x);
+            uint16_t noc_y = NOC_0_Y(noc, grid_size.y, l1_bank_map[bank_id].y);
             uint16_t xy = ((noc_y << NOC_ADDR_NODE_ID_BITS) | noc_x) << (NOC_ADDR_LOCAL_BITS - 32);
             ss << "        " << xy << "," << "\t// NOC_X=" << noc_x << " NOC_Y=" << noc_y << endl;
         }


### PR DESCRIPTION
I double-checked that NoC-1 is handled fine on device side, only issue was that when reading it out we were showing physical coordinates instead of NoC coordinates in the error message. Check in a test to cover this case as well.

Passing CI: https://github.com/tenstorrent/tt-metal/actions/runs/9088469569