### PR TITLE
#8027: `build_metal.sh` cleanup 

### DIFF
--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -18,4 +18,4 @@ runs:
         cache-dependency-path: |
           tt_metal/python_env/requirements-dev.txt
           pyproject.toml
-        install-cmd: ./scripts/build_scripts/create_venv.sh
+        install-cmd: ./create_venv.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 cmake_policy(VERSION 3.16)
 
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+    message(FATAL_ERROR "CMake generation is not allowed within source directory!! Please set a build folder with '-B'!!")
+endif()
+
 project(tt-metal
         VERSION 1.0
         DESCRIPTION "Tenstorrent Metallium"
@@ -8,17 +12,17 @@ project(tt-metal
         LANGUAGES CXX
 )
 
-############################################
+############################################################################################################################
 # Find all required libraries to build
-############################################
+############################################################################################################################
 find_package(Boost REQUIRED COMPONENTS thread filesystem system regex)
 find_package(GTest REQUIRED)
 find_package (Python3 COMPONENTS Interpreter Development)
 
-############################################
+############################################################################################################################
 # Setting build type flags
 #   Will default to assert build, unless CONFIG env variable is set or manually set -DCMAKE_BUILD_TYPE
-############################################
+############################################################################################################################
 if(DEFINED ENV{CONFIG})
     message(STATUS "CONFIG is set, CMAKE_BUILD_TYPE being set to $ENV{CONFIG}")
     set(CMAKE_BUILD_TYPE $ENV{CONFIG})
@@ -57,11 +61,11 @@ set(CMAKE_INSTALL_BINDIR "${CMAKE_BINARY_DIR}/tmp/bin")
 set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_BINARY_DIR}/tmp/include")
 set(CMAKE_INSTALL_DATAROOTDIR "${CMAKE_BINARY_DIR}/tmp/share")
 
-############################################
+############################################################################################################################
 # Constructing interface libs for common compiler flags, header directories, and libraries
 #   These interface libs are linked with PUBLIC scope at lowest common target (tt_metal/common) and at tt_metal_libs level
 #   in order to propogate to the rest of tt_metal, tt_eager, etc.
-############################################
+############################################################################################################################
 add_library(metal_common_libs INTERFACE)
 target_link_libraries(metal_common_libs INTERFACE
     dl z pthread atomic stdc++  # system libraries
@@ -119,9 +123,9 @@ target_precompile_headers(pch_pybinds INTERFACE
     ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/stl.h
 )
 
-############################################
+############################################################################################################################
 # Build subdirectories
-############################################
+############################################################################################################################
 if($ENV{ENABLE_TRACY})
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/tracy.cmake)
 endif()
@@ -137,11 +141,11 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests EXCLUDE_FROM_ALL)
 
 
-############################################
+############################################################################################################################
 # Install targets for build artifacts and pybinds
 #   If built with Tracy, cannot install 'all' since it will pick up install targets from Tracy
-# For top level install: cmake --build build --target metal-install
-############################################
+# For top level install: cmake --build build --target install  or  make/ninja install -C build
+############################################################################################################################
 # Install for build artifacts that will upload build/lib
 install(TARGETS tt_metal
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -21,3 +21,9 @@ python3 -m pip install -r $(pwd)/tt_metal/python_env/requirements-dev.txt
 echo "Installing tt-metal"
 pip install -e .
 pip install -e ttnn
+
+echo "Generating git hooks"
+pre-commit install
+pre-commit install --hook-type commit-msg
+
+echo "If you want stubs, run ./scripts/build_scripts/create_stubs.sh"

--- a/scripts/build_scripts/build_with_profiler_opt.sh
+++ b/scripts/build_scripts/build_with_profiler_opt.sh
@@ -16,4 +16,4 @@ remove_default_log_locations
 ENABLE_TRACY=1 ENABLE_PROFILER=1 cmake -B build -G Ninja && cmake --build build --target clean
 cmake --build build --target install
 cmake --build build --target programming_examples
-PYTHON_ENV_DIR=$(pwd)/build/python_env ./scripts/build_scripts/create_venv.sh
+PYTHON_ENV_DIR=$(pwd)/build/python_env ./create_venv.sh

--- a/scripts/build_scripts/create_stubs.sh
+++ b/scripts/build_scripts/create_stubs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ -z "$PYTHON_ENV_DIR" ]; then
+    PYTHON_ENV_DIR=$(pwd)/python_env
+fi
+
+sanity=0
+echo "!! Did you build metal and create python_env? !!"
+source $PYTHON_ENV_DIR/bin/activate
+python3 -c "import tt_lib" >/dev/null 2>&1; sanity+=$?
+python3 -c "import ttnn" >/dev/null 2>&1; sanity+=$?
+if [ $sanity -ne 0 ]; then
+    echo "!! tt_lib or ttnn not found. Please build+install metal and create python_env first !!"
+    exit 1
+fi
+
+echo "Generating stubs"
+stubgen -m tt_lib -m tt_lib.device -m tt_lib.profiler -m tt_lib.tensor -m tt_lib.operations -m tt_lib.operations.primary -m tt_lib.operations.primary.transformers -o tt_eager
+stubgen -p ttnn._ttnn -o ttnn
+sed -i 's/\._C/tt_lib/g' tt_eager/tt_lib/__init__.pyi


### PR DESCRIPTION
- moved stubs generation to it's own script
- moved git hooks into`create_venv.sh`
- build_metal now has a description/instructions on how to use the cmake flow (not sure if it belongs there)

postcommit: https://github.com/tenstorrent/tt-metal/actions/runs/9216311409