### PR TITLE
Revert "#0: Add clang-format to pre-commit check for metal repo"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,3 @@ repos:
   hooks:
     - id: black
       language_version: python3
-- repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v18.1.5
-  hooks:
-    - id: clang-format
-      types_or: [c++, c]

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -10,7 +10,7 @@
 #include "llk_math_unary_datacopy_api.h"
 #endif
 #ifdef TRISC_UNPACK
-#include "llk_unpack_A_api.h"
+#include "llk_unpack_AB_api.h"
 #endif
 
 

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -8,7 +8,6 @@
 platformdirs<4.0.0
 pre-commit==3.0.4
 black==23.10.1
-clang-format==18.1.5
 build==0.10.0
 twine==4.0.2
 yamllint==1.32.0


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#8647

![image](https://github.com/tenstorrent/tt-metal/assets/135061747/c726be67-db54-4645-aff0-2e504d6ad0be)
