### PR TITLE
add build artifacts to workflows

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -2,13 +2,19 @@ name: "Build tt-metal artifacts"
 
 on:
   workflow_call:
+    inputs:
+      arch:
+        required: false
+        type: string
+        default: '["grayskull", "wormhole_b0"]'
   workflow_dispatch:
 
 jobs:
   build-artifact:
     strategy:
       matrix:
-        arch: ["grayskull", "wormhole_b0"]
+        arch: ${{ fromJson(inputs.arch || '["grayskull", "wormhole_b0"]') }}
+
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.arch }}

--- a/.github/workflows/multi-device-build-and-unit-tests-frequent.yaml
+++ b/.github/workflows/multi-device-build-and-unit-tests-frequent.yaml
@@ -6,7 +6,14 @@ on:
     - cron: "0 */8 * * *" # This cron schedule runs the workflow every 8 hours
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      arch: '["wormhole_b0"]'
+    secrets: inherit
+
   multi-chip-nightly:
+    needs: build-artifact
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
@@ -23,17 +30,19 @@ jobs:
     runs-on: ${{ matrix.runner-info.runs-on }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
-      - name: Set up dyanmic env vars for build
+      - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: |
-          PYTHON_ENV_DIR=$(pwd)/build/python_env ./build_metal.sh
-      - name: Build tt-metal CPP tests
-        run: cmake --build build --target tests -- -j`nproc`
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.runner-info.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run frequent regression tests
         timeout-minutes: 60
         run: |
-          source build/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type frequent_multi_device --dispatch-mode ""

--- a/.github/workflows/multi-device-build-and-unit-tests.yaml
+++ b/.github/workflows/multi-device-build-and-unit-tests.yaml
@@ -6,7 +6,14 @@ on:
     - cron: "0 */3 * * *" # This cron schedule runs the workflow every 3 hours
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      arch: '["wormhole_b0"]'
+    secrets: inherit
+
   multi-chip-unit-tests:
+    needs: build-artifact
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
@@ -35,17 +42,18 @@ jobs:
     runs-on: ${{ matrix.test-group.runs-on }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
-      - name: Set up dyanmic env vars for build
+      - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: |
-          PYTHON_ENV_DIR=$(pwd)/build/python_env ./build_metal.sh
-      - name: Build tt-metal CPP tests
-        run: cmake --build build --target tests -- -j`nproc`
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.test-group.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run pre/post regression tests
         timeout-minutes: 120
         run: |
-          source build/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}

--- a/.github/workflows/multi-device-end-to-end-demos.yaml
+++ b/.github/workflows/multi-device-end-to-end-demos.yaml
@@ -6,7 +6,14 @@ on:
     - cron: '0 0 * * *' # This cron schedule runs the workflow every day at 12am UTC
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      arch: '["wormhole_b0"]'
+    secrets: inherit
+
   multi-chip-unit-tests:
+    needs: build-artifact
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
@@ -30,17 +37,18 @@ jobs:
     runs-on: ${{ matrix.test-group.runs-on }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
-      - name: Set up dyanmic env vars for build
+      - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: |
-          PYTHON_ENV_DIR=$(pwd)/build/python_env ./build_metal.sh
-      - name: Build tt-metal CPP tests
-        run: cmake --build build --target tests -- -j`nproc`
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.test-group.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run pre/post regression tests
         timeout-minutes: 180
         run: |
-          source build/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}

--- a/.github/workflows/multi-device-perf-models.yaml
+++ b/.github/workflows/multi-device-perf-models.yaml
@@ -6,7 +6,14 @@ on:
     - cron: "0 */12 * * *" # This cron schedule runs the workflow every 12 hours
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      arch: '["wormhole_b0"]'
+    secrets: inherit
+
   multi-device-models-perf:
+    needs: build-artifact
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
@@ -41,12 +48,16 @@ jobs:
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
           echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: PYTHON_ENV_DIR=$(pwd)/build/python_env ./build_metal.sh
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.runner-info.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run performance regressions
         timeout-minutes: 60
         run: |
-          source build/python_env/bin/activate
+          source python_env/bin/activate
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type ${{ matrix.model-type }}_models_performance_${{ matrix.runner-info.machine-type }}_multi_device
       - name: Check perf report exists
         id: check-perf-report

--- a/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
@@ -6,7 +6,12 @@ on:
     - cron: "0 4 * * *"
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+
   stress-build-and-unit-tests:
+    needs: build-artifact
     timeout-minutes: 1440
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
@@ -36,13 +41,17 @@ jobs:
       - name: Set up dyanmic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: PYTHON_ENV_DIR=$(pwd)/build/python_env ./build_metal.sh
-      - name: Build tt-metal CPP tests
-        run: cmake --build build --target tests -- -j`nproc`
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.runner-info.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run pre/post regression tests in a loop
         run: |
-          source build/python_env/bin/activate
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type stress_post_commit --dispatch-mode fast
       - name: Upload watcher log
         if: always()

--- a/.github/workflows/stress-slow-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-slow-dispatch-build-and-unit-tests.yaml
@@ -6,7 +6,12 @@ on:
     - cron: "0 4 * * *"
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+
   stress-build-and-unit-tests:
+    needs: build-artifact
     timeout-minutes: 1440
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
@@ -34,13 +39,15 @@ jobs:
       - name: Set up dyanmic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: PYTHON_ENV_DIR=$(pwd)/build/python_env ./build_metal.sh
-      - name: Build tt-metal CPP tests
-        run: cmake --build build --target tests -- -j`nproc`
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run pre/post regression tests in a loop
         run: |
-          source build/python_env/bin/activate
+          source python_env/bin/activate
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type stress_post_commit --dispatch-mode slow
       - name: Upload watcher log
         if: always()

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -7,7 +7,14 @@ on:
   workflow_call:
 
 jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      arch: '["grayskull"]'
+    secrets: inherit
+
   ttnn-sweeps:
+    needs: build-artifact
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
@@ -24,12 +31,19 @@ jobs:
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: |
-          PYTHON_ENV_DIR=$(pwd)/build/python_env ./build_metal.sh
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run ttnn sweeps
         timeout-minutes: 30
-        run: ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type ttnn_sweeps
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
+          ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type ttnn_sweeps
       - name: Assert that csvs exist in expected ttnn results folder
         run: ls -hal tests/ttnn/sweep_tests/results/*.csv
       - name: Upload ttnn sweep reports csvs

--- a/tests/scripts/run_ttnn_sweeps.sh
+++ b/tests/scripts/run_ttnn_sweeps.sh
@@ -13,7 +13,7 @@ run_ttnn_sweeps() {
   fi
 
   export PYTHONPATH=$TT_METAL_HOME
-  source build/python_env/bin/activate
+  source python_env/bin/activate
 
   python tests/ttnn/sweep_tests/run_sweeps.py
 }


### PR DESCRIPTION
Workflows changed in this PR are changed to build artifacts first from builder BMs instead of building locally.

Major changes

- Additional feature added is to allow for build-artifacts.yaml workflow to allow for building either grayskull, wormhole_b0, or both grayskull and wormhole_b0 artifacts for any job.
- modified run_ttnn_sweeps.sh to point to CMake python env folder in home directory of tt-metal instead of in build folder
- modified workflows below to use build-artifacts.


Affected workflows
Note, we look only for the fact that tests can be executed and in the same state as main
- [ ] multi-device-build-and-unit-tests-frequent - Nightly multi-chip tests https://github.com/tenstorrent/tt-metal/actions/runs/9104577975
- [ ] multi-device-build-and-unit-tests - "Multi-chip unit tests" https://github.com/tenstorrent/tt-metal/actions/runs/9104709579
- [ ] multi-device-e2e-demos - "Multi-chip demo tests" https://github.com/tenstorrent/tt-metal/actions/runs/9104705466
- [ ] multi-device-perf-models - "Multi-Nebula model perf regressions and output report" https://github.com/tenstorrent/tt-metal/actions/runs/9107267341/job/25035975422
- [ ] stress-fast-dispatch-build-and-unit-tests - "Stress fast dispatch tests" https://github.com/tenstorrent/tt-metal/actions/runs/9107288593
- [ ] run_ttnn_sweeps - "ttnn -run sweeps" - https://github.com/tenstorrent/tt-metal/actions/runs/9104772981



