### PR TITLE
#8563: sweep split_query_key_value_and_split_heads, split and concat

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/__init__.py
+++ b/tests/ttnn/sweep_tests/sweeps/__init__.py
@@ -105,9 +105,9 @@ def _run_single_test(run, skip, xfail, permutation, *, device):
             message = None
     except Exception as e:
         should_fail, expected_exception = xfail(**permutation)
-        if should_fail and expected_exception == str(e):
+        if should_fail:
             status = "xfailed"
-            message = expected_exception
+            message = f"Exception: {e}"
         else:
             status = "crashed"
             message = f"Exception: {e}"

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/concat.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/concat.py
@@ -3,78 +3,111 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Optional, Tuple
-
+from copy import deepcopy
 import torch
 import ttnn
 import random
 from tests.ttnn.utils_for_testing import check_with_pcc
 from models.utility_functions import torch_random
 
+
+def dtype_to_rounding_mode(dtype):
+    if dtype == ttnn.bfloat16:
+        return 2
+    elif dtype == ttnn.bfloat8_b:
+        return 4
+    return 1
+
+
+def generate_configurations(
+    number_of_tensors, rank_of_tensors, max_random_size, dimension_to_concatenate_on, layout, dtype
+):
+    base_shape = []
+
+    base_shape = [
+        random.randint(1, max_random_size) for _ in range(rank_of_tensors)
+    ]  # all dims identical except for dim to concat on
+    base_shape[dimension_to_concatenate_on] = -1
+
+    variable_dim = [random.randint(1, max_random_size) for _ in range(number_of_tensors)]
+
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        round_val = dtype_to_rounding_mode(dtype)
+        if dimension_to_concatenate_on == rank_of_tensors - 1:
+            for i in range(number_of_tensors):
+                rem = variable_dim[i] % round_val
+                if rem != 0:
+                    variable_dim[i] = (variable_dim[i] + rem) % max_random_size
+                    if variable_dim[i] == 0:
+                        variable_dim[i] = round_val
+        elif base_shape[-1] % round_val != 0:
+            rem = base_shape[-1] % round_val
+            base_shape[-1] = (base_shape[-1] + rem) % max_random_size
+            if base_shape[-1] == 0:
+                base_shape[-1] = round_val
+
+    return base_shape, variable_dim
+
+
+def generate_shapes(tensor_counts, ranks, layouts, dtypes, configs_per_variant=1):
+    random.seed(0)
+
+    shapes = []
+
+    for _ in range(configs_per_variant):
+        for rank in ranks:
+            for layout in layouts:
+                if rank < 2 and layout == ttnn.TILE_LAYOUT:
+                    continue
+                for dtype in dtypes:
+                    if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+                        continue
+                    for concat_dim in range(rank):
+                        for tensors in tensor_counts:
+                            base_and_variable = generate_configurations(tensors, rank, 48, concat_dim, layout, dtype)
+                            config = {
+                                "tensors": tensors,
+                                "rank": rank,
+                                "concat_dim": concat_dim,
+                                "base_shape": base_and_variable[0],
+                                "variable_dim": base_and_variable[1],
+                                "layout": layout,
+                                "dtype": dtype,
+                            }
+                            shapes.append(config)
+
+    return shapes
+
+
 parameters = {
-    "number_of_tensors": [1, 2, 3, 4, 5],
-    "rank_of_tensors": [1, 2, 3, 4],
-    "max_random_size_of_each_dim": [32],
-    "dimension_to_concatenate_on": [0, 1, 2, 3, 4, 5],
-    "layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
-    "dtype": [ttnn.bfloat16],
-    "memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    "config": generate_shapes(
+        [1, 2, 3, 4, 5], [1, 2, 3, 4], [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT], [ttnn.bfloat16, ttnn.bfloat8_b], 3
+    ),
+    "memory_config": [
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
+        ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+        ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+    ],
 }
 
 
-def skip(rank_of_tensors, layout, **_) -> Tuple[bool, Optional[str]]:
-    if rank_of_tensors < 2 and layout == ttnn.TILE_LAYOUT:
-        return True, "Tile layout is only supported for tensors with rank >= 2"
-    return False, None
+def run(config, memory_config, *, device) -> Tuple[bool, Optional[str]]:
+    base_shape = config["base_shape"]
+    variable_dim = config["variable_dim"]
+    tensors = config["tensors"]
+    rank = config["rank"]
+    concat_dim = config["concat_dim"]
+    layout = config["layout"]
+    dtype = config["dtype"]
 
+    torch_input_tensors = []
 
-def xfail(number_of_tensors, rank_of_tensors, dimension_to_concatenate_on, **_) -> Tuple[bool, Optional[str]]:
-    if number_of_tensors == 1:
-        return True, "You must have at least two tensors to concat!"
-
-    if dimension_to_concatenate_on >= rank_of_tensors:
-        return (
-            True,
-            f"ttnn: Dimension out of range: dim {dimension_to_concatenate_on} cannot be used for tensors of rank {rank_of_tensors}",
-        )
-
-    return False, None
-
-
-def run(
-    number_of_tensors,
-    rank_of_tensors,
-    max_random_size_of_each_dim,
-    dimension_to_concatenate_on,
-    layout,
-    dtype,
-    memory_config,
-    *,
-    device,
-) -> Tuple[bool, Optional[str]]:
-    random.seed(0)
-
-    def get_size_of_dim(index):
-        size_of_dim = random.randint(1, max_random_size_of_each_dim)
-        if layout == ttnn.ROW_MAJOR_LAYOUT and index == rank_of_tensors - 1 and size_of_dim % 2 == 1:
-            size_of_dim = (size_of_dim + 1) % max_random_size_of_each_dim
-            if size_of_dim == 0:
-                size_of_dim = 2
-        return size_of_dim
-
-    def calculate_input_shape():
-        return [get_size_of_dim(index) for index in range(rank_of_tensors)]
-
-    input_shape = calculate_input_shape()
-    torch_input_tensors = [torch_random(input_shape, -0.1, 0.1, dtype=torch.bfloat16)]
-
-    if number_of_tensors > 1:
-        first_tensor = torch_input_tensors[0]
-        for _ in range(number_of_tensors - 1):
-            shape = list(first_tensor.shape)
-            if dimension_to_concatenate_on < rank_of_tensors:
-                shape[dimension_to_concatenate_on] = get_size_of_dim(dimension_to_concatenate_on)
-            new_tensor = torch_random(shape, -0.1, 0.1, dtype=torch.bfloat16)
-            torch_input_tensors.append(new_tensor)
+    for tensor in range(tensors):
+        new_shape = deepcopy(base_shape)
+        new_shape[concat_dim] = variable_dim[tensor]
+        torch_input_tensors.append(torch_random(new_shape, -0.1, 0.1, dtype=torch.bfloat16))
 
     input_tensors = [
         ttnn.from_torch(
@@ -86,8 +119,21 @@ def run(
         )
         for torch_input_tensor in torch_input_tensors
     ]
-    output_tensor = ttnn.concat(input_tensors, dim=dimension_to_concatenate_on)
+    output_tensor = ttnn.concat(input_tensors, dim=concat_dim)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    torch_output_tensor = torch.concat(torch_input_tensors, dim=dimension_to_concatenate_on)
+    torch_output_tensor = torch.concat(torch_input_tensors, dim=concat_dim)
+    if output_tensor.shape != torch_output_tensor.shape:
+        return (
+            False,
+            f"Shapes do not match:  ttnn shape {output_tensor.shape} vs pytorch shape {torch_output_tensor.shape}",
+        )
     return check_with_pcc(torch_output_tensor, output_tensor, 0.9999)
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def xfail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/split.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/split.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple, List
+import torch
+import ttnn
+import random
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def xfail(config, **_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def round_to_nearest(b: int, round_to: int) -> int:
+    return (b + round_to // 2) // round_to * round_to
+
+
+def generate_random_numbers(a: int, round_to=None) -> List[int]:
+    numbers = []
+    remaining_sum = a
+    while remaining_sum > 0:
+        num = random.randint(1, remaining_sum)
+        if round_to is not None:
+            num = round_to_nearest(num, round_to)
+        numbers.append(num)
+        remaining_sum -= num
+    return numbers
+
+
+def dtype_to_rounding_mode(dtype):
+    if dtype == ttnn.bfloat16:
+        return 2
+    elif dtype == ttnn.bfloat8_b:
+        return 4
+    return 1
+
+
+def generate_config(rank, max_random_size, split_dim, layout, dtype):
+    base_shape = []
+    base_shape = [random.randint(1, max_random_size) for _ in range(rank)]
+
+    round_val = dtype_to_rounding_mode(dtype)
+
+    if layout == ttnn.ROW_MAJOR_LAYOUT and base_shape[-1] % round_val != 0:
+        rem = base_shape[-1] % round_val
+        base_shape[-1] = (base_shape[-1] + rem) % max_random_size
+        if base_shape[-1] == 0:
+            base_shape[-1] = round_val
+
+    splits = generate_random_numbers(
+        base_shape[split_dim],
+        round_to=round_val if (layout == ttnn.ROW_MAJOR_LAYOUT and base_shape[-1] % round_val != 0) else None,
+    )
+    return base_shape, splits
+
+
+def generate_configurations(ranks, layouts, dtypes, configs_per_variant=1):
+    random.seed(0)
+
+    configs = []
+
+    for _ in range(configs_per_variant):
+        for rank in ranks:
+            for layout in layouts:
+                if rank < 2 and layout == ttnn.TILE_LAYOUT:
+                    continue
+                for dtype in dtypes:
+                    if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+                        continue
+                    for split_dim in range(rank):
+                        base_and_variable = generate_config(rank, 48, split_dim, layout, dtype)
+                        config = {
+                            "rank": rank,
+                            "split_dim": split_dim,
+                            "shape": base_and_variable[0],
+                            "splits": base_and_variable[1],
+                            "layout": layout,
+                            "dtype": dtype,
+                        }
+                        configs.append(config)
+
+    return configs
+
+
+def known_configs(configs, **_):
+    known_working = [
+        [1, 2, 32, 64],
+        [1, 2, 64, 64],
+        [1, 2, 64, 128],
+        [1, 2, 1024, 128],
+        [1, 2, 256, 2560],
+        [1, 2, 1024, 2560],
+        [1, 2, 256, 5120],
+        [1, 2, 64, 10240],
+        [1, 2, 16, 10240],
+    ]
+
+    for shape in known_working:
+        config2 = {
+            "rank": len(shape),
+            "split_dim": 2,
+            "shape": shape,
+            "splits": [shape[2] // 2, shape[2] // 2],
+            "layout": ttnn.TILE_LAYOUT,
+            "dtype": ttnn.bfloat16,
+        }
+
+        config3 = {
+            "rank": len(shape),
+            "split_dim": 3,
+            "shape": shape,
+            "splits": [shape[3] // 2, shape[3] // 2],
+            "layout": ttnn.TILE_LAYOUT,
+            "dtype": ttnn.bfloat16,
+        }
+
+        configs.append(config2)
+        configs.append(config3)
+
+    return configs
+
+
+configs = generate_configurations(
+    [1, 2, 3, 4], [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT], [ttnn.bfloat16, ttnn.bfloat8_b], 5
+)
+
+# RNG splits don't work because we only have split in 2 chunks, so we need to add some known working configs
+# this can be commented out and removed once our split implementation supports more than 2 chunks
+configs = known_configs(configs)
+
+parameters = {
+    "config": configs,
+    "memory_config": [
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
+        ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+        ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+    ],
+}
+
+
+def run(config, memory_config, *, device) -> Tuple[bool, Optional[str]]:
+    shape = config["shape"]
+    splits = config["splits"]
+    split_dim = config["split_dim"]
+    layout = config["layout"]
+    dtype = config["dtype"]
+
+    torch_input_tensor = torch_random(shape, -0.1, 0.1, dtype=torch.bfloat16)
+    torch_output_tensors = torch.split(torch_input_tensor, splits, dim=split_dim)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=layout, device=device, dtype=dtype, memory_config=memory_config
+    )
+    # TODO: uncomments this when ttnn.split is implemented
+    # ttnn_output_tensors = ttnn.split(ttnn_input_tensor, splits, dim=split_dim)
+    ttnn_output_tensors = ttnn.experimental.tensor.split_dim_two_chunks_tiled(ttnn_input_tensor, split_dim)
+
+    output_tensors = [ttnn.to_torch(ttnn_output_tensor) for ttnn_output_tensor in ttnn_output_tensors]
+
+    if len(torch_output_tensors) != len(output_tensors):
+        return (
+            False,
+            f"Number of tensors do not match: ttnn length {len(output_tensors)} vs pytorch length {len(torch_output_tensors)}",
+        )
+
+    shape_mismatch_exceptions = ""
+    for i in range(len(torch_output_tensors)):
+        if torch_output_tensors[i].shape != output_tensors[i].shape:
+            shape_mismatch_exceptions += (
+                f"tensor {i}: ttnn shape {output_tensors[i].shape} vs pytorch shape {torch_output_tensors[i].shape} "
+            )
+    if len(shape_mismatch_exceptions) > 0:
+        return (
+            False,
+            f"Shapes do not match: " + shape_mismatch_exceptions,
+        )
+
+    pcc_mismatch_exceptions = ""
+    for i in range(len(torch_output_tensors)):
+        pcc_passed, pcc_message = check_with_pcc(torch_output_tensors[i], output_tensors[i], 0.9999)
+        if not pcc_passed:
+            pcc_mismatch_exceptions += f"tensor {i}: {pcc_message} "
+    if len(pcc_mismatch_exceptions) > 0:
+        return (
+            False,
+            f"PCC mismatch: " + pcc_mismatch_exceptions,
+        )
+    return True, None

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/transformer_split_query_key_value_and_split_heads.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/transformer_split_query_key_value_and_split_heads.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,48 +9,193 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc
-from models.utility_functions import torch_random
+from models.utility_functions import is_wormhole_b0, is_grayskull
 
+# use combinations of batch_size/core height and q_heads/kv_heads/core width to keep permutations under control
+# some failures are known (e.g. batch_size > cores_h, seq_q > seq_kv, num_kv_heads != num_q_heads when transpose = true) though they shouldn't be failures
+# try to minimize the number of permutations of known failures that shouldn't fail to keep test quick
+# interleaved tests are all expected to fail since the input format is different for sharded and interleaved, and the test mimicks the sharded path
+# they need to be changed to match the sharded path
 
 parameters = {
-    "batch_size": [1],
-    "sequence_size": [384, 1024],
-    "num_heads": [4, 16],
-    "head_size": [64, 128],
-    "input_dtype": [ttnn.bfloat16],
-    "input_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "batch_size_cores_h": [(2, 2), (7, 7), (4, 2)],  # 3  [batch=1] case also needed
+    "seq_len_q_kv": [
+        (64, 64),
+        (256, 96),
+        (64, 96),
+    ],  # 3 [seq_q = seq_kv = 224, 384, and seq_q = 1024, 4096, seq_kv = 96] cases needed by BERT, SD, falcon
+    "num_q_kv_heads_cores_w": [
+        (8, 8, 8),
+        (4, 4, 2),
+        (16, 8, 8),
+    ],  # 3 [q_heads = kv_heads = 12] cases also used in assorted models
+    "head_dim": [64, 160],  # 2 [96, 128] also used
+    "input_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],  # 2
+    "transpose_k": [True],  # 1
+    "separate_tensors": [False, True],  # 2
+    "input_memory_config": [ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG],  # 2
 }
 
 
-def run(
-    batch_size, num_heads, sequence_size, head_size, input_dtype, input_memory_config, *, device
+def skip(
+    batch_size_cores_h,
+    seq_len_q_kv,
+    num_q_kv_heads_cores_w,
+    head_dim,
+    input_dtype,
+    transpose_k,
+    separate_tensors,
+    input_memory_config,
 ) -> Tuple[bool, Optional[str]]:
-    input_shape = (batch_size, sequence_size, num_heads * head_size * 3)
-    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
-    (
-        torch_query_tensor,
-        torch_key_tensor,
-        torch_value_tensor,
-    ) = ttnn.transformer._torch_split_query_key_value_and_split_heads(torch_input_tensor, num_heads=num_heads)
+    batch_size = batch_size_cores_h[0]
+    cores_h = batch_size_cores_h[1]
 
-    input_tensor = ttnn.from_torch(
-        torch_input_tensor,
-        device=device,
-        dtype=input_dtype,
-        memory_config=input_memory_config,
-        layout=ttnn.TILE_LAYOUT,
-    )
+    seq_len_q = seq_len_q_kv[0]
+    seq_len_kv = seq_len_q_kv[1]
 
-    query_tensor, key_tensor, value_tensor = ttnn.transformer.split_query_key_value_and_split_heads(
-        input_tensor, num_heads=num_heads
-    )
-    query_tensor = ttnn.to_torch(query_tensor)
-    key_tensor = ttnn.to_torch(key_tensor)
-    value_tensor = ttnn.to_torch(value_tensor)
+    num_q_heads = num_q_kv_heads_cores_w[0]
+    num_kv_heads = num_q_kv_heads_cores_w[1]
+    cores_w = num_q_kv_heads_cores_w[2]
 
-    query_matches, query_message = check_with_pcc(torch_query_tensor, query_tensor, 0.999)
-    key_matches, key_message = check_with_pcc(torch_key_tensor, key_tensor, 0.999)
-    value_matches, value_message = check_with_pcc(torch_value_tensor, value_tensor, 0.999)
+    if is_wormhole_b0():
+        if cores_h > 7 or cores_w > 8:
+            return True, "Wormhole B0 does not support more than 7 cores in height and 8 cores in width"
+
+    if is_grayskull():
+        if input_dtype == ttnn.float32:
+            return True, "Grayskull does not support FP32 data type"
+
+    if input_memory_config == ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG:
+        if batch_size % cores_h != 0:
+            return True, "batch_size should be divisible by cores_h"
+
+        if (num_kv_heads * head_dim) % cores_w != 0:
+            return True, "num_kv_heads * head_dim should be divisible by cores_w"
+
+        if (num_q_heads * head_dim) % cores_w != 0:
+            return True, "num_q_heads * head_dim should be divisible by cores_w"
+
+        if (num_kv_heads * head_dim) % 32 != 0:
+            return True, "num_kv_heads * head_dim should be divisible by Tile Width"
+
+        if (num_q_heads * head_dim) % 32 != 0:
+            return True, "num_q_heads * head_dim should be divisible by Tile Width"
+
+    if not separate_tensors:
+        if (num_q_heads % num_kv_heads) != 0:
+            return True, "num_q_heads should be divisible by num_kv_heads when separate_tensors is False"
+        if seq_len_kv != seq_len_q:
+            return True, "seq_len_kv should be equal to seq_len_q when separate_tensors is False"
+
+    return False, None
+
+
+def xfail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run_create_q_and_kv_heads_test(
+    batch,
+    q_seq_len,
+    kv_seq_len,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    cores_h,
+    cores_w,
+    device,
+    transpose_k,
+    in_mem_config=None,
+    out_mem_config=None,
+):
+    torch.manual_seed(1234)
+
+    q_shape = [batch, q_seq_len, num_q_heads, head_dim]
+    k_shape = [batch, kv_seq_len, num_kv_heads, head_dim]
+    v_shape = [batch, kv_seq_len, num_kv_heads, head_dim]
+    KV_shape = [batch, kv_seq_len, 2 * num_kv_heads * head_dim]
+    Q_shape_flattened = [batch, q_seq_len, num_q_heads * head_dim]
+
+    # torch reference vectors
+    if dtype == ttnn.float32:
+        torch_dtype = torch.float32
+    else:
+        torch_dtype = torch.bfloat16
+
+    Q = torch.randn(q_shape, dtype=torch_dtype)
+    K = torch.randn(k_shape, dtype=torch_dtype)
+    V = torch.randn(v_shape, dtype=torch_dtype)
+
+    KV = torch.concat([K.flatten(-2, -1), V.flatten(-2, -1)], -1)
+    KV_interleaved = torch.concat([K, V], -1).flatten(-2, -1)
+    Q_flattened = Q.flatten(-2, -1)
+
+    if in_mem_config == ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG:
+        kv_mem_config = ttnn.create_sharded_memory_config(
+            KV_shape, core_grid=ttnn.CoreGrid(y=cores_h, x=cores_w), strategy=ttnn.ShardStrategy.BLOCK
+        )
+        kv_t = ttnn.from_torch(
+            KV_interleaved, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype, memory_config=kv_mem_config
+        )
+
+        q_mem_config = ttnn.create_sharded_memory_config(
+            Q_shape_flattened, core_grid=ttnn.CoreGrid(y=cores_h, x=cores_w), strategy=ttnn.ShardStrategy.BLOCK
+        )
+        q_t = ttnn.from_torch(
+            Q_flattened, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype, memory_config=q_mem_config
+        )
+
+        out_mem_config = ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
+    else:
+        kv_t = ttnn.from_torch(
+            KV_interleaved, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype, memory_config=in_mem_config
+        )
+        q_t = ttnn.from_torch(
+            Q_flattened, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype, memory_config=in_mem_config
+        )
+        out_mem_config = in_mem_config
+
+    if num_q_heads == num_kv_heads:
+        q, k, v = ttnn.transformer.split_query_key_value_and_split_heads(
+            q_t, kv_input_tensor=kv_t, num_heads=num_q_heads, transpose_key=transpose_k, memory_config=out_mem_config
+        )
+    else:
+        q, k, v = ttnn.transformer.split_query_key_value_and_split_heads(
+            q_t,
+            kv_input_tensor=kv_t,
+            num_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            transpose_key=transpose_k,
+            memory_config=out_mem_config,
+        )
+
+    pyt_got_back_rm_q = ttnn.to_torch(q)
+    pyt_got_back_rm_k = ttnn.to_torch(k)
+    pyt_got_back_rm_v = ttnn.to_torch(v)
+
+    (ref_k, ref_v) = torch.split(KV, [num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1)
+
+    # Additional shuffling for Q, K, V heads
+    ref_q = torch.reshape(Q_flattened, [batch, q_seq_len, num_q_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, kv_seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, kv_seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+
+    if transpose_k:
+        ref_k = torch.transpose(ref_k, -2, -1)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc = 0.99
+    elif (
+        dtype == ttnn.float32 and transpose_k
+    ):  # conversion from fp32 to tf32 when unpack writes to register for compute will decrease pcc in the transpose case
+        pcc = 0.9999999
+    else:
+        pcc = 1.0
+
+    query_matches, query_message = check_with_pcc(ref_q, pyt_got_back_rm_q, pcc)
+    key_matches, key_message = check_with_pcc(ref_k, pyt_got_back_rm_k, pcc)
+    value_matches, value_message = check_with_pcc(ref_v, pyt_got_back_rm_v, pcc)
 
     passed = query_matches and key_matches and value_matches
     message = ""
@@ -60,5 +205,160 @@ def run(
         message += f"key: {key_message}; "
     if not value_matches:
         message += f"value: {value_message}; "
+
+    return passed, message
+
+
+def run_create_qkv_heads_test(
+    batch,
+    seq_len,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    cores_h,
+    cores_w,
+    device,
+    transpose_k,
+    in_mem_config=None,
+    out_mem_config=None,
+):
+    torch.manual_seed(1234)
+
+    q_shape = [batch, seq_len, num_kv_heads, num_q_heads // num_kv_heads * head_dim]
+    k_shape = [batch, seq_len, num_kv_heads, head_dim]
+    v_shape = [batch, seq_len, num_kv_heads, head_dim]
+    QKV_shape = [batch, seq_len, (2 * num_kv_heads + num_q_heads) * head_dim]
+
+    # torch reference vectors
+    if dtype == ttnn.float32:
+        torch_dtype = torch.float32
+    else:
+        torch_dtype = torch.bfloat16
+
+    Q = torch.randn(q_shape, dtype=torch_dtype)
+    K = torch.randn(k_shape, dtype=torch_dtype)
+    V = torch.randn(v_shape, dtype=torch_dtype)
+    QKV = torch.concat([Q.flatten(-2, -1), K.flatten(-2, -1), V.flatten(-2, -1)], -1)
+    QKV_interleaved = torch.concat([Q, K, V], -1).flatten(-2, -1)
+
+    if in_mem_config == ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG:
+        in0_mem_config = ttnn.create_sharded_memory_config(
+            QKV_shape, core_grid=ttnn.CoreGrid(y=cores_h, x=cores_w), strategy=ttnn.ShardStrategy.BLOCK
+        )
+        in0_t = ttnn.from_torch(
+            QKV_interleaved, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype, memory_config=in0_mem_config
+        )
+        out_mem_config = ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
+    else:
+        in0_t = ttnn.from_torch(
+            QKV_interleaved, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype, memory_config=in_mem_config
+        )
+        out_mem_config = in_mem_config
+
+    if num_kv_heads == num_q_heads:
+        q, k, v = ttnn.transformer.split_query_key_value_and_split_heads(
+            in0_t, num_heads=num_q_heads, transpose_key=transpose_k, memory_config=out_mem_config
+        )
+    else:
+        q, k, v = ttnn.transformer.split_query_key_value_and_split_heads(
+            in0_t,
+            num_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            transpose_key=transpose_k,
+            memory_config=out_mem_config,
+        )
+
+    pyt_got_back_rm_q = ttnn.to_torch(q)
+    pyt_got_back_rm_k = ttnn.to_torch(k)
+    pyt_got_back_rm_v = ttnn.to_torch(v)
+
+    (ref_q, ref_k, ref_v) = torch.split(
+        QKV, [num_q_heads * head_dim, num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1
+    )
+    # Additional shuffling for Q, K, V heads
+    ref_q = torch.reshape(ref_q, [batch, seq_len, num_q_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+
+    if transpose_k:
+        ref_k = torch.transpose(ref_k, -2, -1)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc = 0.99
+    elif (
+        dtype == ttnn.float32 and transpose_k
+    ):  # conversion from fp32 to tf32 when unpack writes to register for compute will decrease pcc in the transpose case
+        pcc = 0.9999999
+    else:
+        pcc = 1.0
+
+    query_matches, query_message = check_with_pcc(ref_q, pyt_got_back_rm_q, pcc)
+    key_matches, key_message = check_with_pcc(ref_k, pyt_got_back_rm_k, pcc)
+    value_matches, value_message = check_with_pcc(ref_v, pyt_got_back_rm_v, pcc)
+
+    passed = query_matches and key_matches and value_matches
+    message = ""
+    if not query_matches:
+        message += f"query: {query_message}; "
+    if not key_matches:
+        message += f"key: {key_message}; "
+    if not value_matches:
+        message += f"value: {value_message}; "
+
+    return passed, message
+
+
+def run(
+    batch_size_cores_h,
+    seq_len_q_kv,
+    num_q_kv_heads_cores_w,
+    head_dim,
+    input_dtype,
+    transpose_k,
+    separate_tensors,
+    input_memory_config,
+    *,
+    device,
+):
+    batch_size = batch_size_cores_h[0]
+    cores_h = batch_size_cores_h[1]
+
+    seq_len_q = seq_len_q_kv[0]
+    seq_len_kv = seq_len_q_kv[1]
+
+    num_q_heads = num_q_kv_heads_cores_w[0]
+    num_kv_heads = num_q_kv_heads_cores_w[1]
+    cores_w = num_q_kv_heads_cores_w[2]
+
+    if separate_tensors:
+        passed, message = run_create_q_and_kv_heads_test(
+            batch_size,
+            seq_len_q,
+            seq_len_kv,
+            num_q_heads,
+            num_kv_heads,
+            head_dim,
+            input_dtype,
+            cores_h,
+            cores_w,
+            device,
+            transpose_k,
+            input_memory_config,
+        )
+    else:
+        passed, message = run_create_qkv_heads_test(
+            batch_size,
+            seq_len_q,
+            num_q_heads,
+            num_kv_heads,
+            head_dim,
+            input_dtype,
+            cores_h,
+            cores_w,
+            device,
+            transpose_k,
+            input_memory_config,
+        )
 
     return passed, message


### PR DESCRIPTION
Add new sweep tests for ttnn.transformers.split_query_key_value_and_split_heads, split and concat

split_query_key_value_and_split_heads:
- Batch_size, and cores_h are together in a tuple to minimize permutations that are expected to fail
- (Num_q_heads, num_kv_heads, cores_w) and (seq_len_q, seq_len_kv) are also in a tuple for the same reason
- If all required combinations were tested with all data types and memory configurations then we would have 24192 as opposed to the current 2918
- PCC will be low for the interleaved version since the sharded and interleaved versions both expect the logical QKV tensor to be concatenated along different dimensions
- TODO: add expected failure cases too for configurations that shouldn't be supported

split:
- use ttnn.experimental.tensor.split_dim_two_chunks_tiled instead of ttnn test for now since split is not implemented and just a wrapper
- add some known working configs since the current split is hardcoded to split in half
- TODO: ttnn.split should be implemented, potentially call the ttnn.experimental versino
- TODO: remove known working config cases when ttnn.split is implemented

concat:
- concat tests reworked to be able to track the dimensions for each test case (makes for easier debugging)
