### PR TITLE
#8788: Support fp32 dest acc en to moreh_linear OP

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_matmul.py
@@ -360,3 +360,16 @@ def test_moreh_matmul_enable_cache(params, device, use_program_cache):
     for i in range(2):
         passing = moreh_matmul(params, True, None, device)
         assert passing
+
+
+@pytest.mark.parametrize(
+    "params",
+    (
+        # input, other, output shape, transpose input, other
+        ([310, 1020], [1020, 310], [1020, 1020], True, True),  # input, other mask, transpose
+    ),
+)
+def test_moreh_matmul_kernel_build_error(params, device):
+    compute_kernel_config = get_compute_kernel_options(True)
+    passing = moreh_matmul(params, True, compute_kernel_config, device)
+    assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_matmul.py
@@ -364,9 +364,15 @@ def test_moreh_matmul_wo_output(params, device):
 )
 def test_moreh_matmul_enable_cache(params, device, use_program_cache):
     torch.manual_seed(3072)
-    for i in range(2):
+    for i in range(4):
+        # change input's transpose option
+        if i % 2 == 1:
+            param_list = list(params)
+            param_list[3] = False if param_list[3] else True
+            params = tuple(param_list)
         passing = moreh_matmul(params, True, None, device)
         assert passing
+    assert device.num_program_cache_entries() == 2
 
 
 @pytest.mark.parametrize(

--- a/tt_eager/tt_dnn/op_library/moreh_linear/moreh_linear_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear/moreh_linear_op.cpp
@@ -18,7 +18,7 @@ inline void moreh_linear_validate(
     const Tensor& weight) {
     const auto& weight_shape = weight.get_legacy_shape();
     const auto& weight_rank = weight_shape.rank();
-    TT_FATAL(weight_rank == 2, fmt::format("weight rank {} must be 2.", weight_rank));
+    TT_FATAL(weight_rank == 2, "weight rank {} must be 2.", weight_rank);
 }
 
 Tensor _moreh_linear(
@@ -26,7 +26,8 @@ Tensor _moreh_linear(
     const Tensor& weight,
     const std::optional<const Tensor>& bias,
     std::optional<Tensor> output,
-    const MemoryConfig& output_mem_config) {
+    const MemoryConfig& output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     moreh_linear_validate(weight);
     output = moreh_matmul(input, weight, false, true, output, bias, output_mem_config);
     return output.value();
@@ -37,8 +38,9 @@ Tensor moreh_linear(
     const Tensor& weight,
     std::optional<const Tensor> bias,
     std::optional<const Tensor> output,
-    const MemoryConfig& output_mem_config) {
-    return _moreh_linear(input, weight, bias, output, output_mem_config);
+    const MemoryConfig& output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    return _moreh_linear(input, weight, bias, output, output_mem_config, compute_kernel_config);
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_linear/moreh_linear_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear/moreh_linear_op.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/compute_kernel_config.hpp"
 #include "tt_dnn/op_library/operation.hpp"
 
 namespace tt {
@@ -22,7 +23,8 @@ Tensor moreh_linear(
     const Tensor& weight,
     std::optional<const Tensor> bias = std::nullopt,
     std::optional<const Tensor> output = std::nullopt,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_h/moreh_bias_backward_multi_core_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_h/moreh_bias_backward_multi_core_h.cpp
@@ -15,7 +15,7 @@ namespace operations {
 
 namespace primary {
 
-operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &output_grad, const Tensor &bias_grad) {
+operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &output_grad, const Tensor &bias_grad, const DeviceComputeKernelConfig &compute_kernel_config) {
     Program program{};
 
     DataFormat cb_data_format = datatype_to_dataformat_converter(output_grad.get_dtype());

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_h/moreh_bias_backward_multi_core_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_h/moreh_bias_backward_multi_core_h.cpp
@@ -43,6 +43,14 @@ operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &o
     Device *device = output_grad.device();
     auto grid = device->compute_with_storage_grid_size();
     const auto num_cores_y = grid.y;
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(device->arch(), compute_kernel_config);
+    log_debug(
+        LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
 
     const auto
         [num_cores_to_be_used,
@@ -73,7 +81,7 @@ operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &o
             {CB::c_in2, in2_t},    // mask_h_w
             {CB::c_out0, out0_t},  // bias_grad
             {CB::c_intermed0, im0_t},
-            {CB::c_intermed1, im1_t},
+            {CB::c_intermed1, im1_t, (fp32_dest_acc_en) ? tt::DataFormat::Float32: cb_data_format}
         });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -98,10 +106,19 @@ operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &o
     std::map<string, string> compute_defines;
     compute_defines["REDUCE_OP"] = "PoolType::SUM";
     compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_COL";
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
     const auto compute_kernel_file =
         "tt_eager/tt_dnn/op_library/moreh_linear_backward/kernels/moreh_bias_backward_multi_core_h.cpp";
     const auto compute_kernel_1_id = CreateComputeKernel(
-        program, compute_kernel_file, {core_group_1, num_cols_per_core_group_1, compute_args_group_1}, compute_defines);
+        program,
+        compute_kernel_file,
+        {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
 
     std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
     if (!core_group_2.ranges().empty()) {
@@ -110,7 +127,10 @@ operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &o
             program,
             compute_kernel_file,
             {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
-            compute_defines);
+            compute_defines,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_hw/moreh_bias_backward_single_core_hw.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/bias_backward_hw/moreh_bias_backward_single_core_hw.cpp
@@ -14,7 +14,7 @@ namespace operations {
 
 namespace primary {
 
-operation::ProgramWithCallbacks moreh_bias_backward_single_core_hw(const Tensor &output_grad, const Tensor &bias_grad) {
+operation::ProgramWithCallbacks moreh_bias_backward_single_core_hw(const Tensor &output_grad, const Tensor &bias_grad, const DeviceComputeKernelConfig &compute_kernel_config) {
     Program program{};
     CoreCoord core = {0, 0};
     const uint32_t core_num = 1;

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/kernels/moreh_bias_backward_multi_core_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/kernels/moreh_bias_backward_multi_core_h.cpp
@@ -19,11 +19,11 @@ void MAIN {
     constexpr auto cb_mask_h_w = tt::CB::c_in2;
     constexpr auto cb_intermed0 = tt::CB::c_intermed0;
     constexpr auto cb_intermed1 = tt::CB::c_intermed1;
-    constexpr auto cb_out = tt::CB::c_out0;
+    constexpr auto cb_out0 = tt::CB::c_out0;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
 
-    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in0);
+    binary_op_init_common(cb_in0, cb_in0, cb_out0);
     cb_wait_front(cb_scaler, onetile);
 
     if (do_mask_h || do_mask_w) {
@@ -46,18 +46,27 @@ void MAIN {
 
                 if (do_mask) {
                     tile_regs_acquire();
-                    copy_tile_init();
+                    #if defined FP32_DEST_ACC_EN
+                        unpack_reconfig_data_format_srca(cb_in0);
+                    #endif
+                    copy_tile_to_dst_init_short(cb_in0);
                     copy_tile(cb_in0, 0, dst0);
 
                     if (do_mask_h && last_row) {
-                        copy_tile_init();
+                        #if defined FP32_DEST_ACC_EN
+                            unpack_reconfig_data_format_srca(cb_mask_h_w);
+                        #endif
+                        copy_tile_to_dst_init_short(cb_mask_h_w);
                         copy_tile(cb_mask_h_w, 0, dst1);
                         mask_tile_init();
                         mask_tile(dst0, dst1);
                     }
 
                     if (do_mask_w && last_col) {
-                        copy_tile_init();
+                        #if defined FP32_DEST_ACC_EN
+                            unpack_reconfig_data_format_srca(cb_mask_h_w);
+                        #endif
+                        copy_tile_to_dst_init_short(cb_mask_h_w);
                         copy_tile(cb_mask_h_w, 1, dst1);
                         mask_tile_init();
                         mask_tile(dst0, dst1);
@@ -66,6 +75,9 @@ void MAIN {
 
                     tile_regs_wait();
                     cb_reserve_back(cb_intermed0, onetile);
+                    #if defined FP32_DEST_ACC_EN
+                        pack_reconfig_data_format(cb_intermed0);
+                    #endif
                     pack_tile(dst0, cb_intermed0);
                     cb_push_back(cb_intermed0, onetile);
                     tile_regs_release();
@@ -74,7 +86,10 @@ void MAIN {
                 tile_regs_acquire();
                 if (enable_reload) {
                     cb_wait_front(cb_intermed1, onetile);
-                    copy_tile_init();
+                    #if defined FP32_DEST_ACC_EN
+                        unpack_reconfig_data_format_srca(cb_intermed1);
+                    #endif
+                    copy_tile_to_dst_init_short(cb_intermed1);
                     copy_tile(cb_intermed1, 0, 0);
                     cb_pop_front(cb_intermed1, onetile);
                 }
@@ -82,8 +97,12 @@ void MAIN {
                 if (do_mask)
                     cb_wait_front(cb_intermed0, onetile);
 
+                auto cb_reduce = (do_mask) ? (cb_intermed0) : (cb_in0);
+                #if defined FP32_DEST_ACC_EN
+                    unpack_reconfig_data_format(cb_reduce, cb_scaler);
+                #endif
                 reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
-                reduce_tile((do_mask) ? (cb_intermed0) : (cb_in0), cb_scaler, 0, 0, 0);
+                reduce_tile(cb_reduce, cb_scaler, 0, 0, 0);
                 reduce_revert_delta();
 
                 if (do_mask)
@@ -94,13 +113,19 @@ void MAIN {
 
                 tile_regs_wait();
                 if (last_out) {
-                    cb_reserve_back(cb_out, onetile);
-                    pack_tile(0, cb_out);
-                    cb_push_back(cb_out, onetile);
+                    cb_reserve_back(cb_out0, onetile);
+                    #if defined FP32_DEST_ACC_EN
+                        pack_reconfig_data_format(cb_out0);
+                    #endif
+                    pack_tile(0, cb_out0);
+                    cb_push_back(cb_out0, onetile);
 
                 }
                 else {
                     cb_reserve_back(cb_intermed1, onetile);
+                    #if defined FP32_DEST_ACC_EN
+                        pack_reconfig_data_format(cb_intermed1);
+                    #endif
                     pack_tile(0, cb_intermed1);
                     cb_push_back(cb_intermed1, onetile);
                 }

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/compute_kernel_config.hpp"
 #include "tt_dnn/op_library/operation.hpp"
 
 namespace tt {
@@ -21,12 +22,13 @@ using namespace tt_metal;
 //                         MorehBiasAddBackward
 ////////////////////////////////////////////////////////////////////////////
 // TODO: Move bias backward code
-operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &output_grad, const Tensor &bias_grad);
+operation::ProgramWithCallbacks moreh_bias_backward_multi_core_h(const Tensor &output_grad, const Tensor &bias_grad, const DeviceComputeKernelConfig &compute_kernel_config);
 
-operation::ProgramWithCallbacks moreh_bias_backward_single_core_hw(const Tensor &output_grad, const Tensor &bias_grad);
+operation::ProgramWithCallbacks moreh_bias_backward_single_core_hw(const Tensor &output_grad, const Tensor &bias_grad, const DeviceComputeKernelConfig &compute_kernel_config);
 
 struct MorehBiasAddBackward {
     MemoryConfig bias_grad_mem_config;
+    const DeviceComputeKernelConfig compute_kernel_config;
     void validate_with_output_tensors(
         const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -34,8 +36,8 @@ struct MorehBiasAddBackward {
         const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
-    static constexpr auto attribute_names = std::make_tuple("bias_grad_mem_config");
-    const auto attribute_values() const { return std::make_tuple(std::cref(this->bias_grad_mem_config)); }
+    static constexpr auto attribute_names = std::make_tuple("bias_grad_mem_config", "compute_kernel_config");
+    const auto attribute_values() const { return std::make_tuple(std::cref(this->bias_grad_mem_config), std::cref(this->compute_kernel_config)); }
 };
 
 std::vector<std::optional<Tensor>> moreh_linear_backward(
@@ -49,7 +51,8 @@ std::vector<std::optional<Tensor>> moreh_linear_backward(
     std::optional<const Tensor> bias_grad = std::nullopt,
     const MemoryConfig &input_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     const MemoryConfig &weight_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    const MemoryConfig &bias_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &bias_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace primary
 }  // namespace operations

--- a/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.cpp
@@ -264,25 +264,6 @@ void MorehMatmul::validate_with_output_tensors(
     }
 }
 
-const operation::Hash MorehMatmul::compute_program_hash(
-    const std::vector<Tensor>& input_tensors,
-    const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
-    const auto& input = input_tensors.at(0);
-    const auto& other = input_tensors.at(1);
-    const auto& bias = optional_input_tensors.at(0);
-
-    operation::Hash hash = tt::stl::hash::hash_objects(
-        0,
-        typeid(*this).hash_code(),
-        input,
-        other,
-        bias,
-        this->transpose_input,
-        this->transpose_other,
-        this->compute_kernel_config);
-    return hash;
-}
-
 Tensor moreh_matmul_(
     const Tensor& input,
     const Tensor& other,

--- a/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/compute_kernel_config.hpp"
 #include "tt_dnn/op_library/run_operation.hpp"
 
 #include <optional>
@@ -26,12 +27,14 @@ operation::ProgramWithCallbacks moreh_matmul_multi_core(
     const Tensor &output,
     const std::optional<const Tensor> &bias,
     bool transpose_input,
-    bool transpose_other);
+    bool transpose_other,
+    const DeviceComputeKernelConfig &compute_kernel_config);
 
 struct MorehMatmul {
     const MemoryConfig output_mem_config;
     bool transpose_input;
     bool transpose_other;
+    const DeviceComputeKernelConfig compute_kernel_config;
     void validate_with_output_tensors(
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors,
@@ -47,11 +50,12 @@ struct MorehMatmul {
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors) const;
     static constexpr auto attribute_names = std::make_tuple(
-        "transpose_input", "transpose_other");
+        "transpose_input", "transpose_other", "compute_kernel_config");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->transpose_input),
-            std::cref(this->transpose_other));
+            std::cref(this->transpose_other),
+            std::cref(this->compute_kernel_config));
     }
 };
 
@@ -62,7 +66,8 @@ Tensor moreh_matmul(
     bool transpose_other = false,
     const std::optional<const Tensor> output = std::nullopt,
     const std::optional<const Tensor> bias = std::nullopt,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace primary
 

--- a/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.hpp
@@ -46,16 +46,9 @@ struct MorehMatmul {
         const std::vector<Tensor> &input_tensors,
         const std::vector<std::optional<const Tensor>> &optional_input_tensors,
         std::vector<Tensor> &output_tensors) const;
-    const operation::Hash compute_program_hash(
-        const std::vector<Tensor> &input_tensors,
-        const std::vector<std::optional<const Tensor>> &optional_input_tensors) const;
-    static constexpr auto attribute_names = std::make_tuple(
-        "transpose_input", "transpose_other", "compute_kernel_config");
+    static constexpr auto attribute_names = std::make_tuple("transpose_input", "transpose_other", "output_mem_config", "compute_kernel_config");
     const auto attribute_values() const {
-        return std::make_tuple(
-            std::cref(this->transpose_input),
-            std::cref(this->transpose_other),
-            std::cref(this->compute_kernel_config));
+        return std::make_tuple(std::cref(this->transpose_input), std::cref(this->transpose_other), std::cref(this->output_mem_config), std::cref(this->compute_kernel_config));
     }
 };
 

--- a/tt_eager/tt_dnn/op_library/moreh_matmul/multi_core/kernels/moreh_matmul.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_matmul/multi_core/kernels/moreh_matmul.cpp
@@ -231,14 +231,12 @@ FORCE_INLINE void matmul_with_transpose_and_mask(uint32_t output_tidx, uint32_t 
 
             ////////////////////
             // mask: the first two arguments (mm_src0, need_input_mask) are passed by reference.
-            ////////////////////
-            mask_tile_to_cb(mm_src0, need_input_mask, need_input_mask_h, need_input_mask_w, last_out, input_last_row, transpose_input, true);
-            mask_tile_to_cb(mm_src1, need_other_mask, need_other_mask_h, need_other_mask_w, last_out, other_last_col, transpose_other, false);
-
-            ////////////////////
             // transpose: the first argument (mm_src0) is passed by reference.
             ////////////////////
+            mask_tile_to_cb(mm_src0, need_input_mask, need_input_mask_h, need_input_mask_w, last_out, input_last_row, transpose_input, true);
             transpose_tile(mm_src0, transpose_input, need_input_mask, true);
+
+            mask_tile_to_cb(mm_src1, need_other_mask, need_other_mask_h, need_other_mask_w, last_out, other_last_col, transpose_other, false);
             transpose_tile(mm_src1, transpose_other, need_other_mask, false);
 
             ////////////////////

--- a/tt_eager/tt_dnn/op_library/moreh_matmul/multi_core/moreh_matmul_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_matmul/multi_core/moreh_matmul_op_multi_core.cpp
@@ -69,7 +69,8 @@ operation::ProgramWithCallbacks moreh_matmul_multi_core(
     const Tensor &output,
     const std::optional<const Tensor>& bias,
     bool transpose_input,
-    bool transpose_other) {
+    bool transpose_other,
+    const DeviceComputeKernelConfig &compute_kernel_config) {
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup

--- a/tt_eager/tt_dnn/op_library/moreh_matmul_backward/moreh_matmul_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_matmul_backward/moreh_matmul_backward_op.cpp
@@ -41,7 +41,8 @@ std::vector<std::optional<Tensor>> moreh_matmul_backward_(
     const std::vector<bool>& are_required_outputs,
     const std::optional<const Tensor> &input_grad,
     const std::optional<const Tensor> &other_grad,
-    const MemoryConfig& output_mem_config) {
+    const MemoryConfig& output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     std::vector<std::optional<Tensor>> outputs(2);
     outputs.reserve(2);
 
@@ -54,13 +55,13 @@ std::vector<std::optional<Tensor>> moreh_matmul_backward_(
         if (is_same_batch_dim(output_grad, input_grad_tensor)) {
             const auto& input_grad_shape = input_grad_tensor.get_legacy_shape().without_padding();
             const auto& output_grad_shape = output_grad.get_legacy_shape().without_padding();
-            moreh_matmul(output_grad, other, false, true, input_grad_tensor, std::nullopt, output_mem_config);
+            moreh_matmul(output_grad, other, false, true, input_grad_tensor, std::nullopt, output_mem_config, compute_kernel_config);
         } else {
             const auto& input_shape = input.get_legacy_shape().without_padding();
             const auto& temp_input_grad =
-                moreh_matmul(output_grad, other, false, true, std::nullopt, std::nullopt, output_mem_config);
+                moreh_matmul(output_grad, other, false, true, std::nullopt, std::nullopt, output_mem_config, compute_kernel_config);
             auto reduce_dims = find_reduce_dim(temp_input_grad.get_legacy_shape(), input_grad_tensor.get_legacy_shape());
-            moreh_sum(temp_input_grad, reduce_dims, true, input_grad_tensor);
+            moreh_sum(temp_input_grad, reduce_dims, true, input_grad_tensor, output_mem_config, compute_kernel_config);
         }
         outputs[0] = input_grad_tensor;
     }
@@ -69,12 +70,12 @@ std::vector<std::optional<Tensor>> moreh_matmul_backward_(
         TT_ASSERT(other_grad.has_value());
         const auto& other_grad_tensor = other_grad.value();
         if (is_same_batch_dim(output_grad, other_grad_tensor)) {
-            moreh_matmul(input, output_grad, true, false, other_grad_tensor, std::nullopt, output_mem_config);
+            moreh_matmul(input, output_grad, true, false, other_grad_tensor, std::nullopt, output_mem_config, compute_kernel_config);
         } else {
             const auto& temp_other_grad =
-                moreh_matmul(input, output_grad, true, false, std::nullopt, std::nullopt, output_mem_config);
+                moreh_matmul(input, output_grad, true, false, std::nullopt, std::nullopt, output_mem_config, compute_kernel_config);
             auto reduce_dims = find_reduce_dim(temp_other_grad.get_legacy_shape(), other_grad_tensor.get_legacy_shape());
-            moreh_sum(temp_other_grad, reduce_dims, true, other_grad_tensor);
+            moreh_sum(temp_other_grad, reduce_dims, true, other_grad_tensor, output_mem_config, compute_kernel_config);
         }
         outputs[1] = other_grad_tensor;
     }
@@ -89,13 +90,14 @@ std::vector<std::optional<Tensor>> moreh_matmul_backward(
     const std::vector<bool>& are_required_outputs,
     std::optional<const Tensor> input_grad,
     std::optional<const Tensor> other_grad,
-    const MemoryConfig& output_mem_config) {
+    const MemoryConfig& output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     if (is_dot_backward(output_grad, input, other)) {
         // TODO(seunghwan100): Add the argument "are_required_outputs" to moreh_dot_backward.
         return moreh_dot_backward(output_grad, input, other, input_grad, other_grad, output_mem_config);
     } else {
         return moreh_matmul_backward_(
-            output_grad, input, other, are_required_outputs, input_grad, other_grad, output_mem_config);
+            output_grad, input, other, are_required_outputs, input_grad, other_grad, output_mem_config, compute_kernel_config);
     }
 }
 

--- a/tt_eager/tt_dnn/op_library/moreh_matmul_backward/moreh_matmul_backward_op.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_matmul_backward/moreh_matmul_backward_op.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/compute_kernel_config.hpp"
 #include "tt_dnn/op_library/run_operation.hpp"
 
 namespace tt {
@@ -23,7 +24,8 @@ std::vector<std::optional<Tensor>> moreh_matmul_backward(
     const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
     std::optional<const Tensor> input_grad = std::nullopt,
     std::optional<const Tensor> other_grad = std::nullopt,
-    const MemoryConfig &mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig &mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace primary
 

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -671,6 +671,7 @@ void py_module(py::module& m_primary) {
         py::arg("output").noconvert() = std::nullopt,
         py::arg("bias").noconvert() = std::nullopt,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs a moreh_matmul operation.");
 
     // moreh_matmul_backward

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -634,6 +634,7 @@ void py_module(py::module& m_primary) {
         py::arg("bias").noconvert() = std::nullopt,
         py::arg("output").noconvert() = std::nullopt,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         R"doc(
         "Performs a moreh_linear operation.
     )doc");

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -685,6 +685,7 @@ void py_module(py::module& m_primary) {
         py::arg("input_a_grad").noconvert() = std::nullopt,
         py::arg("input_b_grad").noconvert() = std::nullopt,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         R"doc(
         "Performs a moreh_matmul_backward operation.
     )doc");

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -654,6 +654,7 @@ void py_module(py::module& m_primary) {
         py::arg("input_grad_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("weight_grad_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("bias_grad_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         R"doc(
         "Performs a moreh_linear_backward operation.
     )doc");


### PR DESCRIPTION

This PR adds the DeviceComputeKernelConfig parameter to operations like these functions.
- moreh_linear
- moreh_linear_backward
- moreh_matmul
- moreh_matmul_backward
- moreh_bias_add_backward 

This change will allow us to provide kernel configuration settings optionally during function calls.

