### PR TITLE
#8364: Disable implicit fallback for ttnn.repeat

### DIFF
--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -386,7 +386,7 @@ def _repeat_validate_input_tensors(operation_name, input_tensor, *args, **kwargs
     name="ttnn.repeat",
     validate_input_tensors=_repeat_validate_input_tensors,
     golden_function=_golden_function,
-    allow_to_fallback_to_golden_function_on_failure=True,
+    allow_to_fallback_to_golden_function_on_failure=False,
 )
 def repeat(
     input_tensor: ttnn.Tensor,


### PR DESCRIPTION
**What's happening**
This is a part of the #8364 effort

Model developers now have to explicitly use torch fallback when`ttnn.repeat` does not work on a given input.
Automatic/implicit fallback is disabled in this PR.
Use `ttnn.get_fallback_function(ttnn.repeat)`

**Update**
- [x] Disabled implicit fallback
- [x] Updated tests and models to call fallback explicitly where needed

**CI Results**
- [x] Post commit
- [x] Nightly fast dispatch
- [x] T3000 frequent tests
- [x] Model perf regression and output report