### PR TITLE
#0: Add ReleaseLastTrace to test_bert_ops to ensure that trace_buf is…

### DIFF
--- a/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
+++ b/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
@@ -185,6 +185,7 @@ def test_bert_linear(
         passing, output = comp_pcc(pt_out, tt_out)
         logger.info(output)
         assert passing
+    ttl.device.ReleaseLastTrace(device)
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")


### PR DESCRIPTION
… deleted before device close