### PR TITLE
#8800: Name worker threads in tracy

### DIFF
--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -31,6 +31,8 @@ run_async_mode_T3000_test(){
 
         ./tt_metal/tools/profiler/profile_this.py -c "pytest -svv models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py::test_falcon_causal_lm[wormhole_b0-True-True-20-2-BFLOAT16-L1-falcon_7b-layers_2-decode_batch32]" > $PROFILER_ARTIFACTS_DIR/test_out.log
 
+        cat $PROFILER_ARTIFACTS_DIR/test_out.log
+
         if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
         then
             echo "No verification as test was skipped"
@@ -41,7 +43,6 @@ run_async_mode_T3000_test(){
             res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
             echo $res
         fi
-        cat $PROFILER_ARTIFACTS_DIR/test_out.log
     fi
 }
 

--- a/tt_metal/impl/dispatch/work_executor.hpp
+++ b/tt_metal/impl/dispatch/work_executor.hpp
@@ -4,17 +4,27 @@
 
 #pragma once
 
-#include <condition_variable>
-#include <functional>
 #include <pthread.h>
 #include <sched.h>
 #include <sys/resource.h>
-#include <thread>
 #include <unistd.h>
+
+#include <condition_variable>
+#include <functional>
+#include <thread>
 
 #include "common/env_lib.hpp"
 #include "lock_free_queue.hpp"
+#include "tt_metal/third_party/tracy/public/common/TracySystem.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+
+#if defined(TRACY_ENABLE)
+#define TracyTTThreadName(name, id)                     \
+    std::string tmp = fmt::format("{} : {}", name, id); \
+    tracy::SetThreadName(tmp.c_str());
+#else
+#define TracyTTThreadName(name, id)
+#endif
 
 namespace tt {
 
@@ -42,7 +52,10 @@ inline void set_device_thread_affinity(std::thread& thread_, int managed_device_
     CPU_SET(managed_device_id % num_online_cores, &cpuset);
     int rc = pthread_setaffinity_np(thread_.native_handle(), sizeof(cpu_set_t), &cpuset);
     if (rc) {
-        log_warning(tt::LogMetal, "Unable to bind worker thread to CPU Core. May see performance degradation. Error Code: {}", rc);
+        log_warning(
+            tt::LogMetal,
+            "Unable to bind worker thread to CPU Core. May see performance degradation. Error Code: {}",
+            rc);
     }
 }
 
@@ -50,7 +63,8 @@ inline void set_process_priority(int requested_priority) {
     // Get priority for calling process
     int process_priority = getpriority(PRIO_PROCESS, 0);
     log_debug(tt::LogMetal, "Initial Process Priority: {}", process_priority);
-    if (process_priority == requested_priority) return;
+    if (process_priority == requested_priority)
+        return;
     // Set priority for calling process to user specified value
     int rc = setpriority(PRIO_PROCESS, 0, requested_priority);
     if (rc) {
@@ -59,11 +73,11 @@ inline void set_process_priority(int requested_priority) {
 }
 
 class WorkExecutor {
-    // In asynchronous mode, each device has a worker thread that processes all host <--> cluster commands for this device.
-    // Commands are pushed to the worker queue and picked up + executed asyncrhonously.
-    // Higher level functions that have access to the device handle can queue up tasks asynchronously.
-    // In synchronous/pass through mode, we bypass the queue and tasks are executed immediately after being pushed.
-    public:
+    // In asynchronous mode, each device has a worker thread that processes all host <--> cluster commands for this
+    // device. Commands are pushed to the worker queue and picked up + executed asyncrhonously. Higher level functions
+    // that have access to the device handle can queue up tasks asynchronously. In synchronous/pass through mode, we
+    // bypass the queue and tasks are executed immediately after being pushed.
+   public:
     LockFreeQueue<std::function<void()>> worker_queue;
 
     WorkExecutor(int device_id) : managed_device_id(device_id) {
@@ -74,7 +88,7 @@ class WorkExecutor {
         }
     }
 
-    WorkExecutor(WorkExecutor &&other) {
+    WorkExecutor(WorkExecutor&& other) {
         worker_state = other.worker_state;
         managed_device_id = other.managed_device_id;
     }
@@ -86,15 +100,19 @@ class WorkExecutor {
     }
 
     inline void run_worker() {
+        TracyTTThreadName("TT_WORKER_DEVICE_ID", this->managed_device_id);
         while (true) {
             {
                 // Worker stalls until queue is non-empty or terminate signal is set
                 std::unique_lock<std::mutex> lock(this->cv_mutex);
-                this->cv.wait(lock, [this] {return (not this->worker_queue.empty()) or this->worker_state == WorkerState::TERMINATE;});
+                this->cv.wait(lock, [this] {
+                    return (not this->worker_queue.empty()) or this->worker_state == WorkerState::TERMINATE;
+                });
             }
             if (this->worker_state == WorkerState::TERMINATE) {
                 // Terminate signal set, and queue is empty - worker exits
-                if(this->worker_queue.empty()) break;
+                if (this->worker_queue.empty())
+                    break;
             }
             ZoneScopedN("PopWork");
             // Queue non-empty: run command
@@ -105,8 +123,10 @@ class WorkExecutor {
 
     inline void push_work(const std::function<void()>& work_executor, bool blocking = false) {
         ZoneScopedN("PushWork");
-        if (std::hash<std::thread::id>{}(std::this_thread::get_id()) == this->worker_queue.worker_thread_id.load() or not (this->worker_state == WorkerState::RUNNING)) {
-            // Worker is pushing to itself (nested work) or worker thread is not running. Execute work in current thread.
+        if (std::hash<std::thread::id>{}(std::this_thread::get_id()) == this->worker_queue.worker_thread_id.load() or
+            not(this->worker_state == WorkerState::RUNNING)) {
+            // Worker is pushing to itself (nested work) or worker thread is not running. Execute work in current
+            // thread.
             work_executor();
         } else {
             // Push to worker queue.
@@ -124,8 +144,10 @@ class WorkExecutor {
     inline void push_work(std::shared_ptr<std::function<void()>> work_executor, bool blocking = false) {
         // Latest push API, passing ptrs around for work container. Usually faster, since no data-copies.
         ZoneScopedN("PushWork");
-        if (std::hash<std::thread::id>{}(std::this_thread::get_id()) == this->worker_queue.worker_thread_id.load() or not (this->worker_state == WorkerState::RUNNING)) {
-            // Worker is pushing to itself (nested work) or worker thread is not running. Execute work in current thread.
+        if (std::hash<std::thread::id>{}(std::this_thread::get_id()) == this->worker_queue.worker_thread_id.load() or
+            not(this->worker_state == WorkerState::RUNNING)) {
+            // Worker is pushing to itself (nested work) or worker thread is not running. Execute work in current
+            // thread.
             (*work_executor)();
         } else {
             // Push to worker queue.
@@ -141,15 +163,17 @@ class WorkExecutor {
     }
 
     inline void synchronize() {
-        if (this->work_executor_mode == WorkExecutorMode::ASYNCHRONOUS and not(std::hash<std::thread::id>{}(std::this_thread::get_id()) == worker_queue.worker_thread_id.load())) {
-            // Blocking = wait for queue flushed. Worker thread cannot explcitly insert a synchronize, otherwise we have a deadlock.
-            this->worker_queue.push([](){}); // Send flush command (i.e. empty function)
+        if (this->work_executor_mode == WorkExecutorMode::ASYNCHRONOUS and
+            not(std::hash<std::thread::id>{}(std::this_thread::get_id()) == worker_queue.worker_thread_id.load())) {
+            // Blocking = wait for queue flushed. Worker thread cannot explcitly insert a synchronize, otherwise we have
+            // a deadlock.
+            this->worker_queue.push([]() {});  // Send flush command (i.e. empty function)
             {
                 std::lock_guard lock(this->cv_mutex);
                 cv.notify_one();
             }
             // Wait for queue empty, i.e. flush command picked up
-            while(not this->worker_queue.empty()) {
+            while (not this->worker_queue.empty()) {
                 std::this_thread::sleep_for(std::chrono::microseconds(10));
             };
         }
@@ -173,8 +197,7 @@ class WorkExecutor {
     inline void set_worker_queue_mode(const WorkerQueueMode& mode) {
         if (mode == WorkerQueueMode::LOCKFREE) {
             this->worker_queue.set_lock_free();
-        }
-        else {
+        } else {
             this->worker_queue.set_lock_based();
         }
         this->worker_queue_mode = mode;
@@ -183,7 +206,8 @@ class WorkExecutor {
     WorkerQueueMode get_worker_queue_mode() { return worker_queue_mode; }
 
     inline std::size_t get_parent_thread_id() { return this->worker_queue.parent_thread_id; }
-    private:
+
+   private:
     std::thread worker_thread;
     WorkerState worker_state = WorkerState::IDLE;
     int managed_device_id = 0;
@@ -213,7 +237,8 @@ class WorkExecutor {
     }
 
     static WorkExecutorMode default_worker_executor_mode() {
-        static int value = parse_env<int>("TT_METAL_ASYNC_DEVICE_QUEUE", static_cast<int>(WorkExecutorMode::SYNCHRONOUS));
+        static int value =
+            parse_env<int>("TT_METAL_ASYNC_DEVICE_QUEUE", static_cast<int>(WorkExecutorMode::SYNCHRONOUS));
         return static_cast<WorkExecutorMode>(value);
     }
 
@@ -226,4 +251,4 @@ class WorkExecutor {
     WorkerQueueMode worker_queue_mode = default_worker_queue_mode();
 };
 
-} // namespace tt
+}  // namespace tt


### PR DESCRIPTION
Hopefully by the time you actually review this the massive formatting PR is in main and it will be revealed that infact this is a very tiny PR which only adds a macro for setting the thread names for our workers in Tracy. The macro is nulled in non-Tracy builds.

Sample of the names:
 
<img width="506" alt="Screenshot 2024-05-24 at 10 14 21 AM" src="https://github.com/tenstorrent/tt-metal/assets/109363418/cf35793d-9ef6-44c3-a6c6-c216a1a099a0">
<img width="416" alt="Screenshot 2024-05-24 at 10 14 15 AM" src="https://github.com/tenstorrent/tt-metal/assets/109363418/9d753df5-5184-407b-a395-b45c039e3ca7">
