### PR TITLE
#4858: add typecast fp32 to uint32 op

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -584,6 +584,10 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_identity,
         "pytorch_op": pytorch_ops.eltwise_identity,
     },
+    "eltwise-typecast": {
+        "tt_op": tt_lib_ops.eltwise_typecast,
+        "pytorch_op": pytorch_ops.eltwise_typecast,
+    },
     "eltwise-unary_gt": {
         "tt_op": tt_lib_ops.eltwise_unary_gt,
         "pytorch_op": pytorch_ops.unary_gt,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1331,6 +1331,10 @@ def eltwise_identity(x, *args, **kwargs):
     return x
 
 
+def eltwise_typecast(x, *args, **kwargs):
+    return torch.relu(x.to(torch.int32))  # due to no uint32 support
+
+
 def eltwise_rdiv(x, *args, **kwargs):
     dim = kwargs["factor"]
     return dim / x

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2187,6 +2187,23 @@ def eltwise_identity(
 
 
 @setup_host_and_device
+def eltwise_typecast(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.eltwise_typecast(t0, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
 def eltwise_rpow(
     x,
     *args,

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -68,6 +68,7 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
         case UnaryOpType::TAN: defines["SFPU_OP_TRIG_FAMILY_INCLUDE"] = "1"; break;
         case UnaryOpType::NEG: defines["SFPU_OP_NEG_INCLUDE"] = "1"; break;
         case UnaryOpType::SOFTPLUS: defines["SFPU_OP_SOFTPLUS_INCLUDE"] = "1"; break;
+        case UnaryOpType::TYPECAST: defines["SFPU_OP_TYPECAST_INCLUDE"] = "1"; break;
         default: defines["SFPU_OP_COMPUTE_KERNEL_API_INCLUDE"] = "1"; break;
     };
 }
@@ -257,6 +258,9 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, stri
         case UnaryOpType::NEG:
             op_init_and_name = {"negative_tile_init();", fmt::format("negative_tile({});", idst)};
             break;
+        case UnaryOpType::TYPECAST:
+            op_init_and_name = {"typecast_tile_init();", fmt::format("typecast_tile({});", idst)};
+            break;
         default: TT_ASSERT(false && "Undefined non-parametrized op type");
     }
     return op_init_and_name;
@@ -341,13 +345,13 @@ std::vector<Tensor> EltwiseUnary::create_output_tensors(const std::vector<Tensor
         Shape output_shape = compute_output_shapes(input_tensors).at(0);
         return {create_device_tensor(
             output_shape,
-            input_tensor.get_dtype(),
+            this->output_dtype,
             input_tensor.get_layout(),
             input_tensor.device(),
             this->output_mem_config)};
     }
     return operation::generic_create_output_tensors(
-        *this, input_tensors, input_tensor.get_dtype(), Layout::TILE, this->output_mem_config);
+        *this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
 }
 
 operation::ProgramWithCallbacks EltwiseUnary::create_program(

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/multi_core/eltwise_unary_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/multi_core/eltwise_unary_op_multi_core.cpp
@@ -22,6 +22,8 @@ operation::ProgramWithCallbacks eltwise_unary_multi_core(const Tensor &a, Tensor
 
     tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
     uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
+    tt::DataFormat cb_data_format_output = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t single_tile_size_output = tt_metal::detail::TileSize(cb_data_format_output);
 
     uint32_t num_tiles = a.volume() / TILE_HW;
 
@@ -40,8 +42,8 @@ operation::ProgramWithCallbacks eltwise_unary_multi_core(const Tensor &a, Tensor
 
     uint32_t output_cb_index = 16; // output operands start at index 16
     uint32_t num_output_tiles = 2;
-    tt_metal::CircularBufferConfig cb_output_config = tt_metal::CircularBufferConfig(num_output_tiles * single_tile_size, {{output_cb_index, cb_data_format}})
-		.set_page_size(output_cb_index, single_tile_size);
+    tt_metal::CircularBufferConfig cb_output_config = tt_metal::CircularBufferConfig(num_output_tiles * single_tile_size_output, {{output_cb_index, cb_data_format_output}})
+		.set_page_size(output_cb_index, single_tile_size_output);
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
     auto src_buffer = a.buffer();

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -85,7 +85,7 @@ namespace tt::tt_metal::detail {
         detail::bind_unary_op(m_tensor, "i0", i0, R"doc(Computes the zeroth order modified Bessel function of the first kind applied on the elements of the input tensor ``{0}``, for the input range -10 to 10.)doc");
         detail::bind_unary_op(m_tensor, "silu", silu, R"doc(Returns tensor with the silu all of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "neg", neg, R"doc(Returns tensor with the negate all of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "eltwise_typecast", eltwise_typecast, R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted.)doc");
+        detail::bind_unary_op(m_tensor, "eltwise_typecast", eltwise_typecast, R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted from fp32 to uint32.)doc");
 
         detail::bind_unary_op_with_param(
             m_tensor, "exp", py::overload_cast<const Tensor&, bool, const MemoryConfig&>(&exp),

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -85,6 +85,7 @@ namespace tt::tt_metal::detail {
         detail::bind_unary_op(m_tensor, "i0", i0, R"doc(Computes the zeroth order modified Bessel function of the first kind applied on the elements of the input tensor ``{0}``, for the input range -10 to 10.)doc");
         detail::bind_unary_op(m_tensor, "silu", silu, R"doc(Returns tensor with the silu all of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "neg", neg, R"doc(Returns tensor with the negate all of elements of the input tensor ``{0}``.)doc");
+        detail::bind_unary_op(m_tensor, "eltwise_typecast", eltwise_typecast, R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted.)doc");
 
         detail::bind_unary_op_with_param(
             m_tensor, "exp", py::overload_cast<const Tensor&, bool, const MemoryConfig&>(&exp),

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_typecast_fp16b_to_uint32()
+{
+    #pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat in = dst_reg[0];
+
+        // check sign
+        v_if (in <= 0) {
+            dst_reg[0] = 0;
+        } v_else {
+            // extract exponent
+            vInt exp = exexp(in);
+
+            v_if (exp < 0) {
+                dst_reg[0] = 0;
+            } v_elseif (exp > 31) {
+                // set to uint32 max value in case of overflow
+                vInt tmp = 2147483647;
+                dst_reg[0] = tmp;
+                dst_reg[0] = setsgn(reinterpret<vFloat>(tmp), 1);
+            } v_else {
+                // extract mantissa
+                vInt man = exman8(in);
+                // shift the mantissa by (23-exponent) to the right
+                vInt shift = exp - 23;
+                man = shft(reinterpret<vUInt>(man), shift);
+                dst_reg[0] = man;
+            } v_endif
+        } v_endif
+
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -36,7 +36,6 @@ inline void calculate_typecast_fp16b_to_uint32()
             } v_elseif (exp > 31) {
                 // set to uint32 max value in case of overflow
                 vInt tmp = 2147483647;
-                dst_reg[0] = tmp;
                 dst_reg[0] = setsgn(reinterpret<vFloat>(tmp), 1);
             } v_else {
                 // extract mantissa

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_0_param.h"
+#include "ckernel_sfpu_typecast.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE>
+      (ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE,8>,
+       ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE,8>,
+                                dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_typecast_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+}

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -64,6 +64,10 @@
 #include "compute_kernel_api/eltwise_unary/identity.h"
 #endif
 
+#if SFPU_OP_TYPECAST_INCLUDE
+#include "compute_kernel_api/eltwise_unary/typecast.h"
+#endif
+
 #if SFPU_OP_BINOP_WITH_SCALAR_INCLUDE
 #include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
 #endif

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_typecast.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+
+
+namespace ckernel {
+
+/**
+ * Performs an elementwise typecast operation on the input
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | tile_index     | The index of the tile in DST register buffer to perform typecast operation | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+ALWI void typecast_tile(uint32_t idst) {
+    MATH(( llk_math_eltwise_unary_sfpu_typecast<APPROX>(idst) ));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void typecast_tile_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_typecast_init<APPROX>() ));
+}
+
+
+} // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
@@ -19,7 +19,8 @@
 namespace ckernel {
 
 /**
- * Performs an elementwise typecast operation on the input
+ * Performs an elementwise typecast operation on the input.
+ * Supports typecast from fp32 to uint32.
  *
  * Return value: None
  *

--- a/ttnn/cpp/ttnn/operations/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/unary.hpp
@@ -42,11 +42,12 @@ inline Tensor execute_on_worker_thread(
     const Tensor& input_tensor,
     const std::vector<tt::tt_metal::UnaryWithParam>& op_chain,
     const std::optional<MemoryConfig>& memory_config = std::nullopt) {
+    DataType output_dtype = (op_chain[0].op_type == UnaryOpType::TYPECAST) ? DataType::UINT32 : input_tensor.get_dtype();
     bool fp32_dest_acc_en = input_tensor.get_dtype() == DataType::UINT32 or
                             input_tensor.get_dtype() == DataType::INT32;  // MT: Currently only uint32/int32 is moved to
                                                                           // DST directly, fp32 is converted to fp16b
     return operation::run(
-               EltwiseUnary{op_chain, memory_config.value_or(input_tensor.memory_config()), fp32_dest_acc_en},
+               EltwiseUnary{op_chain, memory_config.value_or(input_tensor.memory_config()), fp32_dest_acc_en, output_dtype},
                {input_tensor})
         .at(0);
 }


### PR DESCRIPTION
Enabling typecast from fp32 to uint32 through SPFU.
Implementation based on eltwise unary identity op.
Required additional "output_dtype" attribute for EltwiseUnary struct to enable output dtype to be different than input dtype.
Post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9343911079