### PR TITLE
#9095: implement callback helper function

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
@@ -194,10 +194,10 @@ def run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device):
 
 @pytest.mark.parametrize(
     "shape",
-    (
-        (1, 1, 32, 32),  # single
-        (12, 6, 64, 64),  # multi tile
-    ),
+    [
+        [1, 1, 32, 32],  # single
+        [12, 6, 64, 64],  # multi tile
+    ],
 )
 @pytest.mark.parametrize("lr", [0.0, 1e-2])
 @pytest.mark.parametrize("betas", ((0.9, 0.999), (0.5, 0.555)))
@@ -213,7 +213,7 @@ def test_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device)
 
 @pytest.mark.parametrize(
     "shape",
-    ((1, 1, 32, 32),),  # single
+    [[1, 1, 32, 32]],  # single
 )
 @pytest.mark.parametrize("lr", [1e-2])
 @pytest.mark.parametrize("betas", [[0.9, 0.999], [0.5, 0.555]])

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
@@ -17,22 +17,7 @@ from models.utility_functions import (
 from loguru import logger
 
 
-@pytest.mark.parametrize(
-    "shape",
-    (
-        (1, 1, 32, 32),  # single
-        (12, 6, 64, 64),  # multi tile
-    ),
-)
-@pytest.mark.parametrize("lr", [0.0, 1e-2])
-@pytest.mark.parametrize("betas", ((0.9, 0.999), (0.5, 0.555)))
-@pytest.mark.parametrize("eps", [1e-06, 1e-08])
-@pytest.mark.parametrize("weight_decay", [0.0, 0.3])
-@pytest.mark.parametrize("amsgrad", [True, False])
-@pytest.mark.parametrize("step", [1, 2, 8])
-def test_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device):
-    torch.manual_seed(0)
-
+def run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device):
     N = shape[0]
     C = shape[1]
     H = shape[2]
@@ -205,3 +190,38 @@ def test_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device)
         whole_passing &= passing
 
     assert whole_passing
+
+
+@pytest.mark.parametrize(
+    "shape",
+    (
+        (1, 1, 32, 32),  # single
+        (12, 6, 64, 64),  # multi tile
+    ),
+)
+@pytest.mark.parametrize("lr", [0.0, 1e-2])
+@pytest.mark.parametrize("betas", ((0.9, 0.999), (0.5, 0.555)))
+@pytest.mark.parametrize("eps", [1e-06, 1e-08])
+@pytest.mark.parametrize("weight_decay", [0.0, 0.3])
+@pytest.mark.parametrize("amsgrad", [True, False])
+@pytest.mark.parametrize("step", [1, 2, 8])
+def test_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device):
+    torch.manual_seed(0)
+
+    run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    ((1, 1, 32, 32),),  # single
+)
+@pytest.mark.parametrize("lr", [1e-2])
+@pytest.mark.parametrize("betas", [[0.9, 0.999], [0.5, 0.555]])
+@pytest.mark.parametrize("eps", [1e-08])
+@pytest.mark.parametrize("weight_decay", [0.3])
+@pytest.mark.parametrize("amsgrad", [True, False])
+@pytest.mark.parametrize("step", [8])
+def test_moreh_adamw_callback(shape, lr, betas, eps, weight_decay, amsgrad, step, device, use_program_cache):
+    torch.manual_seed(0)
+    for _ in range(2):
+        run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device)

--- a/tt_eager/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
@@ -10,8 +10,8 @@
 #include "tt_dnn/op_library/run_operation.hpp"
 #include "tt_eager/tensor/tensor.hpp"
 #include "tt_eager/tensor/tensor_impl.hpp"
-#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "tt_eager/tt_dnn/op_library/moreh_adamw/moreh_adamw_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "tt_eager/tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/common/math.hpp"
 #include "tt_metal/detail/util.hpp"
@@ -26,9 +26,14 @@ operation::ProgramWithCallbacks moreh_adamw_(
     const Tensor& grad,
     const Tensor& exp_avg,
     const Tensor& exp_avg_sq,
-    float lr, float beta1, float beta2, float eps, float weight_decay, uint32_t step, bool amsgrad,
+    float lr,
+    float beta1,
+    float beta2,
+    float eps,
+    float weight_decay,
+    uint32_t step,
+    bool amsgrad,
     const std::optional<std::reference_wrapper<const Tensor>> max_exp_avg_sq) {
-
     uint32_t num_tiles = param.volume() / TILE_HW;
 
     Program program{};
@@ -36,14 +41,15 @@ operation::ProgramWithCallbacks moreh_adamw_(
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::Device *device = param.device();
+    tt_metal::Device* device = param.device();
     auto grid = device->compute_with_storage_grid_size();
     const auto num_cores_y = grid.y;
 
     // auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     // uint32_t num_cores_x = compute_with_storage_grid_size.x;
     // uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_tiles);
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        tt_metal::split_work_to_cores(grid, num_tiles);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup
@@ -54,27 +60,27 @@ operation::ProgramWithCallbacks moreh_adamw_(
         all_cores,
         data_format,
         {
-            {CB::c_in0, 1},        // param
-            {CB::c_in1, 1},        // grad
-            {CB::c_in2, 1},        // exp_avg
-            {CB::c_in3, 1},        // exp_avg_sq
-            {CB::c_in4, 1},        // max_exp_avg_sq (optional)
-            {CB::c_in5, 5},        // lr, beta1, beta2, eps, weight_decay
-            {CB::c_in6, 1},         // 1.0f
+            {CB::c_in0, 1},  // param
+            {CB::c_in1, 1},  // grad
+            {CB::c_in2, 1},  // exp_avg
+            {CB::c_in3, 1},  // exp_avg_sq
+            {CB::c_in4, 1},  // max_exp_avg_sq (optional)
+            {CB::c_in5, 5},  // lr, beta1, beta2, eps, weight_decay
+            {CB::c_in6, 1},  // 1.0f
 
-            {CB::c_intermed0, 1},        // tmp_grad
-            {CB::c_intermed1, 1},        // tmp_exp_avg
-            {CB::c_intermed2, 1},        // tmp_exp_avg_sq
-            {CB::c_intermed3, 1},        // tmp_max_exp_avg_sq
-            {CB::c_intermed4, 1},        //
-            {CB::c_intermed5, 1},        //
-            {CB::c_intermed6, 1},        // tmp1
-            {CB::c_intermed7, 1},        // tmp2
+            {CB::c_intermed0, 1},  // tmp_grad
+            {CB::c_intermed1, 1},  // tmp_exp_avg
+            {CB::c_intermed2, 1},  // tmp_exp_avg_sq
+            {CB::c_intermed3, 1},  // tmp_max_exp_avg_sq
+            {CB::c_intermed4, 1},  //
+            {CB::c_intermed5, 1},  //
+            {CB::c_intermed6, 1},  // tmp1
+            {CB::c_intermed7, 1},  // tmp2
 
-            {CB::c_out0, 1},       // param
-            {CB::c_out1, 1},       // exp_avg
-            {CB::c_out2, 1},       // exp_avg_sq
-            {CB::c_out3, 1},       // max_exp_avg_sq (optional)
+            {CB::c_out0, 1},  // param
+            {CB::c_out1, 1},  // exp_avg
+            {CB::c_out2, 1},  // exp_avg_sq
+            {CB::c_out3, 1},  // max_exp_avg_sq (optional)
         });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -117,19 +123,20 @@ operation::ProgramWithCallbacks moreh_adamw_(
         compute_defines["AMSGRAD"] = "1";
     }
 
-    const std::vector<uint32_t> compute_args_group_1{
-        num_tiles_per_core_group_1};
+    const std::vector<uint32_t> compute_args_group_1{num_tiles_per_core_group_1};
 
     const auto compute_kernel_file =
         "tt_eager/tt_dnn/op_library/moreh_adamw/kernels/"
         "moreh_adamw.cpp";
 
     auto compute_kernel_1_id = CreateComputeKernel(
-        program, compute_kernel_file, {core_group_1, num_tiles_per_core_group_1, compute_args_group_1}, compute_defines);
+        program,
+        compute_kernel_file,
+        {core_group_1, num_tiles_per_core_group_1, compute_args_group_1},
+        compute_defines);
     KernelHandle compute_kernel_2_id = -1;
     if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{
-            num_tiles_per_core_group_2};
+        const std::vector<uint32_t> compute_args_group_2{num_tiles_per_core_group_2};
 
         compute_kernel_2_id = CreateComputeKernel(
             program,
@@ -170,14 +177,24 @@ operation::ProgramWithCallbacks moreh_adamw_(
         }
 
         const std::vector<uint32_t> reader_runtime_args{
-            param_addr, grad_addr, exp_avg_addr, exp_avg_sq_addr, max_exp_avg_sq_addr,
-            f2u_lr.u, f2u_beta1.u, f2u_beta2.u, f2u_eps.u, f2u_weight_decay.u, step, static_cast<uint32_t>(amsgrad),
-            num_tiles_per_core, tile_offset};
+            param_addr,
+            grad_addr,
+            exp_avg_addr,
+            exp_avg_sq_addr,
+            max_exp_avg_sq_addr,
+            f2u_lr.u,
+            f2u_beta1.u,
+            f2u_beta2.u,
+            f2u_eps.u,
+            f2u_weight_decay.u,
+            step,
+            static_cast<uint32_t>(amsgrad),
+            num_tiles_per_core,
+            tile_offset};
         tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
 
         const std::vector<uint32_t> writer_runtime_args{
-            param_addr, exp_avg_addr, exp_avg_sq_addr, max_exp_avg_sq_addr,
-            num_tiles_per_core, tile_offset};
+            param_addr, exp_avg_addr, exp_avg_sq_addr, max_exp_avg_sq_addr, num_tiles_per_core, tile_offset};
         tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
 
         if (core_group_1.core_coord_in_core_ranges(core)) {
@@ -191,50 +208,9 @@ operation::ProgramWithCallbacks moreh_adamw_(
         tile_offset += num_tiles_per_core;
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Callback SetUp
-    ////////////////////////////////////////////////////////////////////////////
-    auto override_runtime_args_callback = [reader_kernel_id = reader_kernel_id,
-                                           writer_kernel_id = writer_kernel_id,
-                                           num_cores = num_cores,
-                                           num_cores_y = num_cores_y](
-                                              const Program& program,
-                                              const std::vector<Buffer*>& input_buffers,
-                                              const std::vector<Buffer*>& output_buffers) {
-        auto param_buffer = input_buffers.at(0);
-        auto grad_buffer = input_buffers.at(1);
-        auto exp_avg_buffer = input_buffers.at(2);
-        auto exp_avg_sq_buffer = input_buffers.at(3);
-        auto max_exp_avg_sq_buffer = input_buffers.at(4);
-
-        for (uint32_t i = 0; i < num_cores; ++i) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = param_buffer->address();
-                runtime_args[1] = grad_buffer->address();
-                runtime_args[2] = exp_avg_buffer->address();
-                runtime_args[3] = exp_avg_sq_buffer->address();
-                if (max_exp_avg_sq_buffer != nullptr) {
-                    runtime_args[4] = max_exp_avg_sq_buffer->address();
-                }
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = param_buffer->address();
-                runtime_args[1] = grad_buffer->address();
-                runtime_args[2] = exp_avg_buffer->address();
-                runtime_args[3] = exp_avg_sq_buffer->address();
-                if (max_exp_avg_sq_buffer != nullptr) {
-                    runtime_args[4] = max_exp_avg_sq_buffer->address();
-                }
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        std::move(program),
+        create_override_addresses_callback(reader_kernel_id, writer_kernel_id, num_cores, num_cores_y)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
@@ -185,7 +185,7 @@ create_override_runtime_arguments_callback(
     KernelHandle writer_kernel_id,
     uint32_t num_cores,
     uint32_t core_h,
-    CallbackArgMap &arg_map) {
+    CallbackArgMap arg_map) {
     return [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, arg_map, num_cores, core_h](
                const void *operation,
                Program &program,

--- a/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
@@ -126,6 +126,138 @@ struct CircularBufferArg {
     tt::DataFormat data_format,
     CircularBufferArg arg);
 
+
+struct CallbackArgMap {
+    std::map<uint32_t, uint32_t> input;
+    std::map<uint32_t, uint32_t> optional_input;
+    std::map<uint32_t, uint32_t> output;
+};
+
+using Tensors = std::vector<Tensor>;
+using OptionalConstTensors = std::vector<std::optional<const Tensor>>;
+
+// To use this function, the arguments in the reader kernel must always be sorted in the order of input followed by
+// optional_input. Furthermore, input and output tensors must always start from the 0th argument.
+template <typename OutputTensors = Tensors>
+const std::function<void(const void *, Program &, const Tensors &, const OptionalConstTensors &, const OutputTensors &)>
+create_override_runtime_arguments_callback(
+    KernelHandle reader_kernel_id, KernelHandle writer_kernel_id, uint32_t num_cores, uint32_t core_h) {
+    return [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h](
+               const void *operation,
+               Program &program,
+               const Tensors &input_tensors,
+               const OptionalConstTensors &optional_input_tensors,
+               const OutputTensors &output_tensors) -> void {
+        for (uint32_t icore = 0; icore < num_cores; icore++) {
+            CoreCoord core = {icore / core_h, icore % core_h};
+
+            // readers
+            {
+                uint32_t rt_idx = 0;
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                for (uint32_t idx = 0; idx < input_tensors.size(); idx++) {
+                    runtime_args[rt_idx++] = input_tensors.at(idx).buffer()->address();
+                }
+                for (uint32_t idx = 0; idx < optional_input_tensors.size(); idx++) {
+                    auto optional_input_tensor = optional_input_tensors.at(idx);
+                    runtime_args[rt_idx++] =
+                        optional_input_tensor.has_value() ? optional_input_tensor.value().buffer()->address() : 0;
+                }
+            }
+
+            // writer
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                for (uint32_t idx = 0; idx < output_tensors.size(); idx++) {
+                    runtime_args[idx] = output_tensors.at(idx).buffer()->address();
+                }
+            }
+        }
+    };
+}
+
+// Using this structure is not recommended because directly setting the callback argument map doesn't significantly
+// reduce the amount of code.
+template <typename OutputTensors = Tensors>
+const std::function<void(const void *, Program &, const Tensors &, const OptionalConstTensors &, const OutputTensors &)>
+create_override_runtime_arguments_callback(
+    KernelHandle reader_kernel_id,
+    KernelHandle writer_kernel_id,
+    uint32_t num_cores,
+    uint32_t core_h,
+    CallbackArgMap &arg_map) {
+    return [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, arg_map, num_cores, core_h](
+               const void *operation,
+               Program &program,
+               const Tensors &input_tensors,
+               const OptionalConstTensors &optional_input_tensors,
+               const OutputTensors &output_tensors) -> void {
+        for (uint32_t icore = 0; icore < num_cores; icore++) {
+            CoreCoord core = {icore / core_h, icore % core_h};
+
+            // readers
+            {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                for (const auto &pair : arg_map.input) {
+                    runtime_args[pair.first] = input_tensors.at(pair.second).buffer()->address();
+                }
+                for (const auto &pair : arg_map.optional_input) {
+                    auto optional_input_tensor = optional_input_tensors.at(pair.second);
+                    runtime_args[pair.first] =
+                        optional_input_tensor.has_value() ? optional_input_tensor.value().buffer()->address() : 0;
+                }
+            }
+
+            // writer
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                for (const auto &pair : arg_map.output) {
+                    runtime_args[pair.first] = output_tensors.at(pair.second).buffer()->address();
+                }
+            }
+        }
+    };
+}
+
+// To use this function, the arguments in the reader kernel must always be sorted in the order of input followed by
+// optional_input. Furthermore, input and output tensors must always start from the 0th argument.
+template <typename OutputTensors = Tensors>
+const std::function<void(const Program&, const std::vector<Buffer*>&, const std::vector<Buffer*>&)>
+create_override_addresses_callback(
+    KernelHandle reader_kernel_id, KernelHandle writer_kernel_id, uint32_t num_cores, uint32_t core_h) {
+    return [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h](
+               const Program& program,
+               const std::vector<Buffer*>& input_buffers,
+               const std::vector<Buffer*>& output_buffers) -> void {
+        for (uint32_t icore = 0; icore < num_cores; icore++) {
+            CoreCoord core = {icore / core_h, icore % core_h};
+
+            // readers
+            {
+                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                for (uint32_t idx = 0; idx < input_buffers.size(); idx++) {
+                    auto buffer = input_buffers.at(idx);
+                    if (buffer != nullptr) {
+                        runtime_args[idx] = buffer->address();
+                    }
+                }
+            }
+
+            // writer
+            {
+                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                for (uint32_t idx = 0; idx < output_buffers.size(); idx++) {
+                    auto buffer = output_buffers.at(idx);
+                    if (buffer != nullptr) {
+                        runtime_args[idx] = buffer->address();
+                    }
+                }
+            }
+        }
+    };
+}
+
+
 }  // namespace primary
 }  // namespace operations
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/moreh_nll_loss_step2.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/moreh_nll_loss_step2.cpp
@@ -186,43 +186,10 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_2d(
         tile_offset += units_per_core;
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h](
-            const Program &program,
-            const std::vector<Buffer *> &input_buffers,
-            const std::vector<Buffer *> &output_buffers) {
-            TT_ASSERT(input_buffers.size() == 4);
-            TT_ASSERT(output_buffers.size() == 1);
-
-            auto src_dram_buffer = input_buffers.at(0);
-            auto target_dram_buffer = input_buffers.at(1);
-            auto weight_dram_buffer = input_buffers.at(2);
-            auto divisor_dram_buffer = input_buffers.at(3);
-            auto dst_dram_buffer = output_buffers.at(0);
-
-            for (uint32_t icore = 0; icore < num_cores; icore++) {
-                CoreCoord core = {icore / core_h, icore % core_h};
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                    runtime_args[0] = src_dram_buffer->address();
-                    runtime_args[1] = target_dram_buffer->address();
-                    if (weight_dram_buffer != nullptr) {
-                        runtime_args[2] = weight_dram_buffer->address();
-                    }
-                    if (divisor_dram_buffer != nullptr) {
-                        runtime_args[3] = divisor_dram_buffer->address();
-                    }
-                }
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                    runtime_args[0] = dst_dram_buffer->address();
-                }
-            }
-        };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_3d(
@@ -397,43 +364,10 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_3d(
         tile_offset += units_per_core;
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h](
-            const Program &program,
-            const std::vector<Buffer *> &input_buffers,
-            const std::vector<Buffer *> &output_buffers) {
-            TT_ASSERT(input_buffers.size() == 4);
-            TT_ASSERT(output_buffers.size() == 1);
-
-            auto src_dram_buffer = input_buffers.at(0);
-            auto target_dram_buffer = input_buffers.at(1);
-            auto weight_dram_buffer = input_buffers.at(2);
-            auto divisor_dram_buffer = input_buffers.at(3);
-            auto dst_dram_buffer = output_buffers.at(0);
-
-            for (uint32_t icore = 0; icore < num_cores; icore++) {
-                CoreCoord core = {icore / core_h, icore % core_h};
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                    runtime_args[0] = src_dram_buffer->address();
-                    runtime_args[1] = target_dram_buffer->address();
-                    if (weight_dram_buffer != nullptr) {
-                        runtime_args[2] = weight_dram_buffer->address();
-                    }
-                    if (divisor_dram_buffer != nullptr) {
-                        runtime_args[3] = divisor_dram_buffer->address();
-                    }
-                }
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                    runtime_args[0] = dst_dram_buffer->address();
-                }
-            }
-        };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_4d(
@@ -616,43 +550,10 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_4d(
         tile_offset += units_per_core;
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h](
-            const Program &program,
-            const std::vector<Buffer *> &input_buffers,
-            const std::vector<Buffer *> &output_buffers) {
-            TT_ASSERT(input_buffers.size() == 4);
-            TT_ASSERT(output_buffers.size() == 1);
-
-            auto src_dram_buffer = input_buffers.at(0);
-            auto target_dram_buffer = input_buffers.at(1);
-            auto weight_dram_buffer = input_buffers.at(2);
-            auto divisor_dram_buffer = input_buffers.at(3);
-            auto dst_dram_buffer = output_buffers.at(0);
-
-            for (uint32_t icore = 0; icore < num_cores; icore++) {
-                CoreCoord core = {icore / core_h, icore % core_h};
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                    runtime_args[0] = src_dram_buffer->address();
-                    runtime_args[1] = target_dram_buffer->address();
-                    if (weight_dram_buffer != nullptr) {
-                        runtime_args[2] = weight_dram_buffer->address();
-                    }
-                    if (divisor_dram_buffer != nullptr) {
-                        runtime_args[3] = divisor_dram_buffer->address();
-                    }
-                }
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                    runtime_args[0] = dst_dram_buffer->address();
-                }
-            }
-        };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 operation::ProgramWithCallbacks moreh_nll_loss_step2_impl(

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_2d.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_2d.cpp
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp"
+#include "dprint.h"
 
 void kernel_main() {
     uint32_t i = 0;
     auto target_addr = get_arg_val<uint32_t>(i++);
+    auto output_grad_addr = get_arg_val<uint32_t>(i++);
     auto weight_addr = get_arg_val<uint32_t>(i++);
     auto divisor_addr = get_arg_val<uint32_t>(i++);
-    auto output_grad_addr = get_arg_val<uint32_t>(i++);
     auto ignore_index = static_cast<int32_t>(get_arg_val<uint32_t>(i++));
     auto num_tiles_per_core = get_arg_val<uint32_t>(i++);
     auto start_id = get_arg_val<uint32_t>(i++);

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_3d.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_3d.cpp
@@ -7,9 +7,9 @@
 void kernel_main() {
     uint32_t i = 0;
     auto target_addr = get_arg_val<uint32_t>(i++);
+    auto output_grad_addr = get_arg_val<uint32_t>(i++);
     auto weight_addr = get_arg_val<uint32_t>(i++);
     auto divisor_addr = get_arg_val<uint32_t>(i++);
-    auto output_grad_addr = get_arg_val<uint32_t>(i++);
     auto ignore_index = static_cast<int32_t>(get_arg_val<uint32_t>(i++));
     auto num_tiles_per_core = get_arg_val<uint32_t>(i++);
     auto start_id = get_arg_val<uint32_t>(i++);

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_4d.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_4d.cpp
@@ -8,9 +8,9 @@
 void kernel_main() {
     uint32_t i = 0;
     auto target_addr = get_arg_val<uint32_t>(i++);
+    auto output_grad_addr = get_arg_val<uint32_t>(i++);
     auto weight_addr = get_arg_val<uint32_t>(i++);
     auto divisor_addr = get_arg_val<uint32_t>(i++);
-    auto output_grad_addr = get_arg_val<uint32_t>(i++);
     auto ignore_index = static_cast<int32_t>(get_arg_val<uint32_t>(i++));
     auto num_tiles_per_core = get_arg_val<uint32_t>(i++);
     auto start_id = get_arg_val<uint32_t>(i++);

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/moreh_nll_loss_backward.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/moreh_nll_loss_backward.cpp
@@ -156,9 +156,9 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_4d(
 
         std::vector<uint32_t> reader_args = {
             target_addr,
+            output_grad_addr,
             weight_addr,
             divisor_addr,
-            output_grad_addr,
             static_cast<uint32_t>(ignore_index),
             units_per_core,
             tile_offset,
@@ -187,46 +187,11 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_4d(
         tile_offset += units_per_core;
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h](
-            const void *operation,
-            Program &program,
-            const std::vector<Tensor> &input_tensors,
-            const std::vector<std::optional<const Tensor>> &optional_input_tensors,
-            const std::vector<Tensor> &output_tensors) {
-            TT_ASSERT(input_tensors.size() == 2);
-            TT_ASSERT(optional_input_tensors.size() == 2);
-            TT_ASSERT(output_tensors.size() == 1);
-
-            auto target_addr = input_tensors.at(0).buffer()->address();
-            auto output_grad_addr = input_tensors.at(1).buffer()->address();
-            auto weight_addr =
-                optional_input_tensors.at(0).has_value() ? optional_input_tensors.at(0).value().buffer()->address() : 0;
-            auto divisor_addr =
-                optional_input_tensors.at(1).has_value() ? optional_input_tensors.at(1).value().buffer()->address() : 0;
-            auto input_grad_addr = output_tensors.at(0).buffer()->address();
-
-            for (uint32_t icore = 0; icore < num_cores; icore++) {
-                CoreCoord core = {icore / core_h, icore % core_h};
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                    runtime_args[0] = target_addr;
-                    runtime_args[1] = weight_addr;
-                    runtime_args[2] = divisor_addr;
-                    runtime_args[3] = output_grad_addr;
-                }
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                    runtime_args[0] = input_grad_addr;
-                }
-            }
-        };
-
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
-
 
 operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_3d(
     const Tensor &target,
@@ -238,7 +203,6 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_3d(
     const bool reduction_mean,
     const CoreRange core_range,
     const DeviceComputeKernelConfig compute_kernel_config) {
-
     // split work
 
     // input_grad: (N, C, W)
@@ -370,9 +334,9 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_3d(
 
         std::vector<uint32_t> reader_args = {
             target_addr,
+            output_grad_addr,
             weight_addr,
             divisor_addr,
-            output_grad_addr,
             static_cast<uint32_t>(ignore_index),
             units_per_core,
             tile_offset,
@@ -401,46 +365,11 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_3d(
         tile_offset += units_per_core;
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h](
-            const void *operation,
-            Program &program,
-            const std::vector<Tensor> &input_tensors,
-            const std::vector<std::optional<const Tensor>> &optional_input_tensors,
-            const std::vector<Tensor> &output_tensors) {
-            TT_ASSERT(input_tensors.size() == 2);
-            TT_ASSERT(optional_input_tensors.size() == 2);
-            TT_ASSERT(output_tensors.size() == 1);
-
-            auto target_addr = input_tensors.at(0).buffer()->address();
-            auto output_grad_addr = input_tensors.at(1).buffer()->address();
-            auto weight_addr =
-                optional_input_tensors.at(0).has_value() ? optional_input_tensors.at(0).value().buffer()->address() : 0;
-            auto divisor_addr =
-                optional_input_tensors.at(1).has_value() ? optional_input_tensors.at(1).value().buffer()->address() : 0;
-            auto input_grad_addr = output_tensors.at(0).buffer()->address();
-
-            for (uint32_t icore = 0; icore < num_cores; icore++) {
-                CoreCoord core = {icore / core_h, icore % core_h};
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                    runtime_args[0] = target_addr;
-                    runtime_args[1] = weight_addr;
-                    runtime_args[2] = divisor_addr;
-                    runtime_args[3] = output_grad_addr;
-                }
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                    runtime_args[0] = input_grad_addr;
-                }
-            }
-        };
-
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
-
 
 operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_2d(
     const Tensor &target,
@@ -579,9 +508,9 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_2d(
 
         std::vector<uint32_t> reader_args = {
             target_addr,
+            output_grad_addr,
             weight_addr,
             divisor_addr,
-            output_grad_addr,
             static_cast<uint32_t>(ignore_index),
             units_per_core,
             tile_offset,
@@ -609,47 +538,11 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_2d(
         tile_offset += units_per_core;
     }
 
-    auto override_runtime_args_callback =
-        [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h](
-            const void *operation,
-            Program &program,
-            const std::vector<Tensor> &input_tensors,
-            const std::vector<std::optional<const Tensor>> &optional_input_tensors,
-            const std::vector<Tensor> &output_tensors) {
-            TT_ASSERT(input_tensors.size() == 2);
-            TT_ASSERT(optional_input_tensors.size() == 2);
-            TT_ASSERT(output_tensors.size() == 1);
-
-            auto target_addr = input_tensors.at(0).buffer()->address();
-            auto output_grad_addr = input_tensors.at(1).buffer()->address();
-            auto weight_addr =
-                optional_input_tensors.at(0).has_value() ? optional_input_tensors.at(0).value().buffer()->address() : 0;
-            auto divisor_addr =
-                optional_input_tensors.at(1).has_value() ? optional_input_tensors.at(1).value().buffer()->address() : 0;
-            auto input_grad_addr = output_tensors.at(0).buffer()->address();
-
-            for (uint32_t icore = 0; icore < num_cores; icore++) {
-                CoreCoord core = {icore / core_h, icore % core_h};
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                    runtime_args[0] = target_addr;
-                    runtime_args[1] = weight_addr;
-                    runtime_args[2] = divisor_addr;
-                    runtime_args[3] = output_grad_addr;
-                }
-
-                {
-                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                    runtime_args[0] = input_grad_addr;
-                }
-            }
-        };
-
-    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
-
-
 
 }  // namespace
 

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
@@ -129,39 +129,10 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
         tile_offset += num_tiles_per_core;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
@@ -123,39 +123,10 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
         tile_offset += num_tiles_per_core;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
@@ -145,39 +145,10 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
         tile_offset += num_tiles_per_core;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
@@ -124,39 +124,10 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
         tile_offset += num_tiles_per_core * Wt;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
@@ -145,39 +145,10 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
         tile_offset += num_tiles_per_core * Wt;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 1);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto src_dram_buffer = input_buffers.at(0);
-        auto dst_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -135,41 +135,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
         tile_offset += num_tiles_per_core;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto output_dram_buffer = input_buffers.at(0);
-        auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = output_dram_buffer->address();
-                runtime_args[1] = output_grad_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = input_grad_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -130,41 +130,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
         tile_offset += num_tiles_per_core;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto output_dram_buffer = input_buffers.at(0);
-        auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = output_dram_buffer->address();
-                runtime_args[1] = output_grad_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = input_grad_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -152,41 +152,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
         tile_offset += num_tiles_per_core;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto output_dram_buffer = input_buffers.at(0);
-        auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = output_dram_buffer->address();
-                runtime_args[1] = output_grad_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = input_grad_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -130,41 +130,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
         tile_offset += num_tiles_per_core * Wt;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto output_dram_buffer = input_buffers.at(0);
-        auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = output_dram_buffer->address();
-                runtime_args[1] = output_grad_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = input_grad_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary

--- a/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -153,41 +153,10 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_small(const Tensor &out
         tile_offset += num_tiles_per_core * Wt;
     }
 
-    auto override_runtime_args_callback = [
-            reader_kernel_id=reader_kernel_id,
-            writer_kernel_id=writer_kernel_id,
-            num_cores,
-            core_h
-        ]
-    (
-        const Program &program,
-        const std::vector<Buffer*>& input_buffers,
-        const std::vector<Buffer*>& output_buffers
-    ) {
-        TT_ASSERT(input_buffers.size() == 2);
-        TT_ASSERT(output_buffers.size() == 1);
-
-        auto output_dram_buffer = input_buffers.at(0);
-        auto output_grad_dram_buffer = input_buffers.at(1);
-        auto input_grad_dram_buffer = output_buffers.at(0);
-
-        for (uint32_t icore = 0; icore < num_cores; icore++) {
-            CoreCoord core = {icore / core_h, icore % core_h};
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = output_dram_buffer->address();
-                runtime_args[1] = output_grad_dram_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = input_grad_dram_buffer->address();
-            }
-        }
-    };
-
-    return {std::move(program), override_runtime_args_callback};
+    return {
+        .program = std::move(program),
+        .override_runtime_arguments_callback =
+            create_override_runtime_arguments_callback(reader_kernel_id, writer_kernel_id, num_cores, core_h)};
 }
 
 }  // namespace primary


### PR DESCRIPTION
All ops must implement a cache-related callback lambda function at the end after implementation.

The implementation of this callback function is voluminous and has often been a source of human error.


As a result of implementing several callbacks so far, most of the code content is just updating tensor addresses, so I decided that creating a function to do this could significantly reduce the amount of code.

