### PR TITLE
Add support for bfloat4 weights in Mamba

### DIFF
--- a/models/demos/mamba/tt/full_model.py
+++ b/models/demos/mamba/tt/full_model.py
@@ -99,7 +99,7 @@ class MambaTT(torch.nn.Module):
         self.lm_head_weights = load_fn(
             "lm_head.weight",
             lambda x: x.transpose(-1, -2),
-            tt_dtype=ttnn.bfloat16,
+            tt_dtype=ttnn.bfloat8_b,
         )
         self.compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
             math_fidelity=ttl.tensor.MathFidelity.HiFi2,

--- a/models/demos/mamba/tt/full_model.py
+++ b/models/demos/mamba/tt/full_model.py
@@ -118,10 +118,11 @@ class MambaTT(torch.nn.Module):
         x = ttnn.from_torch(
             x,
             device=self.device,
-            layout=ttnn.TILE_LAYOUT,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
             memory_config=ttnn.L1_MEMORY_CONFIG,
-            dtype=self.configs["dtype"]["activations"],
+            dtype=ttnn.bfloat16,
         )
+        x = ttnn.to_layout(x, layout=ttnn.TILE_LAYOUT, dtype=self.configs["dtype"]["activations"])
 
         for layer in self.layers:
             x = layer(x)

--- a/models/demos/mamba/tt/mamba_block.py
+++ b/models/demos/mamba/tt/mamba_block.py
@@ -30,7 +30,7 @@ class TtMambaBlock(torch.nn.Module):
             in_proj_weight_name,
             lambda x: x[: self.args.d_inner, :].transpose(-1, -2),
             postfix="ssm",
-            tt_dtype=ttnn.bfloat8_b,
+            tt_dtype=self.configs["dtype"]["weights"],
         )
 
         # mlp wt
@@ -38,12 +38,14 @@ class TtMambaBlock(torch.nn.Module):
             in_proj_weight_name,
             lambda x: x[self.args.d_inner :, :].transpose(-1, -2),
             postfix="mlp",
-            tt_dtype=ttnn.bfloat8_b,
+            tt_dtype=self.configs["dtype"]["weights"],
         )
 
         # down proj wt
         out_proj_weight_name = "mixer.out_proj.weight"
-        self.out_proj_weights = load_fn(out_proj_weight_name, lambda x: x.transpose(-1, -2), tt_dtype=ttnn.bfloat8_b)
+        self.out_proj_weights = load_fn(
+            out_proj_weight_name, lambda x: x.transpose(-1, -2), tt_dtype=self.configs["dtype"]["weights"]
+        )
 
         # conv states
         conv1d_weight_name = "mixer.conv1d.weight"
@@ -78,7 +80,7 @@ class TtMambaBlock(torch.nn.Module):
         self.tt_ssm = TtMambaSSM(self.args, self.device, configs, load_fn)
 
         self.compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttl.tensor.MathFidelity.HiFi3,
+            math_fidelity=ttl.tensor.MathFidelity.HiFi2,
             math_approx_mode=False,
             fp32_dest_acc_en=True,
         )

--- a/models/demos/mamba/tt/mamba_one_step_ssm.py
+++ b/models/demos/mamba/tt/mamba_one_step_ssm.py
@@ -163,7 +163,9 @@ class TtMambaSSM(torch.nn.Module):
         ttnn.deallocate(abar1)
 
         # multiply abar and hidden_state
-        hidden_state0 = ttnn.to_memory_config(self.tt_hidden_state, memory_config=ttnn.L1_MEMORY_CONFIG)
+        hidden_state0 = ttnn.to_memory_config(
+            self.tt_hidden_state, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=self.configs["dtype"]["activations"]
+        )
         amulh0 = ttnn.mul(
             abar2, hidden_state0, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=self.configs["dtype"]["activations"]
         )
@@ -213,7 +215,9 @@ class TtMambaSSM(torch.nn.Module):
             amulh0, bmulx0, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=self.configs["dtype"]["activations"]
         )
         ttnn.deallocate(self.tt_hidden_state)
-        self.tt_hidden_state = ttnn.to_memory_config(hidden_state1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        self.tt_hidden_state = ttnn.to_memory_config(
+            hidden_state1, memory_config=ttnn.DRAM_MEMORY_CONFIG, dtype=self.configs["dtype"]["activations"]
+        )
         ttnn.deallocate(amulh0)
         ttnn.deallocate(bmulx0)
 

--- a/models/demos/mamba/tt/mamba_one_step_ssm.py
+++ b/models/demos/mamba/tt/mamba_one_step_ssm.py
@@ -40,7 +40,7 @@ class TtMambaSSM(torch.nn.Module):
             x_proj_weight_name,
             lambda x: x[: self.args.dt_rank, :].transpose(-1, -2),
             postfix="delta_t",
-            tt_dtype=ttnn.bfloat8_b,
+            tt_dtype=self.configs["dtype"]["weights"],
         )
 
         # B_proj_weights
@@ -54,7 +54,7 @@ class TtMambaSSM(torch.nn.Module):
             x_proj_weight_name,
             tm_fn=preprocess_B,
             postfix="B_proj",
-            tt_dtype=ttnn.bfloat8_b,
+            tt_dtype=self.configs["dtype"]["weights"],
         )
 
         # C_proj_weights
@@ -63,13 +63,17 @@ class TtMambaSSM(torch.nn.Module):
             x = torch.nn.functional.pad(x, (0, 16), "constant", 0)
             return x
 
-        self.C_proj_weights = load_fn(x_proj_weight_name, preprocess_C, postfix="C_proj", tt_dtype=ttnn.bfloat8_b)
+        self.C_proj_weights = load_fn(
+            x_proj_weight_name, preprocess_C, postfix="C_proj", tt_dtype=self.configs["dtype"]["weights"]
+        )
 
         # dt_proj_weights
         dt_proj_weight_name = "mixer.dt_proj.weight"
         dt_proj_bias_name = "mixer.dt_proj.bias"
-        self.dt_proj_weights = load_fn(dt_proj_weight_name, lambda x: x.transpose(-1, -2), tt_dtype=ttnn.bfloat8_b)
-        self.dt_proj_bias = load_fn(dt_proj_bias_name, tt_dtype=ttnn.bfloat8_b)
+        self.dt_proj_weights = load_fn(
+            dt_proj_weight_name, lambda x: x.transpose(-1, -2), tt_dtype=self.configs["dtype"]["weights"]
+        )
+        self.dt_proj_bias = load_fn(dt_proj_bias_name, tt_dtype=self.configs["dtype"]["weights"])
 
         A_weight_name = "mixer.A_log"
 
@@ -94,7 +98,7 @@ class TtMambaSSM(torch.nn.Module):
         self.tt_hidden_state = load_fn(f"tt_hidden_state_{args.batch_size}", torch_tensor=prev_hidden_states)
 
         self.compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttl.tensor.MathFidelity.HiFi3,
+            math_fidelity=ttl.tensor.MathFidelity.HiFi2,
             math_approx_mode=False,
             fp32_dest_acc_en=True,
         )

--- a/models/demos/mamba/tt/model_config.py
+++ b/models/demos/mamba/tt/model_config.py
@@ -34,7 +34,7 @@ def create_model_config(batch_size, hidden_size):
         block_w=(hidden_size // (col * row)) // 32,
         inplace=False,
     )
-    configs["dtype"] = {"activations": ttnn.bfloat8_b}
+    configs["dtype"] = {"activations": ttnn.bfloat8_b, "weights": ttnn.bfloat4_b}
     return configs
 
 

--- a/models/demos/mamba/tt/residual_block.py
+++ b/models/demos/mamba/tt/residual_block.py
@@ -42,4 +42,6 @@ class TtResidualBlock(torch.nn.Module):
         ttnn.deallocate(rms_norm_weights)
         mamba_x = self.tt_mamba_block(mamba_x)
 
-        return ttnn.add(residual, mamba_x, dtype=self.configs["dtype"]["activations"])
+        return ttnn.add(
+            residual, mamba_x, dtype=self.configs["dtype"]["activations"], memory_config=ttnn.L1_MEMORY_CONFIG
+        )


### PR DESCRIPTION
This change makes all Mamba MLP weights configurable through the model configuration, while also setting the weights to `bfloat4` format.

There are also some smaller performance improvements (split into separate commits):
- Move input tilization to device which increases model end-to-end performance
- Lower LM head precision to `bfloat8` since this can be done without losing model PCC
- Add missing dtype parameters on some output tensors