### PR TITLE
Dataformat update for falcon40b

### DIFF
--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -97,19 +97,19 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
 
     if data_type == "BFLOAT8_B":
         if seq_len == 32:
-            out_pcc = 0.91
-            k_cache_pcc = 0.97
-            v_cache_pcc = 0.94
+            out_pcc = 0.983
+            k_cache_pcc = 0.985
+            v_cache_pcc = 0.957
             token_pcc = 0.99
         elif seq_len == 128:
-            out_pcc = 0.91
-            k_cache_pcc = 0.98
-            v_cache_pcc = 0.94
+            out_pcc = 0.990
+            k_cache_pcc = 0.990
+            v_cache_pcc = 0.963
             token_pcc = 0.99
         elif seq_len == 2048:
-            out_pcc = 0.92
-            k_cache_pcc = 0.96
-            v_cache_pcc = 0.92
+            out_pcc = 0.993
+            k_cache_pcc = 0.992
+            v_cache_pcc = 0.979
             token_pcc = 0.99
     elif data_type == "BFLOAT16":
         if seq_len == 32:

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -113,19 +113,19 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
             token_pcc = 0.99
     elif data_type == "BFLOAT16":
         if seq_len == 32:
-            out_pcc = 0.98
-            k_cache_pcc = 0.99
-            v_cache_pcc = 0.98
+            out_pcc = 0.986
+            k_cache_pcc = 0.993
+            v_cache_pcc = 0.978
             token_pcc = 0.99
         elif seq_len == 128:
-            out_pcc = 0.99
-            k_cache_pcc = 0.98
-            v_cache_pcc = 0.93
+            out_pcc = 0.991
+            k_cache_pcc = 0.994
+            v_cache_pcc = 0.982
             token_pcc = 0.99
         elif seq_len == 2048:
-            out_pcc = 0.99
-            k_cache_pcc = 0.98
-            v_cache_pcc = 0.97
+            out_pcc = 0.992
+            k_cache_pcc = 0.992
+            v_cache_pcc = 0.980
             token_pcc = 0.99
 
     disable_persistent_kernel_cache()

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_loops.py
@@ -17,9 +17,9 @@ from models.utility_functions import (
 @pytest.mark.timeout(3600)
 @pytest.mark.parametrize(
     "num_loops",
-    (5,),
+    (1,),
     ids=[
-        "loops_5",
+        "loops_1",
     ],
 )
 @pytest.mark.parametrize("perf_mode", (False,))  # Option to measure perf using max seq length (with invalid outputs)

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -489,19 +489,19 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
                     token_pcc = 0.99
             elif data_type == "BFLOAT16":
                 if seq_len == 32:
-                    out_pcc = 0.98
-                    k_cache_pcc = 0.99
-                    v_cache_pcc = 0.98
+                    out_pcc = 0.986
+                    k_cache_pcc = 0.993
+                    v_cache_pcc = 0.978
                     token_pcc = 0.99
                 elif seq_len == 128:
-                    out_pcc = 0.99
-                    k_cache_pcc = 0.98
-                    v_cache_pcc = 0.93
+                    out_pcc = 0.991
+                    k_cache_pcc = 0.994
+                    v_cache_pcc = 0.982
                     token_pcc = 0.99
                 elif seq_len == 2048:
-                    out_pcc = 0.99
-                    k_cache_pcc = 0.98
-                    v_cache_pcc = 0.97
+                    out_pcc = 0.992
+                    k_cache_pcc = 0.992
+                    v_cache_pcc = 0.980
                     token_pcc = 0.99
         elif num_layers == 12:
             out_pcc = 0.99

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -473,19 +473,19 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
         if num_layers == 60:
             if data_type == "BFLOAT8_B":
                 if seq_len == 32:
-                    out_pcc = 0.91
-                    k_cache_pcc = 0.97
-                    v_cache_pcc = 0.94
+                    out_pcc = 0.983
+                    k_cache_pcc = 0.985
+                    v_cache_pcc = 0.957
                     token_pcc = 0.99
                 elif seq_len == 128:
-                    out_pcc = 0.91
-                    k_cache_pcc = 0.98
-                    v_cache_pcc = 0.94
+                    out_pcc = 0.990
+                    k_cache_pcc = 0.990
+                    v_cache_pcc = 0.963
                     token_pcc = 0.99
                 elif seq_len == 2048:
-                    out_pcc = 0.92
-                    k_cache_pcc = 0.96
-                    v_cache_pcc = 0.92
+                    out_pcc = 0.993
+                    k_cache_pcc = 0.992
+                    v_cache_pcc = 0.979
                     token_pcc = 0.99
             elif data_type == "BFLOAT16":
                 if seq_len == 32:

--- a/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
@@ -304,7 +304,7 @@ def run_test_FalconCausalLM_end_to_end(
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
-@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-SHARDED", "BFLOAT8_B-DRAM"))
+@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"))
 def test_perf_bare_metal(
     num_devices,
     model_version,
@@ -323,8 +323,8 @@ def test_perf_bare_metal(
     all_devices,
     use_program_cache,
 ):
-    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
-        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config and 8 chips!")
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
     if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED"]:
         pytest.skip("Decode is only supported for SHARDED memory config!")
 

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -349,7 +349,7 @@ def run_test_FalconCausalLM_end_to_end(
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
-@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-SHARDED", "BFLOAT8_B-DRAM"))
+@pytest.mark.parametrize("model_config_str", ("BFLOAT8_B-SHARDED", "BFLOAT8_B-DRAM", "BFLOAT16-DRAM"))
 def test_perf_bare_metal(
     num_devices,
     model_version,
@@ -368,8 +368,8 @@ def test_perf_bare_metal(
     all_devices,
     use_program_cache,
 ):
-    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM"] or num_devices != 8):
-        pytest.skip("Prefill is only supported for BFLOAT8_B-DRAM memory config and 8 chips!")
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
     if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED"]:
         pytest.skip("Decode is only supported for SHARDED memory config!")
 

--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -518,6 +518,7 @@ class TtFalconAttention:
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             output_mem_config=self.model_config["DEFAULT_MEMCFG"],
         )
+
         for i in range(len(attn_output)):
             attn_output[i] = falcon_prefill_matmul(
                 attn_output[i],
@@ -566,7 +567,7 @@ class TtFalconAttention:
                     compute_kernel_config=self.model_config["COMPUTE_KERNEL_FP16_ACC_CONFIG"],
                     output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
                     program_config=self.model_config["ATTENTION_MM_2_PROGCFG"],
-                    output_dtype=self.model_config["ATTENTION_DTYPE"],
+                    output_dtype=self.model_config["ATTENTION_OUT_DTYPE"],
                 )
             )
             attn_weights[i].deallocate(True)

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -162,12 +162,14 @@ class TtFalconMLP:
                 )
             )
             x[i].deallocate(True)
+
         hidden_states = tt_lib.tensor.all_gather(
             hidden_states,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             output_mem_config=self.model_config["DEFAULT_MEMCFG"],
         )
+
         for i in range(len(hidden_states)):
             hidden_states[i] = falcon_prefill_matmul(
                 hidden_states[i],

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -320,12 +320,21 @@ class TtFalconModelShared:
             presents += layer_output[1:]
             layer_output = layer_output[0]
 
+        if layer_output[0].dtype != self.model_config["BFP8_DTYPE"]:
+            for i in range(len(layer_output)):
+                layer_output[i] = tt_lib.tensor.typecast(layer_output[i], self.model_config["BFP8_DTYPE"])
+
         layer_output = tt_lib.tensor.all_gather(
             layer_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             output_mem_config=self.model_config["DEFAULT_MEMCFG"],
         )
+
+        if self.model_config["LN_INPUT_DTYPE"] != self.model_config["BFP8_DTYPE"]:
+            for i in range(len(layer_output)):
+                layer_output[i] = tt_lib.tensor.typecast(layer_output[i], self.model_config["LN_INPUT_DTYPE"])
+
         # apply final norm layer
         layer_output = partial_layernorm(
             layer_output,

--- a/models/demos/t3000/falcon40b/tt/model_config.py
+++ b/models/demos/t3000/falcon40b/tt/model_config.py
@@ -722,6 +722,7 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
     model_config["LN_INPUT_DTYPE"] = BFLOAT16_DTYPE
     model_config["LN_MLP_OUTPUT_DTYPE"] = BFLOAT16_DTYPE
     model_config["ATTENTION_DTYPE"] = BFLOAT16_DTYPE  # used for SDPA
+    model_config["WORD_EMBEDDING_OUTPUT_DTYPE"] = BFLOAT16_DTYPE  # embeddings output and the residual stream
 
     # Set input df for AllGathers to bfp8 to save data bandwidth
     model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"] = BFP8_DTYPE  # MLP AllGather

--- a/models/demos/t3000/falcon40b/tt/model_config.py
+++ b/models/demos/t3000/falcon40b/tt/model_config.py
@@ -15,6 +15,7 @@ OP_KEYS = (
     "WORD_EMBEDDING_WEIGHTS",
     "WORD_EMBEDDING_OUTPUT",
     # Decoder
+    "LN_INPUT",
     "LN_ATTN_WEIGHTS",
     "LN_ATTN_BIAS",
     "LN_ATTN_OUTPUT",
@@ -26,6 +27,7 @@ OP_KEYS = (
     "COS_CACHED_WEIGHTS",
     # Attention
     "ATTN_INPUT",
+    "ATTENTION_OUT",
     "FUSED_QKV_MM_WEIGHTS",
     "FUSED_QKV_MM_INPUT",
     "FUSED_QKV_MM_OUTPUT",
@@ -716,6 +718,15 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
     model_config["KV_CACHE_DTYPE"] = BFP8_DTYPE
 
     model_config["ATTN_MASK_DTYPE"] = BFP4_DTYPE
+
+    model_config["LN_INPUT_DTYPE"] = BFLOAT16_DTYPE
+    model_config["LN_MLP_OUTPUT_DTYPE"] = BFLOAT16_DTYPE
+    model_config["ATTENTION_DTYPE"] = BFLOAT16_DTYPE  # used for SDPA
+
+    # Set input df for AllGathers to bfp8 to save data bandwidth
+    model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"] = BFP8_DTYPE  # MLP AllGather
+    model_config["ATTENTION_OUT_DTYPE"] = BFP8_DTYPE  # Attention AllGather
+    model_config["SELFOUT_MM_OUTPUT_DTYPE"] = BFP8_DTYPE  # AllGather at start of the decoder layer and final AllGather
 
     head_dim = 64
     hidden_size = model_config_entries["hidden_size"]

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -12,7 +12,7 @@ run_t3000_falcon40b_tests() {
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
 
   # Falcon40B end to end demo (prefill + decode)
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_5_loops.py
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_loops.py
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
- fp16 config: use bfp8 for all AllGathers
    - MLP and attention use matmul out df and in df implicitly for the conversion
    - All layernorm inputs are casted explicitly
    - residual stream is kept in fp16
- bfp8 config: uses fp16 for the residual stream, layernorm and softmax
- PCC improved, see updated PCC targets in the end to end test
- Reduced number of loops for the demo to 1 in order to reduce ci test runtime

https://github.com/tenstorrent/tt-metal/actions/runs/9175432029
