### PR TITLE
#0: Don't error on unused functions in compiler call

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -77,7 +77,8 @@ void JitBuildEnv::init(uint32_t build_key, tt::ARCH arch) {
         "-fno-use-cxa-atexit -fno-exceptions "
         "-Wall -Werror -Wno-unknown-pragmas "
         "-Wno-error=multistatement-macros -Wno-error=parentheses "
-        "-Wno-error=unused-but-set-variable -Wno-unused-variable ";
+        "-Wno-error=unused-but-set-variable -Wno-unused-variable "
+        "-Wno-unused-function ";
 
     // Defines
     switch (arch) {


### PR DESCRIPTION
Issue comes up after sfpi bump I think, in case where we use TT_METAL_WATCHER_NOINLINE. Figured it's fine to just not error on this, but let me know if we should investigate further.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/9321544881