### PR TITLE
#8725: Warn user if kernel cache is enabled

### DIFF
--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -117,6 +117,9 @@ def enable_persistent_kernel_cache():
     """
     Enables persistent compiled kernel caching - disables recompiling the kernels for the duration of running process if built_kernels/.../hash directory with kernel binaries is present.
     """
+    logger.warning(
+        "Persistent kernel cache is enabled. Cache invalidation may fail after a rebase and may require deleting the build directory."
+    )
     tt_lib.device.EnablePersistentKernelCache()
 
 


### PR DESCRIPTION
**What should be done**
#8725
Warn users that cache deletion might be required

**Why**
Cache invalidation may fail during rebase