### PR TITLE
#5337: Mixtral dense matmul after all-gather

### DIFF
--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -90,11 +90,11 @@ class TtMixtralAttention(LightweightModule):
             .unsqueeze(0)
             .unsqueeze(0),
             device=self.device_mesh,
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=-2),
+            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
             dtype=self.dtype,
             memory_config=self.model_config["ATTN_WEIGHTS_MEMCFG"],
             layout=self.model_config["ATTN_W_LAYOUT_TILE"],
-            cache_file_name=cache_name(f"wo_multidevice4d"),
+            cache_file_name=cache_name(f"wo_multidevice4d_H"),
         )
 
         cache_k = torch.zeros(
@@ -128,17 +128,6 @@ class TtMixtralAttention(LightweightModule):
         ]
 
         self.scale = self.head_dim**-0.5
-
-        reduce_mask_torch = torch.zeros(1, 1, self.max_batch_size, self.max_batch_size * 8)
-        for i in range(self.max_batch_size):
-            reduce_mask_torch[:, :, i, range(i, self.max_batch_size * 8, self.max_batch_size)] = 1
-        self.reduce_mask = ttnn.from_torch(
-            reduce_mask_torch,
-            device=self.device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
-            dtype=ttnn.bfloat8_b,
-            layout=ttnn.TILE_LAYOUT,
-        )
 
         self.compute_kernel = self.model_args.get_compute_kernel_config()
         self.compute_kernel_attn = self.model_args.get_compute_kernel_attn_config()
@@ -300,16 +289,19 @@ class TtMixtralAttention(LightweightModule):
         )
         attn_output_1B4D.deallocate(True)
 
-        # attn_output_11BH = ttnn.experimental.tensor.sharded_to_interleaved(
-        #     attn_output_11BH, output_mem_config=ttnn.L1_MEMORY_CONFIG
-        # )
+        attn_output_11BH = ttnn.experimental.tensor.sharded_to_interleaved(
+            attn_output_11BH, output_mem_config=ttnn.L1_MEMORY_CONFIG
+        )
 
         ###
         # Output matmul
         ###
+        # All gather
+        dense_outputs_11BH_gathered = ttnn.all_gather(attn_output_11BH, dim=3, num_links=1)
 
-        dense_out_11BH = ttnn.experimental.operations.primary.matmul(
-            attn_output_11BH,
+        # return the sum of the outputs
+        dense_outputs_11BH = ttnn.experimental.operations.primary.matmul(
+            dense_outputs_11BH_gathered,
             wo,
             output_mem_config=self.model_config["LM_HEAD_OUTPUT_MEMCFG"],
             # compute_with_storage_grid_size=(8, 8),
@@ -317,10 +309,6 @@ class TtMixtralAttention(LightweightModule):
             compute_kernel_config=self.compute_kernel,
             output_dtype=ttnn.bfloat8_b,
         )
-        attn_output_11BH.deallocate(True)
-        # All gather
-        dense_outputs_11BH = ttnn.all_gather(dense_out_11BH, dim=2, num_links=1)
 
-        # return the sum of the outputs
-        dense_outputs_11BH = ttnn.experimental.operations.primary.matmul(self.reduce_mask, dense_outputs_11BH)
+        dense_outputs_11BH_gathered.deallocate(True)
         return dense_outputs_11BH


### PR DESCRIPTION
Latest perf numbers (1L):


torch_embed_initial: 0.156ms
prepare_inputs_for_inference_0: 217.649ms
python_dispatch_for_inference_0: 0.613ms
model_run_for_inference_0: 22.304ms
result_wait_for_inference_0: 21.697ms
torch_argmax_and_embed_0: 0.359ms
deallocate_tt_tensors_0: 0.082ms
end_to_end_inference: 240.600ms
