### PR TITLE
#8973: Remove TT_METAL_ENV because we don't need it anymore

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -83,7 +83,6 @@ git submodule foreach 'git lfs fetch --all && git lfs pull'
 export ARCH_NAME=grayskull
 export TT_METAL_HOME=$(pwd)
 export PYTHONPATH=$(pwd)
-export TT_METAL_ENV=dev
 ```
 
 For Wormhole boards, use:
@@ -92,7 +91,6 @@ For Wormhole boards, use:
 export ARCH_NAME=wormhole_b0
 export TT_METAL_HOME=$(pwd)
 export PYTHONPATH=$(pwd)
-export TT_METAL_ENV=dev
 ```
 
 4. Build & activate.

--- a/scripts/docker/run_docker_func.sh
+++ b/scripts/docker/run_docker_func.sh
@@ -44,7 +44,6 @@ function run_docker_common {
         -v /etc/shadow:/etc/shadow:ro \
         -w ${TT_METAL_HOME} \
         -e TT_METAL_HOME=${TT_METAL_HOME} \
-        -e TT_METAL_ENV=${TT_METAL_ENV} \
         -e LOGURU_LEVEL=${LOGURU_LEVEL} \
         -e LD_LIBRARY_PATH=${LD_LIBRARY_PATH} \
         -e CONFIG=${CONFIG} \

--- a/setup.py
+++ b/setup.py
@@ -34,15 +34,6 @@ def get_is_srcdir_build():
     return git_dir.exists()
 
 
-def get_is_dev_build():
-    try:
-        is_dev_build = attempt_get_env_var("TT_METAL_ENV") == "dev"
-    except EnvVarNotFoundException as e:
-        is_dev_build = False
-
-    return is_dev_build
-
-
 def get_arch_name():
     return attempt_get_env_var("ARCH_NAME")
 
@@ -87,7 +78,6 @@ def get_version(metal_build_config):
 
 @dataclass(frozen=True)
 class MetalliumBuildConfig:
-    is_dev_build = get_is_dev_build()
     is_srcdir_build = get_is_srcdir_build()
     arch_name = get_arch_name()
 
@@ -106,7 +96,6 @@ class CMakeBuild(build_ext):
         return {
             **os.environ.copy(),
             "TT_METAL_HOME": Path(__file__).parent,
-            "TT_METAL_ENV": "production",
             "CXX": "clang++-17",
             # Currently, the ttnn (ttnn/_ttnn.so) and tt_lib (tt_lib/_C.so)
             # both link to the tt_metal runtime. The specific thing in


### PR DESCRIPTION
 and there'sno need to programmatically differentiate between arbitrary
       environments at the runtime level 
