### PR TITLE
#0: Revert "#0: Use build machines for static checks for now (#8679)"

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -10,36 +10,30 @@ on:
 
 jobs:
   check-spdx-licenses:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5.0.0
         with:
           cache: 'pip'
           cache-dependency-path: infra/requirements-infra.txt
-      - name: Create python env
-        run: python3 -m venv env
       - name: Install infra deps
-        run: |
-          source env/bin/activate
-          python3 -m pip install -r infra/requirements-infra.txt
+        run: python -m pip install -r infra/requirements-infra.txt
       - name: Check SPDX licenses
-        run: |
-          source env/bin/activate
-          python3 -m check_copyright --verbose --dry-run --config ./check_copyright_config.yaml .
+        run: python -m check_copyright --verbose --dry-run --config ./check_copyright_config.yaml .
   check-metal-kernel-count:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check kernel count in base metal is less than maximum
         run: if (( $(find tt_metal/kernels/ -type f | wc -l) > 7 )); then exit 1; fi
   check-black:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@23.10.1
   check-doc:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install ASPELL
@@ -47,7 +41,7 @@ jobs:
       - name: Run checks on docs
         run: TT_METAL_HOME=$(pwd) docs/spellcheck.sh
   check-forbidden-imports:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check ttnn is not used in tt_metal tests

--- a/check_copyright_config.yaml
+++ b/check_copyright_config.yaml
@@ -43,5 +43,4 @@ ignore:  # You can also select ignoring files here
     - env/
     - eevenv/
     - built/
-    - models/experimental/llama2_70b/reference/
     - models/demos/t3000/llama2_70b/reference/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dynamic = ["version"]
 [tool.black]
 line-length = 120
 include = '^.*(ttnn|tests/scripts|tests/ttnn|tests/tt_eager/python_api_testing|tt_eager/tt_lib|tests/scripts|models/demos)/.*\.py$'
-exclude = '^.*(models/experimental/llama2_70b/reference|models/demos/t3000/llama2_70b/reference)/.*$'
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
This reverts commit e68f0cef451977a899d4a894b5c849cbf61d9498.

Actions is operating normally again.