### PR TITLE
#0: enable multi-device tensor support for moreh sum op

### DIFF
--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
@@ -53,7 +53,7 @@ Tensor _moreh_sum(
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input}))};
 
-    TT_FATAL(input.storage_type() == StorageType::DEVICE);
+    TT_FATAL(input.storage_type() == StorageType::DEVICE || input.storage_type() == StorageType::MULTI_DEVICE);
     auto kernel_config_val = init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
 
     operation::launch_op(


### PR DESCRIPTION
The moreh sum op has much faster reduction on dim 1 and can be applied on the Mixtral7x8B model. See comparison below:

<img width="664" alt="image" src="https://github.com/tenstorrent/tt-metal/assets/61562234/68538701-70b9-4175-a750-d8945631d0ab">

To enable the use of multi-device tensors with moreh sum, a simple change is needed, hence this pr.

