### PR TITLE
Support math fidelity option in `ssm_eltwise_mul` and `ssm_1d_sum_reduce` custom ops

### DIFF
--- a/models/demos/mamba/tt/mamba_one_step_ssm.py
+++ b/models/demos/mamba/tt/mamba_one_step_ssm.py
@@ -98,6 +98,7 @@ class TtMambaSSM(torch.nn.Module):
             math_approx_mode=False,
             fp32_dest_acc_en=True,
         )
+        self.eltwise_math_fidelity = ttl.tensor.MathFidelity.HiFi2
         self.core_grid_row = 5
         self.core_grid_col = 8
 
@@ -144,6 +145,7 @@ class TtMambaSSM(torch.nn.Module):
                 ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
             ),
             output_dtype=self.configs["dtype"]["activations"],
+            math_fidelity=self.eltwise_math_fidelity,
         )
         ttnn.deallocate(abar0)
 
@@ -183,6 +185,7 @@ class TtMambaSSM(torch.nn.Module):
                 ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
             ),
             output_dtype=self.configs["dtype"]["activations"],
+            math_fidelity=self.eltwise_math_fidelity,
         )
         ttnn.deallocate(delta_t2)
         ttnn.deallocate(B0)
@@ -195,6 +198,7 @@ class TtMambaSSM(torch.nn.Module):
                 ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
             ),
             output_dtype=self.configs["dtype"]["activations"],
+            math_fidelity=self.eltwise_math_fidelity,
         )
 
         # deallocate bbar
@@ -228,6 +232,7 @@ class TtMambaSSM(torch.nn.Module):
                 ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
             ),
             output_dtype=self.configs["dtype"]["activations"],
+            math_fidelity=self.eltwise_math_fidelity,
         )
         ttnn.deallocate(hidden_state1)
         ttnn.deallocate(C0)

--- a/models/demos/mamba/tt/mamba_one_step_ssm.py
+++ b/models/demos/mamba/tt/mamba_one_step_ssm.py
@@ -244,6 +244,7 @@ class TtMambaSSM(torch.nn.Module):
                 ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1
             ),
             output_dtype=self.configs["dtype"]["activations"],
+            math_fidelity=self.eltwise_math_fidelity,
         )
         ttnn.deallocate(C1)
 

--- a/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_1d_sum_reduce/multi_core_ssm_1d_sum_reduce.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_1d_sum_reduce/multi_core_ssm_1d_sum_reduce.cpp
@@ -16,7 +16,7 @@ namespace primary {
 namespace transformers {
 
 operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(
-    const Tensor& a, Tensor& output, CoreCoord compute_with_storage_grid_size) {
+    const Tensor& a, Tensor& output, MathFidelity math_fidelity, CoreCoord compute_with_storage_grid_size) {
     constexpr uint32_t ONE_TILE = 1;
     constexpr uint32_t TILE_WIDTH = 32;
     constexpr uint32_t LATENT_DIM = TILE_WIDTH;
@@ -119,7 +119,11 @@ operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(
         program,
         "tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_1d_sum_reduce.cpp",
         all_cores,
-        tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = false,
+            .math_approx_mode = false,
+            .compile_args = compute_compile_time_args});
 
     uint32_t g1_numcores = core_group_1.num_cores();
     uint32_t g2_numcores = core_group_2.num_cores();

--- a/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_eltwise_mul/multi_core_ssm_eltwise_mul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_eltwise_mul/multi_core_ssm_eltwise_mul.cpp
@@ -4,9 +4,9 @@
 
 #include "tt_dnn/op_library/transformer_tms/transformer_tms.hpp"
 #include "tt_dnn/op_library/work_split.hpp"
-#include "tt_metal/host_api.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
 
 using namespace tt::constants;
 using namespace tt;
@@ -16,16 +16,21 @@ namespace operations {
 namespace primary {
 namespace transformers {
 
-operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &a, const Tensor &b, Tensor& output, const uint32_t hidden_size, CoreCoord compute_with_storage_grid_size) {
+operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(
+    const Tensor& a,
+    const Tensor& b,
+    Tensor& output,
+    const uint32_t hidden_size,
+    MathFidelity math_fidelity,
+    CoreCoord compute_with_storage_grid_size) {
+    const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
 
-    const auto& ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
+    tt_metal::Device* device = a.device();
 
-    tt_metal::Device *device = a.device();
+    tt_metal::Buffer* src0_buffer = a.buffer();
+    tt_metal::Buffer* src1_buffer = b.buffer();
 
-    tt_metal::Buffer *src0_buffer = a.buffer();
-    tt_metal::Buffer *src1_buffer = b.buffer();
-
-    tt_metal::Buffer *out_buffer = output.buffer();
+    tt_metal::Buffer* out_buffer = output.buffer();
     TT_ASSERT(out_buffer != nullptr, "Output buffer should be allocated on device!");
 
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
@@ -38,7 +43,6 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &a, cons
     uint32_t interm_single_tile_size = tt_metal::detail::TileSize(interm_data_format);
     uint32_t output_single_tile_size = tt_metal::detail::TileSize(output_data_format);
 
-
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -50,56 +54,61 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &a, cons
     // Parallelize on bshape[-1]
     auto num_output_blocks_total = bshape[-1] / TILE_WIDTH;
     const bool row_major = false;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_output_blocks_total, row_major);
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_output_blocks_total, row_major);
 
-   uint32_t g1_numcores = core_group_1.num_cores();
-   uint32_t g2_numcores = core_group_2.num_cores();
-   std::vector<CoreCoord> cores = grid_to_cores(
-       num_cores,
-       compute_with_storage_grid_size.x,
-       compute_with_storage_grid_size.y,
-       row_major
-   );
+    uint32_t g1_numcores = core_group_1.num_cores();
+    uint32_t g2_numcores = core_group_2.num_cores();
+    std::vector<CoreCoord> cores =
+        grid_to_cores(num_cores, compute_with_storage_grid_size.x, compute_with_storage_grid_size.y, row_major);
 
     // Create circular buffers
     uint32_t src0_cb_index = CB::c_in0;
-    uint32_t cb0_tiles = ONE_TILE * 2; // double buffer
-    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(cb0_tiles * in0_single_tile_size, {{src0_cb_index, in0_data_format}})
-		.set_page_size(src0_cb_index, in0_single_tile_size);
+    uint32_t cb0_tiles = ONE_TILE * 2;  // double buffer
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(cb0_tiles * in0_single_tile_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
     uint32_t src1_cb_index = CB::c_in1;
-    uint32_t cb1_tiles = ONE_TILE * 2; // double buffer
-    tt_metal::CircularBufferConfig cb_src1_config = tt_metal::CircularBufferConfig(cb1_tiles * in1_single_tile_size, {{src1_cb_index, in1_data_format}})
-		.set_page_size(src1_cb_index, in1_single_tile_size);
+    uint32_t cb1_tiles = ONE_TILE * 2;  // double buffer
+    tt_metal::CircularBufferConfig cb_src1_config =
+        tt_metal::CircularBufferConfig(cb1_tiles * in1_single_tile_size, {{src1_cb_index, in1_data_format}})
+            .set_page_size(src1_cb_index, in1_single_tile_size);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
 
     uint32_t output_cb_index = 16;
-    uint32_t output_cb_tiles = ONE_TILE * 2; // double buffer
-    tt_metal::CircularBufferConfig cb_output_config = tt_metal::CircularBufferConfig(output_cb_tiles * output_single_tile_size, {{output_cb_index, output_data_format}})
-		.set_page_size(output_cb_index, output_single_tile_size);
+    uint32_t output_cb_tiles = ONE_TILE * 2;  // double buffer
+    tt_metal::CircularBufferConfig cb_output_config =
+        tt_metal::CircularBufferConfig(
+            output_cb_tiles * output_single_tile_size, {{output_cb_index, output_data_format}})
+            .set_page_size(output_cb_index, output_single_tile_size);
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
 
-    uint32_t interm_num_tiles = ONE_TILE * 2; // double buffer
+    uint32_t interm_num_tiles = ONE_TILE * 2;  // double buffer
     uint32_t interm_cb_size = interm_num_tiles * interm_single_tile_size;
-    uint32_t cb_intermed0_index = CB::c_intermed0; // cb_in0_transposed
-    tt_metal::CircularBufferConfig cb_intermed0_config = tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed0_index, interm_data_format}})
-		.set_page_size(cb_intermed0_index, interm_single_tile_size);
+    uint32_t cb_intermed0_index = CB::c_intermed0;  // cb_in0_transposed
+    tt_metal::CircularBufferConfig cb_intermed0_config =
+        tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed0_index, interm_data_format}})
+            .set_page_size(cb_intermed0_index, interm_single_tile_size);
     auto cb_intermed0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
 
-    uint32_t cb_intermed1_index = CB::c_intermed1; // cb_in1_transposed
-    tt_metal::CircularBufferConfig cb_intermed1_config = tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed1_index, interm_data_format}})
-		.set_page_size(cb_intermed1_index, interm_single_tile_size);
+    uint32_t cb_intermed1_index = CB::c_intermed1;  // cb_in1_transposed
+    tt_metal::CircularBufferConfig cb_intermed1_config =
+        tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed1_index, interm_data_format}})
+            .set_page_size(cb_intermed1_index, interm_single_tile_size);
     auto cb_intermed1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
 
-    uint32_t cb_intermed2_index = CB::c_intermed2; // cb_in1_bcast_row
-    tt_metal::CircularBufferConfig cb_intermed2_config = tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed2_index, interm_data_format}})
-		.set_page_size(cb_intermed2_index, interm_single_tile_size);
+    uint32_t cb_intermed2_index = CB::c_intermed2;  // cb_in1_bcast_row
+    tt_metal::CircularBufferConfig cb_intermed2_config =
+        tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed2_index, interm_data_format}})
+            .set_page_size(cb_intermed2_index, interm_single_tile_size);
     auto cb_intermed2 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed2_config);
 
-    uint32_t cb_intermed3_index = CB::c_intermed3; // cb_out_transposed
-    tt_metal::CircularBufferConfig cb_intermed3_config = tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed3_index, interm_data_format}})
-		.set_page_size(cb_intermed3_index, interm_single_tile_size);
+    uint32_t cb_intermed3_index = CB::c_intermed3;  // cb_out_transposed
+    tt_metal::CircularBufferConfig cb_intermed3_config =
+        tt_metal::CircularBufferConfig(interm_cb_size, {{cb_intermed3_index, interm_data_format}})
+            .set_page_size(cb_intermed3_index, interm_single_tile_size);
     auto cb_intermed3 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed3_config);
 
     // Compile time args
@@ -107,31 +116,30 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &a, cons
     bool in1_is_dram = src1_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool out_is_dram = out_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t) src0_cb_index,
-        (std::uint32_t) src1_cb_index,
-        (std::uint32_t) cb_intermed1_index,
-        (std::uint32_t) cb_intermed2_index,
-        (std::uint32_t) in0_is_dram,
-        (std::uint32_t) in1_is_dram,
+        (std::uint32_t)src0_cb_index,
+        (std::uint32_t)src1_cb_index,
+        (std::uint32_t)cb_intermed1_index,
+        (std::uint32_t)cb_intermed2_index,
+        (std::uint32_t)in0_is_dram,
+        (std::uint32_t)in1_is_dram,
     };
     std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t) output_cb_index,
-        (std::uint32_t) out_is_dram,
+        (std::uint32_t)output_cb_index,
+        (std::uint32_t)out_is_dram,
     };
     std::vector<uint32_t> compute_args = {
-        (std::uint32_t) src0_cb_index,
-        (std::uint32_t) src1_cb_index,
-        (std::uint32_t) output_cb_index,
-        (std::uint32_t) cb_intermed0_index,
-        (std::uint32_t) cb_intermed1_index,
-        (std::uint32_t) cb_intermed2_index,
-        (std::uint32_t) cb_intermed3_index,
+        (std::uint32_t)src0_cb_index,
+        (std::uint32_t)src1_cb_index,
+        (std::uint32_t)output_cb_index,
+        (std::uint32_t)cb_intermed0_index,
+        (std::uint32_t)cb_intermed1_index,
+        (std::uint32_t)cb_intermed2_index,
+        (std::uint32_t)cb_intermed3_index,
     };
 
     std::map<string, string> ssm_eltwise_defines;
     if (ashape[-1] == TILE_WIDTH) {
         ssm_eltwise_defines["REPEAT_IN0"] = "1";
-
     }
     if (bshape[-1] == hidden_size) {
         ssm_eltwise_defines["REPEAT_INTERLEAVE_IN1"] = "1";
@@ -154,36 +162,32 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &a, cons
         program,
         "tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_eltwise_mul.cpp",
         all_cores,
-        tt_metal::ComputeConfig{.compile_args = compute_args, .defines = ssm_eltwise_defines}
-    );
+        tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = false,
+            .math_approx_mode = false,
+            .compile_args = compute_args,
+            .defines = ssm_eltwise_defines});
 
     // Update runtime args function
-    auto set_runtime_args = [
-            reader_kernel_id,
-            writer_kernel_id,
-            compute_kernel_id,
-            compute_with_storage_grid_size,
-            all_cores,
+    auto set_runtime_args = [reader_kernel_id,
+                             writer_kernel_id,
+                             compute_kernel_id,
+                             compute_with_storage_grid_size,
+                             all_cores,
 
-            // Args to iterate across cores
-            cores,
-            num_cores,
-            g1_numcores,
-            g2_numcores,
-            num_blocks_per_core_group_1,
-            num_blocks_per_core_group_2,
-            bshape,
-            hidden_size
-        ]
-    (
-        Program& program,
-        const Tensor& a,
-        const Tensor& b,
-        const Tensor& output
-    ) {
-        tt_metal::Buffer *src0_buffer = a.buffer();
-        tt_metal::Buffer *src1_buffer = b.buffer();
-        tt_metal::Buffer *dst_buffer = output.buffer();
+                             // Args to iterate across cores
+                             cores,
+                             num_cores,
+                             g1_numcores,
+                             g2_numcores,
+                             num_blocks_per_core_group_1,
+                             num_blocks_per_core_group_2,
+                             bshape,
+                             hidden_size](Program& program, const Tensor& a, const Tensor& b, const Tensor& output) {
+        tt_metal::Buffer* src0_buffer = a.buffer();
+        tt_metal::Buffer* src1_buffer = b.buffer();
+        tt_metal::Buffer* dst_buffer = output.buffer();
 
         // Default reader runtime args
         std::vector<uint32_t> reader_runtime_args = {
@@ -205,14 +209,14 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &a, cons
             0,
         };
 
-        std::vector<std::vector<uint32_t>> all_reader_runtime_args = { cores.size(), reader_runtime_args };
-        std::vector<std::vector<uint32_t>> all_writer_runtime_args = { cores.size(), writer_runtime_args };
-        std::vector<std::vector<uint32_t>> all_compute_runtime_args = { cores.size(), compute_runtime_args };
+        std::vector<std::vector<uint32_t>> all_reader_runtime_args = {cores.size(), reader_runtime_args};
+        std::vector<std::vector<uint32_t>> all_writer_runtime_args = {cores.size(), writer_runtime_args};
+        std::vector<std::vector<uint32_t>> all_compute_runtime_args = {cores.size(), compute_runtime_args};
 
         // Set runtime args
         uint32_t num_blocks_per_core;
-        for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++){
-            const CoreCoord &core = cores.at(i);
+        for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
+            const CoreCoord& core = cores.at(i);
 
             if (i < g1_numcores) {
                 num_blocks_per_core = num_blocks_per_core_group_1;
@@ -232,8 +236,7 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &a, cons
             if (bshape[-1] == hidden_size) {
                 all_writer_runtime_args[i][1] = num_blocks_per_core * TILE_WIDTH;
                 all_writer_runtime_args[i][2] = num_blocks_written * TILE_WIDTH;
-            }
-            else {
+            } else {
                 all_writer_runtime_args[i][1] = num_blocks_per_core;
                 all_writer_runtime_args[i][2] = num_blocks_written;
             }
@@ -250,16 +253,12 @@ operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &a, cons
 
     set_runtime_args(program, a, b, output);
 
-    auto override_runtime_arguments_callback = [
-            set_runtime_args
-        ]
-    (
-        const void* operation,
-        Program& program,
-        const std::vector<Tensor>& input_tensors,
-        const std::vector<std::optional<const Tensor>>&,
-        const std::vector<Tensor>& output_tensors
-    ) {
+    auto override_runtime_arguments_callback = [set_runtime_args](
+                                                   const void* operation,
+                                                   Program& program,
+                                                   const std::vector<Tensor>& input_tensors,
+                                                   const std::vector<std::optional<const Tensor>>&,
+                                                   const std::vector<Tensor>& output_tensors) {
         const auto& output_tensor = output_tensors.at(0);
 
         set_runtime_args(program, input_tensors.at(0), input_tensors.at(1), output_tensor);

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -655,7 +655,7 @@ operation::ProgramWithCallbacks SSM1DSumReduce::create_program(
     const auto& input_tensor_a = input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
     auto device_compute_with_storage_grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
-    return multi_core_ssm_1d_sum_reduce(input_tensor_a, output_tensor, device_compute_with_storage_grid_size);
+    return multi_core_ssm_1d_sum_reduce(input_tensor_a, output_tensor, math_fidelity, device_compute_with_storage_grid_size);
 }
 
 tt::stl::reflection::Attributes SSM1DSumReduce::attributes() const {

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -592,7 +592,7 @@ operation::ProgramWithCallbacks SSMEltwiseMul::create_program(
     auto device_compute_with_storage_grid_size = input_tensor_a.device()->compute_with_storage_grid_size();
 
     return multi_core_ssm_eltwise_mul(
-        input_tensor_a, input_tensor_b, output_tensor, hidden_size, device_compute_with_storage_grid_size);
+        input_tensor_a, input_tensor_b, output_tensor, hidden_size, this->math_fidelity, device_compute_with_storage_grid_size);
 }
 
 tt::stl::reflection::Attributes SSMEltwiseMul::attributes() const {

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
@@ -26,7 +26,7 @@ operation::ProgramWithCallbacks multi_core_concat_heads(const Tensor &input_tens
 // TODO: Group attention matmul will support sharding, mcasting, and should be faster; we should make attn_matmul (ie. KV heads = 1) a special case of group_attn_matmul and run the same op
 operation::ProgramWithCallbacks multi_core_attn_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, Tensor &output_tensor, std::optional<const uint32_t> num_tokens, std::optional<const bool> transpose_hw, CoreCoord compute_with_storage_grid_size, DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, Tensor &output_tensor, std::optional<const uint32_t> num_tokens, std::optional<const bool> transpose_hw, const uint32_t out_subblock_w, CoreCoord compute_with_storage_grid_size, const bool row_major, DeviceComputeKernelConfig compute_kernel_config);
-operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, Tensor &output_tensor, const uint32_t hidden_size, CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, Tensor &output_tensor, const uint32_t hidden_size, MathFidelity math_fidelity, CoreCoord compute_with_storage_grid_size);
 operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(const Tensor &input_tensor_a, Tensor &output_tensor, CoreCoord compute_with_storage_grid_size);
 
 struct SplitFusedQKVAndSplitHeads {
@@ -173,6 +173,7 @@ inline Tensor group_attn_matmul(const Tensor &input_tensor_a, const Tensor &inpu
 struct SSMEltwiseMul {
     MemoryConfig output_mem_config;
     DataType output_dtype;
+    MathFidelity math_fidelity;
     const uint32_t HIDDEN_SIZE = 5120;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
@@ -182,13 +183,13 @@ struct SSMEltwiseMul {
     tt::stl::reflection::Attributes attributes() const;
 };
 
-inline Tensor ssm_eltwise_mul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt) {
+inline Tensor ssm_eltwise_mul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt, MathFidelity math_fidelity = MathFidelity::HiFi4) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
     operation::launch_op(
-        [mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+        [mem_config, output_dtype, math_fidelity] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor_a = input_tensors.at(0);
 
-            return operation::run(SSMEltwiseMul{mem_config, output_dtype.value_or(input_tensor_a.get_dtype())}, input_tensors);
+            return operation::run(SSMEltwiseMul{mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), math_fidelity}, input_tensors);
         }, {input_tensor_a, input_tensor_b}, output_tensors);
     return output_tensors.at(0);
 }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
@@ -27,7 +27,7 @@ operation::ProgramWithCallbacks multi_core_concat_heads(const Tensor &input_tens
 operation::ProgramWithCallbacks multi_core_attn_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, Tensor &output_tensor, std::optional<const uint32_t> num_tokens, std::optional<const bool> transpose_hw, CoreCoord compute_with_storage_grid_size, DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, Tensor &output_tensor, std::optional<const uint32_t> num_tokens, std::optional<const bool> transpose_hw, const uint32_t out_subblock_w, CoreCoord compute_with_storage_grid_size, const bool row_major, DeviceComputeKernelConfig compute_kernel_config);
 operation::ProgramWithCallbacks multi_core_ssm_eltwise_mul(const Tensor &input_tensor_a, const Tensor &input_tensor_b, Tensor &output_tensor, const uint32_t hidden_size, MathFidelity math_fidelity, CoreCoord compute_with_storage_grid_size);
-operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(const Tensor &input_tensor_a, Tensor &output_tensor, CoreCoord compute_with_storage_grid_size);
+operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(const Tensor &input_tensor_a, Tensor &output_tensor, MathFidelity math_fidelity, CoreCoord compute_with_storage_grid_size);
 
 struct SplitFusedQKVAndSplitHeads {
     CoreCoord compute_with_storage_grid_size;
@@ -197,6 +197,7 @@ inline Tensor ssm_eltwise_mul(const Tensor &input_tensor_a, const Tensor &input_
 struct SSM1DSumReduce {
     MemoryConfig output_mem_config;
     DataType output_dtype;
+    MathFidelity math_fidelity;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
@@ -205,12 +206,12 @@ struct SSM1DSumReduce {
     tt::stl::reflection::Attributes attributes() const;
 };
 
-inline Tensor ssm_1d_sum_reduce(const Tensor &input_tensor_a, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt) {
+inline Tensor ssm_1d_sum_reduce(const Tensor &input_tensor_a, const MemoryConfig& mem_config, std::optional<const DataType> output_dtype=std::nullopt, MathFidelity math_fidelity = MathFidelity::HiFi4) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a}))};
     operation::launch_op(
-        [mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+        [mem_config, output_dtype, math_fidelity] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor_a = input_tensors.at(0);
-            return operation::run(SSM1DSumReduce{mem_config, output_dtype.value_or(input_tensor_a.get_dtype())}, input_tensors);
+            return operation::run(SSM1DSumReduce{mem_config, output_dtype.value_or(input_tensor_a.get_dtype()), math_fidelity}, input_tensors);
         }, {input_tensor_a}, output_tensors);
     return output_tensors.at(0);
 }

--- a/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
@@ -54,7 +54,7 @@ void py_module(py::module& m_transformers) {
             A.repeat(1, 1, 1, W) * B.repeat_interleave(32, dim=-1)
     )doc");
     m_transformers.def("ssm_1d_sum_reduce", &ssm_1d_sum_reduce,
-        py::arg().noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, R"doc(
+        py::arg().noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, py::arg("math_fidelity").noconvert() = MathFidelity::HiFi4, R"doc(
         Performs a custom reduction along dim 3 which is used in the SSM block of the Mamba architecture. Performs the following PyTorch equivalent (where latent_size = 32):
             x = torch.sum(x.reshape(1, 1, shape[2], shape[3] // latent_size, latent_size), dim=-1).reshape(1, 1, shape[2], shape[3] // latent_size)
     )doc");

--- a/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
@@ -49,7 +49,7 @@ void py_module(py::module& m_transformers) {
             torch.matmul(A.transpose(0, 2), B).transpose(0, 2). Similar concept for post-softmax matmul.
     )doc");
     m_transformers.def("ssm_eltwise_mul", &ssm_eltwise_mul,
-        py::arg().noconvert(), py::arg().noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, R"doc(
+        py::arg().noconvert(), py::arg().noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, py::arg("math_fidelity").noconvert() = MathFidelity::HiFi4, R"doc(
         Performs a special eltwise multiply for SSM models. Given tensor A with shape [1, 1, 32, 32] and tensor B with shape [1, 1, 32, W] where W is some multiple of 32, perform the following PyTorch equivalent:
             A.repeat(1, 1, 1, W) * B.repeat_interleave(32, dim=-1)
     )doc");


### PR DESCRIPTION
This PR adds support for passing a math fidelity option to the Mamba custom eltwise ops. Using lower math fidelity across these ops gives us a small speedup without any meaningful PCC reduction.