### PR TITLE
#9767: removed `attributes` method as it's no longer needed because of reflect library

### DIFF
--- a/tt_eager/tt_dnn/op_library/copy/copy_op.cpp
+++ b/tt_eager/tt_dnn/op_library/copy/copy_op.cpp
@@ -61,13 +61,6 @@ CopyOpParallelizationStrategy Copy::get_parallelization_strategy(const std::vect
     return CopyOpParallelizationStrategy::MULTI_CORE;
 }
 
-tt::stl::reflection::Attributes Copy::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-        {"output_dtype", this->output_dtype}
-    };
-}
-
 Tensor copy(const Tensor& src_tensor, const Tensor& dst_tensor) {
     std::vector<Tensor> dummy_outputs = {Tensor(operation::get_workers_for_op_output({src_tensor}))};
     operation::launch_op(

--- a/tt_eager/tt_dnn/op_library/copy/copy_op.hpp
+++ b/tt_eager/tt_dnn/op_library/copy/copy_op.hpp
@@ -31,7 +31,6 @@ struct Copy {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     CopyOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 operation::ProgramWithCallbacks copy_multi_core(const Tensor &input, const Tensor &output, bool backwards = false);

--- a/tt_eager/tt_dnn/op_library/data_transfer/data_transfer_op.cpp
+++ b/tt_eager/tt_dnn/op_library/data_transfer/data_transfer_op.cpp
@@ -27,10 +27,6 @@ std::vector<Tensor> DataTransferToHost::compute_output_tensors(const std::vector
     }
 }
 
-tt::stl::reflection::Attributes DataTransferToHost::attributes() const {
-    return {};
-}
-
 Tensor data_transfer_to_host(const Tensor &input_tensor) {
     return operation::run(DataTransferToHost(), {input_tensor}).at(0);
 }
@@ -53,13 +49,6 @@ std::vector<Tensor> DataTransferToDevice::compute_output_tensors(const std::vect
     } else {
         return {input_tensor.to(this->device, this->mem_config)};
     }
-}
-
-tt::stl::reflection::Attributes DataTransferToDevice::attributes() const {
-    return {
-        {"device", this->device->id()},
-        {"mem_config", this->mem_config},
-    };
 }
 
 Tensor data_transfer_to_device(const Tensor &input_tensor, Device* device, const MemoryConfig &mem_config) {

--- a/tt_eager/tt_dnn/op_library/data_transfer/data_transfer_op.hpp
+++ b/tt_eager/tt_dnn/op_library/data_transfer/data_transfer_op.hpp
@@ -15,7 +15,6 @@ struct DataTransferToHost {
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> compute_output_tensors(const std::vector<Tensor> &input_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 Tensor data_transfer_to_host (const Tensor &input_tensor);
@@ -27,7 +26,6 @@ struct DataTransferToDevice {
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> compute_output_tensors(const std::vector<Tensor> &input_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 Tensor data_transfer_to_device (const Tensor &input_tensor, Device* device, const MemoryConfig &mem_config);

--- a/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.cpp
+++ b/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.cpp
@@ -566,14 +566,5 @@ operation::ProgramWithCallbacks Embeddings::create_program(
     return embeddings_(a, weights, output_tensor, this->tilized, this->embeddings_type, this->pad_token);
 }
 
-tt::stl::reflection::Attributes Embeddings::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-        {"tilized", this->tilized},
-        {"embeddings_type", this->embeddings_type},
-        {"pad_token", this->pad_token},
-        {"output_dtype", this->output_dtype}};
-}
-
 }  // namespace tt_metal
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.hpp
+++ b/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.hpp
@@ -30,7 +30,6 @@ struct Embeddings {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 inline Tensor embeddings(

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp
@@ -46,11 +46,6 @@ struct FastReduceNC {
         const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
-    stl::reflection::Attributes attributes() const;
-    static constexpr auto attribute_names = std::make_tuple("dim", "output_mem_config", "compute_kernel_config");
-    const auto attribute_values() const {
-        return std::make_tuple(std::cref(this->dim), std::cref(this->output_mem_config), std::cref(this->compute_kernel_config));
-    }
 };
 
 operation::ProgramWithCallbacks reduce_nc_impl(const Tensor &input, const Tensor &output, int64_t dim, const DeviceComputeKernelConfig &compute_kernel_config);

--- a/tt_eager/tt_dnn/op_library/fill_rm/fill_rm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fill_rm/fill_rm_op.cpp
@@ -97,20 +97,6 @@ operation::ProgramWithCallbacks FillRM::create_program(const std::vector<Tensor>
 
 }
 
-tt::stl::reflection::Attributes FillRM::attributes() const {
-    return {
-        {"N", this->N},
-        {"C", this->C},
-        {"H", this->H},
-        {"W", this->W},
-        {"hFill", this->hFill},
-        {"wFill", this->wFill},
-        {"val_hi", this->val_hi},
-        {"val_lo", this->val_lo},
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 tt_metal::Tensor fill_rm(uint32_t N, uint32_t C, uint32_t H, uint32_t W, uint32_t hFill, uint32_t wFill, const tt_metal::Tensor& any, float val_hi, float val_lo, const MemoryConfig& output_mem_config) {
     return operation::run_without_autoformat(FillRM{N, C, H, W, hFill, wFill, val_hi, val_lo, output_mem_config}, {any}).at(0);
 }

--- a/tt_eager/tt_dnn/op_library/fill_rm/fill_rm_op.hpp
+++ b/tt_eager/tt_dnn/op_library/fill_rm/fill_rm_op.hpp
@@ -31,7 +31,6 @@ struct FillRM  {
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 Tensor fill_rm (uint32_t N, uint32_t C, uint32_t H, uint32_t W, uint32_t hFill, uint32_t wFill, const Tensor& any, float val_hi, float val_lo, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_dnn/op_library/groupnorm/groupnorm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/groupnorm/groupnorm_op.cpp
@@ -1895,13 +1895,6 @@ operation::ProgramWithCallbacks GroupNorm::create_program(
                                     );
     }
 }
-tt::stl::reflection::Attributes GroupNorm::attributes() const {
-    return {
-        {"eps", this->eps},
-        {"num_groups", this->num_groups},
-        {"output_mem_config", this->output_mem_config}
-    };
-}
 
 }   // namespace primary
 }   // namespace operations

--- a/tt_eager/tt_dnn/op_library/groupnorm/groupnorm_op.hpp
+++ b/tt_eager/tt_dnn/op_library/groupnorm/groupnorm_op.hpp
@@ -51,8 +51,6 @@ struct GroupNormShardedMultiCoreProgramConfig {
     DataType out_data_format;
     bool inplace;
     Layout output_layout;
-
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 struct GroupNorm {
@@ -69,7 +67,6 @@ struct GroupNorm {
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor> &output_tensors
     ) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 inline Tensor groupnorm(const Tensor &a, const uint32_t num_groups, float eps, std::optional<const Tensor> gamma = std::nullopt, std::optional<const Tensor> beta = std::nullopt, std::optional<const Tensor> input_mask = std::nullopt, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, const GroupNormShardedMultiCoreProgramConfig& program_config = GroupNormShardedMultiCoreProgramConfig{}) {

--- a/tt_eager/tt_dnn/op_library/indexed_fill/indexed_fill_op.cpp
+++ b/tt_eager/tt_dnn/op_library/indexed_fill/indexed_fill_op.cpp
@@ -49,13 +49,6 @@ operation::ProgramWithCallbacks IndexedFill::create_program(const std::vector<Te
     return indexed_fill_multi_core(batch_ids, input_tensor_a, input_tensor_b, output_tensor);
 }
 
-
-tt::stl::reflection::Attributes IndexedFill::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 Tensor indexed_fill(const Tensor &batch_ids, const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config, std::int64_t dim) {
     return operation::run_without_autoformat(IndexedFill{output_mem_config, dim}, {batch_ids, input_a, input_b}).at(0);
 }

--- a/tt_eager/tt_dnn/op_library/indexed_fill/indexed_fill_op.hpp
+++ b/tt_eager/tt_dnn/op_library/indexed_fill/indexed_fill_op.hpp
@@ -25,7 +25,6 @@ struct IndexedFill {
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 operation::ProgramWithCallbacks indexed_fill_multi_core(const Tensor &batch_ids, const Tensor &input_a, const Tensor& input_b, const Tensor &output);

--- a/tt_eager/tt_dnn/op_library/layernorm_distributed/layernorm_post_allgather_op.cpp
+++ b/tt_eager/tt_dnn/op_library/layernorm_distributed/layernorm_post_allgather_op.cpp
@@ -109,17 +109,6 @@ operation::ProgramWithCallbacks LayerNormPostAllGather::create_program(
         a, stats, gamma, beta, output_tensor, this->norm_type, this->eps, this->compute_kernel_config
     );
 }
-
-tt::stl::reflection::Attributes LayerNormPostAllGather::attributes() const {
-    return {
-        {"norm_type", this->norm_type},
-        {"eps", this->eps},
-        {"output_mem_config", this->output_mem_config},
-        {"compute_kernel_config", this->compute_kernel_config}
-        // {"program_config", this->program_config}
-    };
-}
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/layernorm_distributed/layernorm_post_allgather_op.hpp
+++ b/tt_eager/tt_dnn/op_library/layernorm_distributed/layernorm_post_allgather_op.hpp
@@ -45,7 +45,6 @@ struct LayerNormPostAllGather {
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor> &output_tensors
     ) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 }  // namespace metal

--- a/tt_eager/tt_dnn/op_library/layernorm_distributed/layernorm_pre_allgather_op.cpp
+++ b/tt_eager/tt_dnn/op_library/layernorm_distributed/layernorm_pre_allgather_op.cpp
@@ -67,13 +67,6 @@ operation::ProgramWithCallbacks LayerNormPreAllGather::create_program(
     );
 }
 
-tt::stl::reflection::Attributes LayerNormPreAllGather::attributes() const {
-    return {
-        {"norm_type", this->norm_type},
-        {"compute_kernel_config", this->compute_kernel_config}
-    };
-}
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/layernorm_distributed/layernorm_pre_allgather_op.hpp
+++ b/tt_eager/tt_dnn/op_library/layernorm_distributed/layernorm_pre_allgather_op.hpp
@@ -36,7 +36,6 @@ struct LayerNormPreAllGather {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 }  // namespace metal

--- a/tt_eager/tt_dnn/op_library/layout_conversion/layout_conversion_op.cpp
+++ b/tt_eager/tt_dnn/op_library/layout_conversion/layout_conversion_op.cpp
@@ -31,12 +31,6 @@ std::vector<Tensor> LayoutConversionOnHost::compute_output_tensors(const std::ve
     }
 }
 
-tt::stl::reflection::Attributes LayoutConversionOnHost::attributes() const {
-    return {
-        {"target_layout", this->target_layout},
-    };
-}
-
 Tensor layout_conversion_on_host(const Tensor &input_tensor, const Layout target_layout) {
     return operation::run(LayoutConversionOnHost{target_layout}, {input_tensor}).at(0);
 }

--- a/tt_eager/tt_dnn/op_library/layout_conversion/layout_conversion_op.hpp
+++ b/tt_eager/tt_dnn/op_library/layout_conversion/layout_conversion_op.hpp
@@ -17,7 +17,6 @@ struct LayoutConversionOnHost {
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> compute_output_tensors(const std::vector<Tensor> &input_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 Tensor layout_conversion_on_host (const Tensor &input_tensor, const Layout target_layout);

--- a/tt_eager/tt_dnn/op_library/moreh_adam/moreh_adam_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_adam/moreh_adam_op.cpp
@@ -107,12 +107,6 @@ std::vector<Tensor> MorehAdam::create_output_tensors(
     return std::move(result);
 }
 
-tt::stl::reflection::Attributes MorehAdam::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 operation::ProgramWithCallbacks MorehAdam::create_program(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,

--- a/tt_eager/tt_dnn/op_library/moreh_adam/moreh_adam_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_adam/moreh_adam_op.hpp
@@ -40,7 +40,6 @@ struct MorehAdam {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 
     static constexpr auto attribute_names = std::make_tuple(
         "lr",

--- a/tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_cumsum/moreh_cumsum_op.hpp
@@ -28,9 +28,6 @@ struct MorehCumSum {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
-    stl::reflection::Attributes attributes() const;
-    static constexpr auto attribute_names = std::make_tuple("dim", "flip");
-    const auto attribute_values() const { return std::make_tuple(std::cref(this->dim), std::cref(this->flip)); }
 };
 
 operation::ProgramWithCallbacks moreh_cumsum_nc(const Tensor &input, const Tensor &output, const int64_t &dim, const bool &flip);

--- a/tt_eager/tt_dnn/op_library/moreh_dot_backward/moreh_dot_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_dot_backward/moreh_dot_backward_op.cpp
@@ -85,8 +85,6 @@ operation::ProgramWithCallbacks MorehDotBackward::create_program(
     return moreh_dot_backward_single_core(output_grad, input, other, input_grad, other_grad);
 }
 
-tt::stl::reflection::Attributes MorehDotBackward::attributes() const { return {}; }
-
 std::vector<std::optional<Tensor>> moreh_dot_backward(
     const Tensor& output_grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/moreh_dot_backward/moreh_dot_backward_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_dot_backward/moreh_dot_backward_op.hpp
@@ -35,7 +35,6 @@ struct MorehDotBackward {
         const std::vector<Tensor> &inputs,
         const std::vector<std::optional<const Tensor>> &optional_inputs,
         std::vector<Tensor> &outputs) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 std::vector<std::optional<Tensor>> moreh_dot_backward(

--- a/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp
@@ -27,9 +27,6 @@ struct MorehMean {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
-    stl::reflection::Attributes attributes() const;
-    static constexpr auto attribute_names = std::make_tuple("dim");
-    const auto attribute_values() const { return std::make_tuple(std::cref(this->dim)); }
 };
 
 operation::ProgramWithCallbacks moreh_mean_nc(const Tensor &input, const Tensor &output, int64_t dim);

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.cpp
@@ -72,8 +72,6 @@ std::vector<Shape> MorehMeanBackward::compute_output_shapes(const std::vector<Te
     return {};
 }
 
-tt::stl::reflection::Attributes MorehMeanBackward::attributes() const { return {}; }
-
 Tensor moreh_mean_backward_(const Tensor& output_grad, const Tensor& input_grad) {
     std::vector<Tensor> dummy_output_tensors = {
         Tensor(operation::get_workers_for_op_output({output_grad, input_grad}))};

--- a/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp
@@ -24,7 +24,6 @@ struct MorehMeanBackward {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output_grad, const Tensor &input_grad);

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp
@@ -98,7 +98,6 @@ struct MorehSum {
         const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
-    stl::reflection::Attributes attributes() const;
     static constexpr auto attribute_names = std::make_tuple("dim", "output_mem_config", "compute_kernel_config");
     const auto attribute_values() const {
         return std::make_tuple(std::cref(this->dim), std::cref(this->output_mem_config), std::cref(this->compute_kernel_config));

--- a/tt_eager/tt_dnn/op_library/move/move_op.cpp
+++ b/tt_eager/tt_dnn/op_library/move/move_op.cpp
@@ -59,13 +59,6 @@ MoveOpParallelizationStrategy Move::get_parallelization_strategy(const std::vect
     return this->move_op_parallelization_strategy;
 }
 
-tt::stl::reflection::Attributes Move::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-        {"move_op_parallelization_strategy", this->move_op_parallelization_strategy},
-    };
-}
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/move/move_op.hpp
+++ b/tt_eager/tt_dnn/op_library/move/move_op.hpp
@@ -38,7 +38,6 @@ struct Move {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     MoveOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 operation::ProgramWithCallbacks move_multi_core(const Tensor &input, Tensor &output);

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -53,13 +53,6 @@ operation::ProgramWithCallbacks NlpCreateHeadsFalcon7B::create_program(const std
     return  multi_core_nlp_create_qkv_heads_falcon7b(input_tensor, output_tensors, compute_with_storage_grid_size);
 }
 
-tt::stl::reflection::Attributes NlpCreateHeadsFalcon7B::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
-
 // Generic NLP CreateHeads op for decode
 void NlpCreateHeadsDecode::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
@@ -267,16 +260,6 @@ operation::ProgramWithCallbacks NlpCreateHeads::create_program(const std::vector
     }
 }
 
-tt::stl::reflection::Attributes NlpCreateHeads::attributes() const {
-    return {
-        {"num_q_heads", this->num_q_heads},
-        {"num_kv_heads", this->num_kv_heads},
-        {"transpose_k_heads", this->transpose_k_heads},
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
-
 // Generic NLP ConcatHeads op
 void NlpConcatHeads::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
@@ -337,12 +320,6 @@ operation::ProgramWithCallbacks NlpConcatHeads::create_program(const std::vector
     CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
 
     return  multi_core_nlp_concat_heads(input_tensor, output_tensor, compute_with_storage_grid_size);
-}
-
-tt::stl::reflection::Attributes NlpConcatHeads::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-    };
 }
 
 // NLP ConcatHeads op for decode
@@ -581,15 +558,6 @@ std::vector<Tensor> CreateQKVHeads::create_output_tensors(const std::vector<Tens
     return {out_tensor_q, out_tensor_k, out_tensor_v};
 }
 
-tt::stl::reflection::Attributes CreateQKVHeads::attributes() const {
-    return {
-        {"num_q_heads", this->num_q_heads},
-        {"num_kv_heads", this->num_kv_heads},
-        {"transpose_k_heads", this->transpose_k_heads},
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 
 void CreateQKVHeadsSeparateTensors::validate(const std::vector<Tensor> &input_tensors) const {
     const auto& q_input_tensor = input_tensors.at(0);
@@ -718,15 +686,6 @@ std::vector<Tensor> CreateQKVHeadsSeparateTensors::create_output_tensors(const s
     auto out_tensor_k = create_device_tensor(k_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_k);
     auto out_tensor_v = create_device_tensor(v_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config_v);
     return {out_tensor_q, out_tensor_k, out_tensor_v};
-}
-
-tt::stl::reflection::Attributes CreateQKVHeadsSeparateTensors::attributes() const {
-    return {
-        {"num_q_heads", this->num_q_heads},
-        {"num_kv_heads", this->num_kv_heads},
-        {"transpose_k_heads", this->transpose_k_heads},
-        {"output_mem_config", this->output_mem_config},
-    };
 }
 
 } // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/nlp_tms.hpp
@@ -31,7 +31,6 @@ struct CreateQKVHeads {
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 inline std::tuple<Tensor, Tensor, Tensor> create_qkv_heads(const Tensor &input_tensor, const uint32_t num_q_heads, const std::optional<uint32_t> num_kv_heads, const bool transpose_k_heads, const MemoryConfig& output_mem_config) {
@@ -51,8 +50,8 @@ struct CreateQKVHeadsSeparateTensors {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 
 inline std::tuple<Tensor, Tensor, Tensor> create_qkv_heads_from_separate_tensors(const Tensor &input_tensor_q, const Tensor &input_tensor_kv, const uint32_t num_q_heads, const std::optional<uint32_t> num_kv_heads, const bool transpose_k_heads, const MemoryConfig& output_mem_config) {
@@ -77,8 +76,8 @@ struct NlpCreateHeadsFalcon7B {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 
 struct NlpCreateHeadsDecode {
@@ -109,8 +108,10 @@ struct NlpCreateHeads {
     void validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        std::vector<Tensor>& output_tensors) const;
 };
 
 struct NlpConcatHeads {
@@ -119,8 +120,8 @@ struct NlpConcatHeads {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 
 struct NlpConcatHeadsDecode {

--- a/tt_eager/tt_dnn/op_library/non_zero_indices/non_zero_indices_op.cpp
+++ b/tt_eager/tt_dnn/op_library/non_zero_indices/non_zero_indices_op.cpp
@@ -39,13 +39,6 @@ operation::ProgramWithCallbacks NonZeroIndices::create_program(const std::vector
     return non_zero_indices_single_core(input_tensor, out_num_indices, out_indices);
 }
 
-
-tt::stl::reflection::Attributes NonZeroIndices::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 std::vector<Tensor> non_zero_indices(const Tensor& input, const MemoryConfig& output_mem_config) {
     return operation::run_without_autoformat(NonZeroIndices{output_mem_config}, {input});
 }

--- a/tt_eager/tt_dnn/op_library/non_zero_indices/non_zero_indices_op.hpp
+++ b/tt_eager/tt_dnn/op_library/non_zero_indices/non_zero_indices_op.hpp
@@ -24,7 +24,6 @@ struct NonZeroIndices {
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 operation::ProgramWithCallbacks non_zero_indices_single_core(const Tensor &input, const Tensor &out_num_indices, const Tensor &out_indices);

--- a/tt_eager/tt_dnn/op_library/pad/pad_op.cpp
+++ b/tt_eager/tt_dnn/op_library/pad/pad_op.cpp
@@ -582,15 +582,6 @@ operation::ProgramWithCallbacks Pad::create_program(const std::vector<Tensor>& i
     }
 }
 
-tt::stl::reflection::Attributes Pad::attributes() const {
-    return {
-        {"output_tensor_shape", this->output_tensor_shape},
-        {"input_tensor_start", this->input_tensor_start},
-        {"pad_value", this->pad_value},
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 Tensor pad(const Tensor &input_tensor, const Shape &output_tensor_shape, const Shape &input_tensor_start, float pad_value, const MemoryConfig& output_mem_config, bool use_multicore) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     operation::launch_op(
@@ -634,14 +625,6 @@ std::vector<Tensor> PadOnHost::compute_output_tensors(const std::vector<Tensor>&
     } else {
         return {input_tensor.pad(output_shape, this->input_tensor_start, this->pad_value)};
     }
-}
-
-tt::stl::reflection::Attributes PadOnHost::attributes() const {
-    return {
-        {"output_tensor_shape", this->output_tensor_shape},
-        {"input_tensor_start", this->input_tensor_start},
-        {"pad_value", this->pad_value},
-    };
 }
 
 Tensor pad_on_host(const Tensor &input_tensor, const Shape &output_tensor_shape, const Shape &input_tensor_start, float pad_value) {

--- a/tt_eager/tt_dnn/op_library/pad/pad_op.hpp
+++ b/tt_eager/tt_dnn/op_library/pad/pad_op.hpp
@@ -22,7 +22,6 @@ struct Pad {
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 operation::ProgramWithCallbacks pad_rm_reader_writer(const Tensor &a,
@@ -45,7 +44,6 @@ struct PadOnHost {
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> compute_output_tensors(const std::vector<Tensor> &input_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 Tensor pad_on_host(const Tensor &input_tensor_a, const Shape &output_tensor_shape, const Shape &input_tensor_start, float pad_value);

--- a/tt_eager/tt_dnn/op_library/prod/prod_nc_op.hpp
+++ b/tt_eager/tt_dnn/op_library/prod/prod_nc_op.hpp
@@ -27,9 +27,6 @@ struct Prod {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
-    stl::reflection::Attributes attributes() const;
-    static constexpr auto attribute_names = std::make_tuple("dim");
-    const auto attribute_values() const { return std::make_tuple(std::cref(this->dim)); }
 };
 
 operation::ProgramWithCallbacks prod_nc_format(const Tensor &input, const Tensor &output, int64_t dim);

--- a/tt_eager/tt_dnn/op_library/reshape/reshape_op.cpp
+++ b/tt_eager/tt_dnn/op_library/reshape/reshape_op.cpp
@@ -315,16 +315,6 @@ operation::ProgramWithCallbacks Reshape::create_program(const std::vector<Tensor
     }
 }
 
-tt::stl::reflection::Attributes Reshape::attributes() const {
-    return {
-        {"N", this->N},
-        {"C", this->C},
-        {"H", this->H},
-        {"W", this->W},
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 Tensor reshape (const Tensor &input_tensor_a, int N, int C, int H, int W, const MemoryConfig& output_mem_config) {
     // No-op (Will do a tensor copy)
     auto output_shape = infer_dims_for_reshape(N, C, H, W, input_tensor_a.volume());

--- a/tt_eager/tt_dnn/op_library/reshape/reshape_op.hpp
+++ b/tt_eager/tt_dnn/op_library/reshape/reshape_op.hpp
@@ -20,7 +20,6 @@ struct Reshape {
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 Tensor reshape (const Tensor &a, int N, int C, int H, int W, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_dnn/op_library/rotary_embedding/rotary_embedding_llama_op.cpp
+++ b/tt_eager/tt_dnn/op_library/rotary_embedding/rotary_embedding_llama_op.cpp
@@ -79,13 +79,6 @@ operation::ProgramWithCallbacks RotaryEmbeddingLlama::create_program(
     return rotary_embedding_llama_multi_core(input_tensor, cos, sin, trans_mat, output_tensor, this->compute_kernel_config);
 }
 
-tt::stl::reflection::Attributes RotaryEmbeddingLlama::attributes() const {
-    return {
-        {"seq_len", this->seq_len},
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/rotary_embedding/rotary_embedding_llama_op.hpp
+++ b/tt_eager/tt_dnn/op_library/rotary_embedding/rotary_embedding_llama_op.hpp
@@ -29,7 +29,6 @@ struct RotaryEmbeddingLlama {
 
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 inline Tensor rotary_embedding_llama(

--- a/tt_eager/tt_dnn/op_library/rotary_embedding/rotary_embedding_op.cpp
+++ b/tt_eager/tt_dnn/op_library/rotary_embedding/rotary_embedding_op.cpp
@@ -121,14 +121,6 @@ RotaryEmbeddingOpParallelizationStrategy RotaryEmbedding::get_parallelization_st
     return RotaryEmbeddingOpParallelizationStrategy::MULTI_CORE;
 }
 
-tt::stl::reflection::Attributes RotaryEmbedding::attributes() const {
-    return {
-        {"seq_len", this->seq_len},
-        {"token_idx", this->token_idx},
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 const operation::Hash RotaryEmbedding::compute_program_hash(const std::vector<Tensor>& input_tensors) const {
     return operation::hash_operation<RotaryEmbedding>(this->seq_len, this->output_mem_config, input_tensors);
 }

--- a/tt_eager/tt_dnn/op_library/rotary_embedding/rotary_embedding_op.hpp
+++ b/tt_eager/tt_dnn/op_library/rotary_embedding/rotary_embedding_op.hpp
@@ -35,7 +35,6 @@ struct RotaryEmbedding {
 
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 
     const operation::Hash compute_program_hash(const std::vector<Tensor> &input_tensors) const;
 };

--- a/tt_eager/tt_dnn/op_library/rotate_half/rotate_half_op.cpp
+++ b/tt_eager/tt_dnn/op_library/rotate_half/rotate_half_op.cpp
@@ -47,12 +47,6 @@ RotateHalfOpParallelizationStrategy RotateHalf::get_parallelization_strategy(con
     return RotateHalfOpParallelizationStrategy::SINGLE_CORE;
 }
 
-tt::stl::reflection::Attributes RotateHalf::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/rotate_half/rotate_half_op.hpp
+++ b/tt_eager/tt_dnn/op_library/rotate_half/rotate_half_op.hpp
@@ -32,7 +32,6 @@ struct RotateHalf {
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors,
         std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 inline Tensor rotate_half(const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {

--- a/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.cpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.cpp
@@ -222,17 +222,6 @@ operation::ProgramWithCallbacks ScaledDotProductAttention::create_program(
         this->valid_seq_len);
 }
 
-tt::stl::reflection::Attributes ScaledDotProductAttention::attributes() const {
-    // fill out with everything in struct
-    return {
-        {"scale", this->scale},
-        {"output_mem_config", this->output_mem_config},
-        {"program_config", this->program_config},
-        {"is_causal", this->is_causal},
-        {"compute_kernel_config", this->compute_kernel_config},
-        {"valid_seq_len", this->valid_seq_len.value_or(0)}};
-}
-
 void ScaledDotProductAttentionDecode::validate(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
@@ -399,15 +388,6 @@ operation::ProgramWithCallbacks ScaledDotProductAttentionDecode::create_program(
         this->compute_kernel_config,
         this->program_config,
         this->valid_seq_len);
-}
-
-tt::stl::reflection::Attributes ScaledDotProductAttentionDecode::attributes() const {
-    // fill out with everything in struct
-    return {
-        {"scale", this->scale},
-        {"output_mem_config", this->output_mem_config},
-        {"program_config", this->program_config},
-        {"compute_kernel_config", this->compute_kernel_config}};
 }
 
 namespace transformers {

--- a/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.hpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.hpp
@@ -20,22 +20,12 @@ namespace primary {
 using namespace tt_metal;
 
 namespace transformers {
-struct SDPADefaultProgramConfig{
-    tt::stl::reflection::Attributes attributes() const { return {}; };
-};
+struct SDPADefaultProgramConfig {};
 
 struct SDPAMultiCoreProgramConfig {
     CoreCoord compute_with_storage_grid_size;
     std::size_t q_chunk_size;
     std::size_t k_chunk_size;
-
-    tt::stl::reflection::Attributes attributes() const {
-        return {
-            {"compute_with_storage_grid_size", compute_with_storage_grid_size},
-            {"q_chunk_size", q_chunk_size},
-            {"k_chunk_size", k_chunk_size}
-        };
-    };
 };
 
 using SDPAProgramConfig = std::variant<
@@ -61,7 +51,6 @@ struct ScaledDotProductAttention {
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor> &output_tensors
     ) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 operation::ProgramWithCallbacks sdpa_multi_core(
@@ -90,11 +79,9 @@ struct ScaledDotProductAttentionDecode {
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        std::vector<Tensor> &output_tensors
-    ) const;
-    tt::stl::reflection::Attributes attributes() const;
+        const std::vector<Tensor> &input_tensors,
+        const std::vector<std::optional<const Tensor>> &optional_input_tensors,
+        std::vector<Tensor> &output_tensors) const;
 };
 
 operation::ProgramWithCallbacks sdpa_decode_multi_core(

--- a/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.hpp
+++ b/tt_eager/tt_dnn/op_library/split/split_last_dim_two_chunks_tiled.hpp
@@ -18,6 +18,9 @@ struct SplitLastDimTwoChunksTiled : public SplitTiled {
     SplitLastDimTwoChunksTiled(const MemoryConfig &mem_config) : SplitTiled{3, 2, mem_config} { ; }
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
+
+    static constexpr auto attribute_names = std::make_tuple("dim", "num_chunks", "output_mem_config");
+    const auto attribute_values() const { return std::forward_as_tuple(dim, num_chunks, output_mem_config); }
 };
 
 std::vector<Tensor> split_last_dim_two_chunks_tiled(

--- a/tt_eager/tt_dnn/op_library/split/split_tiled.cpp
+++ b/tt_eager/tt_dnn/op_library/split/split_tiled.cpp
@@ -88,14 +88,6 @@ operation::ProgramWithCallbacks SplitTiled::create_program(
     return {};
 }
 
-tt::stl::reflection::Attributes SplitTiled::attributes() const {
-    return {
-        {"dim", this->dim},
-        {"num_chunks", this->num_chunks},
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/split/split_tiled.hpp
+++ b/tt_eager/tt_dnn/op_library/split/split_tiled.hpp
@@ -28,7 +28,6 @@ struct SplitTiled {
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors,
         std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 }  // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -117,14 +117,6 @@ operation::ProgramWithCallbacks SplitFusedQKVAndSplitHeads::create_program(
     }
 }
 
-tt::stl::reflection::Attributes SplitFusedQKVAndSplitHeads::attributes() const {
-    return {
-        {"compute_with_storage_grid_size", this->compute_with_storage_grid_size.str()},
-        {"output_mem_config", this->output_mem_config},
-        {"num_heads", this->num_heads},
-    };
-}
-
 void ConcatenateHeads::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     const auto batch_size = input_tensor.get_legacy_shape()[0];
@@ -166,13 +158,6 @@ operation::ProgramWithCallbacks ConcatenateHeads::create_program(
         "Unsupported grid shape");
 
     return multi_core_concat_heads(input_tensor, output_tensor, this->compute_with_storage_grid_size);
-}
-
-tt::stl::reflection::Attributes ConcatenateHeads::attributes() const {
-    return {
-        {"compute_with_storage_grid_size", this->compute_with_storage_grid_size.str()},
-        {"output_mem_config", this->output_mem_config},
-    };
 }
 
 void AttnMatmul::validate(const std::vector<Tensor>& input_tensors) const {
@@ -274,15 +259,6 @@ operation::ProgramWithCallbacks AttnMatmul::create_program(
         this->transpose_hw,
         this->compute_with_storage_grid_size,
         this->compute_kernel_config);
-}
-
-tt::stl::reflection::Attributes AttnMatmul::attributes() const {
-    return {
-        {"transpose_hw", this->transpose_hw},
-        {"compute_with_storage_grid_size", this->compute_with_storage_grid_size.str()},
-        {"output_mem_config", this->output_mem_config},
-        {"output_dtype", this->output_dtype},
-    };
 }
 
 const operation::Hash AttnMatmul::compute_program_hash(const std::vector<Tensor>& input_tensors) const {
@@ -479,17 +455,6 @@ operation::ProgramWithCallbacks GroupAttnMatmul::create_program(
         this->compute_kernel_config);
 }
 
-tt::stl::reflection::Attributes GroupAttnMatmul::attributes() const {
-    return {
-        {"transpose_hw", this->transpose_hw},
-        {"out_subblock_w", this->out_subblock_w},
-        {"compute_with_storage_grid_size", this->compute_with_storage_grid_size.str()},
-        {"output_mem_config", this->output_mem_config},
-        {"output_dtype", this->output_dtype},
-        {"row_major", this->row_major},
-    };
-}
-
 const operation::Hash GroupAttnMatmul::compute_program_hash(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
@@ -599,13 +564,6 @@ operation::ProgramWithCallbacks SSMEltwiseMul::create_program(
         input_tensor_a, input_tensor_b, output_tensor, hidden_size, this->math_fidelity, device_compute_with_storage_grid_size);
 }
 
-tt::stl::reflection::Attributes SSMEltwiseMul::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-        {"output_dtype", this->output_dtype},
-        {"hidden_size", this->HIDDEN_SIZE},
-    };
-}
 
 void SSM1DSumReduce::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensors.size() == 1);
@@ -662,13 +620,6 @@ operation::ProgramWithCallbacks SSM1DSumReduce::create_program(
     return multi_core_ssm_1d_sum_reduce(input_tensor_a, output_tensor, math_fidelity, device_compute_with_storage_grid_size);
 }
 
-tt::stl::reflection::Attributes SSM1DSumReduce::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-        {"output_dtype", this->output_dtype},
-    };
-}
-
 void SSMPrefixScan::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensors.size() == 3, "Expected 3 input tensors (A, Bx, H)");
 
@@ -719,13 +670,6 @@ operation::ProgramWithCallbacks SSMPrefixScan::create_program(
     auto& output = output_tensors.at(0);
     auto device_compute_with_storage_grid_size = a.device()->compute_with_storage_grid_size();
     return multi_core_ssm_prefix_scan(a, bx, h, output, math_fidelity, device_compute_with_storage_grid_size);
-}
-
-tt::stl::reflection::Attributes SSMPrefixScan::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-        {"output_dtype", this->output_dtype},
-    };
 }
 
 }  // namespace transformers

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
@@ -47,7 +47,6 @@ struct SplitFusedQKVAndSplitHeads {
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 inline std::tuple<Tensor, Tensor, Tensor> split_query_key_value_and_split_heads(const Tensor &input_tensor, const CoreCoord& compute_with_storage_grid_size, const MemoryConfig& mem_config, const uint32_t num_heads = 16) {
@@ -67,7 +66,6 @@ struct ConcatenateHeads {
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 inline Tensor concatenate_heads(const Tensor &input_tensor, const CoreCoord& compute_with_storage_grid_size, const MemoryConfig& mem_config) {
@@ -90,8 +88,8 @@ struct AttnMatmul {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
     const operation::Hash compute_program_hash(const std::vector<Tensor> &input_tensors) const;
 };
 
@@ -132,8 +130,8 @@ struct GroupAttnMatmul {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
     const operation::Hash compute_program_hash(const std::vector<Tensor> &input_tensors) const;
 };
 
@@ -188,8 +186,8 @@ struct SSMEltwiseMul {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 
 inline Tensor ssm_eltwise_mul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt, MathFidelity math_fidelity = MathFidelity::HiFi4) {
@@ -211,8 +209,8 @@ struct SSM1DSumReduce {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
-    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 };
 
 inline Tensor ssm_1d_sum_reduce(const Tensor &input_tensor_a, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt, MathFidelity math_fidelity = MathFidelity::HiFi4) {
@@ -235,7 +233,6 @@ struct SSMPrefixScan {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 inline Tensor ssm_prefix_scan(

--- a/tt_eager/tt_dnn/op_library/unpad/unpad_op.cpp
+++ b/tt_eager/tt_dnn/op_library/unpad/unpad_op.cpp
@@ -137,14 +137,6 @@ UnpadOpParallelizationStrategy Unpad::get_parallelization_strategy(const std::ve
     return UnpadOpParallelizationStrategy::MULTI_CORE;
 }
 
-tt::stl::reflection::Attributes Unpad::attributes() const {
-    return {
-        {"output_tensor_start", this->output_tensor_start},
-        {"output_tensor_end", this->output_tensor_end},
-        {"output_mem_config", this->output_mem_config},
-    };
-}
-
 const operation::Hash Unpad::compute_program_hash(const std::vector<Tensor> &input_tensors) const {
     auto input_tensor = input_tensors.at(0);
     TT_ASSERT(std::holds_alternative<DeviceStorage>(input_tensor.storage()), fmt::format("Unexpected type {} in {}:{} ",tt::stl::get_active_type_name_in_variant(input_tensor.get_storage()),__FILE__, __LINE__));
@@ -244,14 +236,6 @@ std::vector<Tensor> UnpadOnHost::compute_output_tensors(const std::vector<Tensor
         return {input_tensor.unpad(this->output_tensor_start, this->output_tensor_end)};
     }
 }
-
-tt::stl::reflection::Attributes UnpadOnHost::attributes() const {
-    return {
-        {"output_tensor_start", this->output_tensor_start},
-        {"output_tensor_end", this->output_tensor_end},
-    };
-}
-
 Tensor unpad_on_host(
     const Tensor &input_tensor,
     const Shape &output_tensor_start,

--- a/tt_eager/tt_dnn/op_library/unpad/unpad_op.hpp
+++ b/tt_eager/tt_dnn/op_library/unpad/unpad_op.hpp
@@ -34,7 +34,7 @@ struct Unpad {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const;
     UnpadOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
+
     const operation::Hash compute_program_hash(
         const std::vector<Tensor> &input_tensors) const;
 };
@@ -48,7 +48,6 @@ struct UnpadOnHost {
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> compute_output_tensors(const std::vector<Tensor> &input_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 
 Tensor unpad_on_host(const Tensor &input_tensor, const Shape &output_tensor_start, const Shape &output_tensor_end, const MemoryConfig& mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/ttnn/cpp/ttnn/operations/embedding/embedding/device/embeddings_op.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding/device/embeddings_op.cpp
@@ -75,13 +75,4 @@ operation::ProgramWithCallbacks Embeddings::create_program(
     return detail::embeddings_(a, weights, output_tensor, this->tilized, this->embeddings_type, this->pad_token);
 }
 
-tt::stl::reflection::Attributes Embeddings::attributes() const {
-    return {
-        {"output_mem_config", this->output_mem_config},
-        {"tilized", this->tilized},
-        {"embeddings_type", this->embeddings_type},
-        {"pad_token", this->pad_token},
-        {"output_dtype", this->output_dtype}};
-}
-
 }  // namespace ttnn::operations::embedding::detail

--- a/ttnn/cpp/ttnn/operations/embedding/embedding/device/embeddings_op.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding/device/embeddings_op.hpp
@@ -28,6 +28,5 @@ struct Embeddings {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
-    tt::stl::reflection::Attributes attributes() const;
 };
 }  // namespace ttnn::operations::embedding

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.hpp
@@ -16,22 +16,12 @@
 namespace ttnn::operations::normalization {
 
 struct SoftmaxDefaultProgramConfig{
-    tt::stl::reflection::Attributes attributes() const { return {}; };
 };
 struct SoftmaxShardedMultiCoreProgramConfig {
     CoreCoord compute_with_storage_grid_size;
     std::size_t subblock_w;
     std::size_t block_h;
     std::size_t block_w;
-
-    tt::stl::reflection::Attributes attributes() const {
-        return {
-            {"compute_with_storage_grid_size", compute_with_storage_grid_size},
-            {"subblock_w", subblock_w},
-            {"block_h", block_h},
-            {"block_w", block_w},
-        };
-    };
 };
 
 using SoftmaxProgramConfig = std::variant<


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9767)

### Problem description
`attributes` method can be deleted because `reflect` library can now get the attributes in most cases

### What's changed
- Deleted `attributes` method in most places
- Replaced it with `attribute_names` + `attribute_values` in the cases where the struct is not an aggregate (https://en.cppreference.com/w/cpp/types/is_aggregate)

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
