### PR TITLE
#5044: Add optional output tensor for backward ops

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcdiv.py
@@ -40,3 +40,72 @@ def test_bw_addcdiv(input_shapes, value, device):
 
     comp_pcc = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 0.12])
+@pytest.mark.parametrize(
+    "are_required_outputs",
+    [
+        [True, True, True],
+        [True, True, False],
+        [True, False, False],
+        [True, False, True],
+        [False, True, True],
+        [False, True, False],
+        [False, False, True],
+    ],
+)
+def test_bw_addcdiv_with_optional(input_shapes, value, are_required_outputs, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 20, 30, device, True)
+    tensor1_data, tensor1_tensor = data_gen_with_range(input_shapes, -30, -20, device, True)
+    tensor2_data, tensor2_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
+    if are_required_outputs[0]:
+        _, input_grad = data_gen_with_range(input_shapes, 1, 10, device)
+    else:
+        input_grad = None
+    if are_required_outputs[1]:
+        _, tensor1_grad = data_gen_with_range(input_shapes, 10, 20, device)
+    else:
+        tensor1_grad = None
+    if are_required_outputs[2]:
+        _, tensor2_grad = data_gen_with_range(input_shapes, 20, 30, device)
+    else:
+        tensor2_grad = None
+
+    tt_output_tensor_on_device = tt_lib.tensor.addcdiv_bw(
+        grad_tensor,
+        input_tensor,
+        tensor1_tensor,
+        tensor2_tensor,
+        value,
+        are_required_outputs=are_required_outputs,
+        input_grad=input_grad,
+        tensor1_grad=tensor1_grad,
+        tensor2_grad=tensor2_grad,
+    )
+
+    in_data.retain_grad()
+    tensor1_data.retain_grad()
+    tensor2_data.retain_grad()
+
+    pyt_y = torch.addcdiv(in_data, tensor1_data, tensor2_data, value=value)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad, tensor1_data.grad, tensor2_data.grad]
+
+    status = True
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]], 0.99)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addcmul.py
@@ -39,3 +39,54 @@ def test_bw_addcmul(input_shapes, value, device):
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 0.12])
+@pytest.mark.parametrize("are_required_outputs", [[True, True, True], [False, True, True], [False, False, False]])
+def test_bw_addcmul_with_optional(input_shapes, value, are_required_outputs, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 20, 30, device, True)
+    tensor1_data, tensor1_tensor = data_gen_with_range(input_shapes, -30, -20, device, True)
+    tensor2_data, tensor2_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = []
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            _, optional_output_tensor = data_gen_with_range(input_shapes, 1, 10, device, True)
+            output_tensor.append(optional_output_tensor)
+        else:
+            output_tensor.append(None)
+
+    tt_output_tensor_on_device = tt_lib.tensor.addcmul_bw(
+        grad_tensor,
+        input_tensor,
+        tensor1_tensor,
+        tensor2_tensor,
+        value,
+        are_required_outputs=are_required_outputs,
+        output_tensor=output_tensor,
+    )
+
+    in_data.retain_grad()
+    tensor1_data.retain_grad()
+    tensor2_data.retain_grad()
+
+    pyt_y = torch.addcmul(in_data, tensor1_data, tensor2_data, value=value)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad, tensor1_data.grad, tensor2_data.grad]
+
+    status = True
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]], 0.99)
+    assert status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -252,32 +252,42 @@ std::vector<Tensor> exp_bw(const Tensor& grad, const Tensor& input, const Memory
     return operation::decorate_as_composite(__func__, _exp_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _addcmul_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    float value,
-    const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    grad_tensor.emplace_back(grad);
-    Tensor grad_a = mul_unary(ttnn::multiply(grad, tensor2, std::nullopt, output_mem_config), value, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    Tensor grad_b = mul_unary(ttnn::multiply(grad, tensor1, std::nullopt, output_mem_config), value, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
 
-    return grad_tensor;
+std::vector<std::optional<Tensor>> _addcmul_bw(const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool> are_required_outputs, std::vector<std::optional<Tensor>> output_tensor) {
+    if(are_required_outputs.at(0)){
+        output_tensor.at(0) = grad;
+    }
+    else
+    {
+        output_tensor.at(0) = std::nullopt;
+    }
+    if(are_required_outputs.at(1)){
+        output_tensor.at(1) = mul_unary(mul(grad, tensor2, std::nullopt, output_mem_config), value, output_mem_config);
+    }
+    else
+    {
+        output_tensor.at(1) = std::nullopt;
+    }
+    if(are_required_outputs.at(2)){
+        output_tensor.at(2) = mul_unary(mul(grad, tensor1, std::nullopt, output_mem_config), value, output_mem_config);
+    }
+    else
+    {
+        output_tensor.at(2) = std::nullopt;
+    }
+
+    return output_tensor;
 }
-std::vector<Tensor> addcmul_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    float value,
-    const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _addcmul_bw)(
-        grad, input, tensor1, tensor2, value, output_mem_config);
+std::vector<std::optional<Tensor>> addcmul_bw(const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool> are_required_outputs, std::vector<std::optional<Tensor>> output_tensor)
+{
+    return operation::decorate_as_composite(__func__, _addcmul_bw)(grad, input, tensor1, tensor2, value, output_mem_config, are_required_outputs, output_tensor);
 }
+
+    // std::vector<std::optional<Tensor>> grad_tensor;
+    // Tensor opt_tensor_a = output_tensor.value();
+
+    // std::vector<bool> are_required_outputs,
+    // grad_tensor.emplace_back(opt_tensor_a);
 
 std::vector<Tensor> _unary_assign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -252,42 +252,83 @@ std::vector<Tensor> exp_bw(const Tensor& grad, const Tensor& input, const Memory
     return operation::decorate_as_composite(__func__, _exp_bw)(grad, input, output_mem_config);
 }
 
+// std::vector<Tensor> _addcmul_bw(
+//     const Tensor& grad,
+//     const Tensor& input,
+//     const Tensor& tensor1,
+//     const Tensor& tensor2,
+//     float value,
+//     const MemoryConfig& output_mem_config) {
+//     std::vector<Tensor> grad_tensor;
+//     grad_tensor.emplace_back(grad);
+//     Tensor grad_a = mul_unary(ttnn::multiply(grad, tensor2, std::nullopt, output_mem_config), value, output_mem_config);
+//     grad_tensor.emplace_back(grad_a);
+//     Tensor grad_b = mul_unary(ttnn::multiply(grad, tensor1, std::nullopt, output_mem_config), value, output_mem_config);
+//     grad_tensor.emplace_back(grad_b);
 
-std::vector<std::optional<Tensor>> _addcmul_bw(const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool> are_required_outputs, std::vector<std::optional<Tensor>> output_tensor) {
-    if(are_required_outputs.at(0)){
-        output_tensor.at(0) = grad;
-    }
-    else
-    {
-        output_tensor.at(0) = std::nullopt;
-    }
-    if(are_required_outputs.at(1)){
-        output_tensor.at(1) = mul_unary(mul(grad, tensor2, std::nullopt, output_mem_config), value, output_mem_config);
-    }
-    else
-    {
-        output_tensor.at(1) = std::nullopt;
-    }
-    if(are_required_outputs.at(2)){
-        output_tensor.at(2) = mul_unary(mul(grad, tensor1, std::nullopt, output_mem_config), value, output_mem_config);
-    }
-    else
-    {
-        output_tensor.at(2) = std::nullopt;
+//     return grad_tensor;
+// }
+// std::vector<Tensor> addcmul_bw(
+//     const Tensor& grad,
+//     const Tensor& input,
+//     const Tensor& tensor1,
+//     const Tensor& tensor2,
+//     float value,
+//     const MemoryConfig& output_mem_config) {
+//     return operation::decorate_as_composite(__func__, _addcmul_bw)(
+//         grad, input, tensor1, tensor2, value, output_mem_config);
+// }
+
+std::vector<std::optional<Tensor>> _addcmul_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> tensor1_grad, std::optional<Tensor> tensor2_grad) {
+    std::vector<std::optional<Tensor>> result;
+
+    if (are_required_outputs.at(0)) {
+        if(input_grad.has_value()){
+            assign(queue_id, grad, input_grad.value());
+        } else {
+            input_grad = grad;
+        }
+        result.emplace_back(input_grad.value());
+    } else {
+        result.emplace_back(std::nullopt);
     }
 
-    return output_tensor;
+    if (are_required_outputs.at(1)) {
+        if(tensor1_grad.has_value()){
+            ttnn::multiply(queue_id, grad, tensor2, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, tensor1_grad);
+            ttnn::multiply(queue_id, tensor1_grad.value(), full_like(tensor1_grad.value(), value, output_mem_config), std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, tensor1_grad);
+        } else {
+            tensor1_grad = ttnn::multiply(queue_id, grad, tensor2, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+            tensor1_grad = mul_unary(queue_id, tensor1_grad.value(), value, output_mem_config);
+        }
+        result.emplace_back(tensor1_grad.value());
+    } else {
+        result.emplace_back(std::nullopt);
+    }
+
+    if (are_required_outputs.at(2)) {
+        if(tensor2_grad.has_value()){
+            ttnn::multiply(queue_id, grad, tensor1, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, tensor2_grad);
+            ttnn::multiply(queue_id, tensor2_grad.value(), full_like(tensor2_grad.value(), value, output_mem_config), std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, tensor2_grad);
+        } else {
+            tensor2_grad = ttnn::multiply(queue_id, grad, tensor1, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+            tensor2_grad = mul_unary(queue_id, tensor2_grad.value(), value, output_mem_config);
+        }
+        result.emplace_back(tensor2_grad.value());
+    } else {
+        result.emplace_back(std::nullopt);
+    }
+    return std::move(result);
 }
-std::vector<std::optional<Tensor>> addcmul_bw(const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool> are_required_outputs, std::vector<std::optional<Tensor>> output_tensor)
+std::vector<std::optional<Tensor>> addcmul_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> tensor1_grad, std::optional<Tensor> tensor2_grad)
 {
-    return operation::decorate_as_composite(__func__, _addcmul_bw)(grad, input, tensor1, tensor2, value, output_mem_config, are_required_outputs, output_tensor);
+    return operation::decorate_as_composite(__func__, _addcmul_bw)(queue_id, grad, input, tensor1, tensor2, value, output_mem_config, are_required_outputs, input_grad, tensor1_grad, tensor2_grad);
 }
-
-    // std::vector<std::optional<Tensor>> grad_tensor;
-    // Tensor opt_tensor_a = output_tensor.value();
-
-    // std::vector<bool> are_required_outputs,
-    // grad_tensor.emplace_back(opt_tensor_a);
+std::vector<std::optional<Tensor>> addcmul_bw(const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> tensor1_grad, std::optional<Tensor> tensor2_grad)
+{
+    uint8_t default_queue_id = 0;
+    return operation::decorate_as_composite(__func__, _addcmul_bw)(default_queue_id, grad, input, tensor1, tensor2, value, output_mem_config, are_required_outputs, input_grad, tensor1_grad, tensor2_grad);
+}
 
 std::vector<Tensor> _unary_assign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
@@ -516,45 +557,125 @@ std::vector<Tensor> tan_bw(const Tensor& grad, const Tensor& input, const Memory
     return operation::decorate_as_composite(__func__, _tan_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _addcdiv_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    float value,
-    const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    grad_tensor.emplace_back(grad);
-    Tensor t_inf = full_like(input, std::numeric_limits<float>::infinity(), output_mem_config);
-    Tensor t_nan = full_like(input, std::nanf(""), output_mem_config);
-    Tensor grad_a = ttnn::multiply(mul_unary(grad, value, output_mem_config), recip(tensor2, output_mem_config));
-    grad_tensor.emplace_back(where(
-        eqz(tensor2, output_mem_config),
-        where(eqz(grad, output_mem_config), t_nan, t_inf, output_mem_config),
-        grad_a,
-        output_mem_config));
-    Tensor tmp = ttnn::multiply(
-        mul_unary(neg(grad, output_mem_config), value, output_mem_config), tensor1, std::nullopt, output_mem_config);
-    Tensor grad_b =
-        ttnn::multiply(tmp, recip(square(tensor2, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(where(
-        eqz(tensor2, output_mem_config),
-        where(eqz(grad, output_mem_config), t_nan, neg(t_inf, output_mem_config), output_mem_config),
-        grad_b,
-        output_mem_config));
-    return grad_tensor;
+// std::vector<Tensor> _addcdiv_bw(
+//     const Tensor& grad,
+//     const Tensor& input,
+//     const Tensor& tensor1,
+//     const Tensor& tensor2,
+//     float value,
+//     const MemoryConfig& output_mem_config) {
+//     std::vector<Tensor> grad_tensor;
+//     grad_tensor.emplace_back(grad);
+//     Tensor t_inf = full_like(input, std::numeric_limits<float>::infinity(), output_mem_config);
+//     Tensor t_nan = full_like(input, std::nanf(""), output_mem_config);
+//     Tensor grad_a = ttnn::multiply(mul_unary(grad, value, output_mem_config), recip(tensor2, output_mem_config));
+//     grad_tensor.emplace_back(where(
+//         eqz(tensor2, output_mem_config),
+//         where(eqz(grad, output_mem_config), t_nan, t_inf, output_mem_config),
+//         grad_a,
+//         output_mem_config));
+//     Tensor tmp = ttnn::multiply(
+//         mul_unary(neg(grad, output_mem_config), value, output_mem_config), tensor1, std::nullopt, output_mem_config);
+//     Tensor grad_b =
+//         ttnn::multiply(tmp, recip(square(tensor2, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
+//     grad_tensor.emplace_back(where(
+//         eqz(tensor2, output_mem_config),
+//         where(eqz(grad, output_mem_config), t_nan, neg(t_inf, output_mem_config), output_mem_config),
+//         grad_b,
+//         output_mem_config));
+//     return grad_tensor;
+// }
+// std::vector<Tensor> addcdiv_bw(
+//     const Tensor& grad,
+//     const Tensor& input,
+//     const Tensor& tensor1,
+//     const Tensor& tensor2,
+//     float value,
+//     const MemoryConfig& output_mem_config) {
+//     return operation::decorate_as_composite(__func__, _addcdiv_bw)(
+//         grad, input, tensor1, tensor2, value, output_mem_config);
+// }
+
+std::vector<std::optional<Tensor>>  _addcdiv_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> tensor1_grad, std::optional<Tensor> tensor2_grad) {
+    std::vector<std::optional<Tensor>> result;
+    if (are_required_outputs.at(0)) {
+        if(input_grad.has_value()){
+            assign(queue_id, grad, input_grad.value());
+        } else {
+            input_grad = grad;
+        }
+        result.emplace_back(input_grad.value());
+    } else {
+        result.emplace_back(std::nullopt);
+    }
+
+    if (are_required_outputs.at(1)) {
+        if(tensor1_grad.has_value()){
+            ttnn::multiply(queue_id, grad, full_like(grad, value, output_mem_config), std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, tensor1_grad);
+            Tensor temp = recip(queue_id, tensor2, output_mem_config);
+            ttnn::multiply(queue_id, tensor1_grad.value(), temp, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, tensor1_grad);
+            where(queue_id, eqz(grad, output_mem_config), std::nanf(""), std::numeric_limits<float>::infinity(), output_mem_config, tensor1_grad.value());
+            where(queue_id, eqz(tensor2, output_mem_config), tensor1_grad.value(), tensor1_grad.value(), output_mem_config, tensor1_grad.value());
+        }
+        else {
+            tensor1_grad = mul_unary(queue_id, grad, value, output_mem_config);
+            Tensor temp = recip(queue_id, tensor2, output_mem_config);
+            tensor1_grad = ttnn::multiply(queue_id, tensor1_grad.value(), temp, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+            tensor1_grad = where(queue_id,
+            eqz(tensor2, output_mem_config),
+            where(queue_id, eqz(grad, output_mem_config), std::nanf(""), std::numeric_limits<float>::infinity(), output_mem_config),
+            tensor1_grad.value(),
+            output_mem_config);
+        }
+        result.emplace_back(tensor1_grad.value());
+    }
+    else {
+        result.emplace_back(std::nullopt);
+    }
+
+    if (are_required_outputs.at(2)) {
+        if(tensor2_grad.has_value()){
+            tensor2_grad = neg(grad, output_mem_config);
+            ttnn::multiply(queue_id, tensor2_grad.value(), full_like(grad, value, output_mem_config), std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, tensor2_grad);
+            ttnn::multiply(queue_id, tensor2_grad.value(), tensor1, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, tensor2_grad);
+
+            ttnn::multiply(queue_id, tensor2_grad.value(), recip(square(tensor2, output_mem_config), output_mem_config), std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, tensor2_grad);
+
+            Tensor temp = where(queue_id, eqz(grad, output_mem_config), std::nanf(""), neg(full_like(input, std::numeric_limits<float>::infinity(), output_mem_config), output_mem_config), output_mem_config);
+
+            where(queue_id, eqz(tensor2, output_mem_config), temp, tensor2_grad.value(), output_mem_config, tensor2_grad.value());
+        }
+        else {
+            tensor2_grad = neg(grad, output_mem_config);
+            tensor2_grad = mul_unary(queue_id, tensor2_grad.value(), value, output_mem_config);
+            tensor2_grad = ttnn::multiply(queue_id, tensor2_grad.value(), tensor1, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+            tensor2_grad = ttnn::multiply(queue_id, tensor2_grad.value(), recip(square(tensor2, output_mem_config), output_mem_config), std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+            tensor2_grad = where(queue_id,
+            eqz(tensor2, output_mem_config),
+            where(queue_id, eqz(grad, output_mem_config), std::nanf(""), neg(full_like(input, std::numeric_limits<float>::infinity(), output_mem_config), output_mem_config), output_mem_config),
+            tensor2_grad.value(),
+            output_mem_config);
+        }
+        result.emplace_back(tensor2_grad.value());
+    }
+    else {
+        result.emplace_back(std::nullopt);
+    }
+    return std::move(result);
 }
-std::vector<Tensor> addcdiv_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& tensor1,
-    const Tensor& tensor2,
-    float value,
-    const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _addcdiv_bw)(
-        grad, input, tensor1, tensor2, value, output_mem_config);
+std::vector<std::optional<Tensor>> addcdiv_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> tensor1_grad,std::optional<Tensor> tensor2_grad)
+{
+    return operation::decorate_as_composite(__func__, _addcdiv_bw)(queue_id, grad, input, tensor1, tensor2, value, output_mem_config, are_required_outputs, input_grad, tensor1_grad, tensor2_grad);
 }
 
+std::vector<std::optional<Tensor>> addcdiv_bw(const Tensor& grad, const Tensor& input, const Tensor& tensor1, const Tensor& tensor2, float value, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> tensor1_grad,std::optional<Tensor> tensor2_grad)
+{
+    uint8_t default_queue_id = 0;
+    return operation::decorate_as_composite(__func__, _addcdiv_bw)(default_queue_id, grad, input, tensor1, tensor2, value, output_mem_config, are_required_outputs, input_grad, tensor1_grad, tensor2_grad);
+}
 
 std::vector<std::optional<Tensor>> _where_bw(
     uint8_t queue_id,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -36,13 +36,30 @@ std::vector<std::optional<Tensor>> addalpha_bw(
     std::optional<Tensor> input_grad = std::nullopt,
     std::optional<Tensor> other_grad = std::nullopt);
 
-std::vector<Tensor> addcmul_bw(
+std::vector<std::optional<Tensor>> addcmul_bw(
+    uint8_t queue_id,
     const Tensor& grad,
     const Tensor& input,
     const Tensor& tensor1,
     const Tensor& tensor2,
     float value,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true, true},
+    std::optional<Tensor> input_grad = std::nullopt,
+    std::optional<Tensor> tensor1_grad = std::nullopt,
+    std::optional<Tensor> tensor2_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> addcmul_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    const Tensor& tensor1,
+    const Tensor& tensor2,
+    float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true, true},
+    std::optional<Tensor> input_grad = std::nullopt,
+    std::optional<Tensor> tensor1_grad = std::nullopt,
+    std::optional<Tensor> tensor2_grad = std::nullopt);
 
 std::vector<Tensor> unary_mul_bw(
     const Tensor& grad,
@@ -62,13 +79,30 @@ std::vector<Tensor> unary_pow_bw(
     float exponent,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> addcdiv_bw(
+std::vector<std::optional<Tensor>> addcdiv_bw(
+    uint8_t queue_id,
     const Tensor& grad,
     const Tensor& input,
     const Tensor& tensor1,
     const Tensor& tensor2,
     float value,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true, true},
+    std::optional<Tensor> input_grad = std::nullopt,
+    std::optional<Tensor> tensor1_grad = std::nullopt,
+    std::optional<Tensor> tensor2_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> addcdiv_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    const Tensor& tensor1,
+    const Tensor& tensor2,
+    float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true, true},
+    std::optional<Tensor> input_grad = std::nullopt,
+    std::optional<Tensor> tensor1_grad = std::nullopt,
+    std::optional<Tensor> tensor2_grad = std::nullopt);
 
 std::vector<std::optional<Tensor>> mul_bw(
     const Tensor& grad,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -191,14 +191,37 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-
-    m_tensor.def("addcmul_bw", &tt::tt_metal::addcmul_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("value") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true, true}, py::arg("output_tensor").noconvert() = std::vector<std::optional<Tensor>>{std::nullopt, std::nullopt, std::nullopt}, R"doc(
+    m_tensor.def("addcmul_bw",
+            [](const Tensor& grad,
+                const Tensor& input,
+                const Tensor& tensor1,
+                const Tensor& tensor2,
+                const float value,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                std::optional<Tensor> tensor1_grad,
+                std::optional<Tensor> tensor2_grad,
+                uint8_t queue_id) {
+                    return addcmul_bw(queue_id, grad, input, tensor1, tensor2, value, output_mem_config, are_required_outputs, input_grad, tensor1_grad, tensor2_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input").noconvert(),
+            py::arg("tensor1").noconvert(),
+            py::arg("tensor2").noconvert(),
+            py::arg("value") = 1.0f,
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true, true},
+            py::arg("input_grad").noconvert() = std::nullopt,
+            py::arg("tensor1_grad").noconvert() = std::nullopt,
+            py::arg("tensor2_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Performs backward operations for multiplication of ``tensor1``, ``tensor2`` and ``value`` tensors with given ``grad``.
 
             Input tensor must have BFLOAT16 data type.
 
-            Output tensor will have BFLOAT16 data type.
+            Output tensors will have BFLOAT16 data type.
 
             .. csv-table::
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
@@ -210,7 +233,10 @@ namespace tt::tt_metal::detail{
                 "value", "Value", "float", "default to 1.0f", "No"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "are_required_outputs", "Are Required Outputs", "List of bool", "Default value is [True, True, True]", "No"
-                "output_tensor", "Optional Output Tensor", "List of tensor", "Default value is [None, None, None]", "No"
+                "input_grad", "Optional Output Tensor", "tensor", "Default value is None", "No"
+                "tensor1_grad", "Optional Output Tensor", "tensor", "Default value is None", "No"
+                "tensor2_grad", "Optional Output Tensor", "tensor", "Default value is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
 
     m_tensor.def("unary_assign_bw", &tt::tt_metal::unary_assign_bw,
@@ -294,13 +320,37 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("addcdiv_bw", &tt::tt_metal::addcdiv_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("value") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def("addcdiv_bw",
+            [](const Tensor& grad,
+                const Tensor& input,
+                const Tensor& tensor1,
+                const Tensor& tensor2,
+                const float value,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                std::optional<Tensor> tensor1_grad,
+                std::optional<Tensor> tensor2_grad,
+                uint8_t queue_id) {
+                    return addcdiv_bw(queue_id, grad, input, tensor1, tensor2, value, output_mem_config, are_required_outputs, input_grad, tensor1_grad, tensor2_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input").noconvert(),
+            py::arg("tensor1").noconvert(),
+            py::arg("tensor2").noconvert(),
+            py::arg("value") = 1.0f,
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true, true},
+            py::arg("input_grad").noconvert() = std::nullopt,
+            py::arg("tensor1_grad").noconvert() = std::nullopt,
+            py::arg("tensor2_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Performs backward operations for multiplication and division of ``tensor1``, ``tensor2`` and ``value`` tensors with given ``grad``.
 
             Input tensor must have BFLOAT16 data type.
 
-            Output tensor will have BFLOAT16 data type.
+            Output tensors will have BFLOAT16 data type.
 
             .. csv-table::
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
@@ -311,6 +361,11 @@ namespace tt::tt_metal::detail{
                 "tensor2", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "value", "Value", "float", "default to 1.0f", "No"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "are_required_outputs", "Are Required Outputs", "List of bool", "Default value is [True, True, True]", "No"
+                "input_grad", "Optional Output Tensor", "tensor", "Default value is None", "No"
+                "tensor1_grad", "Optional Output Tensor", "tensor", "Default value is None", "No"
+                "tensor2_grad", "Optional Output Tensor", "tensor", "Default value is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
 
     m_tensor.def("add_bw",

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -193,7 +193,7 @@ namespace tt::tt_metal::detail{
 
 
     m_tensor.def("addcmul_bw", &tt::tt_metal::addcmul_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("value") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("value") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true, true}, py::arg("output_tensor").noconvert() = std::vector<std::optional<Tensor>>{std::nullopt, std::nullopt, std::nullopt}, R"doc(
             Performs backward operations for multiplication of ``tensor1``, ``tensor2`` and ``value`` tensors with given ``grad``.
 
             Input tensor must have BFLOAT16 data type.
@@ -209,6 +209,8 @@ namespace tt::tt_metal::detail{
                 "tensor2", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "value", "Value", "float", "default to 1.0f", "No"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "are_required_outputs", "Are Required Outputs", "List of bool", "Default value is [True, True, True]", "No"
+                "output_tensor", "Optional Output Tensor", "List of tensor", "Default value is [None, None, None]", "No"
         )doc");
 
     m_tensor.def("unary_assign_bw", &tt::tt_metal::unary_assign_bw,


### PR DESCRIPTION
Add  optional output tensor support for backward op addcmul.
Primary issue : #5044 