### PR TITLE
#9151: Add optional tensor to embeddings

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_embedding.py
@@ -10,6 +10,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
 from loguru import logger
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -62,3 +63,126 @@ def test_embedding_bw(input_shapes, device):
 
     logger.debug(comp_out_a)
     assert comp_pass_a
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("are_required_outputs", [[True], [False]])
+def test_embedding_bw_with_opt_out(input_shapes, device, are_required_outputs):
+    torch.manual_seed(1234)
+
+    batch_size = input_shapes[0]
+    no_of_embeddings = input_shapes[1] * input_shapes[2]
+    embedding_dim = input_shapes[3]
+
+    input_shape = [batch_size, 1, 1, no_of_embeddings]
+    input_index = torch.reshape(torch.arange(0, batch_size * no_of_embeddings), shape=input_shape)
+    weights_shape = [batch_size, 1, no_of_embeddings, embedding_dim]
+    weights = torch.randn(weights_shape, requires_grad=True)
+    grad_shape = [1, 1, batch_size * no_of_embeddings, embedding_dim]
+    grad_data = torch.randn(grad_shape, requires_grad=True)
+
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
+    )
+
+    input_tensor = tt_lib.tensor.Tensor(input_index, tt_lib.tensor.DataType.UINT32).to(device)
+    weights_tensor = (
+        tt_lib.tensor.Tensor(weights, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
+    )
+
+    input_grad = None
+    if are_required_outputs[0]:
+        _, input_grad = data_gen_with_range(grad_shape, -1, 1, device, is_row_major=True)
+
+    tt_output_tensor_on_device = ttnn.embedding_bw(
+        grad_tensor,
+        input_tensor,
+        weights_tensor,
+        are_required_outputs=are_required_outputs,
+        input_a_grad=input_grad,
+    )
+    weights.retain_grad()
+
+    pyt_y = torch.nn.functional.embedding(
+        input_index.reshape((batch_size, no_of_embeddings)),
+        weights.reshape((batch_size * no_of_embeddings, embedding_dim)),
+    ).reshape((1, 1, batch_size * no_of_embeddings, embedding_dim))
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_output_tensor_a = weights.grad
+
+    status = True
+    if are_required_outputs[0]:
+        status = status & compare_pcc(tt_output_tensor_on_device, golden_output_tensor_a)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("are_required_outputs", [[True], [False]])
+def test_embedding_bw_with_opt_out_cq_id(input_shapes, device, are_required_outputs):
+    torch.manual_seed(1234)
+
+    batch_size = input_shapes[0]
+    no_of_embeddings = input_shapes[1] * input_shapes[2]
+    embedding_dim = input_shapes[3]
+
+    input_shape = [batch_size, 1, 1, no_of_embeddings]
+    input_index = torch.reshape(torch.arange(0, batch_size * no_of_embeddings), shape=input_shape)
+    weights_shape = [batch_size, 1, no_of_embeddings, embedding_dim]
+    weights = torch.randn(weights_shape, requires_grad=True)
+    grad_shape = [1, 1, batch_size * no_of_embeddings, embedding_dim]
+    grad_data = torch.randn(grad_shape, requires_grad=True)
+
+    grad_tensor = (
+        tt_lib.tensor.Tensor(grad_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
+    )
+
+    input_tensor = tt_lib.tensor.Tensor(input_index, tt_lib.tensor.DataType.UINT32).to(device)
+    weights_tensor = (
+        tt_lib.tensor.Tensor(weights, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
+    )
+
+    input_grad = None
+    if are_required_outputs[0]:
+        _, input_grad = data_gen_with_range(grad_shape, -1, 1, device, is_row_major=True)
+
+    cq_id = 0
+    tt_output_tensor_on_device = ttnn.embedding_bw(
+        grad_tensor,
+        input_tensor,
+        weights_tensor,
+        are_required_outputs=are_required_outputs,
+        input_a_grad=input_grad,
+        queue_id=cq_id,
+    )
+
+    weights.retain_grad()
+
+    pyt_y = torch.nn.functional.embedding(
+        input_index.reshape((batch_size, no_of_embeddings)),
+        weights.reshape((batch_size * no_of_embeddings, embedding_dim)),
+    ).reshape((1, 1, batch_size * no_of_embeddings, embedding_dim))
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_output_tensor_a = weights.grad
+
+    status = True
+    if are_required_outputs[0]:
+        status = status & compare_pcc(tt_output_tensor_on_device, golden_output_tensor_a)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_embedding.py
@@ -103,3 +103,131 @@ def test_embeddings(
     run_embeddings_tests(
         batch_size, num_embeddings, embedding_dim, num_rows, dtype, in0_mem_config, out_mem_config, device, tilized
     )
+
+
+def run_embeddings_optional_output_tests(
+    batch_size,
+    num_embeddings,
+    embedding_dim,
+    num_rows,
+    dtype,
+    in0_mem_config,
+    out_mem_config,
+    device,
+    pass_queue_id,
+    tilized=False,
+):
+    torch.manual_seed(1234)
+
+    tensor = ttl.tensor
+    dev = device
+
+    input_rows_shape = [batch_size, 1, 1, num_rows]
+
+    input_rows_torch = torch.randint(0, num_embeddings - 1, tuple(input_rows_shape))
+
+    weights_shape = [1, 1, num_embeddings, embedding_dim]
+    weights_torch = torch.randn(weights_shape).bfloat16()
+
+    input_tensor = tensor.Tensor(input_rows_torch, ttl.tensor.DataType.UINT32).to(dev, in0_mem_config)
+    weights_tensor = tensor.Tensor(weights_torch, dtype).to(dev, in0_mem_config)
+
+    out_torch = torch.randn([batch_size, 1, num_rows, embedding_dim]).bfloat16()
+    out = tensor.Tensor(out_torch, dtype).to(dev, in0_mem_config)
+
+    cq_id = 0
+    if pass_queue_id:
+        tensor.embeddings(
+            input_tensor, weights_tensor, tilized, output_mem_config=out_mem_config, output_tensor=out, queue_id=cq_id
+        )
+    else:
+        tensor.embeddings(input_tensor, weights_tensor, tilized, output_mem_config=out_mem_config, output_tensor=out)
+
+    if tilized:
+        tt_data = out.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    else:
+        tt_data = out.cpu().to_torch()
+
+    tt_got_back = torch.Tensor(tt_data).reshape((batch_size, 1, num_rows, embedding_dim))
+    t_ref = torch.nn.functional.embedding(
+        input_rows_torch.reshape((batch_size, num_rows)),
+        weights_torch.reshape((num_embeddings, embedding_dim)),
+    ).reshape((batch_size, 1, num_rows, embedding_dim))
+
+    passing_pcc, output_pcc = comp_equal(t_ref, tt_got_back)
+    logger.debug(f"Out passing={passing_pcc}")
+    logger.debug(f"Output pcc={output_pcc}")
+    assert passing_pcc
+
+
+@pytest.mark.parametrize(
+    "out_mem_config",
+    (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),),
+    ids=["out_DRAM"],
+)
+@pytest.mark.parametrize(
+    "in0_mem_config",
+    (ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),),
+    ids=["in0_DRAM"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (ttl.tensor.DataType.BFLOAT16,),
+    ids=["BFLOAT16"],
+)
+@pytest.mark.parametrize(
+    "num_rows",
+    (32, 256, 512),
+    ids=["Num_Rows_32", "Num_Rows_256", "Num_Rows_512"],
+)
+@pytest.mark.parametrize(
+    "num_embeddings",
+    (512, 30522, 2048),
+    ids=[
+        "Bert_Position_Embeddings_512",
+        "Bert_Word_Embeddings_30528",
+        "Llama_Position_Embeddings",
+    ],
+)
+@pytest.mark.parametrize(
+    "embedding_dim",
+    (768, 4096),
+    ids=["Bert_Num_Cols_768", "Llama_Num_Cols"],
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    (1, 8, 9),
+    ids=["Batch_Size_1", "Batch_Size_8", "Batch_Size_9"],
+)
+@pytest.mark.parametrize(
+    "tilized",
+    (False,),
+    ids=[
+        "Tilized",
+    ],
+)
+@pytest.mark.parametrize("pass_queue_id", [True, False])
+def test_embeddings_optional_output(
+    batch_size,
+    num_embeddings,
+    embedding_dim,
+    num_rows,
+    dtype,
+    in0_mem_config,
+    out_mem_config,
+    device,
+    pass_queue_id,
+    tilized,
+):
+    run_embeddings_optional_output_tests(
+        batch_size,
+        num_embeddings,
+        embedding_dim,
+        num_rows,
+        dtype,
+        in0_mem_config,
+        out_mem_config,
+        device,
+        pass_queue_id,
+        tilized,
+    )

--- a/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.hpp
+++ b/tt_eager/tt_dnn/op_library/embeddings/embeddings_op.hpp
@@ -25,9 +25,9 @@ struct Embeddings {
     const std::optional<uint32_t> pad_token;
     const DataType output_dtype;
 
-    void validate(const std::vector<Tensor> &input_tensors) const;
+    void validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
     tt::stl::reflection::Attributes attributes() const;
@@ -40,10 +40,11 @@ inline Tensor embeddings(
     EmbeddingsType embeddings_type = EmbeddingsType::GENERIC,
     std::optional<uint32_t> pad_token = std::nullopt,
     const MemoryConfig &mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<const DataType> output_dtype = std::nullopt) {
+    std::optional<const DataType> output_dtype = std::nullopt,
+    std::optional<Tensor> output_tensor = std::nullopt) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor, weights}))};
     operation::launch_op(
-        [tilized, embeddings_type, pad_token, mem_config, output_dtype] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+        [tilized, embeddings_type, pad_token, mem_config, output_dtype, output_tensor] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             auto& input_tensor = input_tensors.at(0);
             auto& weights = input_tensors.at(1);
             return operation::run_without_autoformat(
@@ -53,8 +54,35 @@ inline Tensor embeddings(
                    .embeddings_type = embeddings_type,
                    .pad_token = pad_token,
                    .output_dtype = output_dtype.value_or(weights.get_dtype())},
-               {input_tensor, weights});
-        }, {input_tensor, weights}, output_tensors);
+               {input_tensor, weights}, {}, {output_tensor});
+        }, {input_tensor, weights}, output_tensors, {}, {output_tensor});
+    return output_tensors.at(0);
+}
+
+inline Tensor embeddings(
+    uint8_t queue_id,
+    const Tensor &input_tensor,
+    const Tensor &weights,
+    bool tilized = true,
+    EmbeddingsType embeddings_type = EmbeddingsType::GENERIC,
+    std::optional<uint32_t> pad_token = std::nullopt,
+    const MemoryConfig &mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DataType> output_dtype = std::nullopt,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor, weights}))};
+    operation::launch_op(
+        [tilized, embeddings_type, pad_token, mem_config, output_dtype, output_tensor, queue_id] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            auto& input_tensor = input_tensors.at(0);
+            auto& weights = input_tensors.at(1);
+            return operation::run_without_autoformat(
+               Embeddings{
+                   .output_mem_config = mem_config,
+                   .tilized = tilized,
+                   .embeddings_type = embeddings_type,
+                   .pad_token = pad_token,
+                   .output_dtype = output_dtype.value_or(weights.get_dtype())},
+               {input_tensor, weights}, {}, {output_tensor}, queue_id);
+        }, {input_tensor, weights}, output_tensors, {}, {output_tensor});
     return output_tensors.at(0);
 }
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -674,7 +674,17 @@ void TensorModule(py::module& m_tensor) {
     // input embeddings
     m_tensor.def(
         "embeddings",
-        &embeddings,
+        [](const Tensor &input,
+        const Tensor &weights,
+        bool tilized,
+        EmbeddingsType embeddings_type,
+        std::optional<uint32_t> pad_token,
+        const MemoryConfig &output_mem_config,
+        std::optional<const DataType> output_dtype,
+        std::optional<Tensor> &output_tensor,
+        uint8_t queue_id) {
+            return embeddings(queue_id, input, weights, tilized, embeddings_type, pad_token, output_mem_config, output_dtype, output_tensor);
+        },
         py::arg("input").noconvert(),
         py::arg("weights").noconvert(),
         py::arg("tilized").noconvert() = false,
@@ -682,6 +692,8 @@ void TensorModule(py::module& m_tensor) {
         py::arg("pad_token").noconvert() = std::nullopt,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_dtype").noconvert() = std::nullopt,
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        py::arg("queue_id").noconvert() = 0,
         R"doc(
         Returns specific indices of the embedding table specified by the input tensor
 
@@ -695,6 +707,8 @@ void TensorModule(py::module& m_tensor) {
             "pad_token", "pad_token used in token ids", "uint32_t", "Default is None", "No"
             "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             "output_dtype", "DataType of output tensor", "DataType", "Default is weights dtype", "No"
+            "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+            "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
     )doc");
 
     // FC

--- a/ttnn/cpp/pybind11/operations/embedding.hpp
+++ b/ttnn/cpp/pybind11/operations/embedding.hpp
@@ -32,6 +32,7 @@ void py_module(py::module& module) {
                 * :attr:`pad_token`: the padding token. Default is None.
                 * :attr:`layout`: the layout of the input and output tensors. Default is ttnn.ROW_MAJOR_LAYOUT.
                 * :attr:`memory_config`: the memory configuration of the output tensor. Default is input tensor memory config.
+                * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensor
 
             Example:
                 >>> device_id = 0
@@ -53,7 +54,8 @@ void py_module(py::module& module) {
             py::arg("weight"),
             py::arg("pad_token") = std::nullopt,
             py::arg("layout") = ttnn::ROW_MAJOR_LAYOUT,
-            py::arg("memory_config") = std::nullopt});
+            py::arg("memory_config") = std::nullopt,
+            py::arg("output_tensor") = std::nullopt});
 }
 
 }  // namespace embedding

--- a/ttnn/cpp/ttnn/operations/embedding.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding.hpp
@@ -36,7 +36,8 @@ struct Embedding {
         const Tensor& weight_arg,
         const std::optional<int>& pad_token = std::nullopt,
         const Layout& layout = ttnn::ROW_MAJOR_LAYOUT,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt) {
         auto embeddings_type = EmbeddingsType::GENERIC;
         if (pad_token.has_value()) {
             embeddings_type = EmbeddingsType::PADDED;
@@ -58,7 +59,9 @@ struct Embedding {
                                   .embeddings_type = embeddings_type,
                                   .pad_token = pad_token,
                                   .output_dtype = weight.get_dtype()},
-                              {input_tensor, weight})
+                              {input_tensor, weight},
+                              {},
+                              {optional_output_tensor})
                               .at(0);
         embeddings = ttnn::reshape(embeddings, ttnn::Shape{{batch_size, sentence_size, hidden_embedding_dim}});
         return embeddings;


### PR DESCRIPTION
Add optional output tensor and queue id for embeddings forward and backward op

All Post commit test : https://github.com/tenstorrent/tt-metal/actions/runs/9415786167