### PR TITLE
#9312: Add single-header `boost-ext/reflect` library as dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,15 @@ if (NOT NUMA_LIBRARY)
     message(FATAL_ERROR "NUMA library not found")
 endif()
 
+CPMAddPackage(
+  NAME reflect
+  GITHUB_REPOSITORY boost-ext/reflect
+  GIT_TAG v1.1.1
+)
+add_library(reflect INTERFACE)
+target_include_directories(reflect SYSTEM INTERFACE ${reflect_SOURCE_DIR})
+add_library(reflect::reflect ALIAS reflect)
+
 ############################################################################################################################
 # Setting build type flags
 #   Will default to assert build, unless CONFIG env variable is set or manually set -DCMAKE_BUILD_TYPE

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -4,11 +4,12 @@ set(TTNN_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_repeat_interleave.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_async_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multiprod_queue.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_reflect.cpp
 )
 
 add_executable(unit_tests_ttnn ${TTNN_UNIT_TESTS_SRC})
 
-target_link_libraries(unit_tests_ttnn PUBLIC test_common_libs ttnn_lib tt_metal tt_eager)
+target_link_libraries(unit_tests_ttnn PUBLIC test_common_libs ttnn_lib tt_metal tt_eager reflect::reflect)
 target_include_directories(unit_tests_ttnn PRIVATE
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}

--- a/tests/ttnn/unit_tests/gtests/test_reflect.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_reflect.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <string_view>
+#include <reflect>
+
+using namespace std::literals;
+
+enum E { A, B };
+struct foo { int a; E b; };
+
+constexpr auto f = foo{.a = 42, .b = B};
+
+// Compile-time checks using static_assert
+static_assert(reflect::size(f) == 2, "Reflect size check failed");
+static_assert(reflect::type_id(f.a) != reflect::type_id(f.b), "Reflect type_id check failed");
+static_assert("foo"sv == reflect::type_name(f), "Reflect type_name (obj) check failed");
+static_assert("int"sv == reflect::type_name(f.a), "Reflect type_name (a) check failed");
+static_assert("E"sv == reflect::type_name(f.b), "Reflect type_name (b) check failed");
+static_assert("B"sv == reflect::enum_name(f.b), "Reflect enum_name check failed");
+static_assert("a"sv == reflect::member_name<0>(f), "Reflect member_name<0> check failed");
+static_assert("b"sv == reflect::member_name<1>(f), "Reflect member_name<1> check failed");
+static_assert(42 == reflect::get<0>(f), "Reflect get<0> check failed");
+static_assert(B == reflect::get<1>(f), "Reflect get<1> check failed");
+static_assert(42 == reflect::get<"a">(f), "Reflect get<\"a\"> check failed");
+static_assert(B == reflect::get<"b">(f), "Reflect get<\"b\"> check failed");
+
+constexpr auto t = reflect::to<std::tuple>(f);
+static_assert(42 == std::get<0>(t), "Reflect to<std::tuple> get<0> check failed");
+static_assert(B == std::get<1>(t), "Reflect to<std::tuple> get<1> check failed");

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -15,7 +15,10 @@ set(TTNN_SRCS
 
 add_library(ttnn_lib OBJECT ${TTNN_SRCS})
 target_compile_options(ttnn_lib PUBLIC -MP -Wno-int-to-pointer-cast -fno-var-tracking)
-target_link_libraries(ttnn_lib PUBLIC compiler_flags metal_header_directories metal_common_libs)
+target_link_libraries(ttnn_lib
+    PUBLIC compiler_flags metal_header_directories metal_common_libs
+    PRIVATE reflect::reflect
+)
 target_include_directories(ttnn_lib PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
### Ticket
#9312

### Problem description
- Introducing boost-ext/reflect header-only static reflection library now that we have C++20 support.

### What's changed
- Introducing single-header dependency on `ttnn_lib` target.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/9574716918 (Pending)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes