### PR TITLE
Mo/8223 fd2 dispatch core profiler support

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -273,7 +273,7 @@ def device(request, device_params):
 
     yield device
 
-    ttl.device.DumpDeviceProfiler(device, True)
+    ttl.device.DumpDeviceProfiler(device)
     ttl.device.DeallocateBuffers(device)
 
     ttl.device.Synchronize(device)
@@ -292,7 +292,7 @@ def pcie_devices(request, device_params):
     yield [devices[i] for i in range(num_devices)]
 
     for device in devices.values():
-        ttl.device.DumpDeviceProfiler(device, True)
+        ttl.device.DumpDeviceProfiler(device)
         ttl.device.DeallocateBuffers(device)
 
     ttl.device.CloseDevices(devices)
@@ -310,7 +310,7 @@ def all_devices(request, device_params):
     yield [devices[i] for i in range(num_devices)]
 
     for device in devices.values():
-        ttl.device.DumpDeviceProfiler(device, True)
+        ttl.device.DumpDeviceProfiler(device)
         ttl.device.DeallocateBuffers(device)
 
     ttl.device.CloseDevices(devices)
@@ -334,7 +334,7 @@ def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
     import tt_lib as ttl
 
     for device in device_mesh.get_devices():
-        ttl.device.DumpDeviceProfiler(device, True)
+        ttl.device.DumpDeviceProfiler(device)
         ttl.device.DeallocateBuffers(device)
 
     ttnn.close_device_mesh(device_mesh)
@@ -361,7 +361,7 @@ def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
     import tt_lib as ttl
 
     for device in device_mesh.get_devices():
-        ttl.device.DumpDeviceProfiler(device, True)
+        ttl.device.DumpDeviceProfiler(device)
         ttl.device.DeallocateBuffers(device)
 
     ttnn.close_device_mesh(device_mesh)
@@ -388,7 +388,7 @@ def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
     import tt_lib as ttl
 
     for device in device_mesh.get_devices():
-        ttl.device.DumpDeviceProfiler(device, True)
+        ttl.device.DumpDeviceProfiler(device)
         ttl.device.DeallocateBuffers(device)
 
     ttnn.close_device_mesh(device_mesh)

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -61,12 +61,7 @@ run_profiling_test(){
 
     run_async_mode_T3000_test
 
-    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py::test_custom_cycle_count -vvv
-    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py::test_full_buffer -vvv
-    #TODO(MO): Needed until #6560 is fixed.
-    if [ "$ARCH_NAME" != "grayskull" ]; then
-        TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py::test_multi_op -vvv
-    fi
+    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py
 
     remove_default_log_locations
 
@@ -92,7 +87,7 @@ run_profiling_no_reset_test(){
     source python_env/bin/activate
     export PYTHONPATH=$TT_METAL_HOME
 
-    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py::test_multi_op -vvv
+    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler_gs_no_reset.py
 
     remove_default_log_locations
 }

--- a/tests/tt_metal/tools/profiler/test_device_profiler_gs_no_reset.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler_gs_no_reset.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from tests.tt_metal.tools.profiler import test_device_profiler
+
+
+def test_multi_op_gs_no_reset():
+    test_device_profiler.test_multi_op()

--- a/tt_eager/tracy.py
+++ b/tt_eager/tracy.py
@@ -300,6 +300,8 @@ def main():
             testCommand = f"python -m tracy {osCmd}"
 
             envVars = dict(os.environ)
+            # No Dispatch cores for op_report
+            envVars["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
             if options.device:
                 envVars["TT_METAL_DEVICE_PROFILER"] = "1"
             else:

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -198,14 +198,14 @@ void DeviceModule(py::module &m_device) {
         the FinishCommand. Once set to false, all subsequent commands will immediately notify the device
         that the write pointer has been updated.
     )doc");
-    m_device.def("DumpDeviceProfiler", &detail::DumpDeviceProfiler, py::arg("device"), py::arg("free_buffers") = false, R"doc(
+    m_device.def("DumpDeviceProfiler", &detail::DumpDeviceProfiler, py::arg("device"), py::arg("last_dump") = false, R"doc(
         Dump device side profiling data.
 
         +------------------+----------------------------------+-----------------------+-------------+----------+
         | Argument         | Description                      | Data type             | Valid range | Required |
         +==================+==================================+=======================+=============+==========+
         | device           | Device to dump profiling data of | tt_lib.device.Device  |             | Yes      |
-        | free_buffers     | Option to free buffer            | bool                  |             | No       |
+        | last_dump        | Last dump before process dies    | bool                  |             | No       |
         +------------------+----------------------------------+-----------------------+-------------+----------+
     )doc");
     m_device.def("DeallocateBuffers", &detail::DeallocateBuffers, R"doc(

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -165,9 +165,9 @@ namespace tt::tt_metal{
          * |---------------|---------------------------------------------------|--------------------------------------------------------------|---------------------------|----------|
          * | device        | The device holding the program being profiled.    | Device *                                                     |                           | True     |
          * | core_coords   | The logical core coordinates being profiled.      | const std::unordered_map<CoreType, std::vector<CoreCoord>> & |                           | True     |
-         * | free_buffers  | Free up the profiler buffer spaces for the device | bool                                                         |                           | False    |
+         * | last_dump     | Last dump before process dies                     | bool                                                         |                           | False    |
          * */
-        void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cores, bool free_buffers = false);
+        void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cores, bool last_dump = false);
 
         /**
          * Traverse all cores and read device side profiler data and dump results into device side CSV log
@@ -177,9 +177,9 @@ namespace tt::tt_metal{
          * | Argument      | Description                                       | Type                                                         | Valid Range               | Required |
          * |---------------|---------------------------------------------------|--------------------------------------------------------------|---------------------------|----------|
          * | device        | The device holding the program being profiled.    | Device *                                                     |                           | True     |
-         * | free_buffers  | Free up the profiler buffer spaces for the device | bool                                                         |                           | False    |
+         * | last_dump     | Last dump before process dies                     | bool                                                         |                           | False    |
          * */
-        void DumpDeviceProfileResults(Device *device, bool free_buffers = false);
+        void DumpDeviceProfileResults(Device *device, bool last_dump = false);
 
         /**
          * Set the directory for device-side CSV logs produced by the profiler instance in the tt-metal module
@@ -333,9 +333,9 @@ namespace tt::tt_metal{
             DispatchStateCheck(true);
             LAZY_COMMAND_QUEUE_MODE = lazy;
         }
-        inline void DumpDeviceProfiler(Device * device, bool free_buffers)
+        inline void DumpDeviceProfiler(Device * device, bool last_dump)
         {
-            tt::tt_metal::detail::DumpDeviceProfileResults(device, free_buffers);
+            tt::tt_metal::detail::DumpDeviceProfileResults(device, last_dump);
         }
 
         void AllocateBuffer(Buffer* buffer, bool bottom_up);

--- a/tt_metal/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/profiler_common.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#define PROFILER_OPT_DO_DISPATCH_CORES 2
+
 namespace kernel_profiler{
 
     constexpr static uint32_t PADDING_MARKER = ((1<<16) - 1);
@@ -40,7 +42,9 @@ namespace kernel_profiler{
         RUN_COUNTER,
         NOC_X,
         NOC_Y,
-        FLAT_ID
+        FLAT_ID,
+        DROPPED_ZONES,
+        PROFILER_DONE,
     };
 
 

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -65,12 +65,15 @@ CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
 #define MEM_MOVER_VIEW_IRAM_BASE_ADDR (0x4 << 12)
 
+#if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
-uint32_t wIndex __attribute__((used));
-uint32_t stackSize __attribute__((used));
-uint32_t sums[SUM_COUNT] __attribute__((used));
-uint32_t sumIDs[SUM_COUNT] __attribute__((used));
-}  // namespace kernel_profiler
+    uint32_t wIndex __attribute__((used));
+    uint32_t stackSize __attribute__((used));
+    uint32_t sums[SUM_COUNT] __attribute__((used));
+    uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+    uint16_t core_flat_id __attribute__((used));
+}
+#endif
 
 void enable_power_management() {
     // Mask and Hyst taken from tb_tensix math_tests

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -24,12 +24,15 @@ void ApplicationHandler(void) __attribute__((__section__(".init")));
 }
 #endif
 
+#if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
     uint32_t wIndex __attribute__((used));
     uint32_t stackSize __attribute__((used));
     uint32_t sums[SUM_COUNT] __attribute__((used));
     uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+    uint16_t core_flat_id __attribute__((used));
 }
+#endif
 
 uint8_t noc_index = 0;  // TODO: remove hardcoding
 uint8_t my_x[NUM_NOCS] __attribute__((used));

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -48,12 +48,15 @@ constexpr uint32_t num_cbs_to_early_init = 4;  // safe small number to overlap w
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
+#if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
     uint32_t wIndex __attribute__((used));
     uint32_t stackSize __attribute__((used));
     uint32_t sums[SUM_COUNT] __attribute__((used));
     uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+    uint16_t core_flat_id __attribute__((used));
 }
+#endif
 
 //inline void RISC_POST_STATUS(uint32_t status) {
 //  volatile uint32_t* ptr = (volatile uint32_t*)(NOC_CFG(ROUTER_CFG_2));
@@ -101,7 +104,7 @@ int main() {
         DEBUG_STATUS("GD");
 
         {
-            DeviceZoneScopedMainN("ERISC-FW");
+            DeviceZoneScopedMainN("ERISC-IDLE-FW");
 
             noc_index = mailboxes->launch.brisc_noc_id;
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -33,12 +33,18 @@ uint32_t atomic_ret_val __attribute__((section("l1_data"))) __attribute__((used)
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
+#if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
-uint32_t wIndex __attribute__((used));
-uint32_t stackSize __attribute__((used));
-uint32_t sums[SUM_COUNT] __attribute__((used));
-uint32_t sumIDs[SUM_COUNT] __attribute__((used));
-}  // namespace kernel_profiler
+    uint32_t wIndex __attribute__((used));
+    uint32_t stackSize __attribute__((used));
+    uint32_t sums[SUM_COUNT] __attribute__((used));
+    uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+    uint16_t core_flat_id __attribute__((used));
+    uint32_t nocWriteSize __attribute__((used));
+    uint32_t *nocWriteBuffer __attribute__((used));
+    uint32_t *nocWriteIndex __attribute__((used));
+}
+#endif
 
 extern "C" void ncrisc_resume(void);
 extern "C" void notify_brisc_and_halt(uint32_t status);

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -16,12 +16,14 @@
 #include "circular_buffer.h"
 // clang-format on
 
+#if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
-uint32_t wIndex __attribute__((used));
-uint32_t stackSize __attribute__((used));
-uint32_t sums[SUM_COUNT] __attribute__((used));
-uint32_t sumIDs[SUM_COUNT] __attribute__((used));
-}  // namespace kernel_profiler
+    uint32_t wIndex __attribute__((used));
+    uint32_t stackSize __attribute__((used));
+    uint32_t sums[SUM_COUNT] __attribute__((used));
+    uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+}
+#endif
 
 namespace ckernel {
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1307,8 +1307,6 @@ bool Device::close() {
     if (not this->initialized_) {
         TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
     }
-    this->deallocate_buffers();
-    watcher_detach(this);
 
     for (const std::unique_ptr<HWCommandQueue> &hw_command_queue : hw_command_queues_) {
         if (hw_command_queue->manager.get_bypass_mode()) {
@@ -1316,8 +1314,15 @@ bool Device::close() {
         }
         hw_command_queue->terminate();
     }
+
+    tt_metal::detail::DumpDeviceProfileResults(this, true);
+
     this->trace_buffer_pool_.clear();
     detail::EnableAllocs(this);
+
+    this->deallocate_buffers();
+    watcher_detach(this);
+
 
     std::unordered_set<CoreCoord> not_done_dispatch_cores;
     std::unordered_set<CoreCoord> cores_to_skip;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -863,6 +863,7 @@ void kernel_main() {
     }
     bool done = false;
     while (!done) {
+        DeviceZoneScopedND("CQ-DISPATCH", block_noc_writes_to_clear, rd_block_idx );
         if (cmd_ptr == cb_fence) {
             get_cb_page<
                 dispatch_cb_base,

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -812,6 +812,7 @@ bool process_cmd(uint32_t& cmd_ptr,
                  uint32_t& downstream_data_ptr,
                  uint32_t& stride) {
 
+    DeviceZoneScopedND("PROCESS-CMD", block_noc_writes_to_clear, rd_block_idx );
     volatile CQPrefetchCmd tt_l1_ptr *cmd = (volatile CQPrefetchCmd tt_l1_ptr *)cmd_ptr;
     bool done = false;
 
@@ -1101,9 +1102,9 @@ void kernel_main_hd() {
 
     uint32_t cmd_ptr = cmddat_q_base;
     uint32_t fence = cmddat_q_base;
-
     bool done = false;
     while (!done) {
+        DeviceZoneScopedND("KERNEL-MAIN-HD", block_noc_writes_to_clear, rd_block_idx );
         constexpr uint32_t preamble_size = 0;
         fetch_q_get_cmds<preamble_size>(fence, cmd_ptr, pcie_read_ptr);
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -86,7 +86,12 @@ void JitBuildEnv::init(uint32_t build_key, tt::ARCH arch) {
     this->defines_ += "-DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 ";
 
     if (tt::tt_metal::getDeviceProfilerState()) {
-        this->defines_ += "-DPROFILE_KERNEL=1 ";
+        if (tt::llrt::OptionsG.get_profiler_do_dispatch_cores()) {
+            //TODO(MO): Standard bit mask for device side profiler options
+            this->defines_ += "-DPROFILE_KERNEL=2 ";
+        } else {
+            this->defines_ += "-DPROFILE_KERNEL=1 ";
+        }
     }
 
     if (tt::llrt::OptionsG.get_watcher_enabled()) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -47,10 +47,15 @@ RunTimeOptions::RunTimeOptions() {
     test_mode_enabled = false;
 
     profiler_enabled = false;
+    profile_dispatch_cores = false;
 #if defined(PROFILER)
     const char *profiler_enabled_str = std::getenv("TT_METAL_DEVICE_PROFILER");
     if (profiler_enabled_str != nullptr && profiler_enabled_str[0] == '1') {
         profiler_enabled = true;
+        const char *profile_dispatch_str = std::getenv("TT_METAL_DEVICE_PROFILER_DISPATCH");
+        if (profile_dispatch_str != nullptr && profile_dispatch_str[0] == '1') {
+            profile_dispatch_cores = true;
+        }
     }
 #endif
     TT_FATAL(

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -86,6 +86,7 @@ class RunTimeOptions {
     bool test_mode_enabled = false;
 
     bool profiler_enabled = false;
+    bool profile_dispatch_cores = false;
 
     bool null_kernels = false;
 
@@ -213,6 +214,7 @@ class RunTimeOptions {
     inline void set_test_mode_enabled(bool enable) { test_mode_enabled = enable; }
 
     inline bool get_profiler_enabled() { return profiler_enabled; }
+    inline bool get_profiler_do_dispatch_cores() { return profile_dispatch_cores; }
 
     inline void set_kernels_nullified(bool v) { null_kernels = v; }
     inline bool get_kernels_nullified() { return null_kernels; }

--- a/tt_metal/programming_examples/profiler/CMakeLists.txt
+++ b/tt_metal/programming_examples/profiler/CMakeLists.txt
@@ -3,6 +3,7 @@ set(PROFILER_EXAMPLES_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/test_custom_cycle_count/test_custom_cycle_count
     ${CMAKE_CURRENT_SOURCE_DIR}/test_full_buffer/test_full_buffer
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_op/test_multi_op
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_dispatch_cores/test_dispatch_cores
 )
 
 CREATE_PGM_EXAMPLES_EXE("${PROFILER_EXAMPLES_SRCS}" "profiler")

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -7,10 +7,8 @@
 
 using namespace tt;
 
-bool RunCustomCycle(tt_metal::Device *device, int loop_count)
+void RunCustomCycle(tt_metal::Device *device, int loop_count)
 {
-    bool pass = true;
-
     CoreCoord compute_with_storage_size = device->compute_with_storage_grid_size();
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {compute_with_storage_size.x - 1, compute_with_storage_size.y - 1};
@@ -44,8 +42,6 @@ bool RunCustomCycle(tt_metal::Device *device, int loop_count)
 
     EnqueueProgram(device->command_queue(), program, false);
     tt_metal::DumpDeviceProfileResults(device, program);
-
-    return pass;
 }
 
 int main(int argc, char **argv) {
@@ -60,7 +56,7 @@ int main(int argc, char **argv) {
             tt_metal::CreateDevice(device_id);
 
         int loop_count = 2000;
-        pass &= RunCustomCycle(device, loop_count);
+        RunCustomCycle(device, loop_count);
 
         pass &= tt_metal::CloseDevice(device);
 

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
 
         // Run 2
         RunCustomCycle(device, PROFILER_OP_SUPPORT_COUNT);
-        tt_metal::detail::DumpDeviceProfileResults(device);
+        Finish(device->command_queue());
 
         pass &= tt_metal::CloseDevice(device);
 

--- a/tt_metal/tools/profiler/device_post_proc_config.py
+++ b/tt_metal/tools/profiler/device_post_proc_config.py
@@ -161,6 +161,36 @@ class test_full_buffer(default_setup):
     detectOps = False
 
 
+class test_dispatch_cores(default_setup):
+    timerAnalysis = {
+        "Tensix CQ Dispatch": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "NCRISC", "zone_name": "CQ-DISPATCH"},
+            "end": {"risc": "NCRISC", "zone_name": "CQ-DISPATCH"},
+        },
+        "Tensix CQ Prefetch": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "NCRISC", "zone_name": "KERNEL-MAIN-HD"},
+            "end": {"risc": "NCRISC", "zone_name": "KERNEL-MAIN-HD"},
+        },
+        "Ethernet CQ Dispatch": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "ERISC", "zone_name": "CQ-DISPATCH"},
+            "end": {"risc": "ERISC", "zone_name": "CQ-DISPATCH"},
+        },
+        "Ethernet CQ Prefetch": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "ERISC", "zone_name": "KERNEL-MAIN-HD"},
+            "end": {"risc": "ERISC", "zone_name": "KERNEL-MAIN-HD"},
+        },
+    }
+    detectOps = False
+
+
 class test_noc(default_setup):
     timerAnalysis = {
         "NoC For Loop": {

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -8,7 +8,7 @@
 
 #include <climits>
 
-#if defined(COMPILE_FOR_NCRISC) | defined(COMPILE_FOR_BRISC) | defined(COMPILE_FOR_ERISC)
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC)
 #include "risc_common.h"
 #include "dataflow_api.h"
 #else
@@ -33,7 +33,7 @@
 #define PROFILER_MSG __FILE__ "," $Line ",KERNEL_PROFILER"
 #define PROFILER_MSG_NAME( name )  name "," PROFILER_MSG
 
-#ifdef PROFILE_KERNEL
+#if  defined(PROFILE_KERNEL) && ( !defined(DISPATCH_KERNEL) || (defined(DISPATCH_KERNEL) && defined(COMPILE_FOR_NCRISC) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES)))
 namespace kernel_profiler{
 
     extern uint32_t wIndex;
@@ -42,20 +42,29 @@ namespace kernel_profiler{
     extern uint32_t sums[SUM_COUNT];
     extern uint32_t sumIDs[SUM_COUNT];
 
+#if (defined(DISPATCH_KERNEL) && defined(COMPILE_FOR_NCRISC) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES))
+    extern uint32_t nocWriteSize;
+    extern uint32_t *nocWriteBuffer;
+    extern uint32_t *nocWriteIndex;
+#endif
+
+    constexpr uint32_t QUICK_PUSH_MARKER_COUNT = 2;
+
 #if defined(COMPILE_FOR_BRISC)
     constexpr uint32_t profilerBuffer = PROFILER_L1_BUFFER_BR;
     constexpr uint32_t deviceBufferEndIndex = DEVICE_BUFFER_END_INDEX_BR;
     volatile tt_l1_ptr uint32_t *profiler_control_buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_CONTROL);
-    uint16_t core_flat_id;
+    extern uint16_t core_flat_id;
 #elif defined(COMPILE_FOR_ERISC)
     constexpr uint32_t profilerBuffer = eth_l1_mem::address_map::PROFILER_L1_BUFFER_ER;
     constexpr uint32_t deviceBufferEndIndex = DEVICE_BUFFER_END_INDEX_ER;
     volatile tt_l1_ptr uint32_t *profiler_control_buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(eth_l1_mem::address_map::PROFILER_L1_BUFFER_CONTROL);
-    uint16_t core_flat_id;
+    extern uint16_t core_flat_id;
 #elif defined(COMPILE_FOR_NCRISC)
     constexpr uint32_t profilerBuffer = PROFILER_L1_BUFFER_NC;
     constexpr uint32_t deviceBufferEndIndex = DEVICE_BUFFER_END_INDEX_NC;
     volatile tt_l1_ptr uint32_t *profiler_control_buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_CONTROL);
+    extern uint16_t core_flat_id;
 #elif COMPILE_FOR_TRISC == 0
     constexpr uint32_t profilerBuffer = PROFILER_L1_BUFFER_T0;
     constexpr uint32_t deviceBufferEndIndex = DEVICE_BUFFER_END_INDEX_T0;
@@ -70,6 +79,18 @@ namespace kernel_profiler{
     volatile tt_l1_ptr uint32_t *profiler_control_buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_CONTROL);
 #endif
 
+    constexpr uint32_t Hash32_CT( const char * str, size_t n, uint32_t basis = UINT32_C( 2166136261 ) ) {
+        return n == 0 ? basis : Hash32_CT( str + 1, n - 1, ( basis ^ str[ 0 ] ) * UINT32_C( 16777619 ) );
+    }
+
+    template< size_t N >
+    constexpr uint32_t Hash16_CT( const char ( &s )[ N ] ) {
+        auto res = Hash32_CT( s, N - 1 );
+        return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
+    }
+
+#define SrcLocNameToHash( name ) DO_PRAGMA(message(PROFILER_MSG_NAME(name))); auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME( name ));
+
     inline __attribute__((always_inline)) void init_profiler(uint16_t briscKernelID = 0, uint16_t ncriscKernelID = 0, uint16_t triscsKernelID = 0)
     {
         wIndex = CUSTOM_MARKERS;
@@ -81,8 +102,13 @@ namespace kernel_profiler{
             sums[i] = 0;
         }
 
-#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_BRISC)
+#if (defined(DISPATCH_KERNEL) && defined(COMPILE_FOR_NCRISC) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES))
+    nocWriteSize = 0;
+#endif
+
+#if defined(COMPILE_FOR_ERISC) ||  defined(COMPILE_FOR_BRISC)
         uint32_t runCounter = profiler_control_buffer[RUN_COUNTER];
+        profiler_control_buffer[PROFILER_DONE] = 0;
 
 #if defined(COMPILE_FOR_ERISC)
         volatile tt_l1_ptr uint32_t *eriscBuffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(eth_l1_mem::address_map::PROFILER_L1_BUFFER_ER);
@@ -114,7 +140,8 @@ namespace kernel_profiler{
         eriscBuffer [ID_LL] = runCounter;
 
 #endif //ERISC_INIT
-#if defined(COMPILE_FOR_BRISC)
+#if  defined(COMPILE_FOR_BRISC)
+
         volatile tt_l1_ptr uint32_t *briscBuffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_BR);
         volatile tt_l1_ptr uint32_t *ncriscBuffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_NC);
         volatile tt_l1_ptr uint32_t *trisc0Buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_T0);
@@ -186,6 +213,22 @@ namespace kernel_profiler{
         buffer[index+1] = p_reg[0];
     }
 
+    inline __attribute__((always_inline)) void mark_start_at_index_inlined(uint32_t index)
+    {
+        volatile tt_l1_ptr uint32_t *buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kernel_profiler::profilerBuffer);
+        volatile tt_reg_ptr uint32_t *p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t *> (RISCV_DEBUG_REG_WALL_CLOCK_L);
+        buffer[index+1] = p_reg[0];
+    }
+
+    inline __attribute__((always_inline)) void mark_end_at_index_inlined(uint32_t index, uint32_t timer_id_s, uint32_t timer_id)
+    {
+        volatile tt_l1_ptr uint32_t *buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kernel_profiler::profilerBuffer);
+        volatile tt_reg_ptr uint32_t *p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t *> (RISCV_DEBUG_REG_WALL_CLOCK_L);
+        buffer[index] = 0x80000000 | ((timer_id_s & 0x7FFFF) << 12) | (p_reg[1] & 0xFFF);
+        buffer[index+2] = 0x80000000 | ((timer_id & 0x7FFFF) << 12) | (p_reg[1] & 0xFFF);
+        buffer[index+3] = p_reg[0];
+    }
+
     PROFILER_INLINE void mark_padding()
     {
         if (wIndex < PROFILER_L1_VECTOR_SIZE)
@@ -204,6 +247,13 @@ namespace kernel_profiler{
 
         profiler_control_buffer[FW_RESET_L] = time_L;
         profiler_control_buffer[FW_RESET_H] = time_H;
+    }
+
+
+    inline __attribute__((always_inline)) void mark_dropped_timestamps(uint32_t index)
+    {
+        uint32_t curr = profiler_control_buffer[DROPPED_ZONES];
+        profiler_control_buffer[DROPPED_ZONES] = (1 << index) | curr;
     }
 
     inline __attribute__((always_inline)) void risc_finished_profiling()
@@ -227,17 +277,19 @@ namespace kernel_profiler{
             mark_padding();
         }
         profiler_control_buffer[kernel_profiler::deviceBufferEndIndex] = wIndex;
-
     }
 
     inline __attribute__((always_inline)) void finish_profiler()
     {
         risc_finished_profiling();
-#if (defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_BRISC))
-
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_BRISC)
+        if (profiler_control_buffer[PROFILER_DONE] == 1){
+            return;
+        }
         uint32_t pageSize =
             PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * PROFILER_RISC_COUNT * profiler_core_count_per_dram;
 
+        while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
         uint32_t dram_profiler_address = profiler_control_buffer[DRAM_PROFILER_ADDRESS];
 
 #if defined(COMPILE_FOR_ERISC)
@@ -269,74 +321,143 @@ namespace kernel_profiler{
         }
         else
         {
-            profiler_control_buffer[hostIndex] = PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC+1;
+            mark_dropped_timestamps(hostIndex);
         }
 #endif
-#if defined(COMPILE_FOR_BRISC)
+#if  defined(COMPILE_FOR_BRISC)
         int hostIndex;
         int deviceIndex;
-        for (hostIndex = kernel_profiler::HOST_BUFFER_END_INDEX_BR, deviceIndex = kernel_profiler::DEVICE_BUFFER_END_INDEX_BR;
-                (hostIndex <= kernel_profiler::HOST_BUFFER_END_INDEX_T2) && (deviceIndex <= kernel_profiler::DEVICE_BUFFER_END_INDEX_T2);
-                hostIndex++, deviceIndex++)
-        {
-            if (profiler_control_buffer[deviceIndex])
-            {
-                uint32_t currEndIndex =
-                    profiler_control_buffer[deviceIndex] +
-                    profiler_control_buffer[hostIndex];
+	for (hostIndex = kernel_profiler::HOST_BUFFER_END_INDEX_BR, deviceIndex = kernel_profiler::DEVICE_BUFFER_END_INDEX_BR;
+		(hostIndex <= kernel_profiler::HOST_BUFFER_END_INDEX_T2) && (deviceIndex <= kernel_profiler::DEVICE_BUFFER_END_INDEX_T2);
+		hostIndex++, deviceIndex++)
+	{
+	    if (profiler_control_buffer[deviceIndex])
+	    {
+		uint32_t currEndIndex =
+		    profiler_control_buffer[deviceIndex] +
+		    profiler_control_buffer[hostIndex];
 
-                uint32_t dram_offset =
-                    (core_flat_id % profiler_core_count_per_dram) * PROFILER_RISC_COUNT * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
-                    hostIndex * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
-                    profiler_control_buffer[hostIndex] * sizeof(uint32_t);
+		if (currEndIndex <= PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC)
+		{
+		    uint32_t dram_offset =
+			(core_flat_id % profiler_core_count_per_dram) * PROFILER_RISC_COUNT * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+			hostIndex * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+			profiler_control_buffer[hostIndex] * sizeof(uint32_t);
 
-                const InterleavedAddrGen<true> s = {
-                    .bank_base_address = dram_profiler_address,
-                    .page_size = pageSize
-                };
+		    const InterleavedAddrGen<true> s = {
+			.bank_base_address = dram_profiler_address,
+			.page_size = pageSize
+		    };
 
-                if ( currEndIndex <= PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC)
-                {
+		    uint64_t dram_bank_dst_noc_addr = s.get_noc_addr(core_flat_id / profiler_core_count_per_dram, dram_offset);
+
+		    noc_async_write(
+			    PROFILER_L1_BUFFER_BR + hostIndex * PROFILER_L1_BUFFER_SIZE,
+			    dram_bank_dst_noc_addr,
+			    profiler_control_buffer[deviceIndex] * sizeof(uint32_t));
+
+		    profiler_control_buffer[hostIndex] = currEndIndex;
+		}
+		else if (profiler_control_buffer[RUN_COUNTER] < 1)
+		{
+                    uint32_t dram_offset =
+                        (core_flat_id % profiler_core_count_per_dram) *
+                        PROFILER_RISC_COUNT * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+                        hostIndex * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC;
+
+                    const InterleavedAddrGen<true> s = {
+                        .bank_base_address = dram_profiler_address,
+                        .page_size = pageSize
+                    };
+
                     uint64_t dram_bank_dst_noc_addr = s.get_noc_addr(core_flat_id / profiler_core_count_per_dram, dram_offset);
 
                     noc_async_write(
                             PROFILER_L1_BUFFER_BR + hostIndex * PROFILER_L1_BUFFER_SIZE,
                             dram_bank_dst_noc_addr,
-                            profiler_control_buffer[deviceIndex] * sizeof(uint32_t));
-
-                    profiler_control_buffer[hostIndex] = currEndIndex;
+                            CUSTOM_MARKERS * sizeof(uint32_t));
+                    mark_dropped_timestamps(hostIndex);
+		}
+                else{
+                    mark_dropped_timestamps(hostIndex);
                 }
-                else
-                {
-                    profiler_control_buffer[hostIndex] = PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC+1;
-                }
-
-                profiler_control_buffer[deviceIndex] = 0;
-            }
-        }
+		profiler_control_buffer[deviceIndex] = 0;
+	    }
+	}
 #endif
         noc_async_write_barrier();
         profiler_control_buffer[RUN_COUNTER] ++;
+        profiler_control_buffer[PROFILER_DONE] = 1;
 #endif
     }
 
-    constexpr uint32_t Hash32_CT( const char * str, size_t n, uint32_t basis = UINT32_C( 2166136261 ) ) {
-        return n == 0 ? basis : Hash32_CT( str + 1, n - 1, ( basis ^ str[ 0 ] ) * UINT32_C( 16777619 ) );
+    inline __attribute__((always_inline)) void quick_push ()
+    {
+#if defined(DISPATCH_KERNEL) && defined(COMPILE_FOR_NCRISC) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES)
+        SrcLocNameToHash("PROFILER-NOC-QUICK-SEND");
+        mark_time_at_index_inlined(wIndex, hash);
+        core_flat_id = noc_xy_to_profiler_flat_id[my_x[0]][my_y[0]];
+
+        uint32_t dram_offset =
+            (core_flat_id % profiler_core_count_per_dram) * PROFILER_RISC_COUNT * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+            HOST_BUFFER_END_INDEX_NC * PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC +
+            profiler_control_buffer[HOST_BUFFER_END_INDEX_NC] * sizeof(uint32_t);
+
+        while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
+        const InterleavedAddrGen<true> s = {
+            .bank_base_address = profiler_control_buffer[DRAM_PROFILER_ADDRESS],
+            .page_size = PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * PROFILER_RISC_COUNT * profiler_core_count_per_dram
+        };
+
+        uint64_t dram_bank_dst_noc_addr = s.get_noc_addr(core_flat_id / profiler_core_count_per_dram, dram_offset);
+
+        mark_end_at_index_inlined(wIndex, hash, get_end_timer_id(hash));
+        wIndex += QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE;
+
+        uint32_t currEndIndex = profiler_control_buffer[HOST_BUFFER_END_INDEX_NC] + wIndex;
+
+        if ( currEndIndex <= PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC)
+        {
+            noc_async_write(
+                    PROFILER_L1_BUFFER_NC,
+                    dram_bank_dst_noc_addr,
+                    wIndex * sizeof(uint32_t));
+
+            nocWriteSize += (wIndex * sizeof(uint32_t));
+
+            profiler_control_buffer[HOST_BUFFER_END_INDEX_NC] = currEndIndex;
+
+        }
+        else
+        {
+            mark_dropped_timestamps(HOST_BUFFER_END_INDEX_NC);
+        }
+
+        wIndex = CUSTOM_MARKERS;
+
+        nocWriteBuffer[(*nocWriteIndex)] = nocWriteBuffer[(*nocWriteIndex)] + (( nocWriteSize + NOC_MAX_BURST_SIZE -1 )/NOC_MAX_BURST_SIZE);
+        nocWriteSize = 0;
+#endif
     }
 
-    template< size_t N >
-    constexpr uint32_t Hash16_CT( const char ( &s )[ N ] ) {
-        auto res = Hash32_CT( s, N - 1 );
-        return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
-    }
 
-    template<uint32_t timer_id>
+    template<uint32_t timer_id, bool dispatch = false>
     struct profileScope
     {
         bool start_marked = false;
-        PROFILER_INLINE profileScope ()
+        inline __attribute__((always_inline)) profileScope ()
         {
-            if (wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize))
+            bool bufferHasRoom = false;
+            if constexpr (dispatch)
+            {
+                bufferHasRoom = wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize - (QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE));
+            }
+            else
+            {
+                bufferHasRoom = wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize);
+            }
+
+            if (bufferHasRoom)
             {
                 stackSize += PROFILER_L1_MARKER_UINT32_SIZE;
                 start_marked = true;
@@ -345,7 +466,7 @@ namespace kernel_profiler{
             }
         }
 
-        PROFILER_INLINE ~profileScope ()
+        inline __attribute__((always_inline)) ~profileScope ()
         {
             if (start_marked)
             {
@@ -353,6 +474,14 @@ namespace kernel_profiler{
                 wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
                 start_marked = false;
                 stackSize -= PROFILER_L1_MARKER_UINT32_SIZE;
+            }
+
+            if constexpr (dispatch)
+            {
+                if (wIndex >= (PROFILER_L1_VECTOR_SIZE - (QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE)))
+                {
+                    quick_push();
+                }
             }
         }
     };
@@ -403,7 +532,10 @@ namespace kernel_profiler{
 }
 
 
+
 #define DeviceZoneScopedN( name ) DO_PRAGMA(message(PROFILER_MSG_NAME(name))); auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); kernel_profiler::profileScope<hash> zone = kernel_profiler::profileScope<hash>();
+
+#define DeviceZoneScopedND( name , nocBuffer, nocIndex ) DO_PRAGMA(message(PROFILER_MSG_NAME(name))); auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); kernel_profiler::profileScope<hash,true> zone = kernel_profiler::profileScope<hash,true>(); kernel_profiler::nocWriteBuffer = nocBuffer; kernel_profiler::nocWriteIndex = &nocIndex;
 
 #define DeviceZoneScopedMainN( name ) DO_PRAGMA(message(PROFILER_MSG_NAME(name))); auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); kernel_profiler::profileScopeGuaranteed<hash, 0> zone = kernel_profiler::profileScopeGuaranteed<hash, 0>();
 
@@ -424,5 +556,7 @@ namespace kernel_profiler{
 #define DeviceZoneScopedSumN1( name )
 
 #define DeviceZoneScopedSumN2( name )
+
+#define DeviceZoneScopedND( name , nocBuffer, nocIndex )
 
 #endif

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -51,7 +51,7 @@ class DeviceProfiler {
         std::map<std::pair<uint16_t,CoreCoord>, TracyTTCtx> device_tracy_contexts;
 
         // Device-Core tracy context
-        std::vector<tracy::TTDeviceEvent> device_events;
+        std::set<tracy::TTDeviceEvent> device_events;
 
         // Hash to zone source locations
         std::unordered_map<uint16_t, std::string> hash_to_zone_src_locations;


### PR DESCRIPTION
This brings profiling dispatch cores. 

Both `cq_prefetch` and `cq_dispatch` can now be profiled with a stack of parent and child functions. 
`DeviceZoneScopedND( name , nocBuffer, nocIndex )` macro is dedicated to dispatch core profiling. Noc Buffer and
index are global to dispatch and prefetch kernels that need to be passed. 
e.g.
<img width="583" alt="Screenshot 2024-06-05 at 9 15 37 AM" src="https://github.com/tenstorrent/tt-metal/assets/109363418/43d012d9-8f61-4f57-bec3-4b65581c45bf">

The main while loops of prefetcher and dispatcher are committed with the profiling macro. 

Dispatch profiling is **disabled by default** to avoid the overhead. It is enabled by env var `TT_METAL_DEVICE_PROFILER_DISPATCH=1`.

Because dispatch cores have much more activity, their profiling overhead can add up and slow the entire model run down. 

Dispatch kernel now runs on NCRISC, this brought the requirement for providing profiler push to DRAM for NCRISC as well. 

For a much more efficient usage of the NOC, `quick_send` was introduced that pushes L1 data to DRAM when profiler L1 buffer is full. This allowed for about 100 iterations of the dispatch loops to happen before a costly L1 to DRAM NOC transactions. 

`quick_send` is marked in tracy with red as shown below, 
<img width="1461" alt="Screenshot 2024-06-04 at 9 37 34 AM" src="https://github.com/tenstorrent/tt-metal/assets/109363418/35b96860-7ad8-46c3-ac01-6e0315555cbf">

### Green CI
Post Commit: https://github.com/tenstorrent/tt-metal/actions/runs/9375214697
T3K Profiler: https://github.com/tenstorrent/tt-metal/actions/runs/9386432350
Device Perf: https://github.com/tenstorrent/tt-metal/actions/runs/9375217111
uBenchmark: https://github.com/tenstorrent/tt-metal/actions/runs/9375219316