### PR TITLE
build UMD with same compiler used to compile metal and remove clang 6 as a dependency

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -124,7 +124,7 @@ Please follow the next additional steps if you want to contribute to the codebas
 1. Install dependencies
 
 ```sh
-sudo apt install clang-6.0=1:6.0.1-14 git git-lfs cmake=3.16.3-1ubuntu1.20.04.1 pandoc libtbb-dev libcapstone-dev pkg-config ninja-build patchelf
+sudo apt install git git-lfs cmake=3.16.3-1ubuntu1.20.04.1 pandoc libtbb-dev libcapstone-dev pkg-config ninja-build patchelf
 ```
 
 2. Download and install [Doxygen](https://www.doxygen.nl/download.html), (v1.9 or higher, but less than v1.10)

--- a/cmake/umd_device.cmake
+++ b/cmake/umd_device.cmake
@@ -55,6 +55,7 @@ ExternalProject_Add(
         STATIC_LIB_FLAGS=${STATIC_LIB_FLAGS_}
         LDFLAGS=${LDFLAGS_}
         CXXFLAGS=${CMAKE_CXX_FLAGS_}
+        DEVICE_CXX=${CMAKE_CXX_COMPILER}
 )
 if($ENV{ENABLE_TRACY})
     add_dependencies(umd_device TracyClient)

--- a/scripts/docker/requirements.txt
+++ b/scripts/docker/requirements.txt
@@ -6,7 +6,6 @@ libgoogle-glog-dev=0.4.0-1build1
 libyaml-cpp-dev=0.6.2-4ubuntu1
 git
 git-lfs
-clang-6.0=1:6.0.1-14
 libboost-all-dev=1.71.0.0ubuntu2
 libsndfile1=1.0.28-7ubuntu0.2
 pandoc
@@ -18,10 +17,8 @@ curl
 wget
 python3-pip
 libhwloc-dev
-
 libhdf5-serial-dev
 ruby=1:2.7+1
 python3.8-venv=3.8.10-0ubuntu1~20.04.9
-
 cargo
 ninja-build


### PR DESCRIPTION
UMD should work with the same compiler we use for Metal