### PR TITLE
#8049: Automate perf measurements

### DIFF
--- a/models/demos/t3000/falcon40b/scripts/get_falcon40b_perf_numbers.sh
+++ b/models/demos/t3000/falcon40b/scripts/get_falcon40b_perf_numbers.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script runs the performance tests for the falcon40b model with different sequence lengths
+seq_lens=(128 2048)
+
+dtype="BFLOAT8_B" #BFLOAT16
+
+for seq_len in ${seq_lens[@]}; do
+    echo "Running seq_len: $seq_len"
+    output_folder="generated/profiler/reports/"
+    WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python3 tt_eager/tracy.py -r -m "pytest models/demos/t3000/falcon40b/tests/test_perf_falcon.py::test_perf_bare_metal[${dtype}-DRAM-falcon_40b-layers_1-prefill_seq${seq_len}-8chips]"
+    # get latest folder in output folder
+    latest_created_folder=$(ls -td $output_folder/* | head -n 1)
+    # find csv file that starts with "ops_perf_results"
+    csv_file=$(find $latest_created_folder -name "ops_perf_results*.csv")
+    # create output summary file from csv file
+    output_perf_filename="${csv_file%.*}_seq_len_${seq_len}_summary.csv"
+    echo "CSV file: $csv_file"
+    echo "Output file: $output_perf_filename"
+    python models/demos/t3000/falcon40b/scripts/perf_summary.py --all $csv_file -o $output_perf_filename --remove-warmup -g --num-chips 8 --layers 60 --seq ${seq_len}
+done


### PR DESCRIPTION
Scripts enable couple of things: 
- perf_summary.py removes all warmup runs from csv and only process latest run
- get_falcon40b_perf_numbers.sh runs 128 and 2048 seq_lens and executes perf_summary script after so only manual step is to get grouped_summary for both seq_lens and paste into excel sheet for getting full report with calculated component times, whole layer time, predicted model time and perf (tok/s). 