### PR TITLE
Add dummy_weights mode for mixtral tests

### DIFF
--- a/models/demos/t3000/mixtral8x7b/tests/test_dummy_weights.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_dummy_weights.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import pytest
+from loguru import logger
+
+# Set to incorrect paths to test dummy weight loading
+os.environ["MIXTRAL_CKPT_DIR"] = "this/path/does/not/exist"
+os.environ["MIXTRAL_TOKENIZER_PATH"] = "this/path/does/not/exist"
+os.environ["MIXTRAL_CACHE_PATH"] = "this/path/does/not/exist"
+os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
+
+import ttnn
+
+from models.demos.t3000.mixtral8x7b.tt.mixtral_model import TtTransformer
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+from models.utility_functions import (
+    comp_pcc,
+    comp_allclose,
+)
+
+
+def test_load_dummy_weights(t3k_device_mesh):
+    model_args = TtModelArgs(t3k_device_mesh.get_device(0), dummy_weights=True)
+    model_args.n_layers = 1
+    state_dict = model_args.load_state_dict()
+    tt_model = TtTransformer(
+        device_mesh=t3k_device_mesh,
+        state_dict=state_dict,
+        args=model_args,
+        layers=list(range(model_args.n_layers)),
+        dtype=ttnn.bfloat8_b,
+    )
+
+    logger.info("Loading dummy weights passed!")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -29,7 +29,7 @@ def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_s
     pcc = 0.99
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))
-    state_dict = torch.load(model_args.consolidated_weights_path(0), map_location="cpu")
+    state_dict = model_args.load_state_dict()
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
     partial_state_dict = {k[19:]: v for k, v in state_dict.items() if (k.startswith("layers.0.attention."))}

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
@@ -33,7 +33,7 @@ def test_mixtral_decoder_inference(t3k_device_mesh, use_program_cache, reset_see
     dtype = ttnn.bfloat8_b
 
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))
-    state_dict = torch.load(model_args.state_dict_path)
+    state_dict = model_args.load_state_dict()
     partial_state_dict = {k[9:]: v for k, v in state_dict.items() if (k.startswith("layers.0."))}
     reference_model = TransformerBlock(args=model_args)
     reference_model.load_state_dict(partial_state_dict)

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
@@ -36,7 +36,7 @@ def test_mixtral_embedding(device, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat16
 
     model_args = TtModelArgs(device)
-    state_dict = torch.load(model_args.state_dict_path)
+    state_dict = model_args.load_state_dict()
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
     reference_emb = Emb()

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
@@ -34,7 +34,7 @@ def test_mixtral_mlp_inference(t3k_device_mesh, use_program_cache, reset_seeds):
     }
 
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))
-    state_dict = torch.load(model_args.state_dict_path)
+    state_dict = model_args.load_state_dict()
 
     tt_model = TtMixtralMLP(
         device_mesh=t3k_device_mesh,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
@@ -57,17 +57,10 @@ def test_mixtral_model_inference(
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))
     model_args.n_layers = n_layers
 
-    state_dict = torch.load(model_args.state_dict_path)
-    keys_dict = list(state_dict.keys())[:]
-    remv = [f"layers.{i}" for i in range(n_layers, 32)]
-    for k in keys_dict:
-        if any([r in k for r in remv]):
-            state_dict.pop(k)
+    state_dict = model_args.load_state_dict()
 
     tokenizer = Tokenizer(model_args.tokenizer_path)
-
     prompts = ["Once"] * 32
-
     encoded_prompts = [tokenizer.encode(prompt) for prompt in prompts]
 
     if validation_type == "pcc":

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
@@ -34,7 +34,7 @@ def test_mixtral_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
 
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))
-    state_dict = torch.load(model_args.state_dict_path)
+    state_dict = model_args.load_state_dict()
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
     partial_state_dict = {

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -29,7 +29,7 @@ def test_mistral_rms_norm_inference(t3k_device_mesh, use_program_cache, reset_se
     dtype = ttnn.bfloat8_b
 
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))
-    state_dict = torch.load(model_args.state_dict_path)
+    state_dict = model_args.load_state_dict(dummy_weights=False)
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
     partial_state_dict = {k[24:]: v for k, v in state_dict.items() if (k.startswith("layers.0.attention_norm."))}

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -29,7 +29,7 @@ def test_mistral_rms_norm_inference(t3k_device_mesh, use_program_cache, reset_se
     dtype = ttnn.bfloat8_b
 
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))
-    state_dict = model_args.load_state_dict(dummy_weights=False)
+    state_dict = model_args.load_state_dict()
 
     # Ref model needs partial state dict, but our models use full state dict keys as cached weight names
     partial_state_dict = {k[24:]: v for k, v in state_dict.items() if (k.startswith("layers.0.attention_norm."))}

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -32,7 +32,11 @@ class TtMixtralAttention(torch.nn.Module):
         self.model_config = self.model_args.get_model_config()
 
         layer_name = f"layers.{layer_num}.attention"
-        cache_name = lambda name: self.model_args.weight_cache_path(dtype) / (f"{layer_name}.{name}")
+
+        if args.dummy_weights:
+            cache_name = lambda _: None
+        else:
+            cache_name = lambda name: self.model_args.weight_cache_path(dtype) / (f"{layer_name}.{name}")
 
         wq_str = f"{layer_name}.wq.weight"
         wk_str = f"{layer_name}.wk.weight"

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_embedding.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_embedding.py
@@ -22,7 +22,12 @@ class TtMixtralEmbedding(torch.nn.Module):
 
         base_name = "tok_embeddings.weight"
         torch_weight = self.state_dict[base_name]
-        cache_name = weight_cache_path / base_name
+
+        if args.dummy_weights:
+            cache_name = None
+        else:
+            cache_name = weight_cache_path / base_name
+
         self.weights = ttnn.as_tensor(
             torch_weight,
             dtype=dtype,

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
@@ -25,9 +25,12 @@ class TtMixtralMLP(torch.nn.Module):
             ],
             dim=0,
         )
-        cache_name = lambda name: args.weight_cache_path(dtypes[name]) / (
-            f"layers.{layer_num}.feed_forward_multidevice_unsqueezed.experts.{name}"
-        )
+        if args.dummy_weights:
+            cache_name = lambda _: None
+        else:
+            cache_name = lambda name: args.weight_cache_path(dtypes[name]) / (
+                f"layers.{layer_num}.feed_forward_multidevice_unsqueezed.experts.{name}"
+            )
         as_tensor = lambda name: ttnn.as_tensor(
             torch_weight(name),
             dtype=dtypes[name],

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -49,13 +49,18 @@ class TtTransformer(torch.nn.Module):
 
         self.state_dict = state_dict
 
+        if args.dummy_weights:
+            output_cache_name = None
+        else:
+            output_cache_name = (args.weight_cache_path(dtype) / "output_multidevice.weight",)
+
         self.output_weight = ttnn.as_tensor(
             self.state_dict["output.weight"].permute(1, 0),
             device=device_mesh,
             layout=self.model_config["OUTPUT_W_LAYOUT_TILE"],
             dtype=dtype,
             memory_config=self.model_config["OUTPUT_WEIGHTS_MEMCFG"],
-            cache_file_name=args.weight_cache_path(dtype) / "output_multidevice.weight",
+            cache_file_name=output_cache_name,
             mesh_mapper=ReplicateTensorToMesh(device_mesh),
         )
 

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -52,7 +52,7 @@ class TtTransformer(torch.nn.Module):
         if args.dummy_weights:
             output_cache_name = None
         else:
-            output_cache_name = (args.weight_cache_path(dtype) / "output_multidevice.weight",)
+            output_cache_name = args.weight_cache_path(dtype) / "output_multidevice.weight"
 
         self.output_weight = ttnn.as_tensor(
             self.state_dict["output.weight"].permute(1, 0),

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -20,7 +20,7 @@ class TtMoeLayer(torch.nn.Module):
         if args.dummy_weights:
             cache_name = None
         else:
-            args.weight_cache_path(dtype) / (gate_name + "_multidevice_repadded")
+            cache_name = args.weight_cache_path(dtype) / (gate_name + "_multidevice_repadded")
 
         self.gates_H8 = ttnn.as_tensor(
             torch.nn.functional.pad(state_dict[gate_name].permute(1, 0), (1, 55), "constant", 0)

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_rms_norm.py
@@ -29,7 +29,11 @@ class TtRMSNorm(torch.nn.Module):
             weight_name = f"layers.{layer_num}.{weight_key}.weight"
 
         torch_weight = self.state_dict[weight_name].unsqueeze(0).expand(32, -1)
-        cache_name = args.weight_cache_path(dtype) / (weight_name + "multidevice")
+
+        if args.dummy_weights:
+            cache_name = None
+        else:
+            cache_name = args.weight_cache_path(dtype) / (weight_name + "multidevice")
 
         self.weight = ttnn.as_tensor(
             torch_weight,
@@ -69,7 +73,10 @@ class TtRMSNormSharded(torch.nn.Module):
             weight_name = f"layers.{layer_num}.{weight_key}.weight"
 
         torch_weight = self.state_dict[weight_name].unsqueeze(0).view(1, 1, 4096).expand([1, 32, 4096])
-        cache_name = args.weight_cache_path(dtype) / (weight_name + "multidevice")
+        if args.dummy_weights:
+            cache_name = None
+        else:
+            cache_name = args.weight_cache_path(dtype) / (weight_name + "multidevice")
 
         self.weight = ttnn.as_tensor(
             torch_weight,

--- a/models/demos/t3000/mixtral8x7b/tt/model_config.py
+++ b/models/demos/t3000/mixtral8x7b/tt/model_config.py
@@ -84,7 +84,8 @@ class TtModelArgs:
         logger.info(f"Checkpoint directory: {self.DEFAULT_CKPT_DIR}")
         logger.info(f"Tokenizer file: {self.DEFAULT_TOKENIZER_PATH + '/tokenizer.model'}")
         logger.info(f"Cache directory: {self.DEFAULT_CACHE_PATH}")
-        logger.info(f"Note: Using dummy weights, weight caching disabled")
+        if dummy_weights:
+            logger.info(f"Note: Using dummy weights, weight caching disabled")
 
         self.model_base_path = Path(self.DEFAULT_CKPT_DIR)
         self.model_cache_path = Path(self.DEFAULT_CACHE_PATH)


### PR DESCRIPTION
Many ttnn devs don't have access to either the CI weights in /mnt or the weka weights in /proj_sw/ and request a dummy_weights mode. This enables that and sets it as default for the model_perf test that doesn't need real weights anyway.