### PR TITLE
#5389: separated ttnn::operations::binary::Binary into ttnn::operations::binary::Binary and ttnn::operations::binary::ExecuteBinary to improve compile time

### DIFF
--- a/ttnn/cpp/ttnn/operations/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/binary.hpp
@@ -9,27 +9,37 @@
 
 namespace ttnn {
 
-constexpr auto add = ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::ADD, false>>("ttnn::add");
-constexpr auto add_ = ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::ADD, true>>("ttnn::add_");
+constexpr auto add =
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::ADD, false>>("ttnn::add");
+constexpr auto add_ =
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::ADD, true>>("ttnn::add_");
 constexpr auto subtract =
-    ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::SUB, false>>("ttnn::subtract");
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::SUB, false>>("ttnn::subtract");
 constexpr auto subtract_ =
-    ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::SUB, true>>("ttnn::subtract_");
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::SUB, true>>("ttnn::subtract_");
 constexpr auto multiply =
-    ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::MUL, false>>("ttnn::multiply");
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::MUL, false>>("ttnn::multiply");
 constexpr auto multiply_ =
-    ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::MUL, true>>("ttnn::multiply_");
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::MUL, true>>("ttnn::multiply_");
 
-constexpr auto eq = ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::EQ, false>>("ttnn::eq");
-constexpr auto ne = ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::NE, false>>("ttnn::ne");
-constexpr auto ge = ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::GTE, false>>("ttnn::ge");
-constexpr auto gt = ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::GT, false>>("ttnn::gt");
-constexpr auto le = ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::LTE, false>>("ttnn::le");
-constexpr auto lt = ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::LT, false>>("ttnn::lt");
+constexpr auto eq =
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::EQ, false>>("ttnn::eq");
+constexpr auto ne =
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::NE, false>>("ttnn::ne");
+constexpr auto ge =
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::GTE, false>>("ttnn::ge");
+constexpr auto gt =
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::GT, false>>("ttnn::gt");
+constexpr auto le =
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::LTE, false>>("ttnn::le");
+constexpr auto lt =
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::LT, false>>("ttnn::lt");
 constexpr auto logical_and =
-    ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::LOGICAL_AND, false>>("ttnn::logical_and");
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::LOGICAL_AND, false>>(
+        "ttnn::logical_and");
 constexpr auto logical_or =
-    ttnn::register_operation<ttnn::operations::binary::Binary<BinaryOpType::LOGICAL_OR, false>>("ttnn::logical_or");
+    ttnn::register_operation<ttnn::operations::binary::ExecuteBinary<BinaryOpType::LOGICAL_OR, false>>(
+        "ttnn::logical_or");
 
 template <typename InputBType>
 ttnn::Tensor operator+(const ttnn::Tensor &input_tensor_a, InputBType scalar) {


### PR DESCRIPTION
Modifying the operation to follow the 5 steps outlined here: https://godbolt.org/z/KrsxqPqvo

Device operation and the API need to be separate for multiple reasons and one of them is that we don't to compile different device operation for every permutation of API