### PR TITLE
#9016: adjust nightly t3000 demo test pipeline to run Mon/Wed/Fri

### DIFF
--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -3,7 +3,7 @@ name: "[T3K] T3000 demo tests"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 6' # This cron schedule runs the workflow every Saturday at 12am UTC
+    - cron: '0 0 * * 1,3,5' # This cron schedule runs the workflow every Monday/Wednesday/Friday at 12am UTC
 
 jobs:
   build-artifact:


### PR DESCRIPTION
Change nightly t3000 demo test pipeline to run Monday/Wed/Fri at 12am UTC time.
Workflow seems to take < 1 hour 
https://github.com/tenstorrent/tt-metal/actions/runs/9323275631