### PR TITLE
#0: Add left shift fw op

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -479,6 +479,8 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.polygamma
 
+.. autofunction:: tt_lib.tensor.left_shift
+
 Tensor relational operations
 ============================
 .. autofunction:: tt_lib.tensor.gtz

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -272,6 +272,10 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_unary_div_no_nan,
         "pytorch_op": pytorch_ops.unary_div_no_nan,
     },
+    "eltwise-left-shift": {
+        "tt_op": tt_lib_ops.eltwise_left_shift,
+        "pytorch_op": pytorch_ops.left_shift,
+    },
     "eltwise-square": {
         "tt_op": tt_lib_ops.eltwise_square,
         "pytorch_op": pytorch_ops.square,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_shift_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_shift_ops.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from functools import partial
+from math import pi
+import copy
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+
+shapes = [
+    [[1, 1, 1, 30], [1, 1, 1, 30]],  # Single core
+    [[1, 1, 300, 380], [1, 1, 300, 380]],  # multi core
+    [[1, 3, 320, 380], [1, 3, 320, 380]],  # multi core
+    [[1, 1, 32, 32], [1, 1, 32, 32]],  # Single core
+    [[1, 1, 320, 384], [1, 1, 320, 384]],  # Multi core
+    [[1, 3, 320, 384], [1, 3, 320, 384]],  # Multi core
+]
+input_mem_cfgs = copy.copy(generation_funcs.supported_mem_configs)
+output_mem_cfgs = copy.copy(generation_funcs.supported_mem_configs)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    shapes,
+)
+@pytest.mark.parametrize("input_mem_config", input_mem_cfgs)
+@pytest.mark.parametrize("output_mem_config", output_mem_cfgs)
+class TestShiftVariants:
+    @pytest.mark.parametrize("shift_kind", ["left"])
+    def test_all_shift_ops(
+        self,
+        input_shapes,
+        shift_kind,
+        device,
+        function_level_defaults,
+        input_mem_config,
+        output_mem_config,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.int64)
+        ] + [generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=1, high=50), torch.int64)]
+        comparison_func = comparison_funcs.comp_pcc
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update(
+            {
+                "input_mem_config": [input_mem_config],
+                "output_mem_config": output_mem_config,
+            }
+        )
+        run_single_pytorch_test(
+            f"eltwise-{shift_kind}-shift",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+        )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -659,6 +659,11 @@ def silu(x, *args, **kwargs):
     return torch.nn.functional.silu(x)
 
 
+def left_shift(x, y, *args, **kwargs):
+    result = torch.bitwise_left_shift(x, y)
+    return result
+
+
 def div(x, y, *args, accurate_mode, **kwargs):
     result = torch.div(x, y)
     return result

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1027,6 +1027,25 @@ def eltwise_addalpha(
 
 
 @setup_host_and_device
+def eltwise_left_shift(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = ttl.tensor.left_shift(t0, t1, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t2)
+
+
+@setup_host_and_device
 def eltwise_div(
     x,
     y,

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -613,6 +613,57 @@ Tensor atan2(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& o
     return operation::decorate_as_composite(__func__, _atan2)(input_a, input_b, output_mem_config);
 }
 
+Tensor _left_shift(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {
+    Tensor number = input_a;
+    Tensor shift_amount = input_b;
+
+    Tensor two = full_like(input_a, 2.0);
+    Tensor one = full_like(input_a, 1.0);
+    Tensor result = one;
+    Tensor two_pow_2 = full_like(input_a, 4.0);
+    Tensor two_pow_5 = full_like(input_a, 32.0);
+    Tensor two_pow_10 = full_like(input_a, 1024.0);
+    Tensor two_pow_25 = full_like(input_a, 33554432.0);
+    Tensor two_pow_50 = full_like(input_a, 1125899906842624.0);
+
+    result = where(gte_unary(shift_amount, 50), mul(result, two_pow_50), result);
+    shift_amount = where(gte_unary(shift_amount, 50), sub_unary(shift_amount, 50.0), shift_amount);
+
+    result = where(gte_unary(shift_amount, 25), mul(result, two_pow_25), result);
+    shift_amount = where(gte_unary(shift_amount, 25), sub_unary(shift_amount, 25.0), shift_amount);
+
+    result = where(gte_unary(shift_amount, 10), mul(result, two_pow_10), result);
+    shift_amount = where(gte_unary(shift_amount, 10), sub_unary(shift_amount, 10.0), shift_amount);
+
+    result = where(gte_unary(shift_amount, 5), mul(result, two_pow_5), result);
+    shift_amount = where(gte_unary(shift_amount, 5), sub_unary(shift_amount, 5.0), shift_amount);
+
+    result = where(gte_unary(shift_amount, 5), mul(result, two_pow_5), result);
+    shift_amount = where(gte_unary(shift_amount, 5), sub_unary(shift_amount, 5.0), shift_amount);
+
+    result = where(gte_unary(shift_amount, 2), mul(result, two_pow_2), result);
+    shift_amount = where(gte_unary(shift_amount, 2), sub_unary(shift_amount, 2.0), shift_amount);
+
+    result = where(gtz(shift_amount), mul(result, two), result);
+    shift_amount = where(gtz(shift_amount), sub_unary(shift_amount, 1.0), shift_amount);
+
+    result = where(gtz(shift_amount), mul(result, two), result);
+    shift_amount = where(gtz(shift_amount), sub_unary(shift_amount, 1.0), shift_amount);
+
+    Tensor mul_result = mul(number, result);
+    one.deallocate();
+    two.deallocate();
+    two_pow_2.deallocate();
+    two_pow_5.deallocate();
+    two_pow_10.deallocate();
+    two_pow_25.deallocate();
+    two_pow_50.deallocate();
+    return mul_result;
+}
+Tensor left_shift(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {
+    return operation::decorate_as_composite(__func__, _left_shift)(input_a, input_b, output_mem_config);
+}
+
 // lerp(input, end, weight) = start + weight * (end - start)
 Tensor _lerp_overload(
     const Tensor& input_a, const Tensor& input_b, const Tensor& input_c, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -165,6 +165,11 @@ Tensor addcdiv(
     float value,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+Tensor left_shift(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 Tensor div(
     const Tensor& input_a,
     const Tensor& input_b,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -808,6 +808,22 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+        m_tensor.def("left_shift", &left_shift,
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs bitwise left shift operation on tensor ``input_a`` and shift amount ``input_b``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input_a", "Tensor left shift is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input_b", "Tensor of shift amount", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
         m_tensor.def("div", &div,
             py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("accurate_mode") = false, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs the element-wise division of ``input_a`` by ``input_b``.


### PR DESCRIPTION
Added Implementation for left shift : [PyTorch Reference](https://pytorch.org/docs/stable/generated/torch.bitwise_left_shift.html)

- Input Range for shift bit tensor : [1,50] (Second input)
- All post-commit tests - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/9157716978) [PASSED]