### PR TITLE
#9196: Merge new op: Fast reduce nc into main

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_fast_reduce_nc.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_fast_reduce_nc.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import tt_lib as ttl
+from models.utility_functions import comp_allclose_and_pcc
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+    get_compute_kernel_options,
+    compute_kernel_options,
+    compute_kernel_ids,
+)
+
+TILE_HEIGHT = 32
+TILE_WIDTH = 32
+
+
+def get_tensors(input_shape, output_shape, device, *, with_padding=True, use_randint=True):
+    npu_dtype = ttl.tensor.DataType.BFLOAT16
+    cpu_dtype = torch.bfloat16
+    npu_layout = ttl.tensor.Layout.TILE
+
+    if use_randint:
+        torch_input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype, requires_grad=True)
+        torch_output = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
+    else:
+        torch_input = torch.rand(input_shape, dtype=cpu_dtype, requires_grad=True)
+        torch_output = torch.rand(output_shape, dtype=cpu_dtype)
+
+    if with_padding:
+        tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+        tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    else:
+        tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).to(npu_layout).to(device)
+        tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).to(npu_layout).to(device)
+
+    return tt_input, tt_output, torch_input
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        [1, 8, 128, 4096],
+        [1, 8, 1024, 4096],
+        [1, 8, 2048, 4096],
+    ),
+    ids=[
+        "mixtral_128",
+        "mixtral_1k",
+        "mixtral_2k",
+    ],
+)
+@pytest.mark.parametrize(
+    "dims",
+    ([1],),
+    ids=[
+        "1",
+    ],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+@pytest.mark.parametrize(
+    "use_provide_output",
+    (False,),
+    ids=[
+        "False",
+    ],
+)
+def test_fast_reduce_nc(input_shape, dims, compute_kernel_options, use_provide_output, device):
+    torch.manual_seed(2023)
+    output_shape = input_shape.copy()
+
+    for dim in dims:
+        output_shape[dim] = 1
+
+    (tt_input, tt_output, torch_input) = get_tensors(input_shape, output_shape, device)
+
+    if not use_provide_output:
+        tt_output = None
+
+    torch_output = torch.sum(torch_input, dims, True)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+    cpu_layout = ttl.tensor.Layout.ROW_MAJOR
+    tt_output_cpu = (
+        ttl.tensor.fast_reduce_nc(tt_input, dims=dims, output=tt_output, compute_kernel_config=compute_kernel_config)
+        .cpu()
+        .to(cpu_layout)
+        .unpad_from_tile(output_shape)
+        .to_torch()
+    )
+
+    # test for equivalance
+    # TODO(Dongjin) : check while changing rtol after enabling fp32_dest_acc_en
+    rtol = atol = 0.12
+    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
+
+    assert passing

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_fast_reduce_nc.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_fast_reduce_nc.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn.experimental as ttl
 import ttnn
-from models.utility_functions import comp_allclose_and_pcc, comp_pcc
+from models.utility_functions import comp_allclose_and_pcc, comp_pcc, skip_for_grayskull
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
@@ -47,13 +47,18 @@ def get_tensors(input_shape, output_shape, device, *, with_padding=True, use_ran
         [1, 8, 128, 4096],
         [1, 8, 1024, 4096],
         [1, 8, 2048, 4096],
+        [8, 1, 128, 4096],
+        [4, 2, 1024, 4096],
     ),
     ids=[
         "mixtral_128",
         "mixtral_1k",
         "mixtral_2k",
+        "dim0_reduce",
+        "dim01_reduce",
     ],
 )
+@skip_for_grayskull()
 @pytest.mark.parametrize(
     "dims",
     ([0], [1], [0, 1]),
@@ -96,6 +101,7 @@ def test_fast_reduce_nc(input_shape, dims, compute_kernel_options, dataformat, d
     ([0], [1], [0, 1]),
     ids=["0", "1", "0_1"],
 )
+@skip_for_grayskull()
 def test_fast_reduce_nc_with_prgm_caching(dims, device, use_program_cache):
     torch.manual_seed(2023)
 

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -48,6 +48,8 @@ set(TT_DNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/reduce/single_core_hw/reduce_op_single_core_hw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/reduce/multi_core_h/reduce_op_multi_core_h.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/reduce/multi_core_w/reduce_op_multi_core_w.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fast_reduce_nc/fast_reduce_nc_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bcast/bcast_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bcast/multi_core_h/bcast_op_multi_core_h.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bcast/multi_core_h/bcast_op_sharded_h.cpp

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
@@ -7,7 +7,7 @@
 #include <numeric>
 
 #include "tt_dnn/op_library/reduce/reduce_op.hpp"
-#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tensor/tensor.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
@@ -19,7 +19,6 @@ namespace tt_metal {
 //                         FastReduceNC
 ////////////////////////////////////////////////////////////////////////////
 namespace {
-    // TODO: move these check functions to a common header.
     inline void check_tensor(
         const Tensor& tensor,
         const std::string& op_name,

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp"
+
+#include <numeric>
+
+#include "tt_dnn/op_library/reduce/reduce_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace tt_metal {
+
+////////////////////////////////////////////////////////////////////////////
+//                         FastReduceNC
+////////////////////////////////////////////////////////////////////////////
+namespace {
+    // TODO: move these check functions to a common header.
+    inline void check_tensor(
+        const Tensor& tensor,
+        const std::string& op_name,
+        DataType data_type = DataType::BFLOAT16,
+        Layout layout = Layout::TILE) {
+        TT_FATAL(tensor.get_layout() == layout, "{} only supports tiled layout.", op_name);
+        TT_FATAL(tensor.get_dtype() == data_type, "{} only supports data type {}.", op_name, data_type);
+        TT_FATAL(
+            tensor.storage_type() == StorageType::DEVICE, "Operands to {} need to be on device!", op_name);
+        TT_FATAL(
+            tensor.buffer() != nullptr, "Operands to {} need to be allocated in buffers on device!", op_name);
+    }
+
+inline void check_tensor(
+    std::optional<Tensor> tensor,
+    const std::string& op_name,
+    tt_metal::DataType data_type = DataType::BFLOAT16,
+    Layout layout = Layout::TILE) {
+    if (!tensor.has_value()) {
+        return;
+    }
+    check_tensor(tensor.value(), op_name, data_type, layout);
+}
+
+Tensor _fast_reduce_nc(
+    const Tensor& input,
+    const int64_t& dim,
+    const std::optional<const Tensor>& output,
+    const MemoryConfig& output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input}))};
+
+    TT_FATAL(input.storage_type() == StorageType::DEVICE || input.storage_type() == StorageType::MULTI_DEVICE);
+    auto kernel_config_val = init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
+
+    operation::launch_op(
+        [dim, output_mem_config, kernel_config_val](
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            return operation::run(
+                FastReduceNC{.dim = dim, .output_mem_config = output_mem_config, .compute_kernel_config = kernel_config_val},
+                input_tensors,
+                optional_input_tensors,
+                optional_output_tensors);
+        },
+        {input},
+        output_tensors,
+        {},
+        {output});
+
+    return output_tensors.at(0);
+}
+}  // namespace
+
+void FastReduceNC::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    const auto& input = input_tensors.at(0);
+    auto& output = output_tensors.at(0);
+
+    // validate tensor
+    check_tensor(input, "input");
+    check_tensor(output, "output");
+
+    // validate input dim
+    auto input_shape = input.get_legacy_shape();
+    auto input_shape_wo_padding = input.get_legacy_shape().without_padding();
+    const auto input_rank = input_shape.rank();
+    log_debug(LogOp, "{}:{} input_rank {}", __func__, __LINE__, input_rank);
+    TT_FATAL(
+        (this->dim >= 0 && this->dim <= tt::tt_metal::MAX_NUM_DIMENSIONS - 2),
+        "dim must be between 0 and {}.",
+        tt::tt_metal::MAX_NUM_DIMENSIONS - 2);
+    TT_FATAL((this->dim < input_rank), "dim must be smaller than input tensor rank {}.", input_rank);
+}
+
+std::vector<Shape> FastReduceNC::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    const auto& input = input_tensors.at(0);
+    const auto& input_shape = input.get_legacy_shape();
+    const auto input_rank = input_shape.rank();
+
+    // keepdim=true
+    auto output_shape = input_shape;
+    auto padding = output_shape.padding();
+
+    // last 2-dim
+    output_shape[this->dim] = 1;
+
+    output_shape = Shape(output_shape, padding);
+    log_debug(LogOp, "{}:{} dim {}", __func__, __LINE__, dim);
+    log_debug(LogOp, "{}:{} output_shape {}", __func__, __LINE__, output_shape);
+    return {output_shape};
+}
+
+std::vector<Tensor> FastReduceNC::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (output_tensors.at(0).has_value()) {
+        log_debug(LogOp, "{}:{} use output tensor", __func__, __LINE__);
+        return {output_tensors.at(0).value()};
+    }
+
+    log_debug(LogOp, "{}:{} create output tensor", __func__, __LINE__);
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, input_tensors.at(0).get_dtype(), Layout::TILE, this->output_mem_config);
+}
+
+operation::ProgramWithCallbacks FastReduceNC::create_program(
+    const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) const {
+    auto& input = inputs.at(0);
+    auto& output = outputs.at(0);
+
+    return reduce_nc_impl(input, output, dim, this->compute_kernel_config);
+}
+
+Tensor fast_reduce_nc(
+    const Tensor& input,
+    std::vector<int64_t>& dims,
+    const std::optional<const Tensor> output,
+    const MemoryConfig& output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+
+    std::vector<int64_t> sorted_dims = dims;
+    std::sort(sorted_dims.begin(), sorted_dims.end());
+
+    auto temp_input = input;
+    for (uint32_t i = dims.size() - 1; i > 0; i--) {
+        log_debug(LogOp, "{}:{} dim {}", __func__, __LINE__, sorted_dims[i]);
+        auto temp_output = _fast_reduce_nc(temp_input, sorted_dims[i], std::nullopt, output_mem_config, compute_kernel_config);
+        temp_input = temp_output;
+    }
+    log_debug(LogOp, "{}:{} dim {}", __func__, __LINE__, sorted_dims.front());
+    return _fast_reduce_nc(temp_input, sorted_dims.front(), output, output_mem_config, compute_kernel_config);
+}
+
+}  // namespace tt-metal
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
@@ -23,10 +23,9 @@ namespace {
     inline void check_tensor(
         const Tensor& tensor,
         const std::string& op_name,
-        DataType data_type = DataType::BFLOAT16,
         Layout layout = Layout::TILE) {
         TT_FATAL(tensor.get_layout() == layout, "{} only supports tiled layout.", op_name);
-        TT_FATAL(tensor.get_dtype() == data_type, "{} only supports data type {}.", op_name, data_type);
+        TT_FATAL(tensor.get_dtype() == DataType::BFLOAT16 || tensor.get_dtype() == DataType::BFLOAT8_B, "{} only supports data type {} and {}.", DataType::BFLOAT16, DataType::BFLOAT8_B);
         TT_FATAL(
             tensor.storage_type() == StorageType::DEVICE, "Operands to {} need to be on device!", op_name);
         TT_FATAL(

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+#include <tuple>
+
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_dnn/op_library/compute_kernel_config.hpp"
+#include "tt_eager/tensor/tensor.hpp"
+
+namespace tt {
+
+namespace tt_metal {
+
+
+inline
+std::tuple<uint32_t, uint32_t, uint32_t> extract_spatial_dims(const Shape& shape) {
+    const auto rank = shape.rank();
+
+    TT_FATAL(rank >= 2, "Shape must have at least two dims.");
+    uint32_t W = shape[-1];
+    uint32_t H = shape[-2];
+
+    uint32_t other_dims_product = 1;
+    for (auto i = 0; i < rank - 2; ++i) {
+        other_dims_product *= shape[i];
+    }
+
+    return { W, H, other_dims_product};
+}
+
+struct FastReduceNC {
+    int64_t dim;
+    MemoryConfig output_mem_config;
+    const DeviceComputeKernelConfig compute_kernel_config;
+    void validate_with_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
+    stl::reflection::Attributes attributes() const;
+    static constexpr auto attribute_names = std::make_tuple("dim", "output_mem_config", "compute_kernel_config");
+    const auto attribute_values() const {
+        return std::make_tuple(std::cref(this->dim), std::cref(this->output_mem_config), std::cref(this->compute_kernel_config));
+    }
+};
+
+operation::ProgramWithCallbacks reduce_nc_impl(const Tensor &input, const Tensor &output, int64_t dim, const DeviceComputeKernelConfig &compute_kernel_config);
+
+Tensor fast_reduce_nc(
+    const Tensor &input,
+    std::vector<int64_t> &dims,
+    const std::optional<const Tensor> output = std::nullopt,
+    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+}  // namespace tt-metal
+
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/reader_reduce_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/reader_reduce_nc.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp"
+#include "tt_eager/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+
+inline uint32_t get_read_tile_id(uint32_t output_tile_id, uint32_t reduce_tile_size, uint32_t inner_tile_size) {
+    return ((output_tile_id / inner_tile_size) * reduce_tile_size) + (output_tile_id % inner_tile_size);
+}
+
+void kernel_main() {
+    // compile-time args
+    constexpr bool input_is_dram = (get_compile_time_arg_val(0) == 1);
+    constexpr uint32_t input_granularity = get_compile_time_arg_val(1);
+
+    // runtime args
+    ArgFetcher arg_fetcher;
+    const auto input_addr = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto num_input_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto num_output_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto dim = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto reduce_tile_size = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto inner_tile_size = arg_fetcher.get_next_arg_val<uint32_t>();
+
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in1 = 1;
+    constexpr uint32_t scaler = 0;
+
+    generate_reduce_scaler(cb_id_in1, scaler);
+
+    uint32_t l1_write_addr_in0;
+    constexpr uint32_t input_tile_bytes = get_tile_size(cb_id_in0);
+    const auto input_data_format = get_dataformat(cb_id_in0);
+    const InterleavedAddrGenFast<input_is_dram> input_addrg = {
+        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+    uint32_t input_granularity_index = 0;
+
+    for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
+        auto read_tile_id = (dim == 0) ? (i) : (get_read_tile_id(i, reduce_tile_size, inner_tile_size));
+        for (uint32_t j = 0; j < num_input_tiles; ++j) {
+            if (input_granularity_index == 0) {
+                cb_reserve_back(cb_id_in0, input_granularity);
+                l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+                DPRINT << "Reseted" << ENDL();
+            }
+            noc_async_read_tile(read_tile_id, input_addrg, l1_write_addr_in0);
+            l1_write_addr_in0 += input_tile_bytes; // correctness error
+            read_tile_id += inner_tile_size;
+            input_granularity_index++;
+            DPRINT << "input_granularity index " << input_granularity_index << ENDL();
+            DPRINT << "l1_write_addr_in0 " << l1_write_addr_in0 << ENDL();
+            if (input_granularity_index == input_granularity) {
+                noc_async_read_barrier();
+                cb_push_back(cb_id_in0, input_granularity);
+                input_granularity_index = 0;
+                DPRINT << "Pushed" << ENDL();
+            }
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/reduce_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/reduce_nc.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_eager/tt_dnn/kernels/compute/moreh_common.hpp"
+#include "debug/dprint.h"  // required in all kernels using DPRINT
+
+namespace NAMESPACE {
+void MAIN {
+    // compile-time args
+    constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t input_granularity = get_compile_time_arg_val(2);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t dst1 = 1;
+    constexpr uint32_t first_tile = 0;
+
+    constexpr uint32_t num_input_tiles_iter = num_input_tiles / input_granularity;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    cb_wait_front(cb_in1, onetile);
+
+    DPRINT_PACK(DPRINT << "Checkpoint 1" << ENDL());
+    DPRINT_PACK(DPRINT << "num_output_tiles: " << num_output_tiles << ENDL());
+    DPRINT_PACK(DPRINT << "num_input_tiles: " << num_input_tiles << ENDL());
+    DPRINT_PACK(DPRINT << "num_input_tiles_iter: " << num_input_tiles_iter << ENDL());
+
+    for (uint32_t i = 0; i < num_output_tiles; i++) {
+
+        add_tiles_init(cb_in1, cb_in1);
+        #if defined FP32_DEST_ACC_EN
+            unpack_reconfig_data_format(cb_in1, cb_in1);
+            pack_reconfig_data_format(cb_intermed0);
+        #endif
+        tile_regs_acquire();
+        add_tiles(cb_in1, cb_in1, first_tile, first_tile, dst0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(dst0, cb_intermed0);
+        tile_regs_release();
+        cb_push_back(cb_intermed0, onetile);
+
+        for (uint32_t j = 0; j < num_input_tiles_iter; ++j) {
+            bool last_out = (j == num_input_tiles_iter - 1);
+
+            cb_wait_front(cb_in0, input_granularity);
+            // DPRINT_PACK(DPRINT << "Iter: "<< i << "," << j << ". Checkpoint 2" << ENDL());
+
+            add_tiles_init(cb_in0, cb_intermed0);
+            #if defined FP32_DEST_ACC_EN
+                pack_reconfig_data_format(cb_intermed0);
+                unpack_reconfig_data_format(cb_in0, cb_intermed0);
+            #endif
+            for (uint32_t k = 0; k < input_granularity; k++) {
+                cb_wait_front(cb_intermed0, onetile);
+                tile_regs_acquire();
+                add_tiles(cb_in0, cb_intermed0, k, first_tile, dst0);
+                tile_regs_commit();
+                if (k < input_granularity - 1) {
+                    cb_pop_front(cb_intermed0, onetile);
+                    tile_regs_wait();
+                    pack_tile(dst0, cb_intermed0);
+                    tile_regs_release();
+                    cb_push_back(cb_intermed0, onetile);
+                }
+            }
+
+            // DPRINT << "Iter: "<< i << "," << j << ". Checkpoint 3" << ENDL();
+
+            cb_pop_front(cb_in0, input_granularity);
+            cb_pop_front(cb_intermed0, onetile);
+
+            uint32_t cb_out = (last_out) ? (cb_out0) : (cb_intermed0);
+            cb_reserve_back(cb_out, onetile);
+            #if defined FP32_DEST_ACC_EN
+                pack_reconfig_data_format(cb_out);
+            #endif
+            tile_regs_wait();
+            pack_tile(dst0, cb_out);
+            tile_regs_release();
+            // DPRINT << "Iter: "<< i << "," << j << ". Checkpoint 4" << ENDL();
+
+            // if (last_out) {
+            //     DPRINT_PACK(DPRINT << "Iter: "<< i << "," << j << ". last out" << ENDL());
+            // }
+
+            cb_push_back(cb_out, onetile);
+
+            // DPRINT_PACK(DPRINT << "Iter: "<< i << "," << j << ". Checkpoint 5" << ENDL());
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/reduce_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/reduce_nc.cpp
@@ -1,104 +1,9 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_eager/tt_dnn/kernels/compute/moreh_common.hpp"
-#include "debug/dprint.h"  // required in all kernels using DPRINT
-
-namespace NAMESPACE {
-void MAIN {
-    // compile-time args
-    constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
-    constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
-    constexpr uint32_t input_granularity = get_compile_time_arg_val(2);
-
-    constexpr auto cb_in0 = tt::CB::c_in0;
-    constexpr auto cb_in1 = tt::CB::c_in1;
-    constexpr auto cb_out0 = tt::CB::c_out0;
-    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
-    constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
-    constexpr uint32_t first_tile = 0;
-
-    constexpr uint32_t num_input_tiles_iter = num_input_tiles / input_granularity;
-
-    binary_op_init_common(cb_in0, cb_in1, cb_out0);
-    cb_wait_front(cb_in1, onetile);
-
-    DPRINT_PACK(DPRINT << "Checkpoint 1" << ENDL());
-    DPRINT_PACK(DPRINT << "num_output_tiles: " << num_output_tiles << ENDL());
-    DPRINT_PACK(DPRINT << "num_input_tiles: " << num_input_tiles << ENDL());
-    DPRINT_PACK(DPRINT << "num_input_tiles_iter: " << num_input_tiles_iter << ENDL());
-
-    for (uint32_t i = 0; i < num_output_tiles; i++) {
-
-        add_tiles_init(cb_in1, cb_in1);
-        unpack_reconfig_data_format(cb_in1, cb_in1);
-        pack_reconfig_data_format(cb_intermed0);
-        tile_regs_acquire();
-        add_tiles(cb_in1, cb_in1, first_tile, first_tile, dst0);
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(dst0, cb_intermed0);
-        tile_regs_release();
-        cb_push_back(cb_intermed0, onetile);
-
-        for (uint32_t j = 0; j < num_input_tiles_iter; ++j) {
-            bool last_out = (j == num_input_tiles_iter - 1);
-
-            cb_wait_front(cb_in0, input_granularity);
-            // DPRINT_PACK(DPRINT << "Iter: "<< i << "," << j << ". Checkpoint 2" << ENDL());
-
-            add_tiles_init(cb_in0, cb_intermed0);
-            pack_reconfig_data_format(cb_intermed0);
-            unpack_reconfig_data_format(cb_in0, cb_intermed0);
-            for (uint32_t k = 0; k < input_granularity; k++) {
-                cb_wait_front(cb_intermed0, onetile);
-                tile_regs_acquire();
-                add_tiles(cb_in0, cb_intermed0, k, first_tile, dst0);
-                tile_regs_commit();
-                if (k < input_granularity - 1) {
-                    cb_pop_front(cb_intermed0, onetile);
-                    tile_regs_wait();
-                    pack_tile(dst0, cb_intermed0);
-                    tile_regs_release();
-                    cb_push_back(cb_intermed0, onetile);
-                }
-            }
-
-            // DPRINT << "Iter: "<< i << "," << j << ". Checkpoint 3" << ENDL();
-
-            cb_pop_front(cb_in0, input_granularity);
-            cb_pop_front(cb_intermed0, onetile);
-
-            uint32_t cb_out = (last_out) ? (cb_out0) : (cb_intermed0);
-            cb_reserve_back(cb_out, onetile);
-            pack_reconfig_data_format(cb_out);
-            tile_regs_wait();
-            pack_tile(dst0, cb_out);
-            tile_regs_release();
-            // DPRINT << "Iter: "<< i << "," << j << ". Checkpoint 4" << ENDL();
-
-            // if (last_out) {
-            //     DPRINT_PACK(DPRINT << "Iter: "<< i << "," << j << ". last out" << ENDL());
-            // }
-
-            cb_push_back(cb_out, onetile);
-
-            // DPRINT_PACK(DPRINT << "Iter: "<< i << "," << j << ". Checkpoint 5" << ENDL());
-        }
-    }
-}
-}  // namespace NAMESPACE
-
-/*
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-//
-// SPDX-License-Identifier: Apache-2.0
-
-#include "tt_eager/tt_dnn/kernels/compute/moreh_common.hpp"
-#include "debug/dprint.h"  // required in all kernels using DPRINT
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_binary.h"
 
 namespace NAMESPACE {
 void MAIN {
@@ -120,48 +25,24 @@ void MAIN {
     binary_op_init_common(cb_in0, cb_in1, cb_out0);
     cb_wait_front(cb_in1, onetile);
 
-    DPRINT_PACK(DPRINT << "Checkpoint 1" << ENDL());
-    DPRINT_PACK(DPRINT << "num_output_tiles: " << num_output_tiles << ENDL());
-    DPRINT_PACK(DPRINT << "num_input_tiles: " << num_input_tiles << ENDL());
-    DPRINT_PACK(DPRINT << "num_input_tiles_iter: " << num_input_tiles_iter << ENDL());
-
     for (uint32_t i = 0; i < num_output_tiles; i++) {
-
-        // add_tiles_init(cb_in1, cb_in1);
-        // // #if defined FP32_DEST_ACC_EN
-        //     unpack_reconfig_data_format(cb_in1, cb_in1);
-        // // #endif
-        // tile_regs_acquire();
-        // add_tiles(cb_in1, cb_in1, first_tile, first_tile, dst0);
-        // tile_regs_commit();
-        // tile_regs_wait();
-        // tile_regs_release();
-
-        binary_dest_reuse_tiles_init(cb_in0);
-        // #if defined FP32_DEST_ACC_EN
-            pack_reconfig_data_format(cb_out0);
-            unpack_reconfig_data_format(cb_in0, cb_in1);
-        // #endif
+        add_tiles_init(cb_in0, cb_in1, true);
+        unpack_reconfig_data_format(cb_in0, cb_in1);
         tile_regs_acquire();
         for (uint32_t j = 0; j < num_input_tiles_iter; ++j) {
             cb_wait_front(cb_in0, input_granularity);
-
             for (uint32_t k = 0; k < input_granularity; k++) {
-                binary_dest_reuse_tiles(cb_in0, k, dst0);
+                add_tiles(cb_in0, cb_in1, k, first_tile, dst0);
             }
             cb_pop_front(cb_in0, input_granularity);
         }
         tile_regs_commit();
         cb_reserve_back(cb_out0, onetile);
-        // #if defined FP32_DEST_ACC_EN
-            pack_reconfig_data_format(cb_out0);
-        // #endif
+        pack_reconfig_data_format(cb_out0);
         tile_regs_wait();
         pack_tile(dst0, cb_out0);
         tile_regs_release();
-
         cb_push_back(cb_out0, onetile);
     }
 }
 }  // namespace NAMESPACE
-*/

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/writer_reduce_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/writer_reduce_nc.cpp
@@ -1,18 +1,17 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp"
+#include "dataflow_api.h"
 
 void kernel_main() {
     // compile-time args
     constexpr bool output_is_dram = (get_compile_time_arg_val(0) == 1);
 
     // runtime args
-    ArgFetcher arg_fetcher;
-    const auto output_addr = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto num_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto output_addr = get_arg_val<uint32_t>(0);
+    const auto num_tiles = get_arg_val<uint32_t>(1);
+    const auto start_id = get_arg_val<uint32_t>(2);
 
     constexpr uint32_t cb_id_out = 16;
     constexpr uint32_t onetile = 1;

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/writer_reduce_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/writer_reduce_nc.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+void kernel_main() {
+    // compile-time args
+    constexpr bool output_is_dram = (get_compile_time_arg_val(0) == 1);
+
+    // runtime args
+    ArgFetcher arg_fetcher;
+    const auto output_addr = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto num_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
+
+    constexpr uint32_t cb_id_out = 16;
+    constexpr uint32_t onetile = 1;
+
+    uint32_t output_tile_bytes = get_tile_size(cb_id_out);
+    const auto output_data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<output_is_dram> output_addrg = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        uint32_t write_tile_id = i;
+        cb_wait_front(cb_id_out, onetile);
+
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        noc_async_write_tile(write_tile_id, output_addrg, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
@@ -145,7 +145,7 @@ operation::ProgramWithCallbacks reduce_nc_impl(const Tensor &input, const Tensor
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1, num_reduce_input_tile, input_granularity};
+    const std::vector<uint32_t> compute_args_group_1 = {num_cols_per_core_group_1, num_reduce_input_tile, input_granularity};
     std::map<string, string> compute_defines;
     if (fp32_dest_acc_en) {
         compute_defines["FP32_DEST_ACC_EN"] = "1";
@@ -159,7 +159,7 @@ operation::ProgramWithCallbacks reduce_nc_impl(const Tensor &input, const Tensor
 
     std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
     if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2, num_reduce_input_tile};
+        const std::vector<uint32_t> compute_args_group_2 = {num_cols_per_core_group_2, num_reduce_input_tile, input_granularity};
         compute_kernel_2_id = tt_metal::CreateKernel(
             program,
             compute_kernel_file,

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
@@ -215,17 +215,14 @@ operation::ProgramWithCallbacks reduce_nc_impl(const Tensor &input, const Tensor
         log_debug(LogOp, "{}:{} args_callback ", __func__, __LINE__);
         const auto *input_buffer = input_tensors.at(0).buffer();
         const auto *output_buffer = output_tensors.at(0).buffer();
+        auto& reader_kernel_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+        auto& writer_kernel_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
         for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = input_buffer->address();
-            }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = output_buffer->address();
-            }
+            auto& reader_kernel_args = reader_kernel_args_by_core[core.x][core.y];
+                reader_kernel_args[0] = input_buffer->address();
+            auto& writer_kernel_args = writer_kernel_args_by_core[core.x][core.y];
+                writer_kernel_args[0] = output_buffer->address();
         }
     };
 

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
@@ -48,6 +48,8 @@ operation::ProgramWithCallbacks reduce_nc_impl(const Tensor &input, const Tensor
     ////////////////////////////////////////////////////////////////////////////
     const auto cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
     const auto single_tile_size = detail::TileSize(cb_data_format);
+    const auto cb_1_data_format = datatype_to_dataformat_converter(DataType::BFLOAT16);
+    const auto cb_1_tile_size = detail::TileSize(cb_1_data_format);
 
     const auto &input_shape = input.get_legacy_shape();
     const auto &input_shape_without_padding = input_shape.without_padding();
@@ -103,8 +105,8 @@ operation::ProgramWithCallbacks reduce_nc_impl(const Tensor &input, const Tensor
     auto cb_scr0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_scr0_config);
 
     tt_metal::CircularBufferConfig cb_scr1_config =
-        tt_metal::CircularBufferConfig(in1_t*single_tile_size, {{CB::c_in1, cb_data_format}})
-            .set_page_size(CB::c_in1, single_tile_size);
+        tt_metal::CircularBufferConfig(in1_t*cb_1_tile_size, {{CB::c_in1, cb_1_data_format}})
+            .set_page_size(CB::c_in1, cb_1_tile_size);
     auto cb_scr1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_scr1_config);
 
     tt_metal::CircularBufferConfig cb_intermed0_config =

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp"
-#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "tt_eager/tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
@@ -123,10 +122,10 @@ operation::ProgramWithCallbacks reduce_nc_impl(const Tensor &input, const Tensor
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> reader_compile_time_args =
-             {static_cast<uint32_t>(tt::operations::primary::is_dram(input)),
+             {static_cast<uint32_t>(input.memory_config().buffer_type == BufferType::DRAM),
               input_granularity} ;
     std::vector<uint32_t> writer_compile_time_args =
-             {static_cast<uint32_t>(tt::operations::primary::is_dram(output)),
+             {static_cast<uint32_t>(output.memory_config().buffer_type == BufferType::DRAM),
               input_granularity} ;
     const auto reader_kernel_file = "tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/reader_reduce_nc.cpp";
     const auto writer_kernel_file = "tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/writer_reduce_nc.cpp";

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/reduce_nc_impl.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_eager/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace tt_metal {
+
+namespace {
+inline
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_and_scale_spatial_dims(const Shape& shape, uint32_t dim) {
+    const auto rank = shape.rank();
+
+    TT_FATAL(rank >= 2, "Shape must have at least two dims.");
+    uint32_t Wt = shape[-1] / TILE_WIDTH;
+    uint32_t Ht = shape[-2] / TILE_HEIGHT;
+
+    uint32_t reduce_dim = shape[dim];
+    uint32_t inner_dims_product = 1;
+    for (auto i = dim + 1; i < rank - 2; ++i) {
+        inner_dims_product *= shape[i];
+    }
+
+    uint32_t inner_tile_size = inner_dims_product * Ht * Wt;
+    uint32_t reduce_tile_size = reduce_dim * inner_tile_size;
+
+    return { Wt, Ht, inner_tile_size, reduce_tile_size};
+}
+
+}
+
+operation::ProgramWithCallbacks reduce_nc_impl(const Tensor &input, const Tensor &output, int64_t dim,const DeviceComputeKernelConfig &compute_kernel_config) {
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto *device = input.device();
+    auto program = Program();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const auto cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
+    const auto single_tile_size = detail::TileSize(cb_data_format);
+
+    const auto &input_shape = input.get_legacy_shape();
+    const auto &input_shape_without_padding = input_shape.without_padding();
+    const auto [Wt, Ht, inner_tile_size, reduce_tile_size] = extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
+    const auto num_reduce_input_tile = input_shape[dim];
+    const auto num_output_tiles = output.volume() / TILE_HW;
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    // choose granularity as the largest factor of num_reduce_input_tile that is less than or equal to 8
+    uint32_t input_granularity;
+    for (input_granularity = 8; input_granularity > 1; --input_granularity) {
+        if (num_reduce_input_tile % input_granularity == 0) {
+            break;
+        }
+    }
+
+    log_debug(LogOp, "reduce_tile_size {} inner_tile_size {} Ht {} Wt {}", reduce_tile_size, inner_tile_size, Ht, Wt);
+    log_debug(
+        LogOp, "dim {} num_reduce_input_tile {} num_output_tiles {}", dim, num_reduce_input_tile, num_output_tiles);
+    log_debug(
+        LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto grid = device->compute_with_storage_grid_size();
+    const auto num_cores_y = grid.y;
+
+    const uint32_t in0_t = input_granularity*2;        // input
+    const uint32_t in1_t = 1;        // zero
+    const uint32_t intermed0_t = 1;  // accumulated sum
+    const uint32_t out0_t = 2;       // output
+    const auto
+        [num_cores_to_be_used,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_cols_per_core_group_1,
+         num_cols_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_output_tiles);
+    const auto intermed_cb_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32: cb_data_format;
+    const auto intermed_cb_single_tile_size = (fp32_dest_acc_en) ? single_tile_size*2: single_tile_size;
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::CircularBufferConfig cb_scr0_config =
+        tt_metal::CircularBufferConfig(in0_t*single_tile_size, {{CB::c_in0, cb_data_format}})
+            .set_page_size(CB::c_in0, single_tile_size);
+    auto cb_scr0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_scr0_config);
+
+    tt_metal::CircularBufferConfig cb_scr1_config =
+        tt_metal::CircularBufferConfig(in1_t*single_tile_size, {{CB::c_in1, cb_data_format}})
+            .set_page_size(CB::c_in1, single_tile_size);
+    auto cb_scr1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_scr1_config);
+
+    tt_metal::CircularBufferConfig cb_intermed0_config =
+        tt_metal::CircularBufferConfig(intermed0_t*intermed_cb_single_tile_size, {{CB::c_intermed0, intermed_cb_data_format}})
+            .set_page_size(CB::c_intermed0, intermed_cb_single_tile_size);
+    auto cb_intermed0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
+
+    tt_metal::CircularBufferConfig cb_output_config =
+        tt_metal::CircularBufferConfig(out0_t*single_tile_size, {{CB::c_out0, cb_data_format}})
+            .set_page_size(CB::c_out0, single_tile_size);
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> reader_compile_time_args =
+             {static_cast<uint32_t>(tt::operations::primary::is_dram(input)),
+              input_granularity} ;
+    std::vector<uint32_t> writer_compile_time_args =
+             {static_cast<uint32_t>(tt::operations::primary::is_dram(output)),
+              input_granularity} ;
+    const auto reader_kernel_file = "tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/reader_reduce_nc.cpp";
+    const auto writer_kernel_file = "tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/writer_reduce_nc.cpp";
+
+    tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        reader_kernel_file,
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt_metal::KernelHandle writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        writer_kernel_file,
+        all_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1, num_reduce_input_tile, input_granularity};
+    std::map<string, string> compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    const auto compute_kernel_file = "tt_eager/tt_dnn/op_library/fast_reduce_nc/reduce_nc_impl/kernels/reduce_nc.cpp";
+    const auto compute_kernel_1_id = tt_metal::CreateKernel(
+        program,
+        compute_kernel_file,
+        core_group_1,
+        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode, .compile_args = compute_args_group_1, .defines = compute_defines});
+
+    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2, num_reduce_input_tile};
+        compute_kernel_2_id = tt_metal::CreateKernel(
+            program,
+            compute_kernel_file,
+            core_group_2,
+            tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode,  .compile_args = compute_args_group_2, .defines = compute_defines});
+
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_tiles_per_core;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        tt_metal::SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_reduce_input_tile,
+             num_tiles_per_core,
+             tile_offset,
+             static_cast<uint32_t>(dim),
+             reduce_tile_size,
+             inner_tile_size
+             });
+
+        tt_metal::SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            { output.buffer()->address(), num_tiles_per_core, tile_offset
+            });
+
+        tile_offset += num_tiles_per_core;
+    }
+
+    auto override_runtime_arguments_callback = [reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y](
+                                                   const void *operation,
+                                                   const Program &program,
+                                                   const std::vector<Tensor> &input_tensors,
+                                                   const std::vector<std::optional<const Tensor>> &,
+                                                   const std::vector<Tensor> &output_tensors) {
+        log_debug(LogOp, "{}:{} args_callback ", __func__, __LINE__);
+        const auto *input_buffer = input_tensors.at(0).buffer();
+        const auto *output_buffer = output_tensors.at(0).buffer();
+        for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+            {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = input_buffer->address();
+            }
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = output_buffer->address();
+            }
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace tt-metal
+}  // namespace tt

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -22,6 +22,7 @@
 #include "tt_dnn/op_library/pool/average_pool.hpp"
 #include "tt_dnn/op_library/pool/max_pool.hpp"
 #include "tt_dnn/op_library/reduce/reduce_op.hpp"
+#include "tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.hpp"
 #include "tt_dnn/op_library/rotary_embedding/rotary_embedding_op.hpp"
 #include "tt_dnn/op_library/rotary_embedding/rotary_embedding_llama_op.hpp"
 #include "tt_dnn/op_library/rotate_half/rotate_half_op.hpp"
@@ -389,6 +390,17 @@ void TensorModule(py::module& m_tensor) {
         py::arg("dim"),
         R"doc(Returns a tensor that is a max  of input tensor with shape ``[W, Z, Y, X]`` along dimensions ``{1}``; input tensor in TILE LAYOUT.)doc",
         R"doc("dimension along which to apply max", "int", "0, 1, 2, or 3")doc");
+
+    m_tensor.def(
+        "fast_reduce_nc",
+        &fast_reduce_nc,
+        py::arg("input").noconvert(),
+        py::kw_only(),
+        py::arg("dims").noconvert() = std::vector<int64_t>(),
+        py::arg("output").noconvert() = std::nullopt,
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
+        "Performs optimized reduction operation on dim 0, 1, or [0,1]. Returns an output tensor.");
 
     m_tensor.def(
         "downsample",


### PR DESCRIPTION
Currently, there are two ways to perform reduction on device. The `ttnn.experimental.tensor.sum` api performs transposes of dim0 and dim1 into row and column dims, and perform row/col reduction. This approach is very slow and creates extra ops. On the other hand, the `moreh_sum` api performs reduction on dim0 and dim1 much more efficiently, with dedicated kernels for those operations. A comparison of two ops can be found #9126  However, more optimization could be done on moreh_sum op by increasing its granularity, using dst accumulation for add_tiles (new feature), and support bfp8_b reduction, which is being used in Mixtral8x7b model.

Hence, I created this new op called `fast_reduce_nc` which dedicates an optimized reduction on dim0 and 1, and supports bfp8_b precision.

A perf comparison of the fast_reduce_nc op and moreh sum op on Mixtral8x7b use cases is below:

<img width="676" alt="image" src="https://github.com/tenstorrent/tt-metal/assets/61562234/fd806084-006b-444b-8dbe-0916c4c4d97e">

FYI @cglagovich @cglagovichTT @sraizada-tt 
