### PR TITLE
Update DPRINT to be disabled properly

### DIFF
--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -36,7 +36,11 @@
 #include "dprint_buffer.h"
 #include "status.h"
 
+#if defined(DEBUG_PRINT_ENABLED)
 #define DPRINT DebugPrinter()
+#else
+#define DPRINT if(0) DebugPrinter()
+#endif
 
 #ifdef UCK_CHLKC_UNPACK
 #define DPRINT_UNPACK(x) x

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -19,9 +19,9 @@
 // Add the ability to skip NOC logging, we can't have the tunneling cores stalling waiting for the
 // print server.
 #if !defined(SKIP_NOC_LOGGING)
-#define LOG_LEN(l) DPRINT << NOC_LOG_XFER(l)
-#define LOG_READ_LEN_FROM_STATE() LOG_LEN(NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE))
-#define LOG_WRITE_LEN_FROM_STATE() LOG_LEN(NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE))
+#define LOG_LEN(l) DPRINT << NOC_LOG_XFER(l);
+#define LOG_READ_LEN_FROM_STATE() LOG_LEN(NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
+#define LOG_WRITE_LEN_FROM_STATE() LOG_LEN(NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
 #else
 #define LOG_LEN(l)
 #define LOG_READ_LEN_FROM_STATE()


### PR DESCRIPTION
Previously was relying on compiler optimizing out the empty dprint object creation and stream operator calls, but it looks like  that doesn't work. Just use an `if (0)` here to accomplish this, which keeps the syntax exactly the same as stdout.

Also fix a thread safety issue with the dprint server teardown.

Passing CI: https://github.com/tenstorrent/tt-metal/actions/runs/9134780012