### PR TITLE
#0: Add core range iterators

### DIFF
--- a/tt_eager/tt_dnn/op_library/softmax/multi_core/softmax_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/softmax/multi_core/softmax_op_multi_core.cpp
@@ -2,20 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_metal/common/logger.hpp"
+#include <optional>
+
 #include "impl/buffers/buffer.hpp"
 #include "tt_dnn/op_library/operation.hpp"
-#include "tt_eager/tt_dnn/op_library/softmax/softmax_op.hpp"
-#include "tt_eager/tt_dnn/op_library/math.hpp"
-#include "tt_eager/tt_dnn/op_library/work_split.hpp"
 #include "tt_dnn/op_library/run_operation.hpp"
-
-#include "tt_metal/host_api.hpp"
+#include "tt_eager/tt_dnn/op_library/math.hpp"
+#include "tt_eager/tt_dnn/op_library/softmax/softmax_op.hpp"
+#include "tt_eager/tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/common/constants.hpp"
+#include "tt_metal/common/logger.hpp"
 #include "tt_metal/common/math.hpp"
 #include "tt_metal/detail/util.hpp"
-
-#include <optional>
+#include "tt_metal/host_api.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -25,23 +24,21 @@ namespace primary {
 
 inline bool is_dram(const Tensor& input_tensor) { return input_tensor.memory_config().buffer_type == BufferType::DRAM; }
 inline bool is_dram(const std::optional<const Tensor> input_tensor) {
-     return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
+    return input_tensor.has_value() ? is_dram(input_tensor.value()) : true;
 }
 inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DRAM; }
 
 // implementation of softmax with optional scale/mask (see the header for input_tensor more detailed description)
 operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
-    const Tensor &input_tensor,
-    const Tensor &output_tensor,
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
     const std::optional<const Tensor> mask,
     std::optional<float> scale,
     bool causal_mask,
-    DeviceComputeKernelConfig compute_kernel_config
-) {
-
+    DeviceComputeKernelConfig compute_kernel_config) {
     const auto shape = input_tensor.get_legacy_shape();
     uint32_t W = shape[-1], H = (input_tensor.volume() / (shape[0] * shape[-1])), NC = shape[0];
-    uint32_t HW = H*W;
+    uint32_t HW = H * W;
 
     bool mask_padded_data = false;
     uint32_t num_datum_padded = 0;
@@ -52,19 +49,19 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
         num_datum_padded = W - W_unpadded;
     }
 
-    uint32_t Wt = W/TILE_WIDTH;
-    uint32_t Ht = H/TILE_HEIGHT;
+    uint32_t Wt = W / TILE_WIDTH;
+    uint32_t Ht = H / TILE_HEIGHT;
 
     uint32_t mask_H = H;
     if (mask.has_value()) {
         mask_H = mask.value().get_legacy_shape()[2];
     }
-    uint32_t mask_Ht = mask_H/TILE_HEIGHT;
+    uint32_t mask_Ht = mask_H / TILE_HEIGHT;
 
     Program program = CreateProgram();
 
     // This should allocate input_tensor DRAM buffer on the device
-    Device *device = input_tensor.device();
+    Device* device = input_tensor.device();
 
     tt::DataFormat in0_cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
     uint32_t in0_tile_size = tt_metal::detail::TileSize(in0_cb_data_format);
@@ -73,23 +70,25 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     bool math_approx_mode;
     bool fp32_dest_acc_en;
 
-    std::visit([&](auto&& compute_kernel_config) {
-        using T = std::decay_t<decltype(compute_kernel_config)>;
-        if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
-            math_fidelity = compute_kernel_config.math_fidelity;
-            math_approx_mode = compute_kernel_config.math_approx_mode;
-            fp32_dest_acc_en = false;
-        } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
-            math_fidelity = compute_kernel_config.math_fidelity;
-            math_approx_mode = compute_kernel_config.math_approx_mode;
-            fp32_dest_acc_en = in0_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
-        } else {
-            TT_FATAL("arch not supported");
-        }
-
-    }, compute_kernel_config);
+    std::visit(
+        [&](auto&& compute_kernel_config) {
+            using T = std::decay_t<decltype(compute_kernel_config)>;
+            if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
+                TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+                math_fidelity = compute_kernel_config.math_fidelity;
+                math_approx_mode = compute_kernel_config.math_approx_mode;
+                fp32_dest_acc_en = false;
+            } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
+                TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
+                math_fidelity = compute_kernel_config.math_fidelity;
+                math_approx_mode = compute_kernel_config.math_approx_mode;
+                fp32_dest_acc_en =
+                    in0_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
+            } else {
+                TT_FATAL("arch not supported");
+            }
+        },
+        compute_kernel_config);
 
     tt::DataFormat scalar_cb_data_format = tt::DataFormat::Float16_b;
     uint32_t scalar_tile_size = tt_metal::detail::TileSize(scalar_cb_data_format);
@@ -97,7 +96,9 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     tt::DataFormat out0_cb_data_format = tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
     uint32_t out0_tile_size = tt_metal::detail::TileSize(out0_cb_data_format);
 
-    tt::DataFormat mask_cb_data_format = mask.has_value() ? tt_metal::datatype_to_dataformat_converter(mask.value().get_dtype()) : tt::DataFormat::Float16_b;
+    tt::DataFormat mask_cb_data_format = mask.has_value()
+                                             ? tt_metal::datatype_to_dataformat_converter(mask.value().get_dtype())
+                                             : tt::DataFormat::Float16_b;
     uint32_t mask_tile_size = tt_metal::detail::TileSize(mask_cb_data_format);
 
     tt::DataFormat im_cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
@@ -114,52 +115,63 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
     auto src0_buffer = input_tensor.buffer();
     auto out0_buffer = output_tensor.buffer();
 
-    uint32_t num_tiles = input_tensor.volume()/TILE_HW;
+    uint32_t num_tiles = input_tensor.volume() / TILE_HW;
 
     uint32_t block_size = fp32_dest_acc_en ? find_max_divisor(Wt, 4) : find_max_divisor(Wt, 8);
 
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
-    uint32_t in0_t  = block_size*2;
-    uint32_t out0_t = block_size*2;
-    uint32_t im1_t  = 1; // 1/sum(exp(x))
-    uint32_t in2_t  = 1; // scaler for reduce coming from reader
-    uint32_t in3_t  = 1; // 1/sqrt() scaler tile cb for fused scale/mask/softmax variant
-    uint32_t in4_t  = div_up(Wt, block_size)*block_size; // attention mask (N,C,32,W) - Wt is reused for each Ht, NC is cycled
+    uint32_t in0_t = block_size * 2;
+    uint32_t out0_t = block_size * 2;
+    uint32_t im1_t = 1;  // 1/sum(exp(x))
+    uint32_t in2_t = 1;  // scaler for reduce coming from reader
+    uint32_t in3_t = 1;  // 1/sqrt() scaler tile cb for fused scale/mask/softmax variant
+    uint32_t in4_t =
+        div_up(Wt, block_size) * block_size;  // attention mask (N,C,32,W) - Wt is reused for each Ht, NC is cycled
     uint32_t in5_t = 1;
 
     // cb_exps - keeps exps in CB in L1 to avoid recomputing
-    uint32_t im0_t  = block_size*div_up(Wt, block_size);
+    uint32_t im0_t = block_size * div_up(Wt, block_size);
     TT_ASSERT(im0_t == Wt);
 
     // used for buffering scale-mask
     // can't easily reuse im0_t because cumulative wait for Wt needs to have Wt tiles contiguous free
-    uint32_t im3_t  = block_size*(div_up(Wt, block_size)+1);
-    TT_ASSERT(im3_t == Wt+block_size);
+    uint32_t im3_t = block_size * (div_up(Wt, block_size) + 1);
+    TT_ASSERT(im3_t == Wt + block_size);
 
     TT_ASSERT(Wt % block_size == 0);
     TT_ASSERT((block_size != -1) && "Wt must be divisible by one of the numbers in the range from 8 to 1.");
-    TT_ASSERT(im0_t % block_size == 0 && "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(out0_t % block_size == 0 && "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
+    TT_ASSERT(
+        im0_t % block_size == 0 &&
+        "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
+    TT_ASSERT(
+        out0_t % block_size == 0 &&
+        "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
     TT_ASSERT(in4_t % block_size == 0);
-    TT_ASSERT(W <= TILE_WIDTH*im0_t && "W exceeds the maximum supported size of tile buffer (kernel limitation right now).");
+    TT_ASSERT(
+        W <= TILE_WIDTH * im0_t &&
+        "W exceeds the maximum supported size of tile buffer (kernel limitation right now).");
 
     uint32_t num_tile_rows = NC * Ht;
     auto grid_size = device->compute_with_storage_grid_size();
-    auto all_device_cores = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tile_rows_per_core_group_1, num_tile_rows_per_core_group_2] = split_work_to_cores(grid_size, num_tile_rows, true);
+    auto
+        [num_cores,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_tile_rows_per_core_group_1,
+         num_tile_rows_per_core_group_2] = split_work_to_cores(grid_size, num_tile_rows, true);
 
     bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool out0_is_dram = out0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
-    std::vector<uint32_t> reader_compile_time_args = {
-        // interleaved accessor args
-        src0_is_dram
-    };
+    std::vector<uint32_t> reader_compile_time_args = {// interleaved accessor args
+                                                      src0_is_dram};
     if (mask.has_value()) {
         bool mask_is_dram = mask.value().buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
         reader_compile_time_args.push_back(mask_is_dram);
     }
     if (causal_mask) {
-        uint32_t num_tiles_causal_mask = mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
+        uint32_t num_tiles_causal_mask =
+            mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
         reader_compile_time_args.push_back(num_tiles_causal_mask);
     }
 
@@ -173,18 +185,16 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
         softmax_defines["CAUSAL_MASK"] = "1";
     }
     auto reader_kernels_id = CreateKernel(
-        program, "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/reader_unary_interleaved_sm.cpp", all_device_cores,
-        tt_metal::ReaderDataMovementConfig(
-            reader_compile_time_args,
-            softmax_defines
-    ));
+        program,
+        "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/reader_unary_interleaved_sm.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, softmax_defines));
 
     auto writer_kernels_id = CreateKernel(
-        program, "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp", all_device_cores,
-        tt_metal::WriterDataMovementConfig(
-            writer_compile_time_args,
-            softmax_defines
-    ));
+        program,
+        "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp",
+        all_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args, softmax_defines));
 
     // for broadcasting in H direction we need to
     // NCHt, Nt, Wt
@@ -193,224 +203,321 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
 
     softmax_defines["EXP_APPROX"] = math_approx_mode ? "1" : "0";
     auto softmax_kernels_id = CreateKernel(
-        program, "tt_eager/tt_dnn/op_library/softmax/kernels/compute/softmax.cpp", all_device_cores,
+        program,
+        "tt_eager/tt_dnn/op_library/softmax/kernels/compute/softmax.cpp",
+        all_cores,
         tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode,
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
             .compile_args = {},
-            .defines = softmax_defines
-    });
+            .defines = softmax_defines});
 
     // Create circular buffers
     // see softmax.cpp for which buffers are needed
 
-    auto c_in0_config = CircularBufferConfig(in0_t * in0_tile_size, {{CB::c_in0, in0_cb_data_format}}).set_page_size(CB::c_in0, in0_tile_size);
-    auto cb_in0_id = CreateCircularBuffer( program, all_device_cores, c_in0_config);
-    auto c_out0_config = CircularBufferConfig(out0_t * out0_tile_size, {{CB::c_out0, out0_cb_data_format}}).set_page_size(CB::c_out0, out0_tile_size);
-    auto cb_out0_id = CreateCircularBuffer( program, all_device_cores, c_out0_config );
-    auto c_intermed1_config = CircularBufferConfig(im1_t * im_tile_size, {{CB::c_intermed1, im_cb_data_format}}).set_page_size(CB::c_intermed1, im_tile_size);
-    auto cb_intermed1_id = CreateCircularBuffer( program, all_device_cores, c_intermed1_config );
-    auto c_in2_config = CircularBufferConfig(in2_t * scalar_tile_size, {{CB::c_in2, scalar_cb_data_format}}).set_page_size(CB::c_in2, scalar_tile_size);
-    auto cb_in2_id = CreateCircularBuffer( program, all_device_cores, c_in2_config );
-    auto c_intermed0_config = CircularBufferConfig(im0_t * im_tile_size, {{CB::c_intermed0, im_cb_data_format}}).set_page_size(CB::c_intermed0, im_tile_size);
-    auto cb_intermed0_id = CreateCircularBuffer( program, all_device_cores, c_intermed0_config );
+    auto c_in0_config = CircularBufferConfig(in0_t * in0_tile_size, {{CB::c_in0, in0_cb_data_format}})
+                            .set_page_size(CB::c_in0, in0_tile_size);
+    auto cb_in0_id = CreateCircularBuffer(program, all_cores, c_in0_config);
+    auto c_out0_config = CircularBufferConfig(out0_t * out0_tile_size, {{CB::c_out0, out0_cb_data_format}})
+                             .set_page_size(CB::c_out0, out0_tile_size);
+    auto cb_out0_id = CreateCircularBuffer(program, all_cores, c_out0_config);
+    auto c_intermed1_config = CircularBufferConfig(im1_t * im_tile_size, {{CB::c_intermed1, im_cb_data_format}})
+                                  .set_page_size(CB::c_intermed1, im_tile_size);
+    auto cb_intermed1_id = CreateCircularBuffer(program, all_cores, c_intermed1_config);
+    auto c_in2_config = CircularBufferConfig(in2_t * scalar_tile_size, {{CB::c_in2, scalar_cb_data_format}})
+                            .set_page_size(CB::c_in2, scalar_tile_size);
+    auto cb_in2_id = CreateCircularBuffer(program, all_cores, c_in2_config);
+    auto c_intermed0_config = CircularBufferConfig(im0_t * im_tile_size, {{CB::c_intermed0, im_cb_data_format}})
+                                  .set_page_size(CB::c_intermed0, im_tile_size);
+    auto cb_intermed0_id = CreateCircularBuffer(program, all_cores, c_intermed0_config);
     std::optional<CBHandle> cb_intermed3_id;
     std::optional<CBHandle> cb_in3_id;
     std::optional<CBHandle> cb_in4_id;
     std::optional<CBHandle> cb_in5_id;
     if (mask.has_value()) {
-        CircularBufferConfig c_intermed3_config = CircularBufferConfig(im3_t * im_tile_size, {{CB::c_intermed3, im_cb_data_format}}).set_page_size(CB::c_intermed3, im_tile_size);
-        cb_intermed3_id = CreateCircularBuffer( program, all_device_cores, c_intermed3_config );
-        CircularBufferConfig c_in3_config = CircularBufferConfig(in3_t * scalar_tile_size, {{CB::c_in3, scalar_cb_data_format}}).set_page_size(CB::c_in3, scalar_tile_size);
-        cb_in3_id = CreateCircularBuffer( program, all_device_cores, c_in3_config );
-        CircularBufferConfig c_in4_config = CircularBufferConfig(in4_t * mask_tile_size, {{CB::c_in4, mask_cb_data_format}}).set_page_size(CB::c_in4, mask_tile_size);
-        cb_in4_id = CreateCircularBuffer( program, all_device_cores, c_in4_config);
+        CircularBufferConfig c_intermed3_config =
+            CircularBufferConfig(im3_t * im_tile_size, {{CB::c_intermed3, im_cb_data_format}})
+                .set_page_size(CB::c_intermed3, im_tile_size);
+        cb_intermed3_id = CreateCircularBuffer(program, all_cores, c_intermed3_config);
+        CircularBufferConfig c_in3_config =
+            CircularBufferConfig(in3_t * scalar_tile_size, {{CB::c_in3, scalar_cb_data_format}})
+                .set_page_size(CB::c_in3, scalar_tile_size);
+        cb_in3_id = CreateCircularBuffer(program, all_cores, c_in3_config);
+        CircularBufferConfig c_in4_config =
+            CircularBufferConfig(in4_t * mask_tile_size, {{CB::c_in4, mask_cb_data_format}})
+                .set_page_size(CB::c_in4, mask_tile_size);
+        cb_in4_id = CreateCircularBuffer(program, all_cores, c_in4_config);
     }
-    CircularBufferConfig c_in5_config = CircularBufferConfig(in5_t * mask_tile_size, {{CB::c_in5, mask_cb_data_format}}).set_page_size(CB::c_in5, mask_tile_size);
-    cb_in5_id = CreateCircularBuffer( program, all_device_cores, c_in5_config);
+    CircularBufferConfig c_in5_config = CircularBufferConfig(in5_t * mask_tile_size, {{CB::c_in5, mask_cb_data_format}})
+                                            .set_page_size(CB::c_in5, mask_tile_size);
+    cb_in5_id = CreateCircularBuffer(program, all_cores, c_in5_config);
 
     uint32_t src_addr = src0_buffer->address();
     uint32_t mask_addr = mask.has_value() ? mask.value().buffer()->address() : 0;
     uint32_t out_addr = out0_buffer->address();
 
     uint32_t curr_row = 0;
-    union { float f; uint32_t u; } s; s.f = scale.value_or(1.0f); // scale for fused scale-mask-softmax
-    for (uint32_t i = 0; i < grid_size.x * grid_size.y; ++i) {
-        CoreCoord core = {i % grid_size.x, i / grid_size.x};
-        if (i >= num_cores) {
-            SetRuntimeArgs(program, reader_kernels_id, core, { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }); // [8]=1.0f is scaler
-            SetRuntimeArgs(program, softmax_kernels_id, core, { 0, 0, 0, 0, 0, 0 });
-            SetRuntimeArgs(program, writer_kernels_id, core, { 0, 0, 0, 0, 0, 0, 0 });
-            continue;
-        }
-        uint32_t num_tile_rows_per_core = 0;
-        if (core_group_1.core_coord_in_core_ranges(core)) {
-            num_tile_rows_per_core = num_tile_rows_per_core_group_1;
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
-            num_tile_rows_per_core = num_tile_rows_per_core_group_2;
-        } else {
-            TT_ASSERT(false, "Core not in specified core ranges");
-        }
+    union {
+        float f;
+        uint32_t u;
+    } s;
+    s.f = scale.value_or(1.0f);  // scale for fused scale-mask-softmax
+
+    for (const auto& core : iterate(all_cores, true)) {
+        uint32_t num_tile_rows_per_core = core_group_1.core_coord_in_core_ranges(core) ? num_tile_rows_per_core_group_1
+                                                                                       : num_tile_rows_per_core_group_2;
 
         uint32_t tile_offset = curr_row * Wt;
         uint32_t curr_ht = curr_row % Ht;
-        uint32_t mask_curr_ht = curr_ht % mask_Ht;   // the start offset for causal mask
-        uint32_t mask_offset = curr_row / Ht * mask_Ht * Wt; // causal mask batch offset
-        uint32_t mask_id = causal_mask ? (mask_curr_ht * Wt + mask_offset) : (curr_row / Ht * Wt); // causal mask start offset + causal mask batch offset
+        uint32_t mask_curr_ht = curr_ht % mask_Ht;            // the start offset for causal mask
+        uint32_t mask_offset = curr_row / Ht * mask_Ht * Wt;  // causal mask batch offset
+        uint32_t mask_id = causal_mask ? (mask_curr_ht * Wt + mask_offset)
+                                       : (curr_row / Ht * Wt);  // causal mask start offset + causal mask batch offset
 
         if (causal_mask) {
-            SetRuntimeArgs(program, reader_kernels_id, core, { src_addr, block_size, s.u, num_tile_rows_per_core, tile_offset, Wt, Ht, mask_addr, curr_ht, mask_id, 0x3f803f80, mask_curr_ht, mask_offset }); // [10]=1.0f is scaler
+            SetRuntimeArgs(
+                program,
+                reader_kernels_id,
+                core,
+                {src_addr,
+                 block_size,
+                 s.u,
+                 num_tile_rows_per_core,
+                 tile_offset,
+                 Wt,
+                 Ht,
+                 mask_addr,
+                 curr_ht,
+                 mask_id,
+                 0x3f803f80,
+                 mask_curr_ht,
+                 mask_offset});  // [10]=1.0f is scaler
         } else {
-            SetRuntimeArgs(program, reader_kernels_id, core, { src_addr, block_size, s.u, num_tile_rows_per_core, tile_offset, Wt, Ht, mask_addr, curr_ht, mask_id, 0x3f803f80 }); // [10]=1.0f is scaler
+            SetRuntimeArgs(
+                program,
+                reader_kernels_id,
+                core,
+                {src_addr,
+                 block_size,
+                 s.u,
+                 num_tile_rows_per_core,
+                 tile_offset,
+                 Wt,
+                 Ht,
+                 mask_addr,
+                 curr_ht,
+                 mask_id,
+                 0x3f803f80});  // [10]=1.0f is scaler
         }
 
-        SetRuntimeArgs(program, softmax_kernels_id, core, { num_tile_rows_per_core, Ht, Wt, block_size, curr_ht, mask_padded_data });
+        SetRuntimeArgs(
+            program, softmax_kernels_id, core, {num_tile_rows_per_core, Ht, Wt, block_size, curr_ht, mask_padded_data});
 
-        SetRuntimeArgs(program, writer_kernels_id, core, { out_addr, num_tile_rows_per_core * Wt, tile_offset, block_size, mask_padded_data, num_datum_padded, 0xFF00FF00});
+        SetRuntimeArgs(
+            program,
+            writer_kernels_id,
+            core,
+            {out_addr,
+             num_tile_rows_per_core * Wt,
+             tile_offset,
+             block_size,
+             mask_padded_data,
+             num_datum_padded,
+             0xFF00FF00});
 
         curr_row += num_tile_rows_per_core;
     }
 
-    auto override_runtime_arguments_callback = [
-            reader_kernels_id,
-            writer_kernels_id,
-            softmax_kernels_id,
-            grid_size,
-            scalar_tile_size,
-            in0_tile_size,
-            im_tile_size,
-            out0_tile_size,
-            mask_tile_size,
-            cb_in0_id,
-            cb_out0_id,
-            cb_intermed1_id,
-            cb_in2_id,
-            cb_intermed0_id,
-            cb_intermed3_id,
-            cb_in3_id,
-            cb_in4_id,
-            causal_mask
-        ]
-    (
-        const void* operation,
-        Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        const std::vector<Tensor>& output_tensors
-    ) {
+    auto override_runtime_arguments_callback =
+        [reader_kernels_id,
+         writer_kernels_id,
+         softmax_kernels_id,
+         grid_size,
+         scalar_tile_size,
+         in0_tile_size,
+         im_tile_size,
+         out0_tile_size,
+         mask_tile_size,
+         cb_in0_id,
+         cb_out0_id,
+         cb_intermed1_id,
+         cb_in2_id,
+         cb_intermed0_id,
+         cb_intermed3_id,
+         cb_in3_id,
+         cb_in4_id,
+         causal_mask](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            const auto scale = static_cast<const Softmax*>(operation)->scale;
 
-        const auto scale = static_cast<const Softmax*>(operation)->scale;
+            auto src_buffer_address = input_tensors.at(0).buffer()->address();
+            auto mask_buffer_address =
+                optional_input_tensors.at(0).has_value() ? optional_input_tensors.at(0).value().buffer()->address() : 0;
+            auto dst_buffer_address =
+                output_tensors.size() == 1 ? output_tensors.at(0).buffer()->address() : src_buffer_address;
 
-        auto src_buffer_address = input_tensors.at(0).buffer()->address();
-        auto mask_buffer_address = optional_input_tensors.at(0).has_value() ? optional_input_tensors.at(0).value().buffer()->address() : 0;
-        auto dst_buffer_address = output_tensors.size() == 1 ? output_tensors.at(0).buffer()->address() : src_buffer_address;
+            const auto shape = input_tensors.at(0).get_legacy_shape();
+            uint32_t W = shape[-1], H = (input_tensors.at(0).volume() / (shape[0] * shape[-1])), NC = shape[0];
+            uint32_t HW = H * W;
 
-        const auto shape = input_tensors.at(0).get_legacy_shape();
-        uint32_t W = shape[-1], H = (input_tensors.at(0).volume() / (shape[0] * shape[-1])), NC = shape[0];
-        uint32_t HW = H*W;
+            uint32_t Wt = W / TILE_WIDTH;
+            uint32_t Ht = H / TILE_HEIGHT;
 
-        uint32_t Wt = W/TILE_WIDTH;
-        uint32_t Ht = H/TILE_HEIGHT;
-
-        bool mask_padded_data = false;
-        uint32_t num_datum_padded = 0;
-        const auto shape_unpadded = input_tensors.at(0).get_shape();
-        uint32_t W_unpadded = shape_unpadded[-1];
-        if (W > W_unpadded) {
-            mask_padded_data = true;
-            num_datum_padded = W - W_unpadded;
-        }
-
-        int32_t num_tiles = input_tensors.at(0).volume()/TILE_HW;
-        uint32_t block_size = find_max_divisor(Wt, 8);
-
-        // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
-        uint32_t in0_t  = block_size*2;
-        uint32_t out0_t = block_size*2;
-        uint32_t im1_t  = 1; // 1/sum(exp(x))
-        uint32_t in2_t  = 1; // scaler for reduce coming from reader
-        uint32_t in3_t  = 1; // 1/sqrt() scaler tile cb for fused scale/mask/softmax variant
-        uint32_t in4_t  = div_up(Wt, block_size)*block_size; // attention mask (N,C,32,W) - Wt is reused for each Ht, NC is cycled
-
-        // cb_exps - keeps exps in CB in L1 to avoid recomputing
-        uint32_t im0_t  = block_size*div_up(Wt, block_size);
-        TT_ASSERT(im0_t == Wt);
-
-        // used for buffering scale-mask
-        // can't easily reuse im0_t because cumulative wait for Wt needs to have Wt tiles contiguous free
-        uint32_t im3_t  = block_size*(div_up(Wt, block_size)+1);
-        TT_ASSERT(im3_t == Wt+block_size);
-
-        TT_ASSERT(Wt % block_size == 0);
-        TT_ASSERT((block_size != -1) && "Wt must be divisible by one of the numbers in the range from 8 to 1.");
-        TT_ASSERT(im0_t % block_size == 0 && "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
-        TT_ASSERT(out0_t % block_size == 0 && "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
-        TT_ASSERT(in4_t % block_size == 0);
-        TT_ASSERT(W <= TILE_WIDTH*im0_t && "W exceeds the maximum supported size of tile buffer (kernel limitation right now).");
-
-        uint32_t NCHt = NC*Ht;
-        uint32_t num_tile_rows = NC * Ht;
-        auto all_device_cores = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
-        auto [num_cores, all_cores, core_group_1, core_group_2, num_tile_rows_per_core_group_1, num_tile_rows_per_core_group_2] = split_work_to_cores(grid_size, num_tile_rows, true);
-
-        UpdateCircularBufferTotalSize(program, cb_in0_id, in0_t * in0_tile_size);
-        UpdateCircularBufferTotalSize(program, cb_out0_id, out0_t * out0_tile_size);
-        UpdateCircularBufferTotalSize(program, cb_intermed1_id, im1_t * im_tile_size);
-        UpdateCircularBufferTotalSize(program, cb_in2_id, in2_t * scalar_tile_size);
-        UpdateCircularBufferTotalSize(program, cb_intermed0_id, im0_t * im_tile_size);
-
-        if (optional_input_tensors.at(0).has_value()) {
-            UpdateCircularBufferTotalSize(program, cb_intermed3_id.value(), im3_t * im_tile_size);
-            UpdateCircularBufferTotalSize(program, cb_in3_id.value(), in3_t * scalar_tile_size);
-            UpdateCircularBufferTotalSize(program, cb_in4_id.value(), in4_t * mask_tile_size);
-        }
-
-        uint32_t curr_row = 0;
-        union { float f; uint32_t u; } s; s.f = scale.value_or(1.0f); // scale for fused scale-mask-softmax
-        for (uint32_t i = 0; i < grid_size.x * grid_size.y; ++i) {
-            CoreCoord core = {i % grid_size.x, i / grid_size.x};
-            if (i >= num_cores) {
-                SetRuntimeArgs(program, reader_kernels_id, core, { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }); // [8]=1.0f is scaler
-                SetRuntimeArgs(program, softmax_kernels_id, core, { 0, 0, 0, 0, 0, 0 });
-                SetRuntimeArgs(program, writer_kernels_id, core, { 0, 0, 0, 0, 0, 0, 0});
-                continue;
+            bool mask_padded_data = false;
+            uint32_t num_datum_padded = 0;
+            const auto shape_unpadded = input_tensors.at(0).get_shape();
+            uint32_t W_unpadded = shape_unpadded[-1];
+            if (W > W_unpadded) {
+                mask_padded_data = true;
+                num_datum_padded = W - W_unpadded;
             }
 
-            uint32_t num_tile_rows_per_core = 0;
-            if (core_group_1.core_coord_in_core_ranges(core)) {
-                num_tile_rows_per_core = num_tile_rows_per_core_group_1;
-            } else if (core_group_2.core_coord_in_core_ranges(core)) {
-                num_tile_rows_per_core = num_tile_rows_per_core_group_2;
-            } else {
-                TT_ASSERT(false, "Core not in specified core ranges");
+            int32_t num_tiles = input_tensors.at(0).volume() / TILE_HW;
+            uint32_t block_size = find_max_divisor(Wt, 8);
+
+            // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
+            uint32_t in0_t = block_size * 2;
+            uint32_t out0_t = block_size * 2;
+            uint32_t im1_t = 1;  // 1/sum(exp(x))
+            uint32_t in2_t = 1;  // scaler for reduce coming from reader
+            uint32_t in3_t = 1;  // 1/sqrt() scaler tile cb for fused scale/mask/softmax variant
+            uint32_t in4_t = div_up(Wt, block_size) *
+                             block_size;  // attention mask (N,C,32,W) - Wt is reused for each Ht, NC is cycled
+
+            // cb_exps - keeps exps in CB in L1 to avoid recomputing
+            uint32_t im0_t = block_size * div_up(Wt, block_size);
+            TT_ASSERT(im0_t == Wt);
+
+            // used for buffering scale-mask
+            // can't easily reuse im0_t because cumulative wait for Wt needs to have Wt tiles contiguous free
+            uint32_t im3_t = block_size * (div_up(Wt, block_size) + 1);
+            TT_ASSERT(im3_t == Wt + block_size);
+
+            TT_ASSERT(Wt % block_size == 0);
+            TT_ASSERT((block_size != -1) && "Wt must be divisible by one of the numbers in the range from 8 to 1.");
+            TT_ASSERT(
+                im0_t % block_size == 0 &&
+                "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
+            TT_ASSERT(
+                out0_t % block_size == 0 &&
+                "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
+            TT_ASSERT(in4_t % block_size == 0);
+            TT_ASSERT(
+                W <= TILE_WIDTH * im0_t &&
+                "W exceeds the maximum supported size of tile buffer (kernel limitation right now).");
+
+            uint32_t NCHt = NC * Ht;
+            uint32_t num_tile_rows = NC * Ht;
+            auto
+                [num_cores,
+                 all_cores,
+                 core_group_1,
+                 core_group_2,
+                 num_tile_rows_per_core_group_1,
+                 num_tile_rows_per_core_group_2] = split_work_to_cores(grid_size, num_tile_rows, true);
+
+            UpdateCircularBufferTotalSize(program, cb_in0_id, in0_t * in0_tile_size);
+            UpdateCircularBufferTotalSize(program, cb_out0_id, out0_t * out0_tile_size);
+            UpdateCircularBufferTotalSize(program, cb_intermed1_id, im1_t * im_tile_size);
+            UpdateCircularBufferTotalSize(program, cb_in2_id, in2_t * scalar_tile_size);
+            UpdateCircularBufferTotalSize(program, cb_intermed0_id, im0_t * im_tile_size);
+
+            if (optional_input_tensors.at(0).has_value()) {
+                UpdateCircularBufferTotalSize(program, cb_intermed3_id.value(), im3_t * im_tile_size);
+                UpdateCircularBufferTotalSize(program, cb_in3_id.value(), in3_t * scalar_tile_size);
+                UpdateCircularBufferTotalSize(program, cb_in4_id.value(), in4_t * mask_tile_size);
             }
 
-            uint32_t tile_offset = curr_row * Wt;
-            uint32_t curr_ht = curr_row % Ht;
-            uint32_t mask_curr_ht = curr_ht % Wt;   // the start offset for causal mask
-            uint32_t mask_offset = curr_row / Ht * Wt * Wt; // causal mask batch offset
-            uint32_t mask_id = causal_mask ? (mask_curr_ht * Wt + mask_offset) : (curr_row / Ht * Wt); // causal mask start offset + causal mask batch offset
+            uint32_t curr_row = 0;
+            union {
+                float f;
+                uint32_t u;
+            } s;
+            s.f = scale.value_or(1.0f);  // scale for fused scale-mask-softmax
 
-            if (causal_mask) {
-                SetRuntimeArgs(program, reader_kernels_id, core, { src_buffer_address, block_size, s.u, num_tile_rows_per_core, tile_offset, Wt, Ht, mask_buffer_address, curr_ht, mask_id, 0x3f803f80, mask_curr_ht, mask_offset }); // [10]=1.0f is scaler
-            } else {
-                SetRuntimeArgs(program, reader_kernels_id, core, { src_buffer_address, block_size, s.u, num_tile_rows_per_core, tile_offset, Wt, Ht, mask_buffer_address, curr_ht, mask_id, 0x3f803f80 }); // [10]=1.0f is scaler
+            for (const auto& core : iterate(all_cores, true)) {
+                uint32_t num_tile_rows_per_core = core_group_1.core_coord_in_core_ranges(core)
+                                                      ? num_tile_rows_per_core_group_1
+                                                      : num_tile_rows_per_core_group_2;
+
+                uint32_t tile_offset = curr_row * Wt;
+                uint32_t curr_ht = curr_row % Ht;
+                uint32_t mask_curr_ht = curr_ht % Wt;            // the start offset for causal mask
+                uint32_t mask_offset = curr_row / Ht * Wt * Wt;  // causal mask batch offset
+                uint32_t mask_id = causal_mask
+                                       ? (mask_curr_ht * Wt + mask_offset)
+                                       : (curr_row / Ht * Wt);  // causal mask start offset + causal mask batch offset
+
+                if (causal_mask) {
+                    SetRuntimeArgs(
+                        program,
+                        reader_kernels_id,
+                        core,
+                        {src_buffer_address,
+                         block_size,
+                         s.u,
+                         num_tile_rows_per_core,
+                         tile_offset,
+                         Wt,
+                         Ht,
+                         mask_buffer_address,
+                         curr_ht,
+                         mask_id,
+                         0x3f803f80,
+                         mask_curr_ht,
+                         mask_offset});  // [10]=1.0f is scaler
+                } else {
+                    SetRuntimeArgs(
+                        program,
+                        reader_kernels_id,
+                        core,
+                        {src_buffer_address,
+                         block_size,
+                         s.u,
+                         num_tile_rows_per_core,
+                         tile_offset,
+                         Wt,
+                         Ht,
+                         mask_buffer_address,
+                         curr_ht,
+                         mask_id,
+                         0x3f803f80});  // [10]=1.0f is scaler
+                }
+
+                SetRuntimeArgs(
+                    program,
+                    softmax_kernels_id,
+                    core,
+                    {num_tile_rows_per_core, Ht, Wt, block_size, curr_ht, mask_padded_data});
+
+                SetRuntimeArgs(
+                    program,
+                    writer_kernels_id,
+                    core,
+                    {dst_buffer_address,
+                     num_tile_rows_per_core * Wt,
+                     tile_offset,
+                     block_size,
+                     mask_padded_data,
+                     num_datum_padded,
+                     0xFF00FF00});
+
+                curr_row += num_tile_rows_per_core;
             }
-
-            SetRuntimeArgs(program, softmax_kernels_id, core, { num_tile_rows_per_core, Ht, Wt, block_size, curr_ht, mask_padded_data });
-
-            SetRuntimeArgs(program, writer_kernels_id, core, { dst_buffer_address, num_tile_rows_per_core * Wt, tile_offset, block_size, mask_padded_data, num_datum_padded, 0xFF00FF00});
-
-            curr_row += num_tile_rows_per_core;
-        }
-    };
+        };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
-} // scale_mask_softmax_multi_core
+}  // scale_mask_softmax_multi_core
 
 // implementation of softmax with optional scale/mask (see the header for input_tensor more detailed description)
 operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
-    const Tensor &input_tensor,
-    const Tensor &output_tensor,
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
     const std::optional<const Tensor> mask,
     std::optional<float> scale,
     bool causal_mask,
@@ -419,12 +526,11 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     uint32_t subblock_wt,
     uint32_t block_ht,
     uint32_t block_wt,
-    DeviceComputeKernelConfig compute_kernel_config
-) {
+    DeviceComputeKernelConfig compute_kernel_config) {
     ////////////////////////////////////////////////////////////////////////////
     //                       Device Setup
     ////////////////////////////////////////////////////////////////////////////
-    Device *device = input_tensor.device();
+    Device* device = input_tensor.device();
 
     // convert data format
     tt::DataFormat in0_cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
@@ -433,29 +539,33 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     bool math_approx_mode;
     bool fp32_dest_acc_en;
 
-    std::visit([&](auto&& compute_kernel_config) {
-        using T = std::decay_t<decltype(compute_kernel_config)>;
-        if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
-            math_fidelity = compute_kernel_config.math_fidelity;
-            math_approx_mode = compute_kernel_config.math_approx_mode;
-            fp32_dest_acc_en = false;
-        } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
-            TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
-            math_fidelity = compute_kernel_config.math_fidelity;
-            math_approx_mode = compute_kernel_config.math_approx_mode;
-            fp32_dest_acc_en = in0_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
-            if (fp32_dest_acc_en)
-                TT_FATAL(subblock_wt <= 4, "in fp32 mode, subblock width must be smaller/equal than 4");
-        } else {
-            TT_FATAL("arch not supported");
-        }
-
-    }, compute_kernel_config);
+    std::visit(
+        [&](auto&& compute_kernel_config) {
+            using T = std::decay_t<decltype(compute_kernel_config)>;
+            if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
+                TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+                math_fidelity = compute_kernel_config.math_fidelity;
+                math_approx_mode = compute_kernel_config.math_approx_mode;
+                fp32_dest_acc_en = false;
+            } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
+                TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
+                math_fidelity = compute_kernel_config.math_fidelity;
+                math_approx_mode = compute_kernel_config.math_approx_mode;
+                fp32_dest_acc_en =
+                    in0_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
+                if (fp32_dest_acc_en)
+                    TT_FATAL(subblock_wt <= 4, "in fp32 mode, subblock width must be smaller/equal than 4");
+            } else {
+                TT_FATAL("arch not supported");
+            }
+        },
+        compute_kernel_config);
 
     tt::DataFormat out0_cb_data_format = tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
     tt::DataFormat im_cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-    tt::DataFormat mask_cb_data_format = mask.has_value() ? tt_metal::datatype_to_dataformat_converter(mask.value().get_dtype()) : tt::DataFormat::Float16_b;
+    tt::DataFormat mask_cb_data_format = mask.has_value()
+                                             ? tt_metal::datatype_to_dataformat_converter(mask.value().get_dtype())
+                                             : tt::DataFormat::Float16_b;
     tt::DataFormat scale_cb_data_format = tt::DataFormat::Float16_b;
     tt::DataFormat scalar_cb_data_format = tt::DataFormat::Float16_b;
 
@@ -476,13 +586,14 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     uint32_t K = shape[3] * shape[1];
     uint32_t Mt = M / TILE_WIDTH;
     uint32_t Kt = K / TILE_WIDTH;
-    uint32_t num_cores_per_batch = (shape[1] * shape[2] * shape[3]) / (input_tensor.shard_spec().value().shape[0] * input_tensor.shard_spec().value().shape[1]);
+    uint32_t num_cores_per_batch = (shape[1] * shape[2] * shape[3]) / (input_tensor.shard_spec().value().shape[0] *
+                                                                       input_tensor.shard_spec().value().shape[1]);
 
     uint32_t mask_H = shape[2];
     if (mask.has_value()) {
         mask_H = mask.value().get_legacy_shape()[2];
     }
-    uint32_t mask_Ht = mask_H/TILE_HEIGHT;
+    uint32_t mask_Ht = mask_H / TILE_HEIGHT;
     // block
     uint32_t block_w = block_wt * TILE_WIDTH;
     uint32_t block_h = block_ht * TILE_WIDTH;
@@ -499,8 +610,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     auto src0_buffer = input_tensor.buffer();
     auto out0_buffer = output_tensor.buffer();
     // num tiles
-    uint32_t num_tiles = input_tensor.volume()/TILE_HW;
-
+    uint32_t num_tiles = input_tensor.volume() / TILE_HW;
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
@@ -547,27 +657,24 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     uint32_t num_cores_r = grid_size.y;
     uint32_t num_cores = num_cores_c * num_cores_r;
     CoreRange all_device_cores(
-        {(std::size_t) start_core_x, (std::size_t) start_core_y},
-        {(std::size_t) start_core_x + num_cores_c - 1, (std::size_t) start_core_y + num_cores_r - 1});
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1});
     // reader compile arg
     bool is_dram_mask = 0;
     if (mask.has_value()) {
         is_dram_mask = mask.value().buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     }
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t) block_wt,
-        (std::uint32_t) is_dram_mask
-    };
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)block_wt, (std::uint32_t)is_dram_mask};
     std::map<string, string> softmax_defines;
     // hw_dims_only_causal_mask does not support RM Layout atm
     bool use_row_major_kernel = (mask.has_value() and mask.value().get_layout() == Layout::ROW_MAJOR);
     if (use_row_major_kernel) {
         auto mask_stick_size = mask.value().get_legacy_shape()[3] * mask.value().element_size();
         bool mask_stick_size_is_power_of_two = is_power_of_two_at_least_32(mask_stick_size);
-        reader_compile_time_args.push_back((std::uint32_t) mask_stick_size_is_power_of_two);
+        reader_compile_time_args.push_back((std::uint32_t)mask_stick_size_is_power_of_two);
         if (mask_stick_size_is_power_of_two) {
             uint32_t mask_log2_stick_size = (std::uint32_t)log2(mask_stick_size);
-            reader_compile_time_args.push_back((std::uint32_t) mask_log2_stick_size);
+            reader_compile_time_args.push_back((std::uint32_t)mask_log2_stick_size);
         } else {
             reader_compile_time_args.push_back(mask_stick_size);
         }
@@ -577,13 +684,14 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     }
     if (causal_mask) {
         if (!hw_dims_only_causal_mask) {
-            reader_compile_time_args.push_back((std::uint32_t) block_ht / mask_Ht); // fused head
+            reader_compile_time_args.push_back((std::uint32_t)block_ht / mask_Ht);  // fused head
         } else {
-            reader_compile_time_args.push_back((std::uint32_t) block_ht);
+            reader_compile_time_args.push_back((std::uint32_t)block_ht);
         }
     }
-    reader_compile_time_args.push_back((std::uint32_t) (mask_cb_data_format == tt::DataFormat::Float32)); // mask float32
-    reader_compile_time_args.push_back((std::uint32_t) mask_Ht);
+    reader_compile_time_args.push_back(
+        (std::uint32_t)(mask_cb_data_format == tt::DataFormat::Float32));  // mask float32
+    reader_compile_time_args.push_back((std::uint32_t)mask_Ht);
 
     if (mask.has_value()) {
         softmax_defines["FUSED_SCALE_MASK"] = "1";
@@ -591,7 +699,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     if (causal_mask) {
         softmax_defines["CAUSAL_MASK"] = "1";
         if (mask.value().is_sharded())
-            softmax_defines["SHARDED_CAUSAL_MASK"] =  "1";
+            softmax_defines["SHARDED_CAUSAL_MASK"] = "1";
     }
     std::string reader_kernel_path;
     if (use_row_major_kernel) {
@@ -599,16 +707,14 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     } else if (!hw_dims_only_causal_mask) {
         reader_kernel_path = "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/reader_unary_sharded_sm.cpp";
     } else {
-        reader_kernel_path = "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/readed_unary_sharded_sm_causal_mask_hw_dims.cpp";
+        reader_kernel_path =
+            "tt_eager/tt_dnn/op_library/softmax/kernels/dataflow/readed_unary_sharded_sm_causal_mask_hw_dims.cpp";
     }
     auto reader_kernels_id = CreateKernel(
         program,
         reader_kernel_path,
         all_device_cores,
-        tt_metal::ReaderDataMovementConfig(
-            reader_compile_time_args,
-            softmax_defines
-    ));
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, softmax_defines));
     // compute kernel compile time args
     std::vector<uint32_t> compute_compile_time_args = {
         block_ht,
@@ -618,21 +724,25 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     };
     softmax_defines["EXP_APPROX"] = math_approx_mode ? "1" : "0";
     auto softmax_kernels_id = CreateKernel(
-        program, "tt_eager/tt_dnn/op_library/softmax/kernels/compute/softmax_sharded.cpp", all_device_cores,
+        program,
+        "tt_eager/tt_dnn/op_library/softmax/kernels/compute/softmax_sharded.cpp",
+        all_device_cores,
         tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode,
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
             .compile_args = compute_compile_time_args,
-            .defines = softmax_defines
-    });
+            .defines = softmax_defines});
 
     // Create circular buffers
     // in0 sharded
     auto c_in0_config = CircularBufferConfig(in0_CB_size, {{CB::c_in0, in0_cb_data_format}})
-        .set_page_size(CB::c_in0, in0_tile_size).set_globally_allocated_address(*src0_buffer);
+                            .set_page_size(CB::c_in0, in0_tile_size)
+                            .set_globally_allocated_address(*src0_buffer);
     auto cb_in0_id = CreateCircularBuffer(program, all_device_cores, c_in0_config);
     // in1 scalar
     auto c_in1_config = CircularBufferConfig(in1_CB_size, {{CB::c_in1, scalar_cb_data_format}})
-        .set_page_size(CB::c_in1, scalar_tile_size);
+                            .set_page_size(CB::c_in1, scalar_tile_size);
     auto cb_in1_id = CreateCircularBuffer(program, all_device_cores, c_in1_config);
     // in2 in3 attn scale mask
     std::optional<CBHandle> cb_intermed2_id;
@@ -641,40 +751,47 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     if (mask.has_value()) {
         // im2
         auto c_intermed2_config = CircularBufferConfig(im2_CB_size, {{CB::c_intermed2, im_cb_data_format}})
-            .set_page_size(CB::c_intermed2, im_tile_size);
-        cb_intermed2_id = CreateCircularBuffer( program, all_device_cores, c_intermed2_config );
+                                      .set_page_size(CB::c_intermed2, im_tile_size);
+        cb_intermed2_id = CreateCircularBuffer(program, all_device_cores, c_intermed2_config);
         // in2 scale
         auto c_in2_config = CircularBufferConfig(in2_CB_size, {{CB::c_in2, scale_cb_data_format}})
-            .set_page_size(CB::c_in2, scale_tile_size);
+                                .set_page_size(CB::c_in2, scale_tile_size);
         cb_in2_id = CreateCircularBuffer(program, all_device_cores, c_in2_config);
         // in3 attn mask
         if (mask.value().is_sharded()) {
             auto mask_buffer = mask.value().buffer();
             auto c_in3_config = CircularBufferConfig(in3_CB_size, {{CB::c_in3, mask_cb_data_format}})
-                .set_page_size(CB::c_in3, mask_tile_size).set_globally_allocated_address(*mask_buffer);
-            cb_in3_id = CreateCircularBuffer( program, all_device_cores, c_in3_config);
+                                    .set_page_size(CB::c_in3, mask_tile_size)
+                                    .set_globally_allocated_address(*mask_buffer);
+            cb_in3_id = CreateCircularBuffer(program, all_device_cores, c_in3_config);
         } else {
             auto c_in3_config = CircularBufferConfig(in3_CB_size, {{CB::c_in3, mask_cb_data_format}})
-                .set_page_size(CB::c_in3, mask_tile_size);
-            cb_in3_id = CreateCircularBuffer( program, all_device_cores, c_in3_config);
+                                    .set_page_size(CB::c_in3, mask_tile_size);
+            cb_in3_id = CreateCircularBuffer(program, all_device_cores, c_in3_config);
         }
     }
     // out
     auto c_out0_config = CircularBufferConfig(out_CB_size, {{CB::c_out0, out0_cb_data_format}})
-        .set_page_size(CB::c_out0, out0_tile_size).set_globally_allocated_address(*out0_buffer);;
-    auto cb_out0_id = CreateCircularBuffer( program, all_device_cores, c_out0_config );
+                             .set_page_size(CB::c_out0, out0_tile_size)
+                             .set_globally_allocated_address(*out0_buffer);
+    ;
+    auto cb_out0_id = CreateCircularBuffer(program, all_device_cores, c_out0_config);
     // im0 for exp(x)
     auto c_intermed0_config = CircularBufferConfig(im0_CB_size, {{CB::c_intermed0, im_cb_data_format}})
-        .set_page_size(CB::c_intermed0, im_tile_size);
-    auto cb_intermed0_id = CreateCircularBuffer( program, all_device_cores, c_intermed0_config );
+                                  .set_page_size(CB::c_intermed0, im_tile_size);
+    auto cb_intermed0_id = CreateCircularBuffer(program, all_device_cores, c_intermed0_config);
     // im1 for 1/sum(exp(x))
     auto c_intermed1_config = CircularBufferConfig(im1_CB_size, {{CB::c_intermed1, im_cb_data_format}})
-        .set_page_size(CB::c_intermed1, im_tile_size);
-    auto cb_intermed1_id = CreateCircularBuffer( program, all_device_cores, c_intermed1_config );
+                                  .set_page_size(CB::c_intermed1, im_tile_size);
+    auto cb_intermed1_id = CreateCircularBuffer(program, all_device_cores, c_intermed1_config);
 
     // Runtime Args
     uint32_t mask_addr = mask.has_value() ? mask.value().buffer()->address() : 0;
-    union { float f; uint32_t u; } s; s.f = scale.value_or(1.0f); // scale for fused scale-mask-softmax
+    union {
+        float f;
+        uint32_t u;
+    } s;
+    s.f = scale.value_or(1.0f);  // scale for fused scale-mask-softmax
     uint32_t mask_start_tile_id = 0;
 
     uint32_t num_tiles_in_attn_mask = 0;
@@ -686,9 +803,9 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
     uint32_t num_cores_per_batch_index = 0;
 
     if (shard_orient == ShardOrientation::COL_MAJOR) {
-        for(int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
-            for(int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
-                CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
+        for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
+            for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
+                CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
 
                 // reader args
                 std::vector<uint32_t> reader_args;
@@ -702,19 +819,23 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
 
                 tt_metal::SetRuntimeArgs(program, reader_kernels_id, core, reader_args);
 
-                num_cores_per_batch_index ++;
+                num_cores_per_batch_index++;
 
                 if (hw_dims_only_causal_mask) {
-                    uint32_t mask_tile_id_end = (mask_start_tile_id + num_tiles_of_attn_mask_needed_per_core) % num_tiles_in_attn_mask;
+                    uint32_t mask_tile_id_end =
+                        (mask_start_tile_id + num_tiles_of_attn_mask_needed_per_core) % num_tiles_in_attn_mask;
                     mask_start_tile_id = mask_tile_id_end;
                 } else {
                     if (num_cores_per_batch_index == num_cores_per_batch) {
                         num_cores_per_batch_index = 0;
                         if (mask.has_value()) {
                             if (causal_mask) {
-                                mask_start_tile_id += mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
+                                mask_start_tile_id += mask.value().get_legacy_shape()[-1] *
+                                                      mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
                             } else {
-                                mask_start_tile_id += use_row_major_kernel ? mask.value().get_legacy_shape()[-2] : mask.value().get_legacy_shape()[-1] / TILE_WIDTH;
+                                mask_start_tile_id += use_row_major_kernel
+                                                          ? mask.value().get_legacy_shape()[-2]
+                                                          : mask.value().get_legacy_shape()[-1] / TILE_WIDTH;
                             }
                         }
                     }
@@ -722,9 +843,9 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
             }
         }
     } else {
-        for(int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
-            for(int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
-                CoreCoord core = {(std::size_t) start_core_x + core_idx_x, (std::size_t) start_core_y + core_idx_y};
+        for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
+            for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
+                CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
 
                 // reader args
                 std::vector<uint32_t> reader_args;
@@ -738,19 +859,23 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
 
                 tt_metal::SetRuntimeArgs(program, reader_kernels_id, core, reader_args);
 
-                num_cores_per_batch_index ++;
+                num_cores_per_batch_index++;
 
                 if (hw_dims_only_causal_mask) {
-                    uint32_t mask_tile_id_end = (mask_start_tile_id + num_tiles_of_attn_mask_needed_per_core) % num_tiles_in_attn_mask;
+                    uint32_t mask_tile_id_end =
+                        (mask_start_tile_id + num_tiles_of_attn_mask_needed_per_core) % num_tiles_in_attn_mask;
                     mask_start_tile_id = mask_tile_id_end;
                 } else {
                     if (num_cores_per_batch_index == num_cores_per_batch) {
                         num_cores_per_batch_index = 0;
                         if (mask.has_value()) {
                             if (causal_mask) {
-                                mask_start_tile_id += mask.value().get_legacy_shape()[-1] * mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
+                                mask_start_tile_id += mask.value().get_legacy_shape()[-1] *
+                                                      mask.value().get_legacy_shape()[-2] / TILE_WIDTH / TILE_HEIGHT;
                             } else {
-                                mask_start_tile_id += use_row_major_kernel ? mask.value().get_legacy_shape()[-2] : mask.value().get_legacy_shape()[-1] / TILE_WIDTH;
+                                mask_start_tile_id += use_row_major_kernel
+                                                          ? mask.value().get_legacy_shape()[-2]
+                                                          : mask.value().get_legacy_shape()[-1] / TILE_WIDTH;
                             }
                         }
                     }
@@ -759,39 +884,32 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
         }
     }
 
-    auto override_runtime_arguments_callback = [
-            reader_kernels_id,
-            cb_in0_id,
-            cb_out0_id,
-            num_cores,
-            grid_size
-        ]
-    (
-        const void* operation,
-        Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-        const std::vector<Tensor>& output_tensors
-    ) {
-        auto in0_buffer = input_tensors.at(0).buffer();
-        auto &mask_tensor = optional_input_tensors.at(0);
-        auto out_buffer = output_tensors.size() == 1 ? output_tensors.at(0).buffer() : in0_buffer;
+    auto override_runtime_arguments_callback =
+        [reader_kernels_id, cb_in0_id, cb_out0_id, num_cores, grid_size](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            auto in0_buffer = input_tensors.at(0).buffer();
+            auto& mask_tensor = optional_input_tensors.at(0);
+            auto out_buffer = output_tensors.size() == 1 ? output_tensors.at(0).buffer() : in0_buffer;
 
-        UpdateDynamicCircularBufferAddress(program, cb_in0_id, *in0_buffer);
-        UpdateDynamicCircularBufferAddress(program, cb_out0_id, *out_buffer);
+            UpdateDynamicCircularBufferAddress(program, cb_in0_id, *in0_buffer);
+            UpdateDynamicCircularBufferAddress(program, cb_out0_id, *out_buffer);
 
-        if (mask_tensor.has_value()) {
-            for (uint32_t i = 0; i < num_cores; ++i) {
-                CoreCoord core = {i % grid_size.x, i / grid_size.x};
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernels_id, core);
+            if (mask_tensor.has_value()) {
+                for (uint32_t i = 0; i < num_cores; ++i) {
+                    CoreCoord core = {i % grid_size.x, i / grid_size.x};
+                    auto& runtime_args = GetRuntimeArgs(program, reader_kernels_id, core);
                     runtime_args[2] = mask_tensor.value().buffer()->address();
+                }
             }
-        }
-    };
+        };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
-} // scale_mask_softmax_sharded_multi_core
+}  // scale_mask_softmax_sharded_multi_core
 
-}  // namespace tt_metal
-}  // namespace tt_metal
+}  // namespace primary
+}  // namespace operations
 }  // namespace tt

--- a/tt_metal/tt_stl/enumerate.hpp
+++ b/tt_metal/tt_stl/enumerate.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tuple>
+
+namespace tt::stl::utils {
+
+template <
+    typename Iterable,
+    typename TIter = decltype(std::begin(std::declval<Iterable>())),
+    typename = decltype(std::end(std::declval<Iterable>()))>
+auto enumerate(Iterable&& iterable, std::size_t start = 0) {
+    struct iterator {
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = std::tuple<std::size_t, typename std::iterator_traits<TIter>::value_type>;
+        using difference_type = typename std::iterator_traits<TIter>::difference_type;
+        using pointer = std::tuple<std::size_t, typename std::iterator_traits<TIter>::pointer>;
+        using reference = std::tuple<std::size_t, typename std::iterator_traits<TIter>::reference>;
+
+        bool operator!=(const iterator& other) const { return iter != other.iter; }
+        void operator++() {
+            ++index;
+            ++iter;
+        }
+        auto operator*() const { return std::tie(index, *iter); }
+
+        std::size_t index;
+        TIter iter;
+    };
+
+    struct iterator_view {
+        Iterable iterable;
+        std::size_t start;
+
+        auto begin() { return iterator{start, std::begin(iterable)}; }
+        auto end() { return iterator{start, std::end(iterable)}; }
+    };
+
+    return iterator_view{std::forward<Iterable>(iterable), start};
+}
+
+}  // namespace tt::stl::utils


### PR DESCRIPTION
We have CoreRange and CoreRangeSet classes that represent a single rectangle or a set of rectangles on a 2D grid of cores. There is currently no way to iterate over instance of these classes, so instead we iterate over all the device cores and then check whether a core belongs to a core range set. This PR adds the ability to directly iterate over these classes.