### PR TITLE
#0: Update common RT args to use no stride flag for packed cmd.

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/runtime_args/runtime_args.rst
@@ -15,6 +15,4 @@ Runtime Arguments
 
 .. doxygenfunction:: SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args)
 
-.. doxygenfunction:: SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const RuntimeArgsData &runtime_args)
-
 .. doxygenfunction:: GetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id)

--- a/tt_eager/tt_dnn/op_library/unpad/multi_core/unpad_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/unpad/multi_core/unpad_op_multi_core.cpp
@@ -319,7 +319,6 @@ inline __attribute__((always_inline)) void set_unpad_runtime_args_tile(
     uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
     if constexpr (!initialize_args) {
         set_common_reader_args(reader_common_args.data(), num_unpadded_tiles_per_dim, num_padded_tiles_per_dim);
-        SetCommonRuntimeArgs(program, unary_reader_kernel_id, reader_common_args);
     }
 
     uint32_t start_offset = get_tiled_start_offset(input_tensor, output_tensor_start);

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -331,19 +331,6 @@ void SetRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const 
  */
 void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args);
 
-/**
- * Set common (shared by all cores) runtime args for a kernel that are sent to all cores during runtime. This API needs to be called to update the common runtime args for the kernel.
- * Maximum of 255 allowed runtime args per core (unique and common runtime args count toward same limit).
- *
- * Return value: void
- *
- * | Argument     | Description                                                            | Type                                                   | Valid Range                                                         | Required |
- * |--------------|------------------------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------|----------|
- * | program      | The program containing kernels, circular buffers, semaphores           | const Program &                                        |                                                                     | Yes      |
- * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)                                |                                                                     | Yes      |
- * | runtime_args | The runtime args to be written                                         | const RuntimeArgsData &                                |                                                                     | Yes      |
- */
-void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const RuntimeArgsData &runtime_args);
 
 /**
  * Get the runtime args for a kernel.
@@ -372,7 +359,6 @@ std::vector< std::vector< RuntimeArgsData > > & GetRuntimeArgs(const Program &pr
 
 /**
  * Get the common runtime args for a kernel.
- * Note that you must call SetCommonRuntimeArgs after updating the returned value to propagate the update.
  *
  * Return value: RuntimeArgsData &
  *

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -169,7 +169,7 @@ std::vector<uint32_t>& Kernel::common_runtime_args() {
     return this->common_runtime_args_;
 }
 
-std::vector<RuntimeArgsData> & Kernel::common_runtime_args_data() {
+RuntimeArgsData & Kernel::common_runtime_args_data() {
     return this->common_runtime_args_data_;
 }
 
@@ -248,31 +248,11 @@ void Kernel::set_runtime_args(const CoreCoord &logical_core, const std::vector<u
 }
 
 void Kernel::set_common_runtime_args(const std::vector<uint32_t> &common_runtime_args) {
-
-    // TODO (abhullar): If we don't include this check then user can write runtime args to a core that the kernel is not placed on.
-    //                  Should this check only be enabled in debug mode?
-    // TT_FATAL(this->is_on_logical_core(logical_core), "Cannot set runtime args for core {} since kernel {} is not placed on it!", logical_core.str(), this->name());
-
     auto &set_rt_args = this->common_runtime_args_;
     TT_FATAL(set_rt_args.empty(), "Illegal Common Runtime Args: Can only set common runtime args once. Get and modify args in place instead.");
     this->validate_runtime_args_size(max_runtime_args_per_core_, common_runtime_args.size(), core_with_max_runtime_args_);
     set_rt_args = common_runtime_args;
-    this->common_runtime_args_data_ = std::vector<RuntimeArgsData>(this->core_range_set_.ranges().size(), RuntimeArgsData{set_rt_args.data(), set_rt_args.size()});
-}
-
-void Kernel::set_common_runtime_args(const RuntimeArgsData& common_runtime_args) {
-
-    // TODO (abhullar): If we don't include this check then user can write runtime args to a core that the kernel is not placed on.
-    //                  Should this check only be enabled in debug mode?
-    // TT_FATAL(this->is_on_logical_core(logical_core), "Cannot set runtime args for core {} since kernel {} is not placed on it!", logical_core.str(), this->name());
-
-    auto &set_rt_args = this->common_runtime_args_;
-    TT_FATAL(!set_rt_args.empty() and set_rt_args.size() == common_runtime_args.size(), "Illegal Common Runtime Args: Number of common runtime args cannot be modified!");
-    for (auto& rt_args_data : this->common_runtime_args_data_) {
-        if (common_runtime_args.data() != rt_args_data.data()) {
-            std::memcpy((void *)rt_args_data.data(),(void *) common_runtime_args.data(), common_runtime_args.size() * sizeof(uint32_t));
-        }
-    }
+    this->common_runtime_args_data_ = RuntimeArgsData{set_rt_args.data(), set_rt_args.size()};
 }
 
 void DataMovementKernel::set_build_options(JitBuildOptions& build_options) const {

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -83,7 +83,7 @@ class Kernel : public JitBuildSettings {
     std::vector< std::vector< std::vector<uint32_t>> > & runtime_args();
     std::vector< std::vector< RuntimeArgsData > > & runtime_args_data();
     std::vector<uint32_t> & common_runtime_args();
-    std::vector<RuntimeArgsData> & common_runtime_args_data();
+    RuntimeArgsData & common_runtime_args_data();
 
     std::map<std::string, std::string> defines() const { return defines_; }
 
@@ -106,7 +106,6 @@ class Kernel : public JitBuildSettings {
     void validate_runtime_args_size(size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core);
     void set_runtime_args(const CoreCoord &logical_core, const std::vector<uint32_t> &runtime_args);
     void set_common_runtime_args(const std::vector<uint32_t> &runtime_args);
-    void set_common_runtime_args(const RuntimeArgsData& common_runtime_args);
 
     int get_watcher_kernel_id() { return watcher_kernel_id_; }
 
@@ -131,7 +130,7 @@ class Kernel : public JitBuildSettings {
     std::vector< std::vector< std::vector<uint32_t>> > core_to_runtime_args_;
     std::vector< std::vector< RuntimeArgsData> > core_to_runtime_args_data_;
     std::vector<uint32_t> common_runtime_args_;
-    std::vector<RuntimeArgsData> common_runtime_args_data_;
+    RuntimeArgsData common_runtime_args_data_;
     std::set<CoreCoord> core_with_runtime_args_;
     std::size_t max_runtime_args_per_core_;             // For validation
     CoreCoord core_with_max_runtime_args_;              // For validation

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -927,15 +927,6 @@ void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const 
     }
 }
 
-void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const RuntimeArgsData &runtime_args) {
-    ZoneScoped;
-    TT_FATAL( not CommandQueue::async_mode_set(), "This variant of SetCommonRuntimeArgs can only be called when Asynchronous SW Command Queues are disabled for Fast Dispatch.");
-    if (runtime_args.size() != 0) {
-        detail::GetKernel(program, kernel_id)->set_common_runtime_args(runtime_args);
-    }
-}
-
-
 RuntimeArgsData & GetRuntimeArgs(const Program &program, KernelHandle kernel_id, const CoreCoord &logical_core) {
     TT_FATAL( not CommandQueue::async_mode_set(), "GetRuntimeArgs can only be called when Asynchronous SW Command Queues are disabled for Fast Dispatch.");
     return detail::GetKernel(program, kernel_id)->runtime_args_data(logical_core);
@@ -948,7 +939,7 @@ std::vector< std::vector< RuntimeArgsData> >& GetRuntimeArgs(const Program &prog
 
 RuntimeArgsData & GetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id) {
     TT_FATAL( not CommandQueue::async_mode_set(), "GetRuntimeArgs can only be called when Asynchronous SW Command Queues are disabled for Fast Dispatch.");
-    return detail::GetKernel(program, kernel_id)->common_runtime_args_data().at(0);
+    return detail::GetKernel(program, kernel_id)->common_runtime_args_data();
 }
 
 uint32_t BeginTraceCapture(Device *device, const uint8_t cq_id, const uint32_t trace_buff_size) {


### PR DESCRIPTION
Remove SetCommonRuntimeArgs requirement when hitting cache since we now have a direct 1 to 1 mapping into device cmd