### PR TITLE
#9150: Add optional output tensor support for prod along N,C dimension

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/test_prod_nc.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_prod_nc.py
@@ -5,9 +5,12 @@
 import pytest
 import torch
 from loguru import logger
-
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt
 import tt_lib as ttl
 from models.utility_functions import comp_allclose_and_pcc
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+)
 
 TILE_HEIGHT = 32
 TILE_WIDTH = 32
@@ -88,3 +91,40 @@ def test_prod_dims(input_shape, dims, device):
     logger.info(f"Output pcc={output_pcc}")
 
     assert passing
+
+
+mem_configs = [
+    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+]
+
+
+@pytest.mark.parametrize(
+    "dst_mem_config",
+    mem_configs,
+)
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        ([1, 1, 32, 32]),
+        ([2, 2, 32, 32]),
+        ([4, 3, 32, 32]),
+    ),
+)
+@pytest.mark.parametrize(
+    "dim",
+    [0, 1],
+)
+@pytest.mark.parametrize("all_dimensions", [False])
+def test_prod_with_output_nc(input_shapes, all_dimensions, dim, dst_mem_config, device):
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device)
+    golden_tensor = torch.prod(in_data, dim, keepdim=True)
+
+    output_shape = input_shapes
+    output_shape[dim] = 1
+    out_data, output_tensor = data_gen_pt_tt(output_shape, device)
+
+    tt_output_tensor_on_device = ttl.tensor.prod(input_tensor, all_dimensions, dim, dst_mem_config, output_tensor)
+    tt_out_tensor = tt_output_tensor_on_device.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    comp_pass, comp_out = comparison_funcs.comp_pcc(golden_tensor, tt_out_tensor)
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -235,7 +235,8 @@ Tensor prod(
     const Tensor& input_a,
     bool all_dimensions = false,
     int64_t dim = 0,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 
 
 /*

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -212,9 +212,10 @@ namespace tt::tt_metal::detail{
         R"doc(dimension to split)doc"
         );
         m_tensor.def("prod", &prod,
-            py::arg("input").noconvert(), py::arg("all_dimensions") = false, py::arg("dim") = 0, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            py::arg("input").noconvert(), py::arg("all_dimensions") = false, py::arg("dim") = 0, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_tensor").noconvert() = std::nullopt, R"doc(
             Computes the prod function along specified ``dim`` or all dimensions on the ``input`` tensor.
             If ``all_dimensions`` is set to ``true`` irrespective of given dimension it will prod along all dimensions.
+            Optional ``output_tensor`` support provided only for ``dim = 0, 1`` .
 
             Input tensor must have BFLOAT16 data type.
 
@@ -227,6 +228,7 @@ namespace tt::tt_metal::detail{
                 "all_dimensions", "Consider all dimension (ignores ``dim`` param)", "bool", "default to false", "No"
                 "dim", "Dimension to perform prod", "int", "default to 0", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
         )doc");
         detail::bind_unary_op_with_param(
             m_tensor, "geglu", &geglu,


### PR DESCRIPTION
Issue #9150 [#9123]
Support provided only for prod along NC branch
Test file : `tests/tt_eager/python_api_testing/unit_testing/test_prod_nc.py`
<img width="996" alt="Screenshot 2024-06-07 at 6 32 27 PM" src="https://github.com/tenstorrent/tt-metal/assets/138196495/5aee614b-45d9-4e83-8659-e45f15bfba67">

CI : [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9427188423) - PASSED