### PR TITLE
#0: Add third codeowner to matmul path

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -109,7 +109,7 @@ tests/scripts/run_performance.sh @tt-rkim @tapspatel
 # **/tensor/**/module.mk @tt-rkim @TT-BrianLiu @tt-aho @arakhmati
 
 # eager - ops (dnn)
-tt_eager/tt_dnn/op_library/bmm/ @TT-BrianLiu @bbradelTT
+tt_eager/tt_dnn/op_library/bmm/ @TT-BrianLiu @bbradelTT @yugaoTT
 
 # eager - tensor and op infra
 tt_eager/tt_dnn/op_library/ccl/ @SeanNijjar


### PR DESCRIPTION
Add @yugaoTT as codeowner to matmul path in case one of the other two codeowners is away.
