### PR TITLE
#0: Run pytest in parallel on multiple TT devices

### DIFF
--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -21,6 +21,7 @@ mypy==1.9.0
 pytest==7.2.2
 pytest-timeout==2.2.0
 pytest-split==0.8.2
+pytest-xdist==3.6.1
 jsbeautifier==1.14.7
 datasets==2.9.0
 torch==2.2.1.0+cpu


### PR DESCRIPTION
Run pytests in parallel across multiple TT devices. Use the `-n auto` flag to enable this. 

For example : `pytest -svv -n auto tests/ttnn/unit_tests/operations/test_add.py`
