### PR TITLE
#0: run RelWithDebInfo build on GH runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,20 +8,16 @@ jobs:
   build-lib:
     strategy:
       matrix:
-        config: [
-          { type: Debug, runs-on: ubuntu-20.04 },
-          { type: Release, runs-on: ubuntu-20.04 },
-          { type: RelWithDebInfo, runs-on: build },
-        ]
+        type: [ Debug, Release, RelWithDebInfo ]
         arch: [grayskull, wormhole_b0, blackhole]
         os: [ubuntu-20.04]
     env:
       ARCH_NAME: ${{ matrix.arch }}
-      CONFIG: ${{ matrix.config.type }}
+      CONFIG: ${{ matrix.type }}
       # So we can get all the makefile output we want
       VERBOSE: 1
-    runs-on: ${{ matrix.config.runs-on }}
-    name: cmake build ${{ matrix.config.type }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    name: cmake build ${{ matrix.type }} ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,12 +40,12 @@ jobs:
         run: |
           find build/ -name *.so -or -name *.a -or -name *.o | xargs strip -d
       - name: 'Tar files'
-        run: tar -cvf ttm_${{ matrix.arch }}-${{ matrix.config.type}}.tar build
+        run: tar -cvf ttm_${{ matrix.arch }}-${{ matrix.type}}.tar build
       - name: Upload libraries as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: metal-build-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.config.type }}
-          path: ttm_${{ matrix.arch }}-${{ matrix.config.type}}.tar
+          name: metal-build-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.type }}
+          path: ttm_${{ matrix.arch }}-${{ matrix.type}}.tar
   build-cpptest:
     strategy:
       matrix:


### PR DESCRIPTION
CMake + clang has increased build speed on GH runners by enough where we can run the RelWithDebInfo build on GH runners, and not have it be the bottleneck in the post-commit pipeline overall execution time