### PR TITLE
Removed unucessary ttnn.to_device() from Mixtral code

### DIFF
--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
@@ -69,7 +69,6 @@ def test_mixtral_mlp_inference(t3k_device_mesh, use_program_cache, reset_seeds):
         layout=ttnn.TILE_LAYOUT,
         mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
     )
-    tt_input = ttnn.to_device(tt_input, t3k_device_mesh)
 
     tt_output = tt_model(tt_input)
     tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -44,10 +44,10 @@ class Emb(torch.nn.Module):
 @pytest.mark.parametrize(
     "generation_start_pos, expected_compile_time, expected_inference_time",
     (
-        (32, 150, 7.5),
-        (128, 150, 7.5),
-        (1024, 150, 7.5),
-        (2048, 150, 7.5),
+        (32, 150, 0.025),
+        (128, 150, 0.025),
+        (1024, 150, 0.025),
+        (2048, 150, 0.025),
     ),
 )
 def test_mixtral_model_perf(

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -55,7 +55,7 @@ def test_mistral_rms_norm_inference(t3k_device_mesh, use_program_cache, reset_se
         layout=ttnn.TILE_LAYOUT,
         mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
     )
-    tt_input = ttnn.to_device(tt_input, t3k_device_mesh)
+
     tt_output = tt_model(tt_input)
     tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
     passing, pcc_message = comp_pcc(reference_output, tt_output_torch)

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -81,7 +81,6 @@ class TtMixtralAttention(LightweightModule):
             cache_file_name=cache_name(f"wqkv_multidevice_4d"),
         )
 
-        self.wqkv = ttnn.to_device(self.wqkv, self.device_mesh)
         self.wo = ttnn.as_tensor(
             torch.transpose(
                 self.state_dict[wo_str],
@@ -97,8 +96,6 @@ class TtMixtralAttention(LightweightModule):
             layout=self.model_config["ATTN_W_LAYOUT_TILE"],
             cache_file_name=cache_name(f"wo_multidevice4d"),
         )
-
-        self.wo = ttnn.to_device(self.wo, self.device_mesh)
 
         cache_k = torch.zeros(
             (
@@ -130,8 +127,6 @@ class TtMixtralAttention(LightweightModule):
             for lp in layer_past
         ]
 
-        self.layer_past = [ttnn.to_device(lp, self.device_mesh) for lp in self.layer_past]
-
         self.scale = self.head_dim**-0.5
 
         reduce_mask_torch = torch.zeros(1, 1, self.max_batch_size, self.max_batch_size * 8)
@@ -145,7 +140,6 @@ class TtMixtralAttention(LightweightModule):
             layout=ttnn.TILE_LAYOUT,
         )
 
-        self.reduce_mask = ttnn.to_device(self.reduce_mask, self.device_mesh)
         self.compute_kernel = self.model_args.get_compute_kernel_config()
         self.compute_kernel_attn = self.model_args.get_compute_kernel_attn_config()
 

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
@@ -81,7 +81,6 @@ def prepare_inputs_ttnn(x_bsh, hidden_size, current_pos, sliding_window, device_
         memory_config=ttnn.L1_MEMORY_CONFIG,
         mesh_mapper=ReplicateTensorToMesh(device_mesh),
     )
-    xs_1SBH = ttnn.to_device(xs_1SBH, device_mesh)
 
     # Attention mask
     padded_layer_past_len = min(nearest_32(current_pos + 1), sliding_window)
@@ -108,7 +107,7 @@ def prepare_inputs_ttnn(x_bsh, hidden_size, current_pos, sliding_window, device_
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         mesh_mapper=ReplicateTensorToMesh(device_mesh),
     )
-    attn_mask = ttnn.to_device(attn_mask, device_mesh)
+
     ATTN_MASK_MEMCFG = ttnn.create_sharded_memory_config(
         shape=(32, padded_layer_past_len),
         core_grid=ttnn.CoreGrid(y=4, x=8),
@@ -137,7 +136,6 @@ def prepare_rotation_mat_ttnn(head_dim, max_seq_len, device_mesh):
         )
         for rot_mat_i in rot_mat
     ]
-    rot_mats = [ttnn.to_device(rot_mat, device_mesh) for rot_mat in rot_mats]
 
     return rot_mats
 
@@ -178,7 +176,6 @@ def cache_attention(device_mesh, state_dict, model_args, rot_emb_matrix_list, se
         memory_config=ttnn.L1_MEMORY_CONFIG,
         mesh_mapper=ReplicateTensorToMesh(device_mesh),
     )
-    attention_inputs = ttnn.to_device(attention_inputs, device_mesh)
 
     tt_attn = TtMixtralAttention(
         device_mesh,
@@ -201,7 +198,7 @@ def cache_attention(device_mesh, state_dict, model_args, rot_emb_matrix_list, se
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=ReplicateTensorToMesh(device_mesh),
         )
-        attn_mask = ttnn.to_device(attn_mask, device_mesh)
+
         ATTN_MASK_MEMCFG = ttnn.create_sharded_memory_config(
             shape=(32, padded_layer_past_len),
             core_grid=ttnn.CoreGrid(y=4, x=8),

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
@@ -43,11 +43,8 @@ class TtMixtralMLP(LightweightModule):
         )
 
         self.w1 = as_tensor("w1")
-        self.w1 = ttnn.to_device(self.w1, device_mesh)
         self.w2 = as_tensor("w2")
-        self.w2 = ttnn.to_device(self.w2, device_mesh)
         self.w3 = as_tensor("w3")
-        self.w3 = ttnn.to_device(self.w3, device_mesh)
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         """

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -48,7 +48,6 @@ class TtMoeLayer(LightweightModule):
             device=self.device_mesh,
             mesh_mapper=ReplicateTensorToMesh(device_mesh),
         )
-        self.reduce_mask = ttnn.to_device(self.reduce_mask, device_mesh)
         self.expert_mask_11BB = ttnn.from_torch(
             torch.cat([torch.full((1, 1, 32, 32), fill_value=i + 1) for i in range(8)], dim=3),
             dtype=ttnn.uint16,

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_rms_norm.py
@@ -88,7 +88,6 @@ class TtRMSNormSharded(LightweightModule):
             cache_file_name=cache_name,
             mesh_mapper=ReplicateTensorToMesh(device_mesh),
         )
-        self.weight = ttnn.to_device(self.weight, device_mesh)
 
     def forward(self, x: ttnn.Tensor, out_sharded=False) -> ttnn.Tensor:
         x = ttnn.experimental.tensor.interleaved_to_sharded(

--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -22,7 +22,7 @@ run_t3000_mixtral_tests() {
 
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
-  env pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py::test_mixtral_model_perf[wormhole_b0-True-2048-150-7.5] -m "model_perf_t3000"
+  env pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py::test_mixtral_model_perf[wormhole_b0-True-2048-150-0.025] -m "model_perf_t3000"
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
Since issue #8895 fixed loading tensors to device we can now remove the explicit call `to_device()` from Mixtral codebase.

Also bundled in this PR is an updated perf time for Mixtral in CI and a change to KV cache from bfloat8 to 16 to increase output correctness after hundreds of iterations.