### PR TITLE
#4858: add uint16 to fp16b typecast support

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1379,6 +1379,8 @@ def eltwise_typecast(x, *args, tt_output_dtype, **kwargs):
         return torch.clamp(x.to(torch.int32), min=0, max=65535)  # due to no uint16 support
     elif tt_output_dtype[0] == ttl.tensor.DataType.UINT32:
         return torch.relu(x.to(torch.int32))  # due to no uint32 support
+    elif tt_output_dtype[0] == ttl.tensor.DataType.BFLOAT16:
+        return x.to(torch.bfloat16)
     else:
         return x
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -113,7 +113,7 @@ namespace tt::tt_metal::detail {
         detail::bind_unary_op_with_param(
             m_tensor, "eltwise_typecast", eltwise_typecast,
             py::arg("tt_output_dtype"),
-            R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted from fp32 to uint32 or uint16.)doc",
+            R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted from fp16b to uint32, fp16b to uint16, or uint16 to fp16b.)doc",
             R"doc("Indicates output dtype of typecast", "ttl.tensor.DataType", "")doc"
         );
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -113,7 +113,7 @@ namespace tt::tt_metal::detail {
         detail::bind_unary_op_with_param(
             m_tensor, "eltwise_typecast", eltwise_typecast,
             py::arg("tt_output_dtype"),
-            R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted from fp16b to uint32, fp16b to uint16, or uint16 to fp16b.)doc",
+            R"doc(Returns tensor with all of the elements of the input tensor ``{0}`` typecasted from bfloat16 to uint32, bfloat16 to uint16, or uint16 to bfloat16.)doc",
             R"doc("Indicates output dtype of typecast", "ttl.tensor.DataType", "")doc"
         );
 
@@ -219,7 +219,7 @@ namespace tt::tt_metal::detail {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
 
         )doc");
-        
+
         detail::bind_unary_op_with_param(
             m_tensor, "unary_ne", unary_ne,
             py::arg("value"),

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -67,5 +67,17 @@ inline void calculate_typecast_fp16b_to_uint16()
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_typecast_uint16_to_fp16b()
+{
+    #pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(0,6,3,0);
+        TTI_SFPCAST(0,1,0);
+        TTI_SFPSTORE(1,2,3,0);
+        dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_typecast.h
@@ -26,6 +26,12 @@ inline void llk_math_eltwise_unary_sfpu_typecast(uint dst_index, int vector_mode
             dst_index,
             vector_mode);
     }
+    else if constexpr (OUT_DTYPE == (uint32_t)DataFormat::Float16_b) {
+        llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+            ckernel::sfpu::calculate_typecast_uint16_to_fp16b<APPROXIMATE,8>,
+            dst_index,
+            vector_mode);
+    }
 }
 
 template <bool APPROXIMATE>

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
@@ -21,8 +21,9 @@ namespace ckernel {
 /**
  * Performs an elementwise typecast operation on the input.
  * Supports following typecasts:
- *  fp32/fp16b -> uint32
- *  fp32/fp16b -> uint16
+ *  fp16b -> uint32
+ *  fp16b -> uint16
+ *  uint16 -> fp16b
  * For output to be uint32, Dest must be in 32 bit mode.
  *
  * Return value: None

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/typecast.h
@@ -21,10 +21,10 @@ namespace ckernel {
 /**
  * Performs an elementwise typecast operation on the input.
  * Supports following typecasts:
- *  fp16b -> uint32
- *  fp16b -> uint16
- *  uint16 -> fp16b
- * For output to be uint32, Dest must be in 32 bit mode.
+ *  Float16_b -> UInt32
+ *  Float16_b -> UInt16
+ *  UInt16 -> Float16_b
+ * For output to be UInt32, Dest must be in 32 bit mode.
  *
  * Return value: None
  *

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -288,6 +288,8 @@ const DataFormat get_single_pack_src_format(
             case DataFormat::RawUInt16: pack_src_format = DataFormat::Float16; break;
             default: pack_src_format = DataFormat::Lf8; break;
         }
+    } else if (input_format == DataFormat::UInt16) {
+        pack_src_format = output_format;
     } else if ((input_format == DataFormat::Invalid) || (output_format == DataFormat::Invalid)) {
         pack_src_format =  DataFormat::Invalid;
     } else if (input_format == DataFormat::Fp8_e4m3) {


### PR DESCRIPTION
Enabling typecast to fp16b from uint16 through SPFU.

Post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9407127730