### PR TITLE
#8885: Add forward support for EQ_, NE_

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -307,6 +307,8 @@ Pointwise Binary
    ttnn/lt_
    ttnn/ge_
    ttnn/le_
+   ttnn/eq_
+   ttnn/ne_
    ttnn/ge
    ttnn/lt
    ttnn/le

--- a/docs/source/ttnn/ttnn/ttnn/eq_.rst
+++ b/docs/source/ttnn/ttnn/ttnn/eq_.rst
@@ -1,0 +1,6 @@
+.. _ttnn.eq_:
+
+ttnn.eq_
+#########
+
+.. autofunction:: ttnn.eq_

--- a/docs/source/ttnn/ttnn/ttnn/ne_.rst
+++ b/docs/source/ttnn/ttnn/ttnn/ne_.rst
@@ -1,0 +1,6 @@
+.. _ttnn.ne_:
+
+ttnn.ne_
+#########
+
+.. autofunction:: ttnn.ne_

--- a/tests/ttnn/unit_tests/operations/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_composite.py
@@ -698,3 +698,85 @@ def test_lei_ttnn(input_shapes, scalar, device):
 
     comp_pass = compare_equal([input_tensor], [golden_tensor])
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_eqi_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+    ttnn.eq_(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.eq_)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_equal([input_tensor1], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "scalar",
+    {random.randint(-100, 100) + 0.5 for _ in range(5)},
+)
+def test_eqi_ttnn(input_shapes, scalar, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    ttnn.eq_(input_tensor, scalar)
+    golden_function = ttnn.get_golden_function(ttnn.eq_)
+    golden_tensor = golden_function(in_data, scalar)
+
+    comp_pass = compare_equal([input_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_nei_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+    ttnn.ne_(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.ne_)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_equal([input_tensor1], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "scalar",
+    {random.randint(-100, 100) + 0.5 for _ in range(5)},
+)
+def test_nei_ttnn(input_shapes, scalar, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    ttnn.ne_(input_tensor, scalar)
+    golden_function = ttnn.get_golden_function(ttnn.ne_)
+    golden_tensor = golden_function(in_data, scalar)
+
+    comp_pass = compare_equal([input_tensor], [golden_tensor])
+    assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -521,6 +521,8 @@ template struct InplaceRelationalBinary<BinaryOpType::GT>;
 template struct InplaceRelationalBinary<BinaryOpType::LT>;
 template struct InplaceRelationalBinary<BinaryOpType::GTE>;
 template struct InplaceRelationalBinary<BinaryOpType::LTE>;
+template struct InplaceRelationalBinary<BinaryOpType::EQ>;
+template struct InplaceRelationalBinary<BinaryOpType::NE>;
 
 
 template struct InplaceLogicalBinary<BinaryOpType::LOGICAL_AND>;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -256,6 +256,12 @@ constexpr auto logical_and_ = ttnn::register_operation_with_auto_launch_op<
 constexpr auto logical_or_ = ttnn::register_operation_with_auto_launch_op<
     "ttnn::logical_or_",
     operations::binary::InplaceLogicalBinary<operations::binary::BinaryOpType::LOGICAL_OR>>();
+constexpr auto eq_ = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::eq_",
+    operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::EQ>>();
+constexpr auto ne_ = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::ne_",
+    operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::NE>>();
 
 template <typename InputBType>
 ttnn::Tensor operator+(const ttnn::Tensor &input_tensor_a, InputBType scalar) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -552,7 +552,6 @@ void bind_binary_overload_operation(py::module& module, const binary_operation_t
 
             Keyword Args:
                 * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
-                * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensor
 
             Example::
                 >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
@@ -948,6 +947,18 @@ void py_module(py::module& module) {
         ttnn::le_,
         R"doc(Perform Less than or equal to in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`
         .. math:: \mathrm{{input\_a}}_i <= \mathrm{{input\_b}}_i)doc");
+
+    detail::bind_inplace_operation(
+        module,
+        ttnn::eq_,
+        R"doc(Perform Equal to in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`
+        .. math:: \mathrm{{input\_a}}_i = \mathrm{{input\_b}}_i)doc");
+
+    detail::bind_inplace_operation(
+        module,
+        ttnn::ne_,
+        R"doc(Perform Not equal to in-place operation on :attr:`input_a` and :attr:`input_b` and returns the tensor with the same layout as :attr:`input_tensor`
+        .. math:: \mathrm{{input\_a}}_i != \mathrm{{input\_b}}_i)doc");
 
 }
 

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -421,4 +421,22 @@ def _golden_function_ge_(input_tensor_a, input_tensor_b, *args, **kwargs):
 ttnn.attach_golden_function(ttnn._ttnn.operations.binary.ge_, golden_function=_golden_function_ge_)
 
 
+def _golden_function_eq_(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return input_tensor_a.eq_(input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.eq_, golden_function=_golden_function_eq_)
+
+
+def _golden_function_ne_(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return input_tensor_a.ne_(input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.ne_, golden_function=_golden_function_ne_)
+
+
 __all__ = []


### PR DESCRIPTION
#### Ticket: #8885

**List of Ops:**
- EQ_ (equal to op)
- NE_ (not equal to op)

**Test Files:**
- Unary EQ_ : `tests/ttnn/unit_tests/operations/test_binary_composite.py::test_eqi_ttnn` - PASSED
- Binary EQ_ : `tests/ttnn/unit_tests/operations/test_binary_composite.py::test_binary_eqi_ttnn` - PASSED
- Unary NE_ : `tests/ttnn/unit_tests/operations/test_binary_composite.py::test_nei_ttnn` - PASSED
- Binary NE_ : `tests/ttnn/unit_tests/operations/test_binary_composite.py::test_binary_nei_ttnn` - PASSED

**CI:** [Link](https://github.com/tenstorrent/tt-metal/actions/runs/10484281090) - PASSED
