### PR TITLE
Add Galaxy support.

### DIFF
--- a/tt_metal/common/core_descriptor.hpp
+++ b/tt_metal/common/core_descriptor.hpp
@@ -119,6 +119,10 @@ inline const core_descriptor_t &get_core_descriptor_config(chip_id_t device_id, 
 
     auto compute_with_storage_start = desc_yaml["compute_with_storage_grid_range"]["start"];
     auto compute_with_storage_end = desc_yaml["compute_with_storage_grid_range"]["end"];
+    if (tt::Cluster::instance().is_galaxy_cluster() and product_name == "nebula_x1") {
+        compute_with_storage_start = desc_yaml["tg_compute_with_storage_grid_range"]["start"];
+        compute_with_storage_end = desc_yaml["tg_compute_with_storage_grid_range"]["end"];
+    }
     TT_ASSERT(compute_with_storage_start.IsSequence() and compute_with_storage_end.IsSequence());
     TT_ASSERT(compute_with_storage_end[0].as<size_t>() >= compute_with_storage_start[0].as<size_t>());
     TT_ASSERT(compute_with_storage_end[1].as<size_t>() >= compute_with_storage_start[1].as<size_t>());
@@ -136,7 +140,11 @@ inline const core_descriptor_t &get_core_descriptor_config(chip_id_t device_id, 
     }
 
     std::vector<RelativeCoreCoord> dispatch_cores;
-    for (const auto& core_node : desc_yaml["dispatch_cores"]) {
+    auto dispatch_cores_string = "dispatch_cores";
+    if (tt::Cluster::instance().is_galaxy_cluster() and product_name == "nebula_x1") {
+        dispatch_cores_string = "tg_dispatch_cores";
+    }
+    for (const auto& core_node : desc_yaml[dispatch_cores_string]) {
         RelativeCoreCoord coord = {};
         if (core_node.IsSequence()) {
             // Logical coord

--- a/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
@@ -49,11 +49,20 @@ nebula_x1:
       start: [0, 0]
       end: [7, 7]
 
+    tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+      start: [0, 0]
+      end: [7, 3]
+
     storage_cores:
       []
 
     dispatch_cores:
       [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+
+    tg_dispatch_cores:
+      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+       [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+       [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3]]
 
     dispatch_core_type:
       "tensix"

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -159,6 +159,10 @@ class Device {
         return tt::Cluster::instance().get_associated_mmio_device(this->id_) == this->id_;
     }
 
+    void setup_tunnel_for_remote_devices();
+
+    void update_workers_build_settings(std::vector<std::vector<std::tuple<tt_cxy_pair, worker_build_settings_t>>> &device_worker_variants);
+
     uint32_t num_banks(const BufferType &buffer_type) const;
     uint32_t bank_size(const BufferType &buffer_type) const;
 
@@ -263,6 +267,8 @@ class Device {
     uint32_t build_key_;
     std::unique_ptr<Allocator> allocator_ = nullptr;
     bool initialized_ = false;
+    std::map<uint32_t, std::map<chip_id_t, std::vector<std::vector<std::tuple<tt_cxy_pair, worker_build_settings_t>>>>> tunnel_device_dispatch_workers_;
+    std::vector<std::vector<chip_id_t>> tunnels_from_mmio_;
 
     JitBuildEnv build_env_;
     JitBuildStateSet firmware_build_states_;

--- a/tt_metal/impl/device/multi_device.cpp
+++ b/tt_metal/impl/device/multi_device.cpp
@@ -26,9 +26,38 @@ DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_id
 
     //TODO: for DevicePool feature delete CreateDevices and merge with this function
     //TODO: should there be an explicit CloseDevices call somewhere?
-    managed_devices = tt::tt_metal::detail::CreateDevices(device_ids, 1, l1_small_size);
-    for (int i = 0; i < num_requested_devices; i++) {
-        mesh_devices.emplace_back(device_ids[i], std::unique_ptr<Device>(managed_devices.at(device_ids[i])));
+    bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
+    std::vector<chip_id_t> mmio_device_ids = {};
+    if (is_galaxy) {
+        mmio_device_ids.push_back(0);
+        if (num_requested_devices > 8) {
+            mmio_device_ids.push_back(1);
+        }
+        if (num_requested_devices > 16) {
+            mmio_device_ids.push_back(2);
+        }
+        if (num_requested_devices > 24) {
+            mmio_device_ids.push_back(3);
+        }
+    } else {
+        mmio_device_ids = device_ids;
+    }
+    managed_devices = tt::tt_metal::detail::CreateDevices(mmio_device_ids, 1, l1_small_size);
+    if (is_galaxy) {
+        DeviceIds galaxy_device_ids;
+        for (const auto &[dev_id, dev]: managed_devices) {
+            galaxy_device_ids.emplace_back(dev_id);
+        }
+        for (int i = 0; i < num_requested_devices; i++) {
+            mesh_devices.emplace_back(device_ids[i], std::unique_ptr<Device>(managed_devices.at(galaxy_device_ids[i])));
+        }
+    } else {
+      for (int i = 0; i < num_requested_devices; i++) {
+            mesh_devices.emplace_back(device_ids[i], std::unique_ptr<Device>(managed_devices.at(device_ids[i])));
+      }
+    }
+    for (const auto& [dev_id, dev]: mesh_devices) {
+        std::cout << "dev_id " << dev_id << " dev " << dev->id() << std::endl;
     }
 }
 
@@ -76,14 +105,7 @@ int DeviceMesh::num_devices() const
 }
 
 void DeviceMesh::close_devices() {
-    // TODO: change api to a yield, shouldn't allow closing sub grids in a pool of devices
-    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
-    for (const auto &[device_id, device] : managed_devices) {
-        if (device->is_initialized()) {
-            tt::tt_metal::detail::DeallocateBuffers(device);
-            device->close();
-        }
-    }
+    tt::tt_metal::detail::CloseDevices(managed_devices);
     mesh_devices.clear();
     managed_devices.clear();
 }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1243,7 +1243,10 @@ HWCommandQueue::HWCommandQueue(Device* device, uint32_t id, NOC noc_index) :
     chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
     this->size_B = tt::Cluster::instance().get_host_channel_size(mmio_device_id, channel) / device->num_hw_cqs();
-
+    if (tt::Cluster::instance().is_galaxy_cluster()) {
+        //Galaxy puts 4 devices per host channel until umd can provide one channel per device.
+        this->size_B = this->size_B / 4;
+    }
     tt_cxy_pair completion_q_writer_location =
         dispatch_core_manager::get(device->num_hw_cqs()).completion_queue_writer_core(device->id(), channel, this->id);
 

--- a/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
@@ -67,6 +67,7 @@ constexpr uint32_t test_results_buf_size_bytes = get_compile_time_arg_val(13);
 tt_l1_ptr uint32_t* const test_results = reinterpret_cast<tt_l1_ptr uint32_t*>(test_results_buf_addr_arg);
 
 constexpr uint32_t timeout_cycles = get_compile_time_arg_val(14);
+constexpr uint32_t inner_stop_mux_d_bypass = get_compile_time_arg_val(15);
 
 void kernel_main() {
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
@@ -139,6 +140,11 @@ void kernel_main() {
             output_queues[i].prev_words_in_flight_check_flush();
             bool output_finished = output_queues[i].is_remote_finished();
             if (output_finished) {
+                if ((i == 1) && (inner_stop_mux_d_bypass != 0)) {
+                    input_queues[1].remote_x = inner_stop_mux_d_bypass & 0xFF;
+                    input_queues[1].remote_y = (inner_stop_mux_d_bypass >> 8) & 0xFF;
+                    input_queues[1].set_remote_ready_status_addr((inner_stop_mux_d_bypass >> 16) & 0xFF);
+                }
                 input_queues[i].send_remote_finished_notification();
             }
             all_outputs_finished &= output_finished;

--- a/tt_metal/impl/dispatch/kernels/packet_queue.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue.hpp
@@ -293,6 +293,10 @@ public:
                                 PACKET_QUEUE_REMOTE_READY_FLAG);
     }
 
+    inline void set_remote_ready_status_addr(uint8_t remote_queue_id) {
+        this->remote_ready_status_addr = STREAM_REG_ADDR(remote_queue_id, STREAM_REMOTE_SRC_REG_INDEX);
+    }
+
     inline void send_remote_finished_notification() {
         this->remote_reg_update(this->remote_ready_status_addr,
                                 PACKET_QUEUE_REMOTE_FINISHED_FLAG);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -273,6 +273,7 @@ std::map<chip_id_t, Device *> CreateDevices(
     std::unordered_set<uint32_t> free_cores = {};
     std::vector<chip_id_t> all_device_ids = {};
 
+    bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
     for (const auto &device_id : device_ids) {
         // Get list of all devices in the cluster connected to the passed in device_ids
         const auto &mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
@@ -282,20 +283,55 @@ std::map<chip_id_t, Device *> CreateDevices(
             }
         }
     }
+
     // Determine which CPU cores the worker threads need to be placed on for each device
     std::unordered_map<uint32_t, uint32_t> device_to_core_map = device_cpu_allocator::get_device_id_to_core_map(all_device_ids, free_cores, use_numa_node_based_thread_binding);
 
-    for (const auto& device_id : all_device_ids) {
-        int core_assigned_to_device = device_to_core_map.at(device_id);
-        Device *dev = new Device(
-            device_id,
-            num_hw_cqs,
-            l1_small_size,
-            l1_bank_remap,
-            false,
-            core_assigned_to_device);
-        active_devices.insert({device_id, dev});
-        detail::InitDeviceProfiler(dev);
+    for (const auto &device_id : all_device_ids) {
+        // For Galaxy init, we only need to loop over mmio devices
+        const auto &mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+        if (is_galaxy and mmio_device_id != device_id) {
+            continue;
+        }
+        if (active_devices.find(mmio_device_id) == active_devices.end()) {
+            log_debug(tt::LogMetal, "MMIO Device {} Tunnel Count: {}", mmio_device_id, tt::Cluster::instance().get_mmio_device_tunnel_count(mmio_device_id));
+            log_debug(tt::LogMetal, "MMIO Device {} Tunnel Depth: {}", mmio_device_id, tt::Cluster::instance().get_mmio_device_max_tunnel_depth(mmio_device_id));
+            log_debug(tt::LogMetal, "MMIO Device {} Tunnel Stop: {}", mmio_device_id, tt::Cluster::instance().get_device_tunnel_depth(mmio_device_id));
+            int core_assigned_to_device = device_to_core_map.at(mmio_device_id);
+            Device *mmio_device = new Device(
+                mmio_device_id,
+                num_hw_cqs,
+                l1_small_size,
+                l1_bank_remap,
+                false,
+                core_assigned_to_device);
+            //Only include the mmio device in the active devices set returned to the caller if we are not running
+            //on a Galaxy cluster.
+            //On Galaxy, gateway (mmio devices) cannot run compute workloads.
+            if (!is_galaxy) {
+                active_devices.insert({mmio_device_id, mmio_device});
+                detail::InitDeviceProfiler(mmio_device);
+            }
+
+            auto tunnels_from_mmio = mmio_device->tunnels_from_mmio_;
+            for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
+                //Need to create devices from farthest to the closest.
+                for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0 ; ts--) {
+                    uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
+                    log_debug(tt::LogMetal, "Tunnel {} Device {} Tunnel Stop: {}", t, mmio_controlled_device_id, ts);
+                    int core_assigned_to_device = device_to_core_map.at(mmio_controlled_device_id);
+                    Device *dev = new Device(
+                        mmio_controlled_device_id,
+                        num_hw_cqs,
+                        l1_small_size,
+                        l1_bank_remap,
+                        false,
+                        core_assigned_to_device);
+                    active_devices.insert({mmio_controlled_device_id, dev});
+                    detail::InitDeviceProfiler(dev);
+                }
+            }
+        }
     }
 
     if (use_numa_node_based_thread_binding) {
@@ -312,7 +348,45 @@ std::map<chip_id_t, Device *> CreateDevices(
 
 void CloseDevices(std::map<chip_id_t, Device *> devices) {
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
-    for (const auto &[device_id, dev] : devices) {
+    std::map<chip_id_t, Device *> mmio_devices = {};
+    bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
+
+    if (is_galaxy) {
+        //On Galaxy, gateway wormhole devices (mmio devices) are not included in the set of devices
+        //created by CreateDevices(). So when closing devices, we need to find the corresponding
+        //gateway chips for all the tunneled devcies.
+        for (const auto &[device_id, dev] : devices) {
+            const auto &mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+            if (mmio_devices.find(mmio_device_id) == mmio_devices.end()) {
+                auto dev_handle = tt::tt_metal::detail::GetDeviceHandle(mmio_device_id);
+                mmio_devices.insert({mmio_device_id, dev_handle});
+            }
+        }
+    } else {
+        for (const auto &[device_id, dev] : devices) {
+            if(dev->is_mmio_capable()) {
+                mmio_devices.insert({device_id, dev});
+            }
+        }
+        for (const auto &[device_id, dev] : mmio_devices) {
+            devices.erase(device_id);
+        }
+    }
+
+    for (const auto &[device_id, dev] : mmio_devices) {
+        //For each mmio device, first close all the remote tunneled devices.
+        //Close the farthest tunneled device first.
+        auto tunnels_from_mmio = dev->tunnels_from_mmio_;
+        //iterate over all tunnels origination from this mmio device
+        for (auto t : tunnels_from_mmio) {
+            //iterate over all tunneled devices (tunnel stops) in this tunnel and close them.
+            for (uint32_t ts = t.size() - 1; ts > 0; ts--) {
+                if (devices.find(t[ts]) != devices.end()) {
+                    devices[t[ts]]->close();
+                }
+            }
+        }
+        //finally close the mmio device
         dev->close();
     }
 }


### PR DESCRIPTION
#0:    Enable metal on galaxy.
#8305: add Galaxy cluster apis
#8305: cleanup, add print
#8450: Establish tunnels originating from an mmio device. Determine the remote chips as well as their order on the tunnel. #8452: add tests for tg pipeline
#0:    patch for tg workflows.
#8450: Add tables for tunnel dispatch workers with build settings.
       Populate build settings for tunnel kernels.
       Launch FD2 kernels based on information in tunnel device dispatch worker map.
       Enable 4 devices per hugepage/channel
#0:    disable hanging/failing tests for Galaxy
#0:    skip using channel 3, 7 which use huge page channel 3. This (4th) huepage is not a full 1GB in size. 256 MB is taken up by syseng tools 4th huge page.
#0:    re-enable Galaxy sharded tests, reduce one test runtime for Galaxy
#0:    fix cluster init for Galaxy
#8953: Fix hardcoding of queue sizes in tests.
#8450: Fix compute grid selection for N150. N150 can be standalone system or part of a TG system. On TG compute grid for N150 is different than standalone N150.
#0:    Reduce prefetch q entries to account for Galaxy CQ size.