### PR TITLE
Fix e2e decode perf regression in multi-chip Falcon7b demo and set cpu governor to performance mode in t3k demo pipeline

### DIFF
--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -34,6 +34,9 @@ jobs:
     runs-on: ${{ matrix.test-group.runs-on }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+      - name: Enable performance mode
+        run: |
+          sudo cpupower frequency-set -g performance
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
@@ -50,3 +53,7 @@ jobs:
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}
+      - name: Disable performance mode
+        if: always()
+        run: |
+          sudo cpupower frequency-set -g ondemand

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -10,7 +10,7 @@ from models.utility_functions import is_wormhole_b0, get_devices_for_t3000
 @pytest.mark.parametrize(
     "perf_mode, expected_perf_prefill_decode, greedy_sampling, expected_greedy_output_path",
     (
-        (True, [5780, 700], False, None),
+        (True, [6600, 1050], False, None),
         (True, None, False, None),
         (False, None, True, "models/demos/t3000/falcon7b/expected_greedy_output.json"),
         (False, None, True, None),


### PR DESCRIPTION
- A regression in e2e decode perf in the 8-chip Falcon7b demo (1400 t/s to 800 t/s) was caused by 4fc1bb4. The cause was the introduction of the ttnn concat and ttnn slice ops in the decode MLP which contain python overhead (serialized with multi-chip async).
- Fixed the regression by changing the two new ops to the tt-lib equivalents and updated the perf mode targets for the falcon7b t3000 demo
- Set the cpu governor in the t3000 demo pipeline to performance mode