### PR TITLE
#8538: Support multi-producer single-consumer for Async Worke Queue

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(TTNN_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_add.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_async_runtime.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_multiprod_queue.cpp
 )
 
 add_executable(unit_tests_ttnn ${TTNN_UNIT_TESTS_SRC})

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensor/tensor.hpp"
+#include "ttnn_multi_command_queue_fixture.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_dnn/op_library/eltwise_binary/eltwise_binary_op.hpp"
+#include "tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp"
+#include "common/bfloat16.hpp"
+#include "ttnn/cpp/ttnn/async_runtime.hpp"
+#include "tt_numpy/functions.hpp"
+#include <cmath>
+#include <thread>
+
+using namespace tt;
+using namespace tt_metal;
+using MultiCommandQueueSingleDeviceFixture = ttnn::MultiCommandQueueSingleDeviceFixture;
+using namespace constants;
+
+TEST_F(MultiCommandQueueSingleDeviceFixture, TestMultiProducerLockBasedQueue) {
+    // Spawn 2 application level threads intefacing with the same device through the async engine.
+    // This leads to shared access of the work_executor and host side worker queue.
+    // Test thread safety.
+    Device* device = this->device_;
+    // Enable async engine and set queue setting to lock_based
+    device->set_worker_mode(WorkExecutorMode::ASYNCHRONOUS);
+    device->set_worker_queue_mode(WorkerQueueMode::LOCKBASED);
+
+    MemoryConfig mem_cfg = MemoryConfig{
+        .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        .buffer_type = BufferType::DRAM,
+        .shard_spec = std::nullopt
+    };
+    // Thread 0 uses cq_0, thread 1 uses cq_1
+    uint32_t t0_io_cq = 0;
+    uint32_t t1_io_cq = 1;
+    uint32_t tensor_buf_size = 1024 * 1024;
+    uint32_t datum_size_bytes = 2;
+
+    ttnn::Shape tensor_shape = ttnn::Shape(Shape({1, 1, 1024, 1024}));
+    auto t0_host_data = std::shared_ptr<bfloat16 []>(new bfloat16[tensor_buf_size]);
+    auto t0_readback_data = std::shared_ptr<bfloat16 []>(new bfloat16[tensor_buf_size]);
+    auto t1_host_data = std::shared_ptr<bfloat16 []>(new bfloat16[tensor_buf_size]);
+    auto t1_readback_data = std::shared_ptr<bfloat16 []>(new bfloat16[tensor_buf_size]);
+
+    // Application level threads issue writes and readbacks.
+    std::thread t0([&]() {
+        for (int j = 0; j < 100; j++) {
+            // Initialize data
+            for (int i = 0; i < tensor_buf_size; i++) {
+                t0_host_data[i] = bfloat16(static_cast<float>(2 + j));
+            }
+            // Allocate and write buffer
+            auto t0_input_buffer = ttnn::allocate_buffer_on_device(tensor_buf_size * datum_size_bytes, device, tensor_shape, DataType::BFLOAT16, Layout::TILE, mem_cfg);
+            auto t0_input_storage = tt::tt_metal::DeviceStorage{t0_input_buffer};
+            Tensor t0_input_tensor = Tensor(t0_input_storage, tensor_shape, DataType::BFLOAT16, Layout::TILE);
+            ttnn::write_buffer(t0_io_cq, t0_input_tensor, {t0_host_data});
+            // Readback and verify
+            ttnn::read_buffer(t0_io_cq, t0_input_tensor, {t0_readback_data});
+            t0_input_tensor.deallocate();
+            for (int i = 0; i < tensor_buf_size; i++) {
+                EXPECT_EQ(t0_readback_data[i], t0_host_data[i]);
+
+            }
+        }
+    });
+
+    std::thread t1([&]() {
+        for (int j = 0; j < 100; j++) {
+            for (int i = 0; i < tensor_buf_size; i++) {
+                t1_host_data[i] = bfloat16(static_cast<float>(4 + j));
+            }
+            auto t1_input_buffer = ttnn::allocate_buffer_on_device(tensor_buf_size * datum_size_bytes, device, tensor_shape, DataType::BFLOAT16, Layout::TILE, mem_cfg);
+            auto t1_input_storage = tt::tt_metal::DeviceStorage{t1_input_buffer};
+            Tensor t1_input_tensor = Tensor(t1_input_storage, tensor_shape, DataType::BFLOAT16, Layout::TILE);
+
+
+            ttnn::write_buffer(t1_io_cq, t1_input_tensor, {t1_host_data});
+            ttnn::read_buffer(t1_io_cq, t1_input_tensor, {t1_readback_data});
+
+            t1_input_tensor.deallocate();
+            for (int i = 0; i < tensor_buf_size; i++) {
+                EXPECT_EQ(t1_readback_data[i], t1_host_data[i]);
+            }
+        }
+    });
+
+    t0.join();
+    t1.join();
+
+}

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -840,7 +840,7 @@ void* get_raw_host_data_ptr(const Tensor& tensor) {
     return dispatch_map.at(tensor.get_dtype())(tensor);
 }
 
-void memcpy(CommandQueue& queue, void* dst, const Tensor& src, const std::optional<std::size_t> transfer_size) {
+void memcpy(CommandQueue& queue, void* dst, const Tensor& src, const std::optional<std::size_t> transfer_size, bool blocking) {
     TT_ASSERT(not transfer_size.has_value(), "transfer_size is not supported for memcpy right now!");
     if (not is_device_tensor(src)) {
         TT_THROW("memcpy: src tensor must be on device");
@@ -850,11 +850,11 @@ void memcpy(CommandQueue& queue, void* dst, const Tensor& src, const std::option
     if (TT_METAL_SLOW_DISPATCH_MODE != nullptr) {
         TT_THROW("SLOW_DISPATCH is not supported for memcpy!");
     }
-    EnqueueReadBuffer(queue, src.device_buffer(), dst, true);
+    EnqueueReadBuffer(queue, src.device_buffer(), dst, blocking);
 }
 
-void memcpy(void* dst, const Tensor& src, const std::optional<std::size_t> transfer_size) {
-    memcpy(src.device()->command_queue(), dst, src, transfer_size);
+void memcpy(void* dst, const Tensor& src, const std::optional<std::size_t> transfer_size, bool blocking) {
+    memcpy(src.device()->command_queue(), dst, src, transfer_size, blocking);
 }
 
 void memcpy(CommandQueue& queue, Tensor& dst, const void* src, const std::optional<std::size_t> transfer_size) {

--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -344,13 +344,13 @@ Tensor create_device_tensor(const Shape& shape, DataType dtype, Layout layout, D
 void *get_raw_host_data_ptr(const Tensor &tensor);
 
 void memcpy(
-    CommandQueue &queue, void *dst, const Tensor &src, const std::optional<std::size_t> transfer_size = std::nullopt);
+    CommandQueue &queue, void *dst, const Tensor &src, const std::optional<std::size_t> transfer_size = std::nullopt, bool blocking = true);
 void memcpy(
     CommandQueue &queue, Tensor &dst, const void *src, const std::optional<std::size_t> transfer_size = std::nullopt);
 void memcpy(
     CommandQueue &queue, Tensor &dst, const Tensor &src, const std::optional<std::size_t> transfer_size = std::nullopt);
 
-void memcpy(void *dst, const Tensor &src, const std::optional<std::size_t> transfer_size = std::nullopt);
+void memcpy(void *dst, const Tensor &src, const std::optional<std::size_t> transfer_size = std::nullopt, bool blocking = true);
 void memcpy(Tensor &dst, const void *src, const std::optional<std::size_t> transfer_size = std::nullopt);
 void memcpy(Tensor &dst, const Tensor &src, const std::optional<std::size_t> transfer_size = std::nullopt);
 

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -238,7 +238,8 @@ class Device {
     void set_worker_mode(const WorkExecutorMode& mode);
     void enable_async(bool enable);
     WorkExecutorMode get_worker_mode() { return work_executor.get_worker_mode(); }
-
+    void set_worker_queue_mode(const WorkerQueueMode& mode) { this->work_executor.set_worker_queue_mode(mode); }
+    WorkerQueueMode get_worker_queue_mode() { return this->work_executor.get_worker_queue_mode(); }
     // TODO: Uplift usage of friends. Buffer and Program just need access to allocator
     friend class Buffer;
     friend class Program;

--- a/ttnn/cpp/ttnn/async_runtime.hpp
+++ b/ttnn/cpp/ttnn/async_runtime.hpp
@@ -16,7 +16,7 @@ namespace ttnn {
 
     void write_buffer(queue_id cq_id, Tensor& dst, std::vector<std::shared_ptr<void>> src, const std::optional<std::size_t> transfer_size = std::nullopt);
 
-    void read_buffer(queue_id cq_id, Tensor& src, std::vector<std::shared_ptr<void>> dst, const std::optional<std::size_t> transfer_size = std::nullopt, size_t src_offset = 0);
+    void read_buffer(queue_id cq_id, Tensor& src, std::vector<std::shared_ptr<void>> dst, const std::optional<std::size_t> transfer_size = std::nullopt, size_t src_offset = 0, bool blocking = true);
 
     void queue_synchronize(CommandQueue& cq);
 


### PR DESCRIPTION
  - Add runtime flag and API for toggling between lock_free and lock_based queue modes
  - Add ttnn cpp test for example usage