### PR TITLE
Disable Mamba end-to-end perf test due to hangs in CI

### DIFF
--- a/models/demos/mamba/tests/test_mamba_perf.py
+++ b/models/demos/mamba/tests/test_mamba_perf.py
@@ -15,10 +15,11 @@ from models.demos.mamba.demo.demo import (
 
 from models.perf.perf_utils import prep_perf_report
 from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
-from models.utility_functions import profiler, enable_persistent_kernel_cache, skip_for_grayskull
+from models.utility_functions import profiler, enable_persistent_kernel_cache, skip_for_grayskull, skip_for_wormhole_b0
 from tt_metal.tools.profiler.process_model_log import get_samples_per_s
 
 
+@skip_for_wormhole_b0("Non-deterministic hang on CI (#8606)")
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(


### PR DESCRIPTION
There is currently a non-deterministic hang on CI, so we are disabling this test until we can figure out what the issue is.