### PR TITLE
#8354: Enable fast runtime mode by default in ttnn

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -18,12 +18,17 @@ jobs:
           # # N300
           {arch: wormhole_b0, runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2"], name: N300},
         ]
-        test-group: [
-          {name: ttnn group 1, cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -v --splits 2 --group 1},
-          {name: ttnn group 2, cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -v --splits 2 --group 2},
-          {name: ttnn cpp tests, cmd: ./build/test/ttnn/unit_tests_ttnn},
-
-        ]
+        test-group:
+          - name: ttnn group 1
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -v --splits 2 --group 1 -m "not disable_fast_runtime_mode"
+          - name: ttnn group 2
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -v --splits 2 --group 2 -m "not disable_fast_runtime_mode"
+          - name: ttnn group 3
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -m requires_fast_runtime_mode_off
+            env:
+              TTNN_CONFIG_OVERRIDES: '{"enable_fast_runtime_mode": false}'
+          - name: ttnn cpp tests
+            cmd: ./build/test/ttnn/unit_tests_ttnn
     name: ${{ matrix.test-group.name }} ${{ matrix.runner-info.arch }} ${{ matrix.runner-info.name }}
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,4 @@ markers =
     models_performance_virtual_machine: mark model silicon tests for performance on virtual_machine
     models_device_performance_bare_metal: mark model silicon tests for device performance on bare metal
     model_perf_t3000: mark model silicon tests for performance on t3000 bare metal
+    requires_fast_runtime_mode_off: mark tests which require fast runtime mode to be off: validation, logging, tracing

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -105,6 +105,9 @@ run_post_proc_test(){
 
 cd $TT_METAL_HOME
 
+#
+TTNN_CONFIG_OVERRIDES='{"enable_fast_runtime_mode": false}'
+
 if [[ $1 == "PROFILER" ]]; then
     run_profiling_test
 elif [[ $1 == "PROFILER_NO_RESET" ]]; then

--- a/tests/ttnn/conftest.py
+++ b/tests/ttnn/conftest.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import copy
 import datetime
 import json
@@ -22,6 +23,19 @@ def pytest_make_parametrize_id(config, val, argname):
     if isinstance(val, ModuleType):
         val = val.__name__
     return f"{argname}={val}"
+
+
+def pytest_collection_modifyitems(config, items):
+    if not ttnn.CONFIG.enable_fast_runtime_mode:
+        return
+
+    logger.warning("Fast Runtime Mode is ON. Skipping tests tagged with @pytest.mark.requires_fast_runtime_mode_off")
+    skip_unmarked = pytest.mark.skip(reason="Skipping test with requires_fast_runtime_mode_off")
+    for item in items:
+        logger.warning(item.keywords)
+        if "requires_fast_runtime_mode_off" in item.keywords:
+            logger.warning(f"Skipping {item}")
+            item.add_marker(skip_unmarked)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ttnn/integration_tests/whisper/test_ttnn_optimized_functional_whisper.py
+++ b/tests/ttnn/integration_tests/whisper/test_ttnn_optimized_functional_whisper.py
@@ -302,6 +302,7 @@ def test_decoder(device, ttnn_model, model_name, batch_size, sequence_size):
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("ttnn_model", [ttnn_optimized_functional_whisper])
 def test_ttnn_whisper(tmp_path, device, ttnn_model):
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -12,6 +12,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("height", [32])
 @pytest.mark.parametrize("width", [32])
 def test_ttnn_experimental_tensor_exp(device, height, width):
@@ -69,6 +70,7 @@ def test_ttnn_experimental_operations_primary_moreh_matmul(device, m_size, k_siz
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("input_a_is_sharded", [True, False])
 @pytest.mark.parametrize("output_is_sharded", [True, False])
 @pytest.mark.parametrize("m_size, num_cores", [[25088, 98]])

--- a/tests/ttnn/unit_tests/operations/test_transformer.py
+++ b/tests/ttnn/unit_tests/operations/test_transformer.py
@@ -464,6 +464,7 @@ def test_split_query_key_value_and_split_heads_when_head_size_is_not_a_multiple_
     assert_with_pcc(torch_value_tensor, value_tensor, 0.999)
 
 
+@pytest.mark.requires_fast_runtime_mode_off
 def test_concatenate_heads_when_head_size_is_not_a_multiple_of_32(device):
     """
     This test is to check that the concatenate_heads function raises an error when the head size is not a multiple of 32
@@ -496,10 +497,11 @@ def test_concatenate_heads_when_head_size_is_not_a_multiple_of_32(device):
 
     with pytest.raises(RuntimeError) as e:
         output_tensor = ttnn.transformer.concatenate_heads(input_tensor)
-        assert (
-            "Head size must be a multiple of 32!  Update matmul that uses the output of this operation to have the padding in the weights!"
-            in str(e.value)
-        )
+
+    assert (
+        "Head size must be a multiple of 32!  Update matmul that uses the output of this operation to have the padding in the weights!"
+        in str(e.value)
+    )
 
     input_tensor = torch.nn.functional.pad(torch_input_tensor, (0, padded_head_size - head_size), "constant", 0)
     input_tensor = ttnn.from_torch(

--- a/tests/ttnn/unit_tests/test_deallocate.py
+++ b/tests/ttnn/unit_tests/test_deallocate.py
@@ -11,6 +11,7 @@ import ttnn
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [2 * 32])
+@pytest.mark.requires_fast_runtime_mode_off
 def test_deallocate(device, h, w):
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
 

--- a/tests/ttnn/unit_tests/test_pre_and_post_operation_hook.py
+++ b/tests/ttnn/unit_tests/test_pre_and_post_operation_hook.py
@@ -36,6 +36,7 @@ def test_pre_and_post_operation_hooks_for_printing(device, batch_size, h, w, dim
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [32])

--- a/tests/ttnn/unit_tests/test_reports.py
+++ b/tests/ttnn/unit_tests/test_reports.py
@@ -12,6 +12,7 @@ import ttnn
 import ttnn.database
 
 
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("height", [1024])
 @pytest.mark.parametrize("width", [1024])
 def test_enable_logging(device, height, width):
@@ -45,6 +46,7 @@ def test_enable_logging(device, height, width):
     assert len(operations) == 5
 
 
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("height", [1024])
 @pytest.mark.parametrize("width", [1024])
 def test_enable_logging_and_enable_graph_report(device, height, width):
@@ -67,6 +69,7 @@ def test_enable_logging_and_enable_graph_report(device, height, width):
         ttnn.to_torch(output_tensor)
 
 
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("height", [1024])
 @pytest.mark.parametrize("width", [1024])
 def test_enable_logging_and_enable_detailed_buffer_report(device, height, width):
@@ -107,6 +110,7 @@ def test_enable_logging_and_enable_detailed_buffer_report(device, height, width)
     assert len(buffer_pages) > 0
 
 
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("height", [1024])
 @pytest.mark.parametrize("width", [1024])
 def test_enable_logging_and_enable_comparison_mode(device, height, width):
@@ -139,6 +143,7 @@ def test_enable_logging_and_enable_comparison_mode(device, height, width):
     assert len(operations) > 0
 
 
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("height", [1024])
 @pytest.mark.parametrize("width", [1024])
 def test_enable_logging_and_enable_detailed_tensor_report(device, height, width):

--- a/tests/ttnn/unit_tests/test_tracer.py
+++ b/tests/ttnn/unit_tests/test_tracer.py
@@ -28,6 +28,7 @@ def test_exp():
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.requires_fast_runtime_mode_off
 def test_reshape():
     with trace():
         tensor = torch.randint(0, 100, (4, 64))
@@ -40,6 +41,7 @@ def test_reshape():
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("show_modules", [True, False])
 def test_torch_bert(show_modules):
     model_name = "google/bert_uncased_L-4_H-256_A-4"
@@ -75,6 +77,7 @@ def test_bloom(show_modules):
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("device_l1_small_size", [0], indirect=True)

--- a/tests/ttnn/unit_tests/test_tutorials.py
+++ b/tests/ttnn/unit_tests/test_tutorials.py
@@ -26,6 +26,7 @@ def collect_tutorials():
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("notebook_path", collect_tutorials())
 def test_tutorials(notebook_path):
     with open(notebook_path) as f:

--- a/tests/ttnn/unit_tests/test_validate_decorator.py
+++ b/tests/ttnn/unit_tests/test_validate_decorator.py
@@ -12,6 +12,7 @@ from models.utility_functions import torch_random
 
 
 @skip_for_wormhole_b0()
+@pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [32])

--- a/tt_eager/ttnn/config.hpp
+++ b/tt_eager/ttnn/config.hpp
@@ -17,7 +17,7 @@ struct Config {
     std::string model_cache_path = "/home/.cache/ttnn/models";
     std::string tmp_dir = "/tmp/ttnn";
     bool enable_model_cache = false;
-    bool enable_fast_runtime_mode = false;
+    bool enable_fast_runtime_mode = true;
     bool throw_exception_on_fallback = false;
     bool enable_logging = false;
     bool enable_graph_report = false;

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -24,7 +24,7 @@ class Config:
     model_cache_path: pathlib.Path = cache_path / "models"
     tmp_dir: pathlib.Path = pathlib.Path("/") / "tmp" / "ttnn"
     enable_model_cache: bool = False
-    enable_fast_runtime_mode: bool = False
+    enable_fast_runtime_mode: bool = True
     throw_exception_on_fallback: bool = False
     enable_logging: bool = False
     enable_graph_report: bool = False


### PR DESCRIPTION
**What's happening**
This change is a final part of #8364
We are enabling fast runtime mode by default in ttnn.

**Implications**
* Some things may work differently in fast mode. For example `logging` gets disabled
* You can disable fast mode by setting env `TTNN_CONFIG_OVERRIDES = '{"enable_fast_runtime_mode": false}'` 
* You can mark your test with `@pytest.mark.requires_fast_runtime_mode_off`

**CI Results**
- [x] Post commit
- [x] Nightly fast dispatch
- [x] T3000 frequent tests
- [x] Model perf regression and output report