### PR TITLE
#8713: add forward support for inplace cmp ops

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -505,6 +505,18 @@ Tensor relational operations
 
 .. autofunction:: tt_lib.tensor.ne
 
+.. autofunction:: tt_lib.tensor.gti
+
+.. autofunction:: tt_lib.tensor.gei
+
+.. autofunction:: tt_lib.tensor.lti
+
+.. autofunction:: tt_lib.tensor.lei
+
+.. autofunction:: tt_lib.tensor.eqi
+
+.. autofunction:: tt_lib.tensor.nei
+
 .. autofunction:: tt_lib.tensor.unary_ne
 
 .. autofunction:: tt_lib.tensor.unary_gt

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -597,6 +597,10 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_ne,
         "pytorch_op": pytorch_ops.ne,
     },
+    "eltwise-nei": {
+        "tt_op": tt_lib_ops.eltwise_ne,
+        "pytorch_op": pytorch_ops.nei,
+    },
     "eltwise-bias_gelu": {
         "tt_op": tt_lib_ops.eltwise_bias_gelu,
         "pytorch_op": pytorch_ops.bias_gelu,
@@ -605,21 +609,41 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_eq,
         "pytorch_op": pytorch_ops.eq,
     },
+    "eltwise-eqi": {
+        "tt_op": tt_lib_ops.eltwise_eqi,
+        "pytorch_op": pytorch_ops.eqi,
+    },
     "eltwise-lt": {
         "tt_op": tt_lib_ops.eltwise_lt,
         "pytorch_op": pytorch_ops.lt,
+    },
+    "eltwise-lti": {
+        "tt_op": tt_lib_ops.eltwise_lti,
+        "pytorch_op": pytorch_ops.lti,
     },
     "eltwise-gt": {
         "tt_op": tt_lib_ops.eltwise_gt,
         "pytorch_op": pytorch_ops.gt,
     },
+    "eltwise-gti": {
+        "tt_op": tt_lib_ops.eltwise_gti,
+        "pytorch_op": pytorch_ops.gti,
+    },
     "eltwise-gte": {
         "tt_op": tt_lib_ops.eltwise_gte,
         "pytorch_op": pytorch_ops.gte,
     },
+    "eltwise-gei": {
+        "tt_op": tt_lib_ops.eltwise_gei,
+        "pytorch_op": pytorch_ops.gei,
+    },
     "eltwise-lte": {
         "tt_op": tt_lib_ops.eltwise_lte,
         "pytorch_op": pytorch_ops.lte,
+    },
+    "eltwise-lei": {
+        "tt_op": tt_lib_ops.eltwise_lei,
+        "pytorch_op": pytorch_ops.lei,
     },
     "eltwise-add": {
         "tt_op": tt_lib_ops.eltwise_add,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_binary_inplace.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_binary_inplace.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import random
+from functools import partial
+import tt_lib as ttl
+
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [[1, 1, 32, 32], [1, 1, 32, 32]],
+        [[1, 1, 320, 384], [1, 1, 320, 384]],
+        [[1, 3, 320, 384], [1, 3, 320, 384]],
+    ],
+)
+@pytest.mark.parametrize(
+    "dst_mem_config",
+    [
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+    ],
+)
+class TestCmpInplace:
+    @pytest.mark.parametrize("cmp_kind", ["lti", "gti", "lei", "gei", "nei", "eqi"])
+    def test_run_inplace_eltwise_binary(
+        self,
+        input_shapes,
+        dst_mem_config,
+        cmp_kind,
+        device,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ] * 2
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update({"input_mem_config": [dst_mem_config, dst_mem_config], "output_mem_config": dst_mem_config})
+        comparison_func = comparison_funcs.comp_equal
+
+        run_single_pytorch_test(
+            f"eltwise-{cmp_kind}",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -912,12 +912,32 @@ def lte(x, y, *args, **kwargs):
         return x <= y
 
 
+def lei(x, y, *args, **kwargs):
+    if "scalar" in kwargs:
+        scalar = kwargs.pop("scalar")
+        x.copy_(x <= scalar)
+        return x
+    else:
+        x.copy_(x <= y)
+        return x
+
+
 def lt(x, y, *args, **kwargs):
     if "scalar" in kwargs:
         scalar = kwargs.pop("scalar")
         return x < scalar
     else:
         return x < y
+
+
+def lti(x, y, *args, **kwargs):
+    if "scalar" in kwargs:
+        scalar = kwargs.pop("scalar")
+        x.copy_(x < scalar)
+        return x
+    else:
+        x.copy_(x < y)
+        return x
 
 
 def gte(x, y, *args, **kwargs):
@@ -928,12 +948,32 @@ def gte(x, y, *args, **kwargs):
         return x >= y
 
 
+def gei(x, y, *args, **kwargs):
+    if "scalar" in kwargs:
+        scalar = kwargs.pop("scalar")
+        x.copy_(x >= scalar)
+        return x
+    else:
+        x.copy_(x >= y)
+        return x
+
+
 def gt(x, y, *args, **kwargs):
     if "scalar" in kwargs:
         scalar = kwargs.pop("scalar")
         return x > scalar
     else:
         return x > y
+
+
+def gti(x, y, *args, **kwargs):
+    if "scalar" in kwargs:
+        scalar = kwargs.pop("scalar")
+        x.copy_(x > scalar)
+        return x
+    else:
+        x.copy_(x > y)
+        return x
 
 
 def eq(x, y, *args, **kwargs):
@@ -944,12 +984,32 @@ def eq(x, y, *args, **kwargs):
         return x == y
 
 
+def eqi(x, y, *args, **kwargs):
+    if "scalar" in kwargs:
+        scalar = kwargs.pop("scalar")
+        x.copy_(x == scalar)
+        return x
+    else:
+        x.copy_(x == y)
+        return x
+
+
 def ne(x, y, *args, **kwargs):
     if "scalar" in kwargs:
         scalar = kwargs.pop("scalar")
         return x != scalar
     else:
         return x != y
+
+
+def nei(x, y, *args, **kwargs):
+    if "scalar" in kwargs:
+        scalar = kwargs.pop("scalar")
+        x.copy_(x != scalar)
+        return x
+    else:
+        x.copy_(x != y)
+        return x
 
 
 def unary_gt(x, *args, **kwargs):

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1026,6 +1026,53 @@ def eltwise_addalpha(
     return tt2torch_tensor(t2)
 
 
+def make_inplace_binary_op(ttl_tensor_binop):
+    @setup_host_and_device
+    def binary_op(
+        x,
+        y,
+        *args,
+        device,
+        dtype,
+        layout,
+        input_mem_config,
+        output_mem_config,
+        **kwargs,
+    ):
+        t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+        t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+        t2 = ttl_tensor_binop(t0, t1, output_mem_config=output_mem_config)
+
+        return tt2torch_tensor(t2)
+
+    return binary_op
+
+
+eltwise_nei = make_inplace_binary_op(ttl.tensor.nei)
+eltwise_eqi = make_inplace_binary_op(ttl.tensor.eqi)
+eltwise_gti = make_inplace_binary_op(ttl.tensor.gti)
+eltwise_lti = make_inplace_binary_op(ttl.tensor.lti)
+eltwise_gei = make_inplace_binary_op(ttl.tensor.gei)
+eltwise_lei = make_inplace_binary_op(ttl.tensor.lei)
+
+# @setup_host_and_device
+# def eltwise_gei(
+#     x,
+#     y,
+#     *args,
+#     device,
+#     dtype,
+#     layout,
+#     input_mem_config,
+#     output_mem_config,
+#     **kwargs,
+# ):
+#     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+#     t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+#     ttl.tensor.gei(t0, t1, output_mem_config=output_mem_config)
+#     return tt2torch_tensor(t0)
+
+
 @setup_host_and_device
 def eltwise_div(
     x,

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.cpp
@@ -54,6 +54,24 @@ std::map<string, string> get_defines(
         case BinaryOpType::NE:
             defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst));
             break;
+        case BinaryOpType::GTI:
+            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::GTZ, std::nullopt, "0", idst));
+            break;
+        case BinaryOpType::LTI:
+            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::LTZ, std::nullopt, "0", idst));
+            break;
+        case BinaryOpType::GEI:
+            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::GEZ, std::nullopt, "0", idst));
+            break;
+        case BinaryOpType::LEI:
+            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::LEZ, std::nullopt, "0", idst));
+            break;
+        case BinaryOpType::EQI:
+            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::EQZ, std::nullopt, "0", idst));
+            break;
+        case BinaryOpType::NEI:
+            defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::NEZ, std::nullopt, "0", idst));
+            break;
         case BinaryOpType::SQUARED_DIFFERENCE:
             defines.merge(eltwise_unary_op_utils::get_defines(UnaryOpType::SQUARE, std::nullopt, "0", idst));
             break;
@@ -146,6 +164,9 @@ void EltwiseBinary::validate(const std::vector<Tensor>& input_tensors) const {
         "Inputs to eltwise binary must be tilized");
     if (this->in_place) {
         TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+        // log_debug(tt::LogOp, "input_tensor_a.memory_config().buffer_type {} ",
+        // input_tensor_a.memory_config().buffer_type); log_debug(tt::LogOp, "output_mem_config.buffer_type {} ",
+        // output_mem_config.buffer_type);
         TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
         TT_FATAL(input_tensor_a.get_dtype() == this->output_dtype);
     }

--- a/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_binary/eltwise_binary_op.hpp
@@ -35,7 +35,13 @@ enum class BinaryOpType {
     LOGICAL_OR,
     LDEXP,
     LOGADDEXP2,
-    DIV_FAST
+    DIV_FAST,
+    GEI,
+    GTI,
+    LEI,
+    LTI,
+    EQI,
+    NEI
 };
 
 enum class BinaryOpParallelizationStrategy { MULTI_CORE };
@@ -106,40 +112,41 @@ struct make_eltwise_binary {
         std::optional<std::vector<UnaryWithParam>> fused_activations = std::nullopt,
         const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         std::optional<const DataType> output_dtype = std::nullopt) const {
-        std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
+        std::vector<Tensor> output_tensors = {
+            Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
         operation::launch_with_autoformat(
-            [fused_activations, output_mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            [fused_activations, output_mem_config, output_dtype](
+                const std::vector<Tensor> &input_tensors,
+                const std::vector<std::optional<const Tensor>> &optional_input_tensors,
+                const std::vector<std::optional<Tensor>> &optional_output_tensors) mutable -> std::vector<Tensor> {
                 Tensor in_a = input_tensors.at(0);
                 Tensor in_b = input_tensors.at(1);
                 Shape shape_a = in_a.get_legacy_shape();
                 Shape shape_b = in_b.get_legacy_shape();
-                if (shape_a[0] != shape_b[0])
-                {
-                    if (shape_a[0] > shape_b[0])
-                    {
-                        Shape shape ({shape_a[0],1,1,1});
+                if (shape_a[0] != shape_b[0]) {
+                    if (shape_a[0] > shape_b[0]) {
+                        Shape shape({shape_a[0], 1, 1, 1});
                         in_b = repeat(in_b, shape, output_mem_config);
-                    }
-                    else
-                    {
-                        Shape shape ({shape_b[0],1,1,1});
+                    } else {
+                        Shape shape({shape_b[0], 1, 1, 1});
                         in_a = repeat(in_a, shape, output_mem_config);
                     }
                 }
                 TT_FATAL(
                     (in_a.get_legacy_shape() == in_b.get_legacy_shape()) or
-                    (in_a.get_legacy_shape().without_padding() == in_b.get_legacy_shape().without_padding()),
+                        (in_a.get_legacy_shape().without_padding() == in_b.get_legacy_shape().without_padding()),
                     "Input shapes must be the same!");
                 return operation::run_with_autoformat(
-                        EltwiseBinary{
-                            binary_op_type,
-                            fused_activations,
-                            output_mem_config,
-                            output_dtype.value_or(in_a.get_dtype()),
-                            false},
-                        {in_a, in_b});
+                    EltwiseBinary{
+                        binary_op_type,
+                        fused_activations,
+                        output_mem_config,
+                        output_dtype.value_or(in_a.get_dtype()),
+                        false},
+                    {in_a, in_b});
             },
-        {input_tensor_a, input_tensor_b}, output_tensors);
+            {input_tensor_a, input_tensor_b},
+            output_tensors);
         return output_tensors.at(0);
     }
 };
@@ -166,6 +173,64 @@ constexpr auto ne = make_eltwise_binary<BinaryOpType::NE>{};
 // logical ops
 constexpr auto logical_and = make_eltwise_binary<BinaryOpType::LOGICAL_AND>{};
 constexpr auto logical_or = make_eltwise_binary<BinaryOpType::LOGICAL_OR>{};
+
+// in_place binary op
+template <BinaryOpType binary_op_type>
+struct make_eltwise_binary_inplace {
+    Tensor operator()(
+        const Tensor &input_tensor_a,
+        const Tensor &input_tensor_b,
+        std::optional<std::vector<UnaryWithParam>> fused_activations = std::nullopt,
+        const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        std::optional<const DataType> output_dtype = std::nullopt) const {
+        std::vector<Tensor> output_tensors = {
+            Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
+        operation::launch_op(
+            [fused_activations, output_mem_config, output_dtype](
+                const std::vector<Tensor> &input_tensors,
+                const std::vector<std::optional<const Tensor>> &optional_input_tensors,
+                const std::vector<std::optional<Tensor>> &optional_output_tensors) mutable -> std::vector<Tensor> {
+                Tensor in_a = input_tensors.at(0);
+                Tensor in_b = input_tensors.at(1);
+                Shape shape_a = in_a.get_legacy_shape();
+                Shape shape_b = in_b.get_legacy_shape();
+                if (shape_a[0] != shape_b[0]) {
+                    if (shape_a[0] > shape_b[0]) {
+                        Shape shape({shape_a[0], 1, 1, 1});
+                        in_b = repeat(in_b, shape, output_mem_config);
+                    } else {
+                        Shape shape({shape_b[0], 1, 1, 1});
+                        in_a = repeat(in_a, shape, output_mem_config);
+                    }
+                }
+                TT_FATAL(
+                    (in_a.get_legacy_shape() == in_b.get_legacy_shape()) or
+                        (in_a.get_legacy_shape().without_padding() == in_b.get_legacy_shape().without_padding()),
+                    "Input shapes must be the same!");
+                auto binary_result = operation::run(
+                    EltwiseBinary{
+                        binary_op_type,
+                        fused_activations,
+                        output_mem_config,
+                        output_dtype.value_or(in_a.get_dtype()),
+                        true},
+                    {in_a, in_b});
+                return {in_a};
+            },
+            {input_tensor_a, input_tensor_b},
+            output_tensors);
+        return output_tensors.at(0);
+    }
+};
+
+// in_place comparative binary ops
+constexpr auto gei = make_eltwise_binary_inplace<BinaryOpType::GEI>{};
+constexpr auto gti = make_eltwise_binary_inplace<BinaryOpType::GTI>{};
+constexpr auto lei = make_eltwise_binary_inplace<BinaryOpType::LEI>{};
+constexpr auto lti = make_eltwise_binary_inplace<BinaryOpType::LTI>{};
+constexpr auto eqi = make_eltwise_binary_inplace<BinaryOpType::EQI>{};
+constexpr auto nei = make_eltwise_binary_inplace<BinaryOpType::NEI>{};
+
 }  // namespace tt_metal
 
 namespace operations {
@@ -179,33 +244,34 @@ inline Tensor add(
     const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<const DataType> output_dtype = std::nullopt,
     bool in_place = false) {
-    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
+    std::vector<Tensor> output_tensors = {
+        Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
 
     operation::launch_op(
-        [fused_activations, output_mem_config, output_dtype, in_place] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            auto& input_tensor_a = input_tensors.at(0);
-            auto& input_tensor_b = input_tensors.at(1);
+        [fused_activations, output_mem_config, output_dtype, in_place](
+            const std::vector<Tensor> &input_tensors,
+            const std::vector<std::optional<const Tensor>> &optional_input_tensors,
+            const std::vector<std::optional<Tensor>> &optional_output_tensors) mutable -> std::vector<Tensor> {
+            auto &input_tensor_a = input_tensors.at(0);
+            auto &input_tensor_b = input_tensors.at(1);
 
             Shape shape_a = input_tensor_a.get_legacy_shape();
             Shape shape_b = input_tensor_b.get_legacy_shape();
             Tensor in_a = input_tensor_a;
             Tensor in_b = input_tensor_b;
-            if (shape_a[0] != shape_b[0])
-            {
-                if (shape_a[0] > shape_b[0])
-                {
-                    Shape shape ({shape_a[0],1,1,1});
+            if (shape_a[0] != shape_b[0]) {
+                if (shape_a[0] > shape_b[0]) {
+                    Shape shape({shape_a[0], 1, 1, 1});
                     in_b = repeat(input_tensor_b, shape, output_mem_config);
-                }
-                else
-                {
-                    Shape shape ({shape_b[0],1,1,1});
+                } else {
+                    Shape shape({shape_b[0], 1, 1, 1});
                     in_a = repeat(input_tensor_a, shape, output_mem_config);
                 }
             }
             TT_FATAL(
                 (input_tensor_a.get_legacy_shape() == input_tensor_b.get_legacy_shape()) or
-                (input_tensor_a.get_legacy_shape().without_padding() == input_tensor_b.get_legacy_shape().without_padding()),
+                    (input_tensor_a.get_legacy_shape().without_padding() ==
+                     input_tensor_b.get_legacy_shape().without_padding()),
                 "Input shapes must be the same!");
             auto add_result = operation::run(
                 EltwiseBinary{
@@ -219,9 +285,11 @@ inline Tensor add(
                 return {in_a};
             }
             return add_result;
-        }, {input_tensor_a, input_tensor_b}, output_tensors);
+        },
+        {input_tensor_a, input_tensor_b},
+        output_tensors);
 
-        return output_tensors.at(0);
+    return output_tensors.at(0);
 }
 
 }  // namespace primary

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -9,206 +9,450 @@
 #include "tt_lib_bindings_tensor_impl.hpp"
 
 namespace tt::tt_metal::detail {
-    void TensorModuleXaryOPs( py::module & m_tensor){
+void TensorModuleXaryOPs(py::module &m_tensor) {
+    // *** eltwise binary ***
 
-        // *** eltwise binary ***
+    detail::bind_binary_op(
+        m_tensor, "add", add, R"doc(Perform an eltwise-binary add (``{0} + {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor, "sub", sub, R"doc(Perform an eltwise-binary sub (``{0} - {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor, "mul", mul, R"doc(Perform an eltwise-binary mul (``{0} * {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "squared_difference",
+        squared_difference,
+        R"doc(Perform an eltwise-binary squared_difference (``{0} - {1}``)^2 on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "logical_and",
+        logical_and,
+        R"doc(Performs the element-wise logical AND of the given input tensors ``{0}`` && ``{1}``, Zeros are treated as False and nonzeros are treated as True.)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "bias_gelu",
+        bias_gelu,
+        R"doc(Perform an eltwise-binary bias_gelu (``{0} + {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor, "gt", gt, R"doc(Perform an eltwise-binary greater-than (``{0} > {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor, "lt", lt, R"doc(Perform an eltwise-binary less-than (``{0} < {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor, "lte", lte, R"doc(Perform an eltwise-binary less-than-or-equal (``{0} <= {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "gte",
+        gte,
+        R"doc(Perform an eltwise-binary greater-than-or-equal (``{0} >= {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor, "eq", eq, R"doc(Perform an eltwise-binary equal (``{0} == {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor, "ne", ne, R"doc(Perform an eltwise-binary not-equal (``{0} != {1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "gti",
+        gt,
+        R"doc(Perform an eltwise-binary greater-than (``{0} > {1}``) on two tensors in place and returns the result in (``{0}``).)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "lti",
+        lt,
+        R"doc(Perform an eltwise-binary less-than (``{0} < {1}``) on two tensors in place and returns the result in (``{0}``).)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "lei",
+        lte,
+        R"doc(Perform an eltwise-binary less-than-or-equal (``{0} <= {1}``) on two tensors in place and returns the result in (``{0}``).)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "gei",
+        gei,
+        R"doc(Perform an eltwise-binary greater-than-or-equal (``{0} >= {1}``) on two tensors in place and returns the result in (``{0}``).)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "eqi",
+        eq,
+        R"doc(Perform an eltwise-binary equal (``{0} == {1}``) on two tensors in place and returns the result in (``{0}``).)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "nei",
+        ne,
+        R"doc(Perform an eltwise-binary not-equal (``{0} != {1}``) on two tensors in place and returns the result in (``{0}``).)doc");
+    detail::bind_binary_op(
+        m_tensor, "ldexp", ldexp, R"doc(Performs eltwise-binary ldexp (``{0} * 2**{1}``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "logaddexp",
+        logaddexp,
+        R"doc(Perform an eltwise-binary logaddexp (``log(exp({0}) + exp({1}))``) on two tensors.)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "logaddexp2",
+        logaddexp2,
+        R"doc(Perform an eltwise-binary logaddexp2 (``log2(2^({0}) + 2^({1}))``) on two tensors for input range [-64,64].)doc");
+    detail::bind_binary_op(
+        m_tensor,
+        "logical_or",
+        logical_or,
+        R"doc(Perform an eltwise-binary logical OR (``{0} || {1}``) on two tensors.)doc");
 
-        detail::bind_binary_op(m_tensor, "add", add, R"doc(Perform an eltwise-binary add (``{0} + {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "sub", sub, R"doc(Perform an eltwise-binary sub (``{0} - {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "mul", mul, R"doc(Perform an eltwise-binary mul (``{0} * {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "squared_difference", squared_difference, R"doc(Perform an eltwise-binary squared_difference (``{0} - {1}``)^2 on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "logical_and", logical_and, R"doc(Performs the element-wise logical AND of the given input tensors ``{0}`` && ``{1}``, Zeros are treated as False and nonzeros are treated as True.)doc");
-        detail::bind_binary_op(m_tensor, "bias_gelu", bias_gelu, R"doc(Perform an eltwise-binary bias_gelu (``{0} + {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "gt", gt, R"doc(Perform an eltwise-binary greater-than (``{0} > {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "lt", lt, R"doc(Perform an eltwise-binary less-than (``{0} < {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "lte", lte, R"doc(Perform an eltwise-binary less-than-or-equal (``{0} <= {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "gte", gte, R"doc(Perform an eltwise-binary greater-than-or-equal (``{0} >= {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "eq", eq, R"doc(Perform an eltwise-binary equal (``{0} == {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "ne", ne, R"doc(Perform an eltwise-binary not-equal (``{0} != {1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "ldexp", ldexp, R"doc(Performs eltwise-binary ldexp (``{0} * 2**{1}``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "logaddexp", logaddexp, R"doc(Perform an eltwise-binary logaddexp (``log(exp({0}) + exp({1}))``) on two tensors.)doc");
-        detail::bind_binary_op(m_tensor, "logaddexp2", logaddexp2, R"doc(Perform an eltwise-binary logaddexp2 (``log2(2^({0}) + 2^({1}))``) on two tensors for input range [-64,64].)doc");
-        detail::bind_binary_op(m_tensor, "logical_or", logical_or, R"doc(Perform an eltwise-binary logical OR (``{0} || {1}``) on two tensors.)doc");
-
-        // *** eltwise unary ***
-        detail::bind_unary_op(m_tensor, "identity", identity, R"doc(Returns a copy of same tensor ``input``; useful for profiling the SFPU.
+    // *** eltwise unary ***
+    detail::bind_unary_op(
+        m_tensor, "identity", identity, R"doc(Returns a copy of same tensor ``input``; useful for profiling the SFPU.
         this shouldn't normally be used; users should normally use clone operation instead for same functionality as this would be lower performance.
         )doc");
-        detail::bind_unary_op(m_tensor, "identity_uint32", identity_uint32, R"doc(Returns a copy of same tensor ``input``; useful for profiling the SFPU.
+    detail::bind_unary_op(
+        m_tensor,
+        "identity_uint32",
+        identity_uint32,
+        R"doc(Returns a copy of same tensor ``input``; useful for profiling the SFPU.
         this shouldn't normally be used; users should normally use clone operation instead for same functionality as this would be lower performance.
         Use this version of identity only if input is in uint32 format
         )doc");
-        detail::bind_unary_op(m_tensor, "recip", recip, R"doc(Returns a new tensor with the reciprocal of the elements of the input tensor ``recip``.)doc");
-        detail::bind_unary_op(m_tensor, "relu", relu, R"doc(Applies the rectified linear unit (ReLU) function to the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "relu6", relu6, R"doc(Returns tensor with the relu6 activation on elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(
-            m_tensor,
-            "sqrt",
-            py::overload_cast<const Tensor &, const MemoryConfig &>(sqrt),
-            R"doc(Returns tensor with the square-root of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "sigmoid", sigmoid, R"doc(Applies the sigmoid function to the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "sigmoid_accurate", sigmoid_accurate, R"doc(Applies the sigmoid_accurate function to the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "log", log, R"doc(Returns tensor with the natural logarithm of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "tanh", tanh, R"doc(Returns tensor with the hyperbolic tangent of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "log2", log2, R"doc(Returns tensor with the base 2 logarithm of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "log10", log10, R"doc(Returns tensor with the base 10 logarithm of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "sin", tt::tt_metal::sin, R"doc(Returns tensor with the sine of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "cos", tt::tt_metal::cos, R"doc(Returns tensor with the cosine of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "tan", tan, R"doc(Returns a new tensor with the tangent of the elements of the input tensor ``{0}`` for the range [-1.45, 1.45].)doc");
-        detail::bind_unary_op(m_tensor, "abs", abs, R"doc(Returns tensor with elementwise absolute value of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "isfinite", isfinite, R"doc(Returns boolean tensor that is True where input tensor ``{0}``, is finite and False elsewhere.)doc");
-        detail::bind_unary_op(m_tensor, "isinf", isinf, R"doc(Returns boolean tensor that is True where input tensor ``{0}``, is infinite and False elsewhere.)doc");
-        detail::bind_unary_op(m_tensor, "isposinf", isposinf, R"doc(Returns each element of input tensor ``{0}``, is positive infinity or not.)doc");
-        detail::bind_unary_op(m_tensor, "tiled_prod", tiled_prod, R"doc(Performs tile-wise multiplication on input tensor ``{0}`` and store the result in the last tile of the input tensor.)doc");
-        detail::bind_unary_op(m_tensor, "isneginf", isneginf, R"doc(Returns each element of input tensor ``{0}``, is negative infinity or not.)doc");
-        detail::bind_unary_op(m_tensor, "isnan", isnan, R"doc(Returns boolean tensor that is True where tensor ``{0}``, is NaN and False elsewhere.)doc");
-        detail::bind_unary_op(m_tensor, "sign", sign, R"doc(Returns tensor with the elementwise signum of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "square", square, R"doc(Returns tensor with the square of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "eqz", eqz, R"doc(Returns tensor with the result of equal to zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "nez", nez, R"doc(Returns tensor with the not equal zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "gtz", gtz, R"doc(Returns tensor with the greater than zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "ltz", ltz, R"doc(Returns tensor with the less than zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "gez", gez, R"doc(Returns tensor with the greater than equal zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "lez", lez, R"doc(Returns tensor with the less than equal zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "exp2", exp2, R"doc(Returns a new tensor with the exp2 (2 power) of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "expm1", expm1,
-            R"doc(Returns a new tensor with the expm1 of the elements of the input tensor ``{0}``.
-            expm1 = exp(x) - 1)doc"
-        );
-        detail::bind_unary_op(m_tensor, "signbit", signbit, R"doc(Applies the signbit function to the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "atan", atan, R"doc(Returns a new tensor with the arctan of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "asin", asin, R"doc(Returns a new tensor with the arcsine of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "acos", acos, R"doc(Returns a new tensor with the arccosine of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "logical_not_unary", logical_not_unary, R"doc(Returns a new tensor with the logical not of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "log_sigmoid", &log_sigmoid, R"doc(Applies the logsigmoid function to the elements of the input tensor ``{0}`` for input range [-4,10].)doc");
-        detail::bind_unary_op(m_tensor, "erfinv", erfinv, R"doc(Computes inverse error function for all elements of the input tensor ``{0}`` in the range (-1,1) .)doc");
-        detail::bind_unary_op(m_tensor, "i0", i0, R"doc(Computes the zeroth order modified Bessel function of the first kind applied on the elements of the input tensor ``{0}``, for the input range -10 to 10.)doc");
-        detail::bind_unary_op(m_tensor, "silu", silu, R"doc(Returns tensor with the silu all of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "neg", neg, R"doc(Returns tensor with the negate all of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "recip",
+        recip,
+        R"doc(Returns a new tensor with the reciprocal of the elements of the input tensor ``recip``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "relu",
+        relu,
+        R"doc(Applies the rectified linear unit (ReLU) function to the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "relu6",
+        relu6,
+        R"doc(Returns tensor with the relu6 activation on elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "sqrt",
+        py::overload_cast<const Tensor &, const MemoryConfig &>(sqrt),
+        R"doc(Returns tensor with the square-root of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "sigmoid",
+        sigmoid,
+        R"doc(Applies the sigmoid function to the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "sigmoid_accurate",
+        sigmoid_accurate,
+        R"doc(Applies the sigmoid_accurate function to the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "log",
+        log,
+        R"doc(Returns tensor with the natural logarithm of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "tanh",
+        tanh,
+        R"doc(Returns tensor with the hyperbolic tangent of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "log2",
+        log2,
+        R"doc(Returns tensor with the base 2 logarithm of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "log10",
+        log10,
+        R"doc(Returns tensor with the base 10 logarithm of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "sin",
+        tt::tt_metal::sin,
+        R"doc(Returns tensor with the sine of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "cos",
+        tt::tt_metal::cos,
+        R"doc(Returns tensor with the cosine of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "tan",
+        tan,
+        R"doc(Returns a new tensor with the tangent of the elements of the input tensor ``{0}`` for the range [-1.45, 1.45].)doc");
+    detail::bind_unary_op(
+        m_tensor, "abs", abs, R"doc(Returns tensor with elementwise absolute value of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "isfinite",
+        isfinite,
+        R"doc(Returns boolean tensor that is True where input tensor ``{0}``, is finite and False elsewhere.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "isinf",
+        isinf,
+        R"doc(Returns boolean tensor that is True where input tensor ``{0}``, is infinite and False elsewhere.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "isposinf",
+        isposinf,
+        R"doc(Returns each element of input tensor ``{0}``, is positive infinity or not.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "tiled_prod",
+        tiled_prod,
+        R"doc(Performs tile-wise multiplication on input tensor ``{0}`` and store the result in the last tile of the input tensor.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "isneginf",
+        isneginf,
+        R"doc(Returns each element of input tensor ``{0}``, is negative infinity or not.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "isnan",
+        isnan,
+        R"doc(Returns boolean tensor that is True where tensor ``{0}``, is NaN and False elsewhere.)doc");
+    detail::bind_unary_op(
+        m_tensor, "sign", sign, R"doc(Returns tensor with the elementwise signum of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor, "square", square, R"doc(Returns tensor with the square of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "eqz",
+        eqz,
+        R"doc(Returns tensor with the result of equal to zero of all of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "nez",
+        nez,
+        R"doc(Returns tensor with the not equal zero of all of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "gtz",
+        gtz,
+        R"doc(Returns tensor with the greater than zero of all of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "ltz",
+        ltz,
+        R"doc(Returns tensor with the less than zero of all of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "gez",
+        gez,
+        R"doc(Returns tensor with the greater than equal zero of all of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "lez",
+        lez,
+        R"doc(Returns tensor with the less than equal zero of all of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "exp2",
+        exp2,
+        R"doc(Returns a new tensor with the exp2 (2 power) of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "expm1",
+        expm1,
+        R"doc(Returns a new tensor with the expm1 of the elements of the input tensor ``{0}``.
+            expm1 = exp(x) - 1)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "signbit",
+        signbit,
+        R"doc(Applies the signbit function to the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "atan",
+        atan,
+        R"doc(Returns a new tensor with the arctan of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "asin",
+        asin,
+        R"doc(Returns a new tensor with the arcsine of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "acos",
+        acos,
+        R"doc(Returns a new tensor with the arccosine of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "logical_not_unary",
+        logical_not_unary,
+        R"doc(Returns a new tensor with the logical not of the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "log_sigmoid",
+        &log_sigmoid,
+        R"doc(Applies the logsigmoid function to the elements of the input tensor ``{0}`` for input range [-4,10].)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "erfinv",
+        erfinv,
+        R"doc(Computes inverse error function for all elements of the input tensor ``{0}`` in the range (-1,1) .)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "i0",
+        i0,
+        R"doc(Computes the zeroth order modified Bessel function of the first kind applied on the elements of the input tensor ``{0}``, for the input range -10 to 10.)doc");
+    detail::bind_unary_op(
+        m_tensor, "silu", silu, R"doc(Returns tensor with the silu all of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor, "neg", neg, R"doc(Returns tensor with the negate all of elements of the input tensor ``{0}``.)doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "exp", py::overload_cast<const Tensor&, bool, const MemoryConfig&>(&exp),
-            py::arg("fast_and_approx") = false,
-            R"doc(Returns a new tensor with the exponential of the elements of the input tensor ``{0}``.)doc",
-            R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of false")doc"
-        );
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "exp",
+        py::overload_cast<const Tensor &, bool, const MemoryConfig &>(&exp),
+        py::arg("fast_and_approx") = false,
+        R"doc(Returns a new tensor with the exponential of the elements of the input tensor ``{0}``.)doc",
+        R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of false")doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "gelu", &gelu,
-            py::arg("fast_and_approx") = true,
-            R"doc(Applies the Gaussian Error Linear Units (GELU) function to the elements of the input tensor ``{0}``.)doc",
-            R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of true")doc"
-        );
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "gelu",
+        &gelu,
+        py::arg("fast_and_approx") = true,
+        R"doc(Applies the Gaussian Error Linear Units (GELU) function to the elements of the input tensor ``{0}``.)doc",
+        R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of true")doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "erf", &erf,
-            py::arg("fast_and_approx") = true,
-            R"doc(Computes error function for all elements of the input tensor ``{0}``.)doc",
-            R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of true")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "erfc", &erfc,
-            py::arg("fast_and_approx") = true,
-            R"doc(Computes complementary error function for all elements of the input tensor ``{0}``.)doc",
-            R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of true")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "rsqrt", &rsqrt,
-            py::arg("fast_and_approx") = true,
-            R"doc(Returns a new tensor with the reciprocal of the square-root of each of the elements of the input tensor ``{0}`` for the input range -10 to 10.)doc",
-            R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of true")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "relu_max", relu_max,
-            py::arg("upper_limit"),
-            R"doc(Returns tensor with the relu max of all of elements of the input tensor ``{0}``. This is equivalent
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "erf",
+        &erf,
+        py::arg("fast_and_approx") = true,
+        R"doc(Computes error function for all elements of the input tensor ``{0}``.)doc",
+        R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of true")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "erfc",
+        &erfc,
+        py::arg("fast_and_approx") = true,
+        R"doc(Computes complementary error function for all elements of the input tensor ``{0}``.)doc",
+        R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of true")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "rsqrt",
+        &rsqrt,
+        py::arg("fast_and_approx") = true,
+        R"doc(Returns a new tensor with the reciprocal of the square-root of each of the elements of the input tensor ``{0}`` for the input range -10 to 10.)doc",
+        R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of true")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "relu_max",
+        relu_max,
+        py::arg("upper_limit"),
+        R"doc(Returns tensor with the relu max of all of elements of the input tensor ``{0}``. This is equivalent
             to relu_max[x] = relu(min(x, ``{1}``)). It caps off the input to a max value and a min value of 0.)doc",
-            R"doc("max value", "float", "")doc"
+        R"doc("max value", "float", "")doc"
 
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "relu_min", relu_min,
-            py::arg("lower_limit"),
-            R"doc(Returns tensor with the relu min of all of elements of the input tensor ``{0}``. This is equivalent
+    );
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "relu_min",
+        relu_min,
+        py::arg("lower_limit"),
+        R"doc(Returns tensor with the relu min of all of elements of the input tensor ``{0}``. This is equivalent
             to relu_min[x] = max(x, ``{1}``). It moves relu function down to carry out operation at minvalue
             instead of the standard 0.)doc",
-            R"doc("min value", "float", "")doc"
+        R"doc("min value", "float", "")doc"
 
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "elu", elu,
-            py::arg("alpha"),
-            R"doc(Returns tensor with the elu activation of all of elements of the input tensor ``{0}`` and scale
+    );
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "elu",
+        elu,
+        py::arg("alpha"),
+        R"doc(Returns tensor with the elu activation of all of elements of the input tensor ``{0}`` and scale
             factor alpha as ``{1}``. ELU(x) = alpha*(exp(x) - 1) if x < 0 else x.)doc",
-            R"doc("alpha value", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "heaviside", heaviside,
-            py::arg("value"),
-            R"doc(Returns tensor with the Heaviside step function of all of elements of the input tensor ``{0}`` and value factor as ``{1}``.
+        R"doc("alpha value", "float", "")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "heaviside",
+        heaviside,
+        py::arg("value"),
+        R"doc(Returns tensor with the Heaviside step function of all of elements of the input tensor ``{0}`` and value factor as ``{1}``.
 
             HEAVISIDE(x) = 0 if x < 0 , 1 if x > 0 , else value.)doc",
-            R"doc("value", "float", "")doc"
+        R"doc("value", "float", "")doc"
 
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "unary_ne", unary_ne,
-            py::arg("value"),
-            R"doc(Perform an eltwise-unary not-equal (``{0} != {1}``) on input tensor.)doc",
-            R"doc("value", "float", "")doc"
+    );
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "unary_ne",
+        unary_ne,
+        py::arg("value"),
+        R"doc(Perform an eltwise-unary not-equal (``{0} != {1}``) on input tensor.)doc",
+        R"doc("value", "float", "")doc"
 
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "rdiv", rdiv,
-            py::arg("denominator"),
-            R"doc(Returns tensor  with value ``{1}`` divided by each of respective elements of the input tensor ``{0}``.)doc",
-            R"doc("denominator value which is actually calculated as numerator", "float", ">=0.0")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "rsub", rsub,
-            py::arg("value"),
-            R"doc(Returns tensor  with respective elements of the input tensor ``{0}`` subtracted from the ``{1}``.)doc",
-            R"doc("subtrahent value which is actually calculated as minuend", "float")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "leaky_relu", leaky_relu,
-            py::arg("slope"),
-            R"doc(Returns tensor with the leaky relu of all of elements of the input tensor ``{0}`` with negative slope as ``{1}``.)doc",
-            R"doc("slope value", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "prelu", prelu,
-            py::arg("weight"),
-            R"doc(Returns tensor with the prelu of all of elements of the input tensor ``{0}`` with negative slope as ``{1}``.)doc",
-            R"doc("weight value", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "unary_chain", &unary_chain,
-            py::arg("unary_chain"),
-            R"doc(Returns tensor with the unary op chain applied to all of elements of the input tensor ``{0}``.)doc",
-            R"doc("Unary op chain", "Vector<FusibleActivation>", "At least 1 activation")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "unary_gt", unary_gt,
-            py::arg("value"),
-            R"doc(Perform an eltwise-unary greater-than (``{0} > {1}``) on input tensor.)doc",
-            R"doc("value", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "unary_lt", unary_lt,
-            py::arg("value"),
-            R"doc(Perform an eltwise-unary less-than (``{0} < {1}``) on input tensor.)doc",
-            R"doc("value", "float", "")doc"
-        );
+    );
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "rdiv",
+        rdiv,
+        py::arg("denominator"),
+        R"doc(Returns tensor  with value ``{1}`` divided by each of respective elements of the input tensor ``{0}``.)doc",
+        R"doc("denominator value which is actually calculated as numerator", "float", ">=0.0")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "rsub",
+        rsub,
+        py::arg("value"),
+        R"doc(Returns tensor  with respective elements of the input tensor ``{0}`` subtracted from the ``{1}``.)doc",
+        R"doc("subtrahent value which is actually calculated as minuend", "float")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "leaky_relu",
+        leaky_relu,
+        py::arg("slope"),
+        R"doc(Returns tensor with the leaky relu of all of elements of the input tensor ``{0}`` with negative slope as ``{1}``.)doc",
+        R"doc("slope value", "float", "")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "prelu",
+        prelu,
+        py::arg("weight"),
+        R"doc(Returns tensor with the prelu of all of elements of the input tensor ``{0}`` with negative slope as ``{1}``.)doc",
+        R"doc("weight value", "float", "")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "unary_chain",
+        &unary_chain,
+        py::arg("unary_chain"),
+        R"doc(Returns tensor with the unary op chain applied to all of elements of the input tensor ``{0}``.)doc",
+        R"doc("Unary op chain", "Vector<FusibleActivation>", "At least 1 activation")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "unary_gt",
+        unary_gt,
+        py::arg("value"),
+        R"doc(Perform an eltwise-unary greater-than (``{0} > {1}``) on input tensor.)doc",
+        R"doc("value", "float", "")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "unary_lt",
+        unary_lt,
+        py::arg("value"),
+        R"doc(Perform an eltwise-unary less-than (``{0} < {1}``) on input tensor.)doc",
+        R"doc("value", "float", "")doc");
 
-        // *** bcast binary tied to unary ***
-        detail::bind_unary_op(m_tensor, "add1", &add1, R"doc(Returns tensor with the addition of one with input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "deg2rad", &deg2rad, R"doc(Returns tensor with the deg2rad conversion of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "rad2deg", &rad2deg, R"doc(Returns tensor with the rad2deg conversion of elements of the input tensor ``{0}``.)doc");
+    // *** bcast binary tied to unary ***
+    detail::bind_unary_op(
+        m_tensor, "add1", &add1, R"doc(Returns tensor with the addition of one with input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "deg2rad",
+        &deg2rad,
+        R"doc(Returns tensor with the deg2rad conversion of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "rad2deg",
+        &rad2deg,
+        R"doc(Returns tensor with the rad2deg conversion of elements of the input tensor ``{0}``.)doc");
 
-
-        m_tensor.def("mul_unary", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&mul_unary),
-            py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "mul_unary",
+        py::overload_cast<float, const Tensor &, const MemoryConfig &>(&mul_unary),
+        py::arg("scalar"),
+        py::arg("input"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Perform an eltwise-binary mul on one tensor and one scalar.
 
             Both inputs, the tensor and scalar, must have BFLOAT16 data type.
@@ -224,8 +468,13 @@ namespace tt::tt_metal::detail {
 
         )doc");
 
-        m_tensor.def("div_unary", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&div_unary),
-            py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "div_unary",
+        py::overload_cast<float, const Tensor &, const MemoryConfig &>(&div_unary),
+        py::arg("scalar"),
+        py::arg("input"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Perform an eltwise-binary div on one tensor and one scalar.
 
             Both inputs, the tensor and scalar, must have BFLOAT16 data type.
@@ -241,8 +490,13 @@ namespace tt::tt_metal::detail {
 
         )doc");
 
-        m_tensor.def("sub_unary", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&sub_unary),
-            py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "sub_unary",
+        py::overload_cast<float, const Tensor &, const MemoryConfig &>(&sub_unary),
+        py::arg("scalar"),
+        py::arg("input"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Perform an eltwise-binary sub on one tensor and one scalar.
 
             Both inputs, the tensor and scalar, must have BFLOAT16 data type.
@@ -258,8 +512,13 @@ namespace tt::tt_metal::detail {
 
         )doc");
 
-        m_tensor.def("add_unary", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&add_unary),
-            py::arg("scalar"), py::arg("input"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "add_unary",
+        py::overload_cast<float, const Tensor &, const MemoryConfig &>(&add_unary),
+        py::arg("scalar"),
+        py::arg("input"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Perform an eltwise-binary add on one tensor and one scalar.
 
             Both inputs, the tensor and scalar, must have BFLOAT16 data type.
@@ -274,40 +533,55 @@ namespace tt::tt_metal::detail {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "sub_unary", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&sub_unary),
-            py::arg("scalar"),
-            R"doc(Perform an eltwise-binary sub on one tensor ``{0}`` and one scalar ``{1}``.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "mul_unary", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&mul_unary),
-            py::arg("scalar"),
-            R"doc(Perform an eltwise-binary mul on one tensor ``{0}`` and one scalar ``{1}``.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "div_unary", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&div_unary),
-            py::arg("scalar"),
-            R"doc(Perform an eltwise-binary div on one tensor ``{0}`` and one scalar ``{1}``.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "add_unary", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&add_unary),
-            py::arg("scalar"),
-            R"doc(Perform an eltwise-binary add on one tensor ``{0}`` and one scalar ``{1}``.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "sub_unary",
+        py::overload_cast<const Tensor &, float, const MemoryConfig &>(&sub_unary),
+        py::arg("scalar"),
+        R"doc(Perform an eltwise-binary sub on one tensor ``{0}`` and one scalar ``{1}``.)doc",
+        R"doc("Scalar", "float", "")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "mul_unary",
+        py::overload_cast<const Tensor &, float, const MemoryConfig &>(&mul_unary),
+        py::arg("scalar"),
+        R"doc(Perform an eltwise-binary mul on one tensor ``{0}`` and one scalar ``{1}``.)doc",
+        R"doc("Scalar", "float", "")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "div_unary",
+        py::overload_cast<const Tensor &, float, const MemoryConfig &>(&div_unary),
+        py::arg("scalar"),
+        R"doc(Perform an eltwise-binary div on one tensor ``{0}`` and one scalar ``{1}``.)doc",
+        R"doc("Scalar", "float", "")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "add_unary",
+        py::overload_cast<const Tensor &, float, const MemoryConfig &>(&add_unary),
+        py::arg("scalar"),
+        R"doc(Perform an eltwise-binary add on one tensor ``{0}`` and one scalar ``{1}``.)doc",
+        R"doc("Scalar", "float", "")doc");
 
-        // softmax
-        m_tensor.def("softmax", &softmax,
-            py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("compute_kernel_config").noconvert() = std::nullopt,
-            "Performs a softmax operation on the last tensor dimension.");
+    // softmax
+    m_tensor.def(
+        "softmax",
+        &softmax,
+        py::arg("input").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
+        "Performs a softmax operation on the last tensor dimension.");
 
-        // softmax with scale and mask, regular mask has a dim of (batch, 1, 1, seq_len), causal mask has a dim of (batch, 1, seq_len, seq_len)
-        m_tensor.def("scale_mask_softmax", &transformers::scale_mask_softmax,
-        py::arg("input").noconvert(), py::arg("scale"), py::arg("mask").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("is_causal_mask").noconvert() = false, py::arg("compute_kernel_config").noconvert() = std::nullopt,
+    // softmax with scale and mask, regular mask has a dim of (batch, 1, 1, seq_len), causal mask has a dim of (batch,
+    // 1, seq_len, seq_len)
+    m_tensor.def(
+        "scale_mask_softmax",
+        &transformers::scale_mask_softmax,
+        py::arg("input").noconvert(),
+        py::arg("scale"),
+        py::arg("mask").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("is_causal_mask").noconvert() = false,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs a fused scale->attention_mask->softmax operation.");
-
-    }
 }
+}  // namespace tt::tt_metal::detail


### PR DESCRIPTION
Add GEI op ( greater than or equal to op with in_place operation)
Once reviewed, will add support for other binary in_place ops as well (LEI, LTI, GTI, EQI and NEI)
CI test : https://github.com/tenstorrent/tt-metal/actions/runs/9191368084