### PR TITLE
#5044: Add optional output to addalpha

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -524,6 +524,10 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_addalpha,
         "pytorch_op": pytorch_ops.addalpha,
     },
+    "eltwise-addalpha-optional": {
+        "tt_op": tt_lib_ops.eltwise_addalpha_optional,
+        "pytorch_op": pytorch_ops.addalpha,
+    },
     "lamb-optimizer": {
         "tt_op": tt_lib_ops.lamb_optimizer,
         "pytorch_op": pytorch_ops.lamb_optimizer,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_addalpha.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_addalpha.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from functools import partial
+import tt_lib as ttl
+import numpy as np
+
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+from models.utility_functions import is_wormhole_b0
+
+shapes = [
+    [[1, 1, 32, 32], [1, 1, 32, 32]],  # Single core
+    [[1, 1, 32, 32], [32, 1, 32, 32]],  # Single core
+    [[64, 1, 32, 32], [1, 1, 32, 32]],  # Single core
+    [[1, 1, 320, 384], [1, 1, 320, 384]],  # Multi core
+    [[1, 3, 320, 384], [1, 3, 320, 384]],  # Multi core
+]
+
+input_mem_cfgs = generation_funcs.supported_mem_configs
+output_mem_cfgs = generation_funcs.supported_mem_configs
+
+if is_wormhole_b0():
+    shapes = [
+        shapes[0],
+    ]
+    input_mem_cfgs = [
+        input_mem_cfgs[0],
+    ]
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    shapes,
+)
+@pytest.mark.parametrize("input_mem_config", input_mem_cfgs)
+@pytest.mark.parametrize("output_mem_config", output_mem_cfgs)
+@pytest.mark.parametrize("fn_kind", ["addalpha"])
+def test_run_addalpha(
+    input_shapes,
+    fn_kind,
+    input_mem_config,
+    output_mem_config,
+    device,
+    function_level_defaults,
+):
+    datagen_func = [
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+    ] * len(input_shapes)
+    test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+    test_args.update(
+        {
+            "input_mem_config": [input_mem_config, input_mem_config],
+            "output_mem_config": output_mem_config,
+            "alpha": np.random.randint(1, 100),
+        }
+    )
+    comparison_func = comparison_funcs.comp_pcc
+    run_single_pytorch_test(
+        f"eltwise-{fn_kind}",
+        input_shapes,
+        datagen_func,
+        comparison_func,
+        device,
+        test_args,
+    )
+
+
+shapes_w_output = [
+    [[1, 1, 32, 32], [1, 1, 32, 32], [1, 1, 32, 32]],  # Single core
+    [[1, 1, 32, 32], [32, 1, 32, 32], [32, 1, 32, 32]],  # Single core
+    [[64, 1, 32, 32], [1, 1, 32, 32], [64, 1, 32, 32]],  # Single core
+    [[1, 1, 320, 384], [1, 1, 320, 384], [1, 1, 320, 384]],  # Multi core
+    [[1, 3, 320, 384], [1, 3, 320, 384], [1, 3, 320, 384]],  # Multi core
+]
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    shapes_w_output,
+)
+@pytest.mark.parametrize("input_mem_config", input_mem_cfgs)
+@pytest.mark.parametrize("fn_kind", ["addalpha"])
+@pytest.mark.parametrize("pass_qid", [True, False])
+def test_run_addalpha_optional_output(
+    input_shapes,
+    fn_kind,
+    input_mem_config,
+    device,
+    pass_qid,
+    function_level_defaults,
+):
+    datagen_func = [
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+    ] * len(input_shapes)
+    datagen_func.append(
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-80, high=80), torch.bfloat16)
+    )
+    test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+    test_args.update(
+        {
+            "input_mem_config": [input_mem_config, input_mem_config, input_mem_config],
+            "alpha": np.random.randint(1, 100),
+            "queue_id": pass_qid,
+        }
+    )
+    comparison_func = comparison_funcs.comp_pcc
+    run_single_pytorch_test(
+        f"eltwise-{fn_kind}-optional",
+        input_shapes,
+        datagen_func,
+        comparison_func,
+        device,
+        test_args,
+    )

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1027,6 +1027,33 @@ def eltwise_addalpha(
 
 
 @setup_host_and_device
+def eltwise_addalpha_optional(
+    x,
+    y,
+    z,
+    *args,
+    alpha,
+    device,
+    dtype,
+    layout,
+    queue_id,
+    input_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+    cq_id = 0
+
+    if queue_id:
+        ttl.tensor.addalpha(cq_id, t0, t1, alpha, output_tensor=t2)
+    else:
+        ttl.tensor.addalpha(t0, t1, alpha, output_tensor=t2)
+
+    return tt2torch_tensor(t2)
+
+
+@setup_host_and_device
 def eltwise_div(
     x,
     y,

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -701,12 +701,52 @@ Tensor subalpha(const Tensor& input_a, const Tensor& input_b, float alpha, const
 }
 
 // addalpha(input, other, alpha) = input + (alpha * other)
-Tensor _addalpha(const Tensor& input_a, const Tensor& input_b, float alpha, const MemoryConfig& output_mem_config) {
-    Tensor result = add(mul_unary(input_b, alpha, output_mem_config), input_a, std::nullopt, output_mem_config);
-    return result;
+Tensor _addalpha(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float alpha,
+    const MemoryConfig& output_mem_config,
+    std::optional<Tensor> output_tensor) {
+    if (output_tensor.has_value()) {
+        add(mul_unary(input_b, alpha, output_mem_config), input_a, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::nullopt, output_tensor.value());
+        return output_tensor.value();
+    }
+
+    return add(mul_unary(input_b, alpha, output_mem_config), input_a, std::nullopt, output_mem_config);
 }
-Tensor addalpha(const Tensor& input_a, const Tensor& input_b, float alpha, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _addalpha)(input_a, input_b, alpha, output_mem_config);
+Tensor addalpha(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float alpha,
+    const MemoryConfig& output_mem_config,
+    std::optional<Tensor> output_tensor) {
+    return operation::decorate_as_composite(__func__, _addalpha)(
+        input_a, input_b, alpha, output_mem_config, output_tensor);
+}
+
+Tensor _addalpha_overload(
+    uint8_t cq_id,
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float alpha,
+    const MemoryConfig& output_mem_config,
+    std::optional<Tensor> output_tensor) {
+    if (output_tensor.has_value()) {
+        add(mul_unary(input_b, alpha, output_mem_config), input_a, std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, std::nullopt, output_tensor.value());
+        return output_tensor.value();
+    }
+
+    return add(mul_unary(input_b, alpha, output_mem_config), input_a, std::nullopt, output_mem_config);
+}
+Tensor addalpha(
+    uint8_t cq_id,
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float alpha,
+    const MemoryConfig& output_mem_config,
+    std::optional<Tensor> output_tensor) {
+    return operation::decorate_as_composite(__func__, _addalpha_overload)(
+        cq_id, input_a, input_b, alpha, output_mem_config, output_tensor);
 }
 
 // repeat interleave supports repeats as 1 to inf, dim between 0 to 2

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -114,9 +114,7 @@ Tensor selu(
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 Tensor celu(
-    const Tensor& x,
-    float alpha,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const Tensor& x, float alpha, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // Function Swish = same as SILU
 // use transformation y = x * sigmoid( x ) by broadcast
@@ -230,13 +228,12 @@ Tensor logical_noti(
     float immediate,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-//prod
+// prod
 Tensor prod(
     const Tensor& input_a,
     bool all_dimensions = false,
     int64_t dim = 0,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 
 /*
 Returns a new tensor with the signed angles in radians between vectors
@@ -267,7 +264,16 @@ Tensor addalpha(
     const Tensor& input_a,
     const Tensor& input_b,
     float alpha,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+
+Tensor addalpha(
+    uint8_t cq_id,
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float alpha,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 
 // repeat interleave
 Tensor repeat_interleave(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -2,18 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_lib_bindings_tensor.hpp"
-#include "tt_lib_bindings_tensor_impl.hpp"
-#include "tt_dnn/op_library/composite/composite_ops.hpp"
 #include "tt_dnn/op_library/complex/complex_ops.hpp"
+#include "tt_dnn/op_library/composite/composite_ops.hpp"
 #include "tt_eager/tt_dnn/op_library/loss/loss_op.hpp"
 #include "tt_eager/tt_dnn/op_library/optimizer/optimizer_ops.hpp"
+#include "tt_lib_bindings_tensor.hpp"
+#include "tt_lib_bindings_tensor_impl.hpp"
 
-namespace tt::tt_metal::detail{
-    void TensorModuleCompositeOPs( py::module & m_tensor){
-
-	m_tensor.def("pow", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&tt::tt_metal::pow),
-		     py::arg("input"), py::arg("exponent"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+namespace tt::tt_metal::detail {
+void TensorModuleCompositeOPs(py::module& m_tensor) {
+    m_tensor.def(
+        "pow",
+        py::overload_cast<const Tensor&, float, const MemoryConfig&>(&tt::tt_metal::pow),
+        py::arg("input"),
+        py::arg("exponent"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
                     Returns a new tensor filled with power of input ``input`` raised to value of ``exponent``.
 
                     Output tensor will have BFLOAT16 data type.
@@ -25,8 +29,13 @@ namespace tt::tt_metal::detail{
                         "exponent", "exponent value", "float", "positive floating point value", "Yes"
                         "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 )doc");
-    m_tensor.def("pow", py::overload_cast<const Tensor&, int, const MemoryConfig&>(&tt::tt_metal::pow),
-		     py::arg("input"), py::arg("exponent"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "pow",
+        py::overload_cast<const Tensor&, int, const MemoryConfig&>(&tt::tt_metal::pow),
+        py::arg("input"),
+        py::arg("exponent"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
                     Returns a new tensor filled with power of input ``input`` raised to value of ``exponent``.
 
                     Output tensor will have BFLOAT16 data type.
@@ -38,8 +47,14 @@ namespace tt::tt_metal::detail{
                         "exponent", "exponent value", "integer", "positive integer value", "Yes"
                         "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 )doc");
-        m_tensor.def("sfpu_eps", &tt::tt_metal::sfpu_eps,
-                py::arg("shape"), py::arg("layout").noconvert() = Layout::ROW_MAJOR, py::arg("device") = nullptr, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "sfpu_eps",
+        &tt::tt_metal::sfpu_eps,
+        py::arg("shape"),
+        py::arg("layout").noconvert() = Layout::ROW_MAJOR,
+        py::arg("device") = nullptr,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
                     Returns a new tensor filled with the machine epsilon value in shape specified by input ``shape``.
 
                     Input shape is specified as a list of 4 integer elements
@@ -54,9 +69,13 @@ namespace tt::tt_metal::detail{
                         "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 )doc");
 
-
-        m_tensor.def("outer", &outer,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "outer",
+        &outer,
+        py::arg("input_a").noconvert(),
+        py::arg("input_b").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Perform a non-batched outer product multiplication ``arg0 x arg1`` with two tensors.
 
             Both input tensors must have BFLOAT16 data type but shape [1,1,N,1] and [1,1,1,M] respectively
@@ -148,71 +167,146 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
         )doc");
-        // *** composite unary ops ***
-        detail::bind_unary_op(m_tensor, "normalize_hw", tt::tt_metal::normalize_hw, R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on H,W axes.)doc");
-        detail::bind_unary_op(m_tensor, "normalize_global", tt::tt_metal::normalize_global, R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on N,C,H,W axes.)doc");
-        detail::bind_unary_op(m_tensor, "var_hw", tt::tt_metal::var_hw, R"doc(  Returns a new tensor with the variance of the input tensor ``{0}`` on H,W axes.)doc");
-        detail::bind_unary_op(m_tensor, "std_hw", tt::tt_metal::std_hw, R"doc(Returns a new tensor with the standard deviation of the input tensor ``{0}`` on H,W axes.)doc");
-        detail::bind_unary_op(m_tensor, "sinh", &tt::tt_metal::sinh, R"doc(Returns tensor with the hyperbolic sine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
-        detail::bind_unary_op(m_tensor, "cosh", &tt::tt_metal::cosh, R"doc(Returns tensor with the hyperbolic cosine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
-        detail::bind_unary_op(m_tensor, "softsign", &softsign, R"doc(Applies the softsign function to the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "log1p", &log1p, R"doc(Returns tensor with the natural log of 1 added to all of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "swish", swish, R"doc(Returns tensor with the swish all of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "mish", &mish, R"doc(Returns tensor with the mish activation of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "cbrt", &cbrt, R"doc(Returns tensor with the cbrt activation of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "asinh", &asinh, R"doc(Returns tensor with the inverse hyperbolic sine of elements of the input tensor ``{0}`` in range [-1e-6, 1e6].
+    // *** composite unary ops ***
+    detail::bind_unary_op(
+        m_tensor,
+        "normalize_hw",
+        tt::tt_metal::normalize_hw,
+        R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on H,W axes.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "normalize_global",
+        tt::tt_metal::normalize_global,
+        R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on N,C,H,W axes.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "var_hw",
+        tt::tt_metal::var_hw,
+        R"doc(  Returns a new tensor with the variance of the input tensor ``{0}`` on H,W axes.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "std_hw",
+        tt::tt_metal::std_hw,
+        R"doc(Returns a new tensor with the standard deviation of the input tensor ``{0}`` on H,W axes.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "sinh",
+        &tt::tt_metal::sinh,
+        R"doc(Returns tensor with the hyperbolic sine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "cosh",
+        &tt::tt_metal::cosh,
+        R"doc(Returns tensor with the hyperbolic cosine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "softsign",
+        &softsign,
+        R"doc(Applies the softsign function to the elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "log1p",
+        &log1p,
+        R"doc(Returns tensor with the natural log of 1 added to all of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "swish",
+        swish,
+        R"doc(Returns tensor with the swish all of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "mish",
+        &mish,
+        R"doc(Returns tensor with the mish activation of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "cbrt",
+        &cbrt,
+        R"doc(Returns tensor with the cbrt activation of elements of the input tensor ``{0}``.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "asinh",
+        &asinh,
+        R"doc(Returns tensor with the inverse hyperbolic sine of elements of the input tensor ``{0}`` in range [-1e-6, 1e6].
             for +input , output = asinh(input)
-            for -input , output = -asinh(input))doc"
-        );
-        detail::bind_unary_op(m_tensor, "acosh", &acosh, R"doc(Returns tensor with the inverse hyperbolic cosine of elements of the input tensor ``{0}`` in range [-1e-6, 1e6].
+            for -input , output = -asinh(input))doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "acosh",
+        &acosh,
+        R"doc(Returns tensor with the inverse hyperbolic cosine of elements of the input tensor ``{0}`` in range [-1e-6, 1e6].
             for  input > 1, output = acosh(input)
             for  input ==1, ouptut = 0
-            for  input < 1, output =  nan)doc"
-        );
-        detail::bind_unary_op(m_tensor, "tanhshrink", &tanhshrink,
-            R"doc(Applies tanh on the input tensor ``{0}`` and subtracted from the input tensor.
+            for  input < 1, output =  nan)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "tanhshrink",
+        &tanhshrink,
+        R"doc(Applies tanh on the input tensor ``{0}`` and subtracted from the input tensor.
 
-            ``tanhshrink(x) = x - tanh(x)``)doc"
-        );
-        detail::bind_unary_op(m_tensor, "digamma", &digamma, R"doc(Computes the logarithmic derivative of the gamma function on input tensor ``{0}`` for the input range 1 to inf.)doc");
-        detail::bind_unary_op(m_tensor, "lgamma", &lgamma, R"doc(Computes the natural logarithm of the absolute value of the gamma function on the  ``{0}`` tensor for inputs greater than 0.)doc");
-        detail::bind_unary_op(m_tensor, "multigammaln", &multigammaln, R"doc(Computes the multivariate log-gamma function with dimension 4 element-wise on the input tensor ``{0}`` for inputs greater than 1.5f. mvlgamma is refered as multigammaln.)doc");
+            ``tanhshrink(x) = x - tanh(x)``)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "digamma",
+        &digamma,
+        R"doc(Computes the logarithmic derivative of the gamma function on input tensor ``{0}`` for the input range 1 to inf.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "lgamma",
+        &lgamma,
+        R"doc(Computes the natural logarithm of the absolute value of the gamma function on the  ``{0}`` tensor for inputs greater than 0.)doc");
+    detail::bind_unary_op(
+        m_tensor,
+        "multigammaln",
+        &multigammaln,
+        R"doc(Computes the multivariate log-gamma function with dimension 4 element-wise on the input tensor ``{0}`` for inputs greater than 1.5f. mvlgamma is refered as multigammaln.)doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "softshrink", &softshrink,
-            py::arg("lambda"),
-            R"doc(Applies the softshrink function to the elements of the input tensor ``{0}`` between limits ``-{1}`` low and
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "softshrink",
+        &softshrink,
+        py::arg("lambda"),
+        R"doc(Applies the softshrink function to the elements of the input tensor ``{0}`` between limits ``-{1}`` low and
             the ``+{1}`` high limits.)doc",
-            R"doc("value limits (-lambda to +lambda)", "float", ">= 0")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "hardshrink", &hardshrink,
-            py::arg("lambda"),
-            R"doc(Applies the hardshrink function to the elements of the input tensor ``{0}`` between limits ``-{1}`` low and
+        R"doc("value limits (-lambda to +lambda)", "float", ">= 0")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "hardshrink",
+        &hardshrink,
+        py::arg("lambda"),
+        R"doc(Applies the hardshrink function to the elements of the input tensor ``{0}`` between limits ``-{1}`` low and
             the ``+{1}`` high limits.)doc",
-            R"doc("value limits (-lambda to +lambda)", "float", ">= 0")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "bias_gelu_unary", &bias_gelu_unary,
-            py::arg("bias"),
-            R"doc(Applies the Gelu activation function to the elements of the biased ``{1}`` input tensor ``{0}``.)doc",
-            R"doc("value limits (-bias to +bias)", "float", ">= 0")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "polyval", &polyval,
-            py::arg("coeffs"),
-            R"doc(Returns tensor with the polyval of all of elements of the input tensor ``{0}`` with coefficients ``{1}``.)doc",
-            R"doc("coefficients value with highest degree first", "List of float", "List size > 0")doc"
-        );
+        R"doc("value limits (-lambda to +lambda)", "float", ">= 0")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "bias_gelu_unary",
+        &bias_gelu_unary,
+        py::arg("bias"),
+        R"doc(Applies the Gelu activation function to the elements of the biased ``{1}`` input tensor ``{0}``.)doc",
+        R"doc("value limits (-bias to +bias)", "float", ">= 0")doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "polyval",
+        &polyval,
+        py::arg("coeffs"),
+        R"doc(Returns tensor with the polyval of all of elements of the input tensor ``{0}`` with coefficients ``{1}``.)doc",
+        R"doc("coefficients value with highest degree first", "List of float", "List size > 0")doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "glu", &glu,
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "glu",
+        &glu,
         py::arg("dim") = -1,
-            R"doc(Applies the Gated Linear Units (GLU) function to the elements of the input tensor ``{0}`` split along dim ``{1}``.)doc",
-        R"doc(dimension to split)doc"
-        );
-        m_tensor.def("prod", &prod,
-            py::arg("input").noconvert(), py::arg("all_dimensions") = false, py::arg("dim") = 0, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+        R"doc(Applies the Gated Linear Units (GLU) function to the elements of the input tensor ``{0}`` split along dim ``{1}``.)doc",
+        R"doc(dimension to split)doc");
+    m_tensor.def(
+        "prod",
+        &prod,
+        py::arg("input").noconvert(),
+        py::arg("all_dimensions") = false,
+        py::arg("dim") = 0,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Computes the prod function along specified ``dim`` or all dimensions on the ``input`` tensor.
             If ``all_dimensions`` is set to ``true`` irrespective of given dimension it will prod along all dimensions.
 
@@ -228,55 +322,67 @@ namespace tt::tt_metal::detail{
                 "dim", "Dimension to perform prod", "int", "default to 0", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
-        detail::bind_unary_op_with_param(
-            m_tensor, "geglu", &geglu,
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "geglu",
+        &geglu,
         py::arg("dim") = -1,
-            R"doc(Applies the Gaussian Error Gated Linear Units function to the elements of the input tensor ``{0}`` split along dim ``{1}``.)doc",
-        R"doc(dimension to split)doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "reglu", &reglu,
-            py::arg("dim") = -1,
-            R"doc(Applies the Rectified Linear Gated Linear Units (ReGLU) function to the elements of the input tensor ``{0}`` split along dim ``{1}``.)doc",
-        R"doc(dimension to split)doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "swiglu", &swiglu,
-            py::arg("dim") = -1,
-            R"doc(Applies the Swish Gated Linear Units (SwiGLU) function to the elements of the input tensor ``{0}`` split along dim ``{1}``.)doc",
-        R"doc(dimension to split)doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "logical_andi", &logical_andi,
-            py::arg("immediate"),
-            R"doc(Perform an eltwise logical AND (``{0} && {1}``) on input tensor and immediate value.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
+        R"doc(Applies the Gaussian Error Gated Linear Units function to the elements of the input tensor ``{0}`` split along dim ``{1}``.)doc",
+        R"doc(dimension to split)doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "reglu",
+        &reglu,
+        py::arg("dim") = -1,
+        R"doc(Applies the Rectified Linear Gated Linear Units (ReGLU) function to the elements of the input tensor ``{0}`` split along dim ``{1}``.)doc",
+        R"doc(dimension to split)doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "swiglu",
+        &swiglu,
+        py::arg("dim") = -1,
+        R"doc(Applies the Swish Gated Linear Units (SwiGLU) function to the elements of the input tensor ``{0}`` split along dim ``{1}``.)doc",
+        R"doc(dimension to split)doc");
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "logical_andi",
+        &logical_andi,
+        py::arg("immediate"),
+        R"doc(Perform an eltwise logical AND (``{0} && {1}``) on input tensor and immediate value.)doc",
+        R"doc("Scalar", "float", "")doc");
 
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "logical_noti",
+        &logical_noti,
+        py::arg("immediate"),
+        R"doc(Perform an eltwise logical NOT (``!{1}``) on immediate value.)doc",
+        R"doc("immediate", "float", "")doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "logical_noti", &logical_noti,
-            py::arg("immediate"),
-            R"doc(Perform an eltwise logical NOT (``!{1}``) on immediate value.)doc",
-            R"doc("immediate", "float", "")doc"
-        );
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "rpow",
+        rpow,
+        py::arg("base"),
+        R"doc(Returns tensor  raising ``{1}`` value to power of respective elements of the input exponent tensor ``{0}``.)doc",
+        R"doc("base value", "float", ">0.0")doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "rpow", rpow,
-            py::arg("base"),
-            R"doc(Returns tensor  raising ``{1}`` value to power of respective elements of the input exponent tensor ``{0}``.)doc",
-            R"doc("base value", "float", ">0.0")doc"
-        );
+    detail::bind_unary_op_with_param(
+        m_tensor,
+        "logical_ori",
+        &logical_ori,
+        py::arg("immediate"),
+        R"doc(Perform an eltwise logical OR (``{0} || {1}``) on input tensor and immediate value.)doc",
+        R"doc("Scalar", "float", "")doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "logical_ori", &logical_ori,
-            py::arg("immediate"),
-            R"doc(Perform an eltwise logical OR (``{0} || {1}``) on input tensor and immediate value.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
-
-        m_tensor.def("argmax", &argmax,
-            py::arg("input").noconvert(), py::arg("dim"), py::arg("all") = false, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "argmax",
+        &argmax,
+        py::arg("input").noconvert(),
+        py::arg("dim"),
+        py::arg("all") = false,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns the indices of the maximum value of elements in the ``input`` tensor
             If ``all`` is set to ``true`` irrespective of given dimension it will return the indices of maximum value of all elements in given ``input``
 
@@ -293,8 +399,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("argmin", &argmin,
-            py::arg("input").noconvert(), py::arg("dim"), py::arg("all") = false, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "argmin",
+        &argmin,
+        py::arg("input").noconvert(),
+        py::arg("dim"),
+        py::arg("all") = false,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns the indices of the minimum value of elements in the ``input`` tensor
             If ``all`` is set to ``true`` irrespective of given dimension it will return the indices of minimum value of all elements in given ``input``
 
@@ -311,8 +423,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("hardtanh", &hardtanh,
-            py::arg("input").noconvert(), py::arg("low") = -1.0f, py::arg("high") = +1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "hardtanh",
+        &hardtanh,
+        py::arg("input").noconvert(),
+        py::arg("low") = -1.0f,
+        py::arg("high") = +1.0f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Applies the hard tanh function to the elements of the input tensor ``input``.
 
             Input tensor must have BFLOAT16 data type.
@@ -328,8 +446,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("clip", &clip,
-            py::arg("input").noconvert(), py::arg("low"), py::arg("high"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "clip",
+        &clip,
+        py::arg("input").noconvert(),
+        py::arg("low"),
+        py::arg("high"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Applies the clip function to the elements of the input tensor ``input`` between limits ``low`` low and
             the ``high`` high limits.
 
@@ -346,8 +470,16 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("isclose", &isclose,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("rtol") = 1e-05f, py::arg("atol") = 1e-08f, py::arg("equal_nan") = false, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "isclose",
+        &isclose,
+        py::arg("input_a").noconvert(),
+        py::arg("input_b").noconvert(),
+        py::arg("rtol") = 1e-05f,
+        py::arg("atol") = 1e-08f,
+        py::arg("equal_nan") = false,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Applies the isclose function to the elements of the input tensor ``input_a`` and ``input_b``.
 
             Input tensor must have BFLOAT16 data type.
@@ -369,8 +501,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("hardsigmoid", &hardsigmoid,
-            py::arg("input").noconvert(), py::arg("scale") = 1.0f/6.0f, py::arg("shift") = 0.5f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "hardsigmoid",
+        &hardsigmoid,
+        py::arg("input").noconvert(),
+        py::arg("scale") = 1.0f / 6.0f,
+        py::arg("shift") = 0.5f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Applies the hardsigmoid function to the elements of the input tensor ``input``.
 
             Input tensor must have BFLOAT16 data type.
@@ -386,8 +524,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("lerp", py::overload_cast<const Tensor&, const Tensor&, float, const MemoryConfig&>(&lerp),
-            py::arg("input").noconvert(), py::arg("end").noconvert(), py::arg("weight"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
+    m_tensor.def(
+        "lerp",
+        py::overload_cast<const Tensor&, const Tensor&, float, const MemoryConfig&>(&lerp),
+        py::arg("input").noconvert(),
+        py::arg("end").noconvert(),
+        py::arg("weight"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Applies the linear interpolation of two tensors ``input`` and ``end`` based on a
             scalar ``weight`` and returns the resulting out tensor.
 
@@ -404,8 +548,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("lerp", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&lerp),
-            py::arg("input").noconvert(), py::arg("end").noconvert(), py::arg("weight").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "lerp",
+        py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&lerp),
+        py::arg("input").noconvert(),
+        py::arg("end").noconvert(),
+        py::arg("weight").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Applies the linear interpolation of two tensors ``input`` and ``end`` based on a
             tensor ``weight`` and returns the resulting out tensor.
 
@@ -422,8 +572,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("hardswish", &hardswish,
-            py::arg("input").noconvert(), py::arg("scale") = 1.0f/6.0f, py::arg("shift") = 0.5f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "hardswish",
+        &hardswish,
+        py::arg("input").noconvert(),
+        py::arg("scale") = 1.0f / 6.0f,
+        py::arg("shift") = 0.5f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Applies the hard swish function to the elements of the input tensor ``input``.
 
             Input tensor must have BFLOAT16 data type.
@@ -439,8 +595,13 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("celu", &celu,
-            py::arg("input").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "celu",
+        &celu,
+        py::arg("input").noconvert(),
+        py::arg("alpha") = 1.0f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Applies the celu function to the elements of the input tensor ``input``.
 
             Input tensor must have BFLOAT16 data type.
@@ -455,8 +616,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("subalpha", &subalpha,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "subalpha",
+        &subalpha,
+        py::arg("input_a").noconvert(),
+        py::arg("input_b").noconvert(),
+        py::arg("alpha") = 1.0f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Subtracts ``input_b``, scaled by ``alpha``, from ``input_a``.
 
             Input tensor must have BFLOAT16 data type.
@@ -472,8 +639,15 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("addalpha", &addalpha,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "addalpha",
+        py::overload_cast<const Tensor&, const Tensor&, float, const MemoryConfig&, std::optional<Tensor> >(&addalpha),
+        py::arg("input_a").noconvert(),
+        py::arg("input_b").noconvert(),
+        py::arg("alpha") = 1.0f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        R"doc(
             Add ``input_b``, scaled by ``alpha``, from ``input_a``.
 
             Input tensor must have BFLOAT16 data type.
@@ -487,10 +661,44 @@ namespace tt::tt_metal::detail{
                 "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "alpha", "Alpha value", "float", "default to 1.0f", "No"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
         )doc");
 
-        m_tensor.def("repeat_interleave", &repeat_interleave,
-            py::arg("input").noconvert(), py::arg("repeat"), py::arg("dim"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "addalpha",
+        py::overload_cast<uint8_t, const Tensor&, const Tensor&, float, const MemoryConfig&, std::optional<Tensor> >(&addalpha),
+        py::arg("cq_id") = 0,
+        py::arg("input_a").noconvert(),
+        py::arg("input_b").noconvert(),
+        py::arg("alpha") = 1.0f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        R"doc(
+            Add ``input_b``, scaled by ``alpha``, from ``input_a``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "cq_id", "Command queue id", "integer", "default to 0", "No"
+                "input_a", "Tensor addalpha is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "alpha", "Alpha value", "float", "default to 1.0f", "No"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+        )doc");
+
+    m_tensor.def(
+        "repeat_interleave",
+        &repeat_interleave,
+        py::arg("input").noconvert(),
+        py::arg("repeat"),
+        py::arg("dim"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Repeated tensor which has the same shape as ``input``, except along the given axis.
 
             Input tensor must have BFLOAT16 data type.
@@ -506,9 +714,13 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-
-        m_tensor.def("full_like", &full_like,
-            py::arg("input").noconvert(), py::arg("fill_value"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "full_like",
+        &full_like,
+        py::arg("input").noconvert(),
+        py::arg("fill_value"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new tensor filled with the scalar value shaped like reference tensor ``arg0``.
 
             Input tensor must have BFLOAT16 data type.
@@ -523,8 +735,12 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("zeros_like", &zeros_like,
-            py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "zeros_like",
+        &zeros_like,
+        py::arg("input").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new tensor filled with zeros shaped like reference tensor ``input``.
 
             Input tensor must have BFLOAT16 data type.
@@ -538,9 +754,12 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-
-        m_tensor.def("ones_like", &ones_like,
-            py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "ones_like",
+        &ones_like,
+        py::arg("input").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new tensor filled with ones shaped like reference tensor ``arg0``.
 
             Input tensor must have BFLOAT16 data type.
@@ -554,9 +773,13 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("triu",
-	     &triu, py::arg("input"), py::arg("diag") = 0
-            , py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "triu",
+        &triu,
+        py::arg("input"),
+        py::arg("diag") = 0,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new tensor with upper triangular elements of input with rest being zero.
 
             Input tensor will have BFLOAT16 data type.
@@ -571,9 +794,13 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("tril",
-	    &tril, py::arg("input"), py::arg("diag") = 0
-            , py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "tril",
+        &tril,
+        py::arg("input"),
+        py::arg("diag") = 0,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new tensor with lower triangular elements of input with rest being zero.
 
             Input tensor will have BFLOAT16 data type.
@@ -588,8 +815,15 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("zeros", &zeros,
-            py::arg("shape"), py::arg("data_type").noconvert() = DataType::BFLOAT16, py::arg("layout").noconvert() = Layout::ROW_MAJOR, py::arg("device") = nullptr, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "zeros",
+        &zeros,
+        py::arg("shape"),
+        py::arg("data_type").noconvert() = DataType::BFLOAT16,
+        py::arg("layout").noconvert() = Layout::ROW_MAJOR,
+        py::arg("device") = nullptr,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new tensor filled with zeros in shape specified by input ``shape``.
 
             Input shape is specified as a list of 4 integer elements
@@ -606,8 +840,15 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("empty", &empty,
-            py::arg("shape"), py::arg("data_type").noconvert() = DataType::BFLOAT16, py::arg("layout").noconvert() = Layout::ROW_MAJOR, py::arg("device") = nullptr, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "empty",
+        &empty,
+        py::arg("shape"),
+        py::arg("data_type").noconvert() = DataType::BFLOAT16,
+        py::arg("layout").noconvert() = Layout::ROW_MAJOR,
+        py::arg("device") = nullptr,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new empty tensor (on device) in shape specified by input ``shape``.
 
             Input shape is specified as a list of 4 integer elements
@@ -624,8 +865,15 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("ones", &ones,
-            py::arg("shape"), py::arg("data_type").noconvert() = DataType::BFLOAT16, py::arg("layout").noconvert() = Layout::ROW_MAJOR, py::arg("device") = nullptr, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "ones",
+        &ones,
+        py::arg("shape"),
+        py::arg("data_type").noconvert() = DataType::BFLOAT16,
+        py::arg("layout").noconvert() = Layout::ROW_MAJOR,
+        py::arg("device") = nullptr,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new tensor filled with ones in shape specified by input ``shape``.
 
             Input shape is specified as a list of 4 integer elements
@@ -642,8 +890,16 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("full", &full,
-            py::arg("shape"), py::arg("fill_value"), py::arg("data_type").noconvert() = DataType::BFLOAT16, py::arg("layout").noconvert() = Layout::ROW_MAJOR, py::arg("device") = nullptr, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "full",
+        &full,
+        py::arg("shape"),
+        py::arg("fill_value"),
+        py::arg("data_type").noconvert() = DataType::BFLOAT16,
+        py::arg("layout").noconvert() = Layout::ROW_MAJOR,
+        py::arg("device") = nullptr,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new tensor filled with the scalar value in shape specified by input ``shape``.
 
             Input shape is specified as a list of 4 integer elements
@@ -661,8 +917,15 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("arange", &arange,
-            py::arg("start"), py::arg("end"), py::arg("step"), py::arg("device") = nullptr, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "arange",
+        &arange,
+        py::arg("start"),
+        py::arg("end"),
+        py::arg("step"),
+        py::arg("device") = nullptr,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns a new 1D tensor with the incremented values in size specified by inputs ``start``, ``end`` and ``step``.
 
             Inpute scalars are integers specifying start, end, and step sizes.
@@ -678,8 +941,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("softplus", &softplus,
-            py::arg("input_a").noconvert(), py::arg("beta")=1.0f, py::arg("threshold") = 20.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "softplus",
+        &softplus,
+        py::arg("input_a").noconvert(),
+        py::arg("beta") = 1.0f,
+        py::arg("threshold") = 20.0f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns tensor with the softplus activation of elements of the input tensor ``{0}``.
             If ``input * beta`` > ``threshold`` returns input
 
@@ -696,7 +965,7 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    #if 0
+#if 0
         m_tensor.def("bitwise_complement", &bitwise_complement, R"doc(
             Returns tensor with the bitwise complement of elements of the input tensor ``arg0``.
 
@@ -727,10 +996,9 @@ namespace tt::tt_metal::detail{
             |          | '!' is applied to         | Tensor    | Tensor of shape [W, Z, Y, X] | Yes      |
             +----------+---------------------------+-----------+------------------------------+----------+
         )doc");
-    #endif
+#endif
 
-
-    #if 0
+#if 0
         m_tensor.def("mean", &mean, R"doc(
             Returns tensor with the mean of elements of the input tensor ``arg0``.
 
@@ -772,10 +1040,17 @@ namespace tt::tt_metal::detail{
             | arg0     | Tensor std normalized     | Tensor    | Tensor of shape [W, Z, Y, X] | Yes      |
             +----------+---------------------------+-----------+------------------------------+----------+
         )doc");
-    #endif
+#endif
 
-        m_tensor.def("addcmul", &addcmul,
-            py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("value"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "addcmul",
+        &addcmul,
+        py::arg("input").noconvert(),
+        py::arg("tensor1").noconvert(),
+        py::arg("tensor2").noconvert(),
+        py::arg("value"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs the element-wise multiplication of tensor1 ``tensor1`` by tensor2 ``tensor2``, multiplies the result
             by the scalar value ``value`` and adds it to input ``input``.
 
@@ -793,8 +1068,15 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("addcdiv", &addcdiv,
-            py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("value"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "addcdiv",
+        &addcdiv,
+        py::arg("input").noconvert(),
+        py::arg("tensor1").noconvert(),
+        py::arg("tensor2").noconvert(),
+        py::arg("value"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs the element-wise division of tensor1 ``tensor1`` by tensor2 ``tensor2``, multiplies the result
             by the scalar value ``value`` and adds it to input ``input``.
 
@@ -812,8 +1094,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("div", &div,
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("accurate_mode") = false, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "div",
+        &div,
+        py::arg("input_a").noconvert(),
+        py::arg("input_b").noconvert(),
+        py::arg("accurate_mode") = false,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs the element-wise division of ``input_a`` by ``input_b``.
             If input_b is a non-zero tensor, then ``accurate_mode`` can be ``false``,else set ``accurate_mode`` to ``true``
 
@@ -830,8 +1118,13 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("div_no_nan", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&div_no_nan),
-            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "div_no_nan",
+        py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&div_no_nan),
+        py::arg("input_a").noconvert(),
+        py::arg("input_b").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs the element-wise div_no_nan on two tensors ``input_a`` and ``input_b``, which returns 0 if ``input_b`` (denominator) is zero.
 
             Input tensor must have BFLOAT16 data type.
@@ -846,8 +1139,13 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("div_no_nan", py::overload_cast<const Tensor&, float, const MemoryConfig&>(&div_no_nan),
-            py::arg("input_a").noconvert(), py::arg("value").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "div_no_nan",
+        py::overload_cast<const Tensor&, float, const MemoryConfig&>(&div_no_nan),
+        py::arg("input_a").noconvert(),
+        py::arg("value").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs the element-wise div_no_nan on  a tensor ``input_a`` and  a scalar ``value``, which returns 0 if ``value`` (denominator) is zero.
 
             Input tensor must have BFLOAT16 data type.
@@ -942,8 +1240,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("mac", py::overload_cast<const Tensor&, float, float, const MemoryConfig&>(&mac),
-            py::arg("input").noconvert(), py::arg("float1"), py::arg("float2"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "mac",
+        py::overload_cast<const Tensor&, float, float, const MemoryConfig&>(&mac),
+        py::arg("input").noconvert(),
+        py::arg("float1"),
+        py::arg("float2"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns tensor with the multiply and accumulation of all of elements of the input tensor ``input11 with``float1, float2``.
             Output is ``tensor1 x float1 + float2`` elementwise operator.
             Input tensor must have BFLOAT16 data type.
@@ -959,8 +1263,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("threshold", &threshold,
-            py::arg("input").noconvert(), py::arg("threshold"), py::arg("value"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "threshold",
+        &threshold,
+        py::arg("input").noconvert(),
+        py::arg("threshold"),
+        py::arg("value"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns tensor with the threshold activation on elements of the input tensors ``arg0`` at threshold ``threshold``,
             and value ``value``.
 
@@ -977,8 +1287,20 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("lamb_optimizer", &lamb_optimizer,
-            py::arg("data").noconvert(), py::arg("grad").noconvert(), py::arg("exp_avg").noconvert(), py::arg("exp_avg_sq").noconvert(), py::arg("beta1"), py::arg("beta2"), py::arg("step_size"), py::arg("eps"), py::arg("weight_decay"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "lamb_optimizer",
+        &lamb_optimizer,
+        py::arg("data").noconvert(),
+        py::arg("grad").noconvert(),
+        py::arg("exp_avg").noconvert(),
+        py::arg("exp_avg_sq").noconvert(),
+        py::arg("beta1"),
+        py::arg("beta2"),
+        py::arg("step_size"),
+        py::arg("eps"),
+        py::arg("weight_decay"),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Returns tensor with the threshold activation on elements of the input tensors ``arg0`` at threshold ``threshold``,
             and value ``value``.
 
@@ -1189,8 +1511,13 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-        m_tensor.def("real_bw", py::overload_cast<const Tensor&, const ComplexTensor&, const MemoryConfig&>(&real_bw),
-                py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "real_bw",
+        py::overload_cast<const Tensor&, const ComplexTensor&, const MemoryConfig&>(&real_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
                 Performs backward operations for real part of complex tensor ``input`` with given ``grad``
 
                 Input tensors must have BFLOAT16 data type.
@@ -1205,8 +1532,13 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-        m_tensor.def("conj_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&conj_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = std::nullopt, R"doc(
+    m_tensor.def(
+        "conj_bw",
+        py::overload_cast<const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&conj_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("output_mem_config").noconvert() = std::nullopt,
+        R"doc(
             Performs backward operations for conjugate for complex tensor ``input`` with given ``grad``
 
             Input tensors must have BFLOAT16 data type.
@@ -1221,8 +1553,16 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("complex_add_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, float, const MemoryConfig&>(&complex_add_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "complex_add_bw",
+        py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, float, const MemoryConfig&>(
+            &complex_add_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("other").noconvert(),
+        py::arg("alpha") = 1.0f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs backward operations for addition of  complex tensors``input`` and ``other`` with given ``grad``.
 
             Input tensors must have BFLOAT16 data type.
@@ -1239,8 +1579,16 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("complex_sub_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, float, const MemoryConfig&>(&complex_sub_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "complex_sub_bw",
+        py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, float, const MemoryConfig&>(
+            &complex_sub_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("other").noconvert(),
+        py::arg("alpha") = 1.0f,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs backward operations for subtraction of  complex tensors``input`` and ``other`` with given ``grad``.
 
             Input tensors must have BFLOAT16 data type.
@@ -1257,8 +1605,15 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("complex_mul_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&complex_mul_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "complex_mul_bw",
+        py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(
+            &complex_mul_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("other").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs backward operations for multiplication of complex tensors``input`` and ``other`` with given ``grad``.
 
             Input tensors must have BFLOAT16 data type.
@@ -1274,8 +1629,15 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("complex_div_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&complex_div_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "complex_div_bw",
+        py::overload_cast<const ComplexTensor&, const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(
+            &complex_div_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("other").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs backward operations for division of complex tensors``input`` and ``other`` with given ``grad``.
 
             Input tensors must have BFLOAT16 data type.
@@ -1291,8 +1653,13 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("complex_abs_bw", py::overload_cast<const Tensor&, const ComplexTensor&, const MemoryConfig&>(&complex_abs_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "complex_abs_bw",
+        py::overload_cast<const Tensor&, const ComplexTensor&, const MemoryConfig&>(&complex_abs_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs backward operations for abs of complex ``input`` tensor with given ``grad``.
 
             Input tensors must have BFLOAT16 data type.
@@ -1307,8 +1674,13 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("complex_recip_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&complex_recip_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "complex_recip_bw",
+        py::overload_cast<const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&complex_recip_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs backward operations for reciprocal of complex tensor ``input`` with given ``grad``
 
             Input tensors must have BFLOAT16 data type.
@@ -1323,8 +1695,14 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("angle_bw", py::overload_cast<const Tensor&, const ComplexTensor&, bool, const MemoryConfig&>(&angle_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("is_complextensor").noconvert() = true, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "angle_bw",
+        py::overload_cast<const Tensor&, const ComplexTensor&, bool, const MemoryConfig&>(&angle_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("is_complextensor").noconvert() = true,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
                 Performs backward operations for angle for the ``input`` with given ``grad``
 
                 Input tensors must have BFLOAT16 data type.
@@ -1340,8 +1718,13 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("polar_bw", py::overload_cast<const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&polar_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(),  py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def(
+        "polar_bw",
+        py::overload_cast<const ComplexTensor&, const ComplexTensor&, const MemoryConfig&>(&polar_bw),
+        py::arg("grad").noconvert(),
+        py::arg("input").noconvert(),
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
             Performs backward operations for polar ``input`` with given ``grad``
 
             Input tensors must have BFLOAT16 data type.
@@ -1355,23 +1738,25 @@ namespace tt::tt_metal::detail{
                 "input", "Input complex tensor", "Tensor", "Tensor of complex shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
-        //loss functions
-        m_tensor.def("mseloss",
-		    py::overload_cast<const Tensor&,const Tensor&,const LossReductionMode,const MemoryConfig&>(tt::tt_metal::mseloss),
-            py::arg("input_reference"),
-            py::arg("input_prediction"),
-            py::arg("reduce_mode"),
-	        py::arg("output_mem_config").noconvert() = std::nullopt,
-	        R"doc(Returns mean squared error loss function for ``{0}`` and ``{1}``.)doc"
-        );
+    // loss functions
+    m_tensor.def(
+        "mseloss",
+        py::overload_cast<const Tensor&, const Tensor&, const LossReductionMode, const MemoryConfig&>(
+            tt::tt_metal::mseloss),
+        py::arg("input_reference"),
+        py::arg("input_prediction"),
+        py::arg("reduce_mode"),
+        py::arg("output_mem_config").noconvert() = std::nullopt,
+        R"doc(Returns mean squared error loss function for ``{0}`` and ``{1}``.)doc");
 
-        m_tensor.def("maeloss",
-		    py::overload_cast<const Tensor&,const Tensor&,const LossReductionMode,const MemoryConfig&>(tt::tt_metal::maeloss),
-            py::arg("input_reference"),
-            py::arg("input_prediction"),
-            py::arg("reduce_mode"),
-	        py::arg("output_mem_config").noconvert() = std::nullopt,
-	        R"doc(Returns mean absolute error loss function for ``{0}`` and ``{1}``.)doc"
-        );
-    }
+    m_tensor.def(
+        "maeloss",
+        py::overload_cast<const Tensor&, const Tensor&, const LossReductionMode, const MemoryConfig&>(
+            tt::tt_metal::maeloss),
+        py::arg("input_reference"),
+        py::arg("input_prediction"),
+        py::arg("reduce_mode"),
+        py::arg("output_mem_config").noconvert() = std::nullopt,
+        R"doc(Returns mean absolute error loss function for ``{0}`` and ``{1}``.)doc");
 }
+}  // namespace tt::tt_metal::detail


### PR DESCRIPTION
Add optional output tensor to addalpha
cq_id to be added once support for add, mul_unary is merged.
CI: https://github.com/tenstorrent/tt-metal/actions/runs/9442805349