### PR TITLE
Falcon40b tt_lib to ttnn.experimental

### DIFF
--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -5,7 +5,7 @@
 import json
 import pytest
 from functools import partial
-import tt_lib
+import ttnn
 import torch
 import torch.nn.functional as F
 from loguru import logger
@@ -120,7 +120,7 @@ def initialize_and_fill_kv_cache(
                 torch2tt_tensor(
                     tt_k_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -129,7 +129,7 @@ def initialize_and_fill_kv_cache(
                 torch2tt_tensor(
                     tt_v_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -147,7 +147,7 @@ def print_output_prompts(generated_ids, tokenizer, num_users_to_display=None):
 
 def synchronize_devices(devices):
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
 
 def top_pk_logits(logits, p=0.9, k=10, temperature=1.0, return_probs=False):

--- a/models/demos/t3000/falcon40b/tests/ops/test_falcon_create_qkv_heads.py
+++ b/models/demos/t3000/falcon40b/tests/ops/test_falcon_create_qkv_heads.py
@@ -6,7 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib as ttl
 import ttnn
 from models.demos.t3000.falcon40b.tt.ops.falcon_nlp_create_qkv_heads import TtFalconCreateQKVHeads
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -103,9 +102,12 @@ def run_test_FalconMLP_inference(
         device, model_config=model_config, num_heads=num_heads, num_kv_heads=num_kv_heads, head_dim=head_dim
     )
 
-    input_host = torch2tt_tensor(input, None, tt_dtype=ttl.tensor.DataType.BFLOAT16)
+    input_host = torch2tt_tensor(input, None, tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16)
     input = input_host.to(
-        device, ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+        device,
+        ttnn.experimental.tensor.MemoryConfig(
+            ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
+        ),
     )
 
     q_tt_out, k_tt_out, v_tt_out = tt_Falconcreate_qkv_heads_model(input)

--- a/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib
+import ttnn
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )
@@ -124,7 +124,7 @@ def run_test_FalconAttention_inference(
                 torch2tt_tensor(
                     tt_k_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -133,7 +133,7 @@ def run_test_FalconAttention_inference(
                 torch2tt_tensor(
                     tt_v_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -209,7 +209,7 @@ def run_test_FalconAttention_inference(
                 torch2tt_tensor(
                     tt_k_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -218,7 +218,7 @@ def run_test_FalconAttention_inference(
                 torch2tt_tensor(
                     tt_v_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )

--- a/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib
+import ttnn
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )
@@ -110,7 +110,7 @@ def run_test_FalconCausalLM_inference(
                     torch2tt_tensor(
                         tt_k_cache_host[i],
                         devices[i],
-                        tt_lib.tensor.Layout.TILE,
+                        ttnn.experimental.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
                     )
@@ -119,7 +119,7 @@ def run_test_FalconCausalLM_inference(
                     torch2tt_tensor(
                         tt_v_cache_host[i],
                         devices[i],
-                        tt_lib.tensor.Layout.TILE,
+                        ttnn.experimental.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
                     )
@@ -157,7 +157,7 @@ def run_test_FalconCausalLM_inference(
                     torch2tt_tensor(
                         tt_k_cache_host[j],
                         devices[j],
-                        tt_lib.tensor.Layout.TILE,
+                        ttnn.experimental.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
                     )
@@ -166,7 +166,7 @@ def run_test_FalconCausalLM_inference(
                     torch2tt_tensor(
                         tt_v_cache_host[j],
                         devices[j],
-                        tt_lib.tensor.Layout.TILE,
+                        ttnn.experimental.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
                     )

--- a/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib
+import ttnn
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )
@@ -93,7 +93,7 @@ def run_test_FalconDecoder_inference(
                 torch2tt_tensor(
                     tt_decoder_input_host[i],
                     devices[i],
-                    tt_layout=tt_lib.tensor.Layout.TILE,
+                    tt_layout=ttnn.experimental.tensor.Layout.TILE,
                     tt_memory_config=model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"],
                     tt_dtype=model_config["WORD_EMBEDDING_OUTPUT_DTYPE"],
                 )
@@ -132,7 +132,7 @@ def run_test_FalconDecoder_inference(
                 torch2tt_tensor(
                     tt_k_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -141,7 +141,7 @@ def run_test_FalconDecoder_inference(
                 torch2tt_tensor(
                     tt_v_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -183,7 +183,7 @@ def run_test_FalconDecoder_inference(
                 torch2tt_tensor(
                     tt_decoder_input_host[i],
                     devices[i],
-                    tt_layout=tt_lib.tensor.Layout.TILE,
+                    tt_layout=ttnn.experimental.tensor.Layout.TILE,
                     tt_memory_config=model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"],
                     tt_dtype=model_config["WORD_EMBEDDING_OUTPUT_DTYPE"],
                 )
@@ -233,7 +233,7 @@ def run_test_FalconDecoder_inference(
                 torch2tt_tensor(
                     tt_k_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -242,7 +242,7 @@ def run_test_FalconDecoder_inference(
                 torch2tt_tensor(
                     tt_v_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib
+import ttnn
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )
@@ -134,7 +134,7 @@ def run_test_FalconCausalLM_end_to_end(
         use_global_cos_sin_cache,
     )
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
     profiler.end("TtFalcon_model_setup")
     logger.info("Done loading TT Falcon Model")
 
@@ -190,7 +190,7 @@ def run_test_FalconCausalLM_end_to_end(
         tt_out = [tt_o.cpu() for tt_o in tt_out]
     profiler.end("first_model_run_with_compile", force_enable=True)
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     del tt_out
     del tt_inputs
@@ -241,7 +241,7 @@ def run_test_FalconCausalLM_end_to_end(
             )
             tt_out = [tt_o.cpu() for tt_o in tt_out]
         for device in devices:
-            tt_lib.device.Synchronize(device)
+            ttnn.device.synchronize_device(device)
 
         del tt_out
         del tt_inputs
@@ -265,7 +265,7 @@ def run_test_FalconCausalLM_end_to_end(
             llm_mode, model_input, kv_cache_len, num_input_tokens=kv_len
         )
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
     profiler.start(f"model_run_for_inference")
 
     if llm_mode == "prefill":
@@ -295,7 +295,7 @@ def run_test_FalconCausalLM_end_to_end(
         tt_out = [tt_o.cpu() for tt_o in tt_out]
     profiler.end(f"model_run_for_inference")
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     if llm_mode == "prefill":
         tt_out = torch.vstack(

--- a/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib
+
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 from loguru import logger
-import tt_lib
+import ttnn
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )
@@ -104,7 +104,7 @@ def run_test_FalconModel_inference(
                     torch2tt_tensor(
                         tt_k_cache_host[j],
                         devices[j],
-                        tt_lib.tensor.Layout.TILE,
+                        ttnn.experimental.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
                     )
@@ -113,7 +113,7 @@ def run_test_FalconModel_inference(
                     torch2tt_tensor(
                         tt_v_cache_host[j],
                         devices[j],
-                        tt_lib.tensor.Layout.TILE,
+                        ttnn.experimental.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
                     )
@@ -151,7 +151,7 @@ def run_test_FalconModel_inference(
                     torch2tt_tensor(
                         tt_k_cache_host[j],
                         devices[j],
-                        tt_lib.tensor.Layout.TILE,
+                        ttnn.experimental.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
                     )
@@ -160,7 +160,7 @@ def run_test_FalconModel_inference(
                     torch2tt_tensor(
                         tt_v_cache_host[j],
                         devices[j],
-                        tt_lib.tensor.Layout.TILE,
+                        ttnn.experimental.tensor.Layout.TILE,
                         model_config["KV_CACHE_MEMCFG"],
                         model_config["KV_CACHE_DTYPE"],
                     )
@@ -191,7 +191,7 @@ def run_test_FalconModel_inference(
         use_global_cos_sin_cache=use_global_cos_sin_cache,
     )
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     # TODO: Generate embeddings and attention_mask on device
     if llm_mode == "prefill":

--- a/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 from loguru import logger
 
-import tt_lib
+import ttnn
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import FalconForCausalLM, FalconConfig
 from models.demos.t3000.falcon40b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.t3000.falcon40b.tt.model_config import get_model_config, model_config_entries
@@ -75,7 +75,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
                 torch2tt_tensor(
                     tt_k_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -84,7 +84,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
                 torch2tt_tensor(
                     tt_v_cache_host[j],
                     devices[j],
-                    tt_lib.tensor.Layout.TILE,
+                    ttnn.experimental.tensor.Layout.TILE,
                     model_config["KV_CACHE_MEMCFG"],
                     model_config["KV_CACHE_DTYPE"],
                 )
@@ -106,7 +106,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
         use_global_cos_sin_cache,
     )
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
     logger.info("Done loading TT Falcon Model")
 
     # Prepare inputs -----------------------------------------------------------------------
@@ -141,7 +141,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
     logger.info("Done running TT Falcon model")
 
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     reference_out = torch.vstack(
         [torch.cat([tt2torch_tensor(tt_o).squeeze(1) for tt_o in tt_out], -1) for tt_out in tt_outs]

--- a/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_e2e_falcon.py
@@ -5,9 +5,9 @@
 import torch
 import pytest
 import time
+import ttnn
 from loguru import logger
 
-import tt_lib
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )
@@ -92,7 +92,7 @@ def run_test_FalconCausalLM_end_to_end(
     else:
         raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     # NOTE: Passing in pytorch tensor here instead of ll buda tensor
     # since we don't yet have embedding support on device
@@ -110,7 +110,7 @@ def run_test_FalconCausalLM_end_to_end(
         use_global_cos_sin_cache,
     )
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     del state_dict
 
@@ -163,7 +163,7 @@ def run_test_FalconCausalLM_end_to_end(
         tt_out = [tt_o.cpu() for tt_o in tt_out]
     compile_duration = time.time() - compile_time_start
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     del tt_out
     del tt_layer_present
@@ -219,7 +219,7 @@ def run_test_FalconCausalLM_end_to_end(
             )
             tt_out = [tt_o.cpu() for tt_o in tt_out]
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     logger.info(f"Enable binary and compile cache, and start timing.")
     enable_persistent_kernel_cache()
@@ -253,7 +253,7 @@ def run_test_FalconCausalLM_end_to_end(
     inference_duration = time.time() - start_time
 
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     logger.info(f"falcon 40b compile time: {compile_duration}")
     logger.info(f"falcon 40b inference time: {inference_duration}")

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -7,6 +7,7 @@ import pytest
 from loguru import logger
 
 import tt_lib
+import ttnn
 from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
     FalconForCausalLM,
 )
@@ -97,7 +98,7 @@ def run_test_FalconCausalLM_end_to_end(
     else:
         raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     # NOTE: Passing in pytorch tensor here instead of ll buda tensor
     # since we don't yet have embedding support on device
@@ -115,7 +116,7 @@ def run_test_FalconCausalLM_end_to_end(
         use_global_cos_sin_cache,
     )
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
     profiler.end("TtFalcon_model_setup")
 
     del state_dict
@@ -181,7 +182,7 @@ def run_test_FalconCausalLM_end_to_end(
         tt_out = [tt_o.cpu() for tt_o in tt_out]
     profiler.end("first_model_run_with_compile", force_enable=True)
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     del tt_out
     del tt_layer_present
@@ -244,7 +245,7 @@ def run_test_FalconCausalLM_end_to_end(
             tt_out = [tt_o.cpu() for tt_o in tt_out]
     profiler.end(f"model_warmup_run_for_inference")
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     # Run for perf iteration - profiler enabled
     for device in devices:
@@ -280,7 +281,7 @@ def run_test_FalconCausalLM_end_to_end(
         tt_out = [tt_o.cpu() for tt_o in tt_out]
     profiler.end(f"model_run_for_inference")
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.device.synchronize_device(device)
 
     profiler.print()
 

--- a/models/demos/t3000/falcon40b/tt/falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_causallm.py
@@ -5,7 +5,7 @@
 import torch
 from typing import Optional, Tuple
 
-import tt_lib
+import ttnn
 
 from models.demos.t3000.falcon40b.tt.falcon_model import TtFalconModelShared
 from models.utility_functions import torch2tt_tensor
@@ -51,7 +51,7 @@ class TtFalconCausalLM(TtFalconModelShared):
             )
             if (lm_head_path).exists():
                 self.lm_head_weights.append(
-                    tt_lib.tensor.load_tensor(str(lm_head_path)).to(
+                    ttnn.experimental.tensor.load_tensor(str(lm_head_path)).to(
                         devices[i], self.model_config["LM_HEAD_MM_WEIGHTS_MEMCFG"]
                     )
                 )
@@ -65,21 +65,21 @@ class TtFalconCausalLM(TtFalconModelShared):
                 self.lm_head_weights.append(
                     lm_head_weights_host.to(devices[i], self.model_config["LM_HEAD_MM_WEIGHTS_MEMCFG"])
                 )
-                tt_lib.tensor.dump_tensor(
+                ttnn.experimental.tensor.dump_tensor(
                     str(lm_head_path),
                     lm_head_weights_host,
                 )
 
     def __call__(
         self,
-        input_ids: tt_lib.tensor.Tensor,
+        input_ids: ttnn.experimental.tensor.Tensor,
         llm_mode: str,
-        attention_mask: tt_lib.tensor.Tensor = None,
+        attention_mask: ttnn.experimental.tensor.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.experimental.tensor.Tensor:
         if llm_mode == "prefill":
             return self.fwd_prefill_causallm(
                 input_ids=input_ids,
@@ -105,14 +105,14 @@ class TtFalconCausalLM(TtFalconModelShared):
 
     def fwd_prefill_causallm(
         self,
-        input_ids: tt_lib.tensor.Tensor,
+        input_ids: ttnn.experimental.tensor.Tensor,
         llm_mode: str,
-        attention_mask: tt_lib.tensor.Tensor = None,
+        attention_mask: ttnn.experimental.tensor.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.experimental.tensor.Tensor:
         hidden_states, presents = super().__call__(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -158,14 +158,14 @@ class TtFalconCausalLM(TtFalconModelShared):
 
     def fwd_decode_causallm(
         self,
-        input_ids: tt_lib.tensor.Tensor,
+        input_ids: ttnn.experimental.tensor.Tensor,
         llm_mode: str,
-        attention_mask: tt_lib.tensor.Tensor = None,
+        attention_mask: ttnn.experimental.tensor.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.experimental.tensor.Tensor:
         hidden_states, presents = super().__call__(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -180,7 +180,7 @@ class TtFalconCausalLM(TtFalconModelShared):
         lm_logits = []
         for i in range(len(hidden_states)):
             lm_logits.append(
-                tt_lib.operations.primary.matmul_1d(
+                ttnn.experimental.operations.primary.matmul_1d(
                     hidden_states[i],
                     self.lm_head_weights[i],
                     program_config=self.model_config["LM_HEAD_MM_PROGCFG"],

--- a/models/demos/t3000/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_decoder.py
@@ -5,7 +5,7 @@
 import torch
 from typing import Optional, Tuple
 
-import tt_lib
+import ttnn
 
 from models.demos.t3000.falcon40b.tt.falcon_attention import TtFalconAttention
 from models.demos.t3000.falcon40b.tt.falcon_mlp import TtFalconMLP
@@ -72,38 +72,38 @@ class TtFalconDecoderLayer:
             tt_cache_path / f"{ln_mlp_weights_str}_rm_{self.model_config['LN_MLP_WEIGHTS_DTYPE'].name}.bin"
         )
         if (ln_mlp_weights_path).exists():
-            ln_mlp_gamma_host = tt_lib.tensor.load_tensor(str(ln_mlp_weights_path))
+            ln_mlp_gamma_host = ttnn.experimental.tensor.load_tensor(str(ln_mlp_weights_path))
             self.ln_mlp_gamma = [
                 ln_mlp_gamma_host.to(device, self.model_config["LN_MLP_WEIGHTS_MEMCFG"]) for device in devices
             ]
         else:
-            ln_mlp_gamma_host = tt_lib.tensor.Tensor(
+            ln_mlp_gamma_host = ttnn.experimental.tensor.Tensor(
                 self.state_dict[ln_mlp_weights_str].reshape([1, 1, -1, 32]),
                 self.model_config["LN_MLP_WEIGHTS_DTYPE"],
             )
             self.ln_mlp_gamma = [
                 ln_mlp_gamma_host.to(device, self.model_config["LN_MLP_WEIGHTS_MEMCFG"]) for device in devices
             ]
-            tt_lib.tensor.dump_tensor(
+            ttnn.experimental.tensor.dump_tensor(
                 str(ln_mlp_weights_path),
                 ln_mlp_gamma_host,
             )
 
         ln_mlp_bias_path = tt_cache_path / f"{ln_mlp_bias_str}_rm_{self.model_config['LN_MLP_BIAS_DTYPE'].name}.bin"
         if (ln_mlp_bias_path).exists():
-            ln_mlp_beta_host = tt_lib.tensor.load_tensor(str(ln_mlp_bias_path))
+            ln_mlp_beta_host = ttnn.experimental.tensor.load_tensor(str(ln_mlp_bias_path))
             self.ln_mlp_beta = [
                 ln_mlp_beta_host.to(device, self.model_config["LN_MLP_BIAS_MEMCFG"]) for device in devices
             ]
         else:
-            ln_mlp_beta_host = tt_lib.tensor.Tensor(
+            ln_mlp_beta_host = ttnn.experimental.tensor.Tensor(
                 self.state_dict[ln_mlp_bias_str].reshape([1, 1, -1, 32]),
                 self.model_config["LN_MLP_BIAS_DTYPE"],
             )
             self.ln_mlp_beta = [
                 ln_mlp_beta_host.to(device, self.model_config["LN_MLP_BIAS_MEMCFG"]) for device in devices
             ]
-            tt_lib.tensor.dump_tensor(
+            ttnn.experimental.tensor.dump_tensor(
                 str(ln_mlp_bias_path),
                 ln_mlp_beta_host,
             )
@@ -115,38 +115,38 @@ class TtFalconDecoderLayer:
             tt_cache_path / f"{ln_attn_weights_str}_rm_{self.model_config['LN_ATTN_WEIGHTS_DTYPE'].name}.bin"
         )
         if (ln_attn_weights_path).exists():
-            ln_attn_gamma_host = tt_lib.tensor.load_tensor(str(ln_attn_weights_path))
+            ln_attn_gamma_host = ttnn.experimental.tensor.load_tensor(str(ln_attn_weights_path))
             self.ln_attn_gamma = [
                 ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"]) for device in devices
             ]
         else:
-            ln_attn_gamma_host = tt_lib.tensor.Tensor(
+            ln_attn_gamma_host = ttnn.experimental.tensor.Tensor(
                 self.state_dict[ln_attn_weights_str].reshape([1, 1, -1, 32]),
                 self.model_config["LN_ATTN_WEIGHTS_DTYPE"],
             )
             self.ln_attn_gamma = [
                 ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"]) for device in devices
             ]
-            tt_lib.tensor.dump_tensor(
+            ttnn.experimental.tensor.dump_tensor(
                 str(ln_attn_weights_path),
                 ln_attn_gamma_host,
             )
 
         ln_attn_bias_path = tt_cache_path / f"{ln_attn_bias_str}_rm_{self.model_config['LN_ATTN_BIAS_DTYPE'].name}.bin"
         if (ln_attn_bias_path).exists():
-            ln_attn_beta_host = tt_lib.tensor.load_tensor(str(ln_attn_bias_path))
+            ln_attn_beta_host = ttnn.experimental.tensor.load_tensor(str(ln_attn_bias_path))
             self.ln_attn_beta = [
                 ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"]) for device in devices
             ]
         else:
-            ln_attn_beta_host = tt_lib.tensor.Tensor(
+            ln_attn_beta_host = ttnn.experimental.tensor.Tensor(
                 self.state_dict[ln_attn_bias_str].reshape([1, 1, -1, 32]),
                 self.model_config["LN_ATTN_BIAS_DTYPE"],
             )
             self.ln_attn_beta = [
                 ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"]) for device in devices
             ]
-            tt_lib.tensor.dump_tensor(
+            ttnn.experimental.tensor.dump_tensor(
                 str(ln_attn_bias_path),
                 ln_attn_beta_host,
             )
@@ -163,16 +163,16 @@ class TtFalconDecoderLayer:
 
     def __call__(
         self,
-        hidden_states: tt_lib.tensor.Tensor,
+        hidden_states: ttnn.experimental.tensor.Tensor,
         alibi: torch.Tensor,
         attention_mask: torch.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[tt_lib.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
-    ) -> Tuple[tt_lib.tensor.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         """Input shape: [batch, 1, seq_len, hidden_size]"""
 
         if llm_mode == "prefill":
@@ -204,16 +204,16 @@ class TtFalconDecoderLayer:
 
     def fwd_prefill(
         self,
-        hidden_states: tt_lib.tensor.Tensor,
+        hidden_states: ttnn.experimental.tensor.Tensor,
         alibi: torch.Tensor,
         attention_mask: torch.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[tt_lib.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
-    ) -> Tuple[tt_lib.tensor.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         """Input shape: [batch, 1, seq_len, hidden_size]"""
 
         assert not output_attentions
@@ -222,7 +222,7 @@ class TtFalconDecoderLayer:
             replicated_hidden_states = []
             for i in range(len(hidden_states)):
                 replicated_hidden_states.append(
-                    tt_lib.tensor.sharded_to_interleaved(
+                    ttnn.experimental.tensor.sharded_to_interleaved(
                         hidden_states[i], output_mem_config=self.model_config["DEFAULT_MEMCFG"]
                     )
                 )
@@ -230,16 +230,18 @@ class TtFalconDecoderLayer:
             replicated_hidden_states = []
             for i in range(len(hidden_states)):
                 replicated_hidden_states.append(
-                    tt_lib.tensor.clone(hidden_states[i], output_mem_config=self.model_config["DEFAULT_MEMCFG"])
+                    ttnn.experimental.tensor.clone(
+                        hidden_states[i], output_mem_config=self.model_config["DEFAULT_MEMCFG"]
+                    )
                 )
 
         if replicated_hidden_states[0].dtype != self.model_config["BFP8_DTYPE"]:
             for i in range(len(replicated_hidden_states)):
-                replicated_hidden_states[i] = tt_lib.tensor.typecast(
+                replicated_hidden_states[i] = ttnn.experimental.tensor.typecast(
                     replicated_hidden_states[i], self.model_config["BFP8_DTYPE"]
                 )
 
-        replicated_hidden_states = tt_lib.tensor.all_gather(
+        replicated_hidden_states = ttnn.experimental.tensor.all_gather(
             replicated_hidden_states,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             dim=3,
@@ -248,7 +250,7 @@ class TtFalconDecoderLayer:
 
         if self.model_config["LN_INPUT_DTYPE"] != self.model_config["BFP8_DTYPE"]:
             for i in range(len(replicated_hidden_states)):
-                replicated_hidden_states[i] = tt_lib.tensor.typecast(
+                replicated_hidden_states[i] = ttnn.experimental.tensor.typecast(
                     replicated_hidden_states[i], self.model_config["LN_INPUT_DTYPE"]
                 )
 
@@ -302,7 +304,7 @@ class TtFalconDecoderLayer:
         # Note that this is only correct in inference when dropout is disabled
         for i in range(len(residual)):
             output.append(
-                tt_lib.operations.primary.add(
+                ttnn.experimental.operations.primary.add(
                     residual[i],
                     attention_output[i],
                     output_mem_config=self.model_config["PARALLEL_ATTN_ADD_OUTPUT_MEMCFG"],
@@ -318,7 +320,7 @@ class TtFalconDecoderLayer:
         # dropout_add
         # For inference, this is just add
         for i in range(len(output)):
-            output[i] = tt_lib.operations.primary.add(
+            output[i] = ttnn.experimental.operations.primary.add(
                 output[i],
                 mlp_output[i],
                 output_mem_config=self.model_config["DROPOUT_ADD_OUTPUT_MEMCFG"],
@@ -339,16 +341,16 @@ class TtFalconDecoderLayer:
 
     def fwd_decode(
         self,
-        hidden_states: tt_lib.tensor.Tensor,
+        hidden_states: ttnn.experimental.tensor.Tensor,
         alibi: torch.Tensor,
         attention_mask: torch.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[tt_lib.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
-    ) -> Tuple[tt_lib.tensor.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         """Input shape: [batch, 1, seq_len, hidden_size]"""
 
         assert not output_attentions
@@ -356,18 +358,18 @@ class TtFalconDecoderLayer:
         replicated_hidden_states = []
         for i in range(len(hidden_states)):
             replicated_hidden_states.append(
-                tt_lib.tensor.sharded_to_interleaved(
+                ttnn.experimental.tensor.sharded_to_interleaved(
                     hidden_states[i], output_mem_config=self.model_config["DEFAULT_MEMCFG"]
                 )
             )
-        replicated_hidden_states = tt_lib.tensor.all_gather(
+        replicated_hidden_states = ttnn.experimental.tensor.all_gather(
             replicated_hidden_states,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             dim=3,
             output_mem_config=self.model_config["DEFAULT_MEMCFG"],
         )
         for i in range(len(replicated_hidden_states)):
-            replicated_hidden_states[i] = tt_lib.tensor.interleaved_to_sharded(
+            replicated_hidden_states[i] = ttnn.experimental.tensor.interleaved_to_sharded(
                 replicated_hidden_states[i], sharded_mem_config=self.model_config["DECODER_ALL_GATHER_OUTPUT_MEMCFG"]
             )
 
@@ -375,7 +377,7 @@ class TtFalconDecoderLayer:
         mlp_ln_output = []
         for i in range(len(replicated_hidden_states)):
             attn_ln_output.append(
-                tt_lib.operations.primary.layernorm(
+                ttnn.experimental.operations.primary.layernorm(
                     replicated_hidden_states[i],
                     self.layernorm_eps,
                     self.ln_attn_gamma[i],
@@ -387,7 +389,7 @@ class TtFalconDecoderLayer:
         # mlp_ln is in place, no need to deallocate original
         for i in range(len(replicated_hidden_states)):
             mlp_ln_output.append(
-                tt_lib.operations.primary.layernorm(
+                ttnn.experimental.operations.primary.layernorm(
                     replicated_hidden_states[i],
                     self.layernorm_eps,
                     self.ln_mlp_gamma[i],
@@ -419,7 +421,7 @@ class TtFalconDecoderLayer:
         # Note that this is only correct in inference when dropout is disabled
         for i in range(len(residual)):
             output.append(
-                tt_lib.operations.primary.add(
+                ttnn.experimental.operations.primary.add(
                     residual[i],
                     attention_output[i],
                     output_mem_config=self.model_config["PARALLEL_ATTN_ADD_OUTPUT_MEMCFG"],
@@ -435,7 +437,7 @@ class TtFalconDecoderLayer:
         # dropout_add
         # For inference, this is just add
         for i in range(len(output)):
-            output[i] = tt_lib.operations.primary.add(
+            output[i] = ttnn.experimental.operations.primary.add(
                 output[i],
                 mlp_output[i],
                 output_mem_config=self.model_config["DROPOUT_ADD_OUTPUT_MEMCFG"],

--- a/models/demos/t3000/falcon40b/tt/falcon_embeddings.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_embeddings.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 import ttnn
 
 
@@ -41,13 +40,13 @@ class TtFalconEmbeddings(torch.nn.Module):
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         for i in range(self.num_devices):
-            x[i] = tt_lib.tensor.embeddings(
+            x[i] = ttnn.experimental.tensor.embeddings(
                 x[i], self.embd_weights[i], tilized=True, output_dtype=self.model_config["WORD_EMBEDDING_OUTPUT_DTYPE"]
             )
 
         if self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"].is_sharded():
             for i in range(self.num_devices):
-                x[i] = tt_lib.tensor.interleaved_to_sharded(
+                x[i] = ttnn.experimental.tensor.interleaved_to_sharded(
                     x[i], sharded_mem_config=self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"]
                 )
 

--- a/models/demos/t3000/falcon40b/tt/ops/falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tt/ops/falcon_layernorm.py
@@ -5,7 +5,7 @@
 import torch
 import math
 from torch import nn
-import tt_lib
+import ttnn
 
 from typing import List
 from models.utility_functions import torch2tt_tensor
@@ -27,120 +27,120 @@ class TtFalconLayernorm:
             tt_cache_path / f"{ln_attn_weights_str}_rm_{self.model_config['LN_ATTN_WEIGHTS_DTYPE'].name}.bin"
         )
         if (ln_attn_weights_path).exists():
-            ln_attn_gamma_host = tt_lib.tensor.load_tensor(str(ln_attn_weights_path))
+            ln_attn_gamma_host = ttnn.experimental.tensor.load_tensor(str(ln_attn_weights_path))
             self.ln_attn_gamma = [
                 ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"]) for device in devices
             ]
         else:
-            ln_attn_gamma_host = tt_lib.tensor.Tensor(
+            ln_attn_gamma_host = ttnn.experimental.tensor.Tensor(
                 self.state_dict[ln_attn_weights_str].reshape([1, 1, -1, 32]),
                 self.model_config["LN_ATTN_WEIGHTS_DTYPE"],
             )
             self.ln_attn_gamma = [
                 ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"]) for device in devices
             ]
-            tt_lib.tensor.dump_tensor(
+            ttnn.experimental.tensor.dump_tensor(
                 str(ln_attn_weights_path),
                 ln_attn_gamma_host,
             )
 
         ln_attn_bias_path = tt_cache_path / f"{ln_attn_bias_str}_rm_{self.model_config['LN_ATTN_BIAS_DTYPE'].name}.bin"
         if (ln_attn_bias_path).exists():
-            ln_attn_beta_host = tt_lib.tensor.load_tensor(str(ln_attn_bias_path))
+            ln_attn_beta_host = ttnn.experimental.tensor.load_tensor(str(ln_attn_bias_path))
             self.ln_attn_beta = [
                 ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"]) for device in devices
             ]
         else:
-            ln_attn_beta_host = tt_lib.tensor.Tensor(
+            ln_attn_beta_host = ttnn.experimental.tensor.Tensor(
                 self.state_dict[ln_attn_bias_str].reshape([1, 1, -1, 32]),
                 self.model_config["LN_ATTN_BIAS_DTYPE"],
             )
             self.ln_attn_beta = [
                 ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"]) for device in devices
             ]
-            tt_lib.tensor.dump_tensor(
+            ttnn.experimental.tensor.dump_tensor(
                 str(ln_attn_bias_path),
                 ln_attn_beta_host,
             )
 
         self.layernorm_eps = config.layer_norm_epsilon
 
-    def __call__(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def __call__(self, x: ttnn.experimental.tensor.Tensor) -> ttnn.experimental.tensor.Tensor:
         if self.is_sharded:
             row_height = x.get_legacy_shape()[2]
             shard_width_hidden_dim_across_32_cores = x.get_legacy_shape()[3] // 32
-            shard_spec_32_cores_grid = tt_lib.tensor.CoreRangeSet(
+            shard_spec_32_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
                 {
-                    tt_lib.tensor.CoreRange(
-                        tt_lib.tensor.CoreCoord(0, 0),
-                        tt_lib.tensor.CoreCoord(7, 3),
+                    ttnn.experimental.tensor.CoreRange(
+                        ttnn.experimental.tensor.CoreCoord(0, 0),
+                        ttnn.experimental.tensor.CoreCoord(7, 3),
                     ),
                 }
             )
             # # Option1 : width sharded; produces bad PCC
-            # out = tt_lib.operations.primary.layernorm(
+            # out = ttnn.experimental.operations.primary.layernorm(
             #     x,
             #     self.layernorm_eps,
             #     self.ln_attn_gamma[0],
             #     self.ln_attn_beta[0],
-            #     tt_lib.tensor.MemoryConfig(
-            #         tt_lib.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            #         tt_lib.tensor.BufferType.L1,
-            #         tt_lib.tensor.ShardSpec(
+            #     ttnn.experimental.tensor.MemoryConfig(
+            #         ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+            #         ttnn.experimental.tensor.BufferType.L1,
+            #         ttnn.experimental.tensor.ShardSpec(
             #             shard_spec_32_cores_grid,
             #             [
             #                 row_height,
             #                 shard_width_hidden_dim_across_32_cores,
             #             ],
-            #             tt_lib.tensor.ShardOrientation.ROW_MAJOR,
+            #             ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
             #             False,
             #         ),
             #     ),
-            #     tt_lib.operations.primary.LayerNormShardedMultiCoreProgramConfig(
+            #     ttnn.experimental.operations.primary.LayerNormShardedMultiCoreProgramConfig(
             #         compute_with_storage_grid_size=[8, 4],
             #         subblock_w=8,
             #         block_h=row_height // 32,
             #         block_w=8,
-            #         math_fidelity=tt_lib.tensor.MathFidelity.HiFi4,
-            #         im_data_format=tt_lib.tensor.DataType.BFLOAT16,
+            #         math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
+            #         im_data_format=ttnn.experimental.tensor.DataType.BFLOAT16,
             #         out_data_format=self.model_config["LN_ATTN_OUTPUT_DTYPE"],
             #         inplace=False,
             #     ),
             # )
 
             # # option 2: block sharded hardcoded for S=128 and 8x4 grid of cores; produces good PCC!
-            # out = tt_lib.operations.primary.layernorm(
+            # out = ttnn.experimental.operations.primary.layernorm(
             #     x,
             #     self.layernorm_eps,
             #     self.ln_attn_gamma[0],
             #     self.ln_attn_beta[0],
-            #     tt_lib.tensor.MemoryConfig(
-            #         tt_lib.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            #         tt_lib.tensor.BufferType.L1,
-            #         tt_lib.tensor.ShardSpec(
+            #     ttnn.experimental.tensor.MemoryConfig(
+            #         ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+            #         ttnn.experimental.tensor.BufferType.L1,
+            #         ttnn.experimental.tensor.ShardSpec(
             #             shard_spec_32_cores_grid,
             #             [
             #                 32,
             #                 1024,
             #             ],
-            #             tt_lib.tensor.ShardOrientation.ROW_MAJOR,
+            #             ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
             #             False,
             #         ),
             #     ),
-            #     tt_lib.operations.primary.LayerNormShardedMultiCoreProgramConfig(
+            #     ttnn.experimental.operations.primary.LayerNormShardedMultiCoreProgramConfig(
             #         compute_with_storage_grid_size=[8, 4],
             #         subblock_w=8,
             #         block_h=1,
             #         block_w=32, # 8
-            #         math_fidelity=tt_lib.tensor.MathFidelity.HiFi4,
-            #         im_data_format=tt_lib.tensor.DataType.BFLOAT16,
+            #         math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
+            #         im_data_format=ttnn.experimental.tensor.DataType.BFLOAT16,
             #         out_data_format=self.model_config["LN_ATTN_OUTPUT_DTYPE"],
             #         inplace=False,
             #     ),
             # )
 
             # version according to model_config for debug
-            out = tt_lib.operations.primary.layernorm(
+            out = ttnn.experimental.operations.primary.layernorm(
                 x,
                 self.layernorm_eps,
                 self.ln_attn_gamma[0],
@@ -152,7 +152,7 @@ class TtFalconLayernorm:
             # Option 1: uses only one core; runs out of L1
             # E           Statically allocated circular buffers on core range {} grow to {} B which is beyond max L1 size of {} B
             # E           [(x=0,y=0) - (x=1,y=0)]
-            out = tt_lib.operations.primary.layernorm(
+            out = ttnn.experimental.operations.primary.layernorm(
                 x,
                 self.layernorm_eps,
                 self.ln_attn_gamma[0],
@@ -165,15 +165,15 @@ class TtFalconLayernorm:
             # Runs out of L1
             # E                       Statically allocated circular buffers on core range {} grow to {} B which is beyond max L1 size of {} B
             # E                       [(x=0,y=0) - (x=1,y=0)]
-            # out = tt_lib.operations.primary.layernorm(
+            # out = ttnn.experimental.operations.primary.layernorm(
             #     x,
             #     self.layernorm_eps,
             #     self.ln_attn_gamma[0],
             #     self.ln_attn_beta[0],
-            #     program_config=tt_lib.operations.primary.LayerNormInterleavedMultiCoreProgramConfig(
-            #         math_fidelity=tt_lib.tensor.MathFidelity.HiFi4,
-            #         im_data_format=tt_lib.tensor.DataType.BFLOAT16,
-            #         out_data_format=tt_lib.tensor.DataType.BFLOAT8_B,
+            #     program_config=ttnn.experimental.operations.primary.LayerNormInterleavedMultiCoreProgramConfig(
+            #         math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
+            #         im_data_format=ttnn.experimental.tensor.DataType.BFLOAT16,
+            #         out_data_format=ttnn.experimental.tensor.DataType.BFLOAT8_B,
             #     ),
             # )
 
@@ -181,23 +181,23 @@ class TtFalconLayernorm:
             # # Runs out of L1
             # # E               Statically allocated circular buffers on core range {} grow to {} B which is beyond max L1 size of {} B
             # # E               [(x=0,y=0) - (x=1,y=0)]
-            # out = tt_lib.tensor.layernorm(
+            # out = ttnn.experimental.tensor.layernorm(
             #     x,
             #     self.layernorm_eps,
             #     output_mem_config=self.model_config["DEFAULT_MEMCFG"],
             # )
-            # out = tt_lib.tensor.bcast(
+            # out = ttnn.experimental.tensor.bcast(
             #     out,
             #     self.ln_attn_gamma[0],
-            #     tt_lib.tensor.BcastOpMath.MUL,
-            #     tt_lib.tensor.BcastOpDim.H,
+            #     ttnn.experimental.tensor.BcastOpMath.MUL,
+            #     ttnn.experimental.tensor.BcastOpDim.H,
             #     output_mem_config=self.model_config["DEFAULT_MEMCFG"],
             # )
-            # out = tt_lib.tensor.bcast(
+            # out = ttnn.experimental.tensor.bcast(
             #     out,
             #     self.ln_attn_beta[0],
-            #     tt_lib.tensor.BcastOpMath.ADD,
-            #     tt_lib.tensor.BcastOpDim.H,
+            #     ttnn.experimental.tensor.BcastOpMath.ADD,
+            #     ttnn.experimental.tensor.BcastOpDim.H,
             #     output_mem_config=self.model_config["DEFAULT_MEMCFG"],
             # )
 

--- a/models/demos/t3000/falcon40b/tt/ops/falcon_nlp_create_qkv_heads.py
+++ b/models/demos/t3000/falcon40b/tt/ops/falcon_nlp_create_qkv_heads.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib as ttl
+import ttnn
 
 from typing import List
 from models.utility_functions import torch2tt_tensor
@@ -23,12 +23,12 @@ class TtFalconCreateQKVHeads:
         self.num_kv_heads = num_kv_heads
         self.model_config = model_config
 
-    def __call__(self, x: ttl.tensor.Tensor) -> ttl.tensor.Tensor:
-        # x = ttl.tensor.interleaved_to_sharded(
+    def __call__(self, x: ttnn.experimental.tensor.Tensor) -> ttnn.experimental.tensor.Tensor:
+        # x = ttnn.experimental.tensor.interleaved_to_sharded(
         #     x, sharded_mem_config=self.model_config["CREATE_QKV_HEADS_INPUT_MEMCFG"]
         # )
 
-        q_layer, k_layer, v_layer = ttl.tensor.nlp_create_qkv_heads(
+        q_layer, k_layer, v_layer = ttnn.experimental.tensor.nlp_create_qkv_heads(
             x,
             num_heads=self.num_heads,
             num_kv_heads=self.num_kv_heads,
@@ -38,15 +38,15 @@ class TtFalconCreateQKVHeads:
             output_mem_config=self.model_config["DRAM_MEMCFG"],
         )
 
-        # q_layer = ttl.tensor.sharded_to_interleaved(
+        # q_layer = ttnn.experimental.tensor.sharded_to_interleaved(
         #     q_layer, output_mem_config=self.model_config["DEFAULT_MEMCFG"]
         # )
 
-        # k_layer = ttl.tensor.sharded_to_interleaved(
+        # k_layer = ttnn.experimental.tensor.sharded_to_interleaved(
         #     k_layer, output_mem_config=self.model_config["DEFAULT_MEMCFG"]
         # )
 
-        # v_layer = ttl.tensor.sharded_to_interleaved(
+        # v_layer = ttnn.experimental.tensor.sharded_to_interleaved(
         #     v_layer, output_mem_config=self.model_config["DEFAULT_MEMCFG"]
         # )
 

--- a/models/demos/t3000/falcon40b/tt/ops/falcon_softmax.py
+++ b/models/demos/t3000/falcon40b/tt/ops/falcon_softmax.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-import tt_lib as ttl
+import ttnn
 
 from typing import List
 from models.utility_functions import torch2tt_tensor
@@ -18,7 +18,9 @@ class TtFalconSoftmax:
         self.seqlen = seqlen
         self.scalar = 1 / math.sqrt(head_dim)
 
-    def __call__(self, x: ttl.tensor.Tensor, attention_mask: ttl.tensor.Tensor) -> ttl.tensor.Tensor:
+    def __call__(
+        self, x: ttnn.experimental.tensor.Tensor, attention_mask: ttnn.experimental.tensor.Tensor
+    ) -> ttnn.experimental.tensor.Tensor:
         softmax_progcfg = self.model_config["SOFTMAX_PROGCFG"]
         softmax_progcfg.block_w = (
             self.seqlen // 32
@@ -26,24 +28,24 @@ class TtFalconSoftmax:
 
         if self.is_sharded:
             # Subtract max value from activation before softmax
-            out = ttl.operations.primary.transformers.scale_mask_softmax_in_place(
+            out = ttnn.experimental.operations.primary.transformers.scale_mask_softmax_in_place(
                 x,
                 self.scalar,
                 attention_mask,
                 program_config=softmax_progcfg,
                 # output_mem_config=self.model_config["DEFAULT_MEMCFG"],
-                # program_config=ttl.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
+                # program_config=ttnn.experimental.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
                 is_causal_mask=True,
             )
         else:
             # Subtract max value from activation before softmax
-            out = ttl.operations.primary.transformers.scale_mask_softmax_in_place(
+            out = ttnn.experimental.operations.primary.transformers.scale_mask_softmax_in_place(
                 x,
                 self.scalar,
                 attention_mask,
                 # program_config=softmax_progcfg,
                 # output_mem_config=self.model_config["DEFAULT_MEMCFG"],
-                program_config=ttl.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
+                program_config=ttnn.experimental.operations.primary.transformers.SoftmaxDefaultProgramConfig(),
                 is_causal_mask=True,
             )
 

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -92,14 +92,15 @@ run_t3000_tests() {
   # Run tteager tests
   #run_t3000_tteager_tests
 
+  # Run falcon40b tests
+  run_t3000_falcon40b_tests
+
   # Run llama2-70b tests
   run_t3000_llama2_70b_tests
 
   # Run mixtral tests
   run_t3000_mixtral_tests
 
-  # Run falcon40b tests
-  run_t3000_falcon40b_tests
 }
 
 main() {


### PR DESCRIPTION
- Replace all `tt_lib` calls to `ttnn.experimental`
- Keep `tt_lib.device.DumpDeviceProfiler` since no support for it in ttnn.experimental