### PR TITLE
#5044: Add optional output for repeat backward

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_repeat.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_repeat.py
@@ -32,3 +32,56 @@ def test_bw_repeat(input_shapes, sizes, device):
     golden_tensor = [in_data.grad]
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("sizes", [[12, 1, 1, 1], [6, 1, 1, 1], [1, 24, 1, 1], [1, 3, 1, 1]])
+@pytest.mark.parametrize(
+    "are_required_outputs",
+    [
+        [True],
+        [False],
+    ],
+)
+def test_bw_repeat_optional_output_cq_id(input_shapes, sizes, are_required_outputs, device):
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    if are_required_outputs[0]:
+        _, optional_output_tensor = data_gen_pt_tt(input_shapes, device, True)
+    else:
+        optional_output_tensor = None
+    pyt_y = in_data.repeat(sizes)
+
+    grad_data, grad_tensor = data_gen_pt_tt(pyt_y.shape, device, True)
+
+    cq_id = 0
+    if are_required_outputs[0]:
+        tt_output_tensor_on_device = tt_lib.tensor.repeat_bw(
+            grad_tensor,
+            input_tensor,
+            sizes,
+            are_required_outputs=are_required_outputs,
+            input_grad=optional_output_tensor,
+            queue_id=cq_id,
+        )
+    else:
+        tt_output_tensor_on_device = tt_lib.tensor.repeat_bw(
+            grad_tensor, input_tensor, sizes, are_required_outputs=are_required_outputs
+        )
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = True
+
+    if are_required_outputs[0]:
+        status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+        assert status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -776,8 +776,22 @@ std::vector<Tensor> multigammaln_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> repeat_bw(
-    const Tensor& grad, const Tensor& input, const Shape& shape, const MemoryConfig& output_mem_config);
+std::vector<std::optional<Tensor>>  repeat_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    const Shape& shape,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>>  repeat_bw(
+    uint8_t queue_id,
+    const Tensor& grad,
+    const Tensor& input,
+    const Shape& shape,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
 
 std::vector<Tensor> floor_bw(
     const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -611,21 +611,39 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("repeat_bw", &tt::tt_metal::repeat_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("shape"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-                    Returns a new tensor filled with repetition of input ``input`` tensor according to number of times specified in ``shape``. The rank of ``shape`` should be same as rank of tensor ``input_a``.
-                    The limitation in our implementation is N and C should be 1 and the repeat is of any number for such dim, other should be 1.
+    m_tensor.def("repeat_bw",
+            [](const Tensor& grad,
+                const Tensor& input,
+                const Shape& shape,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                uint8_t queue_id) {
+                    return repeat_bw(queue_id, grad, input, shape, output_mem_config, are_required_outputs, input_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input").noconvert(),
+            py::arg("shape"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true},
+            py::arg("input_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns a new tensor filled with repetition of input ``input`` tensor according to number of times specified in ``shape``. The rank of ``shape`` should be same as rank of tensor ``input_a``.
 
-                    Output tensor will have BFLOAT16 data type.
+            Output tensors will have BFLOAT16 data type.
 
-                    .. csv-table::
-                        :header: "Argument", "Description", "Data type", "Valid range", "Required"
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
-                        "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                        "input", "Input tensor for which repetition is computed", "Tensor", "Tensor of shape [1, Z, Y, X]", "Yes"
-                        "shape", "Shape value", "Shape", "The number of times to repeat this tensor along each dimension", "Yes"
-                        "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                )doc");
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Input tensor for which repetition is computed", "Tensor", "Tensor of shape [1, Z, Y, X]", "Yes"
+                "shape", "Shape value", "Shape", "The number of times to repeat this tensor along each dimension", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "are_required_outputs", "Are Required Outputs", " Bool", "Default value is True", "No"
+                "input_grad", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
+        )doc");
 
     m_tensor.def("unary_sub_bw", &tt::tt_metal::unary_sub_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(


### PR DESCRIPTION
Add optional output tensor support for backward repeat op.
Primary issue : https://github.com/tenstorrent/tt-metal/issues/5044