### PR TITLE
#8364: Disable implicit fallback for ttnn.split

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_split.py
+++ b/tests/ttnn/unit_tests/operations/test_split.py
@@ -12,6 +12,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import skip_for_wormhole_b0
 
 
+@pytest.mark.skip(reason="ttnn.split is not implemented")
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("split_size", [2, 4])

--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -265,7 +265,7 @@ def _split_validate_input_tensors(operation_name, input_tensor, *args, **kwargs)
     name="ttnn.split",
     validate_input_tensors=_split_validate_input_tensors,
     golden_function=_golden_function,
-    allow_to_fallback_to_golden_function_on_failure=True,
+    allow_to_fallback_to_golden_function_on_failure=False,
 )
 def split(input_tensor: ttnn.Tensor, split_size: int, dim: int) -> ttnn.Tensor:
     r"""


### PR DESCRIPTION
**What's happening**
This is a part of the #8364 effort

Model developers now have to explicitly use torch fallback when`ttnn.split` does not work on a given input.
Automatic/implicit fallback is disabled in this PR.
Use `ttnn.get_fallback_function(ttnn.split)`

**Update**
- [x] Disabled implicit fallback
- [x] Skip test_split ⚠️

**CI Results**
- [x] Post commit
- [x] Nightly fast dispatch
- [x] T3000 frequent tests
- [x] Model perf regression and output report