### PR TITLE
Cache empty kvcache for faster initialization

### DIFF
--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -87,86 +87,24 @@ def run_test_FalconCausalLM_end_to_end(
         assert q_len % 32 == 0, "For prefill, seq_len must be multiple of 32!"
         assert kv_cache_len == 0, "For prefill, no kv_cache is passed in!"
 
-        past_key_values = None
-        tt_layer_past = ()
-        tt_k_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-        tt_v_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-        tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
-        tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
-
-        for _ in range(num_layers):
-            tt_k_cache = []
-            tt_v_cache = []
-            for j in range(len(devices)):
-                tt_k_cache.append(
-                    torch2tt_tensor(
-                        tt_k_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-                tt_v_cache.append(
-                    torch2tt_tensor(
-                        tt_v_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
     elif llm_mode == "decode":
         q_len, kv_len = seq_len, kv_cache_len + 1
         assert batch % 32 == 0, "For decode, batch must be multiple of 32!"
         assert q_len == 1, "For decode, q_len must be 1!"
 
-        past_key_values = ()
-        tt_layer_past = ()
-        for i in range(num_layers):
-            k_cache = torch.rand(batch, num_kv_heads, kv_cache_len, head_dim)
-            v_cache = torch.rand(batch, num_kv_heads, kv_cache_len, head_dim)
-            past_key_values += (
-                (
-                    torch.repeat_interleave(k_cache, num_attention_heads // num_kv_heads, 1),
-                    (torch.repeat_interleave(v_cache, num_attention_heads // num_kv_heads, 1)),
-                ),
-            )
-
-            tt_k_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-            tt_v_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-            tt_k_cache_host[:, :, :kv_cache_len, :] = k_cache
-            tt_v_cache_host[:, :, :kv_cache_len, :] = v_cache
-            tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
-            tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
-
-            tt_k_cache = []
-            tt_v_cache = []
-            for j in range(len(devices)):
-                tt_k_cache.append(
-                    torch2tt_tensor(
-                        tt_k_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-                tt_v_cache.append(
-                    torch2tt_tensor(
-                        tt_v_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
     else:
         raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
+
+    past_key_values = ()
+    for i in range(num_layers):
+        k_cache = torch.zeros(batch, num_kv_heads, kv_cache_len, head_dim)
+        v_cache = torch.zeros(batch, num_kv_heads, kv_cache_len, head_dim)
+        past_key_values += (
+            (
+                torch.repeat_interleave(k_cache, num_attention_heads // num_kv_heads, 1),
+                (torch.repeat_interleave(v_cache, num_attention_heads // num_kv_heads, 1)),
+            ),
+        )
 
     # Prepare output -----------------------------------------------------------------------
     logger.info("Running HF reference model")
@@ -197,6 +135,9 @@ def run_test_FalconCausalLM_end_to_end(
         tt_lib.device.Synchronize(device)
     profiler.end("TtFalcon_model_setup")
     logger.info("Done loading TT Falcon Model")
+
+    # Initialize past layer values
+    tt_layer_past = tt_FalconCausalLM.get_kv_cache()
 
     profiler.start("processing_of_input")
     if llm_mode == "prefill":
@@ -381,12 +322,12 @@ def run_test_FalconCausalLM_end_to_end(
         )
         tt_layer_pres = (
             torch.repeat_interleave(
-                tt_layer_pres[0][:, :, :kv_len, :],
+                tt_layer_pres[0][:batch, :, :kv_len, :],
                 configuration.num_attention_heads // configuration.num_kv_heads,
                 1,
             ),
             torch.repeat_interleave(
-                tt_layer_pres[1][:, :, :kv_len, :],
+                tt_layer_pres[1][:batch, :, :kv_len, :],
                 configuration.num_attention_heads // configuration.num_kv_heads,
                 1,
             ),

--- a/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
@@ -115,7 +115,7 @@ def run_test_FalconCausalLM_end_to_end(
     del state_dict
 
     # Initialize past layer values
-    tt_layer_past = tt_FalconCausalLM.get_kv_cache()
+    tt_layer_past = tt_FalconCausalLM.initialize_kv_cache()
 
     if llm_mode == "prefill":
         model_inputs = torch.split(model_input, 1)

--- a/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
@@ -54,7 +54,6 @@ def run_test_FalconCausalLM_end_to_end(
 ):
     model_name = model_location_generator(model_version, model_subdir="Falcon")
 
-    # profiler.start("hugging_face_model_setup")
     hugging_face_reference_model = FalconForCausalLM.from_pretrained(
         model_name, low_cpu_mem_usage=True, num_hidden_layers=num_layers
     )
@@ -62,7 +61,6 @@ def run_test_FalconCausalLM_end_to_end(
     configuration = hugging_face_reference_model.config
     state_dict = hugging_face_reference_model.state_dict()
     pytorch_FalconCausalLM = PytorchFalconCausalLM(hugging_face_reference_model, num_layers)
-    # profiler.end("hugging_face_model_setup")
 
     # Prepare input ------------------------------------------------------------------------
     torch.manual_seed(0)
@@ -86,99 +84,15 @@ def run_test_FalconCausalLM_end_to_end(
         assert q_len % 32 == 0, "For prefill, seq_len must be multiple of 32!"
         assert kv_cache_len == 0, "For prefill, no kv_cache is passed in!"
 
-        past_key_values = None
-        tt_layer_past = ()
-        tt_k_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-        tt_v_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-        tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
-        tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
-
-        for i in range(num_layers):
-            tt_k_cache = []
-            tt_v_cache = []
-            for i in range(len(devices)):
-                tt_k_cache.append(
-                    torch2tt_tensor(
-                        tt_k_cache_host[i],
-                        devices[i],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-                tt_v_cache.append(
-                    torch2tt_tensor(
-                        tt_v_cache_host[i],
-                        devices[i],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
     elif llm_mode == "decode":
         q_len, kv_len = seq_len, kv_cache_len + 1
         assert batch % 32 == 0, "For decode, batch must be multiple of 32!"
         assert q_len == 1, "For decode, q_len must be 1!"
 
-        past_key_values = ()
-        tt_layer_past = ()
-        for i in range(num_layers):
-            k_cache = torch.rand(batch, num_kv_heads, kv_cache_len, head_dim)
-            v_cache = torch.rand(batch, num_kv_heads, kv_cache_len, head_dim)
-            past_key_values += (
-                (
-                    torch.repeat_interleave(k_cache, num_attention_heads // num_kv_heads, 1),
-                    (torch.repeat_interleave(v_cache, num_attention_heads // num_kv_heads, 1)),
-                ),
-            )
-
-            tt_k_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-            tt_v_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-            tt_k_cache_host[:, :, :kv_cache_len, :] = k_cache
-            tt_v_cache_host[:, :, :kv_cache_len, :] = v_cache
-            tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
-            tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
-
-            tt_k_cache = []
-            tt_v_cache = []
-            for j in range(len(devices)):
-                tt_k_cache.append(
-                    torch2tt_tensor(
-                        tt_k_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-                tt_v_cache.append(
-                    torch2tt_tensor(
-                        tt_v_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
     else:
         raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
     for device in devices:
         tt_lib.device.Synchronize(device)
-
-    # Prepare output -----------------------------------------------------------------------
-    # profiler.start("hugging_face_reference_model")
-    pytorch_out, pytorch_layer_present = pytorch_FalconCausalLM(
-        input_ids=model_input, past_key_values=past_key_values, use_cache=use_cache
-    )
-    # profiler.end("hugging_face_reference_model")
-    del past_key_values
-    del pytorch_layer_present
-    del pytorch_out
-    del pytorch_FalconCausalLM
 
     # NOTE: Passing in pytorch tensor here instead of ll buda tensor
     # since we don't yet have embedding support on device
@@ -197,11 +111,12 @@ def run_test_FalconCausalLM_end_to_end(
     )
     for device in devices:
         tt_lib.device.Synchronize(device)
-    # profiler.end("TtFalcon_model_setup")
 
     del state_dict
 
-    # profiler.start("processing_of_input")
+    # Initialize past layer values
+    tt_layer_past = tt_FalconCausalLM.get_kv_cache()
+
     if llm_mode == "prefill":
         model_inputs = torch.split(model_input, 1)
         tt_inputs, tt_attention_mask = zip(
@@ -214,14 +129,11 @@ def run_test_FalconCausalLM_end_to_end(
         tt_inputs, tt_attention_mask_host = tt_FalconCausalLM.model_preprocessing(
             llm_mode, model_input, kv_cache_len, num_input_tokens=kv_len
         )
-    # profiler.end("processing_of_input")
 
     # First run to fill compile cache ----------------------------------------------------
     logger.info(f"Running Falcon model once to fill caches")
-    # profiler.disable()
 
     # Use force enable to only record this profiler call while others are disabled
-    # profiler.start("first_model_run_with_compile", force_enable=True)
     compile_time_start = time.time()
     if llm_mode == "prefill":
         tt_outs = []
@@ -250,7 +162,6 @@ def run_test_FalconCausalLM_end_to_end(
         )
         tt_out = [tt_o.cpu() for tt_o in tt_out]
     compile_duration = time.time() - compile_time_start
-    # profiler.end("first_model_run_with_compile", force_enable=True)
     for device in devices:
         tt_lib.device.Synchronize(device)
 
@@ -274,7 +185,6 @@ def run_test_FalconCausalLM_end_to_end(
         )
 
     # Run warmup interations - profiler still disabled
-    # profiler.start(f"model_warmup_run_for_inference")
     for _ in range(inference_iterations - 1):
         if llm_mode == "prefill":
             tt_outs = []
@@ -308,7 +218,6 @@ def run_test_FalconCausalLM_end_to_end(
                 use_cache=use_cache,
             )
             tt_out = [tt_o.cpu() for tt_o in tt_out]
-    # profiler.end(f"model_warmup_run_for_inference")
     for device in devices:
         tt_lib.device.Synchronize(device)
 

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -89,99 +89,15 @@ def run_test_FalconCausalLM_end_to_end(
         assert q_len % 32 == 0, "For prefill, seq_len must be multiple of 32!"
         assert kv_cache_len == 0, "For prefill, no kv_cache is passed in!"
 
-        past_key_values = None
-        tt_layer_past = ()
-        tt_k_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-        tt_v_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-        tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
-        tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
-
-        for _ in range(num_layers):
-            tt_k_cache = []
-            tt_v_cache = []
-            for j in range(len(devices)):
-                tt_k_cache.append(
-                    torch2tt_tensor(
-                        tt_k_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-                tt_v_cache.append(
-                    torch2tt_tensor(
-                        tt_v_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
     elif llm_mode == "decode":
         q_len, kv_len = seq_len, kv_cache_len + 1
         assert batch % 32 == 0, "For decode, batch must be multiple of 32!"
         assert q_len == 1, "For decode, q_len must be 1!"
 
-        past_key_values = ()
-        tt_layer_past = ()
-        for i in range(num_layers):
-            k_cache = torch.rand(batch, num_kv_heads, kv_cache_len, head_dim)
-            v_cache = torch.rand(batch, num_kv_heads, kv_cache_len, head_dim)
-            past_key_values += (
-                (
-                    torch.repeat_interleave(k_cache, num_attention_heads // num_kv_heads, 1),
-                    (torch.repeat_interleave(v_cache, num_attention_heads // num_kv_heads, 1)),
-                ),
-            )
-
-            tt_k_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-            tt_v_cache_host = torch.zeros(batch, num_kv_heads, max_position_embeddings, head_dim)
-            tt_k_cache_host[:, :, :kv_cache_len, :] = k_cache
-            tt_v_cache_host[:, :, :kv_cache_len, :] = v_cache
-            tt_k_cache_host = torch.chunk(tt_k_cache_host, len(devices), 1)
-            tt_v_cache_host = torch.chunk(tt_v_cache_host, len(devices), 1)
-
-            tt_k_cache = []
-            tt_v_cache = []
-            for j in range(len(devices)):
-                tt_k_cache.append(
-                    torch2tt_tensor(
-                        tt_k_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-                tt_v_cache.append(
-                    torch2tt_tensor(
-                        tt_v_cache_host[j],
-                        devices[j],
-                        tt_lib.tensor.Layout.TILE,
-                        model_config["KV_CACHE_MEMCFG"],
-                        model_config["KV_CACHE_DTYPE"],
-                    )
-                )
-            tt_layer_past += ((tt_k_cache, tt_v_cache),)
-
     else:
         raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
     for device in devices:
         tt_lib.device.Synchronize(device)
-
-    # Prepare output -----------------------------------------------------------------------
-    profiler.start("hugging_face_reference_model")
-    pytorch_out, pytorch_layer_present = pytorch_FalconCausalLM(
-        input_ids=model_input, past_key_values=past_key_values, use_cache=use_cache
-    )
-    profiler.end("hugging_face_reference_model")
-    del past_key_values
-    del pytorch_layer_present
-    del pytorch_out
-    del pytorch_FalconCausalLM
 
     # NOTE: Passing in pytorch tensor here instead of ll buda tensor
     # since we don't yet have embedding support on device
@@ -203,6 +119,9 @@ def run_test_FalconCausalLM_end_to_end(
     profiler.end("TtFalcon_model_setup")
 
     del state_dict
+
+    # Initialize past layer values
+    tt_layer_past = tt_FalconCausalLM.get_kv_cache()
 
     profiler.start("processing_of_input")
     if llm_mode == "prefill":

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -121,7 +121,7 @@ def run_test_FalconCausalLM_end_to_end(
     del state_dict
 
     # Initialize past layer values
-    tt_layer_past = tt_FalconCausalLM.get_kv_cache()
+    tt_layer_past = tt_FalconCausalLM.initialize_kv_cache()
 
     profiler.start("processing_of_input")
     if llm_mode == "prefill":

--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -163,6 +163,7 @@ class TtFalconAttention:
         self.state_dict = state_dict
         self.model_config = model_config
         self.num_heads_per_device = self.num_heads // len(devices)
+        self.tt_cache_path = tt_cache_path
         self.max_batch_size = 32
 
         if (self.head_dim * self.num_heads) != self.hidden_size:
@@ -250,50 +251,57 @@ class TtFalconAttention:
         # self.scalar = pad_by_zero(torch.Tensor([1 / math.sqrt(self.head_dim)]), self.device)[0]
         self.scalar = 1 / math.sqrt(self.head_dim)
 
-        # Preloading the kvcache
-        attn_cache_shape = (
-            self.max_batch_size,
-            self.num_kv_heads // len(devices),
-            self.max_position_embeddings,
-            # 2048 + 128,  # Meets benchmarking spec needs
-            self.head_dim,
-        )
-        kvcache_path = tt_cache_path / f"empty_attn_cache{attn_cache_shape}.bin"
-        k_cache = []
-        v_cache = []
-        if (kvcache_path).exists():
-            for i in range(len(self.devices)):
-                k_cache.append(
-                    tt_lib.tensor.load_tensor(str(kvcache_path)).to(devices[i], self.model_config["DRAM_MEMCFG"])
-                )
-                v_cache.append(
-                    tt_lib.tensor.load_tensor(str(kvcache_path)).to(devices[i], self.model_config["DRAM_MEMCFG"])
-                )
-        else:
-            attn_cache = torch.zeros(attn_cache_shape)
-            tt_attn_cache = torch2tt_tensor(
-                attn_cache,
-                None,
-                tt_memory_config=self.model_config["DRAM_MEMCFG"],
-                tt_dtype=ttnn.bfloat8_b,
-            )
-            for i in range(len(self.devices)):
-                k_cache.append(tt_attn_cache.to(devices[i], self.model_config["DRAM_MEMCFG"]))
-            for i in range(len(self.devices)):
-                v_cache.append(tt_attn_cache.to(devices[i], self.model_config["DRAM_MEMCFG"]))
-
-            tt_lib.tensor.dump_tensor(
-                str(kvcache_path),
-                tt_attn_cache,
-            )
-        self.layer_past = (
-            (
-                k_cache,
-                v_cache,
-            ),
-        )
-
         self.preprocessing(self.model_config["LLM_MODE"], self.model_config["BATCH_SIZE"], self.model_config["SEQ_LEN"])
+        self.layer_past = None
+
+    def initialize_kvcache(self):
+        if self.layer_past is None:
+            # Preloading the kvcache
+            attn_cache_shape = (
+                self.max_batch_size,
+                self.num_kv_heads // len(self.devices),
+                self.max_position_embeddings,
+                self.head_dim,
+            )
+            kvcache_path = self.tt_cache_path / f"empty_attn_cache{attn_cache_shape}.bin"
+            k_cache = []
+            v_cache = []
+            if (kvcache_path).exists():
+                for i in range(len(self.devices)):
+                    k_cache.append(
+                        tt_lib.tensor.load_tensor(str(kvcache_path)).to(
+                            self.devices[i], self.model_config["DRAM_MEMCFG"]
+                        )
+                    )
+                    v_cache.append(
+                        tt_lib.tensor.load_tensor(str(kvcache_path)).to(
+                            self.devices[i], self.model_config["DRAM_MEMCFG"]
+                        )
+                    )
+            else:
+                attn_cache = torch.zeros(attn_cache_shape)
+                tt_attn_cache = torch2tt_tensor(
+                    attn_cache,
+                    None,
+                    tt_memory_config=self.model_config["DRAM_MEMCFG"],
+                    tt_dtype=ttnn.bfloat8_b,
+                )
+                for i in range(len(self.devices)):
+                    k_cache.append(tt_attn_cache.to(self.devices[i], self.model_config["DRAM_MEMCFG"]))
+                for i in range(len(self.devices)):
+                    v_cache.append(tt_attn_cache.to(self.devices[i], self.model_config["DRAM_MEMCFG"]))
+
+                tt_lib.tensor.dump_tensor(
+                    str(kvcache_path),
+                    tt_attn_cache,
+                )
+            self.layer_past = (
+                (
+                    k_cache,
+                    v_cache,
+                ),
+            )
+        return self.layer_past
 
     def set_model_config(self, model_config):
         self.model_config = model_config

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -133,10 +133,10 @@ class TtFalconModelShared:
 
         self.layernorm_eps = config.layer_norm_epsilon
 
-    def get_kv_cache(self):
+    def initialize_kv_cache(self):
         layer_past = ()
         for layer_num in range(self.num_layers):
-            layer_past += self.layers[layer_num].self_attn.layer_past
+            layer_past += self.layers[layer_num].self_attn.initialize_kvcache()
         return layer_past
 
     def set_model_config(self, model_config):

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -133,6 +133,12 @@ class TtFalconModelShared:
 
         self.layernorm_eps = config.layer_norm_epsilon
 
+    def get_kv_cache(self):
+        layer_past = ()
+        for layer_num in range(self.num_layers):
+            layer_past += self.layers[layer_num].self_attn.layer_past
+        return layer_past
+
     def set_model_config(self, model_config):
         self.model_config = model_config
         self.embeddings.set_model_config(model_config)


### PR DESCRIPTION
- Load kvcache from disk cache
- Use in end to end test, demo, perf, e2e perf tests for now (mostly relevant for large number of layers)

https://github.com/tenstorrent/tt-metal/actions/runs/9097236438