### PR TITLE
Convert Falcon7b tt_lib ops and tensors to ttnn.experimental

### DIFF
--- a/models/demos/falcon7b/demo/demo.py
+++ b/models/demos/falcon7b/demo/demo.py
@@ -8,9 +8,9 @@ import time
 from functools import partial
 from pathlib import Path
 
-import pytest
 import torch
 import torch.nn.functional as F
+import ttnn
 import tt_lib
 from loguru import logger
 from models.demos.falcon7b.reference.hf_modeling_falcon import FalconConfig, FalconForCausalLM
@@ -20,11 +20,9 @@ from models.utility_functions import (
     disable_compilation_reports,
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
-    is_wormhole_b0,
     nearest_32,
     profiler,
     torch2tt_tensor,
-    tt2torch_tensor,
     tt_tensors_to_torch_tensors,
 )
 from tqdm import tqdm
@@ -274,7 +272,7 @@ def run_falcon_demo_kv(
         for i in range(num_devices):
             tt_prefill_input_ids[i].deallocate()
             if tt_prefill_attention_mask is not None:
-                if isinstance(tt_prefill_attention_mask[i], tt_lib.tensor.Tensor):
+                if isinstance(tt_prefill_attention_mask[i], ttnn.experimental.tensor.Tensor):
                     tt_prefill_attention_mask[i].deallocate()
                 elif isinstance(tt_prefill_attention_mask[i], list):
                     for tt_attention_mask_element in tt_prefill_attention_mask[i]:
@@ -389,7 +387,7 @@ def run_falcon_demo_kv(
 
         if tt_prefill_attention_mask is not None:
             for device_id in range(len(tt_prefill_attention_mask)):
-                if isinstance(tt_prefill_attention_mask[device_id], tt_lib.tensor.Tensor):
+                if isinstance(tt_prefill_attention_mask[device_id], ttnn.experimental.tensor.Tensor):
                     tt_prefill_attention_mask[device_id].deallocate()
                 elif isinstance(tt_prefill_attention_mask[device_id], list):
                     for tt_attention_mask_element in tt_prefill_attention_mask[device_id]:

--- a/models/demos/falcon7b/tests/test_falcon_attention.py
+++ b/models/demos/falcon7b/tests/test_falcon_attention.py
@@ -13,10 +13,9 @@ from models.demos.falcon7b.tt.falcon_attention import TtFalconAttentionDecode, T
 from models.demos.falcon7b.tt.model_config import get_model_config
 from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_outputs
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
-    comp_allclose,
     comp_pcc,
 )
-from models.utility_functions import torch2tt_tensor, tt2torch_tensor, get_devices_for_t3000
+from models.utility_functions import get_devices_for_t3000
 
 
 class PytorchFalconAttentionModel(torch.nn.Module):

--- a/models/demos/falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon7b/tests/test_falcon_causallm.py
@@ -6,7 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib
 from models.demos.falcon7b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )

--- a/models/demos/falcon7b/tests/test_falcon_model.py
+++ b/models/demos/falcon7b/tests/test_falcon_model.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 from loguru import logger
-import tt_lib
 from models.demos.falcon7b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )

--- a/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
+++ b/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
@@ -6,7 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib
 from models.demos.falcon7b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )

--- a/models/demos/falcon7b/tests/test_utils.py
+++ b/models/demos/falcon7b/tests/test_utils.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor
 
 

--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_attn_matmul.py
@@ -5,7 +5,7 @@
 import pytest
 from loguru import logger
 
-import tt_lib as ttl
+import ttnn
 from models.utility_functions import comp_pcc, tt2torch_tensor
 import torch
 
@@ -28,7 +28,7 @@ def run_falcon_attn_matmul_test(
 
     pcc = 0.99
 
-    if falcon_op == ttl.operations.primary.transformers.attn_matmul:
+    if falcon_op == ttnn.experimental.operations.primary.transformers.attn_matmul:
         q_len = 1
         kv_heads = 1
         q_heads = 71
@@ -37,9 +37,13 @@ def run_falcon_attn_matmul_test(
         expected_output_shape = [1, q_heads, batch, seq_len]
 
         B = torch.randn(b_shape) - 0.95
-        b_t = ttl.tensor.Tensor(B, in1_dtype).to(ttl.tensor.Layout.TILE).to(device, in1_mem_config)
+        b_t = (
+            ttnn.experimental.tensor.Tensor(B, in1_dtype)
+            .to(ttnn.experimental.tensor.Layout.TILE)
+            .to(device, in1_mem_config)
+        )
 
-    elif falcon_op == ttl.operations.primary.transformers.attn_matmul_from_cache:
+    elif falcon_op == ttnn.experimental.operations.primary.transformers.attn_matmul_from_cache:
         q_len = 1
         kv_heads = 1
         q_heads = 71
@@ -60,33 +64,41 @@ def run_falcon_attn_matmul_test(
             B = kv_cache[:, :, :seq_len, :]
             expected_output_shape = [1, q_heads, batch, K]
 
-        b_t = ttl.tensor.Tensor(kv_cache, in1_dtype).to(ttl.tensor.Layout.TILE).to(device, in1_mem_config)
+        b_t = (
+            ttnn.experimental.tensor.Tensor(kv_cache, in1_dtype)
+            .to(ttnn.experimental.tensor.Layout.TILE)
+            .to(device, in1_mem_config)
+        )
 
     else:
         raise NotImplementedError(f"falcon matmul op is undefined!")
 
     A = torch.randn(a_shape)
 
-    a_t = ttl.tensor.Tensor(A, in0_dtype).to(ttl.tensor.Layout.TILE).to(device, in0_mem_config)
+    a_t = (
+        ttnn.experimental.tensor.Tensor(A, in0_dtype)
+        .to(ttnn.experimental.tensor.Layout.TILE)
+        .to(device, in0_mem_config)
+    )
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
-    if falcon_op == ttl.operations.primary.transformers.attn_matmul:
+    if falcon_op == ttnn.experimental.operations.primary.transformers.attn_matmul:
         out = falcon_op(
             a_t,
             b_t,
-            compute_with_storage_grid_size=ttl.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
+            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
             output_mem_config=out_mem_config,
             output_dtype=out_dtype,
         )
 
-    elif falcon_op == ttl.operations.primary.transformers.attn_matmul_from_cache:
-        out = ttl.operations.primary.transformers.attn_matmul_from_cache(
+    elif falcon_op == ttnn.experimental.operations.primary.transformers.attn_matmul_from_cache:
+        out = ttnn.experimental.operations.primary.transformers.attn_matmul_from_cache(
             a_t,
             b_t,
             seq_len,
             transpose_hw,
-            compute_with_storage_grid_size=ttl.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
+            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
             output_mem_config=out_mem_config,
             output_dtype=out_dtype,
         )
@@ -119,34 +131,40 @@ def run_falcon_attn_matmul_test(
     "in0_mem_config, in1_mem_config, out_mem_config",
     (
         (
-            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+            ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
+            ),
+            ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
+            ),
+            ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
+            ),
         ),
     ),
     ids=["DRAM"],
 )
 @pytest.mark.parametrize(
     "out_dtype",
-    (ttl.tensor.DataType.BFLOAT16,),
+    (ttnn.experimental.tensor.DataType.BFLOAT16,),
     ids=["out_BFLOAT16"],
 )
 @pytest.mark.parametrize(
     "in1_dtype",
-    (ttl.tensor.DataType.BFLOAT16,),
+    (ttnn.experimental.tensor.DataType.BFLOAT16,),
     ids=["in1_BFLOAT16"],
 )
 @pytest.mark.parametrize(
     "in0_dtype",
-    (ttl.tensor.DataType.BFLOAT16,),
+    (ttnn.experimental.tensor.DataType.BFLOAT16,),
     ids=["in0_BFLOAT16"],
 )
 @pytest.mark.parametrize(
     "falcon_op, transpose_hw",
     (
-        (ttl.operations.primary.transformers.attn_matmul, None),
-        (ttl.operations.primary.transformers.attn_matmul_from_cache, True),
-        (ttl.operations.primary.transformers.attn_matmul_from_cache, False),
+        (ttnn.experimental.operations.primary.transformers.attn_matmul, None),
+        (ttnn.experimental.operations.primary.transformers.attn_matmul_from_cache, True),
+        (ttnn.experimental.operations.primary.transformers.attn_matmul_from_cache, False),
     ),
     ids=["attn_matmul", "pre_attn_matmul_from_cache", "post_attn_matmul_from_cache"],
 )

--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_lm_head_matmul_2d.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_lm_head_matmul_2d.py
@@ -6,7 +6,7 @@ from loguru import logger
 import pytest
 import torch
 
-import tt_lib
+import ttnn
 
 from models.demos.falcon7b.tt.falcon_lm_head import falcon_lm_head_matmul_2d
 from models.utility_functions import comp_pcc, tt2torch_tensor, torch2tt_tensor
@@ -42,7 +42,7 @@ def run_falcon_lm_head_matmul_2d(
     a_t = torch2tt_tensor(
         A,
         device,
-        tt_lib.tensor.Layout.TILE,
+        ttnn.experimental.tensor.Layout.TILE,
         in0_mem_config,
         in0_dtype,
     )
@@ -56,7 +56,7 @@ def run_falcon_lm_head_matmul_2d(
             torch2tt_tensor(
                 B_slices[i],
                 device,
-                tt_lib.tensor.Layout.TILE,
+                ttnn.experimental.tensor.Layout.TILE,
                 in1_mem_config,
                 in1_dtype,
             )
@@ -84,19 +84,19 @@ def test_falcon_lm_head_matmul_2d(
     seq_len,
     device,
 ):
-    in0_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    in0_mem_config = ttnn.experimental.tensor.MemoryConfig(
+        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
     )
-    in1_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    in1_mem_config = ttnn.experimental.tensor.MemoryConfig(
+        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
     )
-    out_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
+    out_mem_config = ttnn.experimental.tensor.MemoryConfig(
+        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
     )
 
-    in0_dtype = tt_lib.tensor.DataType.BFLOAT16
-    in1_dtype = tt_lib.tensor.DataType.BFLOAT8_B
-    out_dtype = tt_lib.tensor.DataType.BFLOAT16
+    in0_dtype = ttnn.experimental.tensor.DataType.BFLOAT16
+    in1_dtype = ttnn.experimental.tensor.DataType.BFLOAT8_B
+    out_dtype = ttnn.experimental.tensor.DataType.BFLOAT16
 
     run_falcon_lm_head_matmul_2d(
         seq_len, device, in0_mem_config, in1_mem_config, out_mem_config, in0_dtype, in1_dtype, out_dtype

--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -5,7 +5,7 @@
 import pytest
 from loguru import logger
 
-import tt_lib as ttl
+import ttnn
 from models.utility_functions import comp_pcc, tt2torch_tensor, torch2tt_tensor, skip_for_wormhole_b0
 import torch
 import math
@@ -23,61 +23,61 @@ def run_falcon_matmul_test(
     device,
 ):
     pcc = 0.99
-    if out_dtype == ttl.tensor.DataType.BFLOAT8_B:
+    if out_dtype == ttnn.experimental.tensor.DataType.BFLOAT8_B:
         pcc = 0.98
 
-    if falcon_op == ttl.tensor.falcon_fused_qkv_matmul:
+    if falcon_op == ttnn.experimental.tensor.falcon_fused_qkv_matmul:
         a_shape = [1, 1, seq_len, 4544]
         b_shape = [1, 1, 4544, 4672]
         expected_output_shape = [1, 1, seq_len, 4672]
-    elif falcon_op == ttl.tensor.falcon_selfout_matmul:
+    elif falcon_op == ttnn.experimental.tensor.falcon_selfout_matmul:
         a_shape = [1, 1, seq_len, 4544]
         b_shape = [1, 1, 4544, 4544]
         expected_output_shape = [1, 1, seq_len, 4544]
-    elif falcon_op == ttl.tensor.falcon_dense_4h_to_h_matmul:
+    elif falcon_op == ttnn.experimental.tensor.falcon_dense_4h_to_h_matmul:
         a_shape = [1, 1, seq_len, 18176]
         b_shape = [1, 1, 18176, 4544]
         expected_output_shape = [1, 1, seq_len, 4544]
 
-        if (seq_len == 1024 and in0_dtype == in1_dtype == out_dtype == ttl.tensor.DataType.BFLOAT16) or (
+        if (seq_len == 1024 and in0_dtype == in1_dtype == out_dtype == ttnn.experimental.tensor.DataType.BFLOAT16) or (
             seq_len == 2048
             and (
-                in0_dtype == ttl.tensor.DataType.BFLOAT16
-                or in1_dtype == ttl.tensor.DataType.BFLOAT16
-                or out_dtype == ttl.tensor.DataType.BFLOAT16
+                in0_dtype == ttnn.experimental.tensor.DataType.BFLOAT16
+                or in1_dtype == ttnn.experimental.tensor.DataType.BFLOAT16
+                or out_dtype == ttnn.experimental.tensor.DataType.BFLOAT16
             )
         ):
             logger.warning(
                 f"For seq_len: {seq_len}, in0_dtype: {in0_dtype}, in1_dtype: {in1_dtype}, and out_dtype: {out_dtype}, L1 space is not enough. Running with in0, in1, and out on DRAM instead!"
             )
-            in0_mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            in0_mem_config = ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
             )
-            in1_mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            in1_mem_config = ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
             )
-            out_mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            out_mem_config = ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
             )
-    elif falcon_op == ttl.tensor.falcon_dense_h_to_4h_matmul:
+    elif falcon_op == ttnn.experimental.tensor.falcon_dense_h_to_4h_matmul:
         a_shape = [1, 1, seq_len, 4544]
         b_shape = [1, 1, 4544, 18176]
         expected_output_shape = [1, 1, seq_len, 18176]
 
-        if seq_len == 2048 and out_dtype == ttl.tensor.DataType.BFLOAT16:
+        if seq_len == 2048 and out_dtype == ttnn.experimental.tensor.DataType.BFLOAT16:
             logger.warning(
                 f"For seq_len: {seq_len}, in0_dtype: {in0_dtype}, in1_dtype: {in1_dtype}, and out_dtype: {out_dtype}, L1 space is not enough. Running with in0, in1, and out on DRAM instead!"
             )
-            in0_mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            in0_mem_config = ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
             )
-            in1_mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            in1_mem_config = ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
             )
-            out_mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            out_mem_config = ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
             )
-    elif falcon_op == ttl.tensor.falcon_lm_head_matmul:
+    elif falcon_op == ttnn.experimental.tensor.falcon_lm_head_matmul:
         a_shape = [1, 1, seq_len, 4544]
         b_shape = [1, 1, 4544, 65024]
         expected_output_shape = [1, 1, seq_len, 65024]
@@ -85,9 +85,9 @@ def run_falcon_matmul_test(
         if (
             seq_len == 512
             and (
-                in0_dtype == ttl.tensor.DataType.BFLOAT16
-                or in1_dtype == ttl.tensor.DataType.BFLOAT16
-                or out_dtype == ttl.tensor.DataType.BFLOAT16
+                in0_dtype == ttnn.experimental.tensor.DataType.BFLOAT16
+                or in1_dtype == ttnn.experimental.tensor.DataType.BFLOAT16
+                or out_dtype == ttnn.experimental.tensor.DataType.BFLOAT16
             )
             or seq_len == 1024
             or seq_len == 2048
@@ -95,14 +95,14 @@ def run_falcon_matmul_test(
             logger.warning(
                 f"For seq_len: {seq_len}, in0_dtype: {in0_dtype}, in1_dtype: {in1_dtype}, and out_dtype: {out_dtype}, L1 space is not enough. Running with in0, in1, and out on DRAM instead!"
             )
-            in0_mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            in0_mem_config = ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
             )
-            in1_mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            in1_mem_config = ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
             )
-            out_mem_config = ttl.tensor.MemoryConfig(
-                ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM
+            out_mem_config = ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
             )
     else:
         raise NotImplementedError(f"falcon matmul op is undefined!")
@@ -112,8 +112,16 @@ def run_falcon_matmul_test(
     A = torch.randn(a_shape)
     B = torch.randn(b_shape) - 0.95
 
-    a_t = ttl.tensor.Tensor(A, in0_dtype).to(ttl.tensor.Layout.TILE).to(device, in0_mem_config)
-    b_t = ttl.tensor.Tensor(B, in1_dtype).to(ttl.tensor.Layout.TILE).to(device, in1_mem_config)
+    a_t = (
+        ttnn.experimental.tensor.Tensor(A, in0_dtype)
+        .to(ttnn.experimental.tensor.Layout.TILE)
+        .to(device, in0_mem_config)
+    )
+    b_t = (
+        ttnn.experimental.tensor.Tensor(B, in1_dtype)
+        .to(ttnn.experimental.tensor.Layout.TILE)
+        .to(device, in1_mem_config)
+    )
     bias_t = None
 
     out = falcon_op(a_t, b_t, bias_t, output_mem_config=out_mem_config, output_dtype=out_dtype)
@@ -147,36 +155,42 @@ def run_falcon_matmul_test(
     "in0_mem_config, in1_mem_config, out_mem_config",
     (
         (
-            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
-            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-            ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+            ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.L1
+            ),
+            ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
+            ),
+            ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.L1
+            ),
         ),
     ),
     ids=["weights_DRAM"],
 )
 @pytest.mark.parametrize(
     "out_dtype",
-    (ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.BFLOAT16),
+    (ttnn.experimental.tensor.DataType.BFLOAT8_B, ttnn.experimental.tensor.DataType.BFLOAT16),
     ids=["out_BFLOAT8_B", "out_BFLOAT16"],
 )
 @pytest.mark.parametrize(
     "in1_dtype",
-    (ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.BFLOAT16),
+    (ttnn.experimental.tensor.DataType.BFLOAT8_B, ttnn.experimental.tensor.DataType.BFLOAT16),
     ids=["in1_BFLOAT8_B", "in1_BFLOAT16"],
 )
 @pytest.mark.parametrize(
     "in0_dtype",
-    (ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.BFLOAT16),
+    (ttnn.experimental.tensor.DataType.BFLOAT8_B, ttnn.experimental.tensor.DataType.BFLOAT16),
     ids=["in0_BFLOAT8_B", "in0_BFLOAT16"],
 )
 @pytest.mark.parametrize(
     "falcon_op",
     (
-        ttl.tensor.falcon_fused_qkv_matmul,
-        ttl.tensor.falcon_selfout_matmul,
-        ttl.tensor.falcon_dense_4h_to_h_matmul,
-        ttl.tensor.falcon_dense_h_to_4h_matmul,
-        ttl.tensor.falcon_lm_head_matmul,
+        ttnn.experimental.tensor.falcon_fused_qkv_matmul,
+        ttnn.experimental.tensor.falcon_selfout_matmul,
+        ttnn.experimental.tensor.falcon_dense_4h_to_h_matmul,
+        ttnn.experimental.tensor.falcon_dense_h_to_4h_matmul,
+        ttnn.experimental.tensor.falcon_lm_head_matmul,
     ),
     ids=["fused_qkv", "selfout", "dense_4h_to_h", "dense_h_to_4h", "lm_head"],
 )
@@ -199,7 +213,7 @@ def test_falcon_matmul(
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     is_e75_grid_size = (compute_grid_size.x * compute_grid_size.y) == 88
-    if is_e75_grid_size and (seq_len == 512) and (falcon_op == ttl.tensor.falcon_lm_head_matmul):
+    if is_e75_grid_size and (seq_len == 512) and (falcon_op == ttnn.experimental.tensor.falcon_lm_head_matmul):
         pytest.skip(f"LM Head does not work on E75 grid size {compute_grid_size}")
 
     run_falcon_matmul_test(
@@ -253,13 +267,14 @@ def test_falcon7b_attnention_sliced(
     torch_value_layer = torch.randn(value_layer_shape).bfloat16().float()
     torch_attention_output = torch.randn(attention_output_shape).bfloat16().float()
 
-    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.DRAM,
+    dram_interleaved_memory_config = ttnn.experimental.tensor.MemoryConfig(
+        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttnn.experimental.tensor.BufferType.DRAM,
     )
 
-    height_sharded_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttl.tensor.BufferType.L1
+    height_sharded_memory_config = ttnn.experimental.tensor.MemoryConfig(
+        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=ttnn.experimental.tensor.BufferType.L1,
     )
 
     # compare output to regular case
@@ -267,32 +282,35 @@ def test_falcon7b_attnention_sliced(
         torch_query_layer,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     reference_key_layer_transposed = torch2tt_tensor(
         torch_key_layer_transposed,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     attention_mask = torch2tt_tensor(
         torch_attention_mask,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     reference_scalar = torch2tt_tensor(
-        torch_scalar, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+        torch_scalar,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     reference_value_layer = torch2tt_tensor(
         torch_value_layer,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
 
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.HiFi4,
+    compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
         packer_l1_acc=True,
@@ -305,28 +323,28 @@ def test_falcon7b_attnention_sliced(
         torch_attention_output,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     tiles_per_shard = math.ceil((((71 * seq_len) / num_cores) / num_slices) / 32)
     mm_activations_height_shard_spec = [tiles_per_shard * 32, 2 * 32]
     mm_output_height_shard_spec = [tiles_per_shard * 32, seq_len]
 
     for i in range(num_slices):
-        slice = ttl.tensor.interleaved_to_sharded_partial(
+        slice = ttnn.experimental.tensor.interleaved_to_sharded_partial(
             reference_query_layer,
             grid_size,
             mm_activations_height_shard_spec,
             num_slices,  # num_slices
             i,  # slice_index
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
         )
 
         subblock_h = 1
         subblock_w = 1
         if seq_len == 2048:
             subblock_w = 8  # best option
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=2,
             per_core_M=tiles_per_shard,
@@ -338,20 +356,20 @@ def test_falcon7b_attnention_sliced(
             mcast_in0=False,
         )
 
-        mm_slice = ttl.operations.primary.matmul(
+        mm_slice = ttnn.experimental.operations.primary.matmul(
             slice,
             reference_key_layer_transposed,
             program_config=program_config,
             output_mem_config=height_sharded_memory_config,
-            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
             compute_kernel_config=compute_kernel_config,
         )
 
-        mm_slice = ttl.operations.primary.bcast(
+        mm_slice = ttnn.experimental.operations.primary.bcast(
             mm_slice,
             reference_scalar,
-            ttl.tensor.BcastOpMath.MUL,
-            ttl.tensor.BcastOpDim.HW,
+            ttnn.experimental.tensor.BcastOpMath.MUL,
+            ttnn.experimental.tensor.BcastOpDim.HW,
             output_mem_config=height_sharded_memory_config,
             in_place=True,
         )
@@ -360,22 +378,22 @@ def test_falcon7b_attnention_sliced(
         # So we have to move it after the entire sequence is finished
         # slice.deallocate()
 
-        attn_mask_slice = ttl.tensor.interleaved_to_sharded_partial(
+        attn_mask_slice = ttnn.experimental.tensor.interleaved_to_sharded_partial(
             attention_mask,
             grid_size,
             mm_output_height_shard_spec,
             num_slices,
             i,
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-        mm_slice = ttl.operations.primary.add(
+        mm_slice = ttnn.experimental.operations.primary.add(
             mm_slice,
             attn_mask_slice,
             fused_activations=None,
             output_mem_config=height_sharded_memory_config,
-            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
             in_place=True,
         )
 
@@ -384,20 +402,20 @@ def test_falcon7b_attnention_sliced(
         subblock_w = 1
         if seq_len == 2048:
             subblock_w = 8
-        softmax_program_config = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+        softmax_program_config = ttnn.experimental.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
             compute_with_storage_grid_size=grid_size,
             subblock_w=subblock_w,
             block_h=mm_output_height_shard_spec[0] // 32,
             block_w=mm_output_height_shard_spec[1] // 32,
         )
 
-        mm_slice = ttl.operations.primary.softmax_in_place(
+        mm_slice = ttnn.experimental.operations.primary.softmax_in_place(
             mm_slice, program_config=softmax_program_config, compute_kernel_config=compute_kernel_config
         )
 
         subblock_w = 2
         subblock_h = 1
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=seq_len // 32,
             per_core_M=tiles_per_shard,
@@ -409,16 +427,16 @@ def test_falcon7b_attnention_sliced(
             mcast_in0=False,
         )
 
-        attn_out_slice = ttl.operations.primary.matmul(
+        attn_out_slice = ttnn.experimental.operations.primary.matmul(
             mm_slice,
             reference_value_layer,
             program_config=program_config,
             output_mem_config=height_sharded_memory_config,
-            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
             compute_kernel_config=compute_kernel_config,
         )
 
-        ttl.tensor.sharded_to_interleaved_partial(
+        ttnn.experimental.tensor.sharded_to_interleaved_partial(
             attn_out_slice,
             attention_output_concatenated,
             num_slices,
@@ -432,20 +450,24 @@ def test_falcon7b_attnention_sliced(
 
     attention_output_concatenated_torch = tt2torch_tensor(attention_output_concatenated)
 
-    attn_weights = ttl.tensor.matmul(
+    attn_weights = ttnn.experimental.tensor.matmul(
         reference_query_layer, reference_key_layer_transposed, output_mem_config=dram_interleaved_memory_config
     )
 
-    attn_weights = ttl.operations.primary.bcast(
+    attn_weights = ttnn.experimental.operations.primary.bcast(
         attn_weights,
         reference_scalar,
-        ttl.tensor.BcastOpMath.MUL,
-        ttl.tensor.BcastOpDim.HW,
+        ttnn.experimental.tensor.BcastOpMath.MUL,
+        ttnn.experimental.tensor.BcastOpDim.HW,
         output_mem_config=dram_interleaved_memory_config,
     )
-    attn_weights = ttl.tensor.add(attn_weights, attention_mask, output_mem_config=dram_interleaved_memory_config)
-    attn_weights = ttl.operations.primary.softmax_in_place(attn_weights, compute_kernel_config=compute_kernel_config)
-    attn_output = ttl.tensor.matmul(attn_weights, reference_value_layer)
+    attn_weights = ttnn.experimental.tensor.add(
+        attn_weights, attention_mask, output_mem_config=dram_interleaved_memory_config
+    )
+    attn_weights = ttnn.experimental.operations.primary.softmax_in_place(
+        attn_weights, compute_kernel_config=compute_kernel_config
+    )
+    attn_output = ttnn.experimental.tensor.matmul(attn_weights, reference_value_layer)
     attn_output_torch = tt2torch_tensor(attn_output)
     passing = True
 
@@ -515,13 +537,14 @@ def test_falcon7b_attention_softmax_sequence(
     torch_value_layer = torch.randn(value_layer_shape).bfloat16().float()
     torch_attention_output = torch.randn(attention_output_shape).bfloat16().float()
 
-    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.DRAM,
+    dram_interleaved_memory_config = ttnn.experimental.tensor.MemoryConfig(
+        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttnn.experimental.tensor.BufferType.DRAM,
     )
 
-    height_sharded_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttl.tensor.BufferType.L1
+    height_sharded_memory_config = ttnn.experimental.tensor.MemoryConfig(
+        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=ttnn.experimental.tensor.BufferType.L1,
     )
 
     # compare output to regular case
@@ -529,29 +552,29 @@ def test_falcon7b_attention_softmax_sequence(
         torch_query_layer,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     reference_key_layer_transposed = torch2tt_tensor(
         torch_key_layer_transposed,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     attention_mask = torch2tt_tensor(
         torch_attention_mask,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     attention_mask_proper_dim = torch2tt_tensor(
         torch_attention_mask_proper_dim,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
 
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.HiFi4,
+    compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
         packer_l1_acc=True,
@@ -577,7 +600,7 @@ def test_falcon7b_attention_softmax_sequence(
             torch_attention_mask_per_slice,
             device,
             tt_memory_config=dram_interleaved_memory_config,
-            tt_dtype=ttl.tensor.DataType.BFLOAT16,
+            tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
         )
         attention_masks_per_slice.append(tt_attention_slice)
         attention_mask_starting_index_per_slice = (
@@ -585,13 +608,16 @@ def test_falcon7b_attention_softmax_sequence(
         ) % seq_len  # mod attention_mask.height
 
     reference_scalar = torch2tt_tensor(
-        torch_scalar, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+        torch_scalar,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     reference_value_layer = torch2tt_tensor(
         torch_value_layer,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
 
     passing = True
@@ -601,28 +627,28 @@ def test_falcon7b_attention_softmax_sequence(
         torch_attention_output,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
     tiles_per_shard = math.ceil((((71 * seq_len) / num_cores) / num_slices) / 32)
     mm_activations_height_shard_spec = [tiles_per_shard * 32, 2 * 32]
     mm_output_height_shard_spec = [tiles_per_shard * 32, seq_len]
 
     for i in range(num_slices):
-        slice = ttl.tensor.interleaved_to_sharded_partial(
+        slice = ttnn.experimental.tensor.interleaved_to_sharded_partial(
             reference_query_layer,
             grid_size,
             mm_activations_height_shard_spec,
             num_slices,  # num_slices
             i,  # slice_index
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
         )
 
         subblock_h = 1
         subblock_w = 1
         if seq_len == 2048:
             subblock_w = 8  # best option
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=2,
             per_core_M=tiles_per_shard,
@@ -634,12 +660,12 @@ def test_falcon7b_attention_softmax_sequence(
             mcast_in0=False,
         )
 
-        mm_slice = ttl.operations.primary.matmul(
+        mm_slice = ttnn.experimental.operations.primary.matmul(
             slice,
             reference_key_layer_transposed,
             program_config=program_config,
             output_mem_config=height_sharded_memory_config,
-            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -650,14 +676,14 @@ def test_falcon7b_attention_softmax_sequence(
         subblock_w = 1
         if seq_len == 2048:
             subblock_w = 8
-        softmax_program_config = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+        softmax_program_config = ttnn.experimental.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
             compute_with_storage_grid_size=grid_size,
             subblock_w=subblock_w,
             block_h=mm_output_height_shard_spec[0] // 32,
             block_w=mm_output_height_shard_spec[1] // 32,
         )
 
-        mm_slice = ttl.operations.primary.transformers.scale_causal_mask_hw_dims_softmax_in_place(
+        mm_slice = ttnn.experimental.operations.primary.transformers.scale_causal_mask_hw_dims_softmax_in_place(
             mm_slice,
             scalar_value,
             attention_masks_per_slice[i],
@@ -667,7 +693,7 @@ def test_falcon7b_attention_softmax_sequence(
 
         subblock_w = 2
         subblock_h = 1
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=seq_len // 32,
             per_core_M=tiles_per_shard,
@@ -679,16 +705,16 @@ def test_falcon7b_attention_softmax_sequence(
             mcast_in0=False,
         )
 
-        attn_out_slice = ttl.operations.primary.matmul(
+        attn_out_slice = ttnn.experimental.operations.primary.matmul(
             mm_slice,
             reference_value_layer,
             program_config=program_config,
             output_mem_config=height_sharded_memory_config,
-            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
             compute_kernel_config=compute_kernel_config,
         )
 
-        ttl.tensor.sharded_to_interleaved_partial(
+        ttnn.experimental.tensor.sharded_to_interleaved_partial(
             attn_out_slice,
             attention_output_concatenated,
             num_slices,
@@ -702,20 +728,20 @@ def test_falcon7b_attention_softmax_sequence(
 
     attention_output_concatenated_torch = tt2torch_tensor(attention_output_concatenated)
 
-    attn_weights = ttl.tensor.matmul(
+    attn_weights = ttnn.experimental.tensor.matmul(
         reference_query_layer, reference_key_layer_transposed, output_mem_config=dram_interleaved_memory_config
     )
 
-    attn_weights = ttl.operations.primary.transformers.scale_mask_softmax_in_place(
+    attn_weights = ttnn.experimental.operations.primary.transformers.scale_mask_softmax_in_place(
         attn_weights,
         scalar_value,
         attention_mask_proper_dim,
-        program_config=ttl.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
+        program_config=ttnn.experimental.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
         is_causal_mask=True,
         compute_kernel_config=compute_kernel_config,
     )
 
-    attn_output = ttl.tensor.matmul(attn_weights, reference_value_layer)
+    attn_output = ttnn.experimental.tensor.matmul(attn_weights, reference_value_layer)
     attn_output_torch = tt2torch_tensor(attn_output)
     passing = True
 
@@ -777,27 +803,30 @@ def test_softmax(device, num_cores, seq_len):
 
     torch_outputs = torch.zeros(input_shape).bfloat16().float()
 
-    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.DRAM,
+    dram_interleaved_memory_config = ttnn.experimental.tensor.MemoryConfig(
+        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttnn.experimental.tensor.BufferType.DRAM,
     )
 
     tt_input = torch2tt_tensor(
         torch_input,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
 
     tt_attention_mask_full = torch2tt_tensor(
         torch_attention_mask_full,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttl.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
 
     tt_scalar = torch2tt_tensor(
-        torch_scalar, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+        torch_scalar,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
 
     tt_attention_masks_per_slice = []
@@ -818,7 +847,7 @@ def test_softmax(device, num_cores, seq_len):
             torch_attention_mask_per_slice,
             device,
             tt_memory_config=dram_interleaved_memory_config,
-            tt_dtype=ttl.tensor.DataType.BFLOAT16,
+            tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
         )
         tt_attention_masks_per_slice.append(tt_attention_slice)
         attention_mask_starting_index_per_slice = (
@@ -826,39 +855,42 @@ def test_softmax(device, num_cores, seq_len):
         ) % seq_len  # mod attention_mask.height
 
     tt_output_sharded_softmax = torch2tt_tensor(
-        torch_outputs, device, tt_memory_config=dram_interleaved_memory_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
+        torch_outputs,
+        device,
+        tt_memory_config=dram_interleaved_memory_config,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
 
     # Sharded softmax
     tiles_per_shard = math.ceil((((head_dim * seq_len) / num_cores) / num_slices) / 32)
     height_shard_spec = [tiles_per_shard * 32, seq_len]
 
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.HiFi4,
+    compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
         packer_l1_acc=True,
     )
 
     for i in range(num_slices):
-        input_slice = ttl.tensor.interleaved_to_sharded_partial(
+        input_slice = ttnn.experimental.tensor.interleaved_to_sharded_partial(
             tt_input,
             grid_size,
             height_shard_spec,
             num_slices,
             i,
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-        softmax_program_config = ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+        softmax_program_config = ttnn.experimental.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
             compute_with_storage_grid_size=grid_size,
             subblock_w=1,
             block_h=height_shard_spec[0] // 32,
             block_w=height_shard_spec[1] // 32,
         )
 
-        input_slice = ttl.operations.primary.transformers.scale_causal_mask_hw_dims_softmax_in_place(
+        input_slice = ttnn.experimental.operations.primary.transformers.scale_causal_mask_hw_dims_softmax_in_place(
             input_slice,
             scalar_value,
             tt_attention_masks_per_slice[i],
@@ -866,26 +898,26 @@ def test_softmax(device, num_cores, seq_len):
             compute_kernel_config=compute_kernel_config,
         )
 
-        ttl.tensor.sharded_to_interleaved_partial(
+        ttnn.experimental.tensor.sharded_to_interleaved_partial(
             input_slice, tt_output_sharded_softmax, num_slices, i, dram_interleaved_memory_config
         )
         input_slice.deallocate()
 
-    out = ttl.operations.primary.bcast(
+    out = ttnn.experimental.operations.primary.bcast(
         tt_input,
         tt_scalar,
-        ttl.tensor.BcastOpMath.MUL,
-        ttl.tensor.BcastOpDim.HW,
+        ttnn.experimental.tensor.BcastOpMath.MUL,
+        ttnn.experimental.tensor.BcastOpDim.HW,
         output_mem_config=dram_interleaved_memory_config,
     )
 
-    out = ttl.tensor.add(
+    out = ttnn.experimental.tensor.add(
         out,
         tt_attention_mask_full,
         output_mem_config=dram_interleaved_memory_config,
     )
 
-    out = ttl.operations.primary.softmax_in_place(out, compute_kernel_config=compute_kernel_config)
+    out = ttnn.experimental.operations.primary.softmax_in_place(out, compute_kernel_config=compute_kernel_config)
 
     out_torch = tt2torch_tensor(out)
     out_torch_view = out_torch.view(1, 1, out_torch.shape[1] * out_torch.shape[2], out_torch.shape[3])

--- a/models/demos/falcon7b/tt/falcon_attention.py
+++ b/models/demos/falcon7b/tt/falcon_attention.py
@@ -7,7 +7,7 @@ import math
 from torch import nn
 from typing import List, Optional, Tuple
 
-import tt_lib
+import ttnn
 
 from models.utility_functions import (
     tt2torch_tensor,
@@ -88,14 +88,16 @@ class TtFalconRotaryEmbedding(torch.nn.Module):
             if not overwrite_sin:
                 break
 
-    def forward(self, layer: tt_lib.tensor.Tensor, token_idx: Optional[int] = None) -> tt_lib.tensor.Tensor:
+    def forward(
+        self, layer: ttnn.experimental.tensor.Tensor, token_idx: Optional[int] = None
+    ) -> ttnn.experimental.tensor.Tensor:
         seq_len = layer[0].get_legacy_shape()[2]
         assert seq_len <= self.max_seq_len_cached, "seq_len exceeds max_seq_len_cached in RotaryEmbedding!"
 
         output = []
         for i in range(len(layer)):
             output.append(
-                tt_lib.tensor.rotary_embedding(
+                ttnn.experimental.tensor.rotary_embedding(
                     layer[i],
                     self.tt_cos_cached[i],
                     self.tt_sin_cached[i],
@@ -190,8 +192,8 @@ class TtFalconAttentionPrefill(nn.Module):
 
                 tt_tensors = torch_tensors_to_tt_tensors(
                     [tensor.detach().clone() for _ in range(self.num_devices)],
-                    tt_lib.tensor.Layout.TILE,
-                    tt_lib.tensor.DataType.BFLOAT16,
+                    ttnn.experimental.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.DataType.BFLOAT16,
                     self.model_config["ATTN_OPTIMIZED_MEMCFG"],
                     self.devices,
                 )
@@ -199,16 +201,16 @@ class TtFalconAttentionPrefill(nn.Module):
 
     def forward(
         self,
-        hidden_states: tt_lib.tensor.Tensor,
+        hidden_states: ttnn.experimental.tensor.Tensor,
         alibi: torch.Tensor,
         attention_mask: torch.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[tt_lib.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: bool = False,
         use_cache: bool = False,
-    ) -> Tuple[tt_lib.tensor.Tensor, Optional[Tuple[tt_lib.tensor.Tensor]]]:
+    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[ttnn.experimental.tensor.Tensor]]]:
         """
         Prefill input shape: [1, 1, seq_len, hidden_size]
         """
@@ -236,7 +238,7 @@ class TtFalconAttentionPrefill(nn.Module):
         fused_query_key_value = []
         for i in range(self.num_devices):
             fused_query_key_value.append(
-                tt_lib.tensor.falcon_fused_qkv_matmul(
+                ttnn.experimental.tensor.falcon_fused_qkv_matmul(
                     hidden_states[i],
                     self.query_key_value_weights[i],
                     output_mem_config=self.model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
@@ -249,7 +251,7 @@ class TtFalconAttentionPrefill(nn.Module):
         ###########
         query_layer, key_layer, value_layer = [], [], []
         for i in range(self.num_devices):
-            query_layer_i, key_layer_i, value_layer_i = tt_lib.tensor.nlp_create_qkv_heads_falcon7b(
+            query_layer_i, key_layer_i, value_layer_i = ttnn.experimental.tensor.nlp_create_qkv_heads_falcon7b(
                 fused_query_key_value[i],
                 output_mem_config=self.model_config["CREATE_QKV_HEADS_OUTPUT_MEMCFG"],
             )
@@ -268,7 +270,7 @@ class TtFalconAttentionPrefill(nn.Module):
         ### K CACHE UPDATE ###
         ######################
         for i in range(self.num_devices):
-            tt_lib.tensor.fill_cache(layer_past[i][0], key_layer[i], user_id)
+            ttnn.experimental.tensor.fill_cache(layer_past[i][0], key_layer[i], user_id)
 
         ######################
         ### PRE-SOFTMAX MM ###
@@ -276,15 +278,16 @@ class TtFalconAttentionPrefill(nn.Module):
         key_layer_transposed = []
         for i in range(self.num_devices):
             key_layer_transposed.append(
-                tt_lib.tensor.transpose(
+                ttnn.experimental.tensor.transpose(
                     key_layer[i],
                     -2,
                     -1,
                     output_mem_config=(
                         self.model_config["K_TRANSPOSED_OUTPUT_MEMCFG"]
                         if llm_mode == "prefill" or self.model_config["l1_sharded"] == False
-                        else tt_lib.tensor.MemoryConfig(
-                            tt_lib.tensor.TensorMemoryLayout.HEIGHT_SHARDED, tt_lib.tensor.BufferType.L1
+                        else ttnn.experimental.tensor.MemoryConfig(
+                            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                            ttnn.experimental.tensor.BufferType.L1,
                         )
                     ),
                 ),
@@ -294,7 +297,7 @@ class TtFalconAttentionPrefill(nn.Module):
         attn_weights = []
         for i in range(self.num_devices):
             attn_weights.append(
-                tt_lib.tensor.matmul(
+                ttnn.experimental.tensor.matmul(
                     query_layer[i],
                     key_layer_transposed[i],
                     output_mem_config=self.model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"],
@@ -304,17 +307,17 @@ class TtFalconAttentionPrefill(nn.Module):
             key_layer_transposed[i].deallocate()
 
         for i in range(self.num_devices):
-            attn_weights[i] = tt_lib.tensor.bcast(
+            attn_weights[i] = ttnn.experimental.tensor.bcast(
                 attn_weights[i],
                 self.scalar[i],
-                tt_lib.tensor.BcastOpMath.MUL,
-                tt_lib.tensor.BcastOpDim.HW,
+                ttnn.experimental.tensor.BcastOpMath.MUL,
+                ttnn.experimental.tensor.BcastOpDim.HW,
                 output_mem_config=self.model_config["PRE_SOFTMAX_SCALE_OUTPUT_MEMCFG"],
             )
 
         if attention_mask is not None:
             for i in range(self.num_devices):
-                attn_weights[i] = tt_lib.tensor.add(
+                attn_weights[i] = ttnn.experimental.tensor.add(
                     attn_weights[i],
                     attention_mask[i],
                     output_mem_config=self.model_config["PRE_SOFTMAX_MASK_OUTPUT_MEMCFG"],
@@ -323,13 +326,15 @@ class TtFalconAttentionPrefill(nn.Module):
         ### SOFTMAX ###
         ###############
         for i in range(self.num_devices):
-            attn_weights[i] = tt_lib.operations.primary.transformers.scale_mask_softmax_in_place(attn_weights[i])
+            attn_weights[i] = ttnn.experimental.operations.primary.transformers.scale_mask_softmax_in_place(
+                attn_weights[i]
+            )
 
         ######################
         ### V CACHE UPDATE ###
         ######################
         for i in range(self.num_devices):
-            tt_lib.tensor.fill_cache(layer_past[i][1], value_layer[i], user_id)
+            ttnn.experimental.tensor.fill_cache(layer_past[i][1], value_layer[i], user_id)
 
         layer_present = layer_past if use_cache else None
 
@@ -339,7 +344,7 @@ class TtFalconAttentionPrefill(nn.Module):
         attn_output = []
         for i in range(self.num_devices):
             attn_output.append(
-                tt_lib.tensor.matmul(
+                ttnn.experimental.tensor.matmul(
                     attn_weights[i],
                     value_layer[i],
                     output_mem_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
@@ -352,13 +357,13 @@ class TtFalconAttentionPrefill(nn.Module):
         ### ATTENTION SELFOUT ###
         #########################
         for i in range(self.num_devices):
-            attn_output[i] = tt_lib.tensor.nlp_concat_heads(
+            attn_output[i] = ttnn.experimental.tensor.nlp_concat_heads(
                 attn_output[i],
                 output_mem_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
             )
 
         for i in range(self.num_devices):
-            attn_output[i] = tt_lib.tensor.falcon_selfout_matmul(
+            attn_output[i] = ttnn.experimental.tensor.falcon_selfout_matmul(
                 attn_output[i],
                 self.dense_weights[i],
                 output_mem_config=self.model_config["SELFOUT_MM_OUTPUT_MEMCFG"],
@@ -369,12 +374,12 @@ class TtFalconAttentionPrefill(nn.Module):
 
     def _optimized_forward(
         self,
-        hidden_states: tt_lib.tensor.Tensor,
+        hidden_states: ttnn.experimental.tensor.Tensor,
         attention_mask: torch.Tensor,
         user_id: int = 0,
-        layer_past: Optional[Tuple[tt_lib.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
         use_cache: bool = False,
-    ) -> Tuple[tt_lib.tensor.Tensor, Optional[Tuple[tt_lib.tensor.Tensor]]]:
+    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[ttnn.experimental.tensor.Tensor]]]:
         seq_len = hidden_states[0].get_legacy_shape()[2]
 
         #################
@@ -382,19 +387,19 @@ class TtFalconAttentionPrefill(nn.Module):
         #################
         if seq_len == 2048:
             fused_query_key_value = [
-                tt_lib.operations.primary.matmul(
+                ttnn.experimental.operations.primary.matmul(
                     hidden_states[device_id],
                     self.query_key_value_weights[device_id],
                     program_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_PROGCFG"],
                     output_mem_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_MEMCFG"],
-                    output_dtype=tt_lib.tensor.DataType.BFLOAT16,
+                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
                     compute_kernel_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_KERNEL_CONFIG"],
                 )
                 for device_id in range(self.num_devices)
             ]
         else:
             fused_query_key_value = [
-                tt_lib.tensor.falcon_fused_qkv_matmul(
+                ttnn.experimental.tensor.falcon_fused_qkv_matmul(
                     hidden_states[device_id],
                     self.query_key_value_weights[device_id],
                     output_mem_config=self.model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
@@ -408,7 +413,7 @@ class TtFalconAttentionPrefill(nn.Module):
         ###########
         query_layer, key_layer, value_layer = [], [], []
         for i in range(self.num_devices):
-            query_layer_i, key_layer_i, value_layer_i = tt_lib.tensor.nlp_create_qkv_heads_falcon7b(
+            query_layer_i, key_layer_i, value_layer_i = ttnn.experimental.tensor.nlp_create_qkv_heads_falcon7b(
                 fused_query_key_value[i],
                 output_mem_config=self.model_config["CREATE_QKV_HEADS_OUTPUT_MEMCFG"],
             )
@@ -427,7 +432,7 @@ class TtFalconAttentionPrefill(nn.Module):
         ### K CACHE UPDATE ###
         ######################
         for i in range(self.num_devices):
-            tt_lib.tensor.fill_cache(layer_past[i][0], key_layer[i], user_id)
+            ttnn.experimental.tensor.fill_cache(layer_past[i][0], key_layer[i], user_id)
 
         ######################
         ### PRE-SOFTMAX MM ###
@@ -435,7 +440,7 @@ class TtFalconAttentionPrefill(nn.Module):
         key_layer_transposed = []
         for i in range(self.num_devices):
             key_layer_transposed.append(
-                tt_lib.tensor.transpose(
+                ttnn.experimental.tensor.transpose(
                     key_layer[i],
                     -2,
                     -1,
@@ -458,14 +463,14 @@ class TtFalconAttentionPrefill(nn.Module):
         # Slice inputs and operate on each slice separately
         for i in range(num_slices):
             slices = [
-                tt_lib.tensor.interleaved_to_sharded_partial(
+                ttnn.experimental.tensor.interleaved_to_sharded_partial(
                     query_layer[device_id],
                     grid_size,
                     mm_activations_height_shard_spec,
                     num_slices,  # num_slices
                     i,  # slice_index
-                    tt_lib.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                    tt_lib.tensor.ShardOrientation.ROW_MAJOR,
+                    ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                    ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
                 )
                 for device_id in range(self.num_devices)
             ]
@@ -479,12 +484,12 @@ class TtFalconAttentionPrefill(nn.Module):
 
             ### QKT MATMUL ###
             mm_slices = [
-                tt_lib.operations.primary.matmul(
+                ttnn.experimental.operations.primary.matmul(
                     slices[device_id],
                     key_layer_transposed[device_id],
                     program_config=qkt_prg_cfg,
                     output_mem_config=self.model_config["QKTV_MM_OPTIMIZED_MEMCFG"],
-                    output_dtype=tt_lib.tensor.DataType.BFLOAT16,
+                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
                     compute_kernel_config=self.model_config["QKTV_AND_SOFTMAX_OPTIMIZED_KERNEL_CONFIG"],
                 )
                 for device_id in range(self.num_devices)
@@ -495,7 +500,7 @@ class TtFalconAttentionPrefill(nn.Module):
             )
             ### SOFTMAX ###
             mm_slices = [
-                tt_lib.operations.primary.transformers.scale_causal_mask_hw_dims_softmax_in_place(
+                ttnn.experimental.operations.primary.transformers.scale_causal_mask_hw_dims_softmax_in_place(
                     mm_slices[device_id],
                     self.scalar_for_optimized_prefill,
                     attention_mask[device_id][i],
@@ -508,19 +513,19 @@ class TtFalconAttentionPrefill(nn.Module):
             ### QKTV MATMUL ###
             qktv_prg_cfg = self.model_config["QKTV_MM_OPTIMIZED_PROGCFG"](tiles_per_shard, seq_len, subblock_h)
             attn_out_slices = [
-                tt_lib.operations.primary.matmul(
+                ttnn.experimental.operations.primary.matmul(
                     mm_slices[device_id],
                     value_layer[device_id],
                     program_config=qktv_prg_cfg,
                     output_mem_config=self.model_config["QKTV_MM_OPTIMIZED_MEMCFG"],
-                    output_dtype=tt_lib.tensor.DataType.BFLOAT16,
+                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
                     compute_kernel_config=self.model_config["QKTV_AND_SOFTMAX_OPTIMIZED_KERNEL_CONFIG"],
                 )
                 for device_id in range(self.num_devices)
             ]
 
             for device_id in range(self.num_devices):
-                tt_lib.tensor.sharded_to_interleaved_partial(
+                ttnn.experimental.tensor.sharded_to_interleaved_partial(
                     attn_out_slices[device_id],
                     attention_outputs_concatenated[device_id],
                     num_slices,
@@ -534,12 +539,12 @@ class TtFalconAttentionPrefill(nn.Module):
 
         # V cache update
         for device_id in range(self.num_devices):
-            tt_lib.tensor.fill_cache(layer_past[device_id][1], value_layer[device_id], user_id)
+            ttnn.experimental.tensor.fill_cache(layer_past[device_id][1], value_layer[device_id], user_id)
 
         layer_present = layer_past if use_cache else None
 
         attn_outputs = [
-            tt_lib.tensor.nlp_concat_heads(
+            ttnn.experimental.tensor.nlp_concat_heads(
                 attention_outputs_concatenated[device_id],
                 output_mem_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
             )
@@ -547,7 +552,7 @@ class TtFalconAttentionPrefill(nn.Module):
         ]
 
         attn_outputs = [
-            tt_lib.tensor.falcon_selfout_matmul(
+            ttnn.experimental.tensor.falcon_selfout_matmul(
                 attn_outputs[device_id],
                 self.dense_weights[device_id],
                 output_mem_config=self.model_config["SELFOUT_MM_OUTPUT_MEMCFG"],
@@ -632,16 +637,16 @@ class TtFalconAttentionDecode(nn.Module):
 
     def forward(
         self,
-        hidden_states: tt_lib.tensor.Tensor,
+        hidden_states: ttnn.experimental.tensor.Tensor,
         alibi: torch.Tensor,
         attention_mask: torch.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[tt_lib.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: bool = False,
         use_cache: bool = False,
-    ) -> Tuple[tt_lib.tensor.Tensor, Optional[Tuple[tt_lib.tensor.Tensor]]]:
+    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[ttnn.experimental.tensor.Tensor]]]:
         """
         Prefill input shape: [batch, 1, seq_len, hidden_size]
         Decode input shape: [seq_len, 1, batch, hidden_size]
@@ -664,7 +669,7 @@ class TtFalconAttentionDecode(nn.Module):
         fused_query_key_value = []
         for i in range(self.num_devices):
             fused_query_key_value.append(
-                tt_lib.tensor.falcon_fused_qkv_matmul(
+                ttnn.experimental.tensor.falcon_fused_qkv_matmul(
                     hidden_states[i],
                     self.query_key_value_weights[i],
                     output_mem_config=self.model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
@@ -677,7 +682,7 @@ class TtFalconAttentionDecode(nn.Module):
         ###########
         query_layer, key_layer, value_layer = [], [], []
         for i in range(self.num_devices):
-            query_layer_i, key_layer_i, value_layer_i = tt_lib.tensor.nlp_create_qkv_heads_falcon7b(
+            query_layer_i, key_layer_i, value_layer_i = ttnn.experimental.tensor.nlp_create_qkv_heads_falcon7b(
                 fused_query_key_value[i],
                 output_mem_config=self.model_config["CREATE_QKV_HEADS_OUTPUT_MEMCFG"],
             )
@@ -697,10 +702,10 @@ class TtFalconAttentionDecode(nn.Module):
         ######################
         for i in range(self.num_devices):
             # Update kv_cache in place
-            tt_lib.tensor.update_cache(layer_past[i][0], key_layer[i], layer_past_len)
+            ttnn.experimental.tensor.update_cache(layer_past[i][0], key_layer[i], layer_past_len)
         for i in range(self.num_devices):
             # key and value layers will have kv_seq_len padded to nearest 32
-            key_layer[i] = tt_lib.tensor.unpad(
+            key_layer[i] = ttnn.experimental.tensor.unpad(
                 layer_past[i][0],
                 [0, 0, 0, 0],
                 [batch - 1, 0, nearest_32(layer_past_len + 1) - 1, self.head_dim - 1],
@@ -709,7 +714,7 @@ class TtFalconAttentionDecode(nn.Module):
 
         if self.model_config["l1_sharded"]:
             for i in range(self.num_devices):
-                key_layer[i] = tt_lib.tensor.interleaved_to_sharded(
+                key_layer[i] = ttnn.experimental.tensor.interleaved_to_sharded(
                     key_layer[i],
                     sharded_mem_config=self.model_config["ATTN_BATCH_SHARDED_MEMCFG"](
                         padded_layer_past_len, self.head_dim
@@ -718,19 +723,19 @@ class TtFalconAttentionDecode(nn.Module):
 
             # Pad and transpose Q for batched matmul
             for i in range(self.num_devices):
-                query_layer[i] = tt_lib.tensor.pad(
+                query_layer[i] = ttnn.experimental.tensor.pad(
                     query_layer[i], [1, self.padded_local_heads, batch, self.head_dim], [0, 0, 0, 0], 0.0
                 )
 
             for i in range(self.num_devices):
-                query_layer[i] = tt_lib.tensor.transpose(
+                query_layer[i] = ttnn.experimental.tensor.transpose(
                     query_layer[i],
                     -2,
                     -3,
                 )
 
             for i in range(self.num_devices):
-                query_layer[i] = tt_lib.tensor.reshape(
+                query_layer[i] = ttnn.experimental.tensor.reshape(
                     query_layer[i],
                     batch,
                     1,
@@ -739,7 +744,7 @@ class TtFalconAttentionDecode(nn.Module):
                 )
 
             for i in range(self.num_devices):
-                query_layer[i] = tt_lib.tensor.interleaved_to_sharded(
+                query_layer[i] = ttnn.experimental.tensor.interleaved_to_sharded(
                     query_layer[i],
                     sharded_mem_config=self.model_config["ATTN_BATCH_SHARDED_MEMCFG"](
                         self.padded_local_heads, self.head_dim
@@ -752,15 +757,16 @@ class TtFalconAttentionDecode(nn.Module):
         key_layer_transposed = []
         for i in range(self.num_devices):
             key_layer_transposed.append(
-                tt_lib.tensor.transpose(
+                ttnn.experimental.tensor.transpose(
                     key_layer[i],
                     -2,
                     -1,
                     output_mem_config=(
                         self.model_config["K_TRANSPOSED_OUTPUT_MEMCFG"]
                         if self.model_config["l1_sharded"] == False
-                        else tt_lib.tensor.MemoryConfig(
-                            tt_lib.tensor.TensorMemoryLayout.HEIGHT_SHARDED, tt_lib.tensor.BufferType.L1
+                        else ttnn.experimental.tensor.MemoryConfig(
+                            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+                            ttnn.experimental.tensor.BufferType.L1,
                         )
                     ),
                 ),
@@ -771,7 +777,7 @@ class TtFalconAttentionDecode(nn.Module):
         if self.model_config["l1_sharded"]:
             for i, device in enumerate(self.devices):
                 attn_weights.append(
-                    tt_lib.operations.primary.matmul(
+                    ttnn.experimental.operations.primary.matmul(
                         query_layer[i],
                         key_layer_transposed[i],
                         program_config=self.model_config["ATTN_BATCHED_MM_PROGCFG"](
@@ -789,7 +795,7 @@ class TtFalconAttentionDecode(nn.Module):
         elif is_wormhole_b0():
             for i, device in enumerate(self.devices):
                 attn_weights.append(
-                    tt_lib.operations.primary.transformers.attn_matmul(
+                    ttnn.experimental.operations.primary.transformers.attn_matmul(
                         query_layer[i],
                         key_layer_transposed[i],
                         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
@@ -802,7 +808,7 @@ class TtFalconAttentionDecode(nn.Module):
         else:
             for i, device in enumerate(self.devices):
                 attn_weights.append(
-                    tt_lib.operations.primary.transformers.group_attn_matmul(
+                    ttnn.experimental.operations.primary.transformers.group_attn_matmul(
                         query_layer[i],
                         key_layer_transposed[i],
                         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
@@ -815,17 +821,17 @@ class TtFalconAttentionDecode(nn.Module):
 
         if self.model_config["l1_sharded"] == False:
             for i in range(self.num_devices):
-                attn_weights[i] = tt_lib.tensor.bcast(
+                attn_weights[i] = ttnn.experimental.tensor.bcast(
                     attn_weights[i],
                     self.scalar[i],
-                    tt_lib.tensor.BcastOpMath.MUL,
-                    tt_lib.tensor.BcastOpDim.HW,
+                    ttnn.experimental.tensor.BcastOpMath.MUL,
+                    ttnn.experimental.tensor.BcastOpDim.HW,
                     output_mem_config=self.model_config["PRE_SOFTMAX_SCALE_OUTPUT_MEMCFG"],
                 )
 
             if attention_mask is not None:
                 for i in range(self.num_devices):
-                    attn_weights[i] = tt_lib.tensor.add(
+                    attn_weights[i] = ttnn.experimental.tensor.add(
                         attn_weights[i],
                         attention_mask[i],
                         output_mem_config=self.model_config["PRE_SOFTMAX_MASK_OUTPUT_MEMCFG"],
@@ -834,17 +840,19 @@ class TtFalconAttentionDecode(nn.Module):
             ### SOFTMAX ###
             ###############
             for i in range(self.num_devices):
-                attn_weights[i] = tt_lib.operations.primary.transformers.scale_mask_softmax_in_place(attn_weights[i])
+                attn_weights[i] = ttnn.experimental.operations.primary.transformers.scale_mask_softmax_in_place(
+                    attn_weights[i]
+                )
         else:
             ###############
             ### SOFTMAX ###
             ###############
             for i in range(self.num_devices):
-                attn_weights[i] = tt_lib.operations.primary.transformers.scale_mask_softmax_in_place(
+                attn_weights[i] = ttnn.experimental.operations.primary.transformers.scale_mask_softmax_in_place(
                     attn_weights[i],
                     scale=self.scale,
                     mask=attention_mask[i],
-                    program_config=tt_lib.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+                    program_config=ttnn.experimental.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
                         compute_with_storage_grid_size=(8, 4),
                         subblock_w=1,
                         block_h=self.padded_local_heads // 32,
@@ -858,9 +866,9 @@ class TtFalconAttentionDecode(nn.Module):
         ######################
         for i in range(self.num_devices):
             # Update kv_cache in place
-            tt_lib.tensor.update_cache(layer_past[i][1], value_layer[i], layer_past_len)
+            ttnn.experimental.tensor.update_cache(layer_past[i][1], value_layer[i], layer_past_len)
         for i in range(self.num_devices):
-            value_layer[i] = tt_lib.tensor.unpad(
+            value_layer[i] = ttnn.experimental.tensor.unpad(
                 layer_past[i][1],
                 [0, 0, 0, 0],
                 [batch - 1, 0, nearest_32(layer_past_len + 1) - 1, self.head_dim - 1],
@@ -868,7 +876,7 @@ class TtFalconAttentionDecode(nn.Module):
             )
         if self.model_config["l1_sharded"]:
             for i in range(self.num_devices):
-                value_layer[i] = tt_lib.tensor.interleaved_to_sharded(
+                value_layer[i] = ttnn.experimental.tensor.interleaved_to_sharded(
                     value_layer[i],
                     sharded_mem_config=self.model_config["ATTN_BATCH_SHARDED_MEMCFG"](
                         padded_layer_past_len, self.head_dim
@@ -884,7 +892,7 @@ class TtFalconAttentionDecode(nn.Module):
         if self.model_config["l1_sharded"]:
             for i in range(self.num_devices):
                 attn_output.append(
-                    tt_lib.operations.primary.matmul(
+                    ttnn.experimental.operations.primary.matmul(
                         attn_weights[i],
                         value_layer[i],
                         program_config=self.model_config["ATTN_BATCHED_MM_PROGCFG"](
@@ -904,17 +912,19 @@ class TtFalconAttentionDecode(nn.Module):
                 value_layer[i].deallocate()
 
             for i in range(self.num_devices):
-                attn_output[i] = tt_lib.tensor.sharded_to_interleaved(
+                attn_output[i] = ttnn.experimental.tensor.sharded_to_interleaved(
                     attn_output[i], output_mem_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"]
                 )
 
             # Get batch in dim 1
             for i in range(self.num_devices):
-                attn_output[i] = tt_lib.tensor.reshape(attn_output[i], 1, batch, self.padded_local_heads, self.head_dim)
+                attn_output[i] = ttnn.experimental.tensor.reshape(
+                    attn_output[i], 1, batch, self.padded_local_heads, self.head_dim
+                )
 
             # Get batch in dim 2
             for i in range(self.num_devices):
-                attn_output[i] = tt_lib.tensor.transpose(
+                attn_output[i] = ttnn.experimental.tensor.transpose(
                     attn_output[i],
                     -2,
                     -3,
@@ -923,7 +933,7 @@ class TtFalconAttentionDecode(nn.Module):
             # UNPAD
             attn_output_shape = attn_output[0].get_legacy_shape()
             for i in range(self.num_devices):
-                attn_output[i] = tt_lib.tensor.unpad(
+                attn_output[i] = ttnn.experimental.tensor.unpad(
                     attn_output[i],
                     [0, 0, 0, 0],
                     [
@@ -939,7 +949,7 @@ class TtFalconAttentionDecode(nn.Module):
                 # TODO: switch to group_attn_matmul once multiple q heads is supported (issue #5318)
                 if is_wormhole_b0():
                     attn_output.append(
-                        tt_lib.operations.primary.transformers.attn_matmul(
+                        ttnn.experimental.operations.primary.transformers.attn_matmul(
                             attn_weights[i],
                             value_layer[i],
                             compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
@@ -949,7 +959,7 @@ class TtFalconAttentionDecode(nn.Module):
                     )
                 else:
                     attn_output.append(
-                        tt_lib.operations.primary.transformers.group_attn_matmul(
+                        ttnn.experimental.operations.primary.transformers.group_attn_matmul(
                             attn_weights[i],
                             value_layer[i],
                             compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
@@ -964,13 +974,13 @@ class TtFalconAttentionDecode(nn.Module):
         ### ATTENTION SELFOUT ###
         #########################
         for i in range(self.num_devices):
-            attn_output[i] = tt_lib.tensor.nlp_concat_heads(
+            attn_output[i] = ttnn.experimental.tensor.nlp_concat_heads(
                 attn_output[i],
                 output_mem_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
             )
 
         for i in range(self.num_devices):
-            attn_output[i] = tt_lib.tensor.falcon_selfout_matmul(
+            attn_output[i] = ttnn.experimental.tensor.falcon_selfout_matmul(
                 attn_output[i],
                 self.dense_weights[i],
                 output_mem_config=self.model_config["SELFOUT_MM_OUTPUT_MEMCFG"],

--- a/models/demos/falcon7b/tt/falcon_causallm.py
+++ b/models/demos/falcon7b/tt/falcon_causallm.py
@@ -5,7 +5,7 @@
 from typing import Optional, Tuple
 
 import torch
-import tt_lib
+import ttnn
 from models.demos.falcon7b.tt.falcon_lm_head import falcon_lm_head_matmul_2d
 from models.demos.falcon7b.tt.falcon_model import TtFalconModelShared
 from models.demos.falcon7b.tt.model_utils import get_weights_cached
@@ -69,7 +69,7 @@ class TtFalconCausalLM(TtFalconModelShared):
 
             tt_paddings = torch_tensors_to_tt_tensors(
                 [padding.detach().clone() for _ in range(self.num_devices)],
-                tt_lib.tensor.Layout.TILE,
+                ttnn.experimental.tensor.Layout.TILE,
                 self.model_config["LM_HEAD_MM_INPUT_DTYPE"],
                 self.model_config["LM_HEAD_MM_INPUT_MEMCFG"],
                 self.devices,
@@ -87,14 +87,14 @@ class TtFalconCausalLM(TtFalconModelShared):
 
     def forward(
         self,
-        input_ids: tt_lib.tensor.Tensor,
+        input_ids: ttnn.experimental.tensor.Tensor,
         llm_mode: str,
-        attention_mask: tt_lib.tensor.Tensor = None,
+        attention_mask: ttnn.experimental.tensor.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.experimental.tensor.Tensor:
         hidden_states, presents = super().forward(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -119,7 +119,7 @@ class TtFalconCausalLM(TtFalconModelShared):
             ]
         else:
             lm_logits = [
-                tt_lib.tensor.falcon_lm_head_matmul(
+                ttnn.experimental.tensor.falcon_lm_head_matmul(
                     hidden_states[device_id],
                     self.lm_head_weights[device_id],
                     bias=None,

--- a/models/demos/falcon7b/tt/falcon_lm_head.py
+++ b/models/demos/falcon7b/tt/falcon_lm_head.py
@@ -2,10 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
 from typing import List
 
 import tt_lib
+import ttnn
 
 from models.utility_functions import nearest_y
 
@@ -15,12 +15,12 @@ from models.utility_functions import nearest_y
 # it also takes in number of slices since this should be determined at the moment of pushing weights,
 # but in general with 512 < seq_len <= 1024 we should use 4 slices, with 1024 < seq_len <= 2048 we should use 8 slices
 def falcon_lm_head_matmul_2d(
-    hidden_states: tt_lib.tensor.Tensor,
-    weights: List[tt_lib.tensor.Tensor],
+    hidden_states: ttnn.experimental.tensor.Tensor,
+    weights: List[ttnn.experimental.tensor.Tensor],
     num_slices: int,
-    lm_head_padding: tt_lib.tensor.Tensor,
-    out_mem_config: tt_lib.tensor.MemoryConfig,
-    out_dtype: tt_lib.tensor.DataType,
+    lm_head_padding: ttnn.experimental.tensor.Tensor,
+    out_mem_config: ttnn.experimental.tensor.MemoryConfig,
+    out_dtype: ttnn.experimental.tensor.DataType,
 ):
     assert (
         hidden_states.device().arch() == tt_lib.device.Arch.WORMHOLE_B0
@@ -40,10 +40,10 @@ def falcon_lm_head_matmul_2d(
         weights_inner_dim_in_tiles == 144
     ), f"Weights are expected to be padded to the inner dim 144 in tiles, instead they are {weights_inner_dim_in_tiles}"
 
-    hidden_states = tt_lib.tensor.concat([hidden_states, lm_head_padding], -1)
+    hidden_states = ttnn.experimental.tensor.concat([hidden_states, lm_head_padding], -1)
 
-    compute_kernel_config = tt_lib.tensor.WormholeComputeKernelConfig(
-        math_fidelity=tt_lib.tensor.MathFidelity.LoFi,
+    compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
         packer_l1_acc=True,
@@ -61,7 +61,7 @@ def falcon_lm_head_matmul_2d(
     per_core_N = nearest_y(weights_n_in_tiles / grid.x, out_subblock_w)
     in0_block_w = 4 if seq_len <= 1024 else 8
 
-    program_config = tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -75,7 +75,7 @@ def falcon_lm_head_matmul_2d(
     out_slices = []
     for i in range(num_slices):
         out_slices.append(
-            tt_lib.operations.primary.matmul(
+            ttnn.experimental.operations.primary.matmul(
                 hidden_states,
                 weights[i],
                 program_config=program_config,
@@ -85,7 +85,7 @@ def falcon_lm_head_matmul_2d(
             )
         )
 
-    out = tt_lib.tensor.concat(out_slices, -1)
+    out = ttnn.experimental.tensor.concat(out_slices, -1)
     for i in range(num_slices):
         out_slices[i].deallocate(True)
 

--- a/models/demos/falcon7b/tt/falcon_model.py
+++ b/models/demos/falcon7b/tt/falcon_model.py
@@ -6,7 +6,6 @@ from abc import abstractmethod
 from typing import List, Optional, Tuple
 
 import torch
-import tt_lib
 import ttnn
 
 from models.demos.falcon7b.tt.falcon_decoder import TtFalconDecoderLayer
@@ -50,7 +49,7 @@ class TtFalconModelShared(torch.nn.Module):
             embedding_weights_str,
             weight_config_str="WORD_EMBEDDING_WEIGHTS",
             weights_to_cache=(state_dict[embedding_weights_str] if state_dict else None),
-            tt_layout=tt_lib.tensor.Layout.ROW_MAJOR,
+            tt_layout=ttnn.experimental.tensor.Layout.ROW_MAJOR,
         )
 
         # stack all decoders
@@ -131,8 +130,8 @@ class TtFalconModelShared(torch.nn.Module):
                 attn_masks_unordered = [
                     torch_tensors_to_tt_tensors(
                         [attention_mask_slice for _ in self.devices],
-                        tt_lib.tensor.Layout.ROW_MAJOR,
-                        tt_lib.tensor.DataType.BFLOAT16,  # subsequent tilize op excepts bfloat16 inputs
+                        ttnn.experimental.tensor.Layout.ROW_MAJOR,
+                        ttnn.experimental.tensor.DataType.BFLOAT16,  # subsequent tilize op excepts bfloat16 inputs
                         self.model_config["ATTN_MASK_MEMCFG"],
                         self.devices,
                     )
@@ -141,7 +140,7 @@ class TtFalconModelShared(torch.nn.Module):
                 # Tilize attn masks
                 for tt_attention_mask_slice in attn_masks_unordered:
                     for i in range(self.num_devices):
-                        tt_attention_mask_slice[i] = tt_lib.tensor.tilize(
+                        tt_attention_mask_slice[i] = ttnn.experimental.tensor.tilize(
                             tt_attention_mask_slice[i],
                             output_mem_config=self.model_config["ATTN_MASK_MEMCFG"],
                             output_dtype=self.model_config["ATTN_MASK_DTYPE"],
@@ -155,21 +154,21 @@ class TtFalconModelShared(torch.nn.Module):
                 # Send attn masks to device
                 tt_attention_mask = torch_tensors_to_tt_tensors(
                     attention_masks,
-                    tt_lib.tensor.Layout.ROW_MAJOR,
-                    tt_lib.tensor.DataType.BFLOAT16,  # subsequent tilize op excepts bfloat16 inputs
+                    ttnn.experimental.tensor.Layout.ROW_MAJOR,
+                    ttnn.experimental.tensor.DataType.BFLOAT16,  # subsequent tilize op excepts bfloat16 inputs
                     self.model_config["ATTN_MASK_MEMCFG"],
                     self.devices,
                 )
                 # Repeat attn masks for all heads
                 for i in range(self.num_devices):
-                    tt_attention_mask[i] = tt_lib.tensor.repeat(
+                    tt_attention_mask[i] = ttnn.experimental.tensor.repeat(
                         tt_attention_mask[i],
                         [1, self.config.num_attention_heads, 1, 1],
                         output_mem_config=self.model_config["ATTN_MASK_MEMCFG"],
                     )
                 # Tilize attn masks
                 for i in range(self.num_devices):
-                    tt_attention_mask[i] = tt_lib.tensor.tilize(
+                    tt_attention_mask[i] = ttnn.experimental.tensor.tilize(
                         tt_attention_mask[i],
                         output_mem_config=self.model_config["ATTN_MASK_MEMCFG"],
                         output_dtype=self.model_config["ATTN_MASK_DTYPE"],
@@ -219,14 +218,14 @@ class TtFalconModelShared(torch.nn.Module):
             # Send attn masks to device
             tt_attention_mask = torch_tensors_to_tt_tensors(
                 attention_masks,
-                tt_lib.tensor.Layout.ROW_MAJOR,
-                tt_lib.tensor.DataType.BFLOAT16,  # subsequent tilize op excepts bfloat16 inputs
+                ttnn.experimental.tensor.Layout.ROW_MAJOR,
+                ttnn.experimental.tensor.DataType.BFLOAT16,  # subsequent tilize op excepts bfloat16 inputs
                 self.model_config["ATTN_MASK_MEMCFG"],
                 self.devices,
             )
             # Tilize attn masks
             for i in range(self.num_devices):
-                tt_attention_mask[i] = tt_lib.tensor.tilize(
+                tt_attention_mask[i] = ttnn.experimental.tensor.tilize(
                     tt_attention_mask[i],
                     output_mem_config=self.model_config["ATTN_MASK_MEMCFG"],
                     output_dtype=self.model_config["ATTN_MASK_DTYPE"],
@@ -234,7 +233,7 @@ class TtFalconModelShared(torch.nn.Module):
 
             if self.model_config["l1_sharded"]:
                 for i, device in enumerate(self.devices):
-                    tt_attention_mask[i] = tt_lib.tensor.interleaved_to_sharded(
+                    tt_attention_mask[i] = ttnn.experimental.tensor.interleaved_to_sharded(
                         tt_attention_mask[i],
                         sharded_mem_config=self.model_config["ATTN_BATCH_SHARDED_MEMCFG"](
                             nearest_32(self.config.num_attention_heads), num_max_tokens
@@ -260,14 +259,14 @@ class TtFalconModelShared(torch.nn.Module):
     @abstractmethod
     def forward(
         self,
-        input_ids: tt_lib.tensor.Tensor,
+        input_ids: ttnn.experimental.tensor.Tensor,
         llm_mode: str,
-        attention_mask: tt_lib.tensor.Tensor = None,
+        attention_mask: ttnn.experimental.tensor.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.experimental.tensor.Tensor:
         # Convert input tokens to embeddings
         input_embeddings = [
             ttnn.embedding(
@@ -280,7 +279,7 @@ class TtFalconModelShared(torch.nn.Module):
         for i in range(self.num_devices):
             input_embeddings[i] = ttnn.unsqueeze_to_4D(input_embeddings[i])
         for i in range(self.num_devices):
-            input_embeddings[i] = ttnn.to_layout(input_embeddings[i], tt_lib.tensor.Layout.TILE)
+            input_embeddings[i] = ttnn.to_layout(input_embeddings[i], ttnn.experimental.tensor.Layout.TILE)
 
         layer_output = input_embeddings
         presents = ()
@@ -300,25 +299,25 @@ class TtFalconModelShared(torch.nn.Module):
 
         # apply final norm layer
         for i in range(self.num_devices):
-            layer_output[i] = tt_lib.tensor.layernorm(
+            layer_output[i] = ttnn.experimental.tensor.layernorm(
                 layer_output[i],
                 self.layernorm_eps,
                 output_mem_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
             )
         for i in range(self.num_devices):
-            layer_output[i] = tt_lib.tensor.bcast(
+            layer_output[i] = ttnn.experimental.tensor.bcast(
                 layer_output[i],
                 self.layernorm_gamma[i],
-                tt_lib.tensor.BcastOpMath.MUL,
-                tt_lib.tensor.BcastOpDim.H,
+                ttnn.experimental.tensor.BcastOpMath.MUL,
+                ttnn.experimental.tensor.BcastOpDim.H,
                 output_mem_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
             )
         for i in range(self.num_devices):
-            layer_output[i] = tt_lib.tensor.bcast(
+            layer_output[i] = ttnn.experimental.tensor.bcast(
                 layer_output[i],
                 self.layernorm_beta[i],
-                tt_lib.tensor.BcastOpMath.ADD,
-                tt_lib.tensor.BcastOpDim.H,
+                ttnn.experimental.tensor.BcastOpMath.ADD,
+                ttnn.experimental.tensor.BcastOpDim.H,
                 output_mem_config=self.model_config["LN_F_OUTPUT_MEMCFG"],
             )
 
@@ -350,14 +349,14 @@ class TtFalconModel(TtFalconModelShared):
 
     def forward(
         self,
-        input_ids: tt_lib.tensor.Tensor,
+        input_ids: ttnn.experimental.tensor.Tensor,
         llm_mode: str,
-        attention_mask: tt_lib.tensor.Tensor = None,
+        attention_mask: ttnn.experimental.tensor.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.experimental.tensor.Tensor:
         hidden_states, presents = super().forward(
             input_ids=input_ids,
             llm_mode=llm_mode,

--- a/models/demos/falcon7b/tt/model_config.py
+++ b/models/demos/falcon7b/tt/model_config.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib as ttl
+import ttnn
 from loguru import logger
 from pathlib import Path
 from models.utility_functions import is_grayskull, is_wormhole_b0
@@ -94,9 +94,13 @@ def pretty_print_model_config(model_config):
 
 def get_model_config(model_config_str, prefill_seq_len=0):
     assert model_config_str in ACCEPTABLE_MODEL_CONFIG_STRS
-    DRAM_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
-    L1_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
-    BFP8_DTYPE = ttl.tensor.DataType.BFLOAT8_B
+    DRAM_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
+        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
+    )
+    L1_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
+        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.L1
+    )
+    BFP8_DTYPE = ttnn.experimental.tensor.DataType.BFLOAT8_B
 
     # Set default dtype and mem_config based on model_config_str
     if model_config_str in ("BFLOAT16-DRAM", "BFLOAT16-L1", "BFLOAT16-L1_SHARDED"):
@@ -104,7 +108,11 @@ def get_model_config(model_config_str, prefill_seq_len=0):
         # TODO: Set default memcfg for BFLOAT16-L1 to L1
         # mem_config = DRAM_MEMCFG if mem_config_str == "DRAM" else L1_MEMCFG
         mem_config = DRAM_MEMCFG
-        dtype = ttl.tensor.DataType.BFLOAT16 if dtype_str == "BFLOAT16" else ttl.tensor.DataType.BFLOAT8_B
+        dtype = (
+            ttnn.experimental.tensor.DataType.BFLOAT16
+            if dtype_str == "BFLOAT16"
+            else ttnn.experimental.tensor.DataType.BFLOAT8_B
+        )
     else:
         raise NotImplementedError(f"Model config {model_config_str} is not supported!")
 
@@ -120,7 +128,7 @@ def get_model_config(model_config_str, prefill_seq_len=0):
     model_config.update({f"{key}_DTYPE": dtype for key in OP_KEYS if key not in NO_DTYPE})
 
     # Input ids are UINT32
-    model_config["INPUT_DTYPE"] = ttl.tensor.DataType.UINT32
+    model_config["INPUT_DTYPE"] = ttnn.experimental.tensor.DataType.UINT32
 
     # Matmul Weights must always be BFP8_B
     # Override defaults for certain configs
@@ -140,16 +148,18 @@ def get_model_config(model_config_str, prefill_seq_len=0):
 
     if model_config_str in ("BFLOAT16-L1_SHARDED"):
         # Q, K, V are batch sharded across cores
-        model_config["ATTN_BATCH_SHARDED_MEMCFG"] = lambda shard_height, shard_width: ttl.tensor.MemoryConfig(
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.BufferType.L1,
-            ttl.tensor.ShardSpec(
-                ttl.tensor.CoreRangeSet(
+        model_config[
+            "ATTN_BATCH_SHARDED_MEMCFG"
+        ] = lambda shard_height, shard_width: ttnn.experimental.tensor.MemoryConfig(
+            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.experimental.tensor.BufferType.L1,
+            ttnn.experimental.tensor.ShardSpec(
+                ttnn.experimental.tensor.CoreRangeSet(
                     {
-                        ttl.tensor.CoreRange(
+                        ttnn.experimental.tensor.CoreRange(
                             # Volume must match batch size
-                            ttl.tensor.CoreCoord(0, 0),
-                            ttl.tensor.CoreCoord(7, 3),
+                            ttnn.experimental.tensor.CoreCoord(0, 0),
+                            ttnn.experimental.tensor.CoreCoord(7, 3),
                         ),
                     }
                 ),
@@ -157,14 +167,14 @@ def get_model_config(model_config_str, prefill_seq_len=0):
                     shard_height,
                     shard_width,
                 ],
-                ttl.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
 
         model_config[
             "ATTN_BATCHED_MM_PROGCFG"
-        ] = lambda block_w, per_core_M, per_core_N: ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+        ] = lambda block_w, per_core_M, per_core_N: ttnn.experimental.operations.primary.MatmulMultiCoreReuseProgramConfig(
             compute_with_storage_grid_size=[8, 4],
             in0_block_w=block_w,
             out_subblock_h=1,  # TODO: Maximize
@@ -174,15 +184,15 @@ def get_model_config(model_config_str, prefill_seq_len=0):
         )
 
         if is_wormhole_b0():
-            model_config["COMPUTE_KERNEL_CONFIG"] = ttl.tensor.WormholeComputeKernelConfig(
-                math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            model_config["COMPUTE_KERNEL_CONFIG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
                 math_approx_mode=True,
                 fp32_dest_acc_en=True,
                 packer_l1_acc=True,
             )
         else:
-            model_config["COMPUTE_KERNEL_CONFIG"] = ttl.tensor.GrayskullComputeKernelConfig(
-                math_fidelity=ttl.tensor.MathFidelity.LoFi,
+            model_config["COMPUTE_KERNEL_CONFIG"] = ttnn.experimental.tensor.GrayskullComputeKernelConfig(
+                math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
                 math_approx_mode=True,
             )
 
@@ -200,14 +210,14 @@ def set_prefill_config(model_config, seq_len, dram_memcfg):
     model_config["MLP_PADDING_VALUE"] = 4608
     model_config["MLP_GRID_SIZE"] = (8, 8)
 
-    model_config["MLP_KERNEL_CONFIG"] = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
+    model_config["MLP_KERNEL_CONFIG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
         math_approx_mode=False,
         fp32_dest_acc_en=False,
         packer_l1_acc=True,
     )
 
-    mm_h_to_4h_prog_cfg = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    mm_h_to_4h_prog_cfg = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=model_config["MLP_GRID_SIZE"],
         in0_block_w=3,
         out_subblock_h=1,
@@ -215,11 +225,11 @@ def set_prefill_config(model_config, seq_len, dram_memcfg):
         per_core_M=4,
         per_core_N=72,
         transpose_mcast=False,
-        fused_activation=[ttl.tensor.FusibleActivation.GELU, True],
+        fused_activation=[ttnn.experimental.tensor.FusibleActivation.GELU, True],
     )
     model_config["DENSE_H_TO_4H_MM_PROGCFG"] = mm_h_to_4h_prog_cfg
 
-    mm_4h_to_h_prog_cfg = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    mm_4h_to_h_prog_cfg = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=model_config["MLP_GRID_SIZE"],
         in0_block_w=8,
         out_subblock_h=1,
@@ -233,7 +243,9 @@ def set_prefill_config(model_config, seq_len, dram_memcfg):
     model_config["MLP_INTERLEAVED_TO_SHARDED_MEM_CFG"] = dram_memcfg
 
     model_config["FUSED_QKV_MM_OPTIMIZED_MEMCFG"] = dram_memcfg
-    model_config["FUSED_QKV_MM_OPTIMIZED_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    model_config[
+        "FUSED_QKV_MM_OPTIMIZED_PROGCFG"
+    ] = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=(8, 8),
         in0_block_w=2,
         per_core_M=8,
@@ -243,8 +255,8 @@ def set_prefill_config(model_config, seq_len, dram_memcfg):
         transpose_mcast=False,
         fused_activation=None,
     )
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
+    compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
         packer_l1_acc=True,
@@ -255,7 +267,7 @@ def set_prefill_config(model_config, seq_len, dram_memcfg):
 
     model_config[
         "QKT_OPTIMIZED_PROGCFG"
-    ] = lambda tiles_per_shard, seq_len, subblock_h, subblock_w: ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    ] = lambda tiles_per_shard, seq_len, subblock_h, subblock_w: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=model_config["ATTN_OPTIMIZED_GRID_SIZE"],
         in0_block_w=2,
         per_core_M=tiles_per_shard,
@@ -266,12 +278,13 @@ def set_prefill_config(model_config, seq_len, dram_memcfg):
         fused_activation=None,
         mcast_in0=False,
     )
-    model_config["QKTV_MM_OPTIMIZED_MEMCFG"] = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttl.tensor.BufferType.L1
+    model_config["QKTV_MM_OPTIMIZED_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
+        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=ttnn.experimental.tensor.BufferType.L1,
     )
 
-    model_config["QKTV_AND_SOFTMAX_OPTIMIZED_KERNEL_CONFIG"] = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.HiFi4,
+    model_config["QKTV_AND_SOFTMAX_OPTIMIZED_KERNEL_CONFIG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
         packer_l1_acc=True,
@@ -279,7 +292,7 @@ def set_prefill_config(model_config, seq_len, dram_memcfg):
 
     model_config[
         "SOFTMAX_OPTIMIZED_PROGCFG"
-    ] = lambda grid_size, subblock_w, block_h, block_w: ttl.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
+    ] = lambda grid_size, subblock_w, block_h, block_w: ttnn.experimental.operations.primary.transformers.SoftmaxShardedMultiCoreProgramConfig(
         compute_with_storage_grid_size=grid_size,
         subblock_w=subblock_w,
         block_h=block_h,
@@ -288,7 +301,7 @@ def set_prefill_config(model_config, seq_len, dram_memcfg):
 
     model_config[
         "QKTV_MM_OPTIMIZED_PROGCFG"
-    ] = lambda tiles_per_shard, seq_len, subblock_h: ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    ] = lambda tiles_per_shard, seq_len, subblock_h: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=model_config["ATTN_OPTIMIZED_GRID_SIZE"],
         in0_block_w=seq_len // 32,
         per_core_M=tiles_per_shard,

--- a/models/demos/falcon7b/tt/model_utils.py
+++ b/models/demos/falcon7b/tt/model_utils.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
+import ttnn
 
 from models.utility_functions import torch2tt_tensor, pad_by_zero
 
@@ -17,12 +17,12 @@ def get_weights_cached(
     weights_to_cache,
     overwrite=False,
     padzero=False,
-    tt_layout=tt_lib.tensor.Layout.TILE,
+    tt_layout=ttnn.experimental.tensor.Layout.TILE,
     weights_dict=None,
     custom_output_shape=None,
 ):
     if padzero:
-        assert tt_layout == tt_lib.tensor.Layout.TILE, "padding by zero currently only uses TILE layout"
+        assert tt_layout == ttnn.experimental.tensor.Layout.TILE, "padding by zero currently only uses TILE layout"
 
     """Load weights from weights_dict or cache and duplicate per device. Store if not cached."""
     custom_output_shape_str = ""
@@ -37,7 +37,7 @@ def get_weights_cached(
         weights = weights_dict[str(path)]
     elif not overwrite and path.exists():
         # Load cached weights
-        weights_host = tt_lib.tensor.load_tensor(str(path))
+        weights_host = ttnn.experimental.tensor.load_tensor(str(path))
         # Duplicate weights on all devices
         weights = [weights_host.to(device, model_config[f"{weight_config_str}_MEMCFG"]) for device in devices]
         # Add to weights_dict
@@ -77,6 +77,6 @@ def get_weights_cached(
         if weights_dict is not None:
             weights_dict[str(path)] = weights[0]
         # Store weights
-        tt_lib.tensor.dump_tensor(str(path), weights_host)
+        ttnn.experimental.tensor.dump_tensor(str(path), weights_host)
 
     return weights


### PR DESCRIPTION
- Convert tt_lib.tensor and tt_lib.operations calls to ttnn.experimental
- Note: calls to tt_lib.device are left as is for now since ttnn.experimental.device does not exist