### PR TITLE
#0: Update Falcon7b CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -142,12 +142,12 @@ functional_*/ @eyonland @arakhmati @cfjchu @xanderchin
 models/demos @eyonland @arakhmati @cfjchu @xanderchin
 models/demos/wormhole @uaydonat @eyonland @AleksKnezevic @nsmithtt
 models/demos/t3000 @uaydonat @AleksKnezevic @nsmithtt
-models/demos/falcon7b @skhorasganiTT @djordje-tt @uaydonat
+models/demos/falcon7b @skhorasganiTT @djordje-tt @uaydonat @pavlejosipovic @pavlepopovic @s-jovic
 models/demos/mamba @esmalTT @uaydonat @kpaigwar
 models/demos/wormhole/falcon7b @skhorasganiTT @djordje-tt @uaydonat @pavlejosipovic @pavlepopovic @s-jovic
 models/demos/wormhole/mistral7b @yieldthought @uaydonat @mtairum
 models/demos/t3000/falcon40b @johanna-rock-tt @uaydonat @s-jovic
-models/demos/t3000/falcon7b @skhorasganiTT @djordje-tt @uaydonat
+models/demos/t3000/falcon7b @skhorasganiTT @djordje-tt @uaydonat @pavlejosipovic @pavlepopovic @s-jovic
 models/demos/t3000/llama2_70b @cglagovichTT @caixunshiren @uaydonat
 models/demos/t3000/llama3_70b @cglagovichTT @caixunshiren @uaydonat
 models/demos/t3000/mixtral8x7b @yieldthought @mtairum @uaydonat


### PR DESCRIPTION
In the last CODEOWNERS changes we mistakenly got ownership just for wormhole demo, no the rest of the Falcon7b code. 

cc @pavlejosipovic @pavlepopovic 