### PR TITLE
REVERT: support t3k_device_mesh in use_program_cache, never fa…

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -439,12 +439,6 @@ def use_program_cache(request):
         devices = request.getfixturevalue("all_devices")
         for dev in devices:
             dev.enable_program_cache()
-    elif "t3k_device_mesh" in request.fixturenames:
-        device_mesh = request.getfixturevalue("t3k_device_mesh")
-        for device_id in device_mesh.get_device_ids():
-            device_mesh.get_device(device_id).enable_program_cache()
-    else:
-        raise ValueError("No device fixture found to apply program cache to")
     yield
 
 


### PR DESCRIPTION
…il silently

This reverts commit 6852be150adb0566f1e0be14eda354ae79cc5a0e, which caused CI failures.