### PR TITLE
#8229: Report child functions durations per op in op report

### DIFF
--- a/scripts/build_scripts/build_with_profiler_opt.sh
+++ b/scripts/build_scripts/build_with_profiler_opt.sh
@@ -11,10 +11,15 @@ if [[ -z "$ARCH_NAME" ]]; then
     exit 1
 fi
 
-remove_default_log_locations
-
 ENABLE_TRACY=1 ENABLE_PROFILER=1 cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++-17
-cmake --build build --target clean
+
+if [[ $1 == "NO_CLEAN" ]]; then
+    cmake --build build
+else
+    remove_default_log_locations
+    cmake --build build --target clean
+fi
+
 cmake --build build --target install
 cmake --build build --target programming_examples
 PYTHON_ENV_DIR=$(pwd)/build/python_env ./create_venv.sh

--- a/tt_eager/tracy.py
+++ b/tt_eager/tracy.py
@@ -29,6 +29,8 @@ from tt_metal.tools.profiler.common import (
 
 import tracy_state
 
+DEFAULT_CHILD_CALLS = ["CompileProgram", "HWCommandQueue_write_buffer"]
+
 
 def signpost(header, message=None):
     from tracy_tt_lib import tracy_message
@@ -118,7 +120,7 @@ def run_report_setup(verbose, port):
     return toolsReady, captureProcess
 
 
-def generate_report(outFolder, nameAppend):
+def generate_report(outFolder, nameAppend, childCalls):
     tracyOutFile = PROFILER_LOGS_DIR / TRACY_FILE_NAME
     timeOut = 15
     timeCount = 0
@@ -134,8 +136,14 @@ def generate_report(outFolder, nameAppend):
         timeCount += 1
         time.sleep(1)
     with open(PROFILER_LOGS_DIR / TRACY_OPS_TIMES_FILE_NAME, "w") as csvFile:
+        childCallStr = ""
+        childCallsList = DEFAULT_CHILD_CALLS
+        if childCalls:
+            childCallsList = list(set(childCalls + DEFAULT_CHILD_CALLS))
+        if childCallsList:
+            childCallStr = f"-x {','.join(childCallsList)}"
         subprocess.run(
-            f"{PROFILER_BIN_DIR / TRACY_CSVEXPROT_TOOL} -u -f TT_DNN {PROFILER_LOGS_DIR / TRACY_FILE_NAME}",
+            f"{PROFILER_BIN_DIR / TRACY_CSVEXPROT_TOOL} -u -p TT_DNN {childCallStr} {PROFILER_LOGS_DIR / TRACY_FILE_NAME}",
             shell=True,
             check=True,
             stdout=csvFile,
@@ -173,6 +181,10 @@ def get_available_port():
     return None
 
 
+def split_comma_list(option, opt, value, parser):
+    setattr(parser.values, option.dest, value.split(","))
+
+
 def main():
     from optparse import OptionParser
 
@@ -207,6 +219,13 @@ def main():
         action="store_false",
         help="Show full op info for cached ops as well",
         default=True,
+    )
+    parser.add_option(
+        "--child-functions",
+        type="string",
+        help="Comma separated list of child function to have their duration included for parent OPs",
+        action="callback",
+        callback=split_comma_list,
     )
 
     if not sys.argv[1:]:
@@ -306,7 +325,7 @@ def main():
 
             try:
                 captureProcess.communicate(timeout=15)
-                generate_report(options.output_folder, options.name_append)
+                generate_report(options.output_folder, options.name_append, options.child_functions)
             except subprocess.TimeoutExpired as e:
                 captureProcess.terminate()
                 captureProcess.communicate()


### PR DESCRIPTION
This PR brings adding child function durations such `CompileProgram` to TTNN ops row in op report.

Sample op report:


Last columns in the report, 
BERT: 
[ops_perf_results_2024_05_27_13_45_33.csv](https://github.com/tenstorrent/tt-metal/files/15457102/ops_perf_results_2024_05_27_13_45_33.csv)

