### PR TITLE
#1326: Add checks that kernels are not placed on storage cores / dispatch cores in debug mode

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/basic/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/basic/test_kernel_creation.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp"
+#include "gtest/gtest.h"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/impl/dispatch/command_queue.hpp"
+#include "tt_metal/common/logger.hpp"
+
+
+using namespace tt;
+
+// Ensures we can successfully create kernels on available compute grid
+TEST_F(CommonFixture, CreateKernelsOnComputeCores) {
+    for (unsigned int id = 0; id < devices_.size(); id++) {
+        tt_metal::Program program = CreateProgram();
+        CoreCoord compute_grid = devices_.at(id)->compute_with_storage_grid_size();
+        EXPECT_NO_THROW(
+            auto test_kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
+                CoreRange(CoreCoord(0, 0), CoreCoord(compute_grid.x, compute_grid.y)),
+                {.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}
+            );
+        );
+    }
+}
+
+// Ensure we cannot create kernels on storage cores
+TEST_F(CommonFixture, CreateKernelsOnStorageCores) {
+    for (unsigned int id=0; id < devices_.size(); id++) {
+        if (devices_.at(id)->storage_only_cores().empty()) {
+            GTEST_SKIP() << "This test only runs on devices with storage only cores";
+        }
+        CoreRangeSet storage_core_range_set = CoreRangeSet(devices_.at(id)->storage_only_cores());
+        EXPECT_ANY_THROW(
+            auto test_kernel = tt_metal::CreateKernel(
+                program,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
+                storage_core_range_set,
+                {.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}
+            );
+        );
+    }
+}
+
+TEST_F(CommonFixture, CreateKernelsOnDispatchCores) {
+    if (getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+        GTEST_SKIP() << "This test is only supported in fast dispatch mode";
+    }
+    for (unsigned int id=0; id < devices_.size(); id++) {
+        std::vector<CoreCoord> dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs());
+        CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+        std::set<CoreCoord> dispatch_core_range_set(dispatch_cores.begin(), dispatch_cores.end());
+
+        if (dispatch_core_type == CoreType::WORKER) {
+            EXPECT_ANY_THROW(
+                auto test_kernel = tt_metal::CreateKernel(
+                    program,
+                    "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
+                    dispatch_core_range_set,
+                    {.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}
+                );
+            );
+        } else if (dispatch_core_type == CoreType::ETH) {
+            EXPECT_ANY_THROW(
+                auto test_kernel = tt_metal::CreateKernel(
+                    program,
+                    "tests/tt_metal/tt_metal/test_kernels/misc/erisc_print.cpp",
+                    dispatch_core_range_set,
+                    {.noc = tt_metal::NOC::NOC_0, .eth_mode = Eth::IDLE}
+                );
+            );
+        }
+    }
+}

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -102,12 +102,13 @@ namespace tt::tt_metal{
          *
          *  Return value: void
          *
-         * | Argument       | Description                                                      | Type      | Valid Range                                        | Required |
-         * |----------------|------------------------------------------------------------------|-----------|----------------------------------------------------|----------|
-         * | device         | Which device the program is compiled for                         | Device *  | Must be initialized via tt_metal::InitializeDevice | Yes      |
-         * | program        | The program to compile                                           | Program & |                                                    | Yes      |
+         * | Argument                  | Description                                                      | Type      | Valid Range                                        | Required |
+         * |---------------------------|------------------------------------------------------------------|-----------|----------------------------------------------------|----------|
+         * | device                    | Which device the program is compiled for                         | Device *  | Must be initialized via tt_metal::InitializeDevice | Yes      |
+         * | program                   | The program to compile                                           | Program & |                                                    | Yes      |
+         * | fd_bootloader_mode        | Set when compiling program to initialize fast dispatch           | bool      |                                                    | No       |
          */
-        void CompileProgram(Device *device, Program &program);
+        void CompileProgram(Device *device, Program &program, bool fd_bootloader_mode = false);
 
 
         /**

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1451,7 +1451,7 @@ void Device::compile_command_queue_programs() {
 
             tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_core, 0, dispatch_core_type); // dispatch_sem
         }
-        detail::CompileProgram(this, *command_queue_program_ptr);
+        detail::CompileProgram(this, *command_queue_program_ptr, /*fd_bootloader_mode=*/true);
         this->command_queue_programs.push_back(std::move(command_queue_program_ptr));
         this->setup_tunnel_for_remote_devices();
     } else {
@@ -1706,10 +1706,10 @@ void Device::compile_command_queue_programs() {
             this->hw_command_queues_[0]->noc_index // Only one Mux - use NOC for CQ 0
         );
 
-        detail::CompileProgram(this, *command_queue_program_ptr);
+        detail::CompileProgram(this, *command_queue_program_ptr, /*fd_bootloader_mode=*/true);
         this->command_queue_programs.push_back(std::move(command_queue_program_ptr));
         if (first_tunnel_stop) {
-            detail::CompileProgram(mmio_device, *mmio_command_queue_program_ptr);
+            detail::CompileProgram(mmio_device, *mmio_command_queue_program_ptr, /*fd_bootloader_mode=*/true);
             this->command_queue_programs.push_back(std::move(mmio_command_queue_program_ptr));
         }
     }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -860,7 +860,7 @@ void Program::finalize() {
     finalized_ = true;
 }
 
-void Program::compile(Device *device) {
+void Program::compile(Device *device, bool fd_bootloader_mode) {
     ZoneScoped;
     bool first_compile_on_device = compile_needed_.find(device->id()) == compile_needed_.end();
     if (not first_compile_on_device and (not compile_needed_.at(device->id()))) {
@@ -877,8 +877,43 @@ void Program::compile(Device *device) {
     std::vector<std::shared_future<void>> events;
     DprintServerSetProfilerState(profile_kernel);
 
+    auto validate_kernel_placement = [&device, &fd_bootloader_mode](std::shared_ptr<Kernel> kernel) {
+        // Placement rules:
+        //  Slow dispatch:
+        //      - kernels cannot be on storage only cores
+        //  Fast dispatch (tensix):
+        //      - kernels cannot be on storage only cores an
+        //      - tensix kernels cannot be on dispatch cores
+        //  Fast dispatch (ethernet):
+        //      - kernels cannot be on storage only cores
+        //      - eth kernels cannot be on idle eth cores
+        bool slow_dispatch = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
+
+        const std::vector<CoreCoord> &storage_cores = tt::get_logical_storage_cores(device->id(), device->num_hw_cqs());
+        bool on_storage_only_core =  std::any_of(storage_cores.begin(), storage_cores.end(), [&kernel](const CoreCoord& storage_core) {
+            return kernel->is_on_logical_core(storage_core);
+        });
+        TT_FATAL(not on_storage_only_core, "Illegal kernel placement for {}. Kernels cannot be placed on storage only cores!", kernel->name());
+
+        // Kernels used to implement fast dispatch can be placed on dispatch cores
+        if (not slow_dispatch and not fd_bootloader_mode) {
+            const std::vector<CoreCoord> &dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs());
+            CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+
+            bool on_dispatch_core = std::any_of(dispatch_cores.begin(), dispatch_cores.end(), [&kernel, &dispatch_core_type](const CoreCoord &dispatch_core) {
+                if (kernel->get_kernel_core_type() != dispatch_core_type) {
+                    return false;
+                }
+                return kernel->is_on_logical_core(dispatch_core);
+            });
+
+            TT_FATAL(not on_dispatch_core, "Illegal kernel placement for {}, Kernels cannot be placed on dispatch cores!", kernel->name());
+        }
+    };
+
     for (auto &[core_type, kernels] : kernels_) {
         for (auto &[id, kernel] : kernels) {
+            validate_kernel_placement(kernel);
             launch_build_step(
                 [kernel, device, this] {
                     JitBuildOptions build_options(device->build_env());

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -135,7 +135,7 @@ class Program {
     // Is worker_crs_ used anywhere?
     const CoreRangeSet& get_worker_core_range_set() const { return worker_crs_; };
 
-    void compile(Device * device);
+    void compile(Device * device, bool fd_bootloader_mode = false);
 
     void invalidate_compile();
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -680,9 +680,9 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
     }
 }
 
-void CompileProgram(Device *device, Program &program) {
+void CompileProgram(Device *device, Program &program, bool fd_bootloader_mode) {
     ZoneScoped;
-    program.compile(device);
+    program.compile(device, fd_bootloader_mode);
 }
 
 void AllocateBuffer(Buffer *buffer, bool bottom_up) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/1326
https://github.com/tenstorrent/tt-metal/issues/7613

### Problem description
We don't have checks to stop users from putting kernels on storage only cores or dispatch cores 

### What's changed
Added check before compiling program to validate kernel placement

### Checklist

- [x]  [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10354968334)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/10354974255)
- [x] [e2e Model perf](https://github.com/tenstorrent/tt-metal/actions/runs/10354979772)
- [x] added test_kernel_creation.cpp
