### PR TITLE
#5906: add single core topk interleaved implementation

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_topk.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_topk.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from loguru import logger
+
+import tt_lib as ttl
+from models.utility_functions import tt2torch_tensor, comp_pcc
+from models.utility_functions import skip_for_grayskull
+import torch
+
+
+def run_topk_test(N, C, H, W, k, dtype, device):
+    torch.manual_seed(1234)
+    shape = [N, C, H, W]
+    torch_dtype = torch.bfloat16
+
+    input = torch.randn(shape, dtype=torch_dtype)
+    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=-1, largest=True, sorted=True)
+
+    ttl_input = ttl.tensor.Tensor(input, dtype).to(ttl.tensor.Layout.TILE).to(device)
+    ttl_topk_values, ttl_topk_indices = ttl.operations.primary.topk(ttl_input, k)
+
+    assert list(ttl_topk_values.get_legacy_shape()) == [N, C, H, k]
+    assert list(ttl_topk_indices.get_legacy_shape()) == [N, C, H, k]
+
+    ttl_torch_topk_values = tt2torch_tensor(ttl_topk_values)
+    ttl_torch_topk_indices = tt2torch_tensor(ttl_topk_indices)
+
+    if dtype == ttl.tensor.DataType.BFLOAT8_B:
+        pcc_values = 0.99
+        pcc_index = 0.99
+    else:
+        pcc_index = 1.0
+        pcc_values = 1.0
+
+    # pcc is not a good measure for the raw indices
+    # if index 49 and index 8 are tied, the order of the indices can be different
+    # but the values associated with the indices should be the same
+    # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
+    # so we will use pcc for the values and not the indices
+    # to make sure the indices are correct, we gather the relevant values from the original torch tensor and test to see if they are similar
+    # rounding may also cause more ties than expected
+    ttl_torch_gather_from_device_indices = torch.gather(input, -1, ttl_torch_topk_indices.to(torch.int64))
+    val_is_passing, val_pcc = comp_pcc(pyt_topk_values, ttl_torch_topk_values, pcc_values)
+    ind_is_passing, ind_pcc = comp_pcc(pyt_topk_values, ttl_torch_gather_from_device_indices, pcc_index)
+
+    logger.debug(f"Values pcc = {val_pcc}")
+    logger.debug(f"Indices pcc = {ind_pcc}")
+
+    assert val_is_passing
+    assert ind_is_passing
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.DataType.BFLOAT8_B,
+        # ttl.tensor.DataType.FLOAT32, top bits in float32 get cut off somewhere, LLK does not work for this
+    ),
+    ids=[
+        "BFLOAT16_B",
+        "BFLOAT8_B",
+        # "FLOAT32",
+    ],
+)
+@pytest.mark.parametrize("N, C, H, W, k,", ((1, 1, 32, 64, 32),))
+def test_topk(N, C, H, W, k, dtype, device):
+    run_topk_test(N, C, H, W, k, dtype, device)
+
+
+def run_topk_pad_test_32(N, C, H, W, k, dtype, device):
+    torch.manual_seed(1234)
+    torch_dtype = torch.bfloat16
+    old_k = k
+    if k < 32:
+        k = 32
+
+    if dtype != ttl.tensor.DataType.BFLOAT8_B:
+        shape = [N, C, H, W]
+        input = torch.randn(shape, dtype=torch_dtype)
+        input_unpadded = ttl.tensor.Tensor(input, dtype).pad_to_tile(-float("inf"))
+    else:
+        # pad to tile doesn't work for bfloat8_b as the pad function is not implemented for bfloat8 row major tensors
+        shape = [N, C, H, max(32, W)]
+        input = torch.full(shape, float("-inf"), dtype=torch_dtype)
+        values = torch.randn(shape, dtype=torch_dtype)
+        input[:, :, :, :old_k] = values[:, :, :, :old_k]
+        input_unpadded = ttl.tensor.Tensor(input)
+
+    pyt_topk_values, pyt_topk_indices = torch.topk(input, old_k, dim=-1, largest=True, sorted=True)
+
+    padding = ((0, 0), (0, 0), (0, 0), (0, 64 - max(32, W)))
+    input_shape_with_tile_padding = input_unpadded.get_legacy_shape()
+    pad_start = tuple(start for start, _ in padding)
+    pad_end = tuple(end for _, end in padding)
+
+    padded_shape = tuple(dim + end for dim, end in zip(input_shape_with_tile_padding, pad_end))
+    value = -float("inf")
+    ttl_input = ttl.tensor.pad(
+        input_unpadded.to(ttl.tensor.Layout.TILE).to(device), padded_shape, pad_start, value, use_multicore=True
+    )
+
+    ttl_topk_values, ttl_topk_indices = ttl.operations.primary.topk(ttl_input, k)
+    assert list(ttl_topk_values.get_legacy_shape()) == [N, C, H, k]
+    assert list(ttl_topk_indices.get_legacy_shape()) == [N, C, H, k]
+
+    ttl_torch_topk_values = tt2torch_tensor(ttl_topk_values)
+    ttl_torch_topk_indices = tt2torch_tensor(ttl_topk_indices)
+
+    ttl_torch_topk_values = ttl_torch_topk_values[:, :, :, :old_k]
+    ttl_torch_topk_indices = ttl_torch_topk_indices[:, :, :, :old_k]
+
+    if dtype == ttl.tensor.DataType.BFLOAT8_B:
+        pcc_values = 0.99
+        pcc_index = 0.99
+    else:
+        pcc_index = 1.0
+        pcc_values = 1.0
+
+    # pcc is not a good measure for the raw indices
+    # if index 49 and index 8 are tied, the order of the indices can be different
+    # but the values associated with the indices should be the same
+    # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
+    # so we will use pcc for the values and not the indices
+    # to make sure the indices are correct, we gather the relevant values from the original torch tensor and test to see if they are similar
+    # rounding may also cause more ties than expected
+    ttl_torch_gather_from_device_indices = torch.gather(input, -1, ttl_torch_topk_indices.to(torch.int64))
+
+    val_is_passing, val_pcc = comp_pcc(pyt_topk_values, ttl_torch_topk_values, pcc_values)
+    ind_is_passing, ind_pcc = comp_pcc(pyt_topk_values, ttl_torch_gather_from_device_indices, pcc_index)
+
+    logger.debug(f"Values pcc = {val_pcc}")
+    logger.debug(f"Indices pcc = {ind_pcc}")
+
+    assert val_is_passing
+    assert ind_is_passing
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.DataType.BFLOAT8_B,
+    ),
+    ids=[
+        "BFLOAT16_B",
+        "BFLOAT8_B",
+    ],
+)
+@pytest.mark.parametrize(
+    "N, C, H, W, k",
+    (
+        (1, 1, 32, 8, 2),
+        (1, 1, 32, 16, 4),
+    ),
+)
+def test_topk_32(N, C, H, W, k, dtype, device):
+    run_topk_pad_test_32(N, C, H, W, k, dtype, device)

--- a/tt_eager/tt_dnn/module.mk
+++ b/tt_eager/tt_dnn/module.mk
@@ -209,6 +209,8 @@ TT_DNN_SRCS = \
 	tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/moreh_getitem_rm.cpp \
 	tt_eager/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp \
 	tt_eager/tt_dnn/op_library/scan/scan_op.cpp \
+	tt_eager/tt_dnn/op_library/topk/topk_op.cpp \
+	tt_eager/tt_dnn/op_library/topk/single_core/single_core_topk.cpp \
 
 TT_DNN_LIB = $(LIBDIR)/libtt_dnn.a
 TT_DNN_DEFINES =

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -211,6 +211,8 @@ set(TT_DNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/moreh_getitem/moreh_getitem_rm/moreh_getitem_rm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scan/scan_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/topk/topk_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/topk/single_core/single_core_topk.cpp
 )
 
 add_library(tt_dnn OBJECT ${TT_DNN_SRCS})

--- a/tt_eager/tt_dnn/op_library/topk/kernels/compute/topk.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/kernels/compute/topk.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/transpose_wh.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/unpack.h"
+#include "compute_kernel_api/pack.h"
+
+// topk llk needs a global variable atm
+// this can only be removed once that's fixed
+int32_t topk_replay_init = 0;
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t index_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t input_transposed_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t index_transposed_cb_index = get_compile_time_arg_val(3);
+    constexpr uint32_t values_cb_index = get_compile_time_arg_val(4);
+    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(5);
+    constexpr uint32_t Ht = get_compile_time_arg_val(6);
+    constexpr uint32_t Wt = get_compile_time_arg_val(7);
+    constexpr uint32_t K = get_compile_time_arg_val(8);
+    constexpr uint32_t logk = get_compile_time_arg_val(9);
+    constexpr uint32_t logWt = get_compile_time_arg_val(10);
+
+    // init pack, compute and unpack
+    ckernel::topk_tile_init();
+    transpose_wh_init(input_cb_index, input_transposed_cb_index);
+    for(uint32_t ht = 0; ht < Ht; ++ht) {
+        bool ascending = false;
+        cb_reserve_back(input_transposed_cb_index, Wt);
+        cb_reserve_back(index_transposed_cb_index, Wt);
+
+        for (uint32_t wt = 0; wt < Wt; wt+=2) {
+            acquire_dst(tt::DstMode::Half);
+            // local sort into k groups
+            cb_wait_front(input_cb_index, 2);
+            cb_wait_front(index_cb_index, 2);
+
+            unpack_reconfig_data_format_srca(input_cb_index);
+            transpose_wh_init_short(input_cb_index);
+            transpose_wh_tile(input_cb_index, wt, 0);
+            transpose_wh_tile(input_cb_index, wt+1, 1);
+
+            unpack_reconfig_data_format_srca(index_cb_index);
+            transpose_wh_init_short(index_cb_index);
+            transpose_wh_tile(index_cb_index, wt, 2);
+            transpose_wh_tile(index_cb_index, wt+1, 3);
+
+            // llk_topk_sort -> inplace
+            ckernel::topk_local_sort(0, (int) ascending, logk - 1);
+
+            // pack value tiles into cb_intermed1
+            pack_reconfig_data_format(input_transposed_cb_index);
+            pack_tile(0, input_transposed_cb_index, wt);
+            pack_tile(1, input_transposed_cb_index, wt+1);
+
+            // pack index tiles into cb_intermed2
+            pack_reconfig_data_format(index_transposed_cb_index);
+            pack_tile(2, index_transposed_cb_index, wt);
+            pack_tile(3, index_transposed_cb_index, wt+1);
+
+            cb_pop_front(input_cb_index, 2);
+            cb_pop_front(index_cb_index, 2);
+
+            release_dst(tt::DstMode::Half);
+            ascending = !ascending;
+        }
+
+        cb_push_back(input_transposed_cb_index, Wt);
+        cb_push_back(index_transposed_cb_index, Wt);
+
+        cb_wait_front(input_transposed_cb_index, Wt);
+        cb_wait_front(index_transposed_cb_index, Wt);
+
+        cb_reserve_back(input_transposed_cb_index, Wt);
+        cb_reserve_back(index_transposed_cb_index, Wt);
+
+
+        // iterative merge and rebuild on pairs of tiles
+        constexpr uint32_t num_iterations = logWt;
+        for (uint32_t m_iter = 0; m_iter < num_iterations; ++m_iter) {
+            bool a = false;
+            for (uint32_t left_ind = 0; left_ind < Wt / 2; left_ind += 1 << m_iter) {
+                acquire_dst(tt::DstMode::Half);
+
+                uint32_t right_ind = left_ind + (1 << m_iter);
+
+                // unpack values into dest
+                copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+                copy_tile(input_transposed_cb_index, left_ind, 0);
+                copy_tile(input_transposed_cb_index, right_ind, 1);
+
+                // unpack indices into dest
+                copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+                copy_tile(index_transposed_cb_index, left_ind, 2);
+                copy_tile(index_transposed_cb_index, right_ind, 3);
+
+                // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+                ckernel::topk_merge(0, m_iter, K);
+                // sort within the larger 32 values
+                ckernel::topk_rebuild(0, (uint32_t) a, m_iter, K, logk, true);
+
+                // pack value tiles
+                pack_reconfig_data_format(input_transposed_cb_index);
+                pack_tile(0, input_transposed_cb_index, left_ind);
+                pack_tile(1, input_transposed_cb_index, right_ind);
+
+                // pack index tiles
+                pack_reconfig_data_format(index_transposed_cb_index);
+                pack_tile(2, index_transposed_cb_index, left_ind);
+                pack_tile(3, index_transposed_cb_index, right_ind);
+
+                release_dst(tt::DstMode::Half);
+                a = !a;
+            }
+        }
+
+        cb_push_back(input_transposed_cb_index, Wt);
+        cb_push_back(index_transposed_cb_index, Wt);
+
+        cb_pop_front(input_transposed_cb_index, Wt);
+        cb_pop_front(index_transposed_cb_index, Wt);
+
+
+        constexpr uint32_t Kt =  K % TILE_WIDTH == 0 ? K/TILE_WIDTH : K/TILE_WIDTH + 1;
+
+        // transpose value tiles and pack into output buffer
+        unpack_reconfig_data_format_srca(input_transposed_cb_index);
+        transpose_wh_init_short(input_transposed_cb_index);
+        pack_reconfig_data_format(input_transposed_cb_index);
+        cb_wait_front(input_transposed_cb_index, Kt);
+        for (uint32_t i = 0; i < Kt; ++i) {
+            acquire_dst(tt::DstMode::Half);
+            cb_reserve_back(values_cb_index, 1);
+
+            transpose_wh_tile(input_transposed_cb_index, i, 0);
+            pack_tile(0, values_cb_index);
+
+            cb_push_back(values_cb_index, 1);
+            release_dst(tt::DstMode::Half);
+        }
+        cb_pop_front(input_transposed_cb_index, Kt);
+
+        // transpose index tiles and pack into output buffer
+        unpack_reconfig_data_format_srca(index_transposed_cb_index);
+        transpose_wh_init_short(index_transposed_cb_index);
+        pack_reconfig_data_format(index_transposed_cb_index);
+        cb_wait_front(index_transposed_cb_index, Kt);
+        for (uint32_t i = 0; i < Kt; ++i) {
+            acquire_dst(tt::DstMode::Half);
+            cb_reserve_back(output_ind_cb_index, 1);
+
+            transpose_wh_tile(index_transposed_cb_index, i, 0);
+            pack_tile(0, output_ind_cb_index);
+
+            cb_push_back(output_ind_cb_index, 1);
+            release_dst(tt::DstMode::Half);
+        }
+        cb_pop_front(index_transposed_cb_index, Kt);
+    }
+}
+}

--- a/tt_eager/tt_dnn/op_library/topk/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/kernels/dataflow/reader_create_index_tensor.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+/**
+ * add a cb full of indices for the tile
+ * each row is identical in the index tensor, so we just need to add an offset based on which row tile it is
+ * first 32 elements are {0,..31}, then next 32 are {32,..64}
+ * wt is which tile it is along the row [0, Wt) so j + 32*wt is the value in the tile at each element
+*/
+FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
+    cb_reserve_back(cb_id, 1);
+    uint32_t write_addr = get_write_ptr(cb_id);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
+    uint16_t wt_offset = wt << 5;
+
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < 2; ++i) {
+        for (uint32_t j = 0; j < 2; ++j) {
+            for (uint32_t k = 0; k < 16; ++k) {
+                for (uint32_t l = 0; l < 16; l+=2) {
+                    uint16_t value = l + 16*j + wt_offset;
+                    ptr[count] = (value + 1) << 16 | value;
+                    count++;
+                }
+            }
+        }
+    }
+    cb_push_back(cb_id, 1);
+}
+
+
+void kernel_main() {
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_intermed_index = get_compile_time_arg_val(1);
+    constexpr bool src_is_dram = get_compile_time_arg_val(2) == 1;
+
+    constexpr uint32_t Ht = get_compile_time_arg_val(3);
+    constexpr uint32_t Wt = get_compile_time_arg_val(4);
+
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    // there's an argument to processing two tiles at once since llk requires two index and two value tiles at at ime
+    for (uint32_t i = 0; i < Ht; ++i) {
+        for (uint32_t j = 0; j < Wt; ++j) {
+            cb_reserve_back(cb_id_in0, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            noc_async_read_tile(i*Wt + j, s, l1_write_addr);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            generate_index_tile(cb_intermed_index, j);
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/topk/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/kernels/dataflow/writer_binary_interleaved.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr0  = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr1  = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t values_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(1);
+    constexpr bool values_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr bool output_ind_is_dram = get_compile_time_arg_val(3) == 1;
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(4);
+
+    // can amortize the noc reads by doing them side by side for the two tensors
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes_values = get_tile_size(values_cb_index);
+    const DataFormat data_format_values = get_dataformat(values_cb_index);
+
+    const InterleavedAddrGenFast<values_is_dram> interleaved_accessor0 = {
+        .bank_base_address = dst_addr0,
+        .page_size = tile_bytes_values,
+        .data_format = data_format_values
+    };
+
+    for (uint32_t i = 0; i < num_tiles; ++ i) {
+        cb_wait_front(values_cb_index, onetile);
+        uint32_t l1_read_addr = get_read_ptr(values_cb_index);
+        noc_async_write_tile(i, interleaved_accessor0, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(values_cb_index, onetile);
+    }
+
+    // single-tile ublocks
+    const uint32_t tile_bytes_ind = get_tile_size(output_ind_cb_index);
+    const DataFormat data_format_ind = get_dataformat(output_ind_cb_index);
+
+    const InterleavedAddrGenFast<output_ind_is_dram> interleaved_accessor1 = {
+        .bank_base_address = dst_addr1,
+        .page_size = tile_bytes_ind,
+        .data_format = data_format_ind
+    };
+
+    for (uint32_t i = 0; i < num_tiles; ++ i) {
+        cb_wait_front(output_ind_cb_index, onetile);
+        uint32_t l1_read_addr = get_read_ptr(output_ind_cb_index);
+        noc_async_write_tile(i, interleaved_accessor1, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(output_ind_cb_index, onetile);
+    }
+
+}

--- a/tt_eager/tt_dnn/op_library/topk/single_core/single_core_topk.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/single_core/single_core_topk.cpp
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_eager/tt_dnn/op_library/topk/topk_op.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+
+namespace tt {
+namespace tt_metal{
+
+operation::ProgramWithCallbacks single_core_topk_interleaved(const Tensor &input_tensor, const uint32_t k, Tensor &value_tensor, Tensor &index_tensor) {
+    Program program{};
+
+    CoreRange core({0, 0}, {0, 0});
+    tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat value_cb_data_format = tt_metal::datatype_to_dataformat_converter(value_tensor.get_dtype());
+    tt::DataFormat index_cb_data_format = tt_metal::datatype_to_dataformat_converter(index_tensor.get_dtype());
+
+    uint32_t input_tile_size = tile_size(input_cb_data_format);
+    uint32_t value_tile_size = tile_size(value_cb_data_format);
+    uint32_t index_tile_size = tile_size(index_cb_data_format);
+
+    auto input_buffer = input_tensor.buffer();
+    auto values_buffer = value_tensor.buffer();
+    auto index_buffer = index_tensor.buffer();
+
+    bool input_is_dram = input_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    bool values_is_dram = values_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+    bool index_is_dram = index_buffer->buffer_type() == tt_metal::BufferType::DRAM;
+
+    uint32_t num_input_tiles = input_tensor.volume()/TILE_HW;
+    uint32_t num_value_tiles = value_tensor.volume()/TILE_HW;
+
+    auto input_shape = input_tensor.get_legacy_shape();
+    uint32_t Ht = (input_shape[0]*input_shape[1]*input_shape[2])/TILE_HEIGHT;
+    uint32_t Wt = input_shape[3]/TILE_WIDTH;
+    // for streaming in input
+    uint32_t num_cb_unit = 2;
+
+    uint32_t input_cb_index = CB::c_in0;
+    tt_metal::CircularBufferConfig input_cb_config = tt_metal::CircularBufferConfig(num_cb_unit * value_tile_size, {{input_cb_index, input_cb_data_format}})
+		.set_page_size(input_cb_index, input_tile_size);
+    auto cb_input_tensor = tt_metal::CreateCircularBuffer(program, core, input_cb_config);
+
+    // populate this as input is streamed
+    uint32_t index_cb_index = CB::c_in1;
+    tt_metal::CircularBufferConfig index_input_intermed0_config = tt_metal::CircularBufferConfig(num_cb_unit * index_tile_size, {{index_cb_index, index_cb_data_format}})
+		.set_page_size(index_cb_index, index_tile_size);
+    auto cb_index_tensor = tt_metal::CreateCircularBuffer(program, core, index_input_intermed0_config);
+
+
+    // transpose and populate a CB with one row of tiles at a time - precisely one row of space, since we only work on it when it's full we shouldn't need to double buffer...I think, will have to ask
+    uint32_t input_transposed_cb_index = CB::c_intermed0;
+    tt_metal::CircularBufferConfig input_transposed_cb_config = tt_metal::CircularBufferConfig(num_cb_unit * (input_shape[-1]/TILE_WIDTH) * value_tile_size, {{input_transposed_cb_index, input_cb_data_format}})
+		.set_page_size(input_transposed_cb_index, input_tile_size);
+    auto cb_input_transposed_tiles = tt_metal::CreateCircularBuffer(program, core, input_transposed_cb_config);
+
+    uint32_t index_transposed_cb_index = CB::c_intermed1;
+    tt_metal::CircularBufferConfig index_transposed_cb_config = tt_metal::CircularBufferConfig(num_cb_unit * (input_shape[-1]/TILE_WIDTH) * index_tile_size, {{index_transposed_cb_index, index_cb_data_format}})
+		.set_page_size(index_transposed_cb_index, index_tile_size);
+    auto cb_index_transposed_tiles = tt_metal::CreateCircularBuffer(program, core, index_transposed_cb_config);
+
+
+
+    uint32_t values_cb_index = CB::c_out0; // output operands start at index 16
+    tt_metal::CircularBufferConfig values_cb_config = tt_metal::CircularBufferConfig(num_cb_unit * value_tile_size, {{values_cb_index, value_cb_data_format}})
+        .set_page_size(values_cb_index, value_tile_size);
+    auto cb_values_tensor = tt_metal::CreateCircularBuffer(program, core, values_cb_config);
+
+
+    uint32_t output_ind_cb_index = CB::c_out1; // output operands start at index 16
+    tt_metal::CircularBufferConfig output_ind_cb_config = tt_metal::CircularBufferConfig(num_cb_unit * index_tile_size, {{output_ind_cb_index, index_cb_data_format}})
+        .set_page_size(output_ind_cb_index, index_tile_size);
+    auto cb_output_ind_tensor = tt_metal::CreateCircularBuffer(program, core, output_ind_cb_config);
+
+    std::vector<uint32_t> reader_compile_time_args = {
+                                                        input_cb_index,
+                                                        index_cb_index,
+                                                        (uint32_t)input_is_dram,
+                                                        Ht,
+                                                        Wt};
+    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/topk/kernels/dataflow/reader_create_index_tensor.cpp",
+        core,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+
+    SetRuntimeArgs(
+        program,
+        unary_reader_kernel_id,
+        core,
+        {
+            input_buffer->address(),
+        }
+    );
+
+    std::vector<uint32_t> writer_compile_time_args = {
+                                                        values_cb_index,
+                                                        output_ind_cb_index,
+                                                        (std::uint32_t) values_is_dram,
+                                                        (std::uint32_t) index_is_dram,
+                                                        num_value_tiles};
+    tt_metal::KernelHandle binary_writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/topk/kernels/dataflow/writer_binary_interleaved.cpp",
+        core,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    SetRuntimeArgs(
+        program,
+        binary_writer_kernel_id,
+        core,
+        {
+            values_buffer->address(),
+            index_buffer->address(),
+
+        }
+    );
+
+    std::vector<uint32_t> compute_args = {
+                                        input_cb_index,
+                                        index_cb_index,
+                                        input_transposed_cb_index,
+                                        index_transposed_cb_index,
+                                        values_cb_index,
+                                        output_ind_cb_index,
+                                        Ht,
+                                        Wt,
+                                        k,
+                                        (std::uint32_t) std::log2(k),
+                                        (std::uint32_t) std::log2(Wt),
+                                        };
+    tt_metal::KernelHandle topk_compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/topk/kernels/compute/topk.cpp",
+        core,
+        tt_metal::ComputeConfig{.compile_args = compute_args}
+    );
+
+
+    auto override_runtime_args_callback = [unary_reader_kernel_id, binary_writer_kernel_id](
+        const Program &program,
+        const std::vector<Buffer*>& input_buffers,
+        const std::vector<Buffer*>& output_buffers
+    ) {
+
+        auto input_buffer = input_buffers.at(0);
+        auto values_buffer = output_buffers.at(0);
+        auto index_buffer = output_buffers.at(1);
+
+        CoreCoord core = {0, 0};
+
+        {
+            auto &reader_runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            reader_runtime_args[0] = input_buffer->address();
+
+            auto &writer_runtime_args = GetRuntimeArgs(program, binary_writer_kernel_id, core);
+            writer_runtime_args[0] = values_buffer->address();
+            writer_runtime_args[1] = index_buffer->address();
+        }
+
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+}
+}

--- a/tt_eager/tt_dnn/op_library/topk/topk_op.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/topk_op.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/topk/topk_op.hpp"
+#include "tt_metal/host_api.hpp"
+
+void TopK::validate(const std::vector<Tensor>& input_tensors) const {
+    auto input_shape = input_tensors.at(0).get_legacy_shape();
+    TT_FATAL(k == 32, fmt::format("K must be equal to 32, pad with -infinity if necessary"));
+    TT_FATAL(input_shape[-1] == 64, fmt::format("Input shape inner dim {} must be 64, pad with -infinity if necessary", input_shape[-1]));
+    TT_FATAL((input_shape[0] * input_shape[1] * input_shape[2]) == 32, "Input height must be 32");
+    TT_FATAL(this->output_mem_config.is_sharded() == false, "Sharded implementation not supported yet");
+    TT_FATAL(input_tensors.at(0).get_layout() == Layout::TILE, "The input must be in tiled format");
+}
+
+std::vector<Shape> TopK::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto input_shape = input_tensor.get_legacy_shape();
+    return {{input_shape[0], input_shape[1], input_shape[2], this->k}, {input_shape[0], input_shape[1], input_shape[2], this->k}};
+}
+
+std::vector<Tensor> TopK::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto shapes = compute_output_shapes(input_tensors);
+    auto values_tensor = create_device_tensor(shapes[0], input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), this->output_mem_config);
+    auto index_tensor = create_device_tensor(shapes[0], DataType::UINT16, Layout::TILE, input_tensor.device(), this->output_mem_config);
+    return {values_tensor, index_tensor};
+}
+
+operation::ProgramWithCallbacks TopK::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    return single_core_topk_interleaved(input_tensor, this->k, output_tensors.at(0), output_tensors.at(1));
+}
+
+tt::stl::reflection::Attributes TopK::attributes() const {
+    return {
+        {"k", this->k},
+        {"output_mem_config", this->output_mem_config},
+    };
+}

--- a/tt_eager/tt_dnn/op_library/topk/topk_op.hpp
+++ b/tt_eager/tt_dnn/op_library/topk/topk_op.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "ttnn/operations/core.hpp"
+
+namespace tt {
+
+namespace tt_metal {
+
+operation::ProgramWithCallbacks single_core_topk_interleaved(const Tensor &input_tensor, const uint32_t k, Tensor &value_tensor, Tensor &index_tensor);
+
+struct TopK {
+    uint32_t k;
+    MemoryConfig output_mem_config;
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
+    tt::stl::reflection::Attributes attributes() const;
+};
+
+inline std::tuple<Tensor, Tensor> topk(const Tensor &input_tensor, const uint32_t k, const MemoryConfig &output_mem_config) {
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor})),
+                                        Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    operation::launch_op(
+        [k, output_mem_config] (std::vector<Tensor> input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_input_tensors_const) mutable -> std::vector<Tensor> {
+
+            return operation::run(TopK{k, output_mem_config}, input_tensors);
+
+        }, {input_tensor}, output_tensors);
+    return {output_tensors.at(0), output_tensors.at(1)};
+}
+
+} // namespace tt_metal
+} // namespace tt

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -41,6 +41,7 @@
 #include "tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp"
 #include "tt_dnn/op_library/moreh_getitem/moreh_getitem_op.hpp"
 #include "tt_dnn/op_library/prod/prod_op_all.hpp"
+#include "tt_dnn/op_library/topk/topk_op.hpp"
 
 namespace py = pybind11;
 
@@ -1029,6 +1030,14 @@ void py_module(py::module& m_primary) {
         py::arg("output_tensor").noconvert() = std::nullopt,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         "Performs a getitem operation. Returns an output tensor.");
+
+    m_primary.def(
+        "topk",
+        &tt::tt_metal::topk,
+        py::arg("input_tensor").noconvert(),
+        py::arg("k").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        "Get the Top K values and their indices in the input tensor");
 }
 
 }  // namespace

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -254,8 +254,12 @@ static void PrintTensixRegisterData(ostream& stream, int setwidth, uint32_t raw_
         case static_cast<std::uint8_t>(tt::DataFormat::UInt32):
             stream << setw(setwidth) << datum << " ";
             break;
+        case static_cast<std::uint8_t>(tt::DataFormat::UInt16):
+            stream << setw(setwidth) << (datum & 0xffff) << " ";
+            stream << setw(setwidth) << (datum >> 16) << " ";
+            break;
         default:
-            stream << "Unknown data format " << data_format;
+            stream << "Unknown data format " << data_format << " ";
             break;
    }
 }


### PR DESCRIPTION
Add a topk implementation for the 32, 64 case. Anything with dimensions below that can be supported via padding. Will follow up with a more efficient, and corrected approach for dimensions that are greater. Eventually want to extend to sharded as well.

https://github.com/tenstorrent/tt-metal/actions/runs/9085576460