### PR TITLE
#7944: add convenience script that installs docker deps and compose

### DIFF
--- a/scripts/docker/build_docker_image.sh
+++ b/scripts/docker/build_docker_image.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TT_METAL_DOCKER_IMAGE_TAG=${1:-ubuntu-20.04-amd64:latest}
+
+TT_METAL_HOME=$(git rev-parse --show-toplevel)
+(
+  cd ${TT_METAL_HOME} || exit
+  docker build -f dockerfile/ubuntu-20.04-x86.Dockerfile -t ${TT_METAL_DOCKER_IMAGE_TAG} .
+)

--- a/scripts/docker/run_docker_cmd.sh
+++ b/scripts/docker/run_docker_cmd.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [[ -z "${TT_METAL_DOCKER_IMAGE_TAG}" ]]; then
+  echo "TT_METAL_DOCKER_IMAGE_TAG is not set or is empty, setting to ubuntu-20.04-amd64:latest"
+  TT_METAL_DOCKER_IMAGE_TAG="ubuntu-20.04-amd64:latest"
+else
+  echo "TT_METAL_DOCKER_IMAGE_TAG is set to ${TT_METAL_DOCKER_IMAGE_TAG}"
+fi
+
+if [[ -z "${ARCH_NAME}" ]]; then
+  echo "Must provide ARCH_NAME in environment" 1>&2
+  exit 1
+fi
+
+if [[ $# -eq 0 ]] ; then
+    echo 'You must provide an argument to run in docker!'
+    exit 1
+fi
+TT_METAL_HOME=$(git rev-parse --show-toplevel)
+# Allows this script to be called anywhere in the tt-metal repo
+source $TT_METAL_HOME/scripts/docker/run_docker_func.sh
+
+run_docker_common "$@"

--- a/scripts/docker/run_docker_func.sh
+++ b/scripts/docker/run_docker_func.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+if [[ -z "${TT_METAL_DOCKER_IMAGE_TAG}" ]]; then
+  echo "TT_METAL_DOCKER_IMAGE_TAG is not set or is empty, setting to ubuntu-20.04-amd64:latest"
+  TT_METAL_DOCKER_IMAGE_TAG="ubuntu-20.04-amd64:latest"
+else
+  echo "TT_METAL_DOCKER_IMAGE_TAG is set to ${TT_METAL_DOCKER_IMAGE_TAG}"
+fi
+
+GID=$(id -g "${USER}")
+
+if [[ -z "${TT_METAL_HOME}" ]]; then
+  TT_METAL_HOME=$(git rev-parse --show-toplevel)
+else
+  echo "TT_METAL_DOCKER_IMAGE_TAG is set to ${TT_METAL_DOCKER_IMAGE_TAG}"
+fi
+
+[ -d ${TT_METAL_HOME}/.pipcache ] || mkdir ${TT_METAL_HOME}/.pipcache
+
+function run_docker_common {
+    # Split the arguments into docker options and command
+    local docker_opts=()
+    local cmd=()
+    local append_cmd=false
+    for arg in "$@"; do
+        if $append_cmd; then
+            cmd+=("$arg")
+        elif [[ $arg == "--" && $append_cmd == false ]]; then
+            append_cmd=true
+        else
+            docker_opts+=("$arg")
+        fi
+    done
+
+    docker run \
+        --rm \
+        -v ${TT_METAL_HOME}:/${TT_METAL_HOME} \
+        -v /home:/home \
+        -v /dev/hugepages-1G:/dev/hugepages-1G \
+        -v /etc/group:/etc/group:ro \
+        -v /etc/passwd:/etc/passwd:ro \
+        -v /etc/shadow:/etc/shadow:ro \
+        -w ${TT_METAL_HOME} \
+        -e TT_METAL_HOME=${TT_METAL_HOME} \
+        -e TT_METAL_ENV=${TT_METAL_ENV} \
+        -e LOGURU_LEVEL=${LOGURU_LEVEL} \
+        -e LD_LIBRARY_PATH=${LD_LIBRARY_PATH} \
+        -e CONFIG=${CONFIG} \
+        -e ARCH_NAME=${ARCH_NAME} \
+        -e PYTHONPATH=${TT_METAL_HOME} \
+        -e XDG_CACHE_HOME=${TT_METAL_HOME}/.pipcache \
+        -e SILENT=${SILENT} \
+		-e VERBOSE=${VERBOSE} \
+        -u ${UID}:${GID} \
+        --net host \
+        "${docker_opts[@]}" \
+        ${TT_METAL_DOCKER_IMAGE_TAG} \
+        "${cmd[@]}"
+}


### PR DESCRIPTION
This PR is splitting #7949  for reviewability purposes

This PR provides some convenience scripts for building docker images and running docker run commands.

Scripts descriptino

- ./scripts/docker/build_docker_image.sh

Builds docker image

- ./scripts/docker/run_docker_func.sh

provides a common docker run function that captures most env variables for ease of use.
not intended to be run directly but written for portability for others to write their own script to if they so wish

- ./scripts/docker/run_docker_cmd.sh

script that executes functionality provided in run_docker_func.sh
usage should follow the following format
```
./run_docker_cmd.sh ${DOCKER_OPTS} -- ${COMMAND}
```
${DOCKER_OPTS} is for adding any additional docker arguments required.
-- is used as a delimiter to split between DOCKER_OPTS and COMMAND
A common use case is adding --device /dev/tenstorrent and building an example would be as follows.
```
./run_docker_cmd.sh --device /dev/tenstorrent -e TT_METAL_ENV=dev -- ./run_tests.sh
```
in this case, run_tests.sh shell script is executed in the docker image.
