### PR TITLE
#0: Update some perf thresholds, check desc

### DIFF
--- a/models/demos/bert/tests/test_perf_device_bert.py
+++ b/models/demos/bert/tests/test_perf_device_bert.py
@@ -11,7 +11,7 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [8, "384-8-phiyodr/bert-large-finetuned-squad2", 248],
+        [8, "384-8-phiyodr/bert-large-finetuned-squad2", 252],
     ],
 )
 def test_perf_device_bare_metal(batch_size, test, expected_perf):

--- a/models/demos/resnet/tests/test_perf_device_resnet.py
+++ b/models/demos/resnet/tests/test_perf_device_resnet.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [16, "HiFi2-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16-24576", 5420],
+        [16, "HiFi2-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16-24576", 5460],
         [20, "HiFi2-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20-24576", 5780],
         [16, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_16-24576", 6940],
         [20, "LoFi-activations_BFLOAT8_B-weights_BFLOAT8_B-batch_20-24576", 7500],

--- a/tests/ttnn/integration_tests/resnet/test_performance.py
+++ b/tests/ttnn/integration_tests/resnet/test_performance.py
@@ -55,7 +55,7 @@ def test_perf_device_bare_metal(batch_size, test, expected_perf):
 @pytest.mark.parametrize("device_l1_small_size", [24576], indirect=True)
 @pytest.mark.parametrize(
     "model_name,batch_size,act_dtype,weight_dtype,math_fidelity,expected_compile_time,expected_inference_time",
-    [("ResNet50", 20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, 14.3, 0.015)],  ## pass
+    [("ResNet50", 20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, 15, 0.015)],
 )
 def test_performance(
     device,


### PR DESCRIPTION
- ttnn resnet 50 batch 20 e2e compile time slight regression to 15 seconds
- slight improvements to on-device perf for ttnn bert and ttlib resnet50 batch 16