### PR TITLE
#8027: change sentry python_env caching to use `create_venv.sh` inste…

### DIFF
--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -18,4 +18,4 @@ runs:
         cache-dependency-path: |
           tt_metal/python_env/requirements-dev.txt
           pyproject.toml
-        install-cmd: CONFIG=ci ./build_metal.sh
+        install-cmd: ./scripts/build_scripts/create_venv.sh

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ class CMakeBuild(build_ext):
         nproc = subprocess.check_output(["nproc"]).decode().strip()
         build_args = [f"-j{nproc}"]
 
-        subprocess.check_call(["cmake", source_dir, *cmake_args], cwd=build_dir, env=build_env)
+        subprocess.check_call(["cmake", "-G", "Ninja", source_dir, *cmake_args], cwd=build_dir, env=build_env)
         subprocess.check_call(
             ["cmake", "--build", ".", "--target", "install", *build_args], cwd=build_dir, env=build_env
         )


### PR DESCRIPTION
…ad of `build_metal.sh`

forgot to do this in previous PR