### PR TITLE
#8349: Use BFP4_B for attention mask in falcon7b optimised prefill.

### DIFF
--- a/models/demos/falcon7b/tests/test_utils.py
+++ b/models/demos/falcon7b/tests/test_utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
+import ttnn
 from models.demos.falcon7b.reference.hf_modeling_falcon import FalconForCausalLM
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor
 
@@ -106,7 +107,10 @@ def get_rand_falcon_inputs(
                             configuration.num_attention_heads,
                             q_len,
                         )
-                        tt_attn_masks = [torch2tt_tensor(attn_mask, device) for attn_mask in attn_masks]
+                        tt_attn_masks = [
+                            torch2tt_tensor(attn_mask, device, tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT4_B)
+                            for attn_mask in attn_masks
+                        ]
                         tt_attention_mask.append(tt_attn_masks)
                     else:
                         tt_attention_mask.append(

--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -560,17 +560,12 @@ def test_falcon7b_attention_softmax_sequence(
         tt_memory_config=dram_interleaved_memory_config,
         tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
     )
-    attention_mask = torch2tt_tensor(
-        torch_attention_mask,
-        device,
-        tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
-    )
+
     attention_mask_proper_dim = torch2tt_tensor(
         torch_attention_mask_proper_dim,
         device,
         tt_memory_config=dram_interleaved_memory_config,
-        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+        tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT4_B,
     )
 
     compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
@@ -600,7 +595,7 @@ def test_falcon7b_attention_softmax_sequence(
             torch_attention_mask_per_slice,
             device,
             tt_memory_config=dram_interleaved_memory_config,
-            tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+            tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT4_B,
         )
         attention_masks_per_slice.append(tt_attention_slice)
         attention_mask_starting_index_per_slice = (

--- a/models/demos/falcon7b/tt/falcon_model.py
+++ b/models/demos/falcon7b/tt/falcon_model.py
@@ -139,7 +139,7 @@ class TtFalconModelShared(torch.nn.Module):
                         tt_attention_mask_slice[i] = ttnn.experimental.tensor.tilize(
                             tt_attention_mask_slice[i],
                             output_mem_config=self.model_config["ATTN_MASK_MEMCFG"],
-                            output_dtype=self.model_config["ATTN_MASK_DTYPE"],
+                            output_dtype=self.model_config["ATTN_MASK_OPTIMIZED_PREFILL_DTYPE"],
                         )
                 # Expected output attention_masks
                 # [dev0: [slice0, slice1, ...], dev1: [slice0, slice1, ...], ...]

--- a/models/demos/falcon7b/tt/model_config.py
+++ b/models/demos/falcon7b/tt/model_config.py
@@ -11,6 +11,7 @@ OP_KEYS = (
     # Inputs
     "INPUT",
     "ATTN_MASK",
+    "ATTN_MASK_OPTIMIZED_PREFILL",
     # Embeddings
     "WORD_EMBEDDING_WEIGHTS",
     "WORD_EMBEDDING_OUTPUT",
@@ -101,6 +102,7 @@ def get_model_config(model_config_str, prefill_seq_len=0):
         ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.L1
     )
     BFP8_DTYPE = ttnn.experimental.tensor.DataType.BFLOAT8_B
+    BFP4_DTYPE = ttnn.experimental.tensor.DataType.BFLOAT4_B
 
     # Set default dtype and mem_config based on model_config_str
     if model_config_str in ("BFLOAT16-DRAM", "BFLOAT16-L1", "BFLOAT16-L1_SHARDED"):
@@ -129,6 +131,9 @@ def get_model_config(model_config_str, prefill_seq_len=0):
 
     # Input ids are UINT32
     model_config["INPUT_DTYPE"] = ttnn.experimental.tensor.DataType.UINT32
+
+    # Use BFP4_B for attention mask in optimized prefill
+    model_config["ATTN_MASK_OPTIMIZED_PREFILL_DTYPE"] = BFP4_DTYPE
 
     # Matmul Weights must always be BFP8_B
     # Override defaults for certain configs


### PR DESCRIPTION
Impact:
1k seq len - 0.6 ms/layer speedup
2k seq len - 3.4 ms/layer speedup