### PR TITLE
#9006: single-core topk extension to include larger width and height

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_topk.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_topk.py
@@ -67,7 +67,16 @@ def run_topk_test(N, C, H, W, k, dtype, device):
         # "FLOAT32",
     ],
 )
-@pytest.mark.parametrize("N, C, H, W, k,", ((1, 1, 32, 64, 32),))
+@pytest.mark.parametrize(
+    "N, C, H, W, k,",
+    (
+        (1, 1, 32, 64, 32),
+        (1, 1, 32, 256, 32),
+        (1, 1, 128, 64, 32),
+        (1, 1, 1024, 64, 32),
+        (1, 1, 2048, 64, 32),
+    ),
+)
 def test_topk(N, C, H, W, k, dtype, device):
     run_topk_test(N, C, H, W, k, dtype, device)
 

--- a/tt_eager/tt_dnn/op_library/topk/kernels/compute/topk.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/kernels/compute/topk.cpp
@@ -28,14 +28,23 @@ void MAIN {
     constexpr uint32_t logk = get_compile_time_arg_val(9);
     constexpr uint32_t logWt = get_compile_time_arg_val(10);
 
+    // dest indices for where to unpack the tiles for the llk
+    // the input goes in index 0,1 and the index goes in index 2,3
+    constexpr uint32_t input_dest_start = 0;
+    constexpr uint32_t index_dest_start = 2;
+    constexpr uint32_t input_dest_end = 1;
+    constexpr uint32_t index_dest_end = 3;
     // init pack, compute and unpack
+
     ckernel::topk_tile_init();
     transpose_wh_init(input_cb_index, input_transposed_cb_index);
+
     for(uint32_t ht = 0; ht < Ht; ++ht) {
         bool ascending = false;
         cb_reserve_back(input_transposed_cb_index, Wt);
         cb_reserve_back(index_transposed_cb_index, Wt);
 
+        // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
         for (uint32_t wt = 0; wt < Wt; wt+=2) {
             acquire_dst(tt::DstMode::Half);
             // local sort into k groups
@@ -44,89 +53,83 @@ void MAIN {
 
             unpack_reconfig_data_format_srca(input_cb_index);
             transpose_wh_init_short(input_cb_index);
-            transpose_wh_tile(input_cb_index, wt, 0);
-            transpose_wh_tile(input_cb_index, wt+1, 1);
+            transpose_wh_tile(input_cb_index, 0, 0);
+            transpose_wh_tile(input_cb_index, 1, 1);
 
             unpack_reconfig_data_format_srca(index_cb_index);
             transpose_wh_init_short(index_cb_index);
-            transpose_wh_tile(index_cb_index, wt, 2);
-            transpose_wh_tile(index_cb_index, wt+1, 3);
+            transpose_wh_tile(index_cb_index, 0, 2);
+            transpose_wh_tile(index_cb_index, 1, 3);
 
             // llk_topk_sort -> inplace
             ckernel::topk_local_sort(0, (int) ascending, logk - 1);
 
-            // pack value tiles into cb_intermed1
+            // pack value tiles into cb_intermed0
             pack_reconfig_data_format(input_transposed_cb_index);
-            pack_tile(0, input_transposed_cb_index, wt);
-            pack_tile(1, input_transposed_cb_index, wt+1);
+            pack_tile(0, input_transposed_cb_index);
+            pack_tile(1, input_transposed_cb_index);
 
-            // pack index tiles into cb_intermed2
+            // pack index tiles into cb_intermed1
             pack_reconfig_data_format(index_transposed_cb_index);
-            pack_tile(2, index_transposed_cb_index, wt);
-            pack_tile(3, index_transposed_cb_index, wt+1);
+            pack_tile(2, index_transposed_cb_index);
+            pack_tile(3, index_transposed_cb_index);
 
             cb_pop_front(input_cb_index, 2);
             cb_pop_front(index_cb_index, 2);
-
             release_dst(tt::DstMode::Half);
-            ascending = !ascending;
         }
 
         cb_push_back(input_transposed_cb_index, Wt);
         cb_push_back(index_transposed_cb_index, Wt);
 
-        cb_wait_front(input_transposed_cb_index, Wt);
-        cb_wait_front(index_transposed_cb_index, Wt);
-
-        cb_reserve_back(input_transposed_cb_index, Wt);
-        cb_reserve_back(index_transposed_cb_index, Wt);
-
-
-        // iterative merge and rebuild on pairs of tiles
-        constexpr uint32_t num_iterations = logWt;
-        for (uint32_t m_iter = 0; m_iter < num_iterations; ++m_iter) {
+        // iterative divide and conquer on pairs of tiles (bitonic topk merge and rebuild)
+        // first iteration we compare 0th and 1st tile, then 2nd and 3rd, etc. We get the sorted top 32 values in each pair.
+        // second iteration we compare 0th and 2nd tile, then 4th and 6th, etc.
+        // logWt iteration we compare 0th and Wt/2 tile
+        // single buffer as we can pack tiles back in-place
+        for (uint32_t m_iter = 0; m_iter < logWt; ++m_iter) {
             bool a = false;
-            for (uint32_t left_ind = 0; left_ind < Wt / 2; left_ind += 1 << m_iter) {
+            cb_wait_front(input_transposed_cb_index, Wt);
+            cb_wait_front(index_transposed_cb_index, Wt);
+
+            for (uint32_t left_ind = 0; left_ind < Wt - (1 << m_iter); left_ind += 2 << m_iter) {
+                uint32_t right_ind = left_ind + (1 << m_iter);
                 acquire_dst(tt::DstMode::Half);
 
-                uint32_t right_ind = left_ind + (1 << m_iter);
-
-                // unpack values into dest
                 copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
-                copy_tile(input_transposed_cb_index, left_ind, 0);
-                copy_tile(input_transposed_cb_index, right_ind, 1);
+                copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
+                copy_tile(input_transposed_cb_index, right_ind, input_dest_end);
 
                 // unpack indices into dest
                 copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
-                copy_tile(index_transposed_cb_index, left_ind, 2);
-                copy_tile(index_transposed_cb_index, right_ind, 3);
+                copy_tile(index_transposed_cb_index, left_ind, index_dest_start);
+                copy_tile(index_transposed_cb_index, right_ind, index_dest_end);
 
                 // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
                 ckernel::topk_merge(0, m_iter, K);
                 // sort within the larger 32 values
                 ckernel::topk_rebuild(0, (uint32_t) a, m_iter, K, logk, true);
 
-                // pack value tiles
+
+                // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values for topk, which was in input_dest_start
                 pack_reconfig_data_format(input_transposed_cb_index);
-                pack_tile(0, input_transposed_cb_index, left_ind);
-                pack_tile(1, input_transposed_cb_index, right_ind);
+                pack_tile<true>(input_dest_start, input_transposed_cb_index, left_ind);
 
-                // pack index tiles
+                // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values for topk, which was in index_dest_start
                 pack_reconfig_data_format(index_transposed_cb_index);
-                pack_tile(2, index_transposed_cb_index, left_ind);
-                pack_tile(3, index_transposed_cb_index, right_ind);
-
+                pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
                 release_dst(tt::DstMode::Half);
                 a = !a;
             }
+            cb_reserve_back(input_transposed_cb_index, Wt);
+            cb_reserve_back(index_transposed_cb_index, Wt);
+
+            cb_pop_front(input_transposed_cb_index, Wt);
+            cb_pop_front(index_transposed_cb_index, Wt);
+
+            cb_push_back(input_transposed_cb_index, Wt);
+            cb_push_back(index_transposed_cb_index, Wt);
         }
-
-        cb_push_back(input_transposed_cb_index, Wt);
-        cb_push_back(index_transposed_cb_index, Wt);
-
-        cb_pop_front(input_transposed_cb_index, Wt);
-        cb_pop_front(index_transposed_cb_index, Wt);
-
 
         constexpr uint32_t Kt =  K % TILE_WIDTH == 0 ? K/TILE_WIDTH : K/TILE_WIDTH + 1;
 
@@ -138,14 +141,13 @@ void MAIN {
         for (uint32_t i = 0; i < Kt; ++i) {
             acquire_dst(tt::DstMode::Half);
             cb_reserve_back(values_cb_index, 1);
-
             transpose_wh_tile(input_transposed_cb_index, i, 0);
             pack_tile(0, values_cb_index);
-
             cb_push_back(values_cb_index, 1);
             release_dst(tt::DstMode::Half);
         }
-        cb_pop_front(input_transposed_cb_index, Kt);
+        cb_wait_front(input_transposed_cb_index, Wt);
+        cb_pop_front(input_transposed_cb_index, Wt);
 
         // transpose index tiles and pack into output buffer
         unpack_reconfig_data_format_srca(index_transposed_cb_index);
@@ -155,14 +157,13 @@ void MAIN {
         for (uint32_t i = 0; i < Kt; ++i) {
             acquire_dst(tt::DstMode::Half);
             cb_reserve_back(output_ind_cb_index, 1);
-
             transpose_wh_tile(index_transposed_cb_index, i, 0);
             pack_tile(0, output_ind_cb_index);
-
             cb_push_back(output_ind_cb_index, 1);
             release_dst(tt::DstMode::Half);
         }
-        cb_pop_front(index_transposed_cb_index, Kt);
+        cb_wait_front(index_transposed_cb_index, Wt);
+        cb_pop_front(index_transposed_cb_index, Wt);
     }
 }
 }

--- a/tt_eager/tt_dnn/op_library/topk/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/kernels/dataflow/reader_create_index_tensor.cpp
@@ -12,6 +12,7 @@
  * wt is which tile it is along the row [0, Wt) so j + 32*wt is the value in the tile at each element
 */
 FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
+    // TODO: investigate moving to compile time (binary size is at risk)
     cb_reserve_back(cb_id, 1);
     uint32_t write_addr = get_write_ptr(cb_id);
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
@@ -46,8 +47,8 @@ void kernel_main() {
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const DataFormat data_format = get_dataformat(cb_id_in0);
+    constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    constexpr DataFormat data_format = get_dataformat(cb_id_in0);
 
     const InterleavedAddrGenFast<src_is_dram> s = {
         .bank_base_address = src_addr,
@@ -55,7 +56,8 @@ void kernel_main() {
         .data_format = data_format
     };
 
-    // there's an argument to processing two tiles at once since llk requires two index and two value tiles at at ime
+    // Stream in input tensor, buffer has four tiles as we double-buffer to continue streaming while waiting for compute and we need two tiles for the bitonic sort llk
+    // We could load in an entire row of tiles at a time but that would require substantially more memory (we would be double buffering four Wt sized CBs)
     for (uint32_t i = 0; i < Ht; ++i) {
         for (uint32_t j = 0; j < Wt; ++j) {
             cb_reserve_back(cb_id_in0, onetile);

--- a/tt_eager/tt_dnn/op_library/topk/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/kernels/dataflow/writer_binary_interleaved.cpp
@@ -12,7 +12,9 @@ void kernel_main() {
     constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(1);
     constexpr bool values_is_dram = get_compile_time_arg_val(2) == 1;
     constexpr bool output_ind_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t num_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);
+    constexpr uint32_t K = get_compile_time_arg_val(5);
+    constexpr uint32_t Kt =  K % 32 == 0 ? K/32 : K/32 + 1;
 
     // can amortize the noc reads by doing them side by side for the two tensors
     constexpr uint32_t onetile = 1;
@@ -25,15 +27,6 @@ void kernel_main() {
         .data_format = data_format_values
     };
 
-    for (uint32_t i = 0; i < num_tiles; ++ i) {
-        cb_wait_front(values_cb_index, onetile);
-        uint32_t l1_read_addr = get_read_ptr(values_cb_index);
-        noc_async_write_tile(i, interleaved_accessor0, l1_read_addr);
-        noc_async_write_barrier();
-        cb_pop_front(values_cb_index, onetile);
-    }
-
-    // single-tile ublocks
     const uint32_t tile_bytes_ind = get_tile_size(output_ind_cb_index);
     const DataFormat data_format_ind = get_dataformat(output_ind_cb_index);
 
@@ -43,12 +36,24 @@ void kernel_main() {
         .data_format = data_format_ind
     };
 
-    for (uint32_t i = 0; i < num_tiles; ++ i) {
-        cb_wait_front(output_ind_cb_index, onetile);
-        uint32_t l1_read_addr = get_read_ptr(output_ind_cb_index);
-        noc_async_write_tile(i, interleaved_accessor1, l1_read_addr);
-        noc_async_write_barrier();
-        cb_pop_front(output_ind_cb_index, onetile);
-    }
+    // Get Kt rows of values and then Kt rows of indices from compute kernel
+    for (uint32_t j = 0; j < Ht; ++j) {
+        // topk values
+        for (uint32_t i = 0; i < Kt; ++i) {
+            cb_wait_front(values_cb_index, onetile);
+            uint32_t l1_read_addr = get_read_ptr(values_cb_index);
+            noc_async_write_tile(j*1 + i, interleaved_accessor0, l1_read_addr);
+            noc_async_write_barrier();
+            cb_pop_front(values_cb_index, onetile);
+        }
 
+        // topk indices
+        for (uint32_t i = 0; i < Kt; ++i) {
+            cb_wait_front(output_ind_cb_index, onetile);
+            uint32_t l1_read_addr = get_read_ptr(output_ind_cb_index);
+            noc_async_write_tile(j*1 + i, interleaved_accessor1, l1_read_addr);
+            noc_async_write_barrier();
+            cb_pop_front(output_ind_cb_index, onetile);
+        }
+    }
 }

--- a/tt_eager/tt_dnn/op_library/topk/topk_op.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/topk_op.cpp
@@ -7,9 +7,11 @@
 
 void TopK::validate(const std::vector<Tensor>& input_tensors) const {
     auto input_shape = input_tensors.at(0).get_legacy_shape();
+    TT_FATAL(input_shape.rank() == 4, fmt::format("Input shape must be 4D, got {}", input_shape.rank()));
     TT_FATAL(k == 32, fmt::format("K must be equal to 32, pad with -infinity if necessary"));
-    TT_FATAL(input_shape[-1] == 64, fmt::format("Input shape inner dim {} must be 64, pad with -infinity if necessary", input_shape[-1]));
-    TT_FATAL((input_shape[0] * input_shape[1] * input_shape[2]) == 32, "Input height must be 32");
+    TT_FATAL(input_shape[-1] >= 64, fmt::format("Input shape inner dim {} must be a multiple of 64, pad with -infinity if necessary", input_shape[-1]));
+    TT_FATAL((input_shape[-1] & (input_shape[-1] - 1)) == 0, fmt::format("Input shape inner dim {} must be a power of 2, pad with -infinity if necessary", input_shape[-1]));
+    TT_FATAL((input_shape[0] * input_shape[1] * input_shape[2]) % 32 == 0, fmt::format("Input height (combined input_shape[0-3]) {} must be a multiple of 32", input_shape[0] * input_shape[1] * input_shape[2]));
     TT_FATAL(this->output_mem_config.is_sharded() == false, "Sharded implementation not supported yet");
     TT_FATAL(input_tensors.at(0).get_layout() == Layout::TILE, "The input must be in tiled format");
 }
@@ -24,7 +26,7 @@ std::vector<Tensor> TopK::create_output_tensors(const std::vector<Tensor>& input
     const auto& input_tensor = input_tensors.at(0);
     const auto shapes = compute_output_shapes(input_tensors);
     auto values_tensor = create_device_tensor(shapes[0], input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), this->output_mem_config);
-    auto index_tensor = create_device_tensor(shapes[0], DataType::UINT16, Layout::TILE, input_tensor.device(), this->output_mem_config);
+    auto index_tensor = create_device_tensor(shapes[1], DataType::UINT16, Layout::TILE, input_tensor.device(), this->output_mem_config);
     return {values_tensor, index_tensor};
 }
 


### PR DESCRIPTION
- Add support for all widths that are a power of 2 and greater than 64
- Add support for arbitrary height (Tiled so a multiple of 32 still)
- Still single core, so perf degrades at higher dimensions, and memory hit of CBs is ~2 times the width so tensors will overflow L1 at W=4096, H=32