### PR TITLE
#9200: Use project paths in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
     message(WARNING "Clang++-17 not found!!!")
 endif()
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
     message(FATAL_ERROR "CMake generation is not allowed within source directory!! Please set a build folder with '-B'!!")
 endif()
 
@@ -26,13 +26,13 @@ project(tt-metal
         LANGUAGES CXX
 )
 
-include(${CMAKE_SOURCE_DIR}/cmake/macros.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/macros.cmake)
 CHECK_COMPILERS()
 
 ############################################################################################################################
 # Find all required libraries to build
 ############################################################################################################################
-include(${CMAKE_SOURCE_DIR}/cmake/CPM_boost.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/CPM_boost.cmake)
 find_package(GTest REQUIRED)
 find_package (Python3 COMPONENTS Interpreter Development)
 find_library(NUMA_LIBRARY NAMES numa)
@@ -63,7 +63,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Set default values for variables/options
-set(UMD_HOME "${CMAKE_SOURCE_DIR}/tt_metal/third_party/umd")
+set(UMD_HOME "${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd")
 
 option(ENABLE_CODE_TIMERS "Enable code timers" OFF)
 option(TT_METAL_VERSIM_DISABLED "Disable TT_METAL_VERSIM" ON)
@@ -77,11 +77,11 @@ endif()
 message(STATUS "Build shared libs: ${BUILD_SHARED_LIBS}")
 
 include(GNUInstallDirs)
-set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}")
-set(CMAKE_INSTALL_LIBDIR "${CMAKE_BINARY_DIR}/lib")
-set(CMAKE_INSTALL_BINDIR "${CMAKE_BINARY_DIR}/tmp/bin")
-set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_BINARY_DIR}/tmp/include")
-set(CMAKE_INSTALL_DATAROOTDIR "${CMAKE_BINARY_DIR}/tmp/share")
+set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}")
+set(CMAKE_INSTALL_LIBDIR "${PROJECT_BINARY_DIR}/lib")
+set(CMAKE_INSTALL_BINDIR "${PROJECT_BINARY_DIR}/tmp/bin")
+set(CMAKE_INSTALL_INCLUDEDIR "${PROJECT_BINARY_DIR}/tmp/include")
+set(CMAKE_INSTALL_DATAROOTDIR "${PROJECT_BINARY_DIR}/tmp/share")
 
 ############################################################################################################################
 # Constructing interface libs for common compiler flags, header directories, and libraries
@@ -122,7 +122,7 @@ if($ENV{ENABLE_TRACY})
 endif()
 
 add_library(metal_header_directories INTERFACE)
-target_include_directories(metal_header_directories INTERFACE ${CMAKE_SOURCE_DIR}/tt_metal/hw/inc)
+target_include_directories(metal_header_directories INTERFACE ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc)
 foreach(lib ${BoostPackages})
     target_include_directories(metal_header_directories INTERFACE ${Boost${lib}_SOURCE_DIR}/include)
 endforeach()
@@ -144,27 +144,27 @@ endif()
 # Can't use the `REUSE_FROM` option bc tt_lib and ttnn have different build flags :(
 add_library(pch_pybinds INTERFACE)
 target_precompile_headers(pch_pybinds INTERFACE
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/operators.h
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/pybind11.h
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/stl.h
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/operators.h
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/pybind11.h
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/stl.h
 )
 
 ############################################################################################################################
 # Build subdirectories
 ############################################################################################################################
 if($ENV{ENABLE_TRACY})
-    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/tracy.cmake)
+    include(${PROJECT_SOURCE_DIR}/cmake/tracy.cmake)
 endif()
 
 # Build umd_device
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/umd_device.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/umd_device.cmake)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/hw)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn)
+add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal/hw)
+add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal)
+add_subdirectory(${PROJECT_SOURCE_DIR}/tt_eager)
+add_subdirectory(${PROJECT_SOURCE_DIR}/ttnn)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests EXCLUDE_FROM_ALL)
+add_subdirectory(${PROJECT_SOURCE_DIR}/tests EXCLUDE_FROM_ALL)
 
 ############################################################################################################################
 # Install targets for build artifacts and pybinds
@@ -197,22 +197,22 @@ install(TARGETS ttnn
 )
 
 # Install .so into src files for pybinds implementation
-install(FILES ${CMAKE_BINARY_DIR}/lib/_ttnn.so
-    DESTINATION ${CMAKE_SOURCE_DIR}/ttnn/ttnn
+install(FILES ${PROJECT_BINARY_DIR}/lib/_ttnn.so
+    DESTINATION ${PROJECT_SOURCE_DIR}/ttnn/ttnn
     COMPONENT tt_pybinds
 )
-install(FILES ${CMAKE_BINARY_DIR}/lib/_C.so
-    DESTINATION ${CMAKE_SOURCE_DIR}/tt_eager/tt_lib
+install(FILES ${PROJECT_BINARY_DIR}/lib/_C.so
+    DESTINATION ${PROJECT_SOURCE_DIR}/tt_eager/tt_lib
     COMPONENT tt_pybinds
 )
 
 # Temporary workaround for Issue #8767
-install(DIRECTORY ${CMAKE_BINARY_DIR}/hw/toolchain
-    DESTINATION ${CMAKE_SOURCE_DIR}/runtime/hw
+install(DIRECTORY ${PROJECT_BINARY_DIR}/hw/toolchain
+    DESTINATION ${PROJECT_SOURCE_DIR}/runtime/hw
 )
 
 # Custom clean target for `built` folder for when new kernel changes are pulled
 add_custom_target(clean-built
-   COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_SOURCE_DIR}/built
+   COMMAND ${CMAKE_COMMAND} -E remove_directory ${PROJECT_SOURCE_DIR}/built
    COMMENT "Cleaning `built` directory"
 )

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -11,7 +11,7 @@ if(CPM_SOURCE_CACHE)
 elseif(DEFINED ENV{CPM_SOURCE_CACHE})
   set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 else()
-  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION "${PROJECT_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 endif()
 
 # Expand relative path. This is important if the provided path contains a tilde (~)

--- a/cmake/CPM_boost.cmake
+++ b/cmake/CPM_boost.cmake
@@ -1,7 +1,7 @@
 
-set(ENV{CPM_SOURCE_CACHE} "${CMAKE_SOURCE_DIR}/.cpmcache")
+set(ENV{CPM_SOURCE_CACHE} "${PROJECT_SOURCE_DIR}/.cpmcache")
 
-include(${CMAKE_SOURCE_DIR}/cmake/CPM.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/CPM.cmake)
 set(BoostPackages
     Align
     Config

--- a/cmake/helper_functions.cmake
+++ b/cmake/helper_functions.cmake
@@ -16,14 +16,14 @@ function(CREATE_EAGER_TEST_EXE TESTLIST)
         target_link_libraries(${TEST_TARGET} PUBLIC test_eager_common_libs)
         target_include_directories(${TEST_TARGET} PRIVATE
             ${UMD_HOME}
-            ${CMAKE_SOURCE_DIR}
-            ${CMAKE_SOURCE_DIR}/tt_metal
-            ${CMAKE_SOURCE_DIR}/ttnn/cpp
-            ${CMAKE_SOURCE_DIR}/tt_metal/common
-            ${CMAKE_SOURCE_DIR}/tests
+            ${PROJECT_SOURCE_DIR}
+            ${PROJECT_SOURCE_DIR}/tt_metal
+            ${PROJECT_SOURCE_DIR}/ttnn/cpp
+            ${PROJECT_SOURCE_DIR}/tt_metal/common
+            ${PROJECT_SOURCE_DIR}/tests
             ${CMAKE_CURRENT_SOURCE_DIR}
         )
-        set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/tt_eager/${TEST_DIR})
+        set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/tt_eager/${TEST_DIR})
         list(APPEND EAGER_TEST_TARGETS ${TEST_TARGET})
     endforeach()
     set(EAGER_TEST_TARGETS "${EAGER_TEST_TARGETS}" PARENT_SCOPE)
@@ -37,12 +37,12 @@ function(CREATE_PGM_EXAMPLES_EXE TESTLIST SUBDIR)
         target_link_libraries(${TEST_TARGET} PUBLIC tt_metal stdc++fs yaml-cpp m pthread)
         target_include_directories(${TEST_TARGET} PRIVATE
             ${UMD_HOME}
-            ${CMAKE_SOURCE_DIR}
-            ${CMAKE_SOURCE_DIR}/tt_metal
-            ${CMAKE_SOURCE_DIR}/tt_metal/common
+            ${PROJECT_SOURCE_DIR}
+            ${PROJECT_SOURCE_DIR}/tt_metal
+            ${PROJECT_SOURCE_DIR}/tt_metal/common
             ${CMAKE_CURRENT_SOURCE_DIR}
         )
-        set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/programming_examples/${SUBDIR})
+        set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/programming_examples/${SUBDIR})
         list(APPEND PROGRAMMING_EXAMPLES_TEST_TARGETS ${TEST_TARGET})
     endforeach()
     set(PROGRAMMING_EXAMPLES_TEST_TARGETS "${PROGRAMMING_EXAMPLES_TEST_TARGETS}" PARENT_SCOPE)

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -1,13 +1,13 @@
 
 # Built as outlined in Tracy documentation (pg.12)
-set(TRACY_HOME ${CMAKE_SOURCE_DIR}/tt_metal/third_party/tracy)
+set(TRACY_HOME ${PROJECT_SOURCE_DIR}/tt_metal/third_party/tracy)
 
 add_subdirectory(${TRACY_HOME})
 set_target_properties(TracyClient PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 set_target_properties(TracyClient PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
+    ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     POSITION_INDEPENDENT_CODE ON    # this is equivalent to adding -fPIC
     OUTPUT_NAME "tracy"
 )
@@ -19,10 +19,10 @@ ExternalProject_Add(
     tracy_csv_tools
     PREFIX ${TRACY_HOME}/csvexport/build/unix
     SOURCE_DIR ${TRACY_HOME}/csvexport/build/unix
-    BINARY_DIR ${CMAKE_BINARY_DIR}/tools/profiler/bin
-    INSTALL_DIR ${CMAKE_BINARY_DIR}/tools/profiler/bin
-    STAMP_DIR "${CMAKE_BINARY_DIR}/tmp/tracy_stamp"
-    TMP_DIR "${CMAKE_BINARY_DIR}/tmp/tracy_tmp"
+    BINARY_DIR ${PROJECT_BINARY_DIR}/tools/profiler/bin
+    INSTALL_DIR ${PROJECT_BINARY_DIR}/tools/profiler/bin
+    STAMP_DIR "${PROJECT_BINARY_DIR}/tmp/tracy_stamp"
+    TMP_DIR "${PROJECT_BINARY_DIR}/tmp/tracy_tmp"
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     INSTALL_COMMAND
@@ -34,10 +34,10 @@ ExternalProject_Add(
     tracy_capture_tools
     PREFIX ${TRACY_HOME}/capture/build/unix
     SOURCE_DIR ${TRACY_HOME}/capture/build/unix
-    BINARY_DIR ${CMAKE_BINARY_DIR}/tools/profiler/bin
-    INSTALL_DIR ${CMAKE_BINARY_DIR}/tools/profiler/bin
-    STAMP_DIR "${CMAKE_BINARY_DIR}/tmp/tracy_stamp"
-    TMP_DIR "${CMAKE_BINARY_DIR}/tmp/tracy_tmp"
+    BINARY_DIR ${PROJECT_BINARY_DIR}/tools/profiler/bin
+    INSTALL_DIR ${PROJECT_BINARY_DIR}/tools/profiler/bin
+    STAMP_DIR "${PROJECT_BINARY_DIR}/tmp/tracy_stamp"
+    TMP_DIR "${PROJECT_BINARY_DIR}/tmp/tracy_tmp"
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     INSTALL_COMMAND

--- a/cmake/umd_device.cmake
+++ b/cmake/umd_device.cmake
@@ -22,7 +22,7 @@ if($ENV{ENABLE_TRACY})
 endif()
 
 # MUST have the RPATH set, or else can't find the tracy lib
-set(LDFLAGS_ "-L${CMAKE_BINARY_DIR}/lib -Wl,-rpath,${CMAKE_BINARY_DIR}/lib ${CONFIG_LDFLAGS} -ldl -lz -lpthread -latomic -lhwloc -lstdc++")
+set(LDFLAGS_ "-L${PROJECT_BINARY_DIR}/lib -Wl,-rpath,${PROJECT_BINARY_DIR}/lib ${CONFIG_LDFLAGS} -ldl -lz -lpthread -latomic -lhwloc -lstdc++")
 set(SHARED_LIB_FLAGS_ "-shared -fPIC")
 set(STATIC_LIB_FLAGS_ "-fPIC")
 
@@ -44,18 +44,18 @@ ExternalProject_Add(
     umd_device
     PREFIX ${UMD_HOME}
     SOURCE_DIR ${UMD_HOME}
-    BINARY_DIR ${CMAKE_BINARY_DIR}
-    INSTALL_DIR ${CMAKE_BINARY_DIR}
-    STAMP_DIR "${CMAKE_BINARY_DIR}/tmp/umd_stamp"
-    TMP_DIR "${CMAKE_BINARY_DIR}/tmp/umd_tmp"
+    BINARY_DIR ${PROJECT_BINARY_DIR}
+    INSTALL_DIR ${PROJECT_BINARY_DIR}
+    STAMP_DIR "${PROJECT_BINARY_DIR}/tmp/umd_stamp"
+    TMP_DIR "${PROJECT_BINARY_DIR}/tmp/umd_tmp"
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     INSTALL_COMMAND ""
     BUILD_COMMAND
         make -f ${UMD_HOME}/device/module.mk umd_device
-        OUT=${CMAKE_BINARY_DIR}
-        LIBDIR=${CMAKE_BINARY_DIR}/lib
-        OBJDIR=${CMAKE_BINARY_DIR}/obj
+        OUT=${PROJECT_BINARY_DIR}
+        LIBDIR=${PROJECT_BINARY_DIR}/lib
+        OBJDIR=${PROJECT_BINARY_DIR}/obj
         UMD_HOME=${UMD_HOME}
         UMD_VERSIM_STUB=${UMD_VERSIM_STUB}
         UMD_VERSIM_HEADERS=${TT_METAL_VERSIM_ROOT}/versim/
@@ -77,21 +77,21 @@ endif()
 if(NOT BUILD_SHARED_LIBS)
     set(UMD_OBJS
         ${UMD_OBJS}
-        ${CMAKE_BINARY_DIR}/obj/umd/device/architecture_implementation.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/blackhole_implementation.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/cpuset_lib.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/grayskull_implementation.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/tt_cluster_descriptor.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/tt_device.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/tt_emulation_stub.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/tt_silicon_driver_common.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/tt_silicon_driver.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/tt_soc_descriptor.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/tt_versim_stub.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/tlb.o
-        ${CMAKE_BINARY_DIR}/obj/umd/device/wormhole_implementation.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/architecture_implementation.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/blackhole_implementation.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/cpuset_lib.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/grayskull_implementation.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/tt_cluster_descriptor.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/tt_device.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/tt_emulation_stub.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/tt_silicon_driver_common.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/tt_silicon_driver.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/tt_soc_descriptor.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/tt_versim_stub.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/tlb.o
+        ${PROJECT_BINARY_DIR}/obj/umd/device/wormhole_implementation.o
     )
-    set(UMD_STATIC_LIB ${CMAKE_BINARY_DIR}/lib/libdevice.a)
+    set(UMD_STATIC_LIB ${PROJECT_BINARY_DIR}/lib/libdevice.a)
 
     # Build static lib with objs created after umd_device is built
     add_custom_command(

--- a/tests/tt_eager/CMakeLists.txt
+++ b/tests/tt_eager/CMakeLists.txt
@@ -43,7 +43,7 @@ set(TT_EAGER_TESTS_INTEGRATION
 )
 
 set(EAGER_TEST_TARGETS "")  # list of all eager test targets, used in CREATE_EAGER_TEST_EXE
-include(${CMAKE_SOURCE_DIR}/cmake/helper_functions.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/helper_functions.cmake)
 
 CREATE_EAGER_TEST_EXE("${TT_EAGER_TESTS_OPS}")
 CREATE_EAGER_TEST_EXE("${TT_EAGER_TESTS_TENSORS}")

--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -44,17 +44,17 @@ foreach (TEST ${TT_METAL_TESTS})
     target_link_libraries(${TEST} PUBLIC test_metal_common_libs)
     target_include_directories(${TEST} PRIVATE
         ${UMD_HOME}
-        ${CMAKE_SOURCE_DIR}
-        ${CMAKE_SOURCE_DIR}/tt_metal
-        ${CMAKE_SOURCE_DIR}/tt_metal/common
-        ${CMAKE_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/tt_metal
+        ${PROJECT_SOURCE_DIR}/tt_metal/common
+        ${PROJECT_SOURCE_DIR}/tests
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
-    set_target_properties(${TEST} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/tt_metal)
+    set_target_properties(${TEST} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/tt_metal)
     list(APPEND METAL_TEST_TARGETS ${TEST})
 endforeach()
 
-add_subdirectory(${CMAKE_SOURCE_DIR}/tt_metal/programming_examples ${CMAKE_BINARY_DIR}/programming_examples)
+add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal/programming_examples ${PROJECT_BINARY_DIR}/programming_examples)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit_tests_common)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit_tests)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -47,14 +47,14 @@ foreach (TEST ${PERF_MICROBENCH_TESTS_SRCS})
     target_link_libraries(${TEST_TARGET} PUBLIC test_metal_common_libs)
     target_include_directories(${TEST_TARGET} PRIVATE
         ${UMD_HOME}
-        ${CMAKE_SOURCE_DIR}
-        ${CMAKE_SOURCE_DIR}/tt_metal
-        ${CMAKE_SOURCE_DIR}/tt_eager
-        ${CMAKE_SOURCE_DIR}/tt_metal/common
-        ${CMAKE_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/tt_metal
+        ${PROJECT_SOURCE_DIR}/tt_eager
+        ${PROJECT_SOURCE_DIR}/tt_metal/common
+        ${PROJECT_SOURCE_DIR}/tests
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
-    set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/tt_metal/perf_microbenchmark/${TEST_DIR})
+    set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/tt_metal/perf_microbenchmark/${TEST_DIR})
     target_compile_options(${TEST_TARGET} PUBLIC ${COMPILE_OPTIONS})
     list(APPEND PERF_MICROBENCH_TEST_TARGETS ${TEST_TARGET})
 endforeach()

--- a/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
@@ -37,11 +37,11 @@ add_executable(unit_tests ${UNIT_TESTS_SRC} $<TARGET_OBJECTS:unit_tests_common_o
 target_link_libraries(unit_tests PUBLIC test_metal_common_libs)
 target_include_directories(unit_tests PRIVATE
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tests
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${CMAKE_CURRENT_SOURCE_DIR}/circular_buffer
 )
-set_target_properties(unit_tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/tt_metal)
+set_target_properties(unit_tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/tt_metal)

--- a/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_common/CMakeLists.txt
@@ -30,10 +30,10 @@ add_library(unit_tests_common_o OBJECT ${UNIT_TESTS_COMMON_SRC})
 target_link_libraries(unit_tests_common_o PUBLIC compiler_flags metal_header_directories)
 target_include_directories(unit_tests_common_o PUBLIC
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/fmt
-    ${CMAKE_SOURCE_DIR}/tt_metal/common
-    ${CMAKE_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
+    ${PROJECT_SOURCE_DIR}/tt_metal/common
+    ${PROJECT_SOURCE_DIR}/tests
     ${CMAKE_CURRENT_SOURCE_DIR}/common
 )

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/CMakeLists.txt
@@ -18,10 +18,10 @@ add_executable(unit_tests_fast_dispatch ${UNIT_TESTS_FD_SRC} $<TARGET_OBJECTS:un
 target_link_libraries(unit_tests_fast_dispatch PUBLIC test_metal_common_libs)
 target_include_directories(unit_tests_fast_dispatch PRIVATE
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tests
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/common
 )
-set_target_properties(unit_tests_fast_dispatch PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/tt_metal)
+set_target_properties(unit_tests_fast_dispatch PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/tt_metal)

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/CMakeLists.txt
@@ -10,10 +10,10 @@ add_executable(unit_tests_fast_dispatch_single_chip_multi_queue ${UNIT_TESTS_FD_
 target_link_libraries(unit_tests_fast_dispatch_single_chip_multi_queue PUBLIC test_metal_common_libs)
 target_include_directories(unit_tests_fast_dispatch_single_chip_multi_queue PRIVATE
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tests
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/common
 )
-set_target_properties(unit_tests_fast_dispatch_single_chip_multi_queue PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/tt_metal)
+set_target_properties(unit_tests_fast_dispatch_single_chip_multi_queue PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/tt_metal)

--- a/tests/tt_metal/tt_metal/unit_tests_frequent/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests_frequent/CMakeLists.txt
@@ -8,10 +8,10 @@ add_executable(unit_tests_frequent ${UNIT_TESTS_FREQUENT_SRCS})
 target_link_libraries(unit_tests_frequent PUBLIC test_metal_common_libs)
 target_include_directories(unit_tests_frequent PRIVATE
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tests
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/common
 )
-set_target_properties(unit_tests_frequent PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/tt_metal)
+set_target_properties(unit_tests_frequent PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/tt_metal)

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -11,9 +11,9 @@ add_executable(unit_tests_ttnn ${TTNN_UNIT_TESTS_SRC})
 target_link_libraries(unit_tests_ttnn PUBLIC test_common_libs ttnn_lib tt_metal tt_eager)
 target_include_directories(unit_tests_ttnn PRIVATE
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tests
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
-set_target_properties(unit_tests_ttnn PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/ttnn)
+set_target_properties(unit_tests_ttnn PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/ttnn)

--- a/tt_eager/CMakeLists.txt
+++ b/tt_eager/CMakeLists.txt
@@ -14,13 +14,13 @@ add_library(tt_eager ${TT_EAGER_OBJECTS})
 target_link_libraries(tt_eager PUBLIC compiler_flags linker_flags tt_metal)     # linker_flags = -rdynamic if tracy enabled
 target_include_directories(tt_eager PUBLIC
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tt_eager
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tt_eager
 )
 
 set_target_properties(tt_eager PROPERTIES
-    INSTALL_RPATH "${CMAKE_BINARY_DIR}/lib"
+    INSTALL_RPATH "${PROJECT_BINARY_DIR}/lib"
 )
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_lib)

--- a/tt_eager/queue/CMakeLists.txt
+++ b/tt_eager/queue/CMakeLists.txt
@@ -7,9 +7,9 @@ add_library(queue OBJECT ${QUEUE_SRCS})
 target_link_libraries(queue PUBLIC metal_header_directories compiler_flags)
 target_include_directories(queue PUBLIC
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tt_eager
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tt_eager
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/fmt
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )

--- a/tt_eager/tensor/CMakeLists.txt
+++ b/tt_eager/tensor/CMakeLists.txt
@@ -12,9 +12,9 @@ add_library(tensor OBJECT ${TENSOR_SRCS})
 target_link_libraries(tensor PUBLIC metal_header_directories compiler_flags)
 target_include_directories(tensor PUBLIC
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tt_eager
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tt_eager
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/fmt
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -219,16 +219,16 @@ add_library(tt_dnn OBJECT ${TT_DNN_SRCS})
 target_link_libraries(tt_dnn PUBLIC metal_header_directories compiler_flags)
 target_include_directories(tt_dnn PUBLIC
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tt_eager
-    ${CMAKE_SOURCE_DIR}/ttnn/cpp
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/fmt
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tt_eager
+    ${PROJECT_SOURCE_DIR}/ttnn/cpp
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )
 
 target_precompile_headers(tt_dnn PUBLIC
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/tracy/public/tracy/Tracy.hpp
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/tracy/public/tracy/Tracy.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/auto_format.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute_kernel_config.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/operation.hpp

--- a/tt_eager/tt_lib/CMakeLists.txt
+++ b/tt_eager/tt_lib/CMakeLists.txt
@@ -16,17 +16,17 @@ add_library(tt_lib SHARED ${TT_LIB_SRCS})
 target_link_libraries(tt_lib PUBLIC compiler_flags linker_flags tt_eager tt_metal pch_pybinds)  # linker_flags = -rdynamic if tracy enabled
 target_include_directories(tt_lib PUBLIC
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/ttnn/cpp
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/ttnn/cpp
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include
     ${Python3_INCLUDE_DIRS}
 )
 target_compile_options(tt_lib PUBLIC -fno-var-tracking -Wno-int-to-pointer-cast)
 target_link_directories(tt_lib PUBLIC
-    ${CMAKE_BINARY_DIR}/tt_eager
-    ${CMAKE_BINARY_DIR}/tt_metal
+    ${PROJECT_BINARY_DIR}/tt_eager
+    ${PROJECT_BINARY_DIR}/tt_metal
     ${Python3_LIBRARIES}
 )
 
@@ -36,8 +36,8 @@ set_target_properties(tt_lib PROPERTIES
     OUTPUT_NAME "_C"
     PREFIX ""
     SUFFIX ".so"
-    BUILD_RPATH "${CMAKE_BINARY_DIR}/tt_metal;${CMAKE_BINARY_DIR}/tt_eager"
-    INSTALL_RPATH "${CMAKE_BINARY_DIR}/lib"
+    BUILD_RPATH "${PROJECT_BINARY_DIR}/tt_metal;${PROJECT_BINARY_DIR}/tt_eager"
+    INSTALL_RPATH "${PROJECT_BINARY_DIR}/lib"
     CXX_VISIBILITY_PRESET "default"
-    ADDITIONAL_CLEAN_FILES "${CMAKE_SOURCE_DIR}/tt_eager/tt_lib/_C.so;${CMAKE_SOURCE_DIR}/tt_eager/metal_libs.egg-info"
+    ADDITIONAL_CLEAN_FILES "${PROJECT_SOURCE_DIR}/tt_eager/tt_lib/_C.so;${PROJECT_SOURCE_DIR}/tt_eager/metal_libs.egg-info"
 )

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -26,17 +26,17 @@ else()
 endif()
 
 target_link_libraries(tt_metal PUBLIC compiler_flags linker_flags metal_header_directories yaml-cpp $<$<BOOL:$ENV{ENABLE_TRACY}>:TracyClient>)  # linker_flags = -rdynamic if tracy enabled
-target_link_directories(tt_metal PUBLIC ${CMAKE_BINARY_DIR}/lib)    # required so tt_metal can find device library
+target_link_directories(tt_metal PUBLIC ${PROJECT_BINARY_DIR}/lib)    # required so tt_metal can find device library
 target_include_directories(tt_metal PUBLIC
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/fmt
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )
 target_compile_options(tt_metal PUBLIC -Wno-int-to-pointer-cast)
 add_dependencies(tt_metal hw_toolchain)
 
 set_target_properties(tt_metal PROPERTIES
-    INSTALL_RPATH "${CMAKE_BINARY_DIR}/lib"
-    ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/lib;${CMAKE_BINARY_DIR}/obj"
+    INSTALL_RPATH "${PROJECT_BINARY_DIR}/lib"
+    ADDITIONAL_CLEAN_FILES "${PROJECT_BINARY_DIR}/lib;${PROJECT_BINARY_DIR}/obj"
 )

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(common PUBLIC compiler_flags metal_header_directories)
 
 target_include_directories(common PUBLIC
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/fmt
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(HW_OUTPUT_DIR ${CMAKE_BINARY_DIR}/hw/toolchain)
+set(HW_OUTPUT_DIR ${PROJECT_BINARY_DIR}/hw/toolchain)
 set(CORES
     brisc
     ncrisc
@@ -10,11 +10,11 @@ set(CORES
 )
 
 if("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
-    set(DEV_MEM_MAP "${CMAKE_SOURCE_DIR}/tt_metal/hw/inc/wormhole/dev_mem_map.h")
-    set(HW_INCLUDES "${CMAKE_SOURCE_DIR}/tt_metal/hw/inc/wormhole")
+    set(DEV_MEM_MAP "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/dev_mem_map.h")
+    set(HW_INCLUDES "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole")
 else()
-    set(DEV_MEM_MAP "${CMAKE_SOURCE_DIR}/tt_metal/hw/inc/$ENV{ARCH_NAME}/dev_mem_map.h")
-    set(HW_INCLUDES "${CMAKE_SOURCE_DIR}/tt_metal/hw/inc/$ENV{ARCH_NAME}")
+    set(DEV_MEM_MAP "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/$ENV{ARCH_NAME}/dev_mem_map.h")
+    set(HW_INCLUDES "${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/$ENV{ARCH_NAME}")
 endif()
 
 foreach(CORE IN LISTS CORES)

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -21,6 +21,6 @@ set(IMPL_SRC
 add_library(impl OBJECT ${IMPL_SRC})
 target_link_libraries(impl PUBLIC common)
 
-target_include_directories(impl PUBLIC ${CMAKE_SOURCE_DIR}/tt_metal ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(impl PUBLIC ${PROJECT_SOURCE_DIR}/tt_metal ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_compile_options(impl PUBLIC -Wno-int-to-pointer-cast)

--- a/tt_metal/programming_examples/CMakeLists.txt
+++ b/tt_metal/programming_examples/CMakeLists.txt
@@ -14,7 +14,7 @@ set(PROGRAMMING_EXAMPLES_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/matmul_single_core/matmul_single_core
 )
 
-include(${CMAKE_SOURCE_DIR}/cmake/helper_functions.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/helper_functions.cmake)
 
 CREATE_PGM_EXAMPLES_EXE("${PROGRAMMING_EXAMPLES_SRCS}" "")  # no subdir, output binaries straight to build/programming_examples
 

--- a/tt_metal/programming_examples/profiler/CMakeLists.txt
+++ b/tt_metal/programming_examples/profiler/CMakeLists.txt
@@ -9,22 +9,3 @@ set(PROFILER_EXAMPLES_SRCS
 CREATE_PGM_EXAMPLES_EXE("${PROFILER_EXAMPLES_SRCS}" "profiler")
 
 add_custom_target(profiler_examples DEPENDS ${PROGRAMMING_EXAMPLES_TEST_TARGETS})
-
-# should throw this into helper_functions.cmake
-# foreach (TEST ${PROFILER_EXAMPLES_SRCS})
-#     get_filename_component(TEST_TARGET ${TEST} NAME)
-
-#     add_executable(${TEST_TARGET} ${TEST})
-#     target_link_libraries(${TEST_TARGET} PUBLIC tt_metal stdc++fs yaml-cpp m)
-#     target_include_directories(${TEST_TARGET} PRIVATE
-#         ${UMD_HOME}
-#         ${CMAKE_SOURCE_DIR}
-#         ${CMAKE_SOURCE_DIR}/tt_metal
-#         ${CMAKE_SOURCE_DIR}/tt_metal/common
-#         ${CMAKE_CURRENT_SOURCE_DIR}
-#     )
-#     set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/programming_examples/profiler)
-#     list(APPEND PROFILER_EXAMPLES_TEST_TARGETS ${TEST_TARGET})
-# endforeach()
-
-# add_custom_target(profiler_examples DEPENDS ${PROFILER_EXAMPLES_TEST_TARGETS})

--- a/tt_metal/tools/watcher_dump/CMakeLists.txt
+++ b/tt_metal/tools/watcher_dump/CMakeLists.txt
@@ -3,10 +3,10 @@ add_executable(watcher_dump ${CMAKE_CURRENT_SOURCE_DIR}/watcher_dump.cpp)
 target_link_libraries(watcher_dump PUBLIC test_metal_common_libs)
 target_include_directories(watcher_dump PRIVATE
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tt_metal/common
-    ${CMAKE_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tt_metal/common
+    ${PROJECT_SOURCE_DIR}/tests
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
-set_target_properties(watcher_dump PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tools)
+set_target_properties(watcher_dump PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/tools)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -12,26 +12,26 @@ target_compile_options(ttnn_lib PUBLIC -MP -Wno-int-to-pointer-cast -fno-var-tra
 target_link_libraries(ttnn_lib PUBLIC compiler_flags metal_header_directories metal_common_libs)
 target_include_directories(ttnn_lib PUBLIC
     ${UMD_HOME}
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/tt_metal
-    ${CMAKE_SOURCE_DIR}/tt_eager        # this is ... should be removed once we only have ttnn
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/tt_metal
+    ${PROJECT_SOURCE_DIR}/tt_eager        # this is ... should be removed once we only have ttnn
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/fmt
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )
 target_precompile_headers(ttnn_lib PRIVATE
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
 )
 
 
 # TODO: should be using pybind11_add_module, but right now it introduces many build problems
 # pybinds will always be built as a shared library
-add_library(ttnn SHARED ${CMAKE_SOURCE_DIR}/ttnn/cpp/pybind11/__init__.cpp $<TARGET_OBJECTS:ttnn_lib>)
+add_library(ttnn SHARED ${PROJECT_SOURCE_DIR}/ttnn/cpp/pybind11/__init__.cpp $<TARGET_OBJECTS:ttnn_lib>)
 target_compile_options(ttnn PUBLIC -Wno-int-to-pointer-cast -fno-var-tracking)
 target_link_libraries(ttnn PUBLIC compiler_flags linker_flags tt_eager pch_pybinds)     # linker_flags = -rdynamic if tracy enabled
 target_include_directories(ttnn PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
-    ${CMAKE_SOURCE_DIR}/tt_metal/third_party/pybind11/include
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include
     ${Python3_INCLUDE_DIRS}
 )
 
@@ -41,8 +41,8 @@ set_target_properties(ttnn PROPERTIES
     OUTPUT_NAME "_ttnn"
     PREFIX ""
     SUFFIX ".so"
-    BUILD_RPATH "${CMAKE_BINARY_DIR}/tt_metal;${CMAKE_BINARY_DIR}/tt_eager;${CMAKE_BINARY_DIR}/ttnn"
-    INSTALL_RPATH "${CMAKE_BINARY_DIR}/lib"
+    BUILD_RPATH "${PROJECT_BINARY_DIR}/tt_metal;${PROJECT_BINARY_DIR}/tt_eager;${PROJECT_BINARY_DIR}/ttnn"
+    INSTALL_RPATH "${PROJECT_BINARY_DIR}/lib"
     CXX_VISIBILITY_PRESET "default"
-    ADDITIONAL_CLEAN_FILES "${CMAKE_SOURCE_DIR}/ttnn/ttnn/_ttnn.so;${CMAKE_SOURCE_DIR}/ttnn/ttnn.egg-info"
+    ADDITIONAL_CLEAN_FILES "${PROJECT_SOURCE_DIR}/ttnn/ttnn/_ttnn.so;${PROJECT_SOURCE_DIR}/ttnn/ttnn.egg-info"
 )


### PR DESCRIPTION
 Replace `CMAKE_SOURCE_DIR` and `CMAKE_BINARY_DIR` with `PROJECT_SOURCE_DIR` and `PROJECT_BINARY_DIR`

post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/9405489772