### PR TITLE
#8965: gc collect before device close

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -263,6 +263,7 @@ def device_params(request):
 @pytest.fixture(scope="function")
 def device(request, device_params):
     import tt_lib as ttl
+    import gc
 
     device_id = request.config.getoption("device_id")
 
@@ -275,6 +276,7 @@ def device(request, device_params):
 
     ttl.device.DumpDeviceProfiler(device, True)
     ttl.device.DeallocateBuffers(device)
+    gc.collect()
 
     ttl.device.Synchronize(device)
     ttl.device.CloseDevice(device)
@@ -283,6 +285,7 @@ def device(request, device_params):
 @pytest.fixture(scope="function")
 def pcie_devices(request, device_params):
     import tt_lib as ttl
+    import gc
 
     num_devices = ttl.device.GetNumPCIeDevices()
 
@@ -295,12 +298,14 @@ def pcie_devices(request, device_params):
         ttl.device.DumpDeviceProfiler(device, True)
         ttl.device.DeallocateBuffers(device)
 
+    gc.collect()
     ttl.device.CloseDevices(devices)
 
 
 @pytest.fixture(scope="function")
 def all_devices(request, device_params):
     import tt_lib as ttl
+    import gc
 
     num_devices = ttl.device.GetNumAvailableDevices()
 
@@ -313,12 +318,14 @@ def all_devices(request, device_params):
         ttl.device.DumpDeviceProfiler(device, True)
         ttl.device.DeallocateBuffers(device)
 
+    gc.collect()
     ttl.device.CloseDevices(devices)
 
 
 @pytest.fixture(scope="function")
 def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
     import ttnn
+    import gc
 
     device_ids = ttnn.get_device_ids()
     try:
@@ -340,6 +347,7 @@ def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
         ttl.device.DumpDeviceProfiler(device, True)
         ttl.device.DeallocateBuffers(device)
 
+    gc.collect()
     ttnn.close_device_mesh(device_mesh)
     del device_mesh
 
@@ -347,6 +355,7 @@ def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
 @pytest.fixture(scope="function")
 def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
     import ttnn
+    import gc
 
     device_ids = ttnn.get_pcie_device_ids()
     try:
@@ -370,6 +379,7 @@ def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
         ttl.device.DumpDeviceProfiler(device, True)
         ttl.device.DeallocateBuffers(device)
 
+    gc.collect()
     ttnn.close_device_mesh(device_mesh)
     del device_mesh
 
@@ -377,6 +387,7 @@ def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
 @pytest.fixture(scope="function")
 def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
     import ttnn
+    import gc
 
     if ttnn.get_num_devices() < 8:
         pytest.skip()
@@ -400,6 +411,7 @@ def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
         ttl.device.DumpDeviceProfiler(device, True)
         ttl.device.DeallocateBuffers(device)
 
+    gc.collect()
     ttnn.close_device_mesh(device_mesh)
     del device_mesh
 

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -125,14 +125,12 @@ void BankManager::deallocate_buffer(uint64_t address) {
     this->allocator_->deallocate(address);
 }
 
-void BankManager::deallocate_all(){
-    detail::BUFFER_MAP.clear();
+void BankManager::deallocate_all() {
     for (uint64_t addr : this->allocated_buffers_)
     {
         this->allocator_->deallocate(addr);
     }
 }
-
 
 void BankManager::clear() {
     if (this->allocator_)

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -271,15 +271,12 @@ class buffer_map_t {
         this->map.erase(buf_attr);
     }
 
-    void clear() {
-        std::scoped_lock<std::mutex> lock(this->map_mutex);
-        this->map.clear();
-    }
-
     std::map<std::tuple<Deviceid, PageAddress>, Buffer *> value() {
         std::scoped_lock<std::mutex> lock(this->map_mutex);
         return this->map;
     }
+
+    ~buffer_map_t() { TT_ASSERT(this->map.empty(), "Not all buffers deallocated by runtime!"); }
 
    private:
     std::mutex map_mutex;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1429,6 +1429,12 @@ bool Device::close() {
 
     tt::Cluster::instance().l1_barrier(id_);
     allocator::clear(*this->allocator_);
+    // After device close, no buffers on this device should be used
+    for (const auto &[dev_addr, buf] : detail::BUFFER_MAP.value()) {
+        if (std::get<0>(dev_addr) == this->id()) {
+            DeallocateBuffer(*buf);
+        }
+    }
 
     this->active_devices_.deactivate_device(this->id_);
     this->disable_and_clear_program_cache();


### PR DESCRIPTION
Seeing post commit CI tests hanging if I call garbage collection before device close. Should we just disable any tests that fail like this? https://github.com/tenstorrent/tt-metal/actions/runs/9352480375/job/25740974650

@tarafdarTT @abhullar-tt @tt-aho 