### PR TITLE
#8364: Remove allow_to_fallback_to_golden_function_on_failure from ttnn.Operation

### DIFF
--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -379,7 +379,6 @@ class Operation:
     postprocess_golden_function_outputs: callable
     is_cpp_function: bool
     is_experimental: bool
-    allow_to_fallback_to_golden_function_on_failure: bool
 
     def __gt__(self, other):
         return self.python_fully_qualified_name < other.python_fully_qualified_name
@@ -397,9 +396,6 @@ class Operation:
             self.postprocess_golden_function_outputs or default_postprocess_golden_function_outputs
         )
 
-        self.will_fallback_to_golden_function_on_failure = (
-            self.allow_to_fallback_to_golden_function_on_failure and self.golden_function is not None
-        )
         if self.validate_input_tensors is not None:
             document_input_tensors(self.python_fully_qualified_name, function, self.validate_input_tensors)
 
@@ -685,9 +681,6 @@ class Operation:
 
             return call_wrapper
 
-        if self.will_fallback_to_golden_function_on_failure:
-            function = fallback_to_golden_function_decorator(function)
-
         function = runtime_decorator(function)
         self.decorated_function = function
 
@@ -748,7 +741,6 @@ def register_operation(
     golden_function=None,
     preprocess_golden_function_inputs=None,
     postprocess_golden_function_outputs=None,
-    allow_to_fallback_to_golden_function_on_failure=False,
     doc=None,
 ):
     def operation_decorator(function: callable):
@@ -803,7 +795,6 @@ def register_operation(
             postprocess_golden_function_outputs=postprocess_golden_function_outputs,
             is_cpp_function=is_cpp_function or is_experimental,
             is_experimental=is_experimental,
-            allow_to_fallback_to_golden_function_on_failure=allow_to_fallback_to_golden_function_on_failure,
         )
 
         if is_method:

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -39,7 +39,6 @@ def _golden_function(input_tensor: ttnn.Tensor, slices):
     validate_input_tensors=_getitem_validate_input_tensors,
     is_method=True,
     golden_function=_golden_function,
-    allow_to_fallback_to_golden_function_on_failure=False,
 )
 def __getitem__(input_tensor: ttnn.Tensor, slices) -> ttnn.Tensor:
     input_rank = len(input_tensor.shape)
@@ -187,7 +186,6 @@ reshape = ttnn.register_operation(
     golden_function=_golden_function,
     preprocess_golden_function_inputs=_preprocess_golden_function_inputs,
     postprocess_golden_function_outputs=_postprocess_golden_function_outputs,
-    allow_to_fallback_to_golden_function_on_failure=False,
     doc=doc,
 )(ttnn._ttnn.operations.core.reshape)
 

--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -77,7 +77,6 @@ def _pad_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
     golden_function=_golden_function,
     preprocess_golden_function_inputs=_preprocess_golden_function_inputs,
     postprocess_golden_function_outputs=_postprocess_golden_function_outputs,
-    allow_to_fallback_to_golden_function_on_failure=False,
 )
 def pad(
     input_tensor: ttnn.Tensor,
@@ -265,7 +264,6 @@ def _split_validate_input_tensors(operation_name, input_tensor, *args, **kwargs)
     name="ttnn.split",
     validate_input_tensors=_split_validate_input_tensors,
     golden_function=_golden_function,
-    allow_to_fallback_to_golden_function_on_failure=False,
 )
 def split(input_tensor: ttnn.Tensor, split_size: int, dim: int) -> ttnn.Tensor:
     r"""
@@ -306,7 +304,6 @@ def _repeat_interleave_validate_input_tensors(operation_name, input_tensor, *arg
     name="ttnn.repeat_interleave",
     validate_input_tensors=_repeat_interleave_validate_input_tensors,
     golden_function=_golden_function,
-    allow_to_fallback_to_golden_function_on_failure=False,
 )
 def repeat_interleave(input_tensor: ttnn.Tensor, repeats: Union[ttnn.Tensor, int], dim: int = 0) -> ttnn.Tensor:
     r"""
@@ -389,7 +386,6 @@ def _repeat_validate_input_tensors(operation_name, input_tensor, *args, **kwargs
     name="ttnn.repeat",
     validate_input_tensors=_repeat_validate_input_tensors,
     golden_function=_golden_function,
-    allow_to_fallback_to_golden_function_on_failure=False,
 )
 def repeat(
     input_tensor: ttnn.Tensor,

--- a/ttnn/visualizer/app.py
+++ b/ttnn/visualizer/app.py
@@ -134,7 +134,6 @@ def apis():
         is_experimental: bool
         is_cpp_function: bool
         golden_function: callable
-        allow_to_fallback_to_golden_function_on_failure: bool
 
         @classmethod
         def from_registered_operation(cls, operation):
@@ -143,7 +142,6 @@ def apis():
                 is_experimental=operation.is_experimental,
                 is_cpp_function=operation.is_cpp_function,
                 golden_function=operation.golden_function,
-                allow_to_fallback_to_golden_function_on_failure=operation.allow_to_fallback_to_golden_function_on_failure,
             )
 
     apis = [Api.from_registered_operation(api) for api in ttnn.query_registered_operations(include_experimental=True)]
@@ -151,9 +149,6 @@ def apis():
     df = pd.DataFrame(apis)
     df.sort_values(by=["is_experimental", "is_cpp_function", "python_fully_qualified_name"], inplace=True)
     df["has_fallback"] = df["golden_function"].apply(lambda golden_function: golden_function is not None)
-    df["will_fallback"] = df[["has_fallback", "allow_to_fallback_to_golden_function_on_failure"]].apply(
-        lambda row: row.has_fallback and row.allow_to_fallback_to_golden_function_on_failure, axis=1
-    )
     return render_template(
         "apis.html",
         apis=df.to_html(
@@ -164,7 +159,6 @@ def apis():
                 "is_cpp_function",
                 "is_experimental",
                 "has_fallback",
-                "will_fallback",
             ],
         ),
     )


### PR DESCRIPTION
**What's happening**
This is a part of the https://github.com/tenstorrent/tt-metal/issues/8364 effort

Prior PRs disabled implicit automatic conversion from ttnn to torch operations.
Now `ttnn.Operation.allow_to_fallback_to_golden_function_on_failure` flag is useless. 

This PR removes it.