### PR TITLE
Applying Llama2 Decode and Prefill Kernels to experimentals folder

### DIFF
--- a/models/experimental/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_attention_optimized.py
@@ -678,7 +678,7 @@ class TtLlamaAttention_optimized:
             memory_config=self.model_config["DRAM_MEMCFG"],
         )
 
-        dense_out_prog_cfg = self.model_config["SELFOUT_MM_PROGCFG_LAMBDA"]
+        dense_out_prog_cfg = self.model_config["SELFOUT_MM_PROGCFG"]
         # print('wo matmul')
         attn_output = tt_lib.operations.primary.matmul(
             attn_output,

--- a/models/experimental/llama2_70b/tt/llama_model_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_model_optimized.py
@@ -60,7 +60,7 @@ class TtLlamaModel_optimized:
 
         self.cache_path = cache_path
         # Transformation matrix for rotary embeddings
-        transformation_mat_torch = get_rot_transformation_mat(self.head_dim)
+        transformation_mat_torch = get_rot_transformation_mat(32)  # 32 for tile size
         transformation_mats = ttnn.as_tensor(
             transformation_mat_torch,
             dtype=ttnn.bfloat16,

--- a/models/experimental/llama2_70b/tt/llama_model_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_model_optimized.py
@@ -249,10 +249,6 @@ class TtLlamaModel_optimized:
                 self.device_mesh,
             )
             attn_masks = ttnn.to_device(attn_masks, self.device_mesh)
-            repeat_shape = (1, self.n_local_heads, 1, 1)
-            attn_masks = tt_lib.tensor.repeat(
-                attn_masks, repeat_shape, output_mem_config=self.model_config["DRAM_MEMCFG"]
-            )
 
         elif self.model_config["LLM_MODE"] == "decode":
             assert seq_len == 1, "Decode mode only supports seq_len=1"

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -106,6 +106,9 @@ run_t3000_tests() {
   # Run tteager tests
   #run_t3000_tteager_tests
 
+  # Run llama2-70b experimental tests
+  run_t3000_llama2_70b_experimental_tests
+
   # Run falcon40b tests
   run_t3000_falcon40b_tests
 

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -39,6 +39,20 @@ run_t3000_llama2_70b_tests() {
   echo "LOG_METAL: run_t3000_llama2_70b_tests $duration seconds to complete"
 }
 
+run_t3000_llama2_70b_experimental_tests() {
+  # Record the start time
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_t3000_llama2_70b_experimental_tests"
+
+  pytest models/experimental/llama2_70b/tests/test_llama_model_t3000.py
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_llama2_70b_experimental_tests $duration seconds to complete"
+}
+
 run_t3000_mixtral_tests() {
   # Record the start time
   start_time=$(date +%s)

--- a/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.cpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.cpp
@@ -3,20 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_eager/tt_dnn/op_library/sdpa/sdpa_op.hpp"
-#include "tt_metal/common/assert.hpp"
-#include "common/base_types.hpp"
-#include "tensor/types.hpp"
-#include "tt_eager/tt_dnn/op_library/math.hpp"
-#include "tt_eager/tt_dnn/op_library/work_split.hpp"
-#include "tt_dnn/op_library/run_operation.hpp"
-
-#include "tt_metal/host_api.hpp"
-#include "tt_metal/common/constants.hpp"
-#include "tt_metal/common/math.hpp"
-#include "tt_metal/detail/util.hpp"
 
 #include <optional>
 #include <type_traits>
+
+#include "common/base_types.hpp"
+#include "tensor/types.hpp"
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_eager/tt_dnn/op_library/math.hpp"
+#include "tt_eager/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/common/math.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
 
 using uint32_t = std::uint32_t;
 using namespace tt::constants;
@@ -26,20 +26,23 @@ namespace tt {
 namespace operations {
 namespace primary {
 
-void ScaledDotProductAttention::validate(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
+void ScaledDotProductAttention::validate(
+    const std::vector<Tensor>& input_tensors,
+    const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
     TT_FATAL(input_tensors.size() == 3 and optional_input_tensors.size() == 1, "Must have 3 input tensors and mask");
 
     TT_FATAL(this->is_causal);
     for (auto& input_tensor : input_tensors) {
         TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to softmax need to be on device!");
-        TT_FATAL(input_tensor.buffer() != nullptr , "Operands to softmax need to be allocated in buffers on device!");
+        TT_FATAL(input_tensor.buffer() != nullptr, "Operands to softmax need to be allocated in buffers on device!");
         TT_FATAL((input_tensor.get_layout() == Layout::TILE), "Inputs to softmax must be tilized");
-        TT_FATAL(input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B);
+        TT_FATAL(
+            input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 ||
+            input_tensor.get_dtype() == DataType::BFLOAT8_B);
         TT_FATAL(input_tensor.is_sharded() == false);
 
         TT_FATAL(input_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM);
     }
-
 
     auto mask = optional_input_tensors.at(0).value();
     TT_FATAL(mask.storage_type() == StorageType::DEVICE, "Operands to softmax need to be on device!");
@@ -57,7 +60,10 @@ void ScaledDotProductAttention::validate(const std::vector<Tensor> &input_tensor
     const auto mask_shape = mask.get_legacy_shape();
 
     // assert all dataformats are the same
-    TT_FATAL(input_tensors.at(0).get_dtype() == input_tensors.at(1).get_dtype() && input_tensors.at(0).get_dtype() == input_tensors.at(2).get_dtype() && input_tensors.at(0).get_dtype() == mask.get_dtype());
+    TT_FATAL(
+        input_tensors.at(0).get_dtype() == input_tensors.at(1).get_dtype() &&
+        input_tensors.at(0).get_dtype() == input_tensors.at(2).get_dtype() &&
+        input_tensors.at(0).get_dtype() == mask.get_dtype());
 
     // Check sequence lengths
     TT_FATAL(q_shape[-2] == k_shape[-2] && q_shape[-2] == v_shape[-2]);
@@ -81,9 +87,9 @@ void ScaledDotProductAttention::validate(const std::vector<Tensor> &input_tensor
     std::visit(
         [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (
-                std::is_same_v<ProgramConfigType, tt::operations::primary::transformers::SDPAMultiCoreProgramConfig>
-            ) {
+            if constexpr (std::is_same_v<
+                              ProgramConfigType,
+                              tt::operations::primary::transformers::SDPAMultiCoreProgramConfig>) {
                 auto q_chunk_size = program_config.q_chunk_size;
                 auto k_chunk_size = program_config.k_chunk_size;
 
@@ -95,28 +101,26 @@ void ScaledDotProductAttention::validate(const std::vector<Tensor> &input_tensor
 
                 // Ensure that batch * num_heads divides the number of cores
                 // auto b_nh = q_shape[-4] * q_shape[-3];
-                // auto num_cores = program_config.compute_with_storage_grid_size.x * program_config.compute_with_storage_grid_size.y;
-                // TT_FATAL((num_cores / b_nh) * b_nh == num_cores);
-
+                // auto num_cores = program_config.compute_with_storage_grid_size.x *
+                // program_config.compute_with_storage_grid_size.y; TT_FATAL((num_cores / b_nh) * b_nh == num_cores);
             }
         },
-        this->program_config
-    );
+        this->program_config);
 }
 
-std::vector<Shape> ScaledDotProductAttention::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+std::vector<Shape> ScaledDotProductAttention::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
     return {input_tensors.at(0).get_legacy_shape()};
 }
 
-std::vector<Tensor> ScaledDotProductAttention::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
-    return operation::generic_create_output_tensors(*this, input_tensors, input_tensors.at(0).get_dtype(), Layout::TILE, this->output_mem_config);
+std::vector<Tensor> ScaledDotProductAttention::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, input_tensors.at(0).get_dtype(), Layout::TILE, this->output_mem_config);
 }
 
 operation::ProgramWithCallbacks ScaledDotProductAttention::create_program(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-    std::vector<Tensor> &output_tensors
-) const {
+    std::vector<Tensor>& output_tensors) const {
     auto& input_tensor_q = input_tensors.at(0);
     auto& input_tensor_k = input_tensors.at(1);
     auto& input_tensor_v = input_tensors.at(2);
@@ -135,19 +139,29 @@ operation::ProgramWithCallbacks ScaledDotProductAttention::create_program(
     std::visit(
         [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            if constexpr (
-                std::is_same_v<ProgramConfigType, tt::operations::primary::transformers::SDPAMultiCoreProgramConfig>
-            ) {
+            if constexpr (std::is_same_v<
+                              ProgramConfigType,
+                              tt::operations::primary::transformers::SDPAMultiCoreProgramConfig>) {
                 q_chunk_size = program_config.q_chunk_size;
                 k_chunk_size = program_config.k_chunk_size;
             } else {
                 q_chunk_size = k_chunk_size = 256;
             }
         },
-        this->program_config
-    );
+        this->program_config);
 
-    return sdpa_multi_core(input_tensor_q, input_tensor_k, input_tensor_v, output_tensor, attn_mask, scale, this->is_causal, q_chunk_size, k_chunk_size, this->compute_kernel_config, this->program_config);
+    return sdpa_multi_core(
+        input_tensor_q,
+        input_tensor_k,
+        input_tensor_v,
+        output_tensor,
+        attn_mask,
+        scale,
+        this->is_causal,
+        q_chunk_size,
+        k_chunk_size,
+        this->compute_kernel_config,
+        this->program_config);
 }
 
 // What is this?
@@ -158,21 +172,53 @@ tt::stl::reflection::Attributes ScaledDotProductAttention::attributes() const {
         {"output_mem_config", this->output_mem_config},
         {"program_config", this->program_config},
         {"is_causal", this->is_causal},
-        {"compute_kernel_config", this->compute_kernel_config}
-    };
+        {"compute_kernel_config", this->compute_kernel_config}};
 }
-
 
 namespace transformers {
 // Function which is bound to the Python API
-Tensor scaled_dot_product_attention(Tensor& input_tensor_q, Tensor& input_tensor_k, Tensor& input_tensor_v, std::optional<const Tensor> causal_mask, const bool is_causal, std::optional<float> scale, const MemoryConfig& output_mem_config, const SDPAProgramConfig& program_config, std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    // make sure output is dram
-    TT_FATAL(output_mem_config.buffer_type == tt_metal::BufferType::DRAM);
-
-    auto kernel_config_val = init_device_compute_kernel_config(input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
-    return operation::run(ScaledDotProductAttention{.scale=scale, .output_mem_config=output_mem_config, .program_config=program_config, .is_causal=is_causal, .compute_kernel_config=kernel_config_val}, {input_tensor_q, input_tensor_k, input_tensor_v}, {causal_mask}).at(0);
+Tensor scaled_dot_product_attention(
+    Tensor& input_tensor_q,
+    Tensor& input_tensor_k,
+    Tensor& input_tensor_v,
+    std::optional<const Tensor> causal_mask,
+    const bool is_causal,
+    std::optional<float> scale,
+    const MemoryConfig& output_mem_config,
+    const SDPAProgramConfig& program_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    std::vector<Tensor> output_tensors = {
+        Tensor(operation::get_workers_for_op_output({input_tensor_q, input_tensor_k, input_tensor_v}))};
+    operation::launch_op(
+        [scale, output_mem_config, program_config, is_causal, compute_kernel_config](
+            std::vector<Tensor> input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            // make sure output is dram
+            TT_FATAL(output_mem_config.buffer_type == tt_metal::BufferType::DRAM);
+            const auto& input_tensor_q = input_tensors.at(0);
+            const auto& input_tensor_k = input_tensors.at(1);
+            const auto& input_tensor_v = input_tensors.at(2);
+            const auto& causal_mask = optional_input_tensors.at(0);
+            auto arch = input_tensor_q.storage_type() == StorageType::DEVICE ? input_tensor_q.device()->arch()
+                                                                             : AutoFormat::GetDefaultDevice()->arch();
+            auto kernel_config_val = init_device_compute_kernel_config(
+                input_tensor_q.device()->arch(), compute_kernel_config, MathFidelity::HiFi2, true, false, false);
+            return operation::run(
+                ScaledDotProductAttention{
+                    .scale = scale,
+                    .output_mem_config = output_mem_config,
+                    .program_config = program_config,
+                    .is_causal = is_causal,
+                    .compute_kernel_config = kernel_config_val},
+                {input_tensor_q, input_tensor_k, input_tensor_v},
+                {causal_mask});
+        },
+        {input_tensor_q, input_tensor_k, input_tensor_v},
+        output_tensors,
+        {causal_mask});
+    return output_tensors.at(0);
 }
-
 
 }  // namespace transformers
 }  // namespace primary


### PR DESCRIPTION
- [x]  Added experimental model test to CI
- [x] appiled kv_cache_load_slice kernel to llama decode
- [x]  appiled sdpa kernel to llama prefill and added lanuch op to support async
- [x]  changed matmul grid size to 8x7 and out_subblock_w to be 1 to avoid di/dt hang on specific devices
- [x]  Integrated ROPE to llama prefill
- [x]  Llama prefill device time improved ~ 23%