### PR TITLE
Enable optimised attention by default in falcon prefill.

### DIFF
--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -511,7 +511,7 @@ class TestParametrized:
         (
             ("prefill", 32, 1, 128, 0, "BFLOAT16-DRAM", 0.97, 0.99, 0.96, 0.1),
             ("prefill", 32, 1, 1024, 0, "BFLOAT16-DRAM", 0.98, 0.99, 0.96, 1),
-            ("prefill", 32, 1, 2048, 0, "BFLOAT16-DRAM", 0.98, 0.99, 0.96, 2),
+            ("prefill", 32, 1, 2048, 0, "BFLOAT16-DRAM", 0.99, 0.99, 0.97, 2),
             ("decode", 32, 32, 1, 128, "BFLOAT16-DRAM", 0.91, 0.92, 0.93, 0.15),
             ("decode", 32, 32, 1, 128, "BFLOAT16-L1", 0.91, 0.92, 0.93, 0.15),
             ("decode", 32, 32, 1, 128, "BFLOAT16-L1_SHARDED", 0.92, 0.95, 0.95, 0.1),
@@ -558,10 +558,6 @@ class TestParametrized:
         async_mode,
     ):
         if async_mode:
-            if llm_mode == "prefill" and seq_len != 1024:
-                pytest.skip(
-                    f"Skipping {llm_mode} with {seq_len} in async mode. Config is supported but provides redundant testing."
-                )
             if llm_mode == "decode" and not (kv_cache_len == 2047):
                 if not (model_config_str == "BFLOAT16-L1_SHARDED" and kv_cache_len == 1024):
                     pytest.skip(
@@ -589,14 +585,22 @@ class TestParametrized:
         "llm_mode, num_devices, num_layers, batch, seq_len, kv_cache_len, model_config_str, expected_output_pcc, expected_k_cache_pcc, expected_v_cache_pcc, expected_inference_time, async_mode",
         (
             ("prefill", 4, 32, 1, 256, 0, "BFLOAT16-DRAM", 0.98, 0.99, 0.96, 0.18, False),  # Issue 7816 Inference time
+            ("prefill", 4, 32, 1, 1024, 0, "BFLOAT16-DRAM", 0.98, 0.99, 0.96, 1, False),
+            ("prefill", 4, 32, 1, 2048, 0, "BFLOAT16-DRAM", 0.98, 0.99, 0.97, 2, False),
             ("decode", 4, 32, 32, 1, 1024, "BFLOAT16-L1_SHARDED", 0.87, 0.91, 0.91, 0.21, False),
             ("prefill", 4, 32, 1, 256, 0, "BFLOAT16-DRAM", 0.98, 0.99, 0.96, 0.18, True),
+            ("prefill", 4, 32, 1, 1024, 0, "BFLOAT16-DRAM", 0.98, 0.99, 0.96, 1, True),
+            ("prefill", 4, 32, 1, 2048, 0, "BFLOAT16-DRAM", 0.98, 0.99, 0.97, 2, True),
             ("decode", 4, 32, 32, 1, 1024, "BFLOAT16-L1_SHARDED", 0.87, 0.91, 0.91, 0.09, True),
         ),
         ids=[
             "prefill_seq256",
+            "prefill_seq1024",
+            "prefill_seq2048",
             "decode_batch32_1024",
             "prefill_seq256_async",
+            "prefill_seq1024_async",
+            "prefill_seq2048_async",
             "decode_batch32_1024_async",
         ],
     )

--- a/models/demos/falcon7b/tt/falcon_model.py
+++ b/models/demos/falcon7b/tt/falcon_model.py
@@ -116,11 +116,7 @@ class TtFalconModelShared(torch.nn.Module):
                 dim=-1,
             )
 
-            if (
-                self.model_config["PREFILL_OPTIMIZED_MODE"]
-                and self.model_config["PREFILL_ATTENTION_OPTIMIZED_MODE"]
-                and num_input_tokens in [128, 1024, 2048]
-            ):
+            if self.model_config["PREFILL_OPTIMIZED_MODE"] and num_input_tokens in [128, 1024, 2048]:
                 attention_mask_ = create_prefill_attn_mask_for_sharded_softmax(
                     attention_mask_bool_padded * -1e5,
                     self.config.num_attention_heads,

--- a/models/demos/falcon7b/tt/model_config.py
+++ b/models/demos/falcon7b/tt/model_config.py
@@ -205,7 +205,6 @@ def get_model_config(model_config_str, prefill_seq_len=0):
 
 def set_prefill_config(model_config, seq_len, dram_memcfg):
     model_config["PREFILL_OPTIMIZED_MODE"] = not is_grayskull()
-    model_config["PREFILL_ATTENTION_OPTIMIZED_MODE"] = False  # enable when #8349 is fixed
     model_config["MLP_SEQ_LEN"] = seq_len
     model_config["MLP_PADDING_VALUE"] = 4608
     model_config["MLP_GRID_SIZE"] = (8, 8)
@@ -264,6 +263,9 @@ def set_prefill_config(model_config, seq_len, dram_memcfg):
     model_config["FUSED_QKV_MM_OPTIMIZED_KERNEL_CONFIG"] = compute_kernel_config
     model_config["ATTN_OPTIMIZED_GRID_SIZE"] = (8, 8)
     model_config["ATTN_OPTIMIZED_MEMCFG"] = dram_memcfg
+    model_config[
+        "ATTN_OPTIMIZED_ALLOWED_NUM_CORES"
+    ] = 57  # We can't use full grid for attention, as it causes di/dt problems. Use 64 cores when issue #8644 is resolved.
 
     model_config[
         "QKT_OPTIMIZED_PROGCFG"

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -10,7 +10,7 @@ from models.utility_functions import is_wormhole_b0, get_devices_for_t3000
 @pytest.mark.parametrize(
     "perf_mode, expected_perf_prefill_decode, greedy_sampling, expected_greedy_output_path",
     (
-        (True, [6600, 1050], False, None),
+        (True, [9000, 1050], False, None),
         (True, None, False, None),
         (False, None, True, "models/demos/t3000/falcon7b/expected_greedy_output.json"),
         (False, None, True, None),


### PR DESCRIPTION
Enable optimised attention by default, with workarounds for di/dt issues (use max 57 cores. issue #8644 ). Put single and multi-chip tests on CI.