### PR TITLE
#9026: Fix FD dispatcher wait on wrapped value

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -480,6 +480,7 @@ void gen_wait_and_stall_cmd(Device *device,
     wait.base.cmd_id = CQ_DISPATCH_CMD_WAIT;
     wait.wait.barrier = true;
     wait.wait.notify_prefetch = true;
+    wait.wait.wait = true;
     wait.wait.addr = dispatch_wait_addr_g;
     wait.wait.count = 0;
     add_bare_dispatcher_cmd(dispatch_cmds, wait);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -875,11 +875,9 @@ void EnqueueProgramCommand::assemble_device_commands() {
             }
         }
 
-        // Wait Noc Write Barrier, wait for binaries to be written to worker cores
+        // Wait Noc Write Barrier, wait for binaries/configs to be written to worker cores
         if (program.program_transfer_info.num_active_cores > 0) {
-            // Wait Noc Write Barrier, wait for binaries to be written to worker cores
-            // TODO: any way to not have dispatcher poll the addr here?
-            program_command_sequence.add_dispatch_wait(true, DISPATCH_MESSAGE_ADDR, 0);
+            program_command_sequence.add_dispatch_wait(true, DISPATCH_MESSAGE_ADDR, 0, 0, false, false);
         }
 
         // Go Signals

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -162,6 +162,9 @@ struct CQDispatchWaitCmd {
     uint8_t barrier;          // if true, issue write barrier
     uint8_t notify_prefetch;  // if true, inc prefetch sem
     uint8_t clear_count;      // if true, reset count to 0
+    uint8_t wait;             // if true, wait on count value below
+    uint8_t pad1;
+    uint16_t pad2;
     uint32_t addr;            // address to read
     uint32_t count;           // wait while address is < count
 } __attribute__((packed));

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -73,7 +73,7 @@ class DeviceCommand {
     vector_memcpy_aligned<uint32_t> cmd_vector() const { return this->cmd_region_vector; }
 
     void add_dispatch_wait(
-        uint8_t barrier, uint32_t address, uint32_t count, uint8_t clear_count = 0, bool notify_prefetch = false) {
+        uint8_t barrier, uint32_t address, uint32_t count, uint8_t clear_count = 0, bool notify_prefetch = false, bool do_wait = true) {
         auto initialize_wait_cmds = [&](CQPrefetchCmd *relay_wait, CQDispatchCmd *wait_cmd) {
             relay_wait->base.cmd_id = CQ_PREFETCH_CMD_RELAY_INLINE;
             relay_wait->relay_inline.length = sizeof(CQDispatchCmd);
@@ -82,6 +82,7 @@ class DeviceCommand {
             wait_cmd->base.cmd_id = CQ_DISPATCH_CMD_WAIT;
             wait_cmd->wait.barrier = barrier;
             wait_cmd->wait.notify_prefetch = notify_prefetch;
+            wait_cmd->wait.wait = do_wait;
             wait_cmd->wait.addr = address;
             wait_cmd->wait.count = count;
             wait_cmd->wait.clear_count = clear_count;
@@ -101,8 +102,8 @@ class DeviceCommand {
     }
 
     void add_dispatch_wait_with_prefetch_stall(
-        uint8_t barrier, uint32_t address, uint32_t count, uint8_t clear_count = 0) {
-        this->add_dispatch_wait(barrier, address, count, clear_count, true);
+        uint8_t barrier, uint32_t address, uint32_t count, uint8_t clear_count = 0, bool do_wait = true) {
+        this->add_dispatch_wait(barrier, address, count, clear_count, true, do_wait);
         uint32_t increment_sizeB = align(sizeof(CQPrefetchCmd), PCIE_ALIGNMENT);
         auto initialize_stall_cmd = [&](CQPrefetchCmd *stall_cmd) {
             *stall_cmd = {};

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -663,9 +663,10 @@ static void process_wait() {
 
     uint32_t barrier = cmd->wait.barrier;
     uint32_t notify_prefetch = cmd->wait.notify_prefetch;
+    uint32_t clear_count = cmd->wait.clear_count;
+    uint32_t wait = cmd->wait.wait;
     uint32_t addr = cmd->wait.addr;
     uint32_t count = cmd->wait.count;
-    uint32_t clear_count = cmd->wait.clear_count;
 
     if (barrier) {
         noc_async_write_barrier();
@@ -677,10 +678,12 @@ static void process_wait() {
 #if defined(COMPILE_FOR_IDLE_ERISC)
     uint32_t heartbeat = 0;
 #endif
-    while (!wrap_ge(*sem_addr, count)) {
+    if (wait) {
+        while (!wrap_ge(*sem_addr, count)) {
 #if defined(COMPILE_FOR_IDLE_ERISC)
-        RISC_POST_HEARTBEAT(heartbeat);
+            RISC_POST_HEARTBEAT(heartbeat);
 #endif
+        }
     }
     DEBUG_STATUS("PWD");
 


### PR DESCRIPTION
EnqueueProgram needs to emit a barrier w/o a wait
It was waiting on a stale semaphore value causing an issue at semaphore wrap time Now waiting is optional