### PR TITLE
#8890: Reduce size of pack_src|dst_format constexprs

### DIFF
--- a/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_outputs.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_outputs.h
@@ -18,12 +18,12 @@ inline const uint32_t get_output_base_id()
    return (OUTPUT_BASE_ID);
 }
 
-inline const uint32_t get_output_src_format(const std::uint32_t output_id)
+inline const unsigned char get_output_src_format(const std::uint32_t output_id)
 {
    return pack_src_format[output_id];
 }
 
-inline const uint32_t get_output_dst_format(const std::uint32_t output_id)
+inline const unsigned char get_output_dst_format(const std::uint32_t output_id)
 {
    return pack_dst_format[output_id];
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_outputs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_outputs.h
@@ -18,12 +18,12 @@ inline const uint32_t get_output_base_id()
    return (OUTPUT_BASE_ID);
 }
 
-inline const uint32_t get_output_src_format(const std::uint32_t output_id)
+inline const unsigned char get_output_src_format(const std::uint32_t output_id)
 {
    return pack_src_format[output_id];
 }
 
-inline const uint32_t get_output_dst_format(const std::uint32_t output_id)
+inline const unsigned char get_output_dst_format(const std::uint32_t output_id)
 {
    return pack_dst_format[output_id];
 }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -199,9 +199,8 @@ generate_pack_data_formats(tt_hlk_desc& desc, DataFormat unpack_conditional_dst_
 static void emit_pack_data_formats(std::string pack_data_format_descs, std::vector<DataFormat> src_formats_all_cbs, std::vector<DataFormat> dst_formats_all_cbs) {
     ofstream file_stream;
     file_stream.open(pack_data_format_descs);
-    // TODO: we should be emitting "unsigned char", no reason to use 4B per data format
-    file_stream << create_formats_array_string("constexpr std::int32_t", "pack_src_format", NUM_CIRCULAR_BUFFERS, data_format_vec_to_string(src_formats_all_cbs));
-    file_stream << create_formats_array_string("constexpr std::int32_t", "pack_dst_format", NUM_CIRCULAR_BUFFERS, data_format_vec_to_string(dst_formats_all_cbs));
+    file_stream << create_formats_array_string("constexpr unsigned char", "pack_src_format", NUM_CIRCULAR_BUFFERS, data_format_vec_to_string(src_formats_all_cbs));
+    file_stream << create_formats_array_string("constexpr unsigned char", "pack_dst_format", NUM_CIRCULAR_BUFFERS, data_format_vec_to_string(dst_formats_all_cbs));
 
     // budabackend-style format array
     // file_stream << create_formats_array_string("const std::int32_t", "pack_src_format", 16, data_format_vec_to_string(src_formats));


### PR DESCRIPTION
Per an issue from Moreh, was seeing `.ldm_data` section being too large, and these `pack_src_format`/`pack_dst_format` constexprs were the only thing in that section. Saw a TODO to make them unsigned char and that appears to fix things for Moreh.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/9370797555 (failing tasks are also failing on main)