### PR TITLE
#9152: Add Optional output tensor and Q_ID support for Tril

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -92,6 +92,10 @@ op_map = {
         "tt_op": tt_lib_ops.tril,
         "pytorch_op": pytorch_ops.tril,
     },
+    "eltwise-tril-optional": {
+        "tt_op": tt_lib_ops.eltwise_tril_optional,
+        "pytorch_op": pytorch_ops.tril,
+    },
     "eltwise-triu": {
         "tt_op": tt_lib_ops.triu,
         "pytorch_op": pytorch_ops.triu,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_tril.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_tril.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from functools import partial
+import tt_lib as ttl
+import numpy as np
+
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+from models.utility_functions import is_wormhole_b0
+
+shapes = [
+    [[1, 1, 32, 32]],  # Single core
+    [[32, 1, 32, 32]],  # Single core
+    [[64, 1, 32, 32]],  # Single core
+    [[1, 1, 320, 384]],  # Multi core
+    [[1, 3, 320, 384]],  # Multi core
+]
+
+input_mem_cfgs = generation_funcs.supported_mem_configs
+output_mem_cfgs = generation_funcs.supported_mem_configs
+
+if is_wormhole_b0():
+    shapes = [
+        shapes[0],
+    ]
+    input_mem_cfgs = [
+        input_mem_cfgs[0],
+    ]
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    shapes,
+)
+@pytest.mark.parametrize("input_mem_config", input_mem_cfgs)
+@pytest.mark.parametrize("output_mem_config", output_mem_cfgs)
+@pytest.mark.parametrize("fn_kind", ["tril"])
+def test_run_tril(
+    input_shapes,
+    fn_kind,
+    input_mem_config,
+    output_mem_config,
+    device,
+    function_level_defaults,
+):
+    datagen_func = [
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+    ] * len(input_shapes)
+    test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+    test_args.update(
+        {
+            "input_mem_config": [input_mem_config],
+            "output_mem_config": output_mem_config,
+            "diag": np.random.randint(1, 100),
+        }
+    )
+    comparison_func = comparison_funcs.comp_pcc
+    run_single_pytorch_test(
+        f"eltwise-{fn_kind}",
+        input_shapes,
+        datagen_func,
+        comparison_func,
+        device,
+        test_args,
+    )
+
+
+shapes_w_output = [
+    [[1, 1, 32, 32], [1, 1, 32, 32]],  # Single core
+    [[32, 1, 32, 32], [32, 1, 32, 32]],  # Single core
+    [[64, 1, 32, 32], [64, 1, 32, 32]],  # Single core
+    [[1, 1, 320, 384], [1, 1, 320, 384]],  # Multi core
+    [[1, 3, 320, 384], [1, 3, 320, 384]],  # Multi core
+]
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    shapes_w_output,
+)
+@pytest.mark.parametrize("input_mem_config", input_mem_cfgs)
+@pytest.mark.parametrize("fn_kind", ["tril"])
+@pytest.mark.parametrize("pass_qid", [True, False])
+def test_run_tril_optional_output(
+    input_shapes,
+    fn_kind,
+    input_mem_config,
+    device,
+    pass_qid,
+    function_level_defaults,
+):
+    datagen_func = [
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.float32)
+    ] * len(input_shapes)
+    datagen_func.append(
+        generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-80, high=80), torch.bfloat16)
+    )
+    test_args = list(generation_funcs.gen_default_dtype_layout_device(input_shapes))[0]
+    test_args.update(
+        {
+            "input_mem_config": [input_mem_config, input_mem_config],
+            "diag": np.random.randint(1, 100),
+            "queue_id": pass_qid,
+        }
+    )
+    comparison_func = comparison_funcs.comp_pcc
+    run_single_pytorch_test(
+        f"eltwise-{fn_kind}-optional",
+        input_shapes,
+        datagen_func,
+        comparison_func,
+        device,
+        test_args,
+    )

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1076,6 +1076,50 @@ def eltwise_div(
 
 
 @setup_host_and_device
+def eltwise_tril(
+    x,
+    y,
+    *args,
+    diag,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.tril(t0, diag, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
+def eltwise_tril_optional(
+    x,
+    y,
+    *args,
+    diag,
+    device,
+    dtype,
+    layout,
+    queue_id,
+    input_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    cq_id = 0
+
+    if queue_id:
+        ttl.tensor.tril(t0, diag, output_tensor=t1, queue_id=cq_id)
+    else:
+        ttl.tensor.tril(t0, diag, output_tensor=t1)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
 def eltwise_floor_div(
     x,
     y,

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tril.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tril.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("diag", [0, 2])
+def test_bw_tril(input_shapes, diag, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
+    tt_output_tensor_on_device = tt_lib.tensor.tril_bw(grad_tensor, input_tensor, diag)
+
+    in_data.retain_grad()
+
+    pyt_y = torch.tril(in_data, diagonal=diag)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("diag", [0, 2])
+@pytest.mark.parametrize("are_required_outputs", [[True], [False]])
+def test_bw_tril_with_opt_output(input_shapes, diag, device, are_required_outputs):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -70, 90, device)
+    input_grad = None
+
+    if are_required_outputs[0]:
+        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+
+    tt_output_tensor_on_device = tt_lib.tensor.tril_bw(
+        grad_tensor,
+        input_tensor,
+        diag,
+        are_required_outputs=are_required_outputs,
+        input_grad=input_grad,
+        queue_id=cq_id,
+    )
+
+    in_data.retain_grad()
+
+    pyt_y = torch.tril(in_data, diag)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = True
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]])
+    assert status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -111,6 +111,50 @@ std::vector<std::optional<Tensor>> add_bw(
         queue_id, grad, input, other, 1, output_mem_config, are_required_outputs, input_grad, other_grad);
 }
 
+std::vector<std::optional<Tensor>> _tril_bw(
+    uint8_t queue_id,
+    const Tensor& grad,
+    const Tensor& input,
+    int32_t diag,
+    const MemoryConfig& output_mem_config,
+    const std::vector<bool>& are_required_outputs,
+    std::optional<Tensor> input_grad) {
+    std::vector<std::optional<Tensor>> result;
+
+    if (are_required_outputs.at(0)) {
+        if(input_grad.has_value()){
+            tril(queue_id, grad, diag, output_mem_config, input_grad);
+        } else {
+            input_grad = tril(queue_id, grad, diag, output_mem_config);
+        }
+        result.emplace_back(input_grad);
+    } else {
+        result.emplace_back(std::nullopt);
+    }
+
+    return std::move(result);
+}
+std::vector<std::optional<Tensor>> tril_bw(
+    uint8_t queue_id,
+    const Tensor& grad,
+    const Tensor& input,
+    int32_t diag,
+    const MemoryConfig& output_mem_config,
+    const std::vector<bool>& are_required_outputs,
+    std::optional<Tensor> input_grad) {
+    return operation::decorate_as_composite(__func__, _tril_bw)(queue_id, grad, input, diag, output_mem_config,  are_required_outputs, input_grad);
+}
+std::vector<std::optional<Tensor>> tril_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    int32_t diag,
+    const MemoryConfig& output_mem_config,
+    const std::vector<bool>& are_required_outputs,
+    std::optional<Tensor> input_grad) {
+    uint8_t default_queue_id = 0;
+    return operation::decorate_as_composite(__func__, _tril_bw)(default_queue_id, grad, input, diag, output_mem_config,  are_required_outputs, input_grad);
+}
+
 std::vector<Tensor> _unary_mul_bw(
     const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -44,6 +44,23 @@ std::vector<Tensor> addcmul_bw(
     float value,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<std::optional<Tensor>> tril_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    int32_t diag,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> tril_bw(
+    uint8_t queue_id,
+    const Tensor& grad,
+    const Tensor& input,
+    int32_t diag,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
+
 std::vector<Tensor> unary_mul_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -603,7 +603,16 @@ Tensor sfpu_eps(const Shape shape, Layout layout, Device* device, const MemoryCo
 Tensor tril(
     const Tensor& input_a,
     int32_t diag = 0,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+
+// tril : select lower triangular region of input matrix
+Tensor tril(
+    uint8_t queue_id,
+    const Tensor& input_a,
+    int32_t diag = 0,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 
 // triu : select upper triangular region of input matrix
 Tensor triu(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -83,6 +83,42 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+    m_tensor.def("tril_bw",
+            [](const Tensor& grad,
+                const Tensor& input,
+                const float diag,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                uint8_t queue_id) {
+                    return tril_bw(queue_id, grad, input, diag, output_mem_config, are_required_outputs, input_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input").noconvert(),
+            py::arg("diag") = 0,
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true},
+            py::arg("input_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Performs backward operations for multiplication with given ``grad`` and ``scalar``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor tril_bw is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "diag", "diagonal to be chosen", "int32_t", "+dim (default to 0)", "No"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "are_required_outputs", "Boolean values for the required outputs: input_a_grad, input_b_grad ", "List of bool", "Default value is [True, True]", "No"
+                "input_grad", "Optional Output Tensor for input_grad", "Tensor", "Default value is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
+            )doc");
+
     m_tensor.def("unary_mul_bw", &tt::tt_metal::unary_mul_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for multiplication with given ``grad`` and ``scalar``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -809,24 +809,34 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
 
     m_tensor.def(
         "tril",
-        &tril,
-        py::arg("input"),
+        [](const Tensor& input_a,
+           const float diag,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return tril(queue_id, input_a, diag, output_mem_config, output_tensor);
+        },
+        py::arg("input_a").noconvert(),
         py::arg("diag") = 0,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        py::arg("queue_id").noconvert() = 0,
         R"doc(
-            Returns a new tensor with lower triangular elements of input with rest being zero.
+            Scaled by ``diag``, from ``input_a``.
 
-            Input tensor will have BFLOAT16 data type.
+            Input tensor must have BFLOAT16 data type.
 
             Output tensor will have BFLOAT16 data type.
 
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+                .. csv-table::
+                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
-                "input", "tensor input to be lower triangular processed", "Tensor", "", "Yes"
-                "diag", "diagonal to be chosen", "int32_t", "-dim to +dim (default to 0)", "No"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
+                    "input", "tensor input to be lower triangular processed", "Tensor", "", "Yes"
+                    "diag", "diagonal to be chosen", "int32_t", "+dim (default to 0)", "No"
+                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                    "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                    "queue_id", "Command queue id", "integer", "default to 0", "No"
+            )doc");
 
     m_tensor.def(
         "zeros",


### PR DESCRIPTION
Added the Optional output tensor and Q_ID support for Tril.

Only mul has cq_id, since index is considered as an numpy function