### PR TITLE
Replace FreeList shared_ptr with local_shared_ptr

### DIFF
--- a/tt_metal/impl/allocator/algorithms/free_list.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.hpp
@@ -1,20 +1,16 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-
 #pragma once
-
 #include <string>
 
 #include "hostdevcommon/common_values.hpp"
 #include "tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp"
+#include <boost/smart_ptr/local_shared_ptr.hpp>
 
 namespace tt {
-
 namespace tt_metal {
-
 namespace allocator {
-
 class FreeList : public Algorithm {
    public:
     enum class SearchPolicy {
@@ -23,7 +19,6 @@ class FreeList : public Algorithm {
     };
 
     FreeList(uint64_t max_size_bytes, uint64_t offset_bytes, uint64_t min_allocation_size, uint64_t alignment, SearchPolicy search_policy);
-
     void init();
 
     std::vector<std::pair<uint64_t, uint64_t>> available_addresses(uint64_t size_bytes) const;
@@ -43,50 +38,47 @@ class FreeList : public Algorithm {
    private:
     struct Block {
         Block(uint64_t address, uint64_t size) : address(address), size(size) {}
-        Block(uint64_t address, uint64_t size, std::shared_ptr<Block> prev_block, std::shared_ptr<Block> next_block, std::shared_ptr<Block> prev_free, std::shared_ptr<Block> next_free)
-            : address(address), size(size), prev_block(prev_block), next_block(next_block), prev_free(prev_free), next_free(next_free) {}
-
+        Block(uint64_t address, uint64_t size, boost::local_shared_ptr<Block> prev_block, boost::local_shared_ptr<Block> next_block, boost::local_shared_ptr<Block> prev_free, boost::local_shared_ptr<Block> next_free)
+              : address(address), size(size), prev_block(prev_block), next_block(next_block), prev_free(prev_free), next_free(next_free) {}
         uint64_t address;
         uint64_t size;
-        std::shared_ptr<Block> prev_block = nullptr;
-        std::shared_ptr<Block> next_block = nullptr;
-        std::shared_ptr<Block> prev_free = nullptr;
-        std::shared_ptr<Block> next_free = nullptr;
+        boost::local_shared_ptr<Block> prev_block = nullptr;
+        boost::local_shared_ptr<Block> next_block = nullptr;
+        boost::local_shared_ptr<Block> prev_free = nullptr;
+        boost::local_shared_ptr<Block> next_free = nullptr;
     };
 
-    void dump_block(const std::shared_ptr<Block> block, std::ofstream &out) const;
+    void dump_block(const boost::local_shared_ptr<Block> block, std::ofstream &out) const;
 
-    bool is_allocated(const std::shared_ptr<Block> block) const;
+    bool is_allocated(const boost::local_shared_ptr<Block> block) const;
 
-    std::shared_ptr<Block> search_best(uint64_t size_bytes, bool bottom_up);
+    boost::local_shared_ptr<Block> search_best(uint64_t size_bytes, bool bottom_up);
 
-    std::shared_ptr<Block> search_first(uint64_t size_bytes, bool bottom_up);
+    boost::local_shared_ptr<Block> search_first(uint64_t size_bytes, bool bottom_up);
 
-    std::shared_ptr<Block> search(uint64_t size_bytes, bool bottom_up);
+    boost::local_shared_ptr<Block> search(uint64_t size_bytes, bool bottom_up);
 
-    void allocate_entire_free_block(std::shared_ptr<Block> free_block_to_allocate);
+    void allocate_entire_free_block(boost::local_shared_ptr<Block> free_block_to_allocate);
 
-    void update_left_aligned_allocated_block_connections(std::shared_ptr<Block> free_block, std::shared_ptr<Block> allocated_block);
+    void update_left_aligned_allocated_block_connections(boost::local_shared_ptr<Block> free_block, boost::local_shared_ptr<Block> allocated_block);
 
-    void update_right_aligned_allocated_block_connections(std::shared_ptr<Block> free_block, std::shared_ptr<Block> allocated_block);
+    void update_right_aligned_allocated_block_connections(boost::local_shared_ptr<Block> free_block, boost::local_shared_ptr<Block> allocated_block);
 
-    std::shared_ptr<Block> allocate_slice_of_free_block(std::shared_ptr<Block> free_block, uint64_t offset, uint64_t size_bytes);
+    boost::local_shared_ptr<Block> allocate_slice_of_free_block(boost::local_shared_ptr<Block> free_block, uint64_t offset, uint64_t size_bytes);
 
-    std::shared_ptr<Block> find_block(uint64_t address);
+    boost::local_shared_ptr<Block> find_block(uint64_t address);
 
     void update_lowest_occupied_address();
 
     void update_lowest_occupied_address(uint64_t address);
 
     SearchPolicy search_policy_;
-    std::shared_ptr<Block> block_head_;
-    std::shared_ptr<Block> block_tail_;
-    std::shared_ptr<Block> free_block_head_;
-    std::shared_ptr<Block> free_block_tail_;
+    boost::local_shared_ptr<Block> block_head_;
+    boost::local_shared_ptr<Block> block_tail_;
+    boost::local_shared_ptr<Block> free_block_head_;
+    boost::local_shared_ptr<Block> free_block_tail_;
 };
 
 }  // namespace allocator
-
 }  // namespace tt_metal
-
 }  // namespace tt


### PR DESCRIPTION
Using a shared_ptr in FreeList is unreasonably slow because it uses atomic operations for all the reference counts and these get hit on every time while iterating through the list.

This update just replaces it with a boost local_shared_ptr that keeps the shared_ptr semantics but does not ensure thread safety. As this datatype wasn't thread-safe anyway we have nothing to lose and only performance to gain.

In my original tests this improved a mistral test case by 40%, but I noticed in CI it made no difference, perhaps indicating something about the speed of atomics on the machine I was testing on.