### PR TITLE
#0: Properly support trivial single core case for 1D matmuls

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config.py
@@ -194,6 +194,64 @@ parameters = {
             ttnn.L1_MEMORY_CONFIG,
             ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
         ),
+        # Matmul 1D mcast in0 (single core)
+        (
+            (1,),
+            (64, 64, 128),
+            False,
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(1, 1),
+                in0_block_w=2,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=4,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=True,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+            ttnn.L1_MEMORY_CONFIG,
+            ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+        ),
+        # Matmul 1D mcast in1 (single core)
+        (
+            (1,),
+            (64, 64, 128),
+            False,
+            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(1, 1),
+                in0_block_w=2,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=4,
+                fuse_batch=True,
+                fused_activation=None,
+                mcast_in0=False,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                    (64, 64),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+            ttnn.L1_MEMORY_CONFIG,
+            ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+        ),
         # Matmul 2D mcast
         (
             (1,),


### PR DESCRIPTION
- For mcast in1, only mcast to cores with work (similar to mcast in0)
- For single core, skip receiver kernel setup
- TODO: For sharded in0, K must be divisible by in0_block_w due to separate bugs:
  * For mcast in0, the sharded reader doesn't support turning off mcast if it's single core ** Bug here is that, we do regular mcast which is mcasting to 0 cores...
  * For mcast in1, the sharded reader doesn't support slicing along shard width