### PR TITLE
#8364: Disable implicit fallback for ttnn.pad

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -12,6 +12,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import skip_for_wormhole_b0
 
 
+@pytest.mark.skip(reason="ttnn.pad does not support row_major tensors because the kernel currently causes a PCC error")
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("padding,torch_padding", [(((0, 1), (0, 2)), (0, 2, 0, 1)), (((1, 1), (4, 2)), (4, 2, 1, 1))])
@@ -35,6 +36,7 @@ def test_pad(device, h, w, padding, torch_padding, value):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
+@pytest.mark.skip(reason="ttnn.pad does not support row_major tensors because the kernel currently causes a PCC error")
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("padding,torch_padding", [(((0, 1), (0, 2)), (0, 2, 0, 1)), (((1, 1), (4, 2)), (4, 2, 1, 1))])
@@ -62,6 +64,7 @@ def test_pad_back_to_back(device, h, w, padding, torch_padding, value):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
+@pytest.mark.skip(reason="ttnn.pad requires pad to start at 0")
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 @pytest.mark.parametrize("padding", [((0, 32), (0, 32)), ((1, 64), (0, 96)), ((0, 64), (0, 43)), ((32, 64), (64, 96))])

--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -77,7 +77,7 @@ def _pad_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
     golden_function=_golden_function,
     preprocess_golden_function_inputs=_preprocess_golden_function_inputs,
     postprocess_golden_function_outputs=_postprocess_golden_function_outputs,
-    allow_to_fallback_to_golden_function_on_failure=True,
+    allow_to_fallback_to_golden_function_on_failure=False,
 )
 def pad(
     input_tensor: ttnn.Tensor,


### PR DESCRIPTION
**What's happening**
This is a part of the #8364 effort

Model developers now have to explicitly use torch fallback when`ttnn.pad` does not work on a given input.
Automatic/implicit fallback is disabled in this PR.
Use `ttnn.get_fallback_function(ttnn.pad)`

**Update**
- [x] Disabled implicit fallback
- [x] Skip unsupported tests

**CI Results**
- [x] Post commit
- [x] Nightly fast dispatch
- [x] T3000 frequent tests
- [x] Model perf regression and output report