### PR TITLE
#8539: Add cq_id to run_operation function args

### DIFF
--- a/tests/tt_eager/ops/test_multi_queue_api.cpp
+++ b/tests/tt_eager/ops/test_multi_queue_api.cpp
@@ -55,6 +55,7 @@ void test_multi_queue_api() {
     auto device = tt::tt_metal::CreateDevice(device_id, num_command_queues);
 
     auto& command_queue_0 = device->command_queue(0);
+    uint8_t cq_id_0 = 0;
     // auto& command_queue_1 = device->command_queue(1);
 
     auto host_input_tensor =
@@ -89,7 +90,7 @@ void test_multi_queue_api() {
     auto cq0_output_tensor = tt::tt_metal::sqrt(input_tensor);  // Default CQ (CQ0)
 
     // Can't use command_queue_1 for now. So, use command_queue_0 for both
-    auto cq1_output_tensor = tt::tt_metal::sqrt(command_queue_0, input_tensor);  // CQ1
+    auto cq1_output_tensor = tt::tt_metal::sqrt(cq_id_0, input_tensor);  // CQ1
     // OP API END
 
     auto blocking = true;

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -232,7 +232,7 @@ inline Tensor run_eltwise_unary(
 }
 
 inline Tensor run_eltwise_unary(
-    CommandQueue& queue,
+    uint8_t cq_id,
     const Tensor& input_tensor,
     const std::vector<UnaryWithParam>& ops_chain,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
@@ -242,9 +242,8 @@ inline Tensor run_eltwise_unary(
         input_tensor.get_dtype() ==
             DataType::INT32;  // MT: Currently only uint32/int32 is moved to DST directly, fp32 is converted to fp16b
     return operation::run(
-               queue,
-               tt::tt_metal::operation::DeviceOperation(EltwiseUnary{ops_chain, output_mem_config, fp32_dest_acc_en}),
-               {input_tensor})
+               EltwiseUnary{ops_chain, output_mem_config, fp32_dest_acc_en},
+               {input_tensor}, {}, {}, cq_id)
         .at(0);
 }
 
@@ -310,10 +309,10 @@ inline Tensor sqrt(
 }
 
 inline Tensor sqrt(
-    CommandQueue& queue,
+    uint8_t cq_id,
     const Tensor& input_tensor,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
-    return run_eltwise_unary(queue, input_tensor, {UnaryWithParam(UnaryOpType::SQRT)}, output_mem_config);
+    return run_eltwise_unary(cq_id, input_tensor, {UnaryWithParam(UnaryOpType::SQRT)}, output_mem_config);
 }
 
 constexpr auto recip = make_eltwise_unary<UnaryOpType::RECIP>{};

--- a/tt_eager/tt_dnn/op_library/run_operation.hpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.hpp
@@ -290,18 +290,11 @@ OutputTensors run(
 
 template<class OutputTensors=Tensors>
 OutputTensors run(
-    CommandQueue& queue,
     const DeviceOperation<OutputTensors>& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors = {},
-    const OptionalTensors& optional_output_tensors = {});
-
-template<class OutputTensors=Tensors>
-OutputTensors run(
-    const DeviceOperation<OutputTensors>& operation,
-    const Tensors& input_tensors,
-    const OptionalConstTensors& optional_input_tensors = {},
-    const OptionalTensors& optional_output_tensors = {});
+    const OptionalTensors& optional_output_tensors = {},
+    uint8_t cq_id = 0);
 
 template<typename ConcreteOperation>
 inline auto run(
@@ -309,7 +302,7 @@ inline auto run(
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors={},
     const OptionalTensors& optional_output_tensors={},
-    std::optional<std::reference_wrapper<CommandQueue>> queue = std::nullopt
+    uint8_t cq_id = 0
 ) -> ProgramOutputTensors<ConcreteOperation> {
     using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     if constexpr (detail::is_host_operation<ConcreteOperation>()) {
@@ -318,10 +311,7 @@ inline auto run(
         return run<OutputTensors>(operation, input_tensors);
     } else if constexpr (detail::is_device_operation<ConcreteOperation>()) {
         const auto operation = DeviceOperation(concrete_op);
-        if (queue.has_value()) {
-            return run<OutputTensors>(queue.value(), operation, input_tensors, optional_input_tensors, optional_output_tensors);
-        }
-        return run<OutputTensors>(operation, input_tensors, optional_input_tensors, optional_output_tensors);
+        return run<OutputTensors>(operation, input_tensors, optional_input_tensors, optional_output_tensors, cq_id);
     } else {
         static_assert(tt::stl::concepts::always_false_v<ConcreteOperation>, "Unsupported Operation");
     }
@@ -332,18 +322,20 @@ OutputTensors run_without_autoformat(
     const DeviceOperation<OutputTensors>& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors = {},
-    const OptionalTensors& optional_output_tensors = {}
+    const OptionalTensors& optional_output_tensors = {},
+    uint8_t cq_id = 0
 );
 template <typename ConcreteOperation>
 inline auto run_without_autoformat(
     ConcreteOperation&& concrete_op,
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<Tensor>>& optional_output_tensors = {})
+    const std::vector<std::optional<Tensor>>& optional_output_tensors = {},
+    uint8_t cq_id = 0)
     -> ProgramOutputTensors<ConcreteOperation>{
     using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     const auto operation = DeviceOperation<OutputTensors>(concrete_op);
-    return run_without_autoformat<OutputTensors>(operation, input_tensors, optional_input_tensors, optional_output_tensors);
+    return run_without_autoformat<OutputTensors>(operation, input_tensors, optional_input_tensors, optional_output_tensors, cq_id);
 }
 
 Tensors run_with_autoformat(
@@ -351,7 +343,8 @@ Tensors run_with_autoformat(
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors = {},
     const float pad_value = 0,
-    const bool pad_c = false
+    const bool pad_c = false,
+    uint8_t cq_id = 0
 );
 
 template<typename ConcreteOperation>
@@ -360,11 +353,12 @@ inline auto run_with_autoformat(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
     const float pad_value = 0,
-    const bool pad_c = false
+    const bool pad_c = false,
+    uint8_t cq_id = 0
 )-> Tensors {
     using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     const auto operation = DeviceOperation<Tensors>(concrete_op);
-    return run_with_autoformat(operation, input_tensors, optional_input_tensors, pad_value, pad_c);
+    return run_with_autoformat(operation, input_tensors, optional_input_tensors, pad_value, pad_c, cq_id);
 }
 
 Tensors run_with_autoformat(
@@ -373,7 +367,8 @@ Tensors run_with_autoformat(
     const std::vector<FormatParams>& input_formatting,
     const std::vector<Layout>& output_layouts,
     const OptionalConstTensors& optional_input_tensors = {},
-    const std::vector<std::optional<FormatParams>>& optional_input_formatting = {}
+    const std::vector<std::optional<FormatParams>>& optional_input_formatting = {},
+    uint8_t cq_id = 0
 );
 template<typename ConcreteOperation>
 inline auto run_with_autoformat(
@@ -382,11 +377,12 @@ inline auto run_with_autoformat(
     const std::vector<FormatParams>& input_formatting,
     const std::vector<Layout>& output_layouts,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
-    const std::vector<std::optional<FormatParams>>& optional_input_formatting = {}
+    const std::vector<std::optional<FormatParams>>& optional_input_formatting = {},
+    uint8_t cq_id = 0
 )-> ProgramOutputTensors<ConcreteOperation> {
     using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     const auto operation = DeviceOperation<OutputTensors>(concrete_op);
-    return run_with_autoformat(operation, input_tensors, input_formatting, output_layouts, optional_input_tensors, optional_input_formatting);
+    return run_with_autoformat(operation, input_tensors, input_formatting, output_layouts, optional_input_tensors, optional_input_formatting, cq_id);
 }
 
 void launch_op(

--- a/ttnn/cpp/ttnn/async_runtime.hpp
+++ b/ttnn/cpp/ttnn/async_runtime.hpp
@@ -47,7 +47,7 @@ namespace ttnn {
         for (auto worker : outputs.at(0).workers) {
             tt::tt_metal::operation::launch_op(
                 [devop, worker, cq_id] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-                    return operation::run(std::move(devop), input_tensors, optional_input_tensors, optional_output_tensors, worker->command_queue(cq_id));
+                    return operation::run(std::move(devop), input_tensors, optional_input_tensors, optional_output_tensors, cq_id);
                 }, input_tensors, outputs, optional_input_tensors, optional_output_tensors);
         }
         return outputs;


### PR DESCRIPTION
  - Delete dead code: run_multi_device_operation and run_device_operation functions taking an explicit CQ by reference
  - TODO: Make cq_id a struct instead of passing around `uint8_t`