### PR TITLE
#4252: Update to C++20

### DIFF
--- a/.github/actions/install-metal-deps/dependencies.json
+++ b/.github/actions/install-metal-deps/dependencies.json
@@ -5,7 +5,6 @@
     "python3.8-venv=3.8.10-0ubuntu1~20.04.9",
     "libgoogle-glog-dev=0.4.0-1build1",
     "libyaml-cpp-dev=0.6.2-4ubuntu1",
-    "libboost-all-dev=1.71.0.0ubuntu2",
     "libsndfile1=1.0.28-7ubuntu0.2",
     "libhwloc-dev",
     "graphviz",

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -32,7 +32,7 @@ jobs:
           git submodule update --init --recursive
       - name: Build tt-metal and libs
         run: |
-          cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++-17
+          cmake -B build -G Ninja
           cmake --build build --target tests
           cmake --build build --target install
       - name: 'Tar files'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - name: Build tt-metal libraries
         run: |
-          cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++-17
+          cmake -B build -G Ninja
           cmake --build build
       - name: Build tt-metal C++ tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ compile_commands.json
 # rpath_check
 tt_eager/tt_lib/.rpath_checked*
 ttnn/ttnn/.rpath_checked
+
+# exclude packages brough in from CPM
+.cpmcache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ CHECK_COMPILERS()
 ############################################################################################################################
 # Find all required libraries to build
 ############################################################################################################################
-find_package(Boost REQUIRED COMPONENTS thread filesystem system regex)
+include(${CMAKE_SOURCE_DIR}/cmake/CPM_boost.cmake)
 find_package(GTest REQUIRED)
 find_package (Python3 COMPONENTS Interpreter Development)
 find_library(NUMA_LIBRARY NAMES numa)
@@ -90,8 +90,7 @@ set(CMAKE_INSTALL_DATAROOTDIR "${CMAKE_BINARY_DIR}/tmp/share")
 ############################################################################################################################
 add_library(metal_common_libs INTERFACE)
 target_link_libraries(metal_common_libs INTERFACE
-    dl z pthread atomic stdc++ numa # system libraries
-    Boost::thread Boost::filesystem Boost::system Boost::regex hwloc    # hwloc has no cmake support, find_package won't find it
+    dl z pthread atomic stdc++ hwloc numa # system libraries, hwloc has no cmake support, find_package won't find it
 )
 
 # Note on flags:
@@ -123,7 +122,11 @@ if($ENV{ENABLE_TRACY})
 endif()
 
 add_library(metal_header_directories INTERFACE)
-target_include_directories(metal_header_directories INTERFACE tt_metal/hw/inc)
+target_include_directories(metal_header_directories INTERFACE ${CMAKE_SOURCE_DIR}/tt_metal/hw/inc)
+foreach(lib ${BoostPackages})
+    target_include_directories(metal_header_directories INTERFACE ${Boost${lib}_SOURCE_DIR}/include)
+endforeach()
+
 if ("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
     target_include_directories(metal_header_directories INTERFACE tt_metal/hw/inc/wormhole
         tt_metal/hw/inc/wormhole/wormhole_b0_defines
@@ -162,7 +165,6 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests EXCLUDE_FROM_ALL)
-
 
 ############################################################################################################################
 # Install targets for build artifacts and pybinds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,15 @@ cmake_policy(VERSION 3.16)
 # Project setup
 ############################################
 
-### Uncomment this if you don't want to manually pass Clang-17 compiler through CLI ###
-# find_program(CLANG_17 clang++-17)
-# if(CLANG_17)
-#     message(STATUS "Found Clang-17 here: ${CLANG_17}")
-#     set(CMAKE_CXX_COMPILER "${CLANG_17}")
-# else()
-#     message(WARNING "Clang++-17 not found, recommended to build with Clang-17 > GCC for better perf")
-# endif()
+# Use Clang-17 by default until we upgrade to Ubuntu version that supports higher GCC
+# No longer support GCC-9 as it does not support C++20
+find_program(CLANG_17 clang++-17)
+if(CLANG_17)
+    message(STATUS "Found Clang-17 here: ${CLANG_17}")
+    set(CMAKE_CXX_COMPILER "${CLANG_17}")
+else()
+    message(WARNING "Clang++-17 not found!!!")
+endif()
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "CMake generation is not allowed within source directory!! Please set a build folder with '-B'!!")
@@ -57,8 +58,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG=DEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DDEBUG=DEBUG")
 set(CMAKE_CXX_FLAGS_CI "-O3 -DDEBUG=DEBUG")
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Set default values for variables/options
 set(UMD_HOME "${CMAKE_SOURCE_DIR}/tt_metal/third_party/umd")

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -28,7 +28,7 @@ Note the current compatability matrix:
 sudo apt update
 sudo apt install software-properties-common=0.99.9.12 build-essential=12.8ubuntu1.1 python3.8-venv=3.8.10-0ubuntu1~20.04.9 libgoogle-glog-dev=0.4.0-1build1 libyaml-cpp-dev=0.6.2-4ubuntu1 libboost-all-dev=1.71.0.0ubuntu2 libsndfile1=1.0.28-7ubuntu0.2 libhwloc-dev graphviz
 
-# Install Clang-17: Recommended to use Clang-17 as that's what is officially supported and tested on CI.
+# Install Clang-17 for C++20 support!!
 wget https://apt.llvm.org/llvm.sh
 chmod u+x llvm.sh
 sudo ./llvm.sh 17

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -43,6 +43,9 @@ Example:
     <run a pytest>                                                  # <- this test ran in Release config
     ninja install -C build_debug                                    # <- install Debug pybinds
     <run a pytest>                                                  # <- this test ran in Debug config
+
+NOTE ON DEBUGGING!:
+    GDB/LLDB is not stable right now. Recommend to use GCC11 or higher for debugging or Clang-17 with GDB 14+
 '
 
 set -eo pipefail
@@ -94,7 +97,7 @@ else
 fi
 
 echo "Building tt-metal"
-cmake_args="-B build -G Ninja -DCMAKE_CXX_COMPILER=clang++-17 -DCMAKE_EXPORT_COMPILE_COMMANDS=$export_compile_commands"
+cmake_args="-B build -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=$export_compile_commands"
 
 if [ "$enable_ccache" = "ON" ]; then
     cmake_args="$cmake_args -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,25 @@
+
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.39.0)
+set(CPM_HASH_SUM "66639bcac9dd2907b2918de466783554c1334446b9874e90d38e3778d404c2ef")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/CPM_boost.cmake
+++ b/cmake/CPM_boost.cmake
@@ -1,0 +1,35 @@
+
+set(ENV{CPM_SOURCE_CACHE} "${CMAKE_SOURCE_DIR}/.cpmcache")
+
+include(${CMAKE_SOURCE_DIR}/cmake/CPM.cmake)
+set(BoostPackages
+    Align
+    Config
+    Container_Hash
+    Core
+    Detail
+    Format
+    Interprocess
+    Smart_Ptr
+    Assert
+    Integer
+    Type_Traits
+    Optional
+    Static_Assert
+    Throw_Exception
+    Move
+    Utility
+    Preprocessor
+    Date_Time
+    Numeric_Conversion
+    Mpl
+)
+
+foreach(package ${BoostPackages})
+    CPMAddPackage(
+        NAME Boost${package}
+        GITHUB_REPOSITORY boostorg/${package}
+        GIT_TAG boost-1.76.0
+        DOWNLOAD_ONLY YES
+    )
+endforeach()

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -12,8 +12,10 @@ macro(CHECK_COMPILERS)
             "\n Set env variable CXX=clang++-17"
             "\n Check top level CMakeLists and uncomment some lines\n"
         )
-        if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL "10.0.0")
+        if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL "11.0.0")
             message(WARNING "Anything after GCC-9 has not been thoroughly tested!")
+        else()
+            message(FATAL_ERROR "Any version lower than GCC-11 will not support necessary C++20 features")
         endif()
     else()
         message(FATAL_ERROR "Compiler is not GCC or Clang")
@@ -23,8 +25,14 @@ endmacro()
 macro(CHECK_COMPILER_WARNINGS)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         target_compile_options(compiler_warnings INTERFACE
-            -Wsometimes-uninitialized -Wno-c++11-narrowing -Wno-c++20-extensions -Wno-c++23-extensions -Wno-error=local-type-template-args
-            -Wno-delete-non-abstract-non-virtual-dtor -Wno-c99-designator -Wno-shift-op-parentheses -Wno-non-c-typedef-for-linkage)
+            -Wsometimes-uninitialized -Wno-c++11-narrowing -Wno-c++23-extensions -Wno-error=local-type-template-args
+            -Wno-delete-non-abstract-non-virtual-dtor -Wno-c99-designator -Wno-shift-op-parentheses -Wno-non-c-typedef-for-linkage
+            -Wno-deprecated-this-capture -Wno-deprecated-volatile -Wno-deprecated-builtins -Wno-deprecated-declarations # -> extra C++20 build flags
+        )
         # -Wsometimes-uninitialized will override the -Wuninitialized added before
+    else() # using GCC-11 or higher
+        target_compile_options(compiler_warnings INTERFACE
+            -Wno-deprecated -Wno-attributes # <-- C++20 warning flags
+        )
     endif()
 endmacro()

--- a/cmake/umd_device.cmake
+++ b/cmake/umd_device.cmake
@@ -22,11 +22,21 @@ if($ENV{ENABLE_TRACY})
 endif()
 
 # MUST have the RPATH set, or else can't find the tracy lib
-set(LDFLAGS_ "-L${CMAKE_BINARY_DIR}/lib -L/usr/local/lib -Wl,-rpath,${CMAKE_BINARY_DIR}/lib -Wl,-rpath,/usr/local/lib ${CONFIG_LDFLAGS} -ldl -lz -lboost_thread -lboost_filesystem -lboost_system -lboost_regex -lpthread -latomic -lhwloc -lstdc++")
+set(LDFLAGS_ "-L${CMAKE_BINARY_DIR}/lib -Wl,-rpath,${CMAKE_BINARY_DIR}/lib ${CONFIG_LDFLAGS} -ldl -lz -lpthread -latomic -lhwloc -lstdc++")
 set(SHARED_LIB_FLAGS_ "-shared -fPIC")
 set(STATIC_LIB_FLAGS_ "-fPIC")
 
 set (CMAKE_CXX_FLAGS_ "--std=c++17 -fvisibility-inlines-hidden")
+foreach(lib ${BoostPackages})
+    set(CMAKE_CXX_FLAGS_ "${CMAKE_CXX_FLAGS_} -I${Boost${lib}_SOURCE_DIR}/include")
+endforeach()
+
+set(UMD_OUTPUT > /dev/null 2>&1)
+if(DEFINED ENV{VERBOSE})
+    if($ENV{VERBOSE} STREQUAL 1)
+        set(UMD_OUTPUT "")
+    endif()
+endif()
 
 # This will build the shared library libdevice.so in build/lib where tt_metal can then find and link it
 include(ExternalProject)
@@ -56,7 +66,9 @@ ExternalProject_Add(
         LDFLAGS=${LDFLAGS_}
         CXXFLAGS=${CMAKE_CXX_FLAGS_}
         DEVICE_CXX=${CMAKE_CXX_COMPILER}
+        ${UMD_OUTPUT}
 )
+# add_dependencies(umd_device umd_boost)
 if($ENV{ENABLE_TRACY})
     add_dependencies(umd_device TracyClient)
 endif()

--- a/cmake/umd_device.cmake
+++ b/cmake/umd_device.cmake
@@ -22,7 +22,7 @@ if($ENV{ENABLE_TRACY})
 endif()
 
 # MUST have the RPATH set, or else can't find the tracy lib
-set(LDFLAGS_ "-L${CMAKE_BINARY_DIR}/lib -Wl,-rpath,${CMAKE_BINARY_DIR}/lib ${CONFIG_LDFLAGS} -ldl -lz -lboost_thread -lboost_filesystem -lboost_system -lboost_regex -lpthread -latomic -lhwloc -lstdc++")
+set(LDFLAGS_ "-L${CMAKE_BINARY_DIR}/lib -L/usr/local/lib -Wl,-rpath,${CMAKE_BINARY_DIR}/lib -Wl,-rpath,/usr/local/lib ${CONFIG_LDFLAGS} -ldl -lz -lboost_thread -lboost_filesystem -lboost_system -lboost_regex -lpthread -latomic -lhwloc -lstdc++")
 set(SHARED_LIB_FLAGS_ "-shared -fPIC")
 set(STATIC_LIB_FLAGS_ "-fPIC")
 

--- a/scripts/build_scripts/build_with_profiler_opt.sh
+++ b/scripts/build_scripts/build_with_profiler_opt.sh
@@ -11,7 +11,7 @@ if [[ -z "$ARCH_NAME" ]]; then
     exit 1
 fi
 
-ENABLE_TRACY=1 ENABLE_PROFILER=1 cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++-17
+ENABLE_TRACY=1 ENABLE_PROFILER=1 cmake -B build -G Ninja
 
 if [[ $1 == "NO_CLEAN" ]]; then
     cmake --build build

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -799,9 +799,9 @@ inline void print_trailing_comma(std::ostream& ss, std::size_t index, std::size_
 template <typename T>
 inline void print_datum(std::ostream& ss, T datum) {
     if (std::is_integral<T>::value) {
-        ss << fmt::format("{:5}", datum);
+        ss << std::setw(5) << datum;
     } else {
-        ss << fmt::format("{:8.5f}", datum);
+        ss << std::fixed << std::setw(8) << std::setprecision(5) << datum;
     }
 }
 

--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -270,6 +270,7 @@ static_assert(
 struct OwnedStorage {
     OwnedBuffer buffer;
     OwnedStorage() = default;
+    OwnedStorage(OwnedBuffer buffer_) : buffer(std::move(buffer_)) {}
 
     static constexpr auto attribute_names = std::make_tuple();
     const auto attribute_values() const { return std::make_tuple(); }
@@ -288,6 +289,7 @@ using DeviceBuffer = std::shared_ptr<Buffer>;
 struct DeviceStorage {
     DeviceBuffer buffer;
     DeviceStorage() = default;
+    DeviceStorage(DeviceBuffer buffer_) : buffer(std::move(buffer_)) {}
 
     const MemoryConfig memory_config() const {
         if (this->buffer.get() == nullptr) {

--- a/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp
@@ -133,7 +133,7 @@ static inline operation::ProgramWithCallbacks create_qkv_separate(const Tensor &
         UpdateDynamicCircularBufferAddress(program, cb_out2_id, *out2_buffer);
     };
 
-    return {std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
 namespace tt {

--- a/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
+++ b/tt_eager/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
@@ -158,7 +158,7 @@ static inline operation::ProgramWithCallbacks create_heads_combined_qkv_sharded(
         UpdateDynamicCircularBufferAddress(program, cb_out2_id, *out2_buffer);
     };
 
-    return {std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
 namespace tt {

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_impl.hpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_impl.hpp
@@ -117,7 +117,7 @@ void bind_op_with_mem_config(py::module_ &module, std::string op_name, Func &&f,
 template <bool fused_activations = true, bool mem_config_arg = true, bool dtype_arg = true, bool opt_output_arg = true, typename Func>
 void bind_binary_op(py::module_ &module, std::string op_name, Func &&f, std::string op_desc) {
     std::vector<std::string> arg_name = {"input_a", "input_b"};
-    op_desc = fmt::format(op_desc, arg_name[0], arg_name[1]);
+    op_desc = fmt::format(fmt::runtime(op_desc), arg_name[0], arg_name[1]);
 
     std::string docstring = fmt::format(R"doc(
         {0}
@@ -156,7 +156,7 @@ void bind_binary_op(py::module_ &module, std::string op_name, Func &&f, std::str
 template <bool mem_config_arg = true, bool dtype_arg = false, typename Func>
 void bind_unary_op(py::module_ &module, std::string op_name, Func &&f, std::string op_desc) {
     const std::string tensor_name = "input";
-    op_desc = fmt::format(op_desc, tensor_name);
+    op_desc = fmt::format(fmt::runtime(op_desc), tensor_name);
     std::string docstring = fmt::format(R"doc(
         {0}
 
@@ -178,7 +178,7 @@ template <bool mem_config_arg = true, bool dtype_arg = false, typename Func, typ
 void bind_unary_op_with_param(py::module_ &module, std::string op_name, Func &&f, PyArg param, std::string op_desc, std::string param_desc) {
     const std::string tensor_name = "input";
     std::string param_name = std::string(param.name);
-    op_desc = fmt::format(op_desc, tensor_name, param_name);
+    op_desc = fmt::format(fmt::runtime(op_desc), tensor_name, param_name);
     const std::string required_param = std::is_same_v<py::arg_v, PyArg> ? "No" : "Yes";
     std::string docstring = fmt::format(R"doc(
         {0}

--- a/tt_metal/common/assert.hpp
+++ b/tt_metal/common/assert.hpp
@@ -103,19 +103,19 @@ void tt_assert_message(std::ostream& os, Ts const&... ts) {
         fmt += "{} ";
     }
     log_fatal(fmt.c_str(), ts...);
-    os << fmt::format(fmt, ts...);
+    ((os << fmt::format("{} ", ts)), ...);
     os << std::endl;
 }
 
 template <typename... Ts>
 void tt_assert_message(std::ostream& os, const char* t, Ts const&... ts) {
-    os << fmt::format(t, ts...);
+    os << fmt::format(fmt::runtime(t), ts...);
     os << std::endl;
 }
 
 template <typename... Ts>
 void tt_assert_message(std::ostream& os, const std::string& t, Ts const&... ts) {
-    os << fmt::format(t, ts...);
+    os << fmt::format(fmt::runtime(t), ts...);
     os << std::endl;
 }
 

--- a/tt_metal/common/utils.hpp
+++ b/tt_metal/common/utils.hpp
@@ -45,6 +45,21 @@ namespace utils
     // instead of letting the program terminate.
     class ThreadManager {
         public:
+            // c++20 fix for -> error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
+            // not tested at all !!!
+            // template <typename Func, typename... Args>
+            // void start(Func&& func, Args&&... args) {
+            //     auto args_tuple = std::make_tuple(std::forward<Args>(args)...);
+            //     threads.emplace_back(std::thread([this, func=std::forward<Func>(func), args_tuple]() mutable{
+            //         try {
+            //             std::apply(func, args_tuple);
+            //         } catch (...) {
+            //             std::lock_guard<std::mutex> lock(exceptionMutex);
+            //             exceptions.push_back(std::current_exception());
+            //         }
+            //     }));
+            // }
+
             template <typename Func, typename... Args>
             void start(Func&& func, Args&&... args) {
                 threads.emplace_back(std::thread([=]() {

--- a/tt_metal/common/utils.hpp
+++ b/tt_metal/common/utils.hpp
@@ -45,21 +45,6 @@ namespace utils
     // instead of letting the program terminate.
     class ThreadManager {
         public:
-            // c++20 fix for -> error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
-            // not tested at all !!!
-            // template <typename Func, typename... Args>
-            // void start(Func&& func, Args&&... args) {
-            //     auto args_tuple = std::make_tuple(std::forward<Args>(args)...);
-            //     threads.emplace_back(std::thread([this, func=std::forward<Func>(func), args_tuple]() mutable{
-            //         try {
-            //             std::apply(func, args_tuple);
-            //         } catch (...) {
-            //             std::lock_guard<std::mutex> lock(exceptionMutex);
-            //             exceptions.push_back(std::current_exception());
-            //         }
-            //     }));
-            // }
-
             template <typename Func, typename... Args>
             void start(Func&& func, Args&&... args) {
                 threads.emplace_back(std::thread([=]() {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -11,7 +11,6 @@
 #include "tt_metal/hostdevcommon/common_values.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/device/device.hpp"
-#include "tt_metal/tt_stl/stacktrace.hpp"
 
 namespace tt {
 


### PR DESCRIPTION
Cleaned up version of https://github.com/tenstorrent/tt-metal/pull/8954. Made a new branch because of submodule issues.

Main blocker: our current native Boost 1.71 is not compatible with C++20, need to update to at least 1.76

~Solution: using [BCP](https://www.boost.org/doc/libs/1_85_0/tools/bcp/doc/html/index.html) to get all the 1.76 headers we need and put it into tt_metal/third_party/boost 
Size rn of all Boost headers: 26M~

Solution: use CPM to bring in boost, it'll add time to cmake config step but only on first runthrough. Afterwards it's cached in `.cpmcache/`

Benefit: no longer need Boost as a dependency

post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/9389649424

Others:
device perf: https://github.com/tenstorrent/tt-metal/actions/runs/9356471028
model perf: https://github.com/tenstorrent/tt-metal/actions/runs/9373974561
uBenchmarks: https://github.com/tenstorrent/tt-metal/actions/runs/9356466830
nightly fd: https://github.com/tenstorrent/tt-metal/actions/runs/9374701500
t3k frequent: https://github.com/tenstorrent/tt-metal/actions/runs/9374640840
t3k unit: https://github.com/tenstorrent/tt-metal/actions/runs/9375357379
t3k model perf: https://github.com/tenstorrent/tt-metal/actions/runs/9379451241