### PR TITLE
#5044: Add optional tensor output for composite ops

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -472,6 +472,10 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_addcdiv,
         "pytorch_op": pytorch_ops.addcdiv,
     },
+    "eltwise-addcdiv": {
+        "tt_op": tt_lib_ops.eltwise_addcdiv_with_output,
+        "pytorch_op": pytorch_ops.addcdiv,
+    },
     "eltwise-sigmoid": {
         "tt_op": tt_lib_ops.eltwise_sigmoid,
         "pytorch_op": pytorch_ops.sigmoid,

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -565,6 +565,30 @@ def eltwise_addcdiv(
 
 
 @setup_host_and_device
+def eltwise_addcdiv_with_output(
+    x,
+    y,
+    z,
+    *args,
+    scalar,
+    output_tensor,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+    output_tensor = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+    t3 = ttl.tensor.addcdiv(t0, t1, t2, scalar, output_mem_config, output_tensor)
+
+    return tt2torch_tensor(t3)
+
+
+@setup_host_and_device
 def unary_div_bw(
     x,  # grad_tensor
     y,  # input_tensor

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_addcdiv_output_tensor.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_addcdiv_output_tensor.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+import sys
+from loguru import logger
+import numpy as np
+import random
+import pytest
+import torch
+import tt_lib as ttl
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.tt_eager.python_api_testing.sweep_tests.pytorch_ops import addcdiv as pt_eltwise_addcdiv
+from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import eltwise_addcdiv as tt_eltwise_addcdiv
+from tests.tt_eager.python_api_testing.sweep_tests.tt_lib_ops import (
+    eltwise_addcdiv_with_output as tt_eltwise_addcdiv_with_output,
+)
+
+
+def run_eltwise_addcdiv_with_output_tests(
+    input_shape, dtype, dlayout, in_mem_config, out_mem_config, scalar, data_seed, device
+):
+    torch.manual_seed(data_seed)
+
+    x = torch.Tensor(size=input_shape).uniform_(-100, 100)
+    y = torch.Tensor(size=input_shape).uniform_(-100, 100)
+    z = torch.Tensor(size=input_shape).uniform_(-100, 100)
+    output_tensor = torch.Tensor(size=input_shape).uniform_(-100, 100)
+
+    # get referent value
+    ref_value = pt_eltwise_addcdiv(x, y, z, scalar=scalar)
+
+    # calculate tt output
+    logger.info("Running Eltwise addcdiv test")
+    output_tensor = tt_eltwise_addcdiv_with_output(
+        x=x,
+        y=y,
+        z=z,
+        scalar=scalar,
+        output_tensor=output_tensor,
+        device=device,
+        dtype=[dtype, dtype, dtype],
+        layout=[dlayout, dlayout, dlayout],
+        input_mem_config=in_mem_config,
+        output_mem_config=out_mem_config,
+    )
+    logger.info("Done")
+
+    # compare tt and golden outputs
+    success, pcc_value = comp_pcc(ref_value, output_tensor)
+    logger.debug(pcc_value)
+
+    assert success
+
+
+test_sweep_args = [
+    (
+        (1, 1, 32, 32),
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.Layout.TILE,
+        [
+            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ],
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        0.78125,
+        3514701,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shape, dtype, dlayout, in_mem_config, out_mem_config, scalar, data_seed",
+    (test_sweep_args),
+)
+def test_eltwise_addcdiv_with_output_test(
+    input_shape, dtype, dlayout, in_mem_config, out_mem_config, scalar, data_seed, device
+):
+    random.seed(0)
+    run_eltwise_addcdiv_with_output_tests(
+        input_shape, dtype, dlayout, in_mem_config, out_mem_config, scalar, data_seed, device
+    )

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -163,7 +163,8 @@ Tensor addcdiv(
     const Tensor& input_b,
     const Tensor& input_c,
     float value,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 
 Tensor div(
     const Tensor& input_a,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -790,7 +790,7 @@ namespace tt::tt_metal::detail{
         )doc");
 
         m_tensor.def("addcdiv", &addcdiv,
-            py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("value"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("value"), py::arg("output_tensor").noconvert() = std::nullopt, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs the element-wise division of tensor1 ``tensor1`` by tensor2 ``tensor2``, multiplies the result
             by the scalar value ``value`` and adds it to input ``input``.
 


### PR DESCRIPTION
Added the optional tensor support for addcdiv for an initial example.
Once it is been approved, further implementing the same for all the composite structures.
Primary issue : #5044 