### PR TITLE
#8536: Allow in0 and output to be sharded on different grids for mcast 1D in0

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
@@ -1,0 +1,372 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple
+from loguru import logger
+import enum
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+from models.utility_functions import torch_random
+
+
+class TensorMemoryConfigs(enum.Enum):
+    CUSTOM_MEMORY_CONFIG = enum.auto()
+
+
+core_grid = ttnn.CoreCoord(8, 7)
+parameters = {
+    "matmul_specs": [
+        # Matmul 1D mcast in0: in0 grid == output grid
+        # loop along in0 shard width
+        (
+            (1,),
+            (64, 32 * 64, 32 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 4),
+                in0_block_w=1,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # no looping along in0 shard width
+        (
+            (1,),
+            (64, 32 * 64, 32 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 4),
+                in0_block_w=2,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # Matmul 1D mcast in0: in0 grid < output grid
+        # loop along in0 shard width
+        (
+            (1,),
+            (64, 28 * 64, 35 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 5),
+                in0_block_w=1,
+                out_subblock_h=1,
+                out_subblock_w=3,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.experimental.tensor.num_cores_to_core_range_set(28, core_grid, row_wise=True),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # no looping along in0 shard width
+        (
+            (1,),
+            (64, 28 * 64, 35 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 5),
+                in0_block_w=2,
+                out_subblock_h=1,
+                out_subblock_w=3,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.experimental.tensor.num_cores_to_core_range_set(28, core_grid, row_wise=True),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # Matmul 1D mcast in0: in0 grid > output grid
+        # loop along in0 shard width
+        (
+            (1,),
+            (64, 35 * 64, 28 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 5),
+                in0_block_w=1,
+                out_subblock_h=1,
+                out_subblock_w=3,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.experimental.tensor.num_cores_to_core_range_set(35, core_grid, row_wise=True),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # no looping along in0 shard width
+        (
+            (1,),
+            (64, 35 * 64, 28 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 5),
+                in0_block_w=2,
+                out_subblock_h=1,
+                out_subblock_w=3,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.experimental.tensor.num_cores_to_core_range_set(35, core_grid, row_wise=True),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # Matmul 1D mcast in0: in0 grid.y == output grid.y but in0 grid.x < output grid.x and output grid.x isn't full row; tests mcast logic for num_active_cores
+        # loop along in0 shard width
+        (
+            (1,),
+            (64, 28 * 64, 30 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 4),
+                in0_block_w=1,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.experimental.tensor.num_cores_to_core_range_set(28, core_grid, row_wise=True),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # no looping along in0 shard width
+        (
+            (1,),
+            (64, 28 * 64, 30 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 4),
+                in0_block_w=2,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.experimental.tensor.num_cores_to_core_range_set(28, core_grid, row_wise=True),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # Matmul 1D mcast in0: in0 grid.y == output grid.y but in0 grid.x > output grid.x and in0 grid.x isn't full row; tests mcast logic for num_active_cores
+        # loop along in0 shard width
+        (
+            (1,),
+            (64, 30 * 64, 28 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 4),
+                in0_block_w=1,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.experimental.tensor.num_cores_to_core_range_set(30, core_grid, row_wise=True),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # no looping along in0 shard width
+        (
+            (1,),
+            (64, 30 * 64, 28 * 96),
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 4),
+                in0_block_w=2,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=3,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.experimental.tensor.num_cores_to_core_range_set(30, core_grid, row_wise=True),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+    ],
+    "batch_matrix_multiply": [False],
+    "input_a_memory_config": [TensorMemoryConfigs.CUSTOM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+    "output_memory_config": [ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG],
+    "input_a_dtype": [ttnn.bfloat16],
+    "input_b_dtype": [ttnn.bfloat8_b],
+    "output_dtype": [ttnn.bfloat16],
+    "input_layout": [ttnn.TILE_LAYOUT],
+    "compute_kernel_config": [None],
+}
+
+
+def skip(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def is_expected_to_fail(**_) -> Tuple[bool, Optional[str]]:
+    return False, None
+
+
+def run(
+    matmul_specs,
+    batch_matrix_multiply,
+    input_a_memory_config,
+    input_b_memory_config,
+    output_memory_config,
+    input_a_dtype,
+    input_b_dtype,
+    output_dtype,
+    input_layout,
+    compute_kernel_config,
+    *,
+    device,
+) -> Tuple[bool, Optional[str]]:
+    (
+        batch_sizes,
+        input_shapes,
+        program_config,
+        input_a_custom_memory_config,
+    ) = matmul_specs
+    if input_a_memory_config == TensorMemoryConfigs.CUSTOM_MEMORY_CONFIG:
+        input_a_memory_config = input_a_custom_memory_config
+
+    (m_size, k_size, n_size) = input_shapes
+    input_shape_a = (*batch_sizes, m_size, k_size)
+    input_shape_b = (k_size, n_size)
+    if batch_matrix_multiply:
+        input_shape_b = (*batch_sizes, k_size, n_size)
+
+    input_a_layout = input_layout
+    input_b_layout = input_layout
+
+    torch_input_tensor_a = torch_random(input_shape_a, -0.1, 0.1, dtype=torch.float32)
+    torch_input_tensor_b = torch_random(input_shape_b, -0.1, 0.1, dtype=torch.float32)
+    torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=input_a_layout,
+        dtype=input_a_dtype,
+        device=device,
+        memory_config=input_a_memory_config,
+    )
+    input_tensor_b = ttnn.from_torch(
+        torch_input_tensor_b,
+        layout=input_b_layout,
+        dtype=input_b_dtype,
+        device=device,
+        memory_config=input_b_memory_config,
+    )
+
+    output_tensor = ttnn.matmul(
+        input_tensor_a,
+        input_tensor_b,
+        memory_config=output_memory_config,
+        dtype=output_dtype,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+    )
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    expected_pcc = 0.99
+    return check_with_pcc(torch_output_tensor, output_tensor, expected_pcc)

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -3,19 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_dnn/op_library/bmm/bmm_op.hpp"
-#include "tt_dnn/op_library/run_operation.hpp"
-#include "tt_dnn/op_library/work_split.hpp"
-#include "tt_metal/tools/profiler/op_profiler.hpp"
-#include "ttnn/types.hpp"
 
-#include "tt_metal/host_api.hpp"
-#include "tt_metal/common/constants.hpp"
-
-#include "third_party/magic_enum/magic_enum.hpp"
-
-#include <optional>
 #include <algorithm>
 #include <cmath>
+#include <optional>
+
+#include "third_party/magic_enum/magic_enum.hpp"
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/tools/profiler/op_profiler.hpp"
+#include "ttnn/types.hpp"
 
 using namespace tt::constants;
 
@@ -24,19 +23,22 @@ vector<uint32_t> _get_prime_factors(uint32_t n) {
 
     vector<uint32_t> prime_factors;
     while (i * i <= n) {
-        if (n % i != 0) i++;
+        if (n % i != 0)
+            i++;
         else {
             n /= i;
             prime_factors.push_back(i);
         }
     }
-    if (n > 1) prime_factors.push_back(n);
+    if (n > 1)
+        prime_factors.push_back(n);
 
     return prime_factors;
 }
 
 vector<uint32_t> _get_possible_products(vector<uint32_t> factors) {
-    if (factors.size() == 0) return {1};
+    if (factors.size() == 0)
+        return {1};
 
     vector<uint32_t> products;
     for (uint32_t& fac : factors) {
@@ -69,7 +71,7 @@ uint32_t _get_maximum_block_dim(int32_t block_dim, int32_t in0_block_w) {
 uint32_t get_batch_size(const ttnn::types::Shape& shape) {
     uint32_t result = 1;
     for (auto i = 0; i < shape.rank() - 2; i++) {
-	result *= shape[i];
+        result *= shape[i];
     }
     return result;
 }
@@ -80,16 +82,14 @@ using namespace tt::tt_metal;
 operation::OpPerformanceModel create_op_performance_model_for_matmul(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor> &output_tensors,
-    const DeviceComputeKernelConfig& compute_kernel_config
-)  {
-
+    std::vector<Tensor>& output_tensors,
+    const DeviceComputeKernelConfig& compute_kernel_config) {
     const auto& in_a_shape = input_tensors.at(0).get_shape();
     const auto& in_b_shape = input_tensors.at(1).get_shape();
     const auto& out_shape = output_tensors.at(0).get_shape();
 
     const auto& t = output_tensors.at(0);
-    if(t.storage_type() != StorageType::DEVICE) {
+    if (t.storage_type() != StorageType::DEVICE) {
         tt::log_warning(tt::LogOp, "Output tensor not on DEVICE?!");
     }
 
@@ -99,24 +99,27 @@ operation::OpPerformanceModel create_op_performance_model_for_matmul(
 
     // Calculate number of mul/add operations
     // TODO: add bias modeling
-    int64_t num_mul_adds_per_elem = in_a_shape[3] * 2; // 1 multiply and 1 add per element
+    int64_t num_mul_adds_per_elem = in_a_shape[3] * 2;  // 1 multiply and 1 add per element
     int64_t num_mul_adds = num_mul_adds_per_elem * out_shape[2] * out_shape[3] * out_shape[1] * out_shape[0];
 
     MathFidelity math_fidelity = MathFidelity::Invalid;
 
-    std::visit([&](auto&& compute_kernel_config) {
-        using T = std::decay_t<decltype(compute_kernel_config)>;
-        if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            math_fidelity = compute_kernel_config.math_fidelity;
-        } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            math_fidelity = compute_kernel_config.math_fidelity;
-        } else {
-            TT_FATAL("arch not supported");
-        }
-    }, compute_kernel_config);
+    std::visit(
+        [&](auto&& compute_kernel_config) {
+            using T = std::decay_t<decltype(compute_kernel_config)>;
+            if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
+                math_fidelity = compute_kernel_config.math_fidelity;
+            } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
+                math_fidelity = compute_kernel_config.math_fidelity;
+            } else {
+                TT_FATAL("arch not supported");
+            }
+        },
+        compute_kernel_config);
 
-
-    int ideal_dev_clock_cycles = std::ceil(((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi)) * (float)operation::OpPerformanceModel::fidelity_multiplier(math_fidelity));
+    int ideal_dev_clock_cycles = std::ceil(
+        ((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi)) *
+        (float)operation::OpPerformanceModel::fidelity_multiplier(math_fidelity));
 
     operation::OpPerformanceModel result(input_tensors, output_tensors, ideal_dev_clock_cycles);
 #if 0
@@ -128,14 +131,14 @@ operation::OpPerformanceModel create_op_performance_model_for_matmul(
     tt::log_info(tt::LogOp, "\t ideal_dev_clock_cycles: {}", ideal_dev_clock_cycles);
 #endif
     return result;
-    }
 }
+}  // namespace
 namespace bmm_op_utils {
 using namespace tt;
 using namespace tt::tt_metal;
 
-
-tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_large_matmul_params(uint32_t Mt, uint32_t Nt, uint32_t num_cores_y, uint32_t num_cores_x, uint32_t in0_block_w) {
+tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_large_matmul_params(
+    uint32_t Mt, uint32_t Nt, uint32_t num_cores_y, uint32_t num_cores_x, uint32_t in0_block_w) {
     auto Nt_fac = _get_prime_factors(Nt);
     auto Mt_fac = _get_prime_factors(Mt);
     uint32_t Npc_min = 1;
@@ -166,8 +169,8 @@ tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_large_matmul_params(uint32_t M
     if (Mpc_min > 1) {
         auto Npc_choices = _get_possible_products(Nt_fac);
         auto Npc_max = _get_maximum_block_dim(Mpc_min, in0_block_w);
-        for (auto &ele : Npc_choices) {
-            if (ele *  Npc_min <= Npc_max)
+        for (auto& ele : Npc_choices) {
+            if (ele * Npc_min <= Npc_max)
                 Npc = ele * Npc_min;
             else
                 break;
@@ -176,7 +179,7 @@ tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_large_matmul_params(uint32_t M
         if (Mt / Mpc > num_cores_y or Nt / Npc > num_cores_x)
             return {0, 0, 0, 0};
 
-        for (auto &subblock_hw : SUBBLOCK_HW_CHOICES) {
+        for (auto& subblock_hw : SUBBLOCK_HW_CHOICES) {
             auto subblock_h = std::get<0>(subblock_hw);
             auto subblock_w = std::get<1>(subblock_hw);
             if (Mpc % subblock_h == 0 and Npc % subblock_w == 0)
@@ -187,8 +190,8 @@ tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_large_matmul_params(uint32_t M
     else if (Npc_min > 1) {
         auto Mpc_choices = _get_possible_products(Mt_fac);
         auto Mpc_max = _get_maximum_block_dim(Npc_min, in0_block_w);
-        for (auto &ele : Mpc_choices) {
-            if (ele *  Mpc_min <= Mpc_max)
+        for (auto& ele : Mpc_choices) {
+            if (ele * Mpc_min <= Mpc_max)
                 Mpc = ele * Mpc_min;
             else
                 break;
@@ -198,7 +201,7 @@ tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_large_matmul_params(uint32_t M
             return {0, 0, 0, 0};
         }
 
-        for (auto &subblock_hw : SUBBLOCK_HW_CHOICES) {
+        for (auto& subblock_hw : SUBBLOCK_HW_CHOICES) {
             auto subblock_h = std::get<0>(subblock_hw);
             auto subblock_w = std::get<1>(subblock_hw);
             if (Mpc % subblock_h == 0 and Npc % subblock_w == 0)
@@ -209,9 +212,9 @@ tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_large_matmul_params(uint32_t M
     else {
         auto Mpc_choices = _get_possible_products(Mt_fac);
         auto Npc_choices = _get_possible_products(Nt_fac);
-        for (auto &Npc : Npc_choices) {
+        for (auto& Npc : Npc_choices) {
             auto Mpc_max = _get_maximum_block_dim(Npc, in0_block_w);
-            for (auto &ele : Mpc_choices) {
+            for (auto& ele : Mpc_choices) {
                 if (ele <= Mpc_max)
                     Mpc = ele;
             }
@@ -219,7 +222,7 @@ tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_large_matmul_params(uint32_t M
             if (Mt / Mpc > num_cores_y or Nt / Npc > num_cores_x)
                 continue;
 
-            for (auto &subblock_hw : SUBBLOCK_HW_CHOICES) {
+            for (auto& subblock_hw : SUBBLOCK_HW_CHOICES) {
                 auto subblock_h = std::get<0>(subblock_hw);
                 auto subblock_w = std::get<1>(subblock_hw);
                 if (Mpc % subblock_h == 0 and Npc % subblock_w == 0)
@@ -231,30 +234,31 @@ tuple<uint32_t, uint32_t, uint32_t, uint32_t> get_large_matmul_params(uint32_t M
     return {0, 0, 0, 0};
 }
 
-
-CoreCoord get_core_range(uint32_t num_blocks_rows, uint32_t num_blocks_cols, uint32_t max_num_rows, uint32_t max_num_cols) {
+CoreCoord get_core_range(
+    uint32_t num_blocks_rows, uint32_t num_blocks_cols, uint32_t max_num_rows, uint32_t max_num_cols) {
     CoreCoord core_range(0, 0);
-    if (!(num_blocks_rows == 1 && num_blocks_cols == 1) && num_blocks_rows <= max_num_rows && num_blocks_cols <= max_num_cols) {
+    if (!(num_blocks_rows == 1 && num_blocks_cols == 1) && num_blocks_rows <= max_num_rows &&
+        num_blocks_cols <= max_num_cols) {
         core_range.x = num_blocks_cols;
         core_range.y = num_blocks_rows;
     }
     return core_range;
 }
 
-MatmulParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) {
+MatmulParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor>& input_tensors) {
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
-    const auto& ashape = input_tensor_a.get_legacy_shape(), bshape = input_tensor_b.get_legacy_shape();
-    uint32_t num_output_tiles = ashape[0] * ashape[1] * ashape[2] * bshape[3] / TILE_HW; // Output M x N
+    const auto &ashape = input_tensor_a.get_legacy_shape(), bshape = input_tensor_b.get_legacy_shape();
+    uint32_t num_output_tiles = ashape[0] * ashape[1] * ashape[2] * bshape[3] / TILE_HW;  // Output M x N
 
     // Parameters for large matmul with reuse
     uint32_t B = ashape[0] * ashape[1];
-    uint32_t Mt = ashape[2]/TILE_HEIGHT;
-    uint32_t Kt = ashape[3]/TILE_WIDTH;
-    uint32_t Nt = bshape[3]/TILE_WIDTH;
+    uint32_t Mt = ashape[2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[3] / TILE_WIDTH;
+    uint32_t Nt = bshape[3] / TILE_WIDTH;
     uint32_t in0_block_w = 2;
 
-    tt::tt_metal::Device *device = input_tensor_a.device();
+    tt::tt_metal::Device* device = input_tensor_a.device();
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
@@ -285,16 +289,24 @@ MatmulParallelizationStrategy get_parallelization_strategy(const std::vector<Ten
         } else {
             return MatmulParallelizationStrategy::MULTI_CORE;
         }
-    }
-    else {
+    } else {
         return MatmulParallelizationStrategy::MULTI_CORE;
     }
 }
 
-tt::operations::primary::MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(const Tensor &input_tensor_a, const Tensor &input_tensor_b, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0, bool out_sharded, std::optional<CoreCoord> compute_with_storage_grid_size, std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+tt::operations::primary::MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    bool fuse_batch,
+    std::optional<UnaryWithParam> fused_activation,
+    bool mcast_in0,
+    bool out_sharded,
+    std::optional<CoreCoord> compute_with_storage_grid_size,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     auto device = input_tensor_a.device();
     auto grid_size = compute_with_storage_grid_size.value_or(device->compute_with_storage_grid_size());
-    uint32_t M = fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] : input_tensor_a.get_legacy_shape()[-2];
+    uint32_t M = fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
+                            : input_tensor_a.get_legacy_shape()[-2];
     uint32_t K = input_tensor_a.get_legacy_shape()[-1];
     uint32_t N = input_tensor_b.get_legacy_shape()[-1];
     uint32_t per_core_M, per_core_N;
@@ -309,7 +321,12 @@ tt::operations::primary::MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_
     bool per_core_N_equals_subblock_w_constraint = out_sharded && !mcast_in0;
     bool per_core_M_equals_subblock_h_constraint = out_sharded && mcast_in0;
     bool fp32_dest_acc_en = bmm_op_utils::get_fp32_dest_acc_en(compute_kernel_config);
-    auto subblock_hw = get_matmul_subblock_params(per_core_M, per_core_N, per_core_M_equals_subblock_h_constraint, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
+    auto subblock_hw = get_matmul_subblock_params(
+        per_core_M,
+        per_core_N,
+        per_core_M_equals_subblock_h_constraint,
+        per_core_N_equals_subblock_w_constraint,
+        fp32_dest_acc_en);
     auto out_subblock_h = std::get<0>(subblock_hw);
     auto out_subblock_w = std::get<1>(subblock_hw);
 
@@ -322,22 +339,28 @@ tt::operations::primary::MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_
         .per_core_N = per_core_N,
         .fuse_batch = fuse_batch,
         .fused_activation = fused_activation,
-        .mcast_in0 = mcast_in0
-    };
+        .mcast_in0 = mcast_in0};
 }
 
-tuple<uint32_t, uint32_t> get_matmul_subblock_params(const uint32_t per_core_M, const uint32_t per_core_N, const bool per_core_M_equals_subblock_h_constraint, bool per_core_N_equals_subblock_w_constraint, bool fp32_dest_acc_en) {
-    TT_FATAL(!(per_core_M_equals_subblock_h_constraint and per_core_N_equals_subblock_w_constraint), "Only one constraint may be true for h or w!");
+tuple<uint32_t, uint32_t> get_matmul_subblock_params(
+    const uint32_t per_core_M,
+    const uint32_t per_core_N,
+    const bool per_core_M_equals_subblock_h_constraint,
+    bool per_core_N_equals_subblock_w_constraint,
+    bool fp32_dest_acc_en) {
+    TT_FATAL(
+        !(per_core_M_equals_subblock_h_constraint and per_core_N_equals_subblock_w_constraint),
+        "Only one constraint may be true for h or w!");
 
     uint32_t out_subblock_h, out_subblock_w;
-    for (auto &subblock_hw : bmm_op_utils::SUBBLOCK_HW_CHOICES) {
+    for (auto& subblock_hw : bmm_op_utils::SUBBLOCK_HW_CHOICES) {
         out_subblock_h = std::get<0>(subblock_hw);
         out_subblock_w = std::get<1>(subblock_hw);
-	if (fp32_dest_acc_en) {
-	    if ((out_subblock_h * out_subblock_w) > 4) {
-		continue;  // Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode
-	    }
-	}
+        if (fp32_dest_acc_en) {
+            if ((out_subblock_h * out_subblock_w) > 4) {
+                continue;  // Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode
+            }
+        }
         if (per_core_N_equals_subblock_w_constraint) {
             if (out_subblock_w != per_core_N || out_subblock_h != 1) {
                 continue;
@@ -356,20 +379,27 @@ tuple<uint32_t, uint32_t> get_matmul_subblock_params(const uint32_t per_core_M, 
     TT_FATAL(false, "Matmul subblock parameters could not be determined for given input shapes");
 }
 
-
 // TODO: Only supports sharded matmul for now; infer most matmul params from shard spec
-tt::operations::primary::MatmulProgramConfig get_matmul_program_config(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const MemoryConfig &output_mem_config, std::optional<UnaryWithParam> fused_activation, const bool matmul, const std::optional<const CoreCoord> user_core_coord, std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+tt::operations::primary::MatmulProgramConfig get_matmul_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const MemoryConfig& output_mem_config,
+    std::optional<UnaryWithParam> fused_activation,
+    const bool matmul,
+    const std::optional<const CoreCoord> user_core_coord,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     TT_FATAL(input_tensor_a.is_sharded());
     bool fp32_dest_acc_en = bmm_op_utils::get_fp32_dest_acc_en(compute_kernel_config);
-    // TODO: allow overwriting of grid size by user_core_coord after allowing support of arbitrary compute grid and more generic sharded output tensor creation
+    // TODO: allow overwriting of grid size by user_core_coord after allowing support of arbitrary compute grid and more
+    // generic sharded output tensor creation
     auto grid_size = input_tensor_a.shard_spec().value().grid.bounding_box().grid_size();
 
     // MCAST matmuls only support input_b in INTERLEAVED
     if (matmul) {
         TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        if ((input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED
-              or input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED)
-            and (grid_size.x > 1 or grid_size.y > 1)) {
+        if ((input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED or
+             input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) and
+            (grid_size.x > 1 or grid_size.y > 1)) {
             TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
 
             bool per_core_N_equals_subblock_w_constraint = false;
@@ -396,13 +426,14 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(const Ten
             } else if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
                 mcast_in0 = false;
                 per_core_M = shard_shape[0] / TILE_HEIGHT;
-                per_core_N = N; // Only necessary if output is sharded; otherwise, can set this to be < N
+                per_core_N = N;  // Only necessary if output is sharded; otherwise, can set this to be < N
                 in0_block_w = K;
             } else {
                 TT_FATAL(false, "Input tensor must be WIDTH or HEIGHT sharded for 1D mcast matmul!");
             }
 
-            auto subblock_hw = get_matmul_subblock_params(per_core_M, per_core_N, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
+            auto subblock_hw = get_matmul_subblock_params(
+                per_core_M, per_core_N, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
             auto out_subblock_h = std::get<0>(subblock_hw);
             auto out_subblock_w = std::get<1>(subblock_hw);
 
@@ -417,8 +448,9 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(const Ten
                 .fused_activation = fused_activation,
                 .mcast_in0 = mcast_in0,
             };
-        } else if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED
-                   and (grid_size.x > 1 and grid_size.y > 1)) {
+        } else if (
+            input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED and
+            (grid_size.x > 1 and grid_size.y > 1)) {
             bool transpose_mcast = input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
 
             bool per_core_N_equals_subblock_w_constraint = false;
@@ -435,14 +467,17 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(const Ten
             auto shard_shape = input_tensor_a.shard_spec().value().shape;
             uint32_t virtual_x = transpose_mcast ? grid_size.y : grid_size.x;
             uint32_t virtual_y = transpose_mcast ? grid_size.x : grid_size.y;
-            TT_FATAL(virtual_y == (M / (shard_shape[0] / TILE_HEIGHT)), "Num cores along y must match provided grid size!");
-            TT_FATAL(virtual_x == (K / (shard_shape[1] / TILE_WIDTH)), "Num cores along x must match provided grid size!");
+            TT_FATAL(
+                virtual_y == (M / (shard_shape[0] / TILE_HEIGHT)), "Num cores along y must match provided grid size!");
+            TT_FATAL(
+                virtual_x == (K / (shard_shape[1] / TILE_WIDTH)), "Num cores along x must match provided grid size!");
 
             uint32_t per_core_M = M / virtual_y;
             uint32_t per_core_N = N / virtual_x;
             uint32_t in0_block_w = shard_shape[1] / TILE_WIDTH;
 
-            auto subblock_hw = get_matmul_subblock_params(per_core_M, per_core_N, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
+            auto subblock_hw = get_matmul_subblock_params(
+                per_core_M, per_core_N, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
             auto out_subblock_h = std::get<0>(subblock_hw);
             auto out_subblock_w = std::get<1>(subblock_hw);
 
@@ -477,22 +512,23 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(const Ten
         uint32_t per_core_N = N;
         uint32_t in0_block_w = in0_shard_shape[1] / TILE_WIDTH;
 
-        auto subblock_hw = get_matmul_subblock_params(per_core_M, per_core_N, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
+        auto subblock_hw = get_matmul_subblock_params(
+            per_core_M, per_core_N, false, per_core_N_equals_subblock_w_constraint, fp32_dest_acc_en);
         auto out_subblock_h = std::get<0>(subblock_hw);
         auto out_subblock_w = std::get<1>(subblock_hw);
 
         // TODO: Temporarily allow for single core; should support bcast_batch in general
-        bool broadcast_batch = (
-            input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] > 1
-            and input_tensor_b.get_legacy_shape()[0] * input_tensor_b.get_legacy_shape()[1] == 1
-        );
+        bool broadcast_batch =
+            (input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] > 1 and
+             input_tensor_b.get_legacy_shape()[0] * input_tensor_b.get_legacy_shape()[1] == 1);
         TT_FATAL(!broadcast_batch);
 
         if (input_tensor_b.is_sharded()) {
             TT_FATAL(input_tensor_a.memory_config().buffer_type == input_tensor_b.memory_config().buffer_type);
             TT_FATAL(input_tensor_a.memory_config().memory_layout == input_tensor_b.memory_config().memory_layout);
             TT_FATAL(input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid);
-            TT_FATAL(input_tensor_a.shard_spec().value().orientation == input_tensor_b.shard_spec().value().orientation);
+            TT_FATAL(
+                input_tensor_a.shard_spec().value().orientation == input_tensor_b.shard_spec().value().orientation);
         }
 
         return tt::operations::primary::MatmulMultiCoreReuseProgramConfig{
@@ -507,29 +543,30 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(const Ten
     TT_FATAL(false, "Matmul program config could not be determined for given input shapes!");
 }
 
-tuple<uint32_t, uint32_t> get_subblock_sizes(uint32_t m_tiles_per_core, uint32_t n_tiles_per_core, bool fp32_dest_acc_en) {
+tuple<uint32_t, uint32_t> get_subblock_sizes(
+    uint32_t m_tiles_per_core, uint32_t n_tiles_per_core, bool fp32_dest_acc_en) {
     uint32_t out_subblock_h, out_subblock_w;
-    for (auto &subblock_hw : SUBBLOCK_HW_CHOICES) {
+    for (auto& subblock_hw : SUBBLOCK_HW_CHOICES) {
         out_subblock_w = std::get<0>(subblock_hw);
         out_subblock_h = std::get<1>(subblock_hw);
-	if ((out_subblock_h * out_subblock_w) <= 4 || !fp32_dest_acc_en) {
-	    if (m_tiles_per_core % out_subblock_h == 0 && n_tiles_per_core % out_subblock_w == 0) {
-		return {out_subblock_h, out_subblock_w};
-	    }
-	}
+        if ((out_subblock_h * out_subblock_w) <= 4 || !fp32_dest_acc_en) {
+            if (m_tiles_per_core % out_subblock_h == 0 && n_tiles_per_core % out_subblock_w == 0) {
+                return {out_subblock_h, out_subblock_w};
+            }
+        }
     }
     TT_FATAL(false, "Unable to find subblock sizes");
 }
 
-} // namespace bmm_op_utils
+}  // namespace bmm_op_utils
 
 namespace tt {
 namespace tt_metal {
 
-CoreCoord get_falcon_matmul_grid_size(Device *device){
+CoreCoord get_falcon_matmul_grid_size(Device* device) {
     CoreCoord grid_size = device->compute_with_storage_grid_size();
     // TODO: Remove this once there are no more hangs on 8x8 (Issue #6795)
-    if (device->arch() == ARCH::WORMHOLE_B0 and grid_size.y >= 8){
+    if (device->arch() == ARCH::WORMHOLE_B0 and grid_size.y >= 8) {
         grid_size.y = 7;
     }
     return grid_size;
@@ -538,85 +575,180 @@ CoreCoord get_falcon_matmul_grid_size(Device *device){
 /**
  * Falcon matmuls using operations::primary::matmul + program_config
  */
-Tensor falcon_fused_qkv_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype) {
+Tensor falcon_fused_qkv_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    std::optional<const Tensor> bias,
+    const MemoryConfig& mem_config,
+    std::optional<const DataType> output_dtype) {
     CoreCoord grid_size = get_falcon_matmul_grid_size(input_tensor_a.device());
-    auto program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, true, std::nullopt, true, mem_config.is_sharded(), grid_size);
-    return operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype);
+    auto program_config = bmm_op_utils::get_mcast_1d_config(
+        input_tensor_a, input_tensor_b, true, std::nullopt, true, mem_config.is_sharded(), grid_size);
+    return operations::primary::matmul_1d(
+        input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype);
 }
 
-Tensor falcon_selfout_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype) {
+Tensor falcon_selfout_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    std::optional<const Tensor> bias,
+    const MemoryConfig& mem_config,
+    std::optional<const DataType> output_dtype) {
     CoreCoord grid_size = get_falcon_matmul_grid_size(input_tensor_a.device());
-    auto program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, true, std::nullopt, true, mem_config.is_sharded(), grid_size);
-    return operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype);
+    auto program_config = bmm_op_utils::get_mcast_1d_config(
+        input_tensor_a, input_tensor_b, true, std::nullopt, true, mem_config.is_sharded(), grid_size);
+    return operations::primary::matmul_1d(
+        input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype);
 }
 
-Tensor falcon_dense_4h_to_h_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype, std::optional<bool> packer_l1_acc) {
+Tensor falcon_dense_4h_to_h_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    std::optional<const Tensor> bias,
+    const MemoryConfig& mem_config,
+    std::optional<const DataType> output_dtype,
+    std::optional<bool> packer_l1_acc) {
     CoreCoord grid_size = get_falcon_matmul_grid_size(input_tensor_a.device());
     std::optional<const DeviceComputeKernelConfig> config = std::nullopt;
-    auto compute_kernel_config = init_device_compute_kernel_config(input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true, false, packer_l1_acc.value_or(false));
+    auto compute_kernel_config = init_device_compute_kernel_config(
+        input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true, false, packer_l1_acc.value_or(false));
     auto program_config = bmm_op_utils::get_mcast_1d_config(
-        input_tensor_a, input_tensor_b, true, std::nullopt, true, mem_config.is_sharded(), grid_size, compute_kernel_config);
-    return operations::primary::matmul_1d(
         input_tensor_a,
         input_tensor_b,
-        bias,
-        program_config,
-        mem_config,
-        output_dtype,
+        true,
+        std::nullopt,
+        true,
+        mem_config.is_sharded(),
+        grid_size,
         compute_kernel_config);
+    return operations::primary::matmul_1d(
+        input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype, compute_kernel_config);
 }
 
-Tensor falcon_dense_h_to_4h_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, std::optional<UnaryWithParam> fused_activation, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype) {
+Tensor falcon_dense_h_to_4h_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    std::optional<const Tensor> bias,
+    std::optional<UnaryWithParam> fused_activation,
+    const MemoryConfig& mem_config,
+    std::optional<const DataType> output_dtype) {
     auto seq_len = input_tensor_a.get_legacy_shape()[2];
     if (seq_len > 1024) {
         TT_FATAL(not fused_activation.has_value());
         // TODO: Check support for seq_len == 128, 256, 512, ..., 2048
         TT_FATAL(seq_len % TILE_HEIGHT == 0, "Falcon mm's seq_len must be a multiple of 32!");
-        TT_FATAL(seq_len >=  128, "Falcon mm's seq_len must be greater than 128!");
+        TT_FATAL(seq_len >= 128, "Falcon mm's seq_len must be greater than 128!");
         TT_FATAL((input_tensor_a.get_legacy_shape() == Shape({1, 1, seq_len, 4544})), "Unsupported input shape");
         TT_FATAL((input_tensor_b.get_legacy_shape() == Shape({1, 1, 4544, 18176})), "Unsupported input shape");
         TT_FATAL(!fused_activation.has_value());
-        return operation::run_with_autoformat(tt::operations::primary::Matmul{.program_config=tt::operations::primary::MatmulDefaultProgramConfig{}, .bcast_batch=true, .output_mem_config=mem_config, .output_dtype=output_dtype.value_or(input_tensor_a.get_dtype())}, {input_tensor_a, input_tensor_b}).at(0);
+        return operation::run_with_autoformat(
+                   tt::operations::primary::Matmul{
+                       .program_config = tt::operations::primary::MatmulDefaultProgramConfig{},
+                       .bcast_batch = true,
+                       .output_mem_config = mem_config,
+                       .output_dtype = output_dtype.value_or(input_tensor_a.get_dtype())},
+                   {input_tensor_a, input_tensor_b})
+            .at(0);
     } else {
         CoreCoord grid_size = get_falcon_matmul_grid_size(input_tensor_a.device());
         std::optional<const DeviceComputeKernelConfig> config = std::nullopt;
-        auto compute_kernel_config = init_device_compute_kernel_config(input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true /* math_approx_mode */, false /* fp32_dest_acc_en */, true /* packer_l1_acc */);
-        auto program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, true, fused_activation, true, mem_config.is_sharded(), grid_size, compute_kernel_config);
-        return operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype, compute_kernel_config);
+        auto compute_kernel_config = init_device_compute_kernel_config(
+            input_tensor_a.device()->arch(),
+            config,
+            MathFidelity::LoFi,
+            true /* math_approx_mode */,
+            false /* fp32_dest_acc_en */,
+            true /* packer_l1_acc */);
+        auto program_config = bmm_op_utils::get_mcast_1d_config(
+            input_tensor_a,
+            input_tensor_b,
+            true,
+            fused_activation,
+            true,
+            mem_config.is_sharded(),
+            grid_size,
+            compute_kernel_config);
+        return operations::primary::matmul_1d(
+            input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype, compute_kernel_config);
     }
 }
 
-Tensor falcon_lm_head_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype) {
+Tensor falcon_lm_head_matmul(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    std::optional<const Tensor> bias,
+    const MemoryConfig& mem_config,
+    std::optional<const DataType> output_dtype) {
     auto seq_len = input_tensor_a.get_legacy_shape()[2];
-    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}, {bias}))};
+    std::vector<Tensor> output_tensors = {
+        Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}, {bias}))};
     if (seq_len > 512) {
         // TODO: Check support for seq_len == 128, 256, 512, ..., 2048
         operation::launch_with_autoformat(
-            [seq_len, mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            [seq_len, mem_config, output_dtype](
+                const std::vector<Tensor>& input_tensors,
+                const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+                const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
                 auto& input_tensor_a = input_tensors.at(0);
                 auto& input_tensor_b = input_tensors.at(1);
                 auto& bias = optional_input_tensors.at(0);
                 TT_FATAL(seq_len % TILE_HEIGHT == 0, "Falcon mm's seq_len must be a multiple of 32!");
-                TT_FATAL(seq_len >=  128, "Falcon mm's seq_len must be greater than 128!");
-                TT_FATAL((input_tensor_a.get_legacy_shape() == Shape({1, 1, seq_len, 4544})), "Unsupported input shape");
+                TT_FATAL(seq_len >= 128, "Falcon mm's seq_len must be greater than 128!");
+                TT_FATAL(
+                    (input_tensor_a.get_legacy_shape() == Shape({1, 1, seq_len, 4544})), "Unsupported input shape");
                 TT_FATAL((input_tensor_b.get_legacy_shape() == Shape({1, 1, 4544, 65024})), "Unsupported input shape");
-                return operation::run_with_autoformat(tt::operations::primary::Matmul{.program_config=tt::operations::primary::MatmulDefaultProgramConfig{}, .bcast_batch=true, .output_mem_config=mem_config, .output_dtype=output_dtype.value_or(input_tensor_a.get_dtype())}, {input_tensor_a, input_tensor_b}, {bias});
+                return operation::run_with_autoformat(
+                    tt::operations::primary::Matmul{
+                        .program_config = tt::operations::primary::MatmulDefaultProgramConfig{},
+                        .bcast_batch = true,
+                        .output_mem_config = mem_config,
+                        .output_dtype = output_dtype.value_or(input_tensor_a.get_dtype())},
+                    {input_tensor_a, input_tensor_b},
+                    {bias});
             },
-        {input_tensor_a, input_tensor_b}, output_tensors, {bias});
+            {input_tensor_a, input_tensor_b},
+            output_tensors,
+            {bias});
 
     } else {
         operation::launch_op(
-            [mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            [mem_config, output_dtype](
+                const std::vector<Tensor>& input_tensors,
+                const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+                const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
                 auto& input_tensor_a = input_tensors.at(0);
                 auto& input_tensor_b = input_tensors.at(1);
                 auto& bias = optional_input_tensors.at(0);
                 CoreCoord grid_size = get_falcon_matmul_grid_size(input_tensor_a.device());
                 std::optional<const DeviceComputeKernelConfig> config = std::nullopt;
-                auto compute_kernel_config = init_device_compute_kernel_config(input_tensor_a.device()->arch(), config, MathFidelity::LoFi, true /* math_approx_mode */, false /* fp32_dest_acc_en */, true /* packer_l1_acc */);
-                auto program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, true, std::nullopt, true, mem_config.is_sharded(), grid_size, compute_kernel_config);
-                return {operations::primary::matmul_1d(input_tensor_a, input_tensor_b, bias, program_config, mem_config, output_dtype, compute_kernel_config)};
+                auto compute_kernel_config = init_device_compute_kernel_config(
+                    input_tensor_a.device()->arch(),
+                    config,
+                    MathFidelity::LoFi,
+                    true /* math_approx_mode */,
+                    false /* fp32_dest_acc_en */,
+                    true /* packer_l1_acc */);
+                auto program_config = bmm_op_utils::get_mcast_1d_config(
+                    input_tensor_a,
+                    input_tensor_b,
+                    true,
+                    std::nullopt,
+                    true,
+                    mem_config.is_sharded(),
+                    grid_size,
+                    compute_kernel_config);
+                return {operations::primary::matmul_1d(
+                    input_tensor_a,
+                    input_tensor_b,
+                    bias,
+                    program_config,
+                    mem_config,
+                    output_dtype,
+                    compute_kernel_config)};
             },
-        {input_tensor_a, input_tensor_b}, output_tensors, {bias});
+            {input_tensor_a, input_tensor_b},
+            output_tensors,
+            {bias});
     }
     return output_tensors.at(0);
 }
@@ -624,17 +756,30 @@ Tensor falcon_lm_head_matmul(const Tensor &input_tensor_a, const Tensor &input_t
 /**
  * Resnet50 matmul with fused batch
  */
-Tensor resnet_matmul(const Tensor& input_a, const Tensor& input_b, std::optional<const Tensor> bias, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype, const MathFidelity math_fidelity) {
+Tensor resnet_matmul(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    std::optional<const Tensor> bias,
+    const MemoryConfig& mem_config,
+    std::optional<const DataType> output_dtype,
+    const MathFidelity math_fidelity) {
     std::optional<const DeviceComputeKernelConfig> config = std::nullopt;
-    auto compute_kernel_config = init_device_compute_kernel_config(input_a.device()->arch(), config, math_fidelity, true, false, false);
-    auto program_config = bmm_op_utils::get_mcast_1d_config(input_a, input_b, true /* fuse_batch */, std::nullopt /* fused_activation */, true /* mcast_in0 */, false /* out_sharded */, std::nullopt /* compute_with_storage_grid_size */, compute_kernel_config);
-    return operations::primary::matmul_1d(input_a, input_b, bias, program_config, mem_config, output_dtype, compute_kernel_config);
+    auto compute_kernel_config =
+        init_device_compute_kernel_config(input_a.device()->arch(), config, math_fidelity, true, false, false);
+    auto program_config = bmm_op_utils::get_mcast_1d_config(
+        input_a,
+        input_b,
+        true /* fuse_batch */,
+        std::nullopt /* fused_activation */,
+        true /* mcast_in0 */,
+        false /* out_sharded */,
+        std::nullopt /* compute_with_storage_grid_size */,
+        compute_kernel_config);
+    return operations::primary::matmul_1d(
+        input_a, input_b, bias, program_config, mem_config, output_dtype, compute_kernel_config);
 }
 
-
 }  // namespace tt_metal
-
-
 
 namespace operations {
 
@@ -642,39 +787,50 @@ namespace primary {
 
 void Matmul::validate(
     const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors
-) const {
-
+    const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
     TT_FATAL(input_tensors.size() == 2);
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
-    TT_FATAL((input_tensor_a.get_layout() == Layout::TILE && input_tensor_b.get_layout() == Layout::TILE), "Inputs to matmul must be tilized");
-    TT_FATAL(input_tensor_a.get_legacy_shape()[3] == input_tensor_b.get_legacy_shape()[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
+    TT_FATAL(
+        (input_tensor_a.get_layout() == Layout::TILE && input_tensor_b.get_layout() == Layout::TILE),
+        "Inputs to matmul must be tilized");
+    TT_FATAL(
+        input_tensor_a.get_legacy_shape()[3] == input_tensor_b.get_legacy_shape()[2] &&
+        "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op");  // A.K == B.K
 
     TT_FATAL(is_floating_point(input_tensor_a.get_dtype()), "Unsupported data format");
-    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE, "Operands to matmul need to be on device!");
-    TT_FATAL(input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE,
+        "Operands to matmul need to be on device!");
+    TT_FATAL(
+        input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr,
+        "Operands to matmul need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
 
     std::visit(
         [input_tensor_a](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (
-                not std::is_same_v<ProgramConfigType, MatmulDefaultProgramConfig>
-            ) {
-                TT_FATAL(program_config.compute_with_storage_grid_size.x <= input_tensor_a.device()->compute_with_storage_grid_size().x, "Matmul grid size exceeds maximum device compute grid size!");
-                TT_FATAL(program_config.compute_with_storage_grid_size.y <= input_tensor_a.device()->compute_with_storage_grid_size().y, "Matmul grid size exceeds maximum device compute grid size!");
+            if constexpr (not std::is_same_v<ProgramConfigType, MatmulDefaultProgramConfig>) {
+                TT_FATAL(
+                    program_config.compute_with_storage_grid_size.x <=
+                        input_tensor_a.device()->compute_with_storage_grid_size().x,
+                    "Matmul grid size exceeds maximum device compute grid size!");
+                TT_FATAL(
+                    program_config.compute_with_storage_grid_size.y <=
+                        input_tensor_a.device()->compute_with_storage_grid_size().y,
+                    "Matmul grid size exceeds maximum device compute grid size!");
             }
         },
-        this->program_config
-    );
+        this->program_config);
 
     TT_FATAL(optional_input_tensors.size() == 1);
     const auto& optional_bias = optional_input_tensors.at(0);
     if (optional_bias.has_value()) {
         const auto& bias = optional_bias.value();
         TT_FATAL(bias.get_layout() == Layout::TILE, "Unsupported input layout");
-        TT_FATAL(bias.get_legacy_shape() == Shape({1, 1, TILE_HEIGHT, input_tensor_b.get_legacy_shape()[3]}), "Unsupported bias shape");
+        TT_FATAL(
+            bias.get_legacy_shape() == Shape({1, 1, TILE_HEIGHT, input_tensor_b.get_legacy_shape()[3]}),
+            "Unsupported bias shape");
     }
 
     if (this->untilize_out) {
@@ -682,27 +838,25 @@ void Matmul::validate(
     }
 
     std::visit(
-        [
-            input_tensor_a,
-            input_tensor_b,
-            this
-        ](const auto& program_config) {
+        [input_tensor_a, input_tensor_b, this](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             // TODO: For 1D and 2D mcasts, we don't check if tensor is single core or single row/col
             // We can uplift these variants to skip mcasting to support single core (1D) or single row/col (2D)
-            if constexpr (
-                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>
-            ) {
+            if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
                 if (program_config.mcast_in0) {
                     if (input_tensor_a.is_sharded()) {
                         TT_FATAL(program_config.fuse_batch);
                         TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
                         if (this->output_mem_config.is_sharded()) {
                             TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
-                            TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+                            TT_FATAL(
+                                input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
                         }
                         TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
-                        uint32_t M = (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] : input_tensor_a.get_legacy_shape()[-2]) / TILE_HEIGHT;
+                        uint32_t M =
+                            (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
+                                                       : input_tensor_a.get_legacy_shape()[-2]) /
+                            TILE_HEIGHT;
                         uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
                         uint32_t K = input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH;
                         uint32_t per_core_M = program_config.per_core_M;
@@ -714,11 +868,13 @@ void Matmul::validate(
                         TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
                         TT_FATAL(K % program_config.in0_block_w == 0);
                         TT_FATAL((shard_shape[1] / TILE_WIDTH) % program_config.in0_block_w == 0);
-                        TT_FATAL(div_up(N, per_core_N) == input_tensor_a.shard_spec().value().grid.num_cores());
                     }
                     if (this->output_mem_config.is_sharded()) {
                         TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
-                        uint32_t M = (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] : input_tensor_a.get_legacy_shape()[-2]) / TILE_HEIGHT;
+                        uint32_t M =
+                            (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
+                                                       : input_tensor_a.get_legacy_shape()[-2]) /
+                            TILE_HEIGHT;
                         uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
                         uint32_t per_core_M = program_config.per_core_M;
                         uint32_t per_core_N = program_config.per_core_N;
@@ -734,10 +890,14 @@ void Matmul::validate(
                         TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
                         if (this->output_mem_config.is_sharded()) {
                             TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
-                            TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+                            TT_FATAL(
+                                input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
                         }
                         TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
-                        uint32_t M = (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] : input_tensor_a.get_legacy_shape()[-2]) / TILE_HEIGHT;
+                        uint32_t M =
+                            (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
+                                                       : input_tensor_a.get_legacy_shape()[-2]) /
+                            TILE_HEIGHT;
                         uint32_t K = input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH;
                         uint32_t per_core_M = program_config.per_core_M;
                         auto shard_shape = input_tensor_a.shard_spec().value().shape;
@@ -749,7 +909,10 @@ void Matmul::validate(
                     }
                     if (this->output_mem_config.is_sharded()) {
                         TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
-                        uint32_t M = (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] : input_tensor_a.get_legacy_shape()[-2]) / TILE_HEIGHT;
+                        uint32_t M =
+                            (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
+                                                       : input_tensor_a.get_legacy_shape()[-2]) /
+                            TILE_HEIGHT;
                         uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
                         uint32_t per_core_M = program_config.per_core_M;
                         uint32_t per_core_N = program_config.per_core_N;
@@ -759,9 +922,7 @@ void Matmul::validate(
                     }
                 }
                 TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-            } else if constexpr (
-                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>
-            ) {
+            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>) {
                 if (input_tensor_a.memory_config().is_sharded()) {
                     auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout;
                     uint32_t M = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
@@ -782,7 +943,8 @@ void Matmul::validate(
                         }
                         if (this->output_mem_config.is_sharded()) {
                             TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
-                            TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+                            TT_FATAL(
+                                input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
                         }
 
                         TT_FATAL(K / (shard_shape[1] / TILE_WIDTH) == div_up(N, program_config.per_core_N));
@@ -816,9 +978,7 @@ void Matmul::validate(
 
                     TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1);
                 }
-            } else if constexpr (
-                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>
-            ) {
+            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
                 uint32_t M = input_tensor_a.get_legacy_shape()[-2] / TILE_HEIGHT;
                 uint32_t total_M = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
                 uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
@@ -841,10 +1001,15 @@ void Matmul::validate(
                     TT_FATAL(per_core_M * TILE_HEIGHT == in0_shard_shape[0]);
 
                     if (input_tensor_b.is_sharded()) {
-                        TT_FATAL(input_tensor_a.memory_config().buffer_type == input_tensor_b.memory_config().buffer_type);
-                        TT_FATAL(input_tensor_a.memory_config().memory_layout == input_tensor_b.memory_config().memory_layout);
+                        TT_FATAL(
+                            input_tensor_a.memory_config().buffer_type == input_tensor_b.memory_config().buffer_type);
+                        TT_FATAL(
+                            input_tensor_a.memory_config().memory_layout ==
+                            input_tensor_b.memory_config().memory_layout);
                         TT_FATAL(input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid);
-                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == input_tensor_b.shard_spec().value().orientation);
+                        TT_FATAL(
+                            input_tensor_a.shard_spec().value().orientation ==
+                            input_tensor_b.shard_spec().value().orientation);
                     }
                     if (this->output_mem_config.is_sharded()) {
                         TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
@@ -852,10 +1017,9 @@ void Matmul::validate(
                     }
                 }
 
-                bool broadcast_batch = (
-                    input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] > 1
-                    and input_tensor_b.get_legacy_shape()[0] * input_tensor_b.get_legacy_shape()[1] == 1
-                );
+                bool broadcast_batch =
+                    (input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] > 1 and
+                     input_tensor_b.get_legacy_shape()[0] * input_tensor_b.get_legacy_shape()[1] == 1);
                 TT_FATAL(!broadcast_batch);
 
                 if (input_tensor_b.is_sharded()) {
@@ -878,16 +1042,19 @@ void Matmul::validate(
             if constexpr (
                 std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig> ||
                 std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig> ||
-                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>
-            ) {
-                TT_FATAL((input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH) % program_config.in0_block_w == 0, "Kt must be divisible by in0_block_w");
-                TT_FATAL(program_config.per_core_M % program_config.out_subblock_h == 0, "per_core_M must be divisible by out_subblock_h");
-                TT_FATAL(program_config.per_core_N % program_config.out_subblock_w == 0, "per_core_N must be divisible by out_subblock_w");
+                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                TT_FATAL(
+                    (input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH) % program_config.in0_block_w == 0,
+                    "Kt must be divisible by in0_block_w");
+                TT_FATAL(
+                    program_config.per_core_M % program_config.out_subblock_h == 0,
+                    "per_core_M must be divisible by out_subblock_h");
+                TT_FATAL(
+                    program_config.per_core_N % program_config.out_subblock_w == 0,
+                    "per_core_N must be divisible by out_subblock_w");
             }
         },
-        this->program_config
-    );
-
+        this->program_config);
 }
 
 std::vector<Shape> Matmul::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
@@ -913,11 +1080,12 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
         return std::visit(
             [&](const auto& program_config) -> std::vector<Tensor> {
                 using ProgramConfigType = std::decay_t<decltype(program_config)>;
-                if constexpr (
-                    std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>
-                ) {
-                    uint32_t M = (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] : input_tensor_a.get_legacy_shape()[-2]) / TILE_HEIGHT;
-                    uint32_t N = input_tensor_b.get_legacy_shape()[-1]/TILE_WIDTH;
+                if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                    uint32_t M =
+                        (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
+                                                   : input_tensor_a.get_legacy_shape()[-2]) /
+                        TILE_HEIGHT;
+                    uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
                     uint32_t per_core_M = program_config.per_core_M;
                     uint32_t per_core_N = program_config.per_core_N;
 
@@ -925,16 +1093,21 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                     uint32_t num_blocks_x = (N - 1) / per_core_N + 1;
                     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
                     uint32_t num_cores = num_blocks_x * num_blocks_y;
-                    CoreRangeSet all_cores = num_cores_to_corerange_set(num_cores, program_config.compute_with_storage_grid_size, true);
-                    ShardSpec shard_spec = ShardSpec{all_cores, {per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, ShardOrientation::ROW_MAJOR};
+                    CoreRangeSet all_cores =
+                        num_cores_to_corerange_set(num_cores, program_config.compute_with_storage_grid_size, true);
+                    ShardSpec shard_spec = ShardSpec{
+                        all_cores, {per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, ShardOrientation::ROW_MAJOR};
                     auto mem_config = this->output_mem_config;
                     mem_config.shard_spec = shard_spec;
-                    return {create_device_tensor(this->compute_output_shapes(input_tensors).at(0), this->output_dtype, output_layout, input_tensor_a.device(), mem_config)};
-                } else if constexpr (
-                    std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>
-                ) {
+                    return {create_device_tensor(
+                        this->compute_output_shapes(input_tensors).at(0),
+                        this->output_dtype,
+                        output_layout,
+                        input_tensor_a.device(),
+                        mem_config)};
+                } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>) {
                     uint32_t M = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
-                    uint32_t N = input_tensor_b.get_legacy_shape()[-1]/TILE_WIDTH;
+                    uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
                     uint32_t per_core_M = program_config.per_core_M;
                     uint32_t per_core_N = program_config.per_core_N;
 
@@ -951,15 +1124,19 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                         all_cores = CoreRangeSet({CoreRange({0, 0}, {num_blocks_x - 1, num_blocks_y - 1})});
                         shard_orientation = ShardOrientation::ROW_MAJOR;
                     }
-                    ShardSpec shard_spec = ShardSpec{all_cores, {per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, shard_orientation};
+                    ShardSpec shard_spec =
+                        ShardSpec{all_cores, {per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, shard_orientation};
                     auto mem_config = this->output_mem_config;
                     mem_config.shard_spec = shard_spec;
-                    return {create_device_tensor(this->compute_output_shapes(input_tensors).at(0), this->output_dtype, output_layout, input_tensor_a.device(), mem_config)};
-                } else if constexpr (
-                    std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>
-                ) {
+                    return {create_device_tensor(
+                        this->compute_output_shapes(input_tensors).at(0),
+                        this->output_dtype,
+                        output_layout,
+                        input_tensor_a.device(),
+                        mem_config)};
+                } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
                     uint32_t M = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
-                    uint32_t N = input_tensor_b.get_legacy_shape()[-1]/TILE_WIDTH;
+                    uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
                     uint32_t per_core_M = program_config.per_core_M;
                     uint32_t per_core_N = program_config.per_core_N;
 
@@ -974,27 +1151,35 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                         shard_orientation = input_tensor_b.shard_spec().value().orientation;
                     }
 
-                    CoreRangeSet all_cores = num_cores_to_corerange_set(num_cores, program_config.compute_with_storage_grid_size, shard_orientation==ShardOrientation::ROW_MAJOR);
-                    ShardSpec shard_spec = ShardSpec{all_cores, {per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, shard_orientation};
+                    CoreRangeSet all_cores = num_cores_to_corerange_set(
+                        num_cores,
+                        program_config.compute_with_storage_grid_size,
+                        shard_orientation == ShardOrientation::ROW_MAJOR);
+                    ShardSpec shard_spec =
+                        ShardSpec{all_cores, {per_core_M * TILE_HEIGHT, per_core_N * TILE_WIDTH}, shard_orientation};
                     auto mem_config = this->output_mem_config;
                     mem_config.shard_spec = shard_spec;
-                    return {create_device_tensor(this->compute_output_shapes(input_tensors).at(0), this->output_dtype, output_layout, input_tensor_a.device(), mem_config)};
+                    return {create_device_tensor(
+                        this->compute_output_shapes(input_tensors).at(0),
+                        this->output_dtype,
+                        output_layout,
+                        input_tensor_a.device(),
+                        mem_config)};
                 } else {
                     TT_FATAL(false, "Unsupported op for output sharding");
                     return {};
                 }
             },
-            this->program_config
-        );
+            this->program_config);
     }
-    return operation::generic_create_output_tensors(*this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
 }
 
 operation::ProgramWithCallbacks Matmul::create_program(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor> &output_tensors
-) const {
+    std::vector<Tensor>& output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     const auto& bias = optional_input_tensors.at(0);
@@ -1003,126 +1188,191 @@ operation::ProgramWithCallbacks Matmul::create_program(
     tt::tt_metal::DataType output_dtype = this->output_dtype;
 
     bool fuse_batch = true;
-    // TODO: If input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] == 1, does matmuls work if we treat it as bmm
+    // TODO: If input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] == 1, does matmuls work if
+    // we treat it as bmm
     // TODO: Only for MatmulMultiCoreReuseProgramConfig we allow this as single core matmul/bmm
     bool broadcast_batch = this->bcast_batch;
-
 
     return std::visit(
         [&](const auto& program_config) -> operation::ProgramWithCallbacks {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, MatmulDefaultProgramConfig>) {
                 auto parallelization_strategy = bmm_op_utils::get_parallelization_strategy(input_tensors);
-		MatmulMultiCoreReuseMultiCast1DProgramConfig config{};
-                switch (parallelization_strategy){
+                MatmulMultiCoreReuseMultiCast1DProgramConfig config{};
+                switch (parallelization_strategy) {
                     case MatmulParallelizationStrategy::MULTI_CORE_REUSE:
-                        TT_FATAL(!bias.has_value(), "Bias is not supported for MatmulParallelizationStrategy::MULTI_CORE_REUSE!");
+                        TT_FATAL(
+                            !bias.has_value(),
+                            "Bias is not supported for MatmulParallelizationStrategy::MULTI_CORE_REUSE!");
                         return matmul_multi_core_reuse(input_tensor_a, input_tensor_b, output_tensor, broadcast_batch);
                     case MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_2D_OPTIMIZED:
                         return matmul_multi_core_reuse_mcast_2d_optimized(
-                            input_tensor_a, input_tensor_b, bias, output_tensor,
+                            input_tensor_a,
+                            input_tensor_b,
+                            bias,
+                            output_tensor,
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
                             this->compute_kernel_config,
-                            2, 4, 2,
-                            16, 16, false, false, std::nullopt,
-                            this->untilize_out
-                        );
+                            2,
+                            4,
+                            2,
+                            16,
+                            16,
+                            false,
+                            false,
+                            std::nullopt,
+                            this->untilize_out);
                     case MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN0_OPTIMIZED:
-			config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, false /* fuse_batch */, std::nullopt /* fused_activation */, true /* mcast_in0 */, false /* out_sharded */, std::nullopt /* compute_with_storage_grid_size */, compute_kernel_config);
-                        TT_FATAL(!bias.has_value(), "Bias is not supported for MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN0_OPTIMIZED!");
+                        config = bmm_op_utils::get_mcast_1d_config(
+                            input_tensor_a,
+                            input_tensor_b,
+                            false /* fuse_batch */,
+                            std::nullopt /* fused_activation */,
+                            true /* mcast_in0 */,
+                            false /* out_sharded */,
+                            std::nullopt /* compute_with_storage_grid_size */,
+                            compute_kernel_config);
+                        TT_FATAL(
+                            !bias.has_value(),
+                            "Bias is not supported for "
+                            "MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN0_OPTIMIZED!");
                         return matmul_multi_core_reuse_mcast_1d_optimized(
-                            input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
+                            input_tensor_a,
+                            input_tensor_b,
+                            std::nullopt,
+                            output_tensor,
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
                             this->compute_kernel_config,
-			    config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
-			    config.per_core_M, config.per_core_N, false, std::nullopt, true,
-                            this->untilize_out
-                        );
+                            config.in0_block_w,
+                            config.out_subblock_h,
+                            config.out_subblock_w,
+                            config.per_core_M,
+                            config.per_core_N,
+                            false,
+                            std::nullopt,
+                            true,
+                            this->untilize_out);
                     case MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN1_OPTIMIZED:
-                        TT_FATAL(!bias.has_value(), "Bias is not supported for MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN1_OPTIMIZED!");
-			config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, false /* fuse_batch */, std::nullopt /* fused_activation */, false /* mcast_in0 */, false /* out_sharded */, std::nullopt /* compute_with_storage_grid_size */, this->compute_kernel_config);
+                        TT_FATAL(
+                            !bias.has_value(),
+                            "Bias is not supported for "
+                            "MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN1_OPTIMIZED!");
+                        config = bmm_op_utils::get_mcast_1d_config(
+                            input_tensor_a,
+                            input_tensor_b,
+                            false /* fuse_batch */,
+                            std::nullopt /* fused_activation */,
+                            false /* mcast_in0 */,
+                            false /* out_sharded */,
+                            std::nullopt /* compute_with_storage_grid_size */,
+                            this->compute_kernel_config);
                         return matmul_multi_core_reuse_mcast_1d_optimized(
-                            input_tensor_a, input_tensor_b, std::nullopt, output_tensor,
+                            input_tensor_a,
+                            input_tensor_b,
+                            std::nullopt,
+                            output_tensor,
                             broadcast_batch,
                             input_tensor_a.device()->compute_with_storage_grid_size(),
                             this->compute_kernel_config,
-			    config.in0_block_w, config.out_subblock_h, config.out_subblock_w,
-			    config.per_core_M, config.per_core_N, false, std::nullopt, false,
-                            this->untilize_out
-                        );
+                            config.in0_block_w,
+                            config.out_subblock_h,
+                            config.out_subblock_w,
+                            config.per_core_M,
+                            config.per_core_N,
+                            false,
+                            std::nullopt,
+                            false,
+                            this->untilize_out);
                     case MatmulParallelizationStrategy::MULTI_CORE_REUSE_PADDING:
-                        TT_FATAL(!bias.has_value(), "Bias is not supported for MatmulParallelizationStrategy::MULTI_CORE_REUSE_PADDING!");
-                        return matmul_multi_core_reuse_padding(input_tensor_a, input_tensor_b, output_tensor, broadcast_batch);
+                        TT_FATAL(
+                            !bias.has_value(),
+                            "Bias is not supported for MatmulParallelizationStrategy::MULTI_CORE_REUSE_PADDING!");
+                        return matmul_multi_core_reuse_padding(
+                            input_tensor_a, input_tensor_b, output_tensor, broadcast_batch);
                     case MatmulParallelizationStrategy::MULTI_CORE:
                     default:
-                        TT_FATAL(!bias.has_value(), "Bias is not supported for MatmulParallelizationStrategy::MULTI_CORE!");
+                        TT_FATAL(
+                            !bias.has_value(), "Bias is not supported for MatmulParallelizationStrategy::MULTI_CORE!");
                         return matmul_multi_core(input_tensor_a, input_tensor_b, output_tensor, broadcast_batch);
                 }
-            }
-            else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
+            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
                 TT_FATAL(!bias.has_value(), "Bias is not supported for MatmulMultiCoreReuseProgramConfig!");
                 // TODO: fuse_batch doesn't do anything for this variant! Code is doing fuse_batch=false
                 return bmm_multi_core_reuse_optimized(
-                    input_tensor_a, input_tensor_b, output_tensor,
+                    input_tensor_a,
+                    input_tensor_b,
+                    output_tensor,
                     broadcast_batch,
                     program_config.compute_with_storage_grid_size,
                     output_dtype,
                     this->compute_kernel_config,
-                    program_config.in0_block_w, program_config.out_subblock_h, program_config.out_subblock_w,
-                    program_config.per_core_M, program_config.per_core_N, /*fuse_batch=*/false,
-                    this->untilize_out
-                );
-            }
-            else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>) {
+                    program_config.in0_block_w,
+                    program_config.out_subblock_h,
+                    program_config.out_subblock_w,
+                    program_config.per_core_M,
+                    program_config.per_core_N,
+                    /*fuse_batch=*/false,
+                    this->untilize_out);
+            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>) {
                 return matmul_multi_core_reuse_mcast_2d_optimized(
-                    input_tensor_a, input_tensor_b, bias, output_tensor,
+                    input_tensor_a,
+                    input_tensor_b,
+                    bias,
+                    output_tensor,
                     broadcast_batch,
                     program_config.compute_with_storage_grid_size,
                     this->compute_kernel_config,
-                    program_config.in0_block_w, program_config.out_subblock_h, program_config.out_subblock_w,
-                    program_config.per_core_M, program_config.per_core_N, fuse_batch, program_config.transpose_mcast, program_config.fused_activation,
-                    this->untilize_out
-                );
-            }
-            else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                    program_config.in0_block_w,
+                    program_config.out_subblock_h,
+                    program_config.out_subblock_w,
+                    program_config.per_core_M,
+                    program_config.per_core_N,
+                    fuse_batch,
+                    program_config.transpose_mcast,
+                    program_config.fused_activation,
+                    this->untilize_out);
+            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
                 return matmul_multi_core_reuse_mcast_1d_optimized(
-                    input_tensor_a, input_tensor_b, bias, output_tensor,
+                    input_tensor_a,
+                    input_tensor_b,
+                    bias,
+                    output_tensor,
                     broadcast_batch,
                     program_config.compute_with_storage_grid_size,
                     this->compute_kernel_config,
-                    program_config.in0_block_w, program_config.out_subblock_h, program_config.out_subblock_w,
-                    program_config.per_core_M, program_config.per_core_N, program_config.fuse_batch, program_config.fused_activation,
+                    program_config.in0_block_w,
+                    program_config.out_subblock_h,
+                    program_config.out_subblock_w,
+                    program_config.per_core_M,
+                    program_config.per_core_N,
+                    program_config.fuse_batch,
+                    program_config.fused_activation,
                     program_config.mcast_in0,
-                    this->untilize_out
-                );
+                    this->untilize_out);
             } else {
                 TT_THROW("Unrecognized Config");
             }
         },
-        this->program_config
-    );
+        this->program_config);
 }
 
-MatmulParallelizationStrategy Matmul::get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const {
+MatmulParallelizationStrategy Matmul::get_parallelization_strategy(const std::vector<Tensor>& input_tensors) const {
     return std::visit(
         [&](const auto& program_config) -> MatmulParallelizationStrategy {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, MatmulDefaultProgramConfig>) {
                 return bmm_op_utils::get_parallelization_strategy(input_tensors);
-            }
-            else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
+            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
                 return MatmulParallelizationStrategy::MULTI_CORE_REUSE_OPTIMIZED;
-            }
-            else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>) {
+            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>) {
                 if (program_config.transpose_mcast) {
                     return MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_2D_TRANSPOSED_OPTIMIZED;
                 } else {
                     return MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_2D_OPTIMIZED;
                 }
-            }
-            else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
                 if (program_config.mcast_in0) {
                     return MatmulParallelizationStrategy::MULTI_CORE_REUSE_MCAST_1D_IN0_OPTIMIZED;
                 } else {
@@ -1132,37 +1382,70 @@ MatmulParallelizationStrategy Matmul::get_parallelization_strategy(const std::ve
                 TT_THROW("Unrecognized Config");
             }
         },
-        this->program_config
-    );
+        this->program_config);
 }
 
-Tensor matmul_1d(const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::optional<const Tensor> bias, std::optional<MatmulMultiCoreReuseMultiCast1DProgramConfig> program_config, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype, std::optional<const DeviceComputeKernelConfig> compute_kernel_config, bool untilize_out) {
-    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}, {bias}))};
+Tensor matmul_1d(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    std::optional<const Tensor> bias,
+    std::optional<MatmulMultiCoreReuseMultiCast1DProgramConfig> program_config,
+    const MemoryConfig& mem_config,
+    std::optional<const DataType> output_dtype,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    bool untilize_out) {
+    std::vector<Tensor> output_tensors = {
+        Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}, {bias}))};
     operation::launch_op(
-        [program_config, mem_config, output_dtype, compute_kernel_config, untilize_out] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+        [program_config, mem_config, output_dtype, compute_kernel_config, untilize_out](
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor_a = input_tensors.at(0);
             const auto& input_tensor_b = input_tensors.at(1);
             if (!program_config.has_value()) {
-                program_config = bmm_op_utils::get_mcast_1d_config(input_tensor_a, input_tensor_b, false /* fuse_batch */, std::nullopt /* fused_activation */, true /* mcast_in0 */, false /* out_sharded */, std::nullopt /* compute_with_storage_grid_size */, compute_kernel_config);
+                program_config = bmm_op_utils::get_mcast_1d_config(
+                    input_tensor_a,
+                    input_tensor_b,
+                    false /* fuse_batch */,
+                    std::nullopt /* fused_activation */,
+                    true /* mcast_in0 */,
+                    false /* out_sharded */,
+                    std::nullopt /* compute_with_storage_grid_size */,
+                    compute_kernel_config);
             }
-            auto kernel_config_val = init_device_compute_kernel_config(input_tensor_a.device()->arch(), compute_kernel_config);
-            return {operations::primary::matmul(input_tensor_a, input_tensor_b, optional_input_tensors.at(0), program_config.value(), mem_config, output_dtype, kernel_config_val, untilize_out)};
+            auto kernel_config_val =
+                init_device_compute_kernel_config(input_tensor_a.device()->arch(), compute_kernel_config);
+            return {operations::primary::matmul(
+                input_tensor_a,
+                input_tensor_b,
+                optional_input_tensors.at(0),
+                program_config.value(),
+                mem_config,
+                output_dtype,
+                kernel_config_val,
+                untilize_out)};
         },
-    {input_tensor_a, input_tensor_b}, output_tensors, {bias});
+        {input_tensor_a, input_tensor_b},
+        output_tensors,
+        {bias});
     return output_tensors.at(0);
 }
 
 operation::OpPerformanceModel Matmul::create_op_performance_model(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor> &output_tensors
-    ) const {
-    return ::create_op_performance_model_for_matmul(input_tensors, optional_input_tensors, output_tensors, this->compute_kernel_config);
+    const std::vector<Tensor>& input_tensors,
+    const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+    std::vector<Tensor>& output_tensors) const {
+    return ::create_op_performance_model_for_matmul(
+        input_tensors, optional_input_tensors, output_tensors, this->compute_kernel_config);
 }
 
-
-
-MatmulProgramConfig create_matmul_1d_systolic_array_program_config(const ttnn::types::Shape& input_shape_a, const ttnn::types::Shape& input_shape_b, const CoreCoord& core_coord, const std::optional<const UnaryWithParam> fused_activation, const bool fp32_dest_acc_en) {
+MatmulProgramConfig create_matmul_1d_systolic_array_program_config(
+    const ttnn::types::Shape& input_shape_a,
+    const ttnn::types::Shape& input_shape_b,
+    const CoreCoord& core_coord,
+    const std::optional<const UnaryWithParam> fused_activation,
+    const bool fp32_dest_acc_en) {
     auto a_padded_shape = input_shape_a.with_tile_padding();
     auto b_padded_shape = input_shape_b.with_tile_padding();
     auto k_size = a_padded_shape[-1];
@@ -1172,7 +1455,11 @@ MatmulProgramConfig create_matmul_1d_systolic_array_program_config(const ttnn::t
     uint32_t batch_size_b = get_batch_size(b_padded_shape);
     bool input_b_is_batched = batch_size_b > 1;
     TT_FATAL(batch_size_b == 1, "Second input cannot be currently batched when running matmul using 1d systolic array");
-    TT_FATAL((batch_size_a * m_size) % ttnn::TILE_SIZE == 0 && k_size % ttnn::TILE_SIZE == 0 && n_size % ttnn::TILE_SIZE == 0, "The last two dimensions of the first tensor and the last dimension of the second tensor must be a multiple of tile size");
+    TT_FATAL(
+        (batch_size_a * m_size) % ttnn::TILE_SIZE == 0 && k_size % ttnn::TILE_SIZE == 0 &&
+            n_size % ttnn::TILE_SIZE == 0,
+        "The last two dimensions of the first tensor and the last dimension of the second tensor must be a multiple of "
+        "tile size");
     uint32_t batch_and_m_tiles = (batch_size_a * m_size) / ttnn::TILE_SIZE;
     uint32_t k_tiles = k_size / ttnn::TILE_SIZE;
     uint32_t n_tiles = n_size / ttnn::TILE_SIZE;
@@ -1183,34 +1470,40 @@ MatmulProgramConfig create_matmul_1d_systolic_array_program_config(const ttnn::t
     uint32_t k_tiles_per_core;
     uint32_t n_tiles_per_core;
     if (is_tall) {
-	batch_and_m_tiles_per_core = div_up(batch_and_m_tiles, num_cores);
-	k_tiles_per_core = div_up(k_tiles, num_cores);
-	n_tiles_per_core = n_tiles;
+        batch_and_m_tiles_per_core = div_up(batch_and_m_tiles, num_cores);
+        k_tiles_per_core = div_up(k_tiles, num_cores);
+        n_tiles_per_core = n_tiles;
     } else {
-	batch_and_m_tiles_per_core = batch_and_m_tiles;
-	k_tiles_per_core = div_up(k_tiles, num_cores);
-	n_tiles_per_core = div_up(n_tiles, num_cores);
+        batch_and_m_tiles_per_core = batch_and_m_tiles;
+        k_tiles_per_core = div_up(k_tiles, num_cores);
+        n_tiles_per_core = div_up(n_tiles, num_cores);
     }
     while (k_tiles % k_tiles_per_core != 0) {
         k_tiles_per_core -= 1;
     }
-    auto matmul_params = bmm_op_utils::get_subblock_sizes(batch_and_m_tiles_per_core, n_tiles_per_core, fp32_dest_acc_en);
+    auto matmul_params =
+        bmm_op_utils::get_subblock_sizes(batch_and_m_tiles_per_core, n_tiles_per_core, fp32_dest_acc_en);
     uint32_t out_subblock_h = std::get<0>(matmul_params);
     uint32_t out_subblock_w = std::get<1>(matmul_params);
     return MatmulMultiCoreReuseMultiCast1DProgramConfig{
-            .compute_with_storage_grid_size = {core_coord.x, core_coord.y},
-            .in0_block_w = k_tiles_per_core,
-            .out_subblock_h = out_subblock_h,
-            .out_subblock_w = out_subblock_w,
-            .per_core_M = batch_and_m_tiles_per_core,
-            .per_core_N = n_tiles_per_core,
-	    .fuse_batch = true,
-            .fused_activation = fused_activation,
-	    .mcast_in0 = is_wide,
+        .compute_with_storage_grid_size = {core_coord.x, core_coord.y},
+        .in0_block_w = k_tiles_per_core,
+        .out_subblock_h = out_subblock_h,
+        .out_subblock_w = out_subblock_w,
+        .per_core_M = batch_and_m_tiles_per_core,
+        .per_core_N = n_tiles_per_core,
+        .fuse_batch = true,
+        .fused_activation = fused_activation,
+        .mcast_in0 = is_wide,
     };
 }
 
-MatmulProgramConfig create_matmul_program_config(const Tensor& input_tensor_a, const Tensor& input_tensor_b, const std::optional<const CoreCoord> user_core_coord, std::optional<UnaryWithParam> fused_activation, std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+MatmulProgramConfig create_matmul_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const CoreCoord> user_core_coord,
+    std::optional<UnaryWithParam> fused_activation,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     auto a_shape = input_tensor_a.get_shape();
     auto b_shape = input_tensor_b.get_shape();
     auto a_padded_shape = a_shape.with_tile_padding();
@@ -1229,43 +1522,50 @@ MatmulProgramConfig create_matmul_program_config(const Tensor& input_tensor_a, c
     bool fp32_dest_acc_en = bmm_op_utils::get_fp32_dest_acc_en(compute_kernel_config);
     bool a_is_sharded = input_tensor_a.is_sharded();
     TT_FATAL(inteneded_k_size_of_a == inteneded_k_size_of_b, "The k dimension does not match between tensors");
-    TT_FATAL((batch_size_a * m_size) % ttnn::TILE_SIZE == 0 && k_size % ttnn::TILE_SIZE == 0 && n_size % ttnn::TILE_SIZE == 0, "The last two dimensions of the first tensor and the last dimension of the second tensor must be a multiple of tile size");
+    TT_FATAL(
+        (batch_size_a * m_size) % ttnn::TILE_SIZE == 0 && k_size % ttnn::TILE_SIZE == 0 &&
+            n_size % ttnn::TILE_SIZE == 0,
+        "The last two dimensions of the first tensor and the last dimension of the second tensor must be a multiple of "
+        "tile size");
     auto core_coord = input_tensor_a.device()->compute_with_storage_grid_size();
     if (user_core_coord.has_value()) {
-	auto x = user_core_coord.value().x;
-	auto y = user_core_coord.value().y;
-	if (x <= core_coord.x && y <= core_coord.y) {
-	    core_coord = user_core_coord.value();
-	}
+        auto x = user_core_coord.value().x;
+        auto y = user_core_coord.value().y;
+        if (x <= core_coord.x && y <= core_coord.y) {
+            core_coord = user_core_coord.value();
+        }
     }
 
     uint32_t m_tiles_per_core;
     uint32_t n_tiles_per_core;
     uint32_t k_tiles_per_core;
     if (input_b_is_batched) {
-	TT_FATAL(!fused_activation.has_value(), "Cannot use activation with batched input b");
-	if (!a_is_sharded && !input_tensor_b.is_sharded()) {
+        TT_FATAL(!fused_activation.has_value(), "Cannot use activation with batched input b");
+        if (!a_is_sharded && !input_tensor_b.is_sharded()) {
             m_tiles_per_core = div_up(m_size, ttnn::TILE_SIZE);
             n_tiles_per_core = div_up(n_size, ttnn::TILE_SIZE);
             k_tiles_per_core = 1;  // TODO(arakhmati): Can it be more than 1 without running out of memory?
-	}
-	else if (a_is_sharded) {
-	    TT_FATAL(input_tensor_a_memory_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "MatmulMultiCoreReuseProgramConfig: Cannot be width sharded");
-	    auto shard_shape = input_tensor_a_memory_config.shard_spec.value().shape;
-	    uint32_t n = b_shape[-1] / ttnn::TILE_SIZE;
-	    m_tiles_per_core = shard_shape[0] / ttnn::TILE_SIZE;
-	    n_tiles_per_core = n;
-	    k_tiles_per_core = shard_shape[1] / ttnn::TILE_SIZE;
-	} else {
-	    TT_FATAL(input_tensor_b_memory_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "MatmulMultiCoreReuseProgramConfig: Cannot be width sharded");
-	    auto shard_shape = input_tensor_b_memory_config.shard_spec.value().shape;
-	    m_tiles_per_core = div_up(m_size, ttnn::TILE_SIZE);
-	    n_tiles_per_core = shard_shape[1] / ttnn::TILE_SIZE;
-	    k_tiles_per_core = 1;
-	}
-	auto matmul_params = bmm_op_utils::get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, fp32_dest_acc_en);
-	uint32_t out_subblock_h = std::get<0>(matmul_params);
-	uint32_t out_subblock_w = std::get<1>(matmul_params);
+        } else if (a_is_sharded) {
+            TT_FATAL(
+                input_tensor_a_memory_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED,
+                "MatmulMultiCoreReuseProgramConfig: Cannot be width sharded");
+            auto shard_shape = input_tensor_a_memory_config.shard_spec.value().shape;
+            uint32_t n = b_shape[-1] / ttnn::TILE_SIZE;
+            m_tiles_per_core = shard_shape[0] / ttnn::TILE_SIZE;
+            n_tiles_per_core = n;
+            k_tiles_per_core = shard_shape[1] / ttnn::TILE_SIZE;
+        } else {
+            TT_FATAL(
+                input_tensor_b_memory_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED,
+                "MatmulMultiCoreReuseProgramConfig: Cannot be width sharded");
+            auto shard_shape = input_tensor_b_memory_config.shard_spec.value().shape;
+            m_tiles_per_core = div_up(m_size, ttnn::TILE_SIZE);
+            n_tiles_per_core = shard_shape[1] / ttnn::TILE_SIZE;
+            k_tiles_per_core = 1;
+        }
+        auto matmul_params = bmm_op_utils::get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, fp32_dest_acc_en);
+        uint32_t out_subblock_h = std::get<0>(matmul_params);
+        uint32_t out_subblock_w = std::get<1>(matmul_params);
 
         return MatmulMultiCoreReuseProgramConfig{
             .compute_with_storage_grid_size = {core_coord.x, core_coord.y},
@@ -1281,38 +1581,41 @@ MatmulProgramConfig create_matmul_program_config(const Tensor& input_tensor_a, c
     auto width = n_size;
     auto height_width_ratio = (height > width) ? height / width : width / height;
     if (height_width_ratio > 8 || any_size_within_tile) {
-	return create_matmul_1d_systolic_array_program_config(a_shape, b_shape, core_coord, fused_activation, fp32_dest_acc_en);
+        return create_matmul_1d_systolic_array_program_config(
+            a_shape, b_shape, core_coord, fused_activation, fp32_dest_acc_en);
     }
     if (!a_is_sharded) {
-            m_tiles_per_core = (uint32_t)std::ceil((((double)batch_size_a * m_size) / ttnn::TILE_SIZE) / core_coord.y);
-            n_tiles_per_core = (uint32_t)std::ceil((double)n_size / ttnn::TILE_SIZE / core_coord.x);
-            k_tiles_per_core = 4; // TODO(arakhmati): What is a good starting point?
-            while ((k_size / ttnn::TILE_SIZE) % k_tiles_per_core != 0) {
-                k_tiles_per_core -= 1;
-	    }
+        m_tiles_per_core = (uint32_t)std::ceil((((double)batch_size_a * m_size) / ttnn::TILE_SIZE) / core_coord.y);
+        n_tiles_per_core = (uint32_t)std::ceil((double)n_size / ttnn::TILE_SIZE / core_coord.x);
+        k_tiles_per_core = 4;  // TODO(arakhmati): What is a good starting point?
+        while ((k_size / ttnn::TILE_SIZE) % k_tiles_per_core != 0) {
+            k_tiles_per_core -= 1;
+        }
     } else {
-	TT_FATAL(input_tensor_a_memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED, "MatmulMultiCoreReuseMultiCastProgramConfig: Must be block sharded");
-            uint32_t k = a_shape[-1] / ttnn::TILE_SIZE;
-            uint32_t n = b_shape[-1] / ttnn::TILE_SIZE;
-            auto shard_shape = input_tensor_a_memory_config.shard_spec.value().shape;
-            m_tiles_per_core = shard_shape[0] / ttnn::TILE_SIZE;
-            n_tiles_per_core = (n * shard_shape[1]) / (k * ttnn::TILE_SIZE);
-            k_tiles_per_core = shard_shape[1] / ttnn::TILE_SIZE;
+        TT_FATAL(
+            input_tensor_a_memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED,
+            "MatmulMultiCoreReuseMultiCastProgramConfig: Must be block sharded");
+        uint32_t k = a_shape[-1] / ttnn::TILE_SIZE;
+        uint32_t n = b_shape[-1] / ttnn::TILE_SIZE;
+        auto shard_shape = input_tensor_a_memory_config.shard_spec.value().shape;
+        m_tiles_per_core = shard_shape[0] / ttnn::TILE_SIZE;
+        n_tiles_per_core = (n * shard_shape[1]) / (k * ttnn::TILE_SIZE);
+        k_tiles_per_core = shard_shape[1] / ttnn::TILE_SIZE;
     }
     auto matmul_params = bmm_op_utils::get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, fp32_dest_acc_en);
     uint32_t out_subblock_h = std::get<0>(matmul_params);
     uint32_t out_subblock_w = std::get<1>(matmul_params);
 
     return MatmulMultiCoreReuseMultiCastProgramConfig{
-            .compute_with_storage_grid_size = {core_coord.x, core_coord.y},
-            .in0_block_w = k_tiles_per_core,
-            .out_subblock_h = out_subblock_h,
-            .out_subblock_w = out_subblock_w,
-            .per_core_M = m_tiles_per_core,
-            .per_core_N = n_tiles_per_core,
-            .transpose_mcast = false,
-            .fused_activation = fused_activation,
-        };
+        .compute_with_storage_grid_size = {core_coord.x, core_coord.y},
+        .in0_block_w = k_tiles_per_core,
+        .out_subblock_h = out_subblock_h,
+        .out_subblock_w = out_subblock_w,
+        .per_core_M = m_tiles_per_core,
+        .per_core_N = n_tiles_per_core,
+        .transpose_mcast = false,
+        .fused_activation = fused_activation,
+    };
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_width_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_width_sharded.cpp
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+
+void kernel_main() {
+    constexpr bool core_has_output_block_work = (bool)get_compile_time_arg_val(0);
+    constexpr bool core_in_in0_receiver_mcast_grid = (bool)get_compile_time_arg_val(1);
+
+    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(2);
+    constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(3);
+    // in0/in1 common args
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(4);
+    // in0 mcast args
+    constexpr uint32_t in0_mcast_sender_semaphore_addr = get_compile_time_arg_val(5);
+    constexpr uint32_t in0_mcast_receiver_semaphore_addr = get_compile_time_arg_val(6);
+    constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(7);
+    constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(8);
+    constexpr uint32_t num_x = get_compile_time_arg_val(9);
+    constexpr uint32_t num_y = get_compile_time_arg_val(10);
+    constexpr bool transpose_mcast = (bool)get_compile_time_arg_val(11);
+    constexpr uint32_t shard_width_in_tiles = get_compile_time_arg_val(12);
+    constexpr uint32_t shard_height_in_tiles = get_compile_time_arg_val(13);
+    constexpr uint32_t in0_block_w = get_compile_time_arg_val(14);
+
+    constexpr uint32_t batch = get_compile_time_arg_val(15);
+
+    const uint32_t sender_id = get_arg_val<uint32_t>(0);
+    const uint32_t in0_mcast_dest_noc_start_x = get_arg_val<uint32_t>(1);
+    const uint32_t in0_mcast_dest_noc_start_y = get_arg_val<uint32_t>(2);
+    const uint32_t in0_mcast_dest_noc_end_x = get_arg_val<uint32_t>(3);
+    const uint32_t in0_mcast_dest_noc_end_y = get_arg_val<uint32_t>(4);
+    volatile tt_l1_ptr uint32_t* in0_mcast_noc_x = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(5));
+    volatile tt_l1_ptr uint32_t* in0_mcast_noc_y = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(5 + num_x));
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in2 = 2;  // Sharded cb
+
+    constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
+    constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
+
+    constexpr uint32_t num_blocks_per_shard = shard_width_in_tiles / in0_block_w;
+    // In case we need to send multiple blocks per shard, and shard height in tiles is greater than 1
+    // Than we first need to extract the sub-blocks from the shard, and then send them to the destinations
+    constexpr bool extract_shard_sub_blocks = shard_height_in_tiles > 1 && num_blocks_per_shard > 1;
+    constexpr uint32_t shard_read_stride = shard_width_in_tiles * in0_single_tile_size_bytes;
+    constexpr uint32_t shard_read_width = in0_single_tile_size_bytes * in0_block_w;
+
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_addr);
+
+    // L1 array
+    constexpr uint32_t cb_l1_array = tt::CB::c_in5;
+    uint32_t in0_mcast_sender_semaphore_valid_addr = get_write_ptr(cb_l1_array);
+    volatile tt_l1_ptr uint32_t* in0_mcast_sender_semaphore_valid_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_sender_semaphore_valid_addr);
+    // Set up local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    in0_mcast_sender_semaphore_valid_addr_ptr[0] =
+        VALID;  // Load const 1 to be used as semaphore valid value sent from sender to receivers
+
+    constexpr uint32_t num_remote_senders = num_blocks / num_blocks_per_shard;
+    uint64_t remote_sender_noc_addrs[num_remote_senders];
+    if constexpr (transpose_mcast) {
+        uint32_t x = 0, y = 0;
+        for (uint32_t i = 0; i < num_remote_senders; ++i) {
+            remote_sender_noc_addrs[i] =
+                get_noc_addr(in0_mcast_noc_x[x], in0_mcast_noc_y[y], in0_mcast_sender_semaphore_addr);
+            ++y;
+            if (y == num_y) {
+                y = 0;
+                ++x;
+            }
+        }
+    } else {
+        uint32_t x = 0, y = 0;
+        for (uint32_t i = 0; i < num_remote_senders; ++i) {
+            remote_sender_noc_addrs[i] =
+                get_noc_addr(in0_mcast_noc_x[x], in0_mcast_noc_y[y], in0_mcast_sender_semaphore_addr);
+            ++x;
+            if (x == num_x) {
+                x = 0;
+                ++y;
+            }
+        }
+    }
+    const uint64_t in0_multicast_data_noc = get_noc_multicast_addr(
+        in0_mcast_dest_noc_start_x, in0_mcast_dest_noc_start_y, in0_mcast_dest_noc_end_x, in0_mcast_dest_noc_end_y, 0);
+
+    uint64_t in0_mcast_receiver_semaphore_noc_addr =
+        in0_multicast_data_noc | (uint64_t)in0_mcast_receiver_semaphore_addr;
+
+    noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+
+    cb_reserve_back(cb_id_in2, batch * in0_block_num_tiles);
+
+    uint32_t local_read_addr = 0;
+    uint64_t noc_shard_read_start_addr = 0;
+    if constexpr (extract_shard_sub_blocks) {
+        noc_shard_read_start_addr = get_noc_addr(get_read_ptr(cb_id_in2));
+    } else {
+        local_read_addr = get_read_ptr(cb_id_in2);
+    }
+
+    for (uint32_t b = 0; b < batch; ++b) {
+        for (uint32_t block = 0; block < num_blocks; ++block) {
+            const uint32_t block_id = block / num_blocks_per_shard;
+            cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+
+            // All cores in receiver grid need to participate in receiving regardless if they produce output work or
+            // not. Otherwise, data corruption since we mcast from and to the same CB (eg. extract_shard_sub_blocks). If
+            // we only ever mcast with loopback src (ie. always to a different CB), we can have just the cores that
+            // produce work participate in receiving.
+            if constexpr (core_in_in0_receiver_mcast_grid) {
+                // Set in0 semaphore value to INVALID
+                noc_semaphore_set(in0_mcast_receiver_semaphore_addr_ptr, INVALID);
+            }
+
+            if (block_id == sender_id) {
+                // Operand 0
+                uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+
+                if constexpr (extract_shard_sub_blocks) {
+                    local_read_addr = l1_write_addr_in0;
+
+                    uint32_t l1_write_extract_shard_in0 = l1_write_addr_in0;
+                    uint64_t noc_shard_read_addr = noc_shard_read_start_addr;
+                    noc_shard_read_start_addr += shard_read_width;
+
+                    for (uint32_t i = 0; i < shard_height_in_tiles; i++) {
+                        noc_async_read(noc_shard_read_addr, l1_write_extract_shard_in0, shard_read_width);
+
+                        l1_write_extract_shard_in0 += shard_read_width;
+                        noc_shard_read_addr += shard_read_stride;
+                    }
+
+                    noc_async_read_barrier();
+                }
+
+                // wait until all in0 mcast destinations have atomically incremented the in0 semaphore_addr (i.e. its
+                // value should be in0_mcast_num_dests), then reset the semaphore_addr value back to zero for the next
+                // block
+                if constexpr (core_in_in0_receiver_mcast_grid) {
+                    // wait for every core in receiver grid EXCLUDING myself
+                    noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests - 1);
+                } else {
+                    // wait for every core in receiver grid
+                    noc_semaphore_wait(in0_mcast_sender_semaphore_addr_ptr, in0_mcast_num_dests);
+                }
+                noc_semaphore_set(in0_mcast_sender_semaphore_addr_ptr, 0);
+
+                // Now we have the block in the CB address, we can mcast to dests!
+                uint64_t in0_multicast_data_addr = in0_multicast_data_noc | l1_write_addr_in0;
+
+                if constexpr (core_in_in0_receiver_mcast_grid) {
+                    // Mcast from/to same CB
+                    if constexpr (extract_shard_sub_blocks) {
+                        // multicast to every core in receiver grid EXCLUDING myself
+                        noc_async_write_multicast(
+                            local_read_addr,
+                            in0_multicast_data_addr,
+                            in0_block_size_bytes,
+                            in0_mcast_num_cores - 1,
+                            false,
+                            false);
+                    }
+                    // Mcast from different CB to another CB
+                    else {
+                        // multicast to every core in receiver grid
+                        noc_async_write_multicast_loopback_src(
+                            local_read_addr,
+                            in0_multicast_data_addr,
+                            in0_block_size_bytes,
+                            in0_mcast_num_cores,
+                            false,
+                            false);
+                    }
+
+                    // We should also multicast the flag to destinations
+                    noc_semaphore_set_multicast_loopback_src(
+                        in0_mcast_sender_semaphore_valid_addr,
+                        in0_mcast_receiver_semaphore_noc_addr,
+                        in0_mcast_num_cores,
+                        false,
+                        false);
+                } else {
+                    // If we are not part of receiver grid, always do a regular noc_async_write_multicast to all cores
+                    // in receiver grid
+                    noc_async_write_multicast(
+                        local_read_addr,
+                        in0_multicast_data_addr,
+                        in0_block_size_bytes,
+                        in0_mcast_num_cores,
+                        false,
+                        false);
+
+                    // We should also multicast the flag to destinations
+                    noc_semaphore_set_multicast(
+                        in0_mcast_sender_semaphore_valid_addr,
+                        in0_mcast_receiver_semaphore_noc_addr,
+                        in0_mcast_num_cores,
+                        false,
+                        false);
+                }
+                // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc,
+                // same cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
+
+                local_read_addr += in0_block_size_bytes;
+            } else if constexpr (core_in_in0_receiver_mcast_grid) {
+                uint64_t in0_mcast_sender_semaphore_noc_addr = remote_sender_noc_addrs[block_id];
+
+                // Atomic increment source core counter
+                noc_semaphore_inc(in0_mcast_sender_semaphore_noc_addr, 1);
+            }
+
+            if constexpr (core_in_in0_receiver_mcast_grid) {
+                // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
+                noc_semaphore_wait(in0_mcast_receiver_semaphore_addr_ptr, VALID);
+            }
+
+            cb_push_back(cb_id_in0, in0_block_num_tiles);
+
+            // If core does not produce output block work, free cb_id_in0 immediately.
+            // This is necessary since mcast is in lockstep; this ensures write ptr addresses are synced properly for
+            // cores that only send and have no compute / writer active. Technically, don't have to do this if cb_id_in0
+            // is not double buffered.
+            if constexpr (!core_has_output_block_work) {
+                cb_pop_front(cb_id_in0, in0_block_num_tiles);
+            }
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -2,17 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_dnn/op_library/bmm/bmm_op.hpp"
-#include "tt_dnn/op_library/operation.hpp"
-#include "tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
-#include "tt_dnn/op_library/work_split.hpp"
-
 #include <algorithm>
-#include "tt_metal/host_api.hpp"
-#include "tt_metal/common/constants.hpp"
+
 #include "hostdevcommon/common_values.hpp"
-#include "tt_metal/detail/util.hpp"
+#include "tt_dnn/op_library/bmm/bmm_op.hpp"
+#include "tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
+#include "tt_dnn/op_library/operation.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
 
 using namespace tt::constants;
 using namespace tt;
@@ -23,30 +23,46 @@ using namespace tt;
 using namespace tt_metal;
 
 operation::ProgramWithCallbacks create_program_mcast_in0(
-    tt_metal::Device *device,
-    MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, bool packer_l1_acc,
-    CoreCoord core_range,
-    uint32_t B, uint32_t M, uint32_t N, uint32_t K,
+    const Tensor& a,
+    tt_metal::Device* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    uint32_t B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
     bool bcast_batch,
     uint32_t in0_block_w,
-    uint32_t out_subblock_h, uint32_t out_subblock_w,
-    uint32_t per_core_M, uint32_t per_core_N,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer, tt_metal::Buffer* in1_buffer, tt_metal::Buffer* bias_buffer, tt_metal::Buffer* out_buffer,
-    tt::DataFormat in0_data_format, tt::DataFormat in1_data_format, tt::DataFormat bias_data_format, tt::DataFormat output_data_format,
-    bool in0_is_sharded, bool output_is_sharded,
-    bool untilize_out
-) {
-
+    tt_metal::Buffer* in0_buffer,
+    tt_metal::Buffer* in1_buffer,
+    tt_metal::Buffer* bias_buffer,
+    tt_metal::Buffer* out_buffer,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out) {
     tt_metal::Program program{};
 
     uint32_t num_blocks = K / in0_block_w;
-    //Only enable packer l1 accumulation when there are spills, otherwise
-    //unnecessary overhead for reconfigs are added
+    // Only enable packer l1 accumulation when there are spills, otherwise
+    // unnecessary overhead for reconfigs are added
     bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
-    tt::DataFormat interm0_data_format = packer_l1_acc_en ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b) : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
 
     uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
@@ -57,18 +73,18 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     uint32_t in0_block_tiles = per_core_M * in0_block_w;
     uint32_t in0_CB_tiles = in0_block_tiles;
     if (B * num_blocks > 1) {
-        in0_CB_tiles = in0_CB_tiles * 2; // double buffer
+        in0_CB_tiles = in0_CB_tiles * 2;  // double buffer
     }
     uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
     uint32_t in1_block_tiles = per_core_N * in0_block_w;
     uint32_t in1_CB_tiles = in1_block_tiles;
     if (B * num_blocks > 1) {
-        in1_CB_tiles = in1_CB_tiles * 2; // double buffer
+        in1_CB_tiles = in1_CB_tiles * 2;  // double buffer
     }
     uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
 
     uint32_t out_block_tiles = per_core_M * per_core_N;
-    uint32_t out_CB_tiles = out_block_tiles; // No double buffer
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
     uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
     uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
 
@@ -84,43 +100,81 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     uint32_t in2_CB_size = in2_CB_tiles * in0_single_tile_size;
 
     uint32_t in3_block_tiles = per_core_N;
-    uint32_t in3_CB_tiles = in3_block_tiles; // No double buffer
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
     uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
 
     uint32_t start_core_x = 0;
     uint32_t start_core_y = 0;
-    uint32_t num_cores_c = core_range.x;
-    uint32_t num_cores_r = core_range.y;
+    uint32_t num_cores_c = compute_with_storage_grid_size.x;
 
     uint32_t num_blocks_y = (M - 1) / per_core_M + 1;
     uint32_t num_blocks_x = (N - 1) / per_core_N + 1;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
-    uint32_t num_cores = num_blocks_total;
-    uint32_t num_mcast_cores = num_cores_c * num_cores_r;
-    CoreRangeSet all_cores = num_cores_to_corerange_set(num_cores, core_range, true);
+    uint32_t num_cores_with_work = num_blocks_total;
 
+    uint32_t in0_sender_num_cores = in0_is_sharded ? a.shard_spec().value().grid.num_cores() : 1;
+    uint32_t num_cores = in0_is_sharded ? std::max(num_cores_with_work, in0_sender_num_cores) : num_cores_with_work;
 
-    CoreRangeSet mcast_sender({});
+    constexpr bool row_major = true;
+    CoreRangeSet all_cores = num_cores_to_corerange_set(num_cores, compute_with_storage_grid_size, row_major);
+
+    CoreRangeSet in0_mcast_sender_cores =
+        num_cores_to_corerange_set(in0_sender_num_cores, compute_with_storage_grid_size, row_major);
+    CoreCoord in0_mcast_sender_cores_grid = in0_mcast_sender_cores.bounding_box().grid_size();
+
+    CoreRangeSet all_cores_with_work =
+        num_cores_to_corerange_set(num_cores_with_work, compute_with_storage_grid_size, row_major);
+    CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
+    uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
+    uint32_t in0_mcast_receiver_num_dests = std::min(
+        in0_mcast_receiver_num_cores,
+        num_cores);  // should always be number of cores in receiver grid up to number of active cores
+
+    CoreRangeSet in0_mcast_cores_with_work_and_in_receiver_grid({});
+    CoreRangeSet in0_mcast_cores_without_work_and_in_receiver_grid({});
+    CoreRangeSet in0_mcast_cores_without_work_and_not_in_receiver_grid({});
     CoreRangeSet mcast_receivers({});
     if (in0_is_sharded) {
-        mcast_sender = all_cores;
+        in0_mcast_cores_with_work_and_in_receiver_grid = all_cores_with_work;
+
+        if (in0_mcast_receiver_num_dests > num_cores_with_work) {
+            const uint32_t in0_mcast_cores_without_work_and_in_receiver_grid_num_cores =
+                in0_mcast_receiver_num_dests - num_cores_with_work;
+            uint32_t core_idx_x = num_cores_with_work % num_cores_c;
+            uint32_t core_idx_y = num_cores_with_work / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_in_receiver_grid = num_cores_to_corerange_set(
+                start_core,
+                in0_mcast_cores_without_work_and_in_receiver_grid_num_cores,
+                compute_with_storage_grid_size,
+                row_major);
+        }
+
+        if (in0_sender_num_cores > in0_mcast_receiver_num_dests) {
+            const uint32_t in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores =
+                in0_sender_num_cores - in0_mcast_receiver_num_dests;
+            uint32_t core_idx_x = in0_mcast_receiver_num_dests % num_cores_c;
+            uint32_t core_idx_y = in0_mcast_receiver_num_dests / num_cores_c;
+            CoreCoord start_core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
+            in0_mcast_cores_without_work_and_not_in_receiver_grid = num_cores_to_corerange_set(
+                start_core,
+                in0_mcast_cores_without_work_and_not_in_receiver_grid_num_cores,
+                compute_with_storage_grid_size,
+                row_major);
+        }
     } else {
-        mcast_sender = CoreRangeSet({
-            CoreRange(
-                {(std::size_t) start_core_x, (std::size_t) start_core_y},
-                {(std::size_t) start_core_x, (std::size_t) start_core_y}
-            )
-        });
+        in0_mcast_cores_with_work_and_in_receiver_grid = CoreRangeSet({CoreRange(
+            {(std::size_t)start_core_x, (std::size_t)start_core_y},
+            {(std::size_t)start_core_x, (std::size_t)start_core_y})});
         // TODO: Optimize difference of corerangesets
         std::set<CoreRange> mcast_receivers_set;
-        for(uint32_t i = 0; i < num_cores; i++) {
+        for (uint32_t i = 0; i < num_cores; i++) {
             uint32_t core_idx_x = i % num_cores_c;
             uint32_t core_idx_y = i / num_cores_c;
             if (!(core_idx_x == 0 && core_idx_y == 0)) {
                 CoreRange core(
-                    {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y},
-                    {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y}
-                );
+                    {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y},
+                    {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y});
                 mcast_receivers_set.insert(core);
             }
         }
@@ -131,8 +185,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     auto in0_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
     auto in0_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
-    CoreCoord top_left_core = {(std::size_t) start_core_x, (std::size_t) start_core_y};
-    CoreCoord bottom_right_core = {(std::size_t) start_core_x + num_cores_c - 1, (std::size_t) start_core_y + num_cores_r - 1};
+    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start;
+    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end;
     auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
     auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
@@ -144,112 +198,116 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     }
     bool out_is_dram = out_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
 
-    uint32_t in0_num_subblocks = (per_core_M/out_subblock_h);
-    uint32_t in0_block_num_tiles = out_subblock_h*in0_block_w*in0_num_subblocks;
+    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
 
     std::vector<uint32_t> in0_sender_compile_time_args;
     if (in0_is_sharded) {
         in0_sender_compile_time_args = {
-            (std::uint32_t)  in0_block_num_tiles, // in0_block_num_tiles
-            (std::uint32_t)  in0_block_num_tiles * in0_single_tile_size, // in0_block_size_bytes
+            (std::uint32_t)1,  // core_has_output_block_work
+            (std::uint32_t)1,  // core_in_in0_receiver_mcast_grid
+
+            (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
+            (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
             // in0/in1 common args
-            (std::uint32_t)  num_blocks, // num_blocks
+            (std::uint32_t)num_blocks,  // num_blocks
             // in0 mcast args
-            (std::uint32_t)  in0_mcast_sender_semaphore,
-            (std::uint32_t)  in0_mcast_receiver_semaphore,
-            (std::uint32_t)  (num_cores - 1), // in0_mcast_num_dests
-            (std::uint32_t)  (num_mcast_cores - 1), // in0_mcast_num_cores includes self
-            (std::uint32_t)  (num_cores_c),
-            (std::uint32_t)  (num_cores_r),
-            (std::uint32_t)  (false),
-            (std::uint32_t)  (in0_shard_width_in_tiles),
-            (std::uint32_t)  (in0_shard_height_in_tiles),
-            (std::uint32_t)  (in0_block_w),
+            (std::uint32_t)in0_mcast_sender_semaphore,
+            (std::uint32_t)in0_mcast_receiver_semaphore,
+            (std::uint32_t)in0_mcast_receiver_num_dests,  // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores,  // in0_mcast_num_cores
+            (std::uint32_t)(in0_mcast_sender_cores_grid.x),
+            (std::uint32_t)(in0_mcast_sender_cores_grid.y),
+            (std::uint32_t)(false),
+            (std::uint32_t)(in0_shard_width_in_tiles),
+            (std::uint32_t)(in0_shard_height_in_tiles),
+            (std::uint32_t)(in0_block_w),
 
             // batch args
-            (std::uint32_t)  B // batch
+            (std::uint32_t)B  // batch
         };
     } else {
         in0_sender_compile_time_args = {
-                // interleaved accessor args
-                (std::uint32_t) in0_is_dram,
+            // interleaved accessor args
+            (std::uint32_t)in0_is_dram,
 
-                // in0 tensor args
-                (std::uint32_t)  1, // in0_tensor_stride_w
-                (std::uint32_t)  K, // in0_tensor_stride_h
-                (std::uint32_t)  in0_block_w, // in0_tensor_next_block_stride
-                // in0 block args
-                (std::uint32_t)  in0_block_w, // in0_block_w
-                (std::uint32_t)  per_core_M, // in0_block_h
-                (std::uint32_t)  in0_block_w * per_core_M, // in0_block_num_tiles
-                // in0/in1 common args
-                (std::uint32_t)  num_blocks, // num_blocks
-                // in0 mcast args
-                (std::uint32_t)  in0_mcast_sender_semaphore,
-                (std::uint32_t)  in0_mcast_receiver_semaphore,
-                (std::uint32_t)  num_cores - 1, // in0_mcast_num_dests
-                (std::uint32_t)  num_mcast_cores - 1, // in0_mcast_num_cores
-                // batch args
-                (std::uint32_t)  M * K, // MtKt
-                (std::uint32_t)  B // batch
+            // in0 tensor args
+            (std::uint32_t)1,            // in0_tensor_stride_w
+            (std::uint32_t)K,            // in0_tensor_stride_h
+            (std::uint32_t)in0_block_w,  // in0_tensor_next_block_stride
+            // in0 block args
+            (std::uint32_t)in0_block_w,               // in0_block_w
+            (std::uint32_t)per_core_M,                // in0_block_h
+            (std::uint32_t)in0_block_w * per_core_M,  // in0_block_num_tiles
+            // in0/in1 common args
+            (std::uint32_t)num_blocks,  // num_blocks
+            // in0 mcast args
+            (std::uint32_t)in0_mcast_sender_semaphore,
+            (std::uint32_t)in0_mcast_receiver_semaphore,
+            (std::uint32_t)num_cores - 1,                     // in0_mcast_num_dests
+            (std::uint32_t)in0_mcast_receiver_num_cores - 1,  // in0_mcast_num_cores
+            // batch args
+            (std::uint32_t)M * K,  // MtKt
+            (std::uint32_t)B       // batch
         };
     }
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
-            // interleaved accessor args
-            (std::uint32_t) in1_is_dram,
-            (std::uint32_t) out_is_dram,
+        // interleaved accessor args
+        (std::uint32_t)in1_is_dram,
+        (std::uint32_t)out_is_dram,
 
-            // READER
-            // in1 tensor args
-            (std::uint32_t)  1, // in1_tensor_stride_w
-            (std::uint32_t)  N, // in1_tensor_stride_h
-            (std::uint32_t)  in0_block_w * N, //in1_tensor_next_block_stride
-            // in1 block args
-            (std::uint32_t)  per_core_N, // in1_block_w
-            (std::uint32_t)  in0_block_w, //in1_block_h
-            (std::uint32_t)  per_core_N * in0_block_w, // in1_block_num_tiles
-            // in0/in1 common args
-            (std::uint32_t)  num_blocks, // num_blocks
-            // in1 mcast args
-            (std::uint32_t)  0,
-            (std::uint32_t)  0,
-            (std::uint32_t)  0, // in1_mcast_num_dests
-            (std::uint32_t)  0, // in1_mcast_num_cores
-            // batch args
-            (std::uint32_t)  K * N, // KtNt
-            (std::uint32_t)  B, // batch
-            (std::uint32_t)  bcast_batch, // bcast_B
+        // READER
+        // in1 tensor args
+        (std::uint32_t)1,                // in1_tensor_stride_w
+        (std::uint32_t)N,                // in1_tensor_stride_h
+        (std::uint32_t)in0_block_w * N,  // in1_tensor_next_block_stride
+        // in1 block args
+        (std::uint32_t)per_core_N,                // in1_block_w
+        (std::uint32_t)in0_block_w,               // in1_block_h
+        (std::uint32_t)per_core_N * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        // in1 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in1_mcast_num_dests
+        (std::uint32_t)0,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)B,            // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
 
-            // WRITER
-            // out tensor args
-            (std::uint32_t)  1, // out_tensor_stride_w
-            (std::uint32_t)  N,  // out_tensor_stride_h
-            (std::uint32_t)  out_subblock_w, // out_tensor_next_subblock_stride_w
-            (std::uint32_t)  out_subblock_h * N, // out_tensor_next_subblock_stride_h
-            // out subblock args
-            (std::uint32_t)  out_subblock_w, // out_subblock_w
-            (std::uint32_t)  out_subblock_h, // out_subblock_h
-            (std::uint32_t)  (out_subblock_w * out_subblock_h), // out_subblocks_w * out_subblocks_h
-            // batch args
-            (std::uint32_t)  M * N // MtNt
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
     };
     if (bias_buffer != nullptr) {
-        in1_sender_writer_compile_time_args.push_back((std::uint32_t)  in3_is_dram);
-        in1_sender_writer_compile_time_args.push_back((std::uint32_t)  1);
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)in3_is_dram);
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);
     }
     std::vector<uint32_t> in0_receiver_compile_time_args = {
-            // in0 block args
-            (std::uint32_t)  in0_block_w * per_core_M, // in0_block_num_tiles
-            // in0/in1 common args
-            (std::uint32_t)  num_blocks, // num_blocks
-            // in0 mcast args
-            (std::uint32_t)  in0_mcast_sender_semaphore,
-            (std::uint32_t)  in0_mcast_receiver_semaphore,
-            // batch args
-            (std::uint32_t)  B // batch
+        // in0 block args
+        (std::uint32_t)in0_block_w * per_core_M,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        // in0 mcast args
+        (std::uint32_t)in0_mcast_sender_semaphore,
+        (std::uint32_t)in0_mcast_receiver_semaphore,
+        // batch args
+        (std::uint32_t)B  // batch
     };
 
     std::map<string, string> mm_kernel_defines;
+    std::map<string, string> mm_kernel_in0_sender_writer_defines;
     std::map<string, string> mm_kernel_in1_sender_writer_defines;
     if (bias_buffer != nullptr) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
@@ -259,7 +317,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
         if (fused_activation.value().op_type == UnaryOpType::RELU) {
             mm_kernel_defines["PACK_RELU"] = "1";
         } else {
-            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
+            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(
+                fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
         }
     }
     if (packer_l1_acc_en) {
@@ -273,61 +332,111 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
         mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
     }
 
+    if (in0_mcast_receiver_num_cores == 1) {
+        mm_kernel_in0_sender_writer_defines["SKIP_MCAST"] = "1";
+    }
+
     mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
 
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = detail::GetPreferredNOCForDRAMWrite(device->arch());
     tt_metal::NOC in1_noc = detail::GetPreferredNOCForDRAMRead(device->arch());
 
-    auto mm_kernel_in0_sender_id = tt_metal::CreateKernel(
+    auto mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id = tt_metal::CreateKernel(
         program,
-        in0_is_sharded ? "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp" : "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp",
-        mcast_sender,
-        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc, .compile_args = in0_sender_compile_time_args});
+        in0_is_sharded
+            ? "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/"
+              "reader_bmm_tile_layout_in0_sender_receiver_padding_width_sharded.cpp"
+            : "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp",
+        in0_mcast_cores_with_work_and_in_receiver_grid,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .compile_args = in0_sender_compile_time_args,
+            .defines = mm_kernel_in0_sender_writer_defines});
 
-    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
-        program,
-        "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
-        all_cores,
-        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc, .compile_args = in1_sender_writer_compile_time_args, .defines = mm_kernel_in1_sender_writer_defines});
+    auto mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id = 0;
+    auto mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = 0;
+    if (in0_is_sharded) {
+        if (in0_mcast_cores_without_work_and_in_receiver_grid.num_cores() > 0) {
+            in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
+            in0_sender_compile_time_args[1] = 1;  // core_in_in0_receiver_mcast_grid
+            mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id = tt_metal::CreateKernel(
+                program,
+                "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_width_sharded.cpp",
+                in0_mcast_cores_without_work_and_in_receiver_grid,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = in0_noc,
+                    .compile_args = in0_sender_compile_time_args});
+        }
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.num_cores() > 0) {
+            in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
+            in0_sender_compile_time_args[1] = 0;  // core_in_in0_receiver_mcast_grid
+            mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = tt_metal::CreateKernel(
+                program,
+                "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/"
+                "reader_bmm_tile_layout_in0_sender_receiver_padding_width_sharded.cpp",
+                in0_mcast_cores_without_work_and_not_in_receiver_grid,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = in0_noc,
+                    .compile_args = in0_sender_compile_time_args});
+        }
+    }
 
     KernelHandle mm_kernel_in0_receiver_id = 0;
-    if (!in0_is_sharded) {
+    if (!in0_is_sharded and mcast_receivers.num_cores() > 0) {
         mm_kernel_in0_receiver_id = tt_metal::CreateKernel(
             program,
             "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp",
             mcast_receivers,
-            tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc, .compile_args = in0_receiver_compile_time_args});
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_receiver_compile_time_args});
     }
+
+    auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
+        all_cores_with_work,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines});
+
     // Compute kernel compile time args
 
     uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
 
-    uint32_t in1_num_subblocks = (per_core_N/out_subblock_w);
-    uint32_t in1_block_num_tiles = out_subblock_w*in0_block_w*in1_num_subblocks;
+    uint32_t in1_num_subblocks = (per_core_N / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
     uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
 
-    uint32_t out_subblock_num_tiles = out_subblock_h*out_subblock_w;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
 
     vector<uint32_t> compute_kernel_args = {
-        in0_block_w, // in0_block_w
-        in0_num_subblocks, // in0_num_subblocks
-        in0_block_num_tiles, // in0_block_num_tiles
-        in0_subblock_num_tiles, // in0_subblock_num_tiles
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
 
-        in1_num_subblocks, // in1_num_subblocks
-        in1_block_num_tiles, // in1_block_num_tiles
-        in1_per_core_w, // in1_per_core_w
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
 
-        num_blocks, // num_blocks
+        num_blocks,  // num_blocks
 
-        out_subblock_h, // out_subblock_h
-        out_subblock_w, // out_subblock_w
-        out_subblock_num_tiles, // out_subblock_num_tiles
-        B, // batch
-        out_block_tiles, // out_block_num_tiles
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch
+        out_block_tiles,         // out_block_num_tiles
 
-        untilize_out // untilize_out
+        untilize_out  // untilize_out
     };
 
     // Create compute kernel
@@ -337,94 +446,144 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     auto mm_kernel = tt_metal::CreateKernel(
         program,
         "tt_eager/tt_dnn/op_library/bmm/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode, .compile_args = compute_kernel_args, .defines = mm_kernel_defines}
-    );
+        all_cores_with_work,
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines});
 
     // Create circular buffers
     uint32_t src0_cb_index = 0;
-    tt_metal::CircularBufferConfig src0_cb_config = tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
-		.set_page_size(src0_cb_index, in0_single_tile_size);
-	auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
-    log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", src0_cb_index, in0_single_tile_size, in0_CB_size / in0_single_tile_size, in0_CB_size);
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
 
     uint32_t src1_cb_index = 1;
-    tt_metal::CircularBufferConfig src1_cb_config = tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
-		.set_page_size(src1_cb_index, in1_single_tile_size);
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_single_tile_size);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
-    log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", src1_cb_index, in1_single_tile_size, in1_CB_size / in1_single_tile_size, in1_CB_size);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
 
     uint32_t src2_cb_index = 2;
     CBHandle cb_src2 = 0;
     if (in0_is_sharded) {
-        tt_metal::CircularBufferConfig src2_cb_config = tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
-            .set_page_size(src2_cb_index, in0_single_tile_size).set_globally_allocated_address(*in0_buffer);
+        tt_metal::CircularBufferConfig src2_cb_config =
+            tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+                .set_page_size(src2_cb_index, in0_single_tile_size)
+                .set_globally_allocated_address(*in0_buffer);
         cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
-        log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", src2_cb_index, in0_single_tile_size, in2_CB_size / in0_single_tile_size, in2_CB_size);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src2_cb_index,
+            in0_single_tile_size,
+            in2_CB_size / in0_single_tile_size,
+            in2_CB_size);
 
         // Local L1 to store temp vars
         uint32_t l1_cb_index = 5;
-        CircularBufferConfig cb_for_l1_array_config = CircularBufferConfig(32 * 2, {{l1_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(l1_cb_index, 32 * 2);
+        CircularBufferConfig cb_for_l1_array_config =
+            CircularBufferConfig(32 * 2, {{l1_cb_index, tt::DataFormat::Float16_b}}).set_page_size(l1_cb_index, 32 * 2);
         tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
     }
 
-    uint32_t output_cb_index = 16; // output operands start at index 16
+    uint32_t output_cb_index = 16;  // output operands start at index 16
     uint32_t interm0_cb_index = 24;
-    tt_metal::CircularBufferConfig interm0_cb_config = tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
-    tt_metal::CircularBufferConfig output_cb_config = tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
 
     if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
         // output
-        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec {
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
             {output_cb_index, output_data_format},
         };
         output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
-            .set_page_size(output_cb_index, output_single_tile_size);
+                               .set_page_size(output_cb_index, output_single_tile_size);
         // interm0
-        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec {
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
             {interm0_cb_index, interm0_data_format},
         };
         interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
-            .set_page_size(interm0_cb_index, interm0_single_tile_size);
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size);
 
         auto cb_interm0 = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
-        log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", interm0_cb_index, interm0_single_tile_size, interm0_CB_size / interm0_single_tile_size, interm0_CB_size);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
     } else {
         // share buffer
-        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec {
-            {output_cb_index, output_data_format},
-            {interm0_cb_index, interm0_data_format}
-        };
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
         output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
-            .set_page_size(output_cb_index, output_single_tile_size)
-            .set_page_size(interm0_cb_index, interm0_single_tile_size);
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size);
     }
 
     if (output_is_sharded) {
         output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
-    log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", output_cb_index, output_single_tile_size, out_CB_size / output_single_tile_size, out_CB_size);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
 
     if (bias_buffer != nullptr) {
         uint32_t src3_cb_index = 3;
-        tt_metal::CircularBufferConfig cb_src3_config = tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
-		    .set_page_size(src3_cb_index, bias_single_tile_size);
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_single_tile_size);
         auto cb_src3 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
-        log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", src3_cb_index, bias_single_tile_size, in3_CB_size / bias_single_tile_size, in3_CB_size);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_single_tile_size,
+            in3_CB_size / bias_single_tile_size,
+            in3_CB_size);
     }
 
     // Parameters for last row, col, or block
     uint32_t last_block_h = M % per_core_M == 0 ? per_core_M : M % per_core_M;
     uint32_t last_block_w = N % per_core_N == 0 ? per_core_N : N % per_core_N;
-    uint32_t last_block_num_nonzero_subblocks_h = (last_block_h  - 1) / out_subblock_h + 1;
-    uint32_t last_block_num_nonzero_subblocks_w = (last_block_w  - 1) / out_subblock_w + 1;
-    uint32_t last_subblock_of_last_block_h = last_block_h % out_subblock_h == 0 ? out_subblock_h : last_block_h % out_subblock_h;
-    uint32_t last_subblock_of_last_block_w = last_block_w % out_subblock_w == 0 ? out_subblock_w : last_block_w % out_subblock_w;
-    uint32_t last_block_padded_subblock_tiles_addr_skip = output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
-    uint32_t last_block_padded_block_tiles_w_skip =  (out_subblock_w * out_subblock_h) * (per_core_N / out_subblock_w - last_block_num_nonzero_subblocks_w);
-    uint32_t last_block_padded_block_tiles_h_skip = (per_core_M / out_subblock_h - last_block_num_nonzero_subblocks_h) * (per_core_N * out_subblock_h);
+    uint32_t last_block_num_nonzero_subblocks_h = (last_block_h - 1) / out_subblock_h + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = (last_block_w - 1) / out_subblock_w + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_block_h % out_subblock_h == 0 ? out_subblock_h : last_block_h % out_subblock_h;
+    uint32_t last_subblock_of_last_block_w =
+        last_block_w % out_subblock_w == 0 ? out_subblock_w : last_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (per_core_N / out_subblock_w - last_block_num_nonzero_subblocks_w);
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (per_core_M / out_subblock_h - last_block_num_nonzero_subblocks_h) * (per_core_N * out_subblock_h);
 
     std::vector<KernelHandle> reader_kernel_ids;
     std::vector<KernelHandle> writer_kernel_ids;
@@ -432,12 +591,12 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     std::vector<uint32_t> in0_mcast_noc_x;
     std::vector<uint32_t> in0_mcast_noc_y;
     if (in0_is_sharded) {
-        in0_mcast_noc_x.reserve(num_cores_c);
-        in0_mcast_noc_y.reserve(num_cores_r);
-        for(uint32_t core_idx_x = 0; core_idx_x < num_cores_c; ++core_idx_x) {
+        in0_mcast_noc_x.reserve(in0_mcast_sender_cores_grid.x);
+        in0_mcast_noc_y.reserve(in0_mcast_sender_cores_grid.y);
+        for (uint32_t core_idx_x = 0; core_idx_x < in0_mcast_sender_cores_grid.x; ++core_idx_x) {
             in0_mcast_noc_x.push_back(device->worker_core_from_logical_core({core_idx_x, 0}).x);
         }
-        for(uint32_t core_idx_y = 0; core_idx_y < num_cores_r; ++core_idx_y) {
+        for (uint32_t core_idx_y = 0; core_idx_y < in0_mcast_sender_cores_grid.y; ++core_idx_y) {
             in0_mcast_noc_y.push_back(device->worker_core_from_logical_core({0, core_idx_y}).y);
         }
     }
@@ -447,12 +606,12 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
         std::swap(start_core_noc, end_core_noc);
     }
 
-    for(uint32_t i = 0; i < num_cores; i++) {
+    for (uint32_t i = 0; i < num_cores; i++) {
         uint32_t core_idx_x = i % num_cores_c;
         uint32_t core_idx_y = i / num_cores_c;
         uint32_t output_idx_x = i % num_blocks_x;
         uint32_t output_idx_y = i / num_blocks_x;
-        CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
+        CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
 
         if (in0_is_sharded) {
             std::vector<uint32_t> mm_in0_sender_args;
@@ -464,184 +623,228 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
             mm_in0_sender_args.push_back(end_core_noc.y);
             mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
             mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
-            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args); // RISCV_0_default
-            reader_kernel_ids.push_back(mm_kernel_in0_sender_id);
+
+            if (i < num_cores_with_work) {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+                reader_kernel_ids.push_back(mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id);
+            } else if (i < in0_mcast_receiver_num_dests) {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+                reader_kernel_ids.push_back(mm_kernel_in0_mcast_cores_without_work_and_in_receiver_grid_id);
+            } else {
+                tt_metal::SetRuntimeArgs(
+                    program,
+                    mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id,
+                    core,
+                    mm_in0_sender_args);  // RISCV_0_default
+                reader_kernel_ids.push_back(mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id);
+            }
         }
         // in0 sender and in1 sender
         else if (core_idx_x == 0 and core_idx_y == 0) {
-            std::vector<uint32_t> mm_in0_sender_args =  {
+            std::vector<uint32_t> mm_in0_sender_args = {
                 // in0 tensor args
-                (std::uint32_t)  in0_buffer->address(),
-                (std::uint32_t)  K * per_core_M * output_idx_y, // in0_tensor_start_tile_id
+                (std::uint32_t)in0_buffer->address(),
+                (std::uint32_t)K * per_core_M * output_idx_y,  // in0_tensor_start_tile_id
                 // in0 mcast args
-                (std::uint32_t)  start_core_noc.x, // in0_mcast_dest_noc_start_x
-                (std::uint32_t)  start_core_noc.y, // in0_mcast_dest_noc_start_y
-                (std::uint32_t)  end_core_noc.x, // in0_mcast_dest_noc_end_x
-                (std::uint32_t)  end_core_noc.y, // in0_mcast_dest_noc_end_y
+                (std::uint32_t)start_core_noc.x,  // in0_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in0_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in0_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in0_mcast_dest_noc_end_y
 
                 // padding args
-                (std::uint32_t) per_core_M // last_block_h
+                (std::uint32_t)per_core_M  // last_block_h
             };
-            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args); // RISCV_0_default
-            reader_kernel_ids.push_back(mm_kernel_in0_sender_id);
+            tt_metal::SetRuntimeArgs(
+                program,
+                mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id,
+                core,
+                mm_in0_sender_args);  // RISCV_0_default
+            reader_kernel_ids.push_back(mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id);
         }
         // in0 receiver and in 1 sender
         else {
             std::vector<uint32_t> mm_in0_receiver_args = {
                 // in0 mcast args
-                (std::uint32_t)  top_left_core_physical.x, // in0_mcast_sender_noc_x
-                (std::uint32_t)  top_left_core_physical.y // in0_mcast_sender_noc_y
+                (std::uint32_t)top_left_core_physical.x,  // in0_mcast_sender_noc_x
+                (std::uint32_t)top_left_core_physical.y   // in0_mcast_sender_noc_y
             };
-            tt_metal::SetRuntimeArgs(program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args); // RISCV_1_default
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in0_receiver_id, core, mm_in0_receiver_args);  // RISCV_1_default
             reader_kernel_ids.push_back(mm_kernel_in0_receiver_id);
         }
-        std::vector<uint32_t> mm_in1_sender_writer_args = {
-            // READER
-            // in1 tensor args
-            (std::uint32_t)  in1_buffer->address(),
-            (std::uint32_t)  per_core_N * output_idx_x, //in1_tensor_start_tile_id
-            // in1 mcast args
-            (std::uint32_t)  0, // in1_mcast_dest_noc_start_x
-            (std::uint32_t)  0, // in1_mcast_dest_noc_start_y
-            (std::uint32_t)  0, // in1_mcast_dest_noc_end_x
-            (std::uint32_t)  0, // in1_mcast_dest_noc_end_y
+        if (i < num_cores_with_work) {
+            std::vector<uint32_t> mm_in1_sender_writer_args = {
+                // READER
+                // in1 tensor args
+                (std::uint32_t)in1_buffer->address(),
+                (std::uint32_t)per_core_N * output_idx_x,  // in1_tensor_start_tile_id
+                // in1 mcast args
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_x
+                (std::uint32_t)0,  // in1_mcast_dest_noc_end_y
 
-            // WRITER
-            // out tensor args
-            (std::uint32_t)  out_buffer->address(),
-            (std::uint32_t)  output_idx_x * per_core_N + output_idx_y * per_core_M * N // out_tensor_start_tile_id
-        };
+                // WRITER
+                // out tensor args
+                (std::uint32_t)out_buffer->address(),
+                (std::uint32_t)output_idx_x * per_core_N + output_idx_y * per_core_M * N  // out_tensor_start_tile_id
+            };
 
-        if (output_idx_x == num_blocks_x - 1) {
-            // padding args (READER)
-            mm_in1_sender_writer_args.push_back(last_block_w);
+            if (output_idx_x == num_blocks_x - 1) {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(last_block_w);
 
-            // padding args (WRITER)
-            mm_in1_sender_writer_args.push_back(per_core_M /out_subblock_h);
-            mm_in1_sender_writer_args.push_back(out_subblock_h);
-            mm_in1_sender_writer_args.push_back(0);
-            mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
-            mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
-            mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
-            mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
-        } else {
-            // padding args (READER)
-            mm_in1_sender_writer_args.push_back(per_core_N);
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(per_core_M / out_subblock_h);
+                mm_in1_sender_writer_args.push_back(out_subblock_h);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(last_block_num_nonzero_subblocks_w);
+                mm_in1_sender_writer_args.push_back(last_subblock_of_last_block_w);
+                mm_in1_sender_writer_args.push_back(last_block_padded_subblock_tiles_addr_skip);
+                mm_in1_sender_writer_args.push_back(last_block_padded_block_tiles_w_skip);
+            } else {
+                // padding args (READER)
+                mm_in1_sender_writer_args.push_back(per_core_N);
 
-            // padding args (WRITER)
-            mm_in1_sender_writer_args.push_back(per_core_M /out_subblock_h);
-            mm_in1_sender_writer_args.push_back(out_subblock_h);
-            mm_in1_sender_writer_args.push_back(0);
-            mm_in1_sender_writer_args.push_back(per_core_N / out_subblock_w);
-            mm_in1_sender_writer_args.push_back(out_subblock_w);
-            mm_in1_sender_writer_args.push_back(0);
-            mm_in1_sender_writer_args.push_back(0);
+                // padding args (WRITER)
+                mm_in1_sender_writer_args.push_back(per_core_M / out_subblock_h);
+                mm_in1_sender_writer_args.push_back(out_subblock_h);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(per_core_N / out_subblock_w);
+                mm_in1_sender_writer_args.push_back(out_subblock_w);
+                mm_in1_sender_writer_args.push_back(0);
+                mm_in1_sender_writer_args.push_back(0);
+            }
+
+            if (bias_buffer != nullptr) {
+                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_buffer->address());
+                mm_in1_sender_writer_args.push_back(
+                    (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
+            }
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_0_default
+            writer_kernel_ids.push_back(mm_kernel_in1_sender_writer_id);
         }
-
-        if (bias_buffer != nullptr) {
-            mm_in1_sender_writer_args.push_back((std::uint32_t)  bias_buffer->address());
-            mm_in1_sender_writer_args.push_back((std::uint32_t)  per_core_N * output_idx_x); //in3_tensor_start_tile_id
-        }
-        tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args); // RISCV_0_default
-        writer_kernel_ids.push_back(mm_kernel_in1_sender_writer_id);
     }
 
-    auto override_runtime_arguments_callback = [
-            reader_kernel_ids,
-            writer_kernel_ids,
-            cb_src2,
-            cb_output,
-            num_cores_r,
-            num_cores_c,
-            num_cores,
-            start_core_x,
-            start_core_y
-        ]
-    (
-        const void* operation,
-        Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        const std::vector<Tensor>& output_tensors
-    ) {
-        TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
-        TT_FATAL(output_tensors.size() == 1);
+    auto override_runtime_arguments_callback =
+        [reader_kernel_ids,
+         writer_kernel_ids,
+         cb_src2,
+         cb_output,
+         num_cores_c,
+         num_cores,
+         num_cores_with_work,
+         start_core_x,
+         start_core_y](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
+            TT_FATAL(output_tensors.size() == 1);
 
-        auto src_buffer_a = input_tensors.at(0).buffer();
-        auto src_buffer_b = input_tensors.at(1).buffer();
-        auto bias_tensor = optional_input_tensors.at(0);
+            auto src_buffer_a = input_tensors.at(0).buffer();
+            auto src_buffer_b = input_tensors.at(1).buffer();
+            auto bias_tensor = optional_input_tensors.at(0);
 
-        auto dst_buffer = output_tensors.at(0).buffer();
+            auto dst_buffer = output_tensors.at(0).buffer();
 
-        bool src0_sharded = input_tensors.at(0).memory_config().is_sharded();
-        bool out_sharded = output_tensors.at(0).memory_config().is_sharded();
+            bool src0_sharded = input_tensors.at(0).memory_config().is_sharded();
+            bool out_sharded = output_tensors.at(0).memory_config().is_sharded();
 
-        for (uint32_t i = 0; i < num_cores; i++) {
-            uint32_t core_idx_x = i % num_cores_c;
-            uint32_t core_idx_y = i / num_cores_c;
-            CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
+            for (uint32_t i = 0; i < num_cores; i++) {
+                uint32_t core_idx_x = i % num_cores_c;
+                uint32_t core_idx_y = i / num_cores_c;
+                CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
 
-            auto reader_kernel_id = reader_kernel_ids.at(i);
-            auto &reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto reader_kernel_id = reader_kernel_ids.at(i);
+                auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
 
-            auto writer_kernel_id = writer_kernel_ids.at(i);
-            auto &writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                // in0 sender
+                if (!src0_sharded && core_idx_x == 0 and core_idx_y == 0) {
+                    reader_runtime_args[0] = src_buffer_a->address();
+                    // in0 receiver
+                } else {
+                }
 
-            // in0 sender
-            if (!src0_sharded && core_idx_x == 0 and core_idx_y == 0) {
-                reader_runtime_args[0] = src_buffer_a->address();
-            // in0 receiver
-            } else {
+                if (i < num_cores_with_work) {
+                    auto writer_kernel_id = writer_kernel_ids.at(i);
+                    auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
 
-            }
-            // in1 sender
-            {
-                writer_runtime_args[0] = src_buffer_b->address();
-                writer_runtime_args[6] = dst_buffer->address();
-                if (bias_tensor.has_value()) {
-                    writer_runtime_args[16] = bias_tensor.value().buffer()->address();
+                    // in1 sender
+                    {
+                        writer_runtime_args[0] = src_buffer_b->address();
+                        writer_runtime_args[6] = dst_buffer->address();
+                        if (bias_tensor.has_value()) {
+                            writer_runtime_args[16] = bias_tensor.value().buffer()->address();
+                        }
+                    }
                 }
             }
-        }
-        if (src0_sharded) {
-            UpdateDynamicCircularBufferAddress(program, cb_src2, *src_buffer_a);
-        }
+            if (src0_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_src2, *src_buffer_a);
+            }
 
-        if (out_sharded) {
-            UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
-        }
-    };
+            if (out_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+            }
+        };
 
-    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
 operation::ProgramWithCallbacks create_program_mcast_in1(
-    tt_metal::Device *device,
-    MathFidelity math_fidelity, bool fp32_dest_acc_en, bool math_approx_mode, bool packer_l1_acc,
-    CoreCoord core_range,
-    uint32_t B, uint32_t M, uint32_t N, uint32_t K,
+    tt_metal::Device* device,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool packer_l1_acc,
+    CoreCoord compute_with_storage_grid_size,
+    uint32_t B,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
     bool bcast_batch,
     uint32_t in0_block_w,
-    uint32_t out_subblock_h, uint32_t out_subblock_w,
-    uint32_t per_core_M, uint32_t per_core_N,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    tt_metal::Buffer* in0_buffer, tt_metal::Buffer* in1_buffer, tt_metal::Buffer* bias_buffer, tt_metal::Buffer* out_buffer,
-    tt::DataFormat in0_data_format, tt::DataFormat in1_data_format, tt::DataFormat bias_data_format, tt::DataFormat output_data_format,
-    bool in0_is_sharded, bool output_is_sharded,
-    bool untilize_out
-) {
-
+    tt_metal::Buffer* in0_buffer,
+    tt_metal::Buffer* in1_buffer,
+    tt_metal::Buffer* bias_buffer,
+    tt_metal::Buffer* out_buffer,
+    tt::DataFormat in0_data_format,
+    tt::DataFormat in1_data_format,
+    tt::DataFormat bias_data_format,
+    tt::DataFormat output_data_format,
+    bool in0_is_sharded,
+    bool output_is_sharded,
+    bool untilize_out) {
     tt_metal::Program program{};
 
     uint32_t num_blocks = K / in0_block_w;
-    //Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
-    //unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
-    //does a spill and reload, so need more than 2 blocks to use l1 acc for packer
-    //For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    // Only enable packer l1 accumulation when there are num_blocks > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
     bool packer_l1_acc_en = packer_l1_acc && (((bias_buffer != nullptr) && num_blocks > 1) || (num_blocks > 2));
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
-    tt::DataFormat interm0_data_format = packer_l1_acc_en ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b) : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
+    tt::DataFormat interm0_data_format = packer_l1_acc_en
+                                             ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b)
+                                             : (fp32_dest_acc_en ? tt::DataFormat::Float32 : output_data_format);
 
     uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
@@ -654,53 +857,49 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     if (in0_is_sharded) {
         in0_CB_tiles = num_blocks * in0_CB_tiles * B;
     } else if (B * num_blocks > 1) {
-        in0_CB_tiles = in0_CB_tiles * 2; // double buffer
+        in0_CB_tiles = in0_CB_tiles * 2;  // double buffer
     }
     uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
     uint32_t in1_block_tiles = per_core_N * in0_block_w;
     uint32_t in1_CB_tiles = in1_block_tiles;
     if (B * num_blocks > 1) {
-        in1_CB_tiles = in1_CB_tiles * 2; // double buffer
+        in1_CB_tiles = in1_CB_tiles * 2;  // double buffer
     }
     uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
     uint32_t out_block_tiles = per_core_M * per_core_N;
-    uint32_t out_CB_tiles = out_block_tiles; // No double buffer
+    uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
     uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
     uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
 
-
     uint32_t in3_block_tiles = per_core_N;
-    uint32_t in3_CB_tiles = in3_block_tiles; // No double buffer
+    uint32_t in3_CB_tiles = in3_block_tiles;  // No double buffer
     uint32_t in3_CB_size = in3_CB_tiles * bias_single_tile_size;
 
     uint32_t start_core_x = 0;
     uint32_t start_core_y = 0;
-    uint32_t num_cores_c = core_range.x;
-    uint32_t num_cores_r = core_range.y;
+    uint32_t num_cores_c = compute_with_storage_grid_size.x;
+    uint32_t num_cores_r = compute_with_storage_grid_size.y;
 
     uint32_t num_blocks_y = (M - 1) / per_core_M + 1;
     uint32_t num_blocks_x = (N - 1) / per_core_N + 1;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
     uint32_t num_cores = num_blocks_total;
-    uint32_t num_mcast_cores = num_cores_c * num_cores_r; // Exclude Sender
+    uint32_t mcast_num_cores = num_cores_c * num_cores_r;  // Exclude Sender
 
-    CoreRangeSet all_cores = num_cores_to_corerange_set(num_cores, core_range, true);
-
+    CoreRangeSet all_cores = num_cores_to_corerange_set(num_cores, compute_with_storage_grid_size, true);
 
     CoreRange mcast_sender(
-        {(std::size_t) start_core_x, (std::size_t) start_core_y},
-        {(std::size_t) start_core_x, (std::size_t) start_core_y});
+        {(std::size_t)start_core_x, (std::size_t)start_core_y}, {(std::size_t)start_core_x, (std::size_t)start_core_y});
 
     // TODO: Optimize difference of corerangesets
     std::set<CoreRange> mcast_receivers_set;
-    for(uint32_t i = 0; i < num_cores; i++) {
+    for (uint32_t i = 0; i < num_cores; i++) {
         uint32_t core_idx_x = i % num_cores_c;
         uint32_t core_idx_y = i / num_cores_c;
         if (!(core_idx_x == 0 && core_idx_y == 0)) {
             CoreRange core(
-                {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y},
-                {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y}
-            );
+                {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y},
+                {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y});
             mcast_receivers_set.insert(core);
         }
     }
@@ -712,8 +911,9 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     uint32_t in3_mcast_sender_semaphore = 0;
     uint32_t in3_mcast_receiver_semaphore = 0;
 
-    CoreCoord top_left_core = {(std::size_t) start_core_x, (std::size_t) start_core_y};
-    CoreCoord bottom_right_core = {(std::size_t) start_core_x + num_cores_c - 1, (std::size_t) start_core_y + num_cores_r - 1};
+    CoreCoord top_left_core = {(std::size_t)start_core_x, (std::size_t)start_core_y};
+    CoreCoord bottom_right_core = {
+        (std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1};
     auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
     auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
@@ -725,102 +925,102 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     }
     bool out_is_dram = out_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> in0_sender_compile_time_args = {
-            // interleaved accessor args
-            (std::uint32_t) in0_is_dram,
+        // interleaved accessor args
+        (std::uint32_t)in0_is_dram,
 
-            // in0 tensor args
-            (std::uint32_t)  1, // in0_tensor_stride_w
-            (std::uint32_t)  K, // in0_tensor_stride_h
-            (std::uint32_t)  in0_block_w, // in0_tensor_next_block_stride
-            // in0 block args
-            (std::uint32_t)  in0_block_w, // in0_block_w
-            (std::uint32_t)  per_core_M, // in0_block_h
-            (std::uint32_t)  in0_block_w * per_core_M, // in0_block_num_tiles
-            // in0/in1 common args
-            (std::uint32_t)  num_blocks, // num_blocks
-            // in0 mcast args
-            (std::uint32_t)  0,
-            (std::uint32_t)  0,
-            (std::uint32_t)  0, // in0_mcast_num_dests
-            (std::uint32_t)  0, // in0_mcast_num_cores
-            // batch args
-            (std::uint32_t)  M * K, // MtKt
-            (std::uint32_t)  B // batch
+        // in0 tensor args
+        (std::uint32_t)1,            // in0_tensor_stride_w
+        (std::uint32_t)K,            // in0_tensor_stride_h
+        (std::uint32_t)in0_block_w,  // in0_tensor_next_block_stride
+        // in0 block args
+        (std::uint32_t)in0_block_w,               // in0_block_w
+        (std::uint32_t)per_core_M,                // in0_block_h
+        (std::uint32_t)in0_block_w * per_core_M,  // in0_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        // in0 mcast args
+        (std::uint32_t)0,
+        (std::uint32_t)0,
+        (std::uint32_t)0,  // in0_mcast_num_dests
+        (std::uint32_t)0,  // in0_mcast_num_cores
+        // batch args
+        (std::uint32_t)M * K,  // MtKt
+        (std::uint32_t)B       // batch
     };
     std::vector<uint32_t> in1_sender_writer_compile_time_args = {
-            // interleaved accessor args
-            (std::uint32_t) in1_is_dram,
-            (std::uint32_t) out_is_dram,
+        // interleaved accessor args
+        (std::uint32_t)in1_is_dram,
+        (std::uint32_t)out_is_dram,
 
-            // READER
-            // in1 tensor args
-            (std::uint32_t)  1, // in1_tensor_stride_w
-            (std::uint32_t)  N, // in1_tensor_stride_h
-            (std::uint32_t)  in0_block_w * N, //in1_tensor_next_block_stride
-            // in1 block args
-            (std::uint32_t)  per_core_N, // in1_block_w
-            (std::uint32_t)  in0_block_w, //in1_block_h
-            (std::uint32_t)  per_core_N * in0_block_w, // in1_block_num_tiles
-            // in0/in1 common args
-            (std::uint32_t)  num_blocks, // num_blocks
-            // in1 mcast args
-            (std::uint32_t)  in1_mcast_sender_semaphore,
-            (std::uint32_t)  in1_mcast_receiver_semaphore,
-            (std::uint32_t)  num_cores - 1, // in1_mcast_num_dests
-            (std::uint32_t)  num_mcast_cores - 1, // in1_mcast_num_cores
-            // batch args
-            (std::uint32_t)  K * N, // KtNt
-            (std::uint32_t)  B, // batch
-            (std::uint32_t)  bcast_batch, // bcast_B
+        // READER
+        // in1 tensor args
+        (std::uint32_t)1,                // in1_tensor_stride_w
+        (std::uint32_t)N,                // in1_tensor_stride_h
+        (std::uint32_t)in0_block_w * N,  // in1_tensor_next_block_stride
+        // in1 block args
+        (std::uint32_t)per_core_N,                // in1_block_w
+        (std::uint32_t)in0_block_w,               // in1_block_h
+        (std::uint32_t)per_core_N * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore,
+        (std::uint32_t)in1_mcast_receiver_semaphore,
+        (std::uint32_t)num_cores - 1,        // in1_mcast_num_dests
+        (std::uint32_t)mcast_num_cores - 1,  // in1_mcast_num_cores
+        // batch args
+        (std::uint32_t)K * N,        // KtNt
+        (std::uint32_t)B,            // batch
+        (std::uint32_t)bcast_batch,  // bcast_B
 
-            // WRITER
-            // out tensor args
-            (std::uint32_t)  1, // out_tensor_stride_w
-            (std::uint32_t)  N,  // out_tensor_stride_h
-            (std::uint32_t)  out_subblock_w, // out_tensor_next_subblock_stride_w
-            (std::uint32_t)  out_subblock_h * N, // out_tensor_next_subblock_stride_h
-            // out subblock args
-            (std::uint32_t)  out_subblock_w, // out_subblock_w
-            (std::uint32_t)  out_subblock_h, // out_subblock_h
-            (std::uint32_t)  (out_subblock_w * out_subblock_h), // out_subblocks_w * out_subblocks_h
-            // batch args
-            (std::uint32_t)  M * N // MtNt
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
     };
     if (bias_buffer != nullptr) {
-        in1_sender_writer_compile_time_args.push_back((std::uint32_t)  in3_is_dram);
-        in1_sender_writer_compile_time_args.push_back((std::uint32_t)  1);
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)in3_is_dram);
+        in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);
     }
     std::vector<uint32_t> in1_receiver_writer_compile_time_args = {
-            // interleaved accessor args
-            (std::uint32_t) out_is_dram,
+        // interleaved accessor args
+        (std::uint32_t)out_is_dram,
 
-            // READER
-            // in1 block args
-            (std::uint32_t)  per_core_N * in0_block_w, // in1_block_num_tiles
-            // in0/in1 common args
-            (std::uint32_t)  num_blocks, // num_blocks
-            // in1 mcast args
-            (std::uint32_t)  in1_mcast_sender_semaphore,
-            (std::uint32_t)  in1_mcast_receiver_semaphore,
-            // batch args
-            (std::uint32_t)  B, // batch
+        // READER
+        // in1 block args
+        (std::uint32_t)per_core_N * in0_block_w,  // in1_block_num_tiles
+        // in0/in1 common args
+        (std::uint32_t)num_blocks,  // num_blocks
+        // in1 mcast args
+        (std::uint32_t)in1_mcast_sender_semaphore,
+        (std::uint32_t)in1_mcast_receiver_semaphore,
+        // batch args
+        (std::uint32_t)B,  // batch
 
-            // WRITER
-            // out tensor args
-            (std::uint32_t)  1, // out_tensor_stride_w
-            (std::uint32_t)  N,  // out_tensor_stride_h
-            (std::uint32_t)  out_subblock_w, // out_tensor_next_subblock_stride_w
-            (std::uint32_t)  out_subblock_h * N, // out_tensor_next_subblock_stride_h
-            // out subblock args
-            (std::uint32_t)  out_subblock_w, // out_subblock_w
-            (std::uint32_t)  out_subblock_h, // out_subblock_h
-            (std::uint32_t)  (out_subblock_w * out_subblock_h), // out_subblocks_w * out_subblocks_h
-            // batch args
-            (std::uint32_t)  M * N // MtNt
+        // WRITER
+        // out tensor args
+        (std::uint32_t)1,                   // out_tensor_stride_w
+        (std::uint32_t)N,                   // out_tensor_stride_h
+        (std::uint32_t)out_subblock_w,      // out_tensor_next_subblock_stride_w
+        (std::uint32_t)out_subblock_h * N,  // out_tensor_next_subblock_stride_h
+        // out subblock args
+        (std::uint32_t)out_subblock_w,                     // out_subblock_w
+        (std::uint32_t)out_subblock_h,                     // out_subblock_h
+        (std::uint32_t)(out_subblock_w * out_subblock_h),  // out_subblocks_w * out_subblocks_h
+        // batch args
+        (std::uint32_t)M * N  // MtNt
     };
 
     if (bias_buffer != nullptr) {
-        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)  per_core_N);
+        in1_receiver_writer_compile_time_args.push_back((std::uint32_t)per_core_N);
     }
 
     std::map<string, string> mm_kernel_defines;
@@ -836,7 +1036,8 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
         if (fused_activation.value().op_type == UnaryOpType::RELU) {
             mm_kernel_defines["PACK_RELU"] = "1";
         } else {
-            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
+            mm_kernel_defines.merge(eltwise_unary_op_utils::get_defines(
+                fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
         }
     }
     if (packer_l1_acc_en) {
@@ -863,51 +1064,64 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
         program,
         "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp",
         all_cores,
-        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc, .compile_args = in0_sender_compile_time_args, .defines = mm_kernel_in0_sender_defines});
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .compile_args = in0_sender_compile_time_args,
+            .defines = mm_kernel_in0_sender_defines});
 
     auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
         program,
         "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
         mcast_sender,
-        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc, .compile_args = in1_sender_writer_compile_time_args, .defines = mm_kernel_in1_sender_writer_defines});
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_compile_time_args,
+            .defines = mm_kernel_in1_sender_writer_defines});
 
     auto mm_kernel_in1_receiver_writer_id = tt_metal::CreateKernel(
         program,
-        "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
+        "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/"
+        "reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
         mcast_receivers,
-        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc, .compile_args = in1_receiver_writer_compile_time_args, .defines = mm_kernel_in1_receiver_writer_defines});
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_receiver_writer_compile_time_args,
+            .defines = mm_kernel_in1_receiver_writer_defines});
 
     // Compute kernel compile time args
 
-    uint32_t in0_num_subblocks = (per_core_M/out_subblock_h);
-    uint32_t in0_block_num_tiles = out_subblock_h*in0_block_w*in0_num_subblocks;
+    uint32_t in0_num_subblocks = (per_core_M / out_subblock_h);
+    uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
     uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
 
-    uint32_t in1_num_subblocks = (per_core_N/out_subblock_w);
-    uint32_t in1_block_num_tiles = out_subblock_w*in0_block_w*in1_num_subblocks;
+    uint32_t in1_num_subblocks = (per_core_N / out_subblock_w);
+    uint32_t in1_block_num_tiles = out_subblock_w * in0_block_w * in1_num_subblocks;
     uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
 
-    uint32_t out_subblock_num_tiles = out_subblock_h*out_subblock_w;
+    uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
 
     vector<uint32_t> compute_kernel_args = {
-        in0_block_w, // in0_block_w
-        in0_num_subblocks, // in0_num_subblocks
-        in0_block_num_tiles, // in0_block_num_tiles
-        in0_subblock_num_tiles, // in0_subblock_num_tiles
+        in0_block_w,             // in0_block_w
+        in0_num_subblocks,       // in0_num_subblocks
+        in0_block_num_tiles,     // in0_block_num_tiles
+        in0_subblock_num_tiles,  // in0_subblock_num_tiles
 
-        in1_num_subblocks, // in1_num_subblocks
-        in1_block_num_tiles, // in1_block_num_tiles
-        in1_per_core_w, // in1_per_core_w
+        in1_num_subblocks,    // in1_num_subblocks
+        in1_block_num_tiles,  // in1_block_num_tiles
+        in1_per_core_w,       // in1_per_core_w
 
-        num_blocks, // num_blocks
+        num_blocks,  // num_blocks
 
-        out_subblock_h, // out_subblock_h
-        out_subblock_w, // out_subblock_w
-        out_subblock_num_tiles, // out_subblock_num_tiles
-        B, // batch
-        out_block_tiles, // out_block_num_tiles
+        out_subblock_h,          // out_subblock_h
+        out_subblock_w,          // out_subblock_w
+        out_subblock_num_tiles,  // out_subblock_num_tiles
+        B,                       // batch
+        out_block_tiles,         // out_block_num_tiles
 
-        untilize_out // untilize_out
+        untilize_out  // untilize_out
     };
 
     // Create compute kernel
@@ -918,81 +1132,123 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
         program,
         "tt_eager/tt_dnn/op_library/bmm/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp",
         all_cores,
-        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode, .compile_args = compute_kernel_args, .defines = mm_kernel_defines}
-    );
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args,
+            .defines = mm_kernel_defines});
 
     // Create circular buffers
     uint32_t src0_cb_index = 0;
-    tt_metal::CircularBufferConfig src0_cb_config = tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
-		.set_page_size(src0_cb_index, in0_single_tile_size);
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size);
     if (in0_is_sharded) {
         src0_cb_config = src0_cb_config.set_globally_allocated_address(*in0_buffer);
     }
-	auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
-    log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", src0_cb_index, in0_single_tile_size, in0_CB_size / in0_single_tile_size, in0_CB_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src0_cb_index,
+        in0_single_tile_size,
+        in0_CB_size / in0_single_tile_size,
+        in0_CB_size);
 
     uint32_t src1_cb_index = 1;
-    tt_metal::CircularBufferConfig src1_cb_config = tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
-		.set_page_size(src1_cb_index, in1_single_tile_size);
+    tt_metal::CircularBufferConfig src1_cb_config =
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_single_tile_size);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
-    log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", src1_cb_index, in1_single_tile_size, in1_CB_size / in1_single_tile_size, in1_CB_size);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        src1_cb_index,
+        in1_single_tile_size,
+        in1_CB_size / in1_single_tile_size,
+        in1_CB_size);
 
-    uint32_t output_cb_index = 16; // output operands start at index 16
+    uint32_t output_cb_index = 16;  // output operands start at index 16
     uint32_t interm0_cb_index = 24;
-    tt_metal::CircularBufferConfig interm0_cb_config = tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
-    tt_metal::CircularBufferConfig output_cb_config = tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
 
     if (interm0_data_format != output_data_format) {
         // output
-        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec {
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
             {output_cb_index, output_data_format},
         };
         output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
-            .set_page_size(output_cb_index, output_single_tile_size);
+                               .set_page_size(output_cb_index, output_single_tile_size);
         // interm0
-        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec {
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
             {interm0_cb_index, interm0_data_format},
         };
         interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
-            .set_page_size(interm0_cb_index, interm0_single_tile_size);
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size);
 
         auto cb_interm0 = tt_metal::CreateCircularBuffer(program, CoreRangeSet({all_cores}), interm0_cb_config);
-        log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", interm0_cb_index, interm0_single_tile_size, interm0_CB_size / interm0_single_tile_size, interm0_CB_size);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            interm0_cb_index,
+            interm0_single_tile_size,
+            interm0_CB_size / interm0_single_tile_size,
+            interm0_CB_size);
     } else {
         // share buffer
-        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec {
-            {output_cb_index, output_data_format},
-            {interm0_cb_index, interm0_data_format}
-        };
+        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
         output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
-            .set_page_size(output_cb_index, output_single_tile_size)
-            .set_page_size(interm0_cb_index, interm0_single_tile_size);
+                               .set_page_size(output_cb_index, output_single_tile_size)
+                               .set_page_size(interm0_cb_index, interm0_single_tile_size);
     }
 
     if (output_is_sharded) {
         output_cb_config = output_cb_config.set_globally_allocated_address(*out_buffer);
     }
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
-    log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", output_cb_index, output_single_tile_size, out_CB_size / output_single_tile_size, out_CB_size);
+    log_debug(
+        LogOp,
+        "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+        output_cb_index,
+        output_single_tile_size,
+        out_CB_size / output_single_tile_size,
+        out_CB_size);
 
     if (bias_buffer != nullptr) {
         uint32_t src3_cb_index = 3;
-        tt_metal::CircularBufferConfig cb_src3_config = tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
-		    .set_page_size(src3_cb_index, bias_single_tile_size);
+        tt_metal::CircularBufferConfig cb_src3_config =
+            tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
+                .set_page_size(src3_cb_index, bias_single_tile_size);
         auto cb_src3 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
-        log_debug(LogOp, "CB {} :: PS = {}, NP = {}, TOTAL = {}", src3_cb_index, bias_single_tile_size, in3_CB_size / bias_single_tile_size, in3_CB_size);
+        log_debug(
+            LogOp,
+            "CB {} :: PS = {}, NP = {}, TOTAL = {}",
+            src3_cb_index,
+            bias_single_tile_size,
+            in3_CB_size / bias_single_tile_size,
+            in3_CB_size);
     }
 
     // Parameters for last row, col, or block
     uint32_t last_block_h = M % per_core_M == 0 ? per_core_M : M % per_core_M;
     uint32_t last_block_w = N % per_core_N == 0 ? per_core_N : N % per_core_N;
-    uint32_t last_block_num_nonzero_subblocks_h = (last_block_h  - 1) / out_subblock_h + 1;
-    uint32_t last_block_num_nonzero_subblocks_w = (last_block_w  - 1) / out_subblock_w + 1;
-    uint32_t last_subblock_of_last_block_h = last_block_h % out_subblock_h == 0 ? out_subblock_h : last_block_h % out_subblock_h;
-    uint32_t last_subblock_of_last_block_w = last_block_w % out_subblock_w == 0 ? out_subblock_w : last_block_w % out_subblock_w;
-    uint32_t last_block_padded_subblock_tiles_addr_skip = output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
-    uint32_t last_block_padded_block_tiles_w_skip =  (out_subblock_w * out_subblock_h) * (per_core_N / out_subblock_w - last_block_num_nonzero_subblocks_w);
-    uint32_t last_block_padded_block_tiles_h_skip = (per_core_M / out_subblock_h - last_block_num_nonzero_subblocks_h) * (per_core_N * out_subblock_h);
+    uint32_t last_block_num_nonzero_subblocks_h = (last_block_h - 1) / out_subblock_h + 1;
+    uint32_t last_block_num_nonzero_subblocks_w = (last_block_w - 1) / out_subblock_w + 1;
+    uint32_t last_subblock_of_last_block_h =
+        last_block_h % out_subblock_h == 0 ? out_subblock_h : last_block_h % out_subblock_h;
+    uint32_t last_subblock_of_last_block_w =
+        last_block_w % out_subblock_w == 0 ? out_subblock_w : last_block_w % out_subblock_w;
+    uint32_t last_block_padded_subblock_tiles_addr_skip =
+        output_single_tile_size * (out_subblock_w - last_subblock_of_last_block_w);
+    uint32_t last_block_padded_block_tiles_w_skip =
+        (out_subblock_w * out_subblock_h) * (per_core_N / out_subblock_w - last_block_num_nonzero_subblocks_w);
+    uint32_t last_block_padded_block_tiles_h_skip =
+        (per_core_M / out_subblock_h - last_block_num_nonzero_subblocks_h) * (per_core_N * out_subblock_h);
 
     std::vector<KernelHandle> reader_kernel_ids;
     std::vector<KernelHandle> writer_kernel_ids;
@@ -1003,49 +1259,50 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
         std::swap(start_core_noc, end_core_noc);
     }
 
-    for(uint32_t i = 0; i < num_cores; i++) {
+    for (uint32_t i = 0; i < num_cores; i++) {
         uint32_t core_idx_x = i % num_cores_c;
         uint32_t core_idx_y = i / num_cores_c;
         uint32_t output_idx_x = i / num_blocks_y;
         uint32_t output_idx_y = i % num_blocks_y;
-        CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
+        CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
 
         // in0 sender and in1 sender
         if (core_idx_x == 0 and core_idx_y == 0) {
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
-                (std::uint32_t)  in1_buffer->address(),
-                (std::uint32_t)  per_core_N * output_idx_x, //in1_tensor_start_tile_id
+                (std::uint32_t)in1_buffer->address(),
+                (std::uint32_t)per_core_N * output_idx_x,  // in1_tensor_start_tile_id
                 // in1 mcast args
-                (std::uint32_t)  start_core_noc.x, // in1_mcast_dest_noc_start_x
-                (std::uint32_t)  start_core_noc.y, // in1_mcast_dest_noc_start_y
-                (std::uint32_t)  end_core_noc.x, // in1_mcast_dest_noc_end_x
-                (std::uint32_t)  end_core_noc.y, // in1_mcast_dest_noc_end_y
+                (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
+                (std::uint32_t)start_core_noc.y,  // in1_mcast_dest_noc_start_y
+                (std::uint32_t)end_core_noc.x,    // in1_mcast_dest_noc_end_x
+                (std::uint32_t)end_core_noc.y,    // in1_mcast_dest_noc_end_y
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)  out_buffer->address(),
-                (std::uint32_t)  output_idx_x * per_core_N + output_idx_y * per_core_M * N, // out_tensor_start_tile_id
+                (std::uint32_t)out_buffer->address(),
+                (std::uint32_t)output_idx_x * per_core_N + output_idx_y * per_core_M * N,  // out_tensor_start_tile_id
 
                 // padding args (READER)
-                (std::uint32_t)  per_core_N, // last_block_w
+                (std::uint32_t)per_core_N,  // last_block_w
                 // padding args (WRITER)
-                (std::uint32_t)  per_core_M / out_subblock_h,
-                (std::uint32_t)  out_subblock_h,
-                (std::uint32_t)  0,
-                (std::uint32_t)  per_core_N / out_subblock_w,
-                (std::uint32_t)  out_subblock_w,
-                (std::uint32_t)  0,
-                (std::uint32_t)  0
-            };
+                (std::uint32_t)per_core_M / out_subblock_h,
+                (std::uint32_t)out_subblock_h,
+                (std::uint32_t)0,
+                (std::uint32_t)per_core_N / out_subblock_w,
+                (std::uint32_t)out_subblock_w,
+                (std::uint32_t)0,
+                (std::uint32_t)0};
 
             if (bias_buffer != nullptr) {
-                mm_in1_sender_writer_args.push_back((std::uint32_t)  bias_buffer->address());
-                mm_in1_sender_writer_args.push_back((std::uint32_t)  per_core_N * output_idx_x); //in3_tensor_start_tile_id
+                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_buffer->address());
+                mm_in1_sender_writer_args.push_back(
+                    (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             }
 
-            tt_metal::SetRuntimeArgs(program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args); // RISCV_1_default
+            tt_metal::SetRuntimeArgs(
+                program, mm_kernel_in1_sender_writer_id, core, mm_in1_sender_writer_args);  // RISCV_1_default
             writer_kernel_ids.push_back(mm_kernel_in1_sender_writer_id);
         }
         // in0 sender and in1 receiver
@@ -1053,13 +1310,13 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
             std::vector<uint32_t> mm_in1_receiver_writer_args = {
                 // READER
                 // in1 mcast args
-                (std::uint32_t)  top_left_core_physical.x, // in1_mcast_sender_noc_x
-                (std::uint32_t)  top_left_core_physical.y, // in1_mcast_sender_noc_y
+                (std::uint32_t)top_left_core_physical.x,  // in1_mcast_sender_noc_x
+                (std::uint32_t)top_left_core_physical.y,  // in1_mcast_sender_noc_y
 
                 // WRITER
                 // out tensor args
-                (std::uint32_t)  out_buffer->address(), // out_tensor_addr
-                (std::uint32_t)  output_idx_x * per_core_N + output_idx_y * per_core_M * N // out_tensor_start_tile_id
+                (std::uint32_t)out_buffer->address(),                                     // out_tensor_addr
+                (std::uint32_t)output_idx_x * per_core_N + output_idx_y * per_core_M * N  // out_tensor_start_tile_id
             };
 
             if (output_idx_y == num_blocks_y - 1) {
@@ -1082,112 +1339,127 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
                 mm_in1_receiver_writer_args.push_back(0);
             }
 
-            tt_metal::SetRuntimeArgs(program, mm_kernel_in1_receiver_writer_id, core, mm_in1_receiver_writer_args); // RISCV_0_default
+            tt_metal::SetRuntimeArgs(
+                program,
+                mm_kernel_in1_receiver_writer_id,
+                core,
+                mm_in1_receiver_writer_args);  // RISCV_0_default
             writer_kernel_ids.push_back(mm_kernel_in1_receiver_writer_id);
         }
-        std::vector<uint32_t> mm_in0_sender_args =  {
+        std::vector<uint32_t> mm_in0_sender_args = {
             // in0 tensor args
-            (std::uint32_t)  in0_buffer->address(),
-            (std::uint32_t)  K * per_core_M * output_idx_y, // in0_tensor_start_tile_id
+            (std::uint32_t)in0_buffer->address(),
+            (std::uint32_t)K * per_core_M * output_idx_y,  // in0_tensor_start_tile_id
             // in0 mcast args
-            (std::uint32_t)  0, // in0_mcast_dest_noc_start_x
-            (std::uint32_t)  0, // in0_mcast_dest_noc_start_y
-            (std::uint32_t)  0, // in0_mcast_dest_noc_end_x
-            (std::uint32_t)  0, // in0_mcast_dest_noc_end_y
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_start_y
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_x
+            (std::uint32_t)0,  // in0_mcast_dest_noc_end_y
 
             // padding args
-            (std::uint32_t) per_core_M // last_block_h
+            (std::uint32_t)per_core_M  // last_block_h
         };
-        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args); // RISCV_1_default
+        tt_metal::SetRuntimeArgs(program, mm_kernel_in0_sender_id, core, mm_in0_sender_args);  // RISCV_1_default
         reader_kernel_ids.push_back(mm_kernel_in0_sender_id);
     }
 
-    auto override_runtime_arguments_callback = [
-            reader_kernel_ids,
-            writer_kernel_ids,
-            cb_src0,
-            cb_output,
-            num_cores_r,
-            num_cores_c,
-            num_cores,
-            start_core_x,
-            start_core_y
-        ]
-    (
-        const void* operation,
-        Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        const std::vector<Tensor>& output_tensors
-    ) {
-        TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
-        TT_FATAL(output_tensors.size() == 1);
+    auto override_runtime_arguments_callback =
+        [reader_kernel_ids,
+         writer_kernel_ids,
+         cb_src0,
+         cb_output,
+         num_cores_r,
+         num_cores_c,
+         num_cores,
+         start_core_x,
+         start_core_y](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
+            TT_FATAL(output_tensors.size() == 1);
 
-        auto src_buffer_a = input_tensors.at(0).buffer();
-        auto src_buffer_b = input_tensors.at(1).buffer();
-        auto bias_tensor = optional_input_tensors.at(0);
+            auto src_buffer_a = input_tensors.at(0).buffer();
+            auto src_buffer_b = input_tensors.at(1).buffer();
+            auto bias_tensor = optional_input_tensors.at(0);
 
-        auto dst_buffer = output_tensors.at(0).buffer();
+            auto dst_buffer = output_tensors.at(0).buffer();
 
-        bool src0_sharded = input_tensors.at(0).memory_config().is_sharded();
-        bool out_sharded = output_tensors.at(0).memory_config().is_sharded();
+            bool src0_sharded = input_tensors.at(0).memory_config().is_sharded();
+            bool out_sharded = output_tensors.at(0).memory_config().is_sharded();
 
-        for (uint32_t i = 0; i < num_cores; i++) {
-            uint32_t core_idx_x = i % num_cores_c;
-            uint32_t core_idx_y = i / num_cores_c;
-            CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
+            for (uint32_t i = 0; i < num_cores; i++) {
+                uint32_t core_idx_x = i % num_cores_c;
+                uint32_t core_idx_y = i / num_cores_c;
+                CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
 
-            auto reader_kernel_id = reader_kernel_ids.at(i);
-            auto &reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto reader_kernel_id = reader_kernel_ids.at(i);
+                auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
 
-            auto writer_kernel_id = writer_kernel_ids.at(i);
-            auto &writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto writer_kernel_id = writer_kernel_ids.at(i);
+                auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
 
-            // in0 sender
-            reader_runtime_args[0] = src_buffer_a->address();
+                // in0 sender
+                reader_runtime_args[0] = src_buffer_a->address();
 
-            // in1 sender
-            if (core_idx_x == 0 and core_idx_y == 0) {
-                writer_runtime_args[0] = src_buffer_b->address();
-                writer_runtime_args[6] = dst_buffer->address();
-                if (bias_tensor.has_value()) {
-                    writer_runtime_args[16] = bias_tensor.value().buffer()->address();
+                // in1 sender
+                if (core_idx_x == 0 and core_idx_y == 0) {
+                    writer_runtime_args[0] = src_buffer_b->address();
+                    writer_runtime_args[6] = dst_buffer->address();
+                    if (bias_tensor.has_value()) {
+                        writer_runtime_args[16] = bias_tensor.value().buffer()->address();
+                    }
+                    // in1 receiver
+                } else {
+                    writer_runtime_args[2] = dst_buffer->address();
                 }
-            // in1 receiver
-            } else {
-                writer_runtime_args[2] = dst_buffer->address();
             }
-        }
 
-        if (src0_sharded) {
-            UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer_a);
-        }
+            if (src0_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer_a);
+            }
 
-        if (out_sharded) {
-            UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
-        }
-    };
-    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
+            if (out_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+            }
+        };
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
-}
+}  // namespace reuse_mcast_1d_optimized_helpers
 
 namespace tt {
 
 namespace tt_metal {
 
-
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(const Tensor &a, const Tensor &b, const std::optional<const Tensor> bias, Tensor& output, bool bcast_batch, CoreCoord compute_with_storage_grid_size, DeviceComputeKernelConfig compute_kernel_config, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0, bool untilize_out) {
-
-    const auto& ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
+    const Tensor& a,
+    const Tensor& b,
+    const std::optional<const Tensor> bias,
+    Tensor& output,
+    bool bcast_batch,
+    CoreCoord compute_with_storage_grid_size,
+    DeviceComputeKernelConfig compute_kernel_config,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool fuse_batch,
+    std::optional<UnaryWithParam> fused_activation,
+    bool mcast_in0,
+    bool untilize_out) {
+    const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
 
     // CB dataformats
-    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype()); // in0
-    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.get_dtype()); // in1
-    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype()); // output
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());          // in0
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.get_dtype());          // in1
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());  // output
 
     tt_metal::Buffer* bias_buffer = nullptr;
-    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b; // bias; doesn't matter if bias=nullptr
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
         TT_FATAL(c.storage_type() == StorageType::DEVICE);
@@ -1199,23 +1471,28 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
         bias_data_format = tt_metal::datatype_to_dataformat_converter(c.get_dtype());
     }
 
-    tt_metal::Device *device = a.device();
+    tt_metal::Device* device = a.device();
 
     uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
-    tt_metal::Buffer *in0_buffer = a.buffer();
-    tt_metal::Buffer *in1_buffer = b.buffer();
+    tt_metal::Buffer* in0_buffer = a.buffer();
+    tt_metal::Buffer* in1_buffer = b.buffer();
     if (bcast_batch)
-        TT_FATAL(bshape[0]*bshape[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
+        TT_FATAL(
+            bshape[0] * bshape[1] == 1 &&
+            "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
     else {
         // same condition as above, different message
-        TT_FATAL(ashape[1] == bshape[1] && ashape[0] == bshape[0]
-            && "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
+        TT_FATAL(
+            ashape[1] == bshape[1] && ashape[0] == bshape[0] &&
+            "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
     }
     TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
     TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
 
-    TT_FATAL(ashape[3] == bshape[2] && "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op"); // A.K == B.K
+    TT_FATAL(
+        ashape[3] == bshape[2] &&
+        "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op");  // A.K == B.K
     TT_FATAL(ashape[2] % TILE_HEIGHT == 0);
     TT_FATAL(ashape[3] % TILE_WIDTH == 0);
     TT_FATAL(bshape[2] % TILE_HEIGHT == 0);
@@ -1226,28 +1503,31 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     bool fp32_dest_acc_en;
     bool packer_l1_acc;
 
-    std::visit([&](auto&& compute_kernel_config) {
-        using T = std::decay_t<decltype(compute_kernel_config)>;
-        if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_FATAL(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
-            math_fidelity = compute_kernel_config.math_fidelity;
-            math_approx_mode = compute_kernel_config.math_approx_mode;
-            fp32_dest_acc_en = false;
-            packer_l1_acc = false;
-        } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            TT_FATAL(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
-            math_fidelity = compute_kernel_config.math_fidelity;
-            math_approx_mode = compute_kernel_config.math_approx_mode;
-            fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
-            packer_l1_acc = compute_kernel_config.packer_l1_acc;
-        } else {
-            TT_FATAL("arch not supported");
-        }
-
-    }, compute_kernel_config);
+    std::visit(
+        [&](auto&& compute_kernel_config) {
+            using T = std::decay_t<decltype(compute_kernel_config)>;
+            if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
+                TT_FATAL(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+                math_fidelity = compute_kernel_config.math_fidelity;
+                math_approx_mode = compute_kernel_config.math_approx_mode;
+                fp32_dest_acc_en = false;
+                packer_l1_acc = false;
+            } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
+                TT_FATAL(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
+                math_fidelity = compute_kernel_config.math_fidelity;
+                math_approx_mode = compute_kernel_config.math_approx_mode;
+                fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
+                packer_l1_acc = compute_kernel_config.packer_l1_acc;
+            } else {
+                TT_FATAL("arch not supported");
+            }
+        },
+        compute_kernel_config);
 
     if (fp32_dest_acc_en) {
-        TT_FATAL(out_subblock_h * out_subblock_w <= 4 && "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
+        TT_FATAL(
+            out_subblock_h * out_subblock_w <= 4 &&
+            "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -1255,11 +1535,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = ashape[0]*ashape[1];
-    uint32_t Mt = ashape[2]/TILE_HEIGHT;
-    uint32_t Kt = ashape[3]/TILE_WIDTH;
-    uint32_t Nt = bshape[3]/TILE_WIDTH;
-
+    uint32_t B = ashape[0] * ashape[1];
+    uint32_t Mt = ashape[2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[3] / TILE_WIDTH;
+    uint32_t Nt = bshape[3] / TILE_WIDTH;
 
     if (fuse_batch) {
         Mt = B * Mt;
@@ -1284,53 +1563,114 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(cons
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Buffer *out_buffer = output.buffer();
+    tt_metal::Buffer* out_buffer = output.buffer();
     TT_FATAL(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
     if (compute_with_storage_grid_size.x > 1 or compute_with_storage_grid_size.y > 1) {
-      if (mcast_in0) {
-          return reuse_mcast_1d_optimized_helpers::create_program_mcast_in0(
-              device,
-              math_fidelity, fp32_dest_acc_en, math_approx_mode, packer_l1_acc,
-              compute_with_storage_grid_size,
-              B, Mt, Nt, Kt,
-              bcast_batch,
-              in0_block_w,
-              out_subblock_h, out_subblock_w,
-              per_core_M, per_core_N,
-              fused_activation,
-              in0_buffer, in1_buffer, bias_buffer, out_buffer,
-              in0_data_format, in1_data_format, bias_data_format, output_data_format,
-              a.memory_config().is_sharded(), output.memory_config().is_sharded(),
-              untilize_out
-          );
-      } else {
-          return reuse_mcast_1d_optimized_helpers::create_program_mcast_in1(
-              device,
-              math_fidelity, fp32_dest_acc_en, math_approx_mode, packer_l1_acc,
-              compute_with_storage_grid_size,
-              B, Mt, Nt, Kt,
-              bcast_batch,
-              in0_block_w,
-              out_subblock_h, out_subblock_w,
-              per_core_M, per_core_N,
-              fused_activation,
-              in0_buffer, in1_buffer, bias_buffer, out_buffer,
-              in0_data_format, in1_data_format, bias_data_format, output_data_format,
-              a.memory_config().is_sharded(), output.memory_config().is_sharded(),
-              untilize_out
-          );
-      }
+        if (mcast_in0) {
+            return reuse_mcast_1d_optimized_helpers::create_program_mcast_in0(
+                a,
+                device,
+                math_fidelity,
+                fp32_dest_acc_en,
+                math_approx_mode,
+                packer_l1_acc,
+                compute_with_storage_grid_size,
+                B,
+                Mt,
+                Nt,
+                Kt,
+                bcast_batch,
+                in0_block_w,
+                out_subblock_h,
+                out_subblock_w,
+                per_core_M,
+                per_core_N,
+                fused_activation,
+                in0_buffer,
+                in1_buffer,
+                bias_buffer,
+                out_buffer,
+                in0_data_format,
+                in1_data_format,
+                bias_data_format,
+                output_data_format,
+                a.memory_config().is_sharded(),
+                output.memory_config().is_sharded(),
+                untilize_out);
+        } else {
+            return reuse_mcast_1d_optimized_helpers::create_program_mcast_in1(
+                device,
+                math_fidelity,
+                fp32_dest_acc_en,
+                math_approx_mode,
+                packer_l1_acc,
+                compute_with_storage_grid_size,
+                B,
+                Mt,
+                Nt,
+                Kt,
+                bcast_batch,
+                in0_block_w,
+                out_subblock_h,
+                out_subblock_w,
+                per_core_M,
+                per_core_N,
+                fused_activation,
+                in0_buffer,
+                in1_buffer,
+                bias_buffer,
+                out_buffer,
+                in0_data_format,
+                in1_data_format,
+                bias_data_format,
+                output_data_format,
+                a.memory_config().is_sharded(),
+                output.memory_config().is_sharded(),
+                untilize_out);
+        }
     } else {
         TT_FATAL(false, "Grid is invalid for mcast matmul!");
     }
 }
 
-operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(const Tensor& a, const Tensor& b, const std::optional<const Tensor> bias, Tensor& output_tensor, bool broadcast_batch, CoreCoord compute_with_storage_grid_size, DeviceComputeKernelConfig compute_kernel_config, uint32_t in0_block_w, uint32_t out_subblock_h, uint32_t out_subblock_w, uint32_t per_core_M, uint32_t per_core_N, bool fuse_batch, std::optional<UnaryWithParam> fused_activation, bool mcast_in0, bool untilize_out) {
-    return matmul_multi_core_reuse_mcast_1d_optimized_(a, b, bias, output_tensor, broadcast_batch, compute_with_storage_grid_size, compute_kernel_config, in0_block_w, out_subblock_h, out_subblock_w, per_core_M, per_core_N, fuse_batch, fused_activation, mcast_in0, untilize_out);
+operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(
+    const Tensor& a,
+    const Tensor& b,
+    const std::optional<const Tensor> bias,
+    Tensor& output_tensor,
+    bool broadcast_batch,
+    CoreCoord compute_with_storage_grid_size,
+    DeviceComputeKernelConfig compute_kernel_config,
+    uint32_t in0_block_w,
+    uint32_t out_subblock_h,
+    uint32_t out_subblock_w,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    bool fuse_batch,
+    std::optional<UnaryWithParam> fused_activation,
+    bool mcast_in0,
+    bool untilize_out) {
+    return matmul_multi_core_reuse_mcast_1d_optimized_(
+        a,
+        b,
+        bias,
+        output_tensor,
+        broadcast_batch,
+        compute_with_storage_grid_size,
+        compute_kernel_config,
+        in0_block_w,
+        out_subblock_h,
+        out_subblock_w,
+        per_core_M,
+        per_core_N,
+        fuse_batch,
+        fused_activation,
+        mcast_in0,
+        untilize_out);
 }
 
 }  // namespace tt_metal


### PR DESCRIPTION
- Fully decouple in0 sender (ie. has in0 data) and receiver (ie. cores that produce work) grids
- This means user can now width shard in0 K and specify per_core_N that divides output width on arbitrary number of cores
- See tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py for examples

Changes:
 - Remove this assert: TT_FATAL(div_up(N, per_core_N) == input_tensor_a.shard_spec().value().grid.num_cores());
 - Separate in0 sender/recv cores into 3 kernel quadrants so all new logic is compile time
    * in0_mcast_cores_with_work_and_in_receiver_grid
    * in0_mcast_cores_without_work_and_in_receiver_grid
    * in0_mcast_cores_without_work_and_not_in_receiver_grid
 - Only load compute and writer kernels onto cores that produce output work
 - For interleaved in0, only mcast to cores with work as well; if single core, skip mcast
 - Add new short matmul sweep to test mcast 1D matmul with different in0 and output grids
 - Fork tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp to *width_sharded.cpp
 - TODO: Merge these kernels back once mcast 2D matmul is uplifted to support this feature