### PR TITLE
Create Falcon7b perplexity test and utility functions for text-gen datasets

### DIFF
--- a/models/datasets/llm_dataset_utils.py
+++ b/models/datasets/llm_dataset_utils.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import re
+import datasets
+
+
+def wikitext_detokenizer(string):
+    """From Megatron-DeepSpeed/tasks/zeroshot_gpt/detokenizer.py"""
+    # contractions
+    string = string.replace("s '", "s'")
+    string = re.sub(r"/' [0-9]/", r"/'[0-9]/", string)
+    # number separators
+    string = string.replace(" @-@ ", "-")
+    string = string.replace(" @,@ ", ",")
+    string = string.replace(" @.@ ", ".")
+    # punctuation
+    string = string.replace(" : ", ": ")
+    string = string.replace(" ; ", "; ")
+    string = string.replace(" . ", ". ")
+    string = string.replace(" ! ", "! ")
+    string = string.replace(" ? ", "? ")
+    string = string.replace(" , ", ", ")
+    # double brackets
+    string = re.sub(r"\(\s*([^\)]*?)\s*\)", r"(\1)", string)
+    string = re.sub(r"\[\s*([^\]]*?)\s*\]", r"[\1]", string)
+    string = re.sub(r"{\s*([^}]*?)\s*}", r"{\1}", string)
+    string = re.sub(r"\"\s*([^\"]*?)\s*\"", r'"\1"', string)
+    string = re.sub(r"'\s*([^']*?)\s*'", r"'\1'", string)
+    # miscellaneous
+    string = string.replace("= = = =", "====")
+    string = string.replace("= = =", "===")
+    string = string.replace("= =", "==")
+    string = string.replace(" " + chr(176) + " ", chr(176))
+    string = string.replace(" \n", "\n")
+    string = string.replace("\n ", "\n")
+    string = string.replace(" N ", " 1 ")
+    string = string.replace(" 's", "'s")
+
+    return string
+
+
+def prepare_textgen_dataset(dataset_name, dataset_config, split):
+    dataset = datasets.load_dataset(dataset_name, dataset_config, split=split, ignore_verifications=True)
+    if dataset_name == "wikitext":
+        dataset = wikitext_detokenizer("\n".join(dataset["text"]))
+    else:
+        assert False, f"Dataset {dataset_name} is not currently supported"
+    return dataset
+
+
+def prepare_textgen_dataloader(
+    encodings,  # Tokenized dataset (1D torch.tensor)
+    batch_size,  # Number of prompts per batch
+    seq_len,  # Seq len of each prompt
+    num_samples=None,  # Total number of prompts
+    stride=None,
+):  # Number of tokens between prompts
+    num_tokens_dataset = encodings.shape[0]
+    if stride is None:
+        stride = seq_len
+    if num_samples is None:
+        num_samples = (num_tokens_dataset - seq_len) // stride
+
+    assert stride <= seq_len, "Stride must be less than or equal to seq_len"
+    assert (
+        num_samples - 1
+    ) * stride + seq_len < num_tokens_dataset, f"The dataset ({num_tokens_dataset} tokens) is too small to generate {num_samples} samples with stride {stride}."
+
+    inputs = []
+    labels = []
+    for begin_loc in range(0, num_samples * stride, stride):
+        end_loc = begin_loc + seq_len
+        inputs.append(encodings[begin_loc:end_loc])
+        labels.append(encodings[begin_loc + 1 : end_loc + 1])
+
+    dataset = torch.utils.data.TensorDataset(torch.stack(inputs), torch.stack(labels))
+    dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False, drop_last=True)
+
+    return dataloader

--- a/models/demos/falcon7b/tests/test_falcon_attention.py
+++ b/models/demos/falcon7b/tests/test_falcon_attention.py
@@ -6,12 +6,9 @@ import torch
 import pytest
 from loguru import logger
 
-from models.demos.falcon7b.reference.hf_modeling_falcon import (
-    FalconForCausalLM,
-)
 from models.demos.falcon7b.tt.falcon_attention import TtFalconAttentionDecode, TtFalconAttentionPrefill
 from models.demos.falcon7b.tt.model_config import get_model_config
-from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_outputs
+from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_outputs, load_hf_model
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
@@ -51,12 +48,10 @@ def run_test_FalconAttention_inference(
 ):
     num_devices = len(devices)
     global_batch = batch * num_devices
-    model_name = model_location_generator(model_version, model_subdir="Falcon")
 
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
     configuration = hugging_face_reference_model.config
-    state_dict = hugging_face_reference_model.state_dict()
+
     use_cache = True
     user_id = 0
 

--- a/models/demos/falcon7b/tests/test_falcon_causallm.py
+++ b/models/demos/falcon7b/tests/test_falcon_causallm.py
@@ -6,15 +6,16 @@ import torch
 import pytest
 from loguru import logger
 
-from models.demos.falcon7b.reference.hf_modeling_falcon import (
-    FalconForCausalLM,
-)
 from models.demos.falcon7b.tt.falcon_causallm import TtFalconCausalLM
 
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
 )
-from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_out_layer_present
+from models.demos.falcon7b.tests.test_utils import (
+    get_rand_falcon_inputs,
+    concat_device_out_layer_present,
+    load_hf_model,
+)
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,
     comp_pcc,
@@ -57,13 +58,9 @@ def run_test_FalconCausalLM_inference(
 ):
     num_devices = len(devices)
     global_batch = batch * num_devices
-    model_name = model_location_generator(model_version, model_subdir="Falcon")
 
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name)
-
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
     configuration = hugging_face_reference_model.config
-    state_dict = hugging_face_reference_model.state_dict()
 
     # Prepare input ------------------------------------------------------------------------
     torch.manual_seed(0)

--- a/models/demos/falcon7b/tests/test_falcon_decoder.py
+++ b/models/demos/falcon7b/tests/test_falcon_decoder.py
@@ -6,12 +6,9 @@ import torch
 import pytest
 from loguru import logger
 
-from models.demos.falcon7b.reference.hf_modeling_falcon import (
-    FalconForCausalLM,
-)
 from models.demos.falcon7b.tt.falcon_decoder import TtFalconDecoderLayer
 from models.demos.falcon7b.tt.model_config import get_model_config
-from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_outputs
+from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_outputs, load_hf_model
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
@@ -52,12 +49,9 @@ def run_test_FalconDecoder_inference(
 ):
     num_devices = len(devices)
     global_batch = batch * num_devices
-    model_name = model_location_generator(model_version, model_subdir="Falcon")
 
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
     configuration = hugging_face_reference_model.config
-    state_dict = hugging_face_reference_model.state_dict()
 
     # Prepare input ========================================================================
     torch.manual_seed(0)

--- a/models/demos/falcon7b/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon7b/tests/test_falcon_end_to_end.py
@@ -7,8 +7,11 @@ import pytest
 import torch
 import tt_lib
 from loguru import logger
-from models.demos.falcon7b.reference.hf_modeling_falcon import FalconForCausalLM
-from models.demos.falcon7b.tests.test_utils import concat_device_out_layer_present, get_rand_falcon_inputs
+from models.demos.falcon7b.tests.test_utils import (
+    concat_device_out_layer_present,
+    get_rand_falcon_inputs,
+    load_hf_model,
+)
 from models.demos.falcon7b.tt.falcon_causallm import TtFalconCausalLM
 
 # TODO: Remove this?
@@ -61,13 +64,10 @@ def run_test_FalconCausalLM_end_to_end(
 ):
     num_devices = len(devices)
     global_batch = batch * num_devices
-    model_name = model_location_generator(model_version, model_subdir="Falcon")
 
     profiler.start("hugging_face_model_setup")
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
     configuration = hugging_face_reference_model.config
-    state_dict = hugging_face_reference_model.state_dict()
     pytorch_FalconCausalLM = PytorchFalconCausalLM(hugging_face_reference_model, num_layers)
     profiler.end("hugging_face_model_setup")
 

--- a/models/demos/falcon7b/tests/test_falcon_mlp.py
+++ b/models/demos/falcon7b/tests/test_falcon_mlp.py
@@ -5,9 +5,9 @@
 import pytest
 import torch
 from loguru import logger
-from models.demos.falcon7b.reference.hf_modeling_falcon import FalconForCausalLM
 from models.demos.falcon7b.tt.falcon_mlp import TtFalconMLPDecode, TtFalconMLPPrefill
 from models.demos.falcon7b.tt.model_config import get_model_config
+from models.demos.falcon7b.tests.test_utils import load_hf_model
 from models.utility_functions import get_devices_for_t3000, torch2tt_tensor, tt2torch_tensor
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_allclose, comp_pcc
 
@@ -38,12 +38,9 @@ def run_test_FalconMLP_inference(
     max_seq_len=2048,
 ):
     num_devices = len(devices)
-    model_name = model_location_generator(model_version, model_subdir="Falcon")
 
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
     configuration = hugging_face_reference_model.config
-    state_dict = hugging_face_reference_model.state_dict()
 
     # Prepare input
     torch.manual_seed(0)

--- a/models/demos/falcon7b/tests/test_falcon_model.py
+++ b/models/demos/falcon7b/tests/test_falcon_model.py
@@ -5,14 +5,15 @@
 import torch
 import pytest
 from loguru import logger
-from models.demos.falcon7b.reference.hf_modeling_falcon import (
-    FalconForCausalLM,
-)
 from models.demos.falcon7b.tt.falcon_model import TtFalconModel
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
 )
-from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_out_layer_present
+from models.demos.falcon7b.tests.test_utils import (
+    get_rand_falcon_inputs,
+    concat_device_out_layer_present,
+    load_hf_model,
+)
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,
     comp_pcc,
@@ -53,11 +54,8 @@ def run_test_FalconModel_inference(
 ):
     num_devices = len(devices)
     global_batch = batch * num_devices
-    model_name = model_location_generator(model_version, model_subdir="Falcon")
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
     configuration = hugging_face_reference_model.config
-    state_dict = hugging_face_reference_model.state_dict()
 
     # Prepare input ------------------------------------------------------------------------
     torch.manual_seed(0)

--- a/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
+++ b/models/demos/falcon7b/tests/test_falcon_prefill_decode.py
@@ -6,14 +6,12 @@ import torch
 import pytest
 from loguru import logger
 
-from models.demos.falcon7b.reference.hf_modeling_falcon import (
-    FalconForCausalLM,
-)
 from models.demos.falcon7b.tt.falcon_causallm import TtFalconCausalLM
 
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
 )
+from models.demos.falcon7b.tests.test_utils import load_hf_model
 
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,
@@ -54,13 +52,8 @@ def run_test_FalconCausalLM_inference(
     tt_cache_path,
     model_location_generator,
 ):
-    model_name = model_location_generator(model_version, model_subdir="Falcon")
-
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
-
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
     configuration = hugging_face_reference_model.config
-    state_dict = hugging_face_reference_model.state_dict()
 
     # Prepare input ------------------------------------------------------------------------
     torch.manual_seed(0)

--- a/models/demos/falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b/tests/test_perf_falcon.py
@@ -22,7 +22,11 @@ from models.demos.falcon7b.tt.falcon_common import (
 from models.demos.falcon7b.tt.model_config import (
     get_model_config,
 )
-from models.demos.falcon7b.tests.test_utils import get_rand_falcon_inputs, concat_device_out_layer_present
+from models.demos.falcon7b.tests.test_utils import (
+    get_rand_falcon_inputs,
+    concat_device_out_layer_present,
+    load_hf_model,
+)
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     get_atol_rtol_pcc,
 )
@@ -81,13 +85,10 @@ def run_test_FalconCausalLM_end_to_end(
 
     num_devices = len(devices)
     global_batch = batch * num_devices
-    model_name = model_location_generator(model_version, model_subdir="Falcon")
 
     profiler.start("hugging_face_model_setup")
-    hugging_face_reference_model = FalconForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
-    hugging_face_reference_model.eval()
+    hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
     configuration = hugging_face_reference_model.config
-    state_dict = hugging_face_reference_model.state_dict()
     pytorch_FalconCausalLM = PytorchFalconCausalLM(hugging_face_reference_model, num_layers)
     profiler.end("hugging_face_model_setup")
 

--- a/models/demos/falcon7b/tests/test_perplexity_falcon.py
+++ b/models/demos/falcon7b/tests/test_perplexity_falcon.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+from transformers import AutoTokenizer
+from tqdm import tqdm
+import time
+from models.demos.falcon7b.tt.falcon_causallm import TtFalconCausalLM
+from models.demos.falcon7b.tt.model_config import get_model_config
+from models.demos.falcon7b.tests.test_utils import initialize_kv_cache, load_hf_model
+from models.datasets.llm_dataset_utils import prepare_textgen_dataset, prepare_textgen_dataloader
+from models.utility_functions import is_wormhole_b0, get_devices_for_t3000, tt_tensors_to_torch_tensors
+
+
+def calculate_perplexity(tt_FalconCausalLM, dataloader, llm_mode, batch_size, seq_len, kv_cache, configuration):
+    if llm_mode == "prefill":
+        assert batch_size == 1
+    use_cache = True
+    loss_func = torch.nn.CrossEntropyLoss()
+    nlls = []
+    with torch.no_grad():
+        for input_ids, labels in tqdm(dataloader, desc="Evaluating batches"):
+            if llm_mode == "prefill":
+                user_id = 0
+                (
+                    tt_prefill_input_ids,
+                    tt_prefill_attention_mask,
+                ) = tt_FalconCausalLM.model_preprocessing(
+                    "prefill", input_ids[user_id::batch_size], 0, num_input_tokens=seq_len
+                )
+                tt_logits, kv_cache = tt_FalconCausalLM(
+                    input_ids=tt_prefill_input_ids,
+                    llm_mode="prefill",
+                    attention_mask=tt_prefill_attention_mask,
+                    user_id=user_id,
+                    layer_past=kv_cache,
+                    layer_past_len=0,
+                    use_cache=use_cache,
+                )
+                # Get outputs from all devices
+                tt_logits = torch.concat(
+                    [tt_out_torch.squeeze(1) for tt_out_torch in tt_tensors_to_torch_tensors(tt_logits)]
+                )
+                loss = loss_func(tt_logits.view(batch_size * seq_len, configuration.vocab_size), labels.view(-1))
+                nlls.append(loss.float())
+                # Deallocate tt tensors
+                for i in range(len(tt_logits)):
+                    tt_prefill_input_ids[i].deallocate()
+                    tt_prefill_attention_mask[i].deallocate()
+                    tt_logits[i].deallocate()
+            elif llm_mode == "decode":
+                output_logits = []
+                for kv_cache_len in tqdm(range(seq_len), desc="Decoding tokens for current batch"):
+                    decode_ids = input_ids[:, kv_cache_len].view(batch_size, 1)
+                    (
+                        tt_decode_input_ids,
+                        tt_decode_attention_mask,
+                    ) = tt_FalconCausalLM.model_preprocessing(
+                        "decode", decode_ids, kv_cache_len, num_input_tokens=kv_cache_len + 1
+                    )
+                    tt_logits, kv_cache = tt_FalconCausalLM(
+                        input_ids=tt_decode_input_ids,
+                        llm_mode="decode",
+                        attention_mask=tt_decode_attention_mask,
+                        layer_past=kv_cache,
+                        layer_past_len=kv_cache_len,
+                        use_cache=use_cache,
+                    )
+                    # Get outputs from all devices
+                    logits = torch.concat(
+                        [torch_logit.squeeze(1) for torch_logit in tt_tensors_to_torch_tensors(tt_logits)], dim=-2
+                    )
+                    output_logits.append(logits.view(-1, 1, configuration.vocab_size))
+                    # Deallocate tt tensors
+                    for i in range(len(tt_logits)):
+                        tt_decode_input_ids[i].deallocate()
+                        tt_decode_attention_mask[i].deallocate()
+                        tt_logits[i].deallocate()
+                output_logits = torch.cat(output_logits, dim=1)
+                loss = loss_func(output_logits.view(batch_size * seq_len, configuration.vocab_size), labels.view(-1))
+                nlls.append(loss.float())
+
+    nll = torch.stack(nlls).mean()
+    ppl = torch.exp(nll)
+    return nll.item(), ppl.item()
+
+
+def run_test_perplexity(
+    llm_mode,
+    batch_size,
+    max_seq_len,
+    model_config_str,
+    model_location_generator,
+    get_tt_cache_path,
+    devices,
+    num_samples,
+    expected_ppl,
+    stride=None,
+    model_version="tiiuae/falcon-7b-instruct",
+    num_layers=32,
+    dataset_name="wikitext",
+    dataset_config="wikitext-2-raw-v1",
+    split="test",
+):
+    # Set random reproducible seed
+    torch.manual_seed(0)
+
+    # Load HF model
+    logger.info("Loading HuggingFace model...")
+    hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
+    configuration = hugging_face_reference_model.config
+
+    # Load tt-metal model config
+    model_config = get_model_config(model_config_str, max_seq_len)
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
+
+    # Load tt-metal model
+    logger.info("Moving weights (all layers) to device; might take some time...")
+    tt_FalconCausalLM = TtFalconCausalLM(
+        devices,
+        state_dict,
+        "",
+        num_layers,
+        configuration,
+        max_seq_len,
+        model_config,
+        tt_cache_path,
+        max_seq_len,
+    )
+
+    # Prepare dataset
+    logger.info("Preparing dataset...")
+    dataset = prepare_textgen_dataset(dataset_name, dataset_config, split)
+    tokenizer = AutoTokenizer.from_pretrained(model_version)
+    encodings = tokenizer(dataset, return_tensors="pt")["input_ids"].squeeze(0)
+    dataloader = prepare_textgen_dataloader(encodings, batch_size, max_seq_len, num_samples, stride)
+
+    # Initialize kvcache
+    logger.info("Initializing kvcache...")
+    kv_cache = initialize_kv_cache(configuration, num_layers, batch_size, max_seq_len, devices)
+
+    # Evaluate perplexity
+    logger.info("Evaluating perplexity...")
+    start = time.time()
+    nll, ppl = calculate_perplexity(
+        tt_FalconCausalLM, dataloader, llm_mode, batch_size, max_seq_len, kv_cache, configuration
+    )
+    logger.info(f"Perplexity evaluation time: {(time.time() - start):.2f} s")
+    logger.info(f"Negative log-likelihood: {nll:.4f}")
+    logger.info(f"Perplexity: {ppl:.4f}")
+
+    if ppl > expected_ppl:
+        assert False, f"Perplexity {ppl} is higher (worse) than {expected_ppl}"
+    elif ppl < 0.95 * expected_ppl:
+        assert False, f"Perplexity {ppl} is lower (better) than {expected_ppl}. Please update the expected perplexity."
+    logger.info("Falcon Perplexity Check Passed!")
+
+
+@pytest.mark.parametrize(
+    "llm_mode, batch_size, max_seq_len, model_config_str, num_samples, expected_ppl",
+    (
+        ("prefill", 1, 1024, "BFLOAT16-DRAM", 128, 11.5),
+        ("decode", 32, 1024, "BFLOAT16-L1_SHARDED", 64, 12.5),
+    ),
+    ids=[
+        "prefill_seq1024_dram",
+        "decode_1024_l1_sharded",
+    ],
+)
+@pytest.mark.parametrize("async_mode", (True,))  # Option to run Falcon in Async mode
+@pytest.mark.parametrize("num_devices", (1,))
+def test_perplexity(
+    llm_mode,
+    batch_size,
+    max_seq_len,
+    model_config_str,
+    num_samples,  # Total number of prompts to evaluate (all if None)
+    expected_ppl,
+    async_mode,
+    num_devices,
+    model_location_generator,
+    get_tt_cache_path,
+    all_devices,
+    use_program_cache,
+):
+    assert is_wormhole_b0(), "Multi-chip is only supported for Wormhole B0"
+    devices = get_devices_for_t3000(all_devices, num_devices)
+
+    for device in devices:
+        device.enable_async(async_mode)
+
+    run_test_perplexity(
+        llm_mode,
+        batch_size,
+        max_seq_len,
+        model_config_str,
+        model_location_generator,
+        get_tt_cache_path,
+        devices,
+        num_samples,
+        expected_ppl,
+    )

--- a/models/demos/falcon7b/tt/falcon_attention.py
+++ b/models/demos/falcon7b/tt/falcon_attention.py
@@ -662,7 +662,7 @@ class TtFalconAttentionDecode(nn.Module):
         # We always store max_position_embeddings for kv_cache,
         # so we need separate variable to store the actual len of the kv_cache
         assert layer_past is not None
-        assert layer_past_len > 0 and layer_past_len <= self.max_position_embeddings
+        assert layer_past_len <= self.max_position_embeddings
 
         #################
         ### FUSED QKV ###


### PR DESCRIPTION
- Create a new Falcon7b perplexity test with prefill and decode evaluations on the Wikitext dataset (current perplexity result for prefill [128 prompts]: `11.1`, current result for decode [64 prompts]: `12.1`)
- Create a new file `models/datasets/llm_dataset_utils.py` containing dataloading utility functions for Wikitext (and potentially other text generation datasets in the future)
- Minor Falcon7b cleanup: add function in test_utils.py for loading the huggingface reference model and remove duplicate code in the model tests