### PR TITLE
#4858: enable typecast fp16b to uint16

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1331,8 +1331,13 @@ def eltwise_identity(x, *args, **kwargs):
     return x
 
 
-def eltwise_typecast(x, *args, **kwargs):
-    return torch.relu(x.to(torch.int32))  # due to no uint32 support
+def eltwise_typecast(x, *args, tt_output_dtype, **kwargs):
+    if tt_output_dtype[0] == ttl.tensor.DataType.UINT16:
+        return torch.clamp(x.to(torch.int32), min=0, max=65535)  # due to no uint16 support
+    elif tt_output_dtype[0] == ttl.tensor.DataType.UINT32:
+        return torch.relu(x.to(torch.int32))  # due to no uint32 support
+    else:
+        return x
 
 
 def eltwise_rdiv(x, *args, **kwargs):

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2192,13 +2192,14 @@ def eltwise_typecast(
     *args,
     device,
     dtype,
+    tt_output_dtype,
     layout,
     input_mem_config,
     output_mem_config,
     **kwargs,
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.eltwise_typecast(t0, output_mem_config=output_mem_config)
+    t1 = ttl.tensor.eltwise_typecast(t0, tt_output_dtype[0], output_mem_config=output_mem_config)
 
     return tt2torch_tensor(t1)
 

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -177,6 +177,11 @@ std::pair<string, string> get_op_init_and_func_parameterized(
                     Converter::to_hex(param1))};
             break;
         }
+        case UnaryOpType::TYPECAST:
+            op_init_and_name = {
+                "typecast_tile_init();",
+                fmt::format("typecast_tile<{1}u>({0});", idst, std::to_string((uint32_t)datatype_to_dataformat_converter((DataType)param0)))};
+            break;
         default: TT_ASSERT(false && "unexpected parameterized type");
     };
     return op_init_and_name;
@@ -257,9 +262,6 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, stri
             break;
         case UnaryOpType::NEG:
             op_init_and_name = {"negative_tile_init();", fmt::format("negative_tile({});", idst)};
-            break;
-        case UnaryOpType::TYPECAST:
-            op_init_and_name = {"typecast_tile_init();", fmt::format("typecast_tile({});", idst)};
             break;
         default: TT_ASSERT(false && "Undefined non-parametrized op type");
     }

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -104,7 +104,8 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::DIV_UNARY_SFPU:
         case UnaryOpType::UNARY_NE:
         case UnaryOpType::UNARY_GT:
-        case UnaryOpType::UNARY_LT: return true;
+        case UnaryOpType::UNARY_LT:
+        case UnaryOpType::TYPECAST: return true;
         default: return false;
     }
     return false;
@@ -195,7 +196,7 @@ inline Tensor run_eltwise_unary(
     const std::vector<UnaryWithParam>& ops_chain,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     TT_FATAL(ops_chain.size() > 0, "At least 1 unary op must be specified");
-    DataType output_dtype = (ops_chain[0].op_type == UnaryOpType::TYPECAST) ? DataType::UINT32 : input_tensor.get_dtype();
+    DataType output_dtype = (ops_chain[0].op_type == UnaryOpType::TYPECAST) ? (DataType)ops_chain[0].params[0] : input_tensor.get_dtype();
     bool fp32_dest_acc_en =
         output_dtype == DataType::UINT32 or
         input_tensor.get_dtype() == DataType::UINT32 or
@@ -241,7 +242,7 @@ inline Tensor run_eltwise_unary(
     const std::vector<UnaryWithParam>& ops_chain,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     TT_FATAL(ops_chain.size() > 0, "At least 1 unary op must be specified");
-    DataType output_dtype = (ops_chain[0].op_type == UnaryOpType::TYPECAST) ? DataType::UINT32 : input_tensor.get_dtype();
+    DataType output_dtype = (ops_chain[0].op_type == UnaryOpType::TYPECAST) ? (DataType)ops_chain[0].params[0] : input_tensor.get_dtype();
     bool fp32_dest_acc_en =
         output_dtype == DataType::UINT32 or
         input_tensor.get_dtype() == DataType::UINT32 or
@@ -369,7 +370,7 @@ constexpr auto rsub = make_eltwise_unary_with_param<UnaryOpType::RSUB>{};
 constexpr auto silu = make_eltwise_unary<UnaryOpType::SILU>{};
 constexpr auto identity = make_eltwise_unary<UnaryOpType::IDENTITY>{};
 constexpr auto identity_uint32 = make_eltwise_unary<UnaryOpType::IDENTITY_UINT32>{};
-constexpr auto eltwise_typecast = make_eltwise_unary<UnaryOpType::TYPECAST>{};
+constexpr auto eltwise_typecast = make_eltwise_unary_with_param<UnaryOpType::TYPECAST, uint32_t>{};
 constexpr auto add_unary_sfpu = make_eltwise_symmetric_binop_unary_with_param<UnaryOpType::ADD_UNARY_SFPU>{};
 constexpr auto mul_unary_sfpu = make_eltwise_symmetric_binop_unary_with_param<UnaryOpType::MUL_UNARY_SFPU>{};
 constexpr auto unary_gt = make_eltwise_unary_with_param<UnaryOpType::UNARY_GT>{};

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -196,7 +196,7 @@ inline Tensor run_eltwise_unary(
     const std::vector<UnaryWithParam>& ops_chain,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     TT_FATAL(ops_chain.size() > 0, "At least 1 unary op must be specified");
-    DataType output_dtype = (ops_chain[0].op_type == UnaryOpType::TYPECAST) ? (DataType)ops_chain[0].params[0] : input_tensor.get_dtype();
+    DataType output_dtype = (ops_chain[0].op_type == UnaryOpType::TYPECAST) ? static_cast<DataType>(ops_chain[0].params[0]) : input_tensor.get_dtype();
     bool fp32_dest_acc_en =
         output_dtype == DataType::UINT32 or
         input_tensor.get_dtype() == DataType::UINT32 or
@@ -242,7 +242,7 @@ inline Tensor run_eltwise_unary(
     const std::vector<UnaryWithParam>& ops_chain,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     TT_FATAL(ops_chain.size() > 0, "At least 1 unary op must be specified");
-    DataType output_dtype = (ops_chain[0].op_type == UnaryOpType::TYPECAST) ? (DataType)ops_chain[0].params[0] : input_tensor.get_dtype();
+    DataType output_dtype = (ops_chain[0].op_type == UnaryOpType::TYPECAST) ? static_cast<DataType>(ops_chain[0].params[0]) : input_tensor.get_dtype();
     bool fp32_dest_acc_en =
         output_dtype == DataType::UINT32 or
         input_tensor.get_dtype() == DataType::UINT32 or

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -85,7 +85,13 @@ namespace tt::tt_metal::detail {
         detail::bind_unary_op(m_tensor, "i0", i0, R"doc(Computes the zeroth order modified Bessel function of the first kind applied on the elements of the input tensor ``{0}``, for the input range -10 to 10.)doc");
         detail::bind_unary_op(m_tensor, "silu", silu, R"doc(Returns tensor with the silu all of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "neg", neg, R"doc(Returns tensor with the negate all of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "eltwise_typecast", eltwise_typecast, R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted from fp32 to uint32.)doc");
+
+        detail::bind_unary_op_with_param(
+            m_tensor, "eltwise_typecast", eltwise_typecast,
+            py::arg("tt_output_dtype"),
+            R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted from fp32 to uint32.)doc",
+            R"doc("Indicates output dtype of typecast", "ttl.tensor.DataType", "")doc"
+        );
 
         detail::bind_unary_op_with_param(
             m_tensor, "exp", py::overload_cast<const Tensor&, bool, const MemoryConfig&>(&exp),

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -89,7 +89,7 @@ namespace tt::tt_metal::detail {
         detail::bind_unary_op_with_param(
             m_tensor, "eltwise_typecast", eltwise_typecast,
             py::arg("tt_output_dtype"),
-            R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted from fp32 to uint32.)doc",
+            R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted from fp32 to uint32 or uint16.)doc",
             R"doc("Indicates output dtype of typecast", "ttl.tensor.DataType", "")doc"
         );
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -51,5 +51,21 @@ inline void calculate_typecast_fp16b_to_uint32()
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_typecast_fp16b_to_uint16()
+{
+    #pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPENCC(0,0,0,0);
+        TTI_SFPLOAD(0,0,3,0);
+        TTI_SFPSETCC(0,0,0,0);
+        TTI_SFPLOADI(0,0,0);
+        TTI_SFPENCC(0,0,0,0);
+        TTI_SFP_STOCH_RND(0,0,2,0,1,14);
+        TTI_SFPSTORE(1,6,3,0);
+        dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "llk_math_eltwise_unary_sfpu_init.h"
-#include "llk_math_eltwise_unary_sfpu_0_param.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_typecast.h"
 
 namespace ckernel {
@@ -15,16 +15,16 @@ namespace ckernel {
 template <bool APPROXIMATE, uint32_t OUT_DTYPE>
 inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     if constexpr (OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
-        llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE>
-            (ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE,8>,
+        llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE,8>,
-                                        dst_index, vector_mode);
+            dst_index,
+            vector_mode);
     }
     else if constexpr (OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
-        llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE>
-            (ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE,8>,
+        llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
             ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE,8>,
-                                        dst_index, vector_mode);
+            dst_index,
+            vector_mode);
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -12,12 +12,20 @@ namespace ckernel {
 
 // New LLK SFPU APIs
 
-template <bool APPROXIMATE>
+template <bool APPROXIMATE, uint32_t OUT_DTYPE>
 inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE>
-      (ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE,8>,
-       ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE,8>,
-                                dst_index, vector_mode);
+    if constexpr (OUT_DTYPE == (uint32_t)DataFormat::UInt16) {
+        llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE>
+            (ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE,8>,
+            ckernel::sfpu::calculate_typecast_fp16b_to_uint16<APPROXIMATE,8>,
+                                        dst_index, vector_mode);
+    }
+    else if constexpr (OUT_DTYPE == (uint32_t)DataFormat::UInt32) {
+        llk_math_eltwise_unary_sfpu_0_param<APPROXIMATE>
+            (ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE,8>,
+            ckernel::sfpu::calculate_typecast_fp16b_to_uint32<APPROXIMATE,8>,
+                                        dst_index, vector_mode);
+    }
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
@@ -20,16 +20,21 @@ namespace ckernel {
 
 /**
  * Performs an elementwise typecast operation on the input.
- * Supports typecast from fp32 to uint32.
+ * Supports following typecasts:
+ *  fp32/fp16b -> uint32
+ *  fp32/fp16b -> uint16
+ * For output to be uint32, Dest must be in 32 bit mode.
  *
  * Return value: None
  *
  * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
  * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | tile_index     | The index of the tile in DST register buffer to perform typecast operation | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | OUT_DTYPE      | Desired output data format                                                 | uint32_t | Must be valid tt::DataFormat                          | True     |
  */
+template <uint32_t OUT_DTYPE>
 ALWI void typecast_tile(uint32_t idst) {
-    MATH(( llk_math_eltwise_unary_sfpu_typecast<APPROX>(idst) ));
+    MATH(( llk_math_eltwise_unary_sfpu_typecast<APPROX, OUT_DTYPE>(idst) ));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/unary.hpp
@@ -42,7 +42,7 @@ inline Tensor execute_on_worker_thread(
     const Tensor& input_tensor,
     const std::vector<tt::tt_metal::UnaryWithParam>& op_chain,
     const std::optional<MemoryConfig>& memory_config = std::nullopt) {
-    DataType output_dtype = (op_chain[0].op_type == UnaryOpType::TYPECAST) ? (DataType)op_chain[0].params[0] : input_tensor.get_dtype();
+    DataType output_dtype = (op_chain[0].op_type == UnaryOpType::TYPECAST) ? static_cast<DataType>(op_chain[0].params[0]) : input_tensor.get_dtype();
     bool fp32_dest_acc_en = output_dtype == DataType::UINT32 or
                             input_tensor.get_dtype() == DataType::UINT32 or
                             input_tensor.get_dtype() == DataType::INT32;  // MT: Currently only uint32/int32 is moved to

--- a/ttnn/cpp/ttnn/operations/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/unary.hpp
@@ -42,8 +42,9 @@ inline Tensor execute_on_worker_thread(
     const Tensor& input_tensor,
     const std::vector<tt::tt_metal::UnaryWithParam>& op_chain,
     const std::optional<MemoryConfig>& memory_config = std::nullopt) {
-    DataType output_dtype = (op_chain[0].op_type == UnaryOpType::TYPECAST) ? DataType::UINT32 : input_tensor.get_dtype();
-    bool fp32_dest_acc_en = input_tensor.get_dtype() == DataType::UINT32 or
+    DataType output_dtype = (op_chain[0].op_type == UnaryOpType::TYPECAST) ? (DataType)op_chain[0].params[0] : input_tensor.get_dtype();
+    bool fp32_dest_acc_en = output_dtype == DataType::UINT32 or
+                            input_tensor.get_dtype() == DataType::UINT32 or
                             input_tensor.get_dtype() == DataType::INT32;  // MT: Currently only uint32/int32 is moved to
                                                                           // DST directly, fp32 is converted to fp16b
     return operation::run(


### PR DESCRIPTION
Enabling typecast from fp16b to uint16 through SPFU.
Next step building on: https://github.com/tenstorrent/tt-metal/pull/9033

Post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9376407658
