### PR TITLE
Fix Mixtral ttnn.eq dtype

### DIFF
--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -99,7 +99,7 @@ class TtMoeLayer(LightweightModule):
         gate_logits_1SB8 = ttnn.add(gate_logits_1SB8, self.top8_mask_11B_64)
         ttl_topk_values, ttl_topk_indices = ttnn.experimental.operations.primary.topk(gate_logits_1SB8, 32)
         ttl_topk_values = ttnn.add(ttl_topk_values, self.top2_mask_11BB)
-        mask_B2 = ttnn.eq(self.expert_mask_11BB, ttl_topk_indices)
+        mask_B2 = ttnn.eq(self.expert_mask_11BB, ttl_topk_indices, dtype=ttnn.bfloat16)
         weights_1SB1 = ttnn.sum(ttnn.softmax(ttl_topk_values, dim=-1) * mask_B2, dim=3)
 
         # MLP and masking


### PR DESCRIPTION
Due to recent changes to typecast and eltwise operators we saw a major regression on Mixtral MoE.

Specifically the issue started on commit [`219c9e5d61852e6b61966165c98779c002ddd755`](https://github.com/tenstorrent/tt-metal/commit/219c9e5d61852e6b61966165c98779c002ddd755)

More information on typecast work can be followed in issue #4858 

Mixtral MoE is currently using `ttnn.eq()` op to compare the expert indices. Thus its inputs are uint16. 
After that, the mask is multiplied by the softmax, which seems to convert incorrectly to bfloat16 leading to bad output.

The solution is to specify `ttnn.eq()` output to bfloat16 which will result in the correct mask in the correct dtype for multiplication later.