### PR TITLE
#8888: Add forward support for NEI

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -314,6 +314,7 @@ Pointwise Binary
    ttnn/le
    ttnn/eq
    ttnn/ne
+   ttnn/ne_
    ttnn/isclose
    ttnn/nextafter
    ttnn/maximum

--- a/docs/source/ttnn/ttnn/ttnn/ne_.rst
+++ b/docs/source/ttnn/ttnn/ttnn/ne_.rst
@@ -1,0 +1,6 @@
+.. _ttnn.ne_:
+
+ttnn.ne_
+#########
+
+.. autofunction:: ttnn.ne_

--- a/tests/ttnn/unit_tests/operations/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_composite.py
@@ -534,3 +534,44 @@ def test_binary_polyval_ttnn(input_shapes, coeffs, device):
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_nei_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+    ttnn.ne_(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.ne_)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([input_tensor1], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "scalar",
+    {random.randint(-100, 100) + 0.5 for _ in range(5)},
+)
+def test_nei_ttnn(input_shapes, scalar, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    ttnn.ne_(input_tensor, scalar)
+    golden_function = ttnn.get_golden_function(ttnn.ne_)
+    golden_tensor = golden_function(in_data, scalar)
+
+    comp_pass = compare_pcc([input_tensor], [golden_tensor])
+    assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -185,6 +185,17 @@ struct ExecuteBinaryRemainder
         const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 
+struct ExecuteBinaryNE
+{
+    static Tensor operator()(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b);
+
+    static Tensor operator()(
+        const Tensor& input_tensor,
+        float scalar);
+};
+
 }  // namespace binary
 }  // namespace operations
 
@@ -254,5 +265,8 @@ constexpr auto outer = ttnn::register_operation_with_auto_launch_op<
 constexpr auto polyval = ttnn::register_operation_with_auto_launch_op<
     "ttnn::polyval",
     operations::binary::ExecuteBinaryCompositeOpsPolyval<operations::binary::BinaryCompositeOpType::POLYVAL>>();
+constexpr auto ne_ = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::ne_",
+    operations::binary::ExecuteBinaryNE>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -386,13 +386,13 @@ void bind_polyval(py::module& module, const binary_operation_t& operation, const
 template <typename binary_operation_t>
 void bind_binary_overload_operation(py::module& module, const binary_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
-        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b:Union[ttnn.Tensor, int], *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+        R"doc({0}(input_tensor: ttnn.Tensor, other:Union[ttnn.Tensor, float], *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
 
         {2}
 
             Args:
-                * :attr:`input_tensor_a`
-                * :attr:`input_tensor_b` (ttnn.Tensor or Number)
+                * :attr:`input_tensor`
+                * :attr:`other` (ttnn.Tensor or Number)
 
             Keyword Args:
                 * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
@@ -434,6 +434,50 @@ void bind_binary_overload_operation(py::module& module, const binary_operation_t
             py::arg("inputr_tensor_b"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt});
+}
+
+
+template <typename binary_operation_t>
+void bind_inplace_operation(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor: ttnn.Tensor, other:Union[ttnn.Tensor, float], *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+        {2}
+
+            Args:
+                * :attr:`input_tensor`
+                * :attr:`other` (ttnn.Tensor or Number)
+
+            Example::
+                >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+                >>> output = {1}(tensor1, tensor2)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+
+        //tensor and scalar
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+            const Tensor& input_tensor,
+            float scalar) {
+                return self(input_tensor, scalar); },
+            py::arg("input_tensor"),
+            py::arg("scalar")},
+
+        //tensor and tensor
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+            const Tensor& input_tensor_a,
+            const Tensor& input_tensor_b) {
+                return self(input_tensor_a, input_tensor_b); },
+            py::arg("input_tensor_a"),
+            py::arg("inputr_tensor_b")});
 }
 
 }  // namespace detail
@@ -684,6 +728,12 @@ void py_module(py::module& module) {
         module,
         ttnn::remainder,
         R"doc(Perform an eltwise-modulus operation a - a.div(b, rounding_mode=floor) * b.", "Support provided only for WH_B0.)doc");
+
+    detail::bind_inplace_operation(
+        module,
+        ttnn::ne_,
+        R"doc(Perform Not equal to in-place operation on :attr:`input_tensor` and :attr:`other` and returns the tensor with the same layout as :attr:`input_tensor`
+        .. math:: \mathrm{{input\_tensor}}_i < \mathrm{{other}}_i)doc");
 
 
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -392,4 +392,12 @@ Tensor _polyval(const Tensor& input_a, const std::vector<float>& coeffs, const s
     return final_tensor;
 }
 
+Tensor ExecuteBinaryNE::operator()(const Tensor& input_a, const Tensor& input_b) {
+    return ttnn::ne(input_a, input_b, std::nullopt, std::nullopt, input_a);
+}
+
+Tensor ExecuteBinaryNE::operator()(const Tensor& input, float scalar) {
+    return ttnn::ne(input, scalar, std::nullopt, std::nullopt, input);
+}
+
 } // namespace ttnn::operations::binary

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -385,4 +385,13 @@ def _golden_function_polyval(input_tensor_a, coeffs, *args, **kwargs):
 ttnn.attach_golden_function(ttnn._ttnn.operations.binary.polyval, golden_function=_golden_function_polyval)
 
 
+def _golden_function_ne_(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return input_tensor_a.ne_(input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.ne_, golden_function=_golden_function_ne_)
+
+
 __all__ = []


### PR DESCRIPTION
#### Ticket: #8888 
Add NE_ op (Not equal to op , in_place operation)

#### Test File:
-  Unary NE_ : `tests/ttnn/unit_tests/operations/test_binary_composite.py::test_nei_ttnn` - PASSED
    <img width="956" alt="Screenshot 2024-08-07 at 17 14 01" src="https://github.com/user-attachments/assets/e268fbe6-f693-47b5-a451-699298f02b99">


-  Binary NE_ : `tests/ttnn/unit_tests/operations/test_binary_composite.py::test_binary_nei_ttnn` - PASSED
   <img width="914" alt="Screenshot 2024-08-07 at 17 13 30" src="https://github.com/user-attachments/assets/b3306c68-e405-4648-904c-f9c5c0042539">