### PR TITLE
Add support for bfloat8 input tensors in Mamba SSM block custom kernels

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_1d_sum_reduce.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_1d_sum_reduce.py
@@ -25,9 +25,10 @@ def run_ssm_1d_sum_reduce(H: int, W: int, latent_size: int, dtype, in_mem_config
     )
 
     assert list(actual.get_legacy_shape()) == [1, 1, H, W // latent_size]
+    assert actual.dtype == dtype
 
     actual = tt2torch_tensor(actual)
-    passing_pcc, output_pcc = comp_pcc(actual, expected, 0.9999)
+    passing_pcc, output_pcc = comp_pcc(actual, expected, 0.9997)
     logger.debug(f"Out passing={passing_pcc}")
     logger.debug(f"Output pcc={output_pcc}")
 
@@ -50,7 +51,7 @@ def run_ssm_1d_sum_reduce(H: int, W: int, latent_size: int, dtype, in_mem_config
 )
 @pytest.mark.parametrize(
     "dtype",
-    (ttl.tensor.DataType.BFLOAT16,),
+    (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
 )
 @pytest.mark.parametrize(
     "H, W, latent_size",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_eltwise_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_eltwise_mul.py
@@ -45,7 +45,7 @@ def run_ssm_eltwise_mul_test(in0_W, in1_W, dtype, in0_mem_config, in1_mem_config
     else:
         raise Exception("Input shapes invalid, use eltwise_mul for same input shapes,", in0_W, in1_W)
 
-    passing_pcc, output_pcc = comp_pcc(out, ref_out, 0.9999)
+    passing_pcc, output_pcc = comp_pcc(out, ref_out, 0.9995)
     logger.debug(f"Out passing={passing_pcc}")
     logger.debug(f"Output pcc={output_pcc}")
 
@@ -75,7 +75,7 @@ def run_ssm_eltwise_mul_test(in0_W, in1_W, dtype, in0_mem_config, in1_mem_config
 )
 @pytest.mark.parametrize(
     "dtype",
-    (ttl.tensor.DataType.BFLOAT16,),
+    (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
 )
 @pytest.mark.parametrize(
     "in0_W, in1_W",

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_1d_sum_reduce.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_1d_sum_reduce.cpp
@@ -69,10 +69,14 @@ void MAIN {
 
     for (uint32_t output_idx = 0; output_idx < num_blocks; output_idx++) {
         for (uint32_t slice_idx = 0; slice_idx < TILE_WIDTH; slice_idx++) {
-            transpose(input_cb_id, intermed_cb_id0);                 // 32 x B
+            unpack_reconfig_data_format_srca(intermed_cb_id2, input_cb_id);
+            pack_reconfig_data_format(output_cb_id, intermed_cb_id0);
+            transpose(input_cb_id, intermed_cb_id0);  // 32 x B
+            unpack_reconfig_data_format_srca(input_cb_id, intermed_cb_id0);
             reduce(intermed_cb_id0, scalar_cb_id, intermed_cb_id1);  // 1 x B
         }
         // Get full tile back from writer and transpose it
+        pack_reconfig_data_format(intermed_cb_id0, output_cb_id);
         transpose(intermed_cb_id2, output_cb_id);
     }
 }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_eltwise_mul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_eltwise_mul.cpp
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "compute_kernel_api/eltwise_binary.h"
+
 #include "compute_kernel_api/bcast.h"
+#include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/transpose_wh.h"
 
 namespace NAMESPACE {
@@ -22,22 +23,82 @@ void MAIN {
     constexpr uint32_t onetile = 1;
     constexpr uint32_t num_rows_in_one_tile = 32;
 
+#ifdef REPEAT_INTERLEAVE_IN1
+    binary_op_init_common(cb_in0_transposed, cb_in1_bcast_row);  // TODO: Is there a specific one for bcast mul?
+#else
+    binary_op_init_common(cb_id_in0, cb_id_in1);
+#endif
 
-    #ifdef REPEAT_INTERLEAVE_IN1
-        binary_op_init_common(cb_in0_transposed, cb_in1_bcast_row); // TODO: Is there a specific one for bcast mul?
-    #else
-        binary_op_init_common(cb_id_in0, cb_id_in1);
-    #endif
+#ifdef REPEAT_IN0
+    // Transpose in0
+    cb_wait_front(cb_id_in0, onetile);
+// No need to transpose in0 if in1 is not repeat_interleaved
+#ifdef REPEAT_INTERLEAVE_IN1
+    tile_regs_acquire();
+    tile_regs_wait();
 
-    #ifdef REPEAT_IN0
-        // Transpose in0
-        cb_wait_front(cb_id_in0, onetile);
-        // No need to transpose in0 if in1 is not repeat_interleaved
-        #ifdef REPEAT_INTERLEAVE_IN1
+    transpose_wh_init_short(cb_id_in0);
+    unpack_reconfig_data_format_srca(cb_out_transposed, cb_id_in0);
+    pack_reconfig_data_format(cb_id_out, cb_in0_transposed);
+    transpose_wh_tile(cb_id_in0, 0, 0);
+
+    cb_reserve_back(cb_in0_transposed, onetile);
+    pack_tile(0, cb_in0_transposed);
+
+    tile_regs_commit();
+    tile_regs_release();
+    cb_push_back(cb_in0_transposed, onetile);
+    cb_pop_front(cb_id_in0, onetile);
+
+    cb_wait_front(cb_in0_transposed, onetile);
+#endif
+#endif
+
+    for (uint32_t in1_block = 0; in1_block < in1_num_blocks; in1_block++) {
+        // Transpose in1
+        cb_wait_front(cb_id_in1, onetile);
+        tile_regs_acquire();
+        tile_regs_wait();
+
+// If input b is not repeat_interleaved, then no need to transpose, bcast row
+#ifndef REPEAT_INTERLEAVE_IN1
+        mul_tiles_init(cb_id_in0, cb_id_in1);
+        unpack_reconfig_data_format_srca(cb_id_out, cb_id_in0);
+        pack_reconfig_data_format(cb_in0_transposed, cb_id_out);
+        mul_tiles(cb_id_in0, cb_id_in1, 0, 0, 0);
+
+        cb_reserve_back(cb_id_out, onetile);
+        pack_tile(0, cb_id_out);
+
+        tile_regs_commit();
+        tile_regs_release();
+        cb_push_back(cb_id_out, onetile);
+        cb_pop_front(cb_id_in1, onetile);
+#else
+        transpose_wh_init_short(cb_id_in1);
+        unpack_reconfig_data_format_srca(cb_id_in1);
+        pack_reconfig_data_format(cb_in1_transposed);
+        transpose_wh_tile(cb_id_in1, 0, 0);
+
+        cb_reserve_back(cb_in1_transposed, onetile);
+        pack_tile(0, cb_in1_transposed);
+
+        tile_regs_commit();
+        tile_regs_release();
+        cb_push_back(cb_in1_transposed, onetile);
+        cb_pop_front(cb_id_in1, onetile);
+
+        // Receive in1 as single rows to bcast mul with in0
+        for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
+#ifndef REPEAT_IN0
+            // Transpose in0
+            cb_wait_front(cb_id_in0, onetile);
             tile_regs_acquire();
             tile_regs_wait();
 
             transpose_wh_init_short(cb_id_in0);
+            unpack_reconfig_data_format_srca(cb_id_in0);
+            pack_reconfig_data_format(cb_in0_transposed);
             transpose_wh_tile(cb_id_in0, 0, 0);
 
             cb_reserve_back(cb_in0_transposed, onetile);
@@ -49,19 +110,37 @@ void MAIN {
             cb_pop_front(cb_id_in0, onetile);
 
             cb_wait_front(cb_in0_transposed, onetile);
-        #endif
-    #endif
+#endif
 
-    for (uint32_t in1_block = 0; in1_block < in1_num_blocks; in1_block++) {
-        // Transpose in1
-        cb_wait_front(cb_id_in1, onetile);
-        tile_regs_acquire();
-        tile_regs_wait();
+            cb_wait_front(cb_in1_bcast_row, onetile);
+            tile_regs_acquire();
+            tile_regs_wait();
 
-        //If input b is not repeat_interleaved, then no need to transpose, bcast row
-        #ifndef REPEAT_INTERLEAVE_IN1
-            mul_tiles_init(cb_id_in0, cb_id_in1);
-            mul_tiles(cb_id_in0, cb_id_in1, 0, 0, 0);
+            mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
+            unpack_reconfig_data_format_srca(cb_in0_transposed);
+            pack_reconfig_data_format(cb_out_transposed);
+            mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
+
+            cb_reserve_back(cb_out_transposed, onetile);
+            pack_tile(0, cb_out_transposed);
+
+            tile_regs_commit();
+            tile_regs_release();
+            cb_push_back(cb_out_transposed, onetile);
+#ifndef REPEAT_IN0
+            cb_pop_front(cb_in0_transposed, onetile);
+#endif
+            cb_pop_front(cb_in1_bcast_row, onetile);
+
+            // Transpose output back
+            cb_wait_front(cb_out_transposed, onetile);
+            tile_regs_acquire();
+            tile_regs_wait();
+
+            transpose_wh_init_short(cb_out_transposed);
+            unpack_reconfig_data_format(cb_in0_transposed, cb_out_transposed);
+            pack_reconfig_data_format(cb_out_transposed, cb_id_out);
+            transpose_wh_tile(cb_out_transposed, 0, 0);
 
             cb_reserve_back(cb_id_out, onetile);
             pack_tile(0, cb_id_out);
@@ -69,104 +148,37 @@ void MAIN {
             tile_regs_commit();
             tile_regs_release();
             cb_push_back(cb_id_out, onetile);
-            cb_pop_front(cb_id_in1, onetile);
-        #else
-            transpose_wh_init_short(cb_id_in1);
-            transpose_wh_tile(cb_id_in1, 0, 0);
+            cb_pop_front(cb_out_transposed, onetile);
 
-            cb_reserve_back(cb_in1_transposed, onetile);
-            pack_tile(0, cb_in1_transposed);
+            /* TODO: Transpose directly on tiles in DST; is something like this possible?
+            cb_reserve_back(cb_id_out, onetile);
+
+            tile_regs_acquire();
+            tile_regs_wait();
+            mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
+            mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
+
+            MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(true, true, cb_id_out)
+            )); MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(0) ));
+
+            pack_tile(0, cb_id_out);
 
             tile_regs_commit();
             tile_regs_release();
-            cb_push_back(cb_in1_transposed, onetile);
-            cb_pop_front(cb_id_in1, onetile);
+            cb_push_back(cb_id_out, onetile);
+            cb_pop_front(cb_in1_bcast_row, onetile);
+            */
+        }
 
-            // Receive in1 as single rows to bcast mul with in0
-            for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_one_tile; tile_row_id++) {
-                #ifndef REPEAT_IN0
-                    // Transpose in0
-                    cb_wait_front(cb_id_in0, onetile);
-                    tile_regs_acquire();
-                    tile_regs_wait();
-
-                    transpose_wh_init_short(cb_id_in0);
-                    transpose_wh_tile(cb_id_in0, 0, 0);
-
-                    cb_reserve_back(cb_in0_transposed, onetile);
-                    pack_tile(0, cb_in0_transposed);
-
-                    tile_regs_commit();
-                    tile_regs_release();
-                    cb_push_back(cb_in0_transposed, onetile);
-                    cb_pop_front(cb_id_in0, onetile);
-
-                    cb_wait_front(cb_in0_transposed, onetile);
-                #endif
-
-                cb_wait_front(cb_in1_bcast_row, onetile);
-                tile_regs_acquire();
-                tile_regs_wait();
-
-                mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
-                mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
-
-                cb_reserve_back(cb_out_transposed, onetile);
-                pack_tile(0, cb_out_transposed);
-
-                tile_regs_commit();
-                tile_regs_release();
-                cb_push_back(cb_out_transposed, onetile);
-                #ifndef REPEAT_IN0
-                    cb_pop_front(cb_in0_transposed, onetile);
-                #endif
-                cb_pop_front(cb_in1_bcast_row, onetile);
-
-                // Transpose output back
-                cb_wait_front(cb_out_transposed, onetile);
-                tile_regs_acquire();
-                tile_regs_wait();
-
-                transpose_wh_init_short(cb_out_transposed);
-                transpose_wh_tile(cb_out_transposed, 0, 0);
-
-                cb_reserve_back(cb_id_out, onetile);
-                pack_tile(0, cb_id_out);
-
-                tile_regs_commit();
-                tile_regs_release();
-                cb_push_back(cb_id_out, onetile);
-                cb_pop_front(cb_out_transposed, onetile);
-
-                /* TODO: Transpose directly on tiles in DST; is something like this possible?
-                cb_reserve_back(cb_id_out, onetile);
-
-                tile_regs_acquire();
-                tile_regs_wait();
-                mul_bcast_rows_init_short(cb_in0_transposed, cb_in1_bcast_row);
-                mul_tiles_bcast_rows(cb_in0_transposed, cb_in1_bcast_row, 0, 0, 0);
-
-                MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(true, true, cb_id_out) ));
-                MATH(( llk_math_eltwise_unary_datacopy<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(0) ));
-
-                pack_tile(0, cb_id_out);
-
-                tile_regs_commit();
-                tile_regs_release();
-                cb_push_back(cb_id_out, onetile);
-                cb_pop_front(cb_in1_bcast_row, onetile);
-                */
-            }
-
-            cb_pop_front(cb_in1_transposed, onetile);
-        #endif
+        cb_pop_front(cb_in1_transposed, onetile);
+#endif
     }
-    #ifdef REPEAT_IN0
-        #ifdef REPEAT_INTERLEAVE_IN1
-            cb_pop_front(cb_in0_transposed, onetile);
-        #else
-            cb_pop_front(cb_id_in0, onetile);
-        #endif
-    #endif
+#ifdef REPEAT_IN0
+#ifdef REPEAT_INTERLEAVE_IN1
+    cb_pop_front(cb_in0_transposed, onetile);
+#else
+    cb_pop_front(cb_id_in0, onetile);
+#endif
+#endif
 }
-}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -597,7 +597,7 @@ void SSM1DSumReduce::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL((input_tensor_a.get_layout() == Layout::TILE), "Inputs to ssm_1d_sum_reduce must be tilized");
 
-    // TODO: Uplift to support BFLOAT8_B and mixed precision
+    // TODO: Uplift to support mixed precision
     TT_FATAL(
         input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to ssm_1d_sum_reduce need to be on device!");
     TT_FATAL(
@@ -606,12 +606,12 @@ void SSM1DSumReduce::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(
         input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
         "Unsupported memory layout for input a!");
-    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Unsupported data format for input a!");
+    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format for input a!");
 
     TT_FATAL(
         this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
         "Unsupported memory layout for output!");
-    TT_FATAL(this->output_dtype == tt::tt_metal::DataType::BFLOAT16, "Unsupported data format for output!");
+    TT_FATAL(this->output_dtype == tt::tt_metal::DataType::BFLOAT16 || this->output_dtype == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format for output!");
 
     constexpr uint32_t latent = 32;
     const auto ashape = input_tensor_a.get_legacy_shape();

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -538,13 +538,25 @@ void SSMEltwiseMul::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(
         input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
         "Unsupported memory layout for input b!");
-    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Unsupported data format for input a!");
-    TT_FATAL(input_tensor_b.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Unsupported data format for input b!");
+    TT_FATAL(
+        input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16 ||
+            input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B,
+        "Unsupported data format for input a!");
+    TT_FATAL(
+        input_tensor_b.get_dtype() == tt::tt_metal::DataType::BFLOAT16 ||
+            input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B,
+        "Unsupported data format for input b!");
+    TT_FATAL(
+        input_tensor_a.get_dtype() == input_tensor_b.get_dtype(),
+        "Input a and input b must have the same data format!");
 
     TT_FATAL(
         this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
         "Unsupported memory layout for output!");
-    TT_FATAL(this->output_dtype == tt::tt_metal::DataType::BFLOAT16, "Unsupported data format for output!");
+    TT_FATAL(
+        this->output_dtype == tt::tt_metal::DataType::BFLOAT16 ||
+            this->output_dtype == tt::tt_metal::DataType::BFLOAT8_B,
+        "Unsupported data format for output!");
 
     const auto ashape = input_tensor_a.get_legacy_shape();
     const auto bshape = input_tensor_b.get_legacy_shape();
@@ -553,8 +565,10 @@ void SSMEltwiseMul::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL((ashape[2] == TILE_HEIGHT), "Num of users must be 32 for input a!");
     TT_FATAL((bshape[2] == TILE_HEIGHT), "Num of users must be 32 for input b!");
     TT_FATAL((ashape[3] != bshape[3]), "Use eltwise mul for same size inputs!");
-    TT_FATAL((ashape[3] == TILE_WIDTH || ashape[3] == TILE_WIDTH * HIDDEN_SIZE), "Input a width must be 32 or 32*5120!");
-    TT_FATAL((bshape[3] == HIDDEN_SIZE || bshape[3] == TILE_WIDTH * HIDDEN_SIZE), "Input b width must be 32 or 32*5120!");
+    TT_FATAL(
+        (ashape[3] == TILE_WIDTH || ashape[3] == TILE_WIDTH * HIDDEN_SIZE), "Input a width must be 32 or 32*5120!");
+    TT_FATAL(
+        (bshape[3] == HIDDEN_SIZE || bshape[3] == TILE_WIDTH * HIDDEN_SIZE), "Input b width must be 32 or 32*5120!");
 }
 
 std::vector<Shape> SSMEltwiseMul::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
@@ -606,12 +620,18 @@ void SSM1DSumReduce::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(
         input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
         "Unsupported memory layout for input a!");
-    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format for input a!");
+    TT_FATAL(
+        input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16 ||
+            input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B,
+        "Unsupported data format for input a!");
 
     TT_FATAL(
         this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
         "Unsupported memory layout for output!");
-    TT_FATAL(this->output_dtype == tt::tt_metal::DataType::BFLOAT16 || this->output_dtype == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format for output!");
+    TT_FATAL(
+        this->output_dtype == tt::tt_metal::DataType::BFLOAT16 ||
+            this->output_dtype == tt::tt_metal::DataType::BFLOAT8_B,
+        "Unsupported data format for output!");
 
     constexpr uint32_t latent = 32;
     const auto ashape = input_tensor_a.get_legacy_shape();


### PR DESCRIPTION
This PR adds support for `bfloat8` inputs in the following ops:

- `ssm_eltwise_mul`
- `ssm_1d_sum_reduce`

This change is required for us to eventually add `bfloat8` activations to the Mamba architecture.