### PR TITLE
#8112: Add support for ND tensors to matmul

### DIFF
--- a/models/demos/resnet/tests/test_perf_accuracy_resnet.py
+++ b/models/demos/resnet/tests/test_perf_accuracy_resnet.py
@@ -166,7 +166,7 @@ def run_perf_resnet(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time, iterations",
-    ((16, 0.015, 14.3, 160), (20, 0.014, 14.3, 160)),
+    ((16, 0.015, 14.5, 160), (20, 0.014, 14.5, 160)),
 )
 def test_perf_bare_metal(
     device,

--- a/tt_eager/tensor/tensor_utils.hpp
+++ b/tt_eager/tensor/tensor_utils.hpp
@@ -161,6 +161,15 @@ inline bool any_tensor_on_multi_device(const std::vector<ttnn::Tensor>& tensors)
     return false;
 }
 
+template<class T>
+inline uint32_t get_batch_size(const T& shape) {
+    uint32_t result = 1;
+    for (auto i = 0; i < shape.rank() - 2; i++) {
+        result *= shape[i];
+    }
+    return result;
+}
+
 DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
 
 }  // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 
 #include "tt_dnn/op_library/bcast/bcast_op.hpp"
-#include "tt_dnn/op_library/bmm/bmm_op.hpp"
+#include "tt_eager/tensor/tensor_utils.hpp"
 #include "tt_metal/common/assert.hpp"
 #include "impl/buffers/buffer.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
@@ -93,7 +93,7 @@ void EltwiseBinaryBroadcast::validate(const std::vector<Tensor> &input_tensors) 
     auto width_b = input_shape_b[-1];
     if((input_tensor_a.is_sharded() && this->dim == BcastOpDim::H) == false){
 
-        uint32_t batch_size_b = tt::operations::primary::get_batch_size(input_shape_b);
+        uint32_t batch_size_b = get_batch_size(input_shape_b);
         if (batch_size_b != 1) {
             TT_FATAL(input_shape_a.rank() == input_shape_b.rank() && "Broadcast with batch is currently only supported when input tensor ranks are the same");
             for (auto i = 0; i < input_shape_a.rank() - 2; i++) {

--- a/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/bcast_op.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "tt_dnn/op_library/bcast/bcast_op.hpp"
+#include "tt_dnn/op_library/bmm/bmm_op.hpp"
 #include "tt_metal/common/assert.hpp"
 #include "impl/buffers/buffer.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
@@ -86,16 +87,21 @@ void EltwiseBinaryBroadcast::validate(const std::vector<Tensor> &input_tensors) 
             "Input and output mem layouts must be the same for bcast HW op!");
     }
 
-    auto batch_size_a = input_shape_a[0];
-    auto num_channels_a = input_shape_a[1];
-    auto height_a = input_shape_a[2];
-    auto width_a = input_shape_a[3];
-    auto batch_size_b = input_shape_b[0];
-    auto num_channels_b = input_shape_b[1];
-    auto height_b = input_shape_b[2];
-    auto width_b = input_shape_b[3];
+    auto height_a = input_shape_a[-2];
+    auto width_a = input_shape_a[-1];
+    auto height_b = input_shape_b[-2];
+    auto width_b = input_shape_b[-1];
     if((input_tensor_a.is_sharded() && this->dim == BcastOpDim::H) == false){
-        TT_FATAL((batch_size_b * num_channels_b == 1 || (batch_size_b == batch_size_a && num_channels_b == num_channels_a)) && "Broadcast is currently only supported when bN*bC=1 or N & C match"); //for H multi-batch weight is supported
+
+        uint32_t batch_size_b = tt::operations::primary::get_batch_size(input_shape_b);
+        if (batch_size_b != 1) {
+            TT_FATAL(input_shape_a.rank() == input_shape_b.rank() && "Broadcast with batch is currently only supported when input tensor ranks are the same");
+            for (auto i = 0; i < input_shape_a.rank() - 2; i++) {
+                TT_FATAL(
+                        input_shape_a[i] == input_shape_b[i] &&
+                        "Broadcast with batch is currently only supported when bN*bC=1 or N & C match or equivalent"); // for H multi-batch weight is supported
+            }
+        }
     }
 
     // validate input dimensions
@@ -172,8 +178,8 @@ BcastOpParallelizationStrategy EltwiseBinaryBroadcast::get_parallelization_strat
     const auto& input_tensor_a = input_tensors.at(0);
 
     uint32_t num_tiles = input_tensor_a.volume() / TILE_HW;
-    uint32_t Ht = input_tensor_a.get_legacy_shape()[2] / TILE_HEIGHT;
-    uint32_t Wt = input_tensor_a.get_legacy_shape()[3] / TILE_WIDTH;
+    uint32_t Ht = input_tensor_a.get_legacy_shape()[-2] / TILE_HEIGHT;
+    uint32_t Wt = input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH;
 
     if(this->dim == BcastOpDim::H){
         if(input_tensor_a.is_sharded())

--- a/tt_eager/tt_dnn/op_library/bcast/bcast_op.hpp
+++ b/tt_eager/tt_dnn/op_library/bcast/bcast_op.hpp
@@ -80,33 +80,33 @@ inline Tensor bcast(
             auto& input_tensor_a = input_tensors.at(0);
             auto& input_tensor_b = input_tensors.at(1);
             if (bcast_dim == BcastOpDim::W) {
-                TT_FATAL(input_tensor_a.get_legacy_shape()[2] == input_tensor_b.get_legacy_shape()[2]);
+                TT_FATAL(input_tensor_a.get_legacy_shape()[-2] == input_tensor_b.get_legacy_shape()[-2]);
                 if (input_tensor_b.get_layout() == Layout::TILE) {
-                    TT_FATAL(input_tensor_b.get_legacy_shape()[3] == TILE_WIDTH);
+                    TT_FATAL(input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH);
                 } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
-                    TT_FATAL(input_tensor_b.get_legacy_shape()[3] == 1 || input_tensor_b.get_legacy_shape()[3] == TILE_WIDTH);
+                    TT_FATAL(input_tensor_b.get_legacy_shape()[-1] == 1 || input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH);
                 } else {
                     TT_FATAL(false, "Unsupported layout");
                 }
             } else if (bcast_dim == BcastOpDim::H) {
-                TT_FATAL(input_tensor_a.get_legacy_shape()[3] == input_tensor_b.get_legacy_shape()[3]);
+                TT_FATAL(input_tensor_a.get_legacy_shape()[-1] == input_tensor_b.get_legacy_shape()[-1]);
                 if (input_tensor_b.get_layout() == Layout::TILE) {
-                    TT_FATAL(input_tensor_b.get_legacy_shape()[2] == TILE_HEIGHT);
+                    TT_FATAL(input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT);
                 } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
-                    TT_FATAL(input_tensor_b.get_legacy_shape()[2] == 1 || input_tensor_b.get_legacy_shape()[2] == TILE_HEIGHT);
+                    TT_FATAL(input_tensor_b.get_legacy_shape()[-2] == 1 || input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT);
                 } else {
                     TT_FATAL(false, "Unsupported layout");
                 }
             } else if (bcast_dim == BcastOpDim::HW) {
                 if (input_tensor_b.get_layout() == Layout::TILE) {
                     TT_FATAL(
-                        input_tensor_b.get_legacy_shape()[2] == TILE_HEIGHT &&
-                        input_tensor_b.get_legacy_shape()[3] == TILE_WIDTH);
+                        input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT &&
+                        input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH);
                 } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
                     TT_FATAL(
-                        (input_tensor_b.get_legacy_shape()[2] == 1 && input_tensor_b.get_legacy_shape()[3] == 1) ||
-                        (input_tensor_b.get_legacy_shape()[2] == TILE_HEIGHT &&
-                        input_tensor_b.get_legacy_shape()[3] == TILE_WIDTH));
+                        (input_tensor_b.get_legacy_shape()[-2] == 1 && input_tensor_b.get_legacy_shape()[-1] == 1) ||
+                        (input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT &&
+                        input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH));
                 }
             }
             return operation::run_with_autoformat(

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.cpp
@@ -68,14 +68,6 @@ uint32_t _get_maximum_block_dim(int32_t block_dim, int32_t in0_block_w) {
     return 0;
 }
 
-uint32_t get_batch_size(const ttnn::types::Shape& shape) {
-    uint32_t result = 1;
-    for (auto i = 0; i < shape.rank() - 2; i++) {
-        result *= shape[i];
-    }
-    return result;
-}
-
 namespace {
 using namespace tt;
 using namespace tt::tt_metal;
@@ -99,8 +91,9 @@ operation::OpPerformanceModel create_op_performance_model_for_matmul(
 
     // Calculate number of mul/add operations
     // TODO: add bias modeling
-    int64_t num_mul_adds_per_elem = in_a_shape[3] * 2;  // 1 multiply and 1 add per element
-    int64_t num_mul_adds = num_mul_adds_per_elem * out_shape[2] * out_shape[3] * out_shape[1] * out_shape[0];
+    int64_t num_mul_adds_per_elem = in_a_shape[-1] * 2;  // 1 multiply and 1 add per element
+    uint32_t batch_size = tt::operations::primary::get_batch_size(out_shape);
+    int64_t num_mul_adds = num_mul_adds_per_elem * out_shape[-2] * out_shape[-1] * batch_size;
 
     MathFidelity math_fidelity = MathFidelity::Invalid;
 
@@ -124,10 +117,12 @@ operation::OpPerformanceModel create_op_performance_model_for_matmul(
     operation::OpPerformanceModel result(input_tensors, output_tensors, ideal_dev_clock_cycles);
 #if 0
     tt::log_info(tt::LogOp, "Matmul PerfModel:");
-    tt::log_info(tt::LogOp, "\t Batch: ({}, {})", out_shape[0], out_shape[1]);
-    tt::log_info(tt::LogOp, "\t In A (H, W): ({}, {})", in_a_shape[2], in_a_shape[3]);
-    tt::log_info(tt::LogOp, "\t In B (H, W): ({}, {})", in_b_shape[2], in_b_shape[3]);
-    tt::log_info(tt::LogOp, "\t Out (H, W): ({}, {})", out_shape[2], out_shape[3]);
+    for (auto i = 0; i < out_shape.rank() - 2; i++) {
+        tt::log_info(tt::LogOp, "\t Batch Values: (Index: {}, Value: {})", i, out_shape[i]);
+    }
+    tt::log_info(tt::LogOp, "\t In A (H, W): ({}, {})", in_a_shape[-2], in_a_shape[-1]);
+    tt::log_info(tt::LogOp, "\t In B (H, W): ({}, {})", in_b_shape[-2], in_b_shape[-1]);
+    tt::log_info(tt::LogOp, "\t Out (H, W): ({}, {})", out_shape[-2], out_shape[-1]);
     tt::log_info(tt::LogOp, "\t ideal_dev_clock_cycles: {}", ideal_dev_clock_cycles);
 #endif
     return result;
@@ -469,9 +464,9 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(
         auto out_subblock_w = std::get<1>(subblock_hw);
 
         // TODO: Temporarily allow for single core; should support bcast_batch in general
-        bool broadcast_batch =
-            (input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] > 1 and
-             input_tensor_b.get_legacy_shape()[0] * input_tensor_b.get_legacy_shape()[1] == 1);
+        uint32_t batch_size_a = tt::operations::primary::get_batch_size(input_tensor_a.get_legacy_shape());
+        uint32_t batch_size_b = tt::operations::primary::get_batch_size(input_tensor_b.get_legacy_shape());
+        bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
         TT_FATAL(!broadcast_batch);
 
         if (input_tensor_b.is_sharded()) {
@@ -740,13 +735,14 @@ inline MatmulProgramConfig create_simple_matmul_program_config(
     const Tensor& input_tensor_b,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     const auto &ashape = input_tensor_a.get_legacy_shape(), bshape = input_tensor_b.get_legacy_shape();
-    uint32_t num_output_tiles = ashape[0] * ashape[1] * ashape[2] * bshape[3] / TILE_HW;  // Output M x N
+    uint32_t batch_size_a = get_batch_size(ashape);
+    uint32_t num_output_tiles = batch_size_a * ashape[-2] * bshape[-1] / TILE_HW;  // Output M x N
 
     // Parameters for large matmul with reuse
-    uint32_t B = ashape[0] * ashape[1];
-    uint32_t Mt = ashape[2] / TILE_HEIGHT;
-    uint32_t Kt = ashape[3] / TILE_WIDTH;
-    uint32_t Nt = bshape[3] / TILE_WIDTH;
+    uint32_t B = batch_size_a;
+    uint32_t Mt = ashape[-2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[-1] / TILE_WIDTH;
+    uint32_t Nt = bshape[-1] / TILE_WIDTH;
     uint32_t in0_block_w = 2;
 
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "input tensor needs to be on device");
@@ -901,8 +897,8 @@ void Matmul::validate(
         (input_tensor_a.get_layout() == Layout::TILE && input_tensor_b.get_layout() == Layout::TILE),
         "Inputs to matmul must be tilized");
     TT_FATAL(
-        input_tensor_a.get_legacy_shape()[3] == input_tensor_b.get_legacy_shape()[2] &&
-        "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op");  // A.K == B.K
+        input_tensor_a.get_legacy_shape()[-1] == input_tensor_b.get_legacy_shape()[-2] &&
+        "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
 
     TT_FATAL(is_floating_point(input_tensor_a.get_dtype()), "Unsupported data format");
     TT_FATAL(
@@ -920,9 +916,11 @@ void Matmul::validate(
     if (optional_bias.has_value()) {
         const auto& bias = optional_bias.value();
         TT_FATAL(bias.get_layout() == Layout::TILE, "Unsupported input layout");
-        TT_FATAL(
-            bias.get_legacy_shape() == Shape({1, 1, TILE_HEIGHT, input_tensor_b.get_legacy_shape()[3]}),
-            "Unsupported bias shape");
+        const auto& bias_shape = bias.get_legacy_shape();
+        uint32_t bias_batch_size = get_batch_size(bias_shape);
+        TT_FATAL(bias_batch_size == 1, "Unsupported bias shape: batch size not equal to 1.");
+        TT_FATAL(bias_shape[-2] == TILE_HEIGHT, "Unsupported bias shape: second last dimension not equal to tile height");
+        TT_FATAL(bias_shape[-1] == input_tensor_b.get_legacy_shape()[-1], "Unsupported bias shape: last dimension not equal to second input's last dimension.");
     }
 
     if (this->untilize_out) {
@@ -1139,9 +1137,9 @@ void Matmul::validate(
                     }
                 }
 
-                bool broadcast_batch =
-                    (input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] > 1 and
-                     input_tensor_b.get_legacy_shape()[0] * input_tensor_b.get_legacy_shape()[1] == 1);
+                uint32_t batch_size_a = get_batch_size(input_tensor_a.get_legacy_shape());
+                uint32_t batch_size_b = get_batch_size(input_tensor_b.get_legacy_shape());
+                bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
                 TT_FATAL(!broadcast_batch);
 
                 if (input_tensor_b.is_sharded()) {
@@ -1354,7 +1352,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
     tt::tt_metal::DataType output_dtype = this->output_dtype;
 
     bool fuse_batch = true;
-    // TODO: If input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] == 1, does matmuls work if
+    // TODO: If input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] * ... except last two dimensions == 1, does matmuls work if
     // we treat it as bmm
     // TODO: Only for MatmulMultiCoreReuseProgramConfig we allow this as single core matmul/bmm
     bool broadcast_batch = this->bcast_batch;

--- a/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
+++ b/tt_eager/tt_dnn/op_library/bmm/bmm_op.hpp
@@ -10,6 +10,7 @@
 #include "tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
 #include "tt_dnn/op_library/run_operation.hpp"
 #include "tt_dnn/op_library/compute_kernel_config.hpp"
+#include "tt_eager/tensor/tensor_utils.hpp"
 #include "ttnn/types.hpp"
 
 namespace tt {
@@ -307,15 +308,6 @@ struct Matmul {
             std::cref(this->user_run_batched));
     }
 };
-
-template<class T>
-uint32_t get_batch_size(const T& shape) {
-    uint32_t result = 1;
-    for (auto i = 0; i < shape.rank() - 2; i++) {
-        result *= shape[i];
-    }
-    return result;
-}
 
 inline bool get_broadcast_batch(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const std::optional<const MatmulProgramConfig> matmul_program_config) {
     uint32_t batch_size_b = get_batch_size(input_tensor_b.get_legacy_shape());

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core/bmm_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core/bmm_op_multi_core.cpp
@@ -39,7 +39,7 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    uint32_t c_batch_size = tt::operations::primary::get_batch_size(cshape);
+    uint32_t c_batch_size = get_batch_size(cshape);
     auto num_output_tiles_total = c_batch_size * cshape[-2] * cshape[-1] / TILE_HW;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_output_tiles_per_core_group_1, num_output_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_output_tiles_total);
 
@@ -48,7 +48,7 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
 
     // C = A*B*...
     // MN = MK*KN
-    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t B = get_batch_size(ashape);
     uint32_t Mt = ashape[-2]/TILE_HEIGHT;
     uint32_t Kt = ashape[-1]/TILE_WIDTH;
     uint32_t Nt = bshape[-1]/TILE_WIDTH;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core/bmm_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core/bmm_op_multi_core.cpp
@@ -39,18 +39,19 @@ operation::ProgramWithCallbacks matmul_multi_core(const Tensor &a, const Tensor 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto num_output_tiles_total = cshape[0] * cshape[1] * cshape[2] * cshape[3] / TILE_HW;
+    uint32_t c_batch_size = tt::operations::primary::get_batch_size(cshape);
+    auto num_output_tiles_total = c_batch_size * cshape[-2] * cshape[-1] / TILE_HW;
     auto [num_cores, all_cores, core_group_1, core_group_2, num_output_tiles_per_core_group_1, num_output_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_output_tiles_total);
 
     tt_metal::Buffer *dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    // C = A*B
+    // C = A*B*...
     // MN = MK*KN
-    uint32_t B = ashape[0]*ashape[1];
-    uint32_t Mt = ashape[2]/TILE_HEIGHT;
-    uint32_t Kt = ashape[3]/TILE_WIDTH;
-    uint32_t Nt = bshape[3]/TILE_WIDTH;
+    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t Mt = ashape[-2]/TILE_HEIGHT;
+    uint32_t Kt = ashape[-1]/TILE_WIDTH;
+    uint32_t Nt = bshape[-1]/TILE_WIDTH;
     uint32_t KtNt = Kt * Nt;
     uint32_t MtKt = Mt * Kt;
     uint32_t MtNt = Mt * Nt;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse/bmm_op_multi_core_reuse.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse/bmm_op_multi_core_reuse.cpp
@@ -252,7 +252,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(const Tensor &a, const T
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Only supports matmuls where output is blocks of 16 x 16 tiles (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t B = get_batch_size(ashape);
     uint32_t Mt = ashape[-2]/TILE_HEIGHT;
     uint32_t Kt = ashape[-1]/TILE_WIDTH;
     uint32_t Nt = bshape[-1]/TILE_WIDTH;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse/bmm_op_multi_core_reuse.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse/bmm_op_multi_core_reuse.cpp
@@ -252,10 +252,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(const Tensor &a, const T
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Only supports matmuls where output is blocks of 16 x 16 tiles (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = ashape[0]*ashape[1];
-    uint32_t Mt = ashape[2]/TILE_HEIGHT;
-    uint32_t Kt = ashape[3]/TILE_WIDTH;
-    uint32_t Nt = bshape[3]/TILE_WIDTH;
+    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t Mt = ashape[-2]/TILE_HEIGHT;
+    uint32_t Kt = ashape[-1]/TILE_WIDTH;
+    uint32_t Nt = bshape[-1]/TILE_WIDTH;
     uint32_t in0_block_w = 2;
     uint32_t out_subblock_h = 4;
     uint32_t out_subblock_w = 2;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -1460,7 +1460,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     tt_metal::Buffer* in1_buffer = b.buffer();
     if (bcast_batch)
         TT_FATAL(
-            tt::operations::primary::get_batch_size(bshape) == 1 &&
+            get_batch_size(bshape) == 1 &&
             "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
     else {
         // same condition as above, different message
@@ -1519,7 +1519,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t B = get_batch_size(ashape);
     uint32_t Mt = ashape[-2] / TILE_HEIGHT;
     uint32_t Kt = ashape[-1] / TILE_WIDTH;
     uint32_t Nt = bshape[-1] / TILE_WIDTH;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -1460,24 +1460,27 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     tt_metal::Buffer* in1_buffer = b.buffer();
     if (bcast_batch)
         TT_FATAL(
-            bshape[0] * bshape[1] == 1 &&
-            "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
+            tt::operations::primary::get_batch_size(bshape) == 1 &&
+            "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
     else {
         // same condition as above, different message
-        TT_FATAL(
-            ashape[1] == bshape[1] && ashape[0] == bshape[0] &&
-            "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
+        TT_FATAL(ashape.rank() == bshape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank");
+        for (auto i = 0; i < ashape.rank() - 2; i++) {
+            TT_FATAL(
+                ashape[i] == bshape[i] &&
+                "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN or equivalent");
+        }
     }
     TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
     TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
 
     TT_FATAL(
-        ashape[3] == bshape[2] &&
-        "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op");  // A.K == B.K
-    TT_FATAL(ashape[2] % TILE_HEIGHT == 0);
-    TT_FATAL(ashape[3] % TILE_WIDTH == 0);
-    TT_FATAL(bshape[2] % TILE_HEIGHT == 0);
-    TT_FATAL(bshape[3] % TILE_WIDTH == 0);
+        ashape[-1] == bshape[-2] &&
+        "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
+    TT_FATAL(ashape[-2] % TILE_HEIGHT == 0);
+    TT_FATAL(ashape[-1] % TILE_WIDTH == 0);
+    TT_FATAL(bshape[-2] % TILE_HEIGHT == 0);
+    TT_FATAL(bshape[-1] % TILE_WIDTH == 0);
 
     MathFidelity math_fidelity;
     bool math_approx_mode;
@@ -1516,10 +1519,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = ashape[0] * ashape[1];
-    uint32_t Mt = ashape[2] / TILE_HEIGHT;
-    uint32_t Kt = ashape[3] / TILE_WIDTH;
-    uint32_t Nt = bshape[3] / TILE_WIDTH;
+    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t Mt = ashape[-2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[-1] / TILE_WIDTH;
+    uint32_t Nt = bshape[-1] / TILE_WIDTH;
 
     if (fuse_batch) {
         Mt = B * Mt;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -1026,7 +1026,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     tt_metal::Buffer* in1_buffer = b.buffer();
     if (bcast_batch)
         TT_FATAL(
-            tt::operations::primary::get_batch_size(bshape) == 1 &&
+            get_batch_size(bshape) == 1 &&
             "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
     else {
         // same condition as above, different message
@@ -1085,7 +1085,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t B = get_batch_size(ashape);
     uint32_t Mt = ashape[-2] / TILE_HEIGHT;
     uint32_t Kt = ashape[-1] / TILE_WIDTH;
     uint32_t Nt = bshape[-1] / TILE_WIDTH;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -1026,24 +1026,27 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     tt_metal::Buffer* in1_buffer = b.buffer();
     if (bcast_batch)
         TT_FATAL(
-            bshape[0] * bshape[1] == 1 &&
-            "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
+            tt::operations::primary::get_batch_size(bshape) == 1 &&
+            "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
     else {
         // same condition as above, different message
-        TT_FATAL(
-            ashape[1] == bshape[1] && ashape[0] == bshape[0] &&
-            "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
+        TT_FATAL(ashape.rank() == bshape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank");
+        for (auto i = 0; i < ashape.rank() - 2; i++) {
+            TT_FATAL(
+                ashape[i] == bshape[i] &&
+                "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN or equivalent");
+        }
     }
     TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
     TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
 
     TT_FATAL(
-        ashape[3] == bshape[2] &&
-        "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in bmm_op");  // A.K == B.K
-    TT_FATAL(ashape[2] % TILE_HEIGHT == 0);
-    TT_FATAL(ashape[3] % TILE_WIDTH == 0);
-    TT_FATAL(bshape[2] % TILE_HEIGHT == 0);
-    TT_FATAL(bshape[3] % TILE_WIDTH == 0);
+        ashape[-1] == bshape[-2] &&
+        "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
+    TT_FATAL(ashape[-2] % TILE_HEIGHT == 0);
+    TT_FATAL(ashape[-1] % TILE_WIDTH == 0);
+    TT_FATAL(bshape[-2] % TILE_HEIGHT == 0);
+    TT_FATAL(bshape[-1] % TILE_WIDTH == 0);
 
     MathFidelity math_fidelity;
     bool math_approx_mode;
@@ -1082,10 +1085,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Pads matmul input dims to 512 x 512 multiples (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = ashape[0] * ashape[1];
-    uint32_t Mt = ashape[2] / TILE_HEIGHT;
-    uint32_t Kt = ashape[3] / TILE_WIDTH;
-    uint32_t Nt = bshape[3] / TILE_WIDTH;
+    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t Mt = ashape[-2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[-1] / TILE_WIDTH;
+    uint32_t Nt = bshape[-1] / TILE_WIDTH;
 
     if (fuse_batch) {
         Mt = B * Mt;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
@@ -465,7 +465,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     tt_metal::Buffer *in1_buffer = b.buffer();
     if (bcast_batch)
         TT_FATAL(
-            tt::operations::primary::get_batch_size(bshape) == 1 &&
+            get_batch_size(bshape) == 1 &&
             "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
     else {
         // same condition as above, different message
@@ -511,7 +511,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Only supports matmuls where output is blocks of 16 x 16 tiles (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t B = get_batch_size(ashape);
     uint32_t Mt = ashape[-2]/TILE_HEIGHT;
     uint32_t Kt = ashape[-1]/TILE_WIDTH;
     uint32_t Nt = bshape[-1]/TILE_WIDTH;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
@@ -450,7 +450,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     const auto& ashape = a.get_legacy_shape();
     const auto& bshape = b.get_legacy_shape();
 
-    TT_FATAL((bcast_batch == false) or (ashape[0] == 1), "Bcast batch not supported for this parallelization");
+    TT_FATAL((bcast_batch == false) or (ashape[0] == 1) or (ashape.rank() == 2), "Bcast batch not supported for this parallelization");
 
     // CB dataformats
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype()); // in0
@@ -464,11 +464,17 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     tt_metal::Buffer *in0_buffer = a.buffer();
     tt_metal::Buffer *in1_buffer = b.buffer();
     if (bcast_batch)
-        TT_FATAL(bshape[0]*bshape[1] == 1 && "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN");
+        TT_FATAL(
+            tt::operations::primary::get_batch_size(bshape) == 1 &&
+            "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
     else {
         // same condition as above, different message
-        TT_FATAL(ashape[1] == bshape[1] && ashape[0] == bshape[0]
-            && "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN");
+        TT_FATAL(ashape.rank() == bshape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank");
+        for (auto i = 0; i < ashape.rank() - 2; i++) {
+            TT_FATAL(
+                ashape[i] == bshape[i] &&
+                "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN or equivalent");
+        }
     }
 
     MathFidelity math_fidelity;
@@ -505,10 +511,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Only supports matmuls where output is blocks of 16 x 16 tiles (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = ashape[0]*ashape[1];
-    uint32_t Mt = ashape[2]/TILE_HEIGHT;
-    uint32_t Kt = ashape[3]/TILE_WIDTH;
-    uint32_t Nt = bshape[3]/TILE_WIDTH;
+    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t Mt = ashape[-2]/TILE_HEIGHT;
+    uint32_t Kt = ashape[-1]/TILE_WIDTH;
+    uint32_t Nt = bshape[-1]/TILE_WIDTH;
 
     // TODO: Generalize
     TT_FATAL(!fuse_batch, "Only fuse_batch=false is supported for optimized bmm!");

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_padding/bmm_op_multi_core_reuse_padding.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_padding/bmm_op_multi_core_reuse_padding.cpp
@@ -278,7 +278,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_padding(const Tensor &a,
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Only supports matmuls where output is blocks of 16 x 16 tiles (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t B = get_batch_size(ashape);
     uint32_t Mt = ashape[-2]/TILE_HEIGHT;
     uint32_t Kt = ashape[-1]/TILE_WIDTH;
     uint32_t Nt = bshape[-1]/TILE_WIDTH;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_padding/bmm_op_multi_core_reuse_padding.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_padding/bmm_op_multi_core_reuse_padding.cpp
@@ -278,10 +278,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_padding(const Tensor &a,
     ////////////////////////////////////////////////////////////////////////////
     // NOTE: Only supports matmuls where output is blocks of 16 x 16 tiles (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
-    uint32_t B = ashape[0]*ashape[1];
-    uint32_t Mt = ashape[2]/TILE_HEIGHT;
-    uint32_t Kt = ashape[3]/TILE_WIDTH;
-    uint32_t Nt = bshape[3]/TILE_WIDTH;
+    uint32_t B = tt::operations::primary::get_batch_size(ashape);
+    uint32_t Mt = ashape[-2]/TILE_HEIGHT;
+    uint32_t Kt = ashape[-1]/TILE_WIDTH;
+    uint32_t Nt = bshape[-1]/TILE_WIDTH;
     uint32_t in0_block_w = 2;
     uint32_t out_subblock_h = 4;
     uint32_t out_subblock_w = 2;

--- a/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core_tilize_untilize.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core_tilize_untilize.cpp
@@ -178,7 +178,7 @@ operation::ProgramWithCallbacks bmm_single_core_tilize_untilize(
 
     // input matrix shape checks
     TT_FATAL(in0_shape.rank() == 2 || in0_shape[0] == 1, "Supports only batch = 1");
-    TT_FATAL(operations::primary::get_batch_size(in0_shape) == operations::primary::get_batch_size(in1_shape), "Batch dimension needs to match for two inputs");
+    TT_FATAL(get_batch_size(in0_shape) == get_batch_size(in1_shape), "Batch dimension needs to match for two inputs");
     TT_FATAL(in0_width == in1_height, "Input matrices should be compatible for multiplication");
     if (has_bias) {
         TT_FATAL(bias.get_legacy_shape()[-1] == in1.get_legacy_shape()[-1], "Bias shape mismatch");

--- a/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core_tilize_untilize.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/single_core/bmm_op_single_core_tilize_untilize.cpp
@@ -169,22 +169,19 @@ operation::ProgramWithCallbacks bmm_single_core_tilize_untilize(
                                     Tensor &out,
                                     DeviceComputeKernelConfig compute_kernel_config) {
 
-    uint32_t in0_batch = in0.get_legacy_shape()[0];
-    uint32_t in0_channel = in0.get_legacy_shape()[1];
-    uint32_t in0_height = in0.get_legacy_shape()[2];
-    uint32_t in0_width = in0.get_legacy_shape()[3];
-    uint32_t in1_batch = in1.get_legacy_shape()[0];
-    uint32_t in1_channel = in1.get_legacy_shape()[1];
-    uint32_t in1_height = in1.get_legacy_shape()[2];
-    uint32_t in1_width = in1.get_legacy_shape()[3];
+    auto& in0_shape = in0.get_legacy_shape();
+    uint32_t in0_height = in0_shape[-2];
+    uint32_t in0_width = in0_shape[-1];
+    auto& in1_shape = in1.get_legacy_shape();
+    uint32_t in1_height = in1_shape[-2];
+    uint32_t in1_width = in1_shape[-1];
 
     // input matrix shape checks
-    TT_FATAL(in0_batch == 1, "Supports only batch = 1");
-    TT_FATAL(in1_batch == in0_batch, "Batch dimension needs to match for two inputs");
-    TT_FATAL(in0_channel == in1_channel, "Channel dimension needs to match for two inputs");
+    TT_FATAL(in0_shape.rank() == 2 || in0_shape[0] == 1, "Supports only batch = 1");
+    TT_FATAL(operations::primary::get_batch_size(in0_shape) == operations::primary::get_batch_size(in1_shape), "Batch dimension needs to match for two inputs");
     TT_FATAL(in0_width == in1_height, "Input matrices should be compatible for multiplication");
     if (has_bias) {
-        TT_FATAL(bias.get_legacy_shape()[3] == in1.get_legacy_shape()[3], "Bias shape mismatch");
+        TT_FATAL(bias.get_legacy_shape()[-1] == in1.get_legacy_shape()[-1], "Bias shape mismatch");
     }
 
     // tile size checks
@@ -193,8 +190,8 @@ operation::ProgramWithCallbacks bmm_single_core_tilize_untilize(
     TT_FATAL(in0_width % constants::TILE_WIDTH == 0, "Input tensor in0 width needs to be divisible by TILE_WIDTH");
     TT_FATAL(in1_width % constants::TILE_WIDTH == 0, "Input tensor in1 width needs to be divisible by TILE_WIDTH");
     if (has_bias) {
-        TT_FATAL(bias.get_legacy_shape()[2] % constants::TILE_HEIGHT == 0);
-        TT_FATAL(bias.get_legacy_shape()[3] % constants::TILE_WIDTH == 0);
+        TT_FATAL(bias.get_legacy_shape()[-2] % constants::TILE_HEIGHT == 0);
+        TT_FATAL(bias.get_legacy_shape()[-1] % constants::TILE_WIDTH == 0);
     }
 
     // device compatibility checks
@@ -326,7 +323,7 @@ operation::ProgramWithCallbacks bmm_single_core_tilize_untilize(
     DataFormat bias_df = in0_df;
     if (has_bias) {
         bias_addr = bias.buffer()->address();
-        bias_ntiles_w = bias.get_legacy_shape()[3] / constants::TILE_WIDTH;
+        bias_ntiles_w = bias.get_legacy_shape()[-1] / constants::TILE_WIDTH;
         bias_df = datatype_to_dataformat_converter(bias.get_dtype());
         bias_tile_nbytes = tile_size(bias_df);
         bias_log2_of_pagesize = (uint32_t) std::log2((float) bias_tile_nbytes);
@@ -601,14 +598,16 @@ std::vector<Shape> BMMTilizeUntilize::compute_output_shapes(const std::vector<Te
     const auto& in0 = inputs.at(0);
     const auto& in1 = inputs.at(1);
 
+    auto& in0_shape = in0.get_legacy_shape();
+    uint32_t in0_height = in0_shape[-2];
+    uint32_t in0_width = in0_shape[-1];
+    auto& in1_shape = in1.get_legacy_shape();
+    uint32_t in1_height = in1_shape[-2];
+    uint32_t in1_width = in1_shape[-1];
     auto in0_batch = in0.get_legacy_shape()[0];
     auto in0_channel = in0.get_legacy_shape()[1];
-    auto in0_height = in0.get_legacy_shape()[2];
-    auto in0_width = in0.get_legacy_shape()[3];
     auto in1_batch = in1.get_legacy_shape()[0];
     auto in1_channel = in1.get_legacy_shape()[1];
-    auto in1_height = in1.get_legacy_shape()[2];
-    auto in1_width = in1.get_legacy_shape()[3];
 
     const Shape out_shape { in0_batch, in0_channel, in0_height, in1_width };
     return {out_shape};

--- a/ttnn/cpp/pybind11/operations/matmul.hpp
+++ b/ttnn/cpp/pybind11/operations/matmul.hpp
@@ -28,7 +28,7 @@ void py_module(py::module& module) {
            const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
            const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::matmul::matmul(
-                input_tensor_a, input_tensor_b, program_config, memory_config, dtype, activation, compute_kernel_config, core_grid);
+                input_tensor_a, input_tensor_b, /*bias=*/std::nullopt, program_config, memory_config, dtype, activation, compute_kernel_config, core_grid);
         },
         py::arg("input_tensor_a"),
         py::arg("input_tensor_b"),
@@ -51,7 +51,7 @@ void py_module(py::module& module) {
                 const std::optional<const std::string>& activation = std::nullopt,
                 const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
                 const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> ttnn::Tensor {
-            return ttnn::operations::matmul::linear(
+            return ttnn::operations::matmul::matmul(
                 input_tensor_a,
                 input_tensor_b,
                 bias,

--- a/ttnn/cpp/pybind11/operations/matmul.hpp
+++ b/ttnn/cpp/pybind11/operations/matmul.hpp
@@ -28,7 +28,7 @@ void py_module(py::module& module) {
            const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
            const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> ttnn::Tensor {
             return ttnn::operations::matmul::matmul(
-                input_tensor_a, input_tensor_b, /*bias=*/std::nullopt, program_config, memory_config, dtype, activation, compute_kernel_config, core_grid);
+                input_tensor_a, input_tensor_b, /*bias=*/std::nullopt, program_config, memory_config, dtype, activation, compute_kernel_config, core_grid, /*propagate_is_b_batched=*/true);
         },
         py::arg("input_tensor_a"),
         py::arg("input_tensor_b"),

--- a/ttnn/cpp/ttnn/operations/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.cpp
@@ -704,7 +704,7 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
                 ttnn::operations::core::deallocate(input_tensor_post_tm);
             }
         }
-        auto matmul_output = ttnn::operations::matmul::linear(
+        auto matmul_output = ttnn::operations::matmul::matmul(
             matmul_input,
             weight_tensor_on_device,
             bias_tensor_on_device,

--- a/ttnn/cpp/ttnn/operations/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul.cpp
@@ -42,54 +42,6 @@ const std::array<ttnn::TensorSchema, 3> input_tensor_schemas() {
             2, 4, {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b}, {ttnn::TILE_LAYOUT}, true, false, true, true}};
 }
 
-ttnn::Tensor matmul(
-    const ttnn::Tensor& input_tensor_a,
-    const ttnn::Tensor& input_tensor_b,
-    const std::optional<const MatmulProgramConfig> program_config,
-    const ttnn::MemoryConfig& memory_config,
-    const std::optional<const DataType> dtype,
-    const std::optional<const std::string>& activation,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const ttnn::CoreGrid> core_grid)
-    {
-    ttnn::validate_input_tensor("ttnn.matmul", input_tensor_a, input_tensor_schemas()[0]);
-    ttnn::validate_input_tensor("ttnn.matmul", input_tensor_b, input_tensor_schemas()[1]);
-
-    const auto input_tensor_a_shape = input_tensor_a.get_shape();
-    const auto input_tensor_b_shape = input_tensor_b.get_shape();
-
-    const auto width_a = input_tensor_a_shape[-1];
-    const auto height_b = input_tensor_b_shape[-2];
-
-    if (width_a != height_b) {
-        TT_THROW("ttnn.matmul: The width of the first tensor must be equal to the height of the second tensor");
-    }
-
-    auto input_b_is_batched = detail::is_input_batched(input_tensor_b_shape);
-
-    std::optional<CoreCoord> user_core_coord;
-    const bool has_user_grid = core_grid.has_value();
-    if (has_user_grid) {
-	user_core_coord = CoreCoord(core_grid->x, core_grid->y);
-    }
-    auto output_tensor = tt::operations::primary::matmul(
-        input_tensor_a, input_tensor_b, /*bias=*/std::nullopt, program_config, memory_config, dtype, compute_kernel_config, /*untilize_out=*/false,  user_core_coord, get_fused_activation(activation), input_b_is_batched);
-
-    if (activation.has_value() && !has_user_grid) {
-        if (activation.value() == "relu") {
-            output_tensor = tt::tt_metal::relu(output_tensor, memory_config);
-        } else if (activation.value() == "gelu") {
-            output_tensor = tt::tt_metal::gelu(output_tensor, false, memory_config);
-        } else if (activation.value() == "silu") {
-            output_tensor = tt::tt_metal::silu(output_tensor, memory_config);
-        } else {
-            TT_THROW("ttnn.matmul: Unsupported activation function");
-        }
-    }
-
-    return output_tensor;
-}
-
 std::optional<UnaryWithParam> get_fused_activation(const std::optional<const std::string>& activation) {
     if (!activation.has_value()) {
 	return std::nullopt;
@@ -97,7 +49,7 @@ std::optional<UnaryWithParam> get_fused_activation(const std::optional<const std
     return string_to_unary_with_param(activation.value());
 }
 
-ttnn::Tensor linear(
+ttnn::Tensor matmul(
     const ttnn::Tensor& input_tensor_a,
     const ttnn::Tensor& input_tensor_b,
     const std::optional<const ttnn::Tensor>& bias,
@@ -117,25 +69,26 @@ ttnn::Tensor linear(
     const auto width_a = input_tensor_a_shape[-1];
     const auto height_b = input_tensor_b_shape[-2];
 
+    if (width_a != height_b) {
+        TT_THROW("ttnn.matmul: The width of the first tensor must be equal to the height of the second tensor");
+    }
+
     auto input_b_is_batched = detail::is_input_batched(input_tensor_b_shape);
-    TT_ASSERT(input_b_is_batched == false, "Batched input not supported");
+    bool batch_with_bias = input_b_is_batched && bias.has_value();
+    TT_FATAL(!batch_with_bias, "Batched input not supported when bias exists (linear operation).");
 
+    std::optional<CoreCoord> user_core_coord;
     const bool has_user_grid = core_grid.has_value();
-    const bool has_program_config = program_config.has_value();
+    if (has_user_grid) {
+	user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+    }
 
+    const bool has_program_config = program_config.has_value();
     bool post_process_bias = false;
     if (bias.has_value()) {
         if (!has_program_config && !has_user_grid) {
 	    post_process_bias = true;
 	}
-    }
-
-    if (width_a != height_b) {
-        TT_THROW("ttnn.matmul: The width of the first tensor must be equal to the height of the second tensor");
-    }
-    std::optional<CoreCoord> user_core_coord;
-    if (has_user_grid) {
-	user_core_coord = CoreCoord(core_grid->x, core_grid->y);
     }
 
     auto output_tensor = tt::operations::primary::matmul(

--- a/ttnn/cpp/ttnn/operations/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul.cpp
@@ -67,8 +67,8 @@ ttnn::Tensor matmul(
 
     auto input_b_is_batched = detail::is_input_batched(input_tensor_b_shape);
 
-    const auto input_tensor_a_4d = ttnn::unsqueeze_to_4D(input_tensor_a);
-    const auto input_tensor_b_4d = ttnn::unsqueeze_to_4D(input_tensor_b);
+    //const auto input_tensor_a_4d = ttnn::unsqueeze_to_4D(input_tensor_a);
+    //const auto input_tensor_b_4d = ttnn::unsqueeze_to_4D(input_tensor_b);
 
     std::optional<CoreCoord> user_core_coord;
     const bool has_user_grid = core_grid.has_value();
@@ -76,7 +76,7 @@ ttnn::Tensor matmul(
 	user_core_coord = CoreCoord(core_grid->x, core_grid->y);
     }
     auto output_tensor = tt::operations::primary::matmul(
-        input_tensor_a_4d, input_tensor_b_4d, /*bias=*/std::nullopt, program_config, memory_config, dtype, compute_kernel_config, /*untilize_out=*/false,  user_core_coord, get_fused_activation(activation), input_b_is_batched);
+        input_tensor_a, input_tensor_b, /*bias=*/std::nullopt, program_config, memory_config, dtype, compute_kernel_config, /*untilize_out=*/false,  user_core_coord, get_fused_activation(activation), input_b_is_batched);
 
     if (activation.has_value() && !has_user_grid) {
         if (activation.value() == "relu") {
@@ -90,9 +90,9 @@ ttnn::Tensor matmul(
         }
     }
 
-    while (output_tensor.get_shape().rank() != input_tensor_a_shape.rank()) {
+    /*while (output_tensor.get_shape().rank() != input_tensor_a_shape.rank()) {
         output_tensor = ttnn::squeeze_from_4D(output_tensor, input_tensor_a_shape.rank());
-    }
+    }*/
     return output_tensor;
 }
 
@@ -126,16 +126,16 @@ ttnn::Tensor linear(
     auto input_b_is_batched = detail::is_input_batched(input_tensor_b_shape);
     TT_ASSERT(input_b_is_batched == false, "Batched input not supported");
 
-    const auto input_tensor_a_4d = ttnn::unsqueeze_to_4D(input_tensor_a);
-    const auto input_tensor_b_4d = ttnn::unsqueeze_to_4D(input_tensor_b);
+    //const auto input_tensor_a_4d = ttnn::unsqueeze_to_4D(input_tensor_a);
+    //const auto input_tensor_b_4d = ttnn::unsqueeze_to_4D(input_tensor_b);
 
-    std::optional<Tensor> bias_4d = std::nullopt;
+    //std::optional<Tensor> bias_4d = std::nullopt;
     const bool has_user_grid = core_grid.has_value();
     const bool has_program_config = program_config.has_value();
 
     bool post_process_bias = false;
     if (bias.has_value()) {
-        bias_4d = ttnn::unsqueeze_to_4D(bias.value());
+        //bias_4d = ttnn::unsqueeze_to_4D(bias.value());
         if (!has_program_config && !has_user_grid) {
 	    post_process_bias = true;
 	}
@@ -150,11 +150,11 @@ ttnn::Tensor linear(
     }
 
     auto output_tensor = tt::operations::primary::matmul(
-        input_tensor_a_4d, input_tensor_b_4d, post_process_bias ? std::nullopt : bias_4d, program_config, memory_config, dtype, compute_kernel_config, false /*untilize_out*/, user_core_coord, get_fused_activation(activation));
+        input_tensor_a, input_tensor_b, post_process_bias ? std::nullopt : bias, program_config, memory_config, dtype, compute_kernel_config, false /*untilize_out*/, user_core_coord, get_fused_activation(activation));
 
     if (post_process_bias) {
         output_tensor = tt::tt_metal::bcast(
-            output_tensor, bias_4d.value(), tt::tt_metal::BcastOpMath::ADD, tt::tt_metal::BcastOpDim::H, memory_config);
+            output_tensor, bias.value(), tt::tt_metal::BcastOpMath::ADD, tt::tt_metal::BcastOpDim::H, memory_config);
     }
 
     if (activation.has_value() && !has_user_grid) {
@@ -169,9 +169,9 @@ ttnn::Tensor linear(
         }
     }
 
-    while (output_tensor.get_shape().rank() != input_tensor_a_shape.rank()) {
+    /*while (output_tensor.get_shape().rank() != input_tensor_a_shape.rank()) {
         output_tensor = ttnn::squeeze_from_4D(output_tensor, input_tensor_a_shape.rank());
-    }
+    }*/
     return output_tensor;
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul.cpp
@@ -153,7 +153,7 @@ ttnn::Tensor linear(
         input_tensor_a, input_tensor_b, post_process_bias ? std::nullopt : bias, program_config, memory_config, dtype, compute_kernel_config, false /*untilize_out*/, user_core_coord, get_fused_activation(activation));
 
     if (post_process_bias) {
-        output_tensor = tt::tt_metal::bcast(
+        output_tensor = tt::operations::primary::bcast(
             output_tensor, bias.value(), tt::tt_metal::BcastOpMath::ADD, tt::tt_metal::BcastOpDim::H, memory_config);
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul.cpp
@@ -58,7 +58,8 @@ ttnn::Tensor matmul(
     std::optional<const DataType> dtype,
     const std::optional<const std::string>& activation,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
-    const std::optional<const ttnn::CoreGrid> core_grid) {
+    const std::optional<const ttnn::CoreGrid> core_grid,
+    const bool propagate_is_b_batched) {
     ttnn::validate_input_tensor("ttnn.linear", input_tensor_a, input_tensor_schemas()[0]);
     ttnn::validate_input_tensor("ttnn.linear", input_tensor_b, input_tensor_schemas()[1]);
     ttnn::validate_input_tensor("ttnn.linear", bias, input_tensor_schemas()[2]);
@@ -92,7 +93,7 @@ ttnn::Tensor matmul(
     }
 
     auto output_tensor = tt::operations::primary::matmul(
-        input_tensor_a, input_tensor_b, post_process_bias ? std::nullopt : bias, program_config, memory_config, dtype, compute_kernel_config, false /*untilize_out*/, user_core_coord, get_fused_activation(activation));
+        input_tensor_a, input_tensor_b, post_process_bias ? std::nullopt : bias, program_config, memory_config, dtype, compute_kernel_config, false /*untilize_out*/, user_core_coord, get_fused_activation(activation), propagate_is_b_batched && input_b_is_batched);
 
     if (post_process_bias) {
         output_tensor = tt::operations::primary::bcast(

--- a/ttnn/cpp/ttnn/operations/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul.cpp
@@ -67,9 +67,6 @@ ttnn::Tensor matmul(
 
     auto input_b_is_batched = detail::is_input_batched(input_tensor_b_shape);
 
-    //const auto input_tensor_a_4d = ttnn::unsqueeze_to_4D(input_tensor_a);
-    //const auto input_tensor_b_4d = ttnn::unsqueeze_to_4D(input_tensor_b);
-
     std::optional<CoreCoord> user_core_coord;
     const bool has_user_grid = core_grid.has_value();
     if (has_user_grid) {
@@ -90,9 +87,6 @@ ttnn::Tensor matmul(
         }
     }
 
-    /*while (output_tensor.get_shape().rank() != input_tensor_a_shape.rank()) {
-        output_tensor = ttnn::squeeze_from_4D(output_tensor, input_tensor_a_shape.rank());
-    }*/
     return output_tensor;
 }
 
@@ -126,16 +120,11 @@ ttnn::Tensor linear(
     auto input_b_is_batched = detail::is_input_batched(input_tensor_b_shape);
     TT_ASSERT(input_b_is_batched == false, "Batched input not supported");
 
-    //const auto input_tensor_a_4d = ttnn::unsqueeze_to_4D(input_tensor_a);
-    //const auto input_tensor_b_4d = ttnn::unsqueeze_to_4D(input_tensor_b);
-
-    //std::optional<Tensor> bias_4d = std::nullopt;
     const bool has_user_grid = core_grid.has_value();
     const bool has_program_config = program_config.has_value();
 
     bool post_process_bias = false;
     if (bias.has_value()) {
-        //bias_4d = ttnn::unsqueeze_to_4D(bias.value());
         if (!has_program_config && !has_user_grid) {
 	    post_process_bias = true;
 	}
@@ -169,9 +158,6 @@ ttnn::Tensor linear(
         }
     }
 
-    /*while (output_tensor.get_shape().rank() != input_tensor_a_shape.rank()) {
-        output_tensor = ttnn::squeeze_from_4D(output_tensor, input_tensor_a_shape.rank());
-    }*/
     return output_tensor;
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul.hpp
@@ -41,7 +41,8 @@ ttnn::Tensor matmul(
     std::optional<const DataType> dtype = std::nullopt,
     const std::optional<const std::string>& activation = std::nullopt,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt);
+    const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt,
+    const bool propagate_is_b_batched = false);
 
 }  // namespace matmul
 }  // namespace operations

--- a/ttnn/cpp/ttnn/operations/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul.hpp
@@ -30,19 +30,9 @@ inline bool is_input_batched(const ttnn::Shape& shape);
 
 extern const std::array<ttnn::TensorSchema, 3> input_tensor_schemas();
 
-ttnn::Tensor matmul(
-    const ttnn::Tensor& input_tensor_a,
-    const ttnn::Tensor& input_tensor_b,
-    const std::optional<const MatmulProgramConfig> program_config = std::nullopt,
-    const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
-    const std::optional<const DataType> dtype = std::nullopt,
-    const std::optional<const std::string>& activation = std::nullopt,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt);
-
 std::optional<UnaryWithParam> get_fused_activation(const std::optional<const std::string>& activation);
 
-ttnn::Tensor linear(
+ttnn::Tensor matmul(
     const ttnn::Tensor& input_tensor_a,
     const ttnn::Tensor& input_tensor_b,
     const std::optional<const ttnn::Tensor>& bias,


### PR DESCRIPTION
Adds support for ND tensors to matmul

Adjusts tensor shape indices to use relative indexing for last two dims and the rest are handled as being able to be any length.

Removes reshaping to 4D in ttnn/cpp/ttnn/operations/matmul.cpp

Aligns output tensor creation behaviour more closely with pytorch. 

No PCC errors on following workflows Workflows:
https://github.com/tenstorrent/tt-metal/actions/runs/9305313462 All post-commit tests
https://github.com/tenstorrent/tt-metal/actions/runs/9305311040 Device perf regressions and output report 
https://github.com/tenstorrent/tt-metal/actions/runs/9305308077 Nightly fast dispatch tests
https://github.com/tenstorrent/tt-metal/actions/runs/9305305294 [post-commit] models tests
https://github.com/tenstorrent/tt-metal/actions/runs/9305302847 [post-commit] ttnn unit tests 
https://github.com/tenstorrent/tt-metal/actions/runs/9305299063 metal - Run microbenchmarks
https://github.com/tenstorrent/tt-metal/actions/runs/9305296211/job/25612050255 Model perf regressions and output report (will need to update compile/inference time thresholds slightly)
https://github.com/tenstorrent/tt-metal/actions/runs/9318619012 [T3K] T3000 model perf tests

