### PR TITLE
#8995: refactoring moreh arange

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_arange.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_arange.py
@@ -148,12 +148,7 @@ def test_arange_tilized_simple(start_end_step, device):
     L = tt_cpu.shape[0]
 
     tt_dev = (
-        tt_npu.cpu()
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .unpad_from_tile((1, 1, 1, L))
-        .to_torch()
-        .reshape((L))
-        .to(torch.bfloat16)
+        tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((1, L)).to_torch().reshape((L)).to(torch.bfloat16)
     )
 
     rtol = atol = 0.1
@@ -188,7 +183,7 @@ def test_arange_tilized_major_optioanl_output(start_end_step, optional_output, d
         output_cpu = torch.empty_like(tt_cpu)
         output = (
             ttl.tensor.Tensor(output_cpu, ttl.tensor.DataType.BFLOAT16)
-            .reshape([1, 1, 1, L])
+            .reshape([1, L])
             .pad_to_tile(float("nan"))
             .to(ttl.tensor.Layout.TILE)
             .to(device)
@@ -200,12 +195,7 @@ def test_arange_tilized_major_optioanl_output(start_end_step, optional_output, d
     tt_dev = tt_npu.cpu().to_torch()
 
     tt_dev = (
-        tt_npu.cpu()
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .unpad_from_tile((1, 1, 1, L))
-        .to_torch()
-        .reshape((L))
-        .to(torch.bfloat16)
+        tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((1, L)).to_torch().reshape((L)).to(torch.bfloat16)
     )
 
     rtol = atol = 0.1
@@ -246,12 +236,7 @@ def test_arange_tilized_dtype(start_end_step, output_dtype, device):
     L = tt_cpu.shape[0]
 
     tt_dev = (
-        tt_npu.cpu()
-        .to(ttl.tensor.Layout.ROW_MAJOR)
-        .unpad_from_tile((1, 1, 1, L))
-        .to_torch()
-        .reshape((L))
-        .to(output_dtype)
+        tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile((1, L)).to_torch().reshape((L)).to(output_dtype)
     )
 
     rtol = atol = 0.1

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_arange.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_arange.py
@@ -13,7 +13,7 @@ from loguru import logger
 
 def get_tt_dtype(torch_dtype):
     if torch_dtype == torch.int32:
-        return ttl.tensor.DataType.UINT32
+        return ttl.tensor.DataType.INT32
     if torch_dtype == torch.bfloat16:
         return ttl.tensor.DataType.BFLOAT16
     if torch_dtype == torch.float32:
@@ -24,7 +24,7 @@ def get_tt_dtype(torch_dtype):
 @pytest.mark.parametrize(
     "start_end_step",
     (
-        (0, 32, 1),  # simple
+        (-5, 27, 1),  # simple
         (2.3, 15.3, 0.5),  # floating point
         (10, 0, -0.3),  # minus step
         (10, 32 * 3, 1),  # multiple cores
@@ -92,7 +92,7 @@ def test_arange_row_major_optioanl_output(start_end_step, optional_output, devic
 
 @pytest.mark.parametrize(
     "start_end_step",
-    ((0, 32 * 5, 1),),  # simple
+    ((-10, 22, 1),),  # simple
 )
 @pytest.mark.parametrize(
     "output_dtype",
@@ -207,7 +207,7 @@ def test_arange_tilized_major_optioanl_output(start_end_step, optional_output, d
 
 @pytest.mark.parametrize(
     "start_end_step",
-    ((0, 32 * 5, 1),),  # simple
+    ((-10, 57, 1),),  # simple
 )
 @pytest.mark.parametrize(
     "output_dtype",

--- a/tt_eager/tt_dnn/op_library/moreh_arange/kernels/writer_moreh_arange.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_arange/kernels/writer_moreh_arange.cpp
@@ -54,17 +54,17 @@ void kernel_main() {
             ptr[w + 256] = uint16_t(val.u >> 16);
         }
         #endif
-        #ifdef OUTPUT_DTYPE_UINT32
+        #ifdef OUTPUT_DTYPE_INT32
         auto ptr = reinterpret_cast<uint32_t *>(w_addr);
         for (uint32_t w = 0; w < 16; w++) {
             int32_t idx = w + tile_idx * TILE_WIDTH;
-            uint32_t val;
+            int32_t val;
             val = start_u.f + step_u.f * idx;
             ptr[w] = val;
         }
         for (uint32_t w = 0; w < 16; w++) {
             int32_t idx = (w + 16) + tile_idx * TILE_WIDTH;
-            uint32_t val;
+            int32_t val;
             val = start_u.f + step_u.f * idx;
             ptr[w + 256] = val;
         }

--- a/tt_eager/tt_dnn/op_library/moreh_arange/kernels/writer_moreh_arange_rm.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_arange/kernels/writer_moreh_arange_rm.cpp
@@ -50,12 +50,12 @@ void kernel_main() {
             ptr[w] = uint16_t(val.u >> 16);
         }
         #endif
-        #ifdef OUTPUT_DTYPE_UINT32
+        #ifdef OUTPUT_DTYPE_INT32
         auto ptr = reinterpret_cast<uint32_t *>(w_addr);
 
         for (uint32_t w = 0; w < TILE_WIDTH; w++) {
             int32_t idx = w + tile_idx * TILE_WIDTH;
-            uint32_t val;
+            int32_t val;
             val = start_u.f + step_u.f * idx;
             ptr[w] = val;
         }

--- a/tt_eager/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
@@ -58,8 +58,8 @@ operation::ProgramWithCallbacks moreh_arange_(
     if (output.get_dtype() == DataType::BFLOAT16) {
         writer_defines["OUTPUT_DTYPE_BFLOAT16"] = 1;
     }
-    if (output.get_dtype() == DataType::UINT32) {
-        writer_defines["OUTPUT_DTYPE_UINT32"] = 1;
+    if (output.get_dtype() == DataType::INT32) {
+        writer_defines["OUTPUT_DTYPE_INT32"] = 1;
     }
     if (output.get_dtype() == DataType::FLOAT32) {
         writer_defines["OUTPUT_DTYPE_FLOAT32"] = 1;
@@ -129,7 +129,13 @@ void MorehArange::validate_with_output_tensors(
         ((this->step > 0) && (this->end >= this->start)) || ((this->step < 0) && (this->end <= this->start)),
         "upper bound and larger bound inconsistent with step sign");
 
-    TT_FATAL(this->output_dtype != DataType::BFLOAT8_B, "moreh arange not support bfloat8_b dtype");
+    auto output_dtype_has_value = this->output_dtype.has_value();
+
+    if (output_dtype_has_value) {
+        auto output_dtype = this->output_dtype.value();
+        TT_FATAL(output_dtype != DataType::BFLOAT8_B, "moreh arange not support bfloat8_b dtype");
+        TT_FATAL(output_dtype != DataType::UINT32, "moreh arange not support uint32 dtype");
+    }
 
     if (output_tensors.empty() || !output_tensors.at(0).has_value()) {
         // If the user decided to not use any optional output tensors, then this would be empty or would be a nullptr.
@@ -141,6 +147,11 @@ void MorehArange::validate_with_output_tensors(
     auto output_memory_layout = output_tensor.memory_config().memory_layout;
     auto output_layout = output_tensor.get_layout();
 
+    if (output_dtype_has_value) {
+        auto output_dtype = this->output_dtype.value();
+        TT_FATAL(output_dtype == output_tensor.get_dtype(), "If output_tensor is provided as input, its dtype should match the output_dtype parameter.");
+    }
+
     TT_FATAL(output_memory_layout == TensorMemoryLayout::INTERLEAVED);
 
     if (this->untilize_out) {
@@ -148,6 +159,7 @@ void MorehArange::validate_with_output_tensors(
     } else {
         TT_FATAL(output_layout == Layout::TILE);
     }
+
 }
 
 std::vector<Shape> MorehArange::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
@@ -178,10 +190,15 @@ std::vector<Tensor> MorehArange::create_output_tensors(
         return {output_tensors.at(0).value()};
     }
 
-    auto dtype = input_tensors.at(0).get_dtype();
+    // default dtype is bfloat16
+    auto output_dtype = DataType::BFLOAT16;
+    if (this->output_dtype.has_value()) {
+        output_dtype = this->output_dtype.value();
+    }
+
     auto layout = (this->untilize_out) ? Layout::ROW_MAJOR : Layout::TILE;
     return operation::generic_create_output_tensors(
-        *this, input_tensors, this->output_dtype, layout, this->output_mem_config);
+        *this, input_tensors, output_dtype, layout, this->output_mem_config);
 }
 
 operation::ProgramWithCallbacks MorehArange::create_program(
@@ -203,12 +220,10 @@ Tensor moreh_arange(
     auto grid_coord = device->compute_with_storage_grid_size();
     const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
-    auto default_output_dtype = DataType::BFLOAT16;
-
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({any}))};
 
     operation::launch_op(
-        [start, end, step, untilize_out, output_dtype, all_cores, output_mem_config, default_output_dtype](
+        [start, end, step, untilize_out, output_dtype, all_cores, output_mem_config](
             const std::vector<Tensor> &input_tensors,
             const std::vector<std::optional<const Tensor>> &optional_input_tensors,
             const std::vector<std::optional<Tensor>> &optional_output_tensors) mutable -> std::vector<Tensor> {
@@ -218,7 +233,7 @@ Tensor moreh_arange(
                     .end = end,
                     .step = step,
                     .untilize_out = untilize_out,
-                    .output_dtype = output_dtype.value_or(default_output_dtype),
+                    .output_dtype = output_dtype,
                     .core_range = all_cores,
                     .output_mem_config = output_mem_config,
                 },
@@ -228,6 +243,7 @@ Tensor moreh_arange(
         },
         {any},
         output_tensors,
+        {},
         {output_tensor});
 
     return output_tensors.at(0);

--- a/tt_eager/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
@@ -159,7 +159,16 @@ std::vector<Shape> MorehArange::compute_output_shapes(const std::vector<Tensor> 
 
         return {output_shape};
     }
-    Shape output_shape = {1, 1, TILE_HEIGHT, round_up(num_elems, TILE_WIDTH)};
+
+    std::vector<uint32_t> output_size_vec = {TILE_HEIGHT, round_up(num_elems, TILE_WIDTH)};
+
+    auto dimensions_pads = std::vector<Padding::PadDimension>();
+    dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 31});
+    dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = round_up(num_elems, TILE_WIDTH) - num_elems});
+
+    const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
+    auto output_shape = Shape(output_size_vec, padding);
+
     return {output_shape};
 }
 

--- a/tt_eager/tt_dnn/op_library/moreh_arange/moreh_arange_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_arange/moreh_arange_op.hpp
@@ -21,7 +21,7 @@ struct MorehArange {
     float end;
     float step;
     bool untilize_out;
-    const DataType output_dtype;
+    const std::optional<DataType> output_dtype;
     const CoreRange core_range;  // unused for now
     const MemoryConfig output_mem_config;
 


### PR DESCRIPTION
- Currently, moreh_arange is unnecessarily generating a 4D output tensor. Considering the functionality of moreh_arange, it should be sufficient to generate a 2D output. I'm planning to modify it accordingly.

-  moreh_arange supports a signed int output dtype.