### PR TITLE
#9217: Add cq_id to add_bw, mul_bw and dependency ops

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_binary_optional_output.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_binary_optional_output.py
@@ -67,6 +67,7 @@ class TestEltwiseBinary:
             {
                 "dtype": [in0_dtype, in1_dtype, in2_dtype],
                 "input_mem_config": [input_mem_config, input_mem_config, input_mem_config],
+                "queue_id": False,
             }
         )
         comparison_func = comparison_funcs.comp_pcc
@@ -117,14 +118,12 @@ class TestEltwiseBinary:
         )
 
     @pytest.mark.parametrize("cmp_kind", ["lt", "gt", "lte", "gte", "ne", "eq"])
-    @pytest.mark.parametrize("pass_queue_id", [True, False])
     def test_run_eltwise_binary_cmp_ops(
         self,
         input_shapes,
         input_mem_config,
         cmp_kind,
         device,
-        pass_queue_id,
         function_level_defaults,
     ):
         datagen_func = [
@@ -137,15 +136,8 @@ class TestEltwiseBinary:
         test_args.update(
             {
                 "input_mem_config": [input_mem_config, input_mem_config, input_mem_config],
-                "queue_id": "skip",
             }
         )
-        if cmp_kind == "eq":
-            test_args.update(
-                {
-                    "queue_id": pass_queue_id,
-                }
-            )
 
         comparison_func = comparison_funcs.comp_equal
         run_single_pytorch_test(

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1047,7 +1047,7 @@ def eltwise_addalpha_optional(
     cq_id = 0
 
     if queue_id:
-        ttl.tensor.addalpha(cq_id, t0, t1, alpha, output_tensor=t2)
+        ttl.tensor.addalpha(t0, t1, alpha, output_tensor=t2, queue_id=cq_id)
     else:
         ttl.tensor.addalpha(t0, t1, alpha, output_tensor=t2)
 
@@ -1643,7 +1643,8 @@ def where_optional(x, y, z, out, device, dtype, layout, input_mem_config, output
     t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
     t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
     t3 = setup_tt_tensor(out, device, layout[3], input_mem_config[3], dtype[3])
-    ttl.tensor.where(t0, t1, t2, output_mem_config=output_mem_config, output_tensor=t3)
+    cq_id = 0
+    ttl.tensor.where(t0, t1, t2, output_tensor=t3, queue_id=cq_id)
 
     return tt2torch_tensor(t3)
 
@@ -1654,7 +1655,8 @@ def where_scalar_optional(
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t3 = setup_tt_tensor(out, device, layout[1], input_mem_config[1], dtype[1])
-    ttl.tensor.where(t0, scalar_true, scalar_false, output_mem_config=output_mem_config, output_tensor=t3)
+    cq_id = 0
+    ttl.tensor.where(t0, scalar_true, scalar_false, output_tensor=t3, queue_id=cq_id)
 
     return tt2torch_tensor(t3)
 
@@ -2582,7 +2584,9 @@ def make_binary_op_optional_output(ttl_tensor_binop):
         t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
         t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
 
-        ttl_tensor_binop(t0, t1, output_tensor=t2)
+        cq_id = 0
+
+        ttl_tensor_binop(t0, t1, output_tensor=t2, queue_id=cq_id)
 
         return tt2torch_tensor(t2)
 
@@ -2595,6 +2599,7 @@ eltwise_mul_optional = make_binary_op_optional_output(ttnn.mul)
 eltwise_bias_gelu_optional = make_binary_op_optional_output(ttnn.bias_gelu)
 eltwise_squared_difference_optional = make_binary_op_optional_output(ttnn.squared_difference)
 eltwise_ne_optional = make_binary_op_optional_output(ttnn.ne)
+eltwise_eq_optional = make_binary_op_optional_output(ttnn.eq)
 eltwise_gt_optional = make_binary_op_optional_output(ttnn.gt)
 eltwise_lt_optional = make_binary_op_optional_output(ttnn.lt)
 eltwise_gte_optional = make_binary_op_optional_output(ttnn.ge)
@@ -2604,31 +2609,6 @@ eltwise_logaddexp_optional = make_binary_op_optional_output(ttnn.logaddexp)
 eltwise_logaddexp2_optional = make_binary_op_optional_output(ttnn.logaddexp2)
 eltwise_logical_and_optional = make_binary_op_optional_output(ttnn.logical_and)
 eltwise_logical_or_optional = make_binary_op_optional_output(ttnn.logical_or)
-
-
-def eltwise_eq_optional(
-    x,
-    y,
-    z,
-    *args,
-    device,
-    dtype,
-    layout,
-    input_mem_config,
-    queue_id,
-    **kwargs,
-):
-    cq_id = 0
-    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
-
-    if queue_id == True:
-        ttnn.eq(t0, t1, output_tensor=t2, queue_id=cq_id)
-    else:
-        ttnn.eq(t0, t1, output_tensor=t2)
-
-    return tt2torch_tensor(t2)
 
 
 ################################################

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -57,13 +57,16 @@ def test_bw_add_with_opt_output(input_shapes, device, are_required_outputs):
     if are_required_outputs[1]:
         _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
 
+    cq_id = 0
+
     tt_output_tensor_on_device = tt_lib.tensor.add_bw(
         grad_tensor,
         input_tensor,
         other_tensor,
         are_required_outputs=are_required_outputs,
-        input_grad=input_grad,
-        other_grad=other_grad,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
+        queue_id=cq_id,
     )
 
     in_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
@@ -59,14 +59,16 @@ def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_o
     if are_required_outputs[1]:
         _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
 
+    cq_id = 0
     tt_output_tensor_on_device = tt_lib.tensor.addalpha_bw(
         grad_tensor,
         input_tensor,
         other_tensor,
         alpha,
         are_required_outputs=are_required_outputs,
-        input_grad=input_grad,
-        other_grad=other_grad,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
+        queue_id=cq_id,
     )
 
     in_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
@@ -85,21 +85,22 @@ def test_bw_binary_eq_opt_output_qid(input_shapes, device, are_required_outputs)
     _, grad_tensor = data_gen_with_range(input_shapes, -20, 40, device)
     input_grad = None
     other_grad = None
+
     if are_required_outputs[0]:
         _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
     if are_required_outputs[1]:
         _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
 
-    queue_id = 0
+    cq_id = 0
 
     tt_output_tensor_on_device = tt_lib.tensor.binary_eq_bw(
-        queue_id,
         grad_tensor,
         input_tensor,
         other_tensor,
         are_required_outputs=are_required_outputs,
         input_grad=input_grad,
         other_grad=other_grad,
+        queue_id=cq_id,
     )
 
     in_grad = torch.zeros_like(in_data)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
@@ -45,26 +45,40 @@ def test_bw_mul(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
-def test_bw_mul_opt_output(input_shapes, device, are_required_outputs):
+@pytest.mark.parametrize("pass_queue_id", [True, False])
+def test_bw_mul_opt_output(input_shapes, device, are_required_outputs, pass_queue_id):
     in_data_a, input_tensor_a = data_gen_with_range(input_shapes, -90, 80, device, True)
     in_data_b, input_tensor_b = data_gen_with_range(input_shapes, -70, 90, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -60, 60, device)
     input_a_grad = None
     input_b_grad = None
+    tt_output_tensor_on_device = None
 
     if are_required_outputs[0]:
         _, input_a_grad = data_gen_with_range(input_shapes, -1, 1, device)
     if are_required_outputs[1]:
         _, input_b_grad = data_gen_with_range(input_shapes, -1, 1, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.mul_bw(
-        grad_tensor,
-        input_tensor_a,
-        input_tensor_b,
-        are_required_outputs=are_required_outputs,
-        input_a_grad=input_a_grad,
-        input_b_grad=input_b_grad,
-    )
+    cq_id = 0
+    if pass_queue_id:
+        tt_output_tensor_on_device = tt_lib.tensor.mul_bw(
+            grad_tensor,
+            input_tensor_a,
+            input_tensor_b,
+            are_required_outputs=are_required_outputs,
+            input_a_grad=input_a_grad,
+            input_b_grad=input_b_grad,
+            queue_id=cq_id,
+        )
+    else:
+        tt_output_tensor_on_device = tt_lib.tensor.mul_bw(
+            grad_tensor,
+            input_tensor_a,
+            input_tensor_b,
+            are_required_outputs=are_required_outputs,
+            input_a_grad=input_a_grad,
+            input_b_grad=input_b_grad,
+        )
 
     in_data_a.retain_grad()
     in_data_b.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_where.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_where.py
@@ -41,3 +41,60 @@ def test_bw_where(input_shapes, device):
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+def test_bw_where_output(input_shapes, are_required_outputs, device):
+    condition_data = torch.zeros(input_shapes, dtype=torch.bool)
+    condition_data.view(-1)[::2] = True
+
+    condition_tensor = (
+        tt_lib.tensor.Tensor(condition_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
+    )
+
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -1, 1, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -4, 4, device)
+    input_grad = None
+    other_grad = None
+
+    if are_required_outputs[0]:
+        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+    if are_required_outputs[1]:
+        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+
+    tt_output_tensor_on_device = tt_lib.tensor.where_bw(
+        grad_tensor,
+        condition_tensor,
+        input_tensor,
+        other_tensor,
+        are_required_outputs=are_required_outputs,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
+        queue_id=cq_id,
+    )
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    pyt_y = torch.where(condition_data, in_data, other_data)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad, other_data.grad]
+
+    status = True
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]])
+    assert status

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -25,6 +25,17 @@ std::vector<std::optional<Tensor>> addalpha_bw(
     std::optional<Tensor> input_grad = std::nullopt,
     std::optional<Tensor> other_grad = std::nullopt);
 
+std::vector<std::optional<Tensor>> addalpha_bw(
+    uint8_t queue_id,
+    const Tensor& grad,
+    const Tensor& input,
+    const Tensor& other,
+    float alpha,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
+    std::optional<Tensor> input_grad = std::nullopt,
+    std::optional<Tensor> other_grad = std::nullopt);
+
 std::vector<Tensor> addcmul_bw(
     const Tensor& grad,
     const Tensor& input,
@@ -67,6 +78,26 @@ std::vector<std::optional<Tensor>> mul_bw(
     const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
     std::optional<Tensor> input_a_grad = std::nullopt,
     std::optional<Tensor> input_b_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> mul_bw(
+    uint8_t cq_id,
+    const Tensor& grad,
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
+    std::optional<Tensor> input_a_grad = std::nullopt,
+    std::optional<Tensor> input_b_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> add_bw(
+    uint8_t cq_id,
+    const Tensor& grad,
+    const Tensor& input,
+    const Tensor& other,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
+    std::optional<Tensor> input_grad = std::nullopt,
+    std::optional<Tensor> other_grad = std::nullopt);
 
 std::vector<std::optional<Tensor>> add_bw(
     const Tensor& grad,
@@ -154,12 +185,26 @@ std::vector<Tensor> tan_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> where_bw(
+std::vector<std::optional<Tensor>> where_bw(
     const Tensor& grad,
     const Tensor& condition,
     const Tensor& input,
     const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
+    std::optional<Tensor> input_grad = std::nullopt,
+    std::optional<Tensor> other_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> where_bw(
+    uint8_t queue_id,
+    const Tensor& grad,
+    const Tensor& condition,
+    const Tensor& input,
+    const Tensor& other,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
+    std::optional<Tensor> input_grad = std::nullopt,
+    std::optional<Tensor> other_grad = std::nullopt);
 
 std::vector<Tensor> fill_zero_bw(
     const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -361,10 +361,45 @@ Tensor where(
     const float value_false,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<Tensor> output_tensor = std::nullopt);
+Tensor where(
+    uint8_t queue_id,
+    const Tensor& predicate,
+    const Tensor& value_true,
+    const Tensor& value_false,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+Tensor where(
+    uint8_t queue_id,
+    const Tensor& predicate,
+    const float value_true,
+    const Tensor& value_false,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+Tensor where(
+    uint8_t queue_id,
+    const Tensor& predicate,
+    const Tensor& value_true,
+    const float value_false,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+Tensor where(
+    uint8_t queue_id,
+    const Tensor& predicate,
+    const float value_true,
+    const float value_false,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 
 // on-device tensor creation 0s like @reference_tensor
 Tensor zeros_like(
-    const Tensor& reference_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    uint8_t queue_id,
+    const Tensor& reference_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor= std::nullopt);
+Tensor zeros_like(
+    const Tensor& reference_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor= std::nullopt);
 
 // on-device tensor creation 1s like @reference_tensor
 Tensor ones_like(
@@ -372,9 +407,16 @@ Tensor ones_like(
 
 // on-device tensor creation with value like @reference_tensor
 Tensor full_like(
+    uint8_t queue_id,
     const Tensor& reference_tensor,
     float value,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor= std::nullopt);
+Tensor full_like(
+    const Tensor& reference_tensor,
+    float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor= std::nullopt);
 
 // on-device tensor creation 0s with shape
 Tensor empty(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -9,8 +9,28 @@
 namespace tt::tt_metal::detail{
     void TensorModuleBackwardOPs( py::module & m_tensor){
 
-    m_tensor.def("addalpha_bw", &tt::tt_metal::addalpha_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true}, py::arg("input_grad").noconvert() = std::nullopt,py::arg("other_grad").noconvert() = std::nullopt, R"doc(
+    m_tensor.def("addalpha_bw",
+            [](const Tensor& grad,
+                const Tensor& input_a,
+                const Tensor& input_b,
+                const float alpha,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                std::optional<Tensor> other_grad,
+                uint8_t queue_id) {
+                    return addalpha_bw(queue_id, grad, input_a, input_b, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input_a").noconvert(),
+            py::arg("input_b").noconvert(),
+            py::arg("alpha") = 1.0f,
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
+            py::arg("input_a_grad").noconvert() = std::nullopt,
+            py::arg("input_b_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Performs backward operations for multiplication of ``input_b`` and ``alpha`` tensors with given ``grad``.
 
             Input tensor must have BFLOAT16 data type.
@@ -28,6 +48,7 @@ namespace tt::tt_metal::detail{
                 "are_required_outputs", "Boolean values for the required outputs: input_a_grad, input_b_grad ", "List of bool", "Default value is [True, True]", "No"
                 "input_grad", "Optional Output Tensor for input_grad", "Tensor", "Default value is None", "No"
                 "other_grad", "Optional Output Tensor for other_grad", "Tensor", "Default value is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
 
     m_tensor.def("conj_bw", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&conj_bw),
@@ -79,8 +100,26 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("mul_bw", &tt::tt_metal::mul_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true}, py::arg("input_a_grad").noconvert() = std::nullopt,py::arg("input_b_grad").noconvert() = std::nullopt, R"doc(
+    m_tensor.def("mul_bw",
+        [](const Tensor& grad,
+           const Tensor& input_a,
+           const Tensor& input_b,
+           const MemoryConfig& output_mem_config,
+           const std::vector<bool>& are_required_outputs,
+           std::optional<Tensor> input_a_grad,
+           std::optional<Tensor> input_b_grad,
+           uint8_t queue_id) {
+            return mul_bw(queue_id, grad, input_a, input_b, output_mem_config, are_required_outputs, input_a_grad, input_b_grad);
+        },
+            py::arg("grad").noconvert(),
+            py::arg("input_a").noconvert(),
+            py::arg("input_b").noconvert(),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
+            py::arg("input_a_grad").noconvert() = std::nullopt,
+            py::arg("input_b_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
                 Performs backward operations for multiplication of two input tensors with given ``grad``
 
                 Input tensors must have BFLOAT16 data type.
@@ -95,8 +134,9 @@ namespace tt::tt_metal::detail{
                     "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                     "are_required_outputs", "Boolean values for the required outputs: input_a_grad, input_b_grad ", "List of bool", "Default value is [True, True]", "No"
-                    "input_grad", "Optional Output Tensor for input_a gradient", "Tensor", "Default value is None", "No"
-                    "other_grad", "Optional Output Tensor for input_b gradient", "Tensor", "Default value is None", "No"
+                    "input_a_grad", "Optional Output Tensor for input_a gradient", "Tensor", "Default value is None", "No"
+                    "input_b_grad", "Optional Output Tensor for input_b gradient", "Tensor", "Default value is None", "No"
+                    "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
             )doc");
 
     m_tensor.def("exp_bw", &tt::tt_metal::exp_bw,
@@ -271,8 +311,26 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("add_bw", &tt::tt_metal::add_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true}, py::arg("input_grad").noconvert() = std::nullopt,py::arg("other_grad").noconvert() = std::nullopt, R"doc(
+    m_tensor.def("add_bw",
+            [](const Tensor& grad,
+                const Tensor& input_a,
+                const Tensor& input_b,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                std::optional<Tensor> other_grad,
+                uint8_t queue_id) {
+                    return add_bw(queue_id, grad, input_a, input_b, output_mem_config, are_required_outputs, input_grad, other_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input_a").noconvert(),
+            py::arg("input_b").noconvert(),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
+            py::arg("input_a_grad").noconvert() = std::nullopt,
+            py::arg("input_b_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Performs backward operations for addition of ``input_b`` tensors with given ``grad``.
 
             Input tensor must have BFLOAT16 data type.
@@ -287,8 +345,9 @@ namespace tt::tt_metal::detail{
                 "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "are_required_outputs", "Boolean values for the required outputs: input_a_grad, input_b_grad ", "List of bool", "Default value is [True, True]", "No"
-                "input_grad", "Optional Output Tensor for input_a gradient", "Tensor", "Default value is None", "No"
-                "other_grad", "Optional Output Tensor for input_b gradient", "Tensor", "Default value is None", "No"
+                "input_a_grad", "Optional Output Tensor for input_a gradient", "Tensor", "Default value is None", "No"
+                "input_b_grad", "Optional Output Tensor for input_b gradient", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
         )doc");
 
     m_tensor.def("relu_bw", &tt::tt_metal::relu_bw,
@@ -442,9 +501,28 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-
-    m_tensor.def("where_bw", &tt::tt_metal::where_bw,
-            py::arg("grad").noconvert(), py::arg("condition").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def("where_bw",
+        [](const Tensor& grad,
+           const Tensor& condition,
+           const Tensor& input,
+           const Tensor& other,
+           const MemoryConfig& output_mem_config,
+           const std::vector<bool>& are_required_outputs,
+           std::optional<Tensor> input_grad,
+           std::optional<Tensor> other_grad,
+           uint8_t queue_id) {
+            return where_bw(queue_id, grad, condition, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
+        },
+            py::arg("grad").noconvert(),
+            py::arg("condition").noconvert(),
+            py::arg("input_a").noconvert(),
+            py::arg("input_b").noconvert(),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
+            py::arg("input_a_grad").noconvert() = std::nullopt,
+            py::arg("input_b_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Performs backward operations for where selected from either ``input_a`` or ``input_b``, depending on ``condition`` with given ``grad``.
             When condition True (nonzero), yield grad, otherwise yield zero's.
 
@@ -460,6 +538,10 @@ namespace tt::tt_metal::detail{
                 "input_a", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "are_required_outputs", "Boolean values for the required outputs: input_a_grad, input_b_grad ", "List of bool", "Default value is [True, True]", "No"
+                "input_a_grad", "Optional Output Tensor for input_a gradient", "Tensor", "Default value is None", "No"
+                "input_b_grad", "Optional Output Tensor for input_b gradient", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
         )doc");
 
 
@@ -1645,8 +1727,26 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("binary_eq_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor> >(&binary_eq_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true}, py::arg("input_grad").noconvert() = std::nullopt,py::arg("other_grad").noconvert() = std::nullopt, R"doc(
+    m_tensor.def("binary_eq_bw",
+        [](const Tensor& grad,
+           const Tensor& input,
+           const Tensor& other,
+           const MemoryConfig& output_mem_config,
+           const std::vector<bool>& are_required_outputs,
+           std::optional<Tensor> input_grad,
+           std::optional<Tensor> other_grad,
+           uint8_t queue_id) {
+            return binary_eq_bw(queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
+        },
+            py::arg("grad").noconvert(),
+            py::arg("input").noconvert(),
+            py::arg("other").noconvert(),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
+            py::arg("input_grad").noconvert() = std::nullopt,
+            py::arg("other_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.
 
             Input tensors must have BFLOAT16 data type.
@@ -1663,27 +1763,7 @@ namespace tt::tt_metal::detail{
                 "are_required_outputs", "Boolean values for the required outputs: input_grad, other_grad ", "List of bool", "Default value is [True, True]", "No"
                 "input_grad", "Optional Output Tensor for input gradient", "Tensor", "Default value is None", "No"
                 "other_grad", "Optional Output Tensor for other gradient", "Tensor", "Default value is None", "No"
-        )doc");
-
-    m_tensor.def("binary_eq_bw", py::overload_cast<uint8_t, const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor> >(&binary_eq_bw),
-            py::arg("queue_id").noconvert() = 0, py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true}, py::arg("input_grad").noconvert() = std::nullopt,py::arg("other_grad").noconvert() = std::nullopt, R"doc(
-            Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Other Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "are_required_outputs", "Boolean values for the required outputs: input_grad, other_grad ", "List of bool", "Default value is [True, True]", "No"
-                "input_grad", "Optional Output Tensor for input gradient", "Tensor", "Default value is None", "No"
-                "other_grad", "Optional Output Tensor for other gradient", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
         )doc");
 
     m_tensor.def("binary_gt_bw", &tt::tt_metal::binary_gt_bw,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -91,8 +91,22 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("where", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, std::optional<Tensor> >(&where),
-            py::arg("predicate"), py::arg("true_value"), py::arg("false_value"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_tensor").noconvert() = std::nullopt, R"doc(
+        m_tensor.def("where",
+        [](const Tensor& predicate,
+           const Tensor& value_true,
+           const Tensor& value_false,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return where(queue_id, predicate, value_true, value_false, output_mem_config, output_tensor);
+        },
+            py::arg("predicate"),
+            py::arg("true_value"),
+            py::arg("false_value"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Perform an ternary where operation on two tensors based on third @predicate.
 
             where(predicate, true_value, false_value) implements (predicate) ? true_value : false_value.
@@ -109,9 +123,24 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "false_value", "False Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
-        m_tensor.def("where", py::overload_cast<const Tensor&, float, const Tensor&, const MemoryConfig&, std::optional<Tensor> >(&where),
-            py::arg("predicate"), py::arg("true_value"), py::arg("false_value"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_tensor").noconvert() = std::nullopt, R"doc(
+        m_tensor.def("where",
+        [](const Tensor& predicate,
+           const float value_true,
+           const Tensor& value_false,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return where(queue_id, predicate, value_true, value_false, output_mem_config, output_tensor);
+        },
+            py::arg("predicate"),
+            py::arg("true_value"),
+            py::arg("false_value"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Perform an ternary where operation on two tensors based on third @predicate.
 
             where(predicate, true_value, false_value) implements (predicate) ? true_value : false_value.
@@ -128,9 +157,24 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "false_value", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
-        m_tensor.def("where", py::overload_cast<const Tensor&, const Tensor&, const float, const MemoryConfig&, std::optional<Tensor> >(&where),
-            py::arg("predicate"), py::arg("true_value"), py::arg("false_value"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_tensor").noconvert() = std::nullopt, R"doc(
+        m_tensor.def("where",
+        [](const Tensor& predicate,
+           const Tensor& value_true,
+           const float value_false,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return where(queue_id, predicate, value_true, value_false, output_mem_config, output_tensor);
+        },
+            py::arg("predicate"),
+            py::arg("true_value"),
+            py::arg("false_value"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Perform an ternary where operation on two tensors based on third @predicate.
 
             where(predicate, true_value, false_value) implements (predicate) ? true_value : false_value.
@@ -147,9 +191,24 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "false_value", "float", "float", "float scalar", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
-        m_tensor.def("where", py::overload_cast<const Tensor&, const float, const float, const MemoryConfig&, std::optional<Tensor> >(&where),
-            py::arg("predicate"), py::arg("true_value"), py::arg("false_value"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_tensor").noconvert() = std::nullopt, R"doc(
+        m_tensor.def("where",
+        [](const Tensor& predicate,
+           const float value_true,
+           const float value_false,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return where(queue_id, predicate, value_true, value_false, output_mem_config, output_tensor);
+        },
+            py::arg("predicate"),
+            py::arg("true_value"),
+            py::arg("false_value"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Perform an ternary where operation on two tensors based on third @predicate.
 
             where(predicate, true_value, false_value) implements (predicate) ? true_value : false_value.
@@ -166,68 +225,21 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "false_value", "float", "float", "float scalar", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
-    // *** composite unary ops ***
-    detail::bind_unary_op(
-        m_tensor,
-        "normalize_hw",
-        tt::tt_metal::normalize_hw,
-        R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on H,W axes.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "normalize_global",
-        tt::tt_metal::normalize_global,
-        R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on N,C,H,W axes.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "var_hw",
-        tt::tt_metal::var_hw,
-        R"doc(  Returns a new tensor with the variance of the input tensor ``{0}`` on H,W axes.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "std_hw",
-        tt::tt_metal::std_hw,
-        R"doc(Returns a new tensor with the standard deviation of the input tensor ``{0}`` on H,W axes.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "sinh",
-        &tt::tt_metal::sinh,
-        R"doc(Returns tensor with the hyperbolic sine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "cosh",
-        &tt::tt_metal::cosh,
-        R"doc(Returns tensor with the hyperbolic cosine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "softsign",
-        &softsign,
-        R"doc(Applies the softsign function to the elements of the input tensor ``{0}``.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "log1p",
-        &log1p,
-        R"doc(Returns tensor with the natural log of 1 added to all of elements of the input tensor ``{0}``.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "swish",
-        swish,
-        R"doc(Returns tensor with the swish all of elements of the input tensor ``{0}``.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "mish",
-        &mish,
-        R"doc(Returns tensor with the mish activation of elements of the input tensor ``{0}``.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "cbrt",
-        &cbrt,
-        R"doc(Returns tensor with the cbrt activation of elements of the input tensor ``{0}``.)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "asinh",
-        &asinh,
-        R"doc(Returns tensor with the inverse hyperbolic sine of elements of the input tensor ``{0}`` in range [-1e-6, 1e6].
+        // *** composite unary ops ***
+        detail::bind_unary_op(m_tensor, "normalize_hw", tt::tt_metal::normalize_hw, R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on H,W axes.)doc");
+        detail::bind_unary_op(m_tensor, "normalize_global", tt::tt_metal::normalize_global, R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on N,C,H,W axes.)doc");
+        detail::bind_unary_op(m_tensor, "var_hw", tt::tt_metal::var_hw, R"doc(  Returns a new tensor with the variance of the input tensor ``{0}`` on H,W axes.)doc");
+        detail::bind_unary_op(m_tensor, "std_hw", tt::tt_metal::std_hw, R"doc(Returns a new tensor with the standard deviation of the input tensor ``{0}`` on H,W axes.)doc");
+        detail::bind_unary_op(m_tensor, "sinh", &tt::tt_metal::sinh, R"doc(Returns tensor with the hyperbolic sine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
+        detail::bind_unary_op(m_tensor, "cosh", &tt::tt_metal::cosh, R"doc(Returns tensor with the hyperbolic cosine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
+        detail::bind_unary_op(m_tensor, "softsign", &softsign, R"doc(Applies the softsign function to the elements of the input tensor ``{0}``.)doc");
+        detail::bind_unary_op(m_tensor, "log1p", &log1p, R"doc(Returns tensor with the natural log of 1 added to all of elements of the input tensor ``{0}``.)doc");
+        detail::bind_unary_op(m_tensor, "swish", swish, R"doc(Returns tensor with the swish all of elements of the input tensor ``{0}``.)doc");
+        detail::bind_unary_op(m_tensor, "mish", &mish, R"doc(Returns tensor with the mish activation of elements of the input tensor ``{0}``.)doc");
+        detail::bind_unary_op(m_tensor, "cbrt", &cbrt, R"doc(Returns tensor with the cbrt activation of elements of the input tensor ``{0}``.)doc");
+        detail::bind_unary_op(m_tensor, "asinh", &asinh, R"doc(Returns tensor with the inverse hyperbolic sine of elements of the input tensor ``{0}`` in range [-1e-6, 1e6].
             for +input , output = asinh(input)
             for -input , output = -asinh(input))doc");
     detail::bind_unary_op(
@@ -641,12 +653,20 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
 
     m_tensor.def(
         "addalpha",
-        py::overload_cast<const Tensor&, const Tensor&, float, const MemoryConfig&, std::optional<Tensor> >(&addalpha),
+        [](const Tensor& input_a,
+           const Tensor& input_b,
+           const float alpha,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return addalpha(queue_id, input_a, input_b, alpha, output_mem_config, output_tensor);
+        },
         py::arg("input_a").noconvert(),
         py::arg("input_b").noconvert(),
         py::arg("alpha") = 1.0f,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_tensor").noconvert() = std::nullopt,
+        py::arg("queue_id").noconvert() = 0,
         R"doc(
             Add ``input_b``, scaled by ``alpha``, from ``input_a``.
 
@@ -662,33 +682,7 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "alpha", "Alpha value", "float", "default to 1.0f", "No"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
-        )doc");
-
-    m_tensor.def(
-        "addalpha",
-        py::overload_cast<uint8_t, const Tensor&, const Tensor&, float, const MemoryConfig&, std::optional<Tensor> >(&addalpha),
-        py::arg("cq_id") = 0,
-        py::arg("input_a").noconvert(),
-        py::arg("input_b").noconvert(),
-        py::arg("alpha") = 1.0f,
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        py::arg("output_tensor").noconvert() = std::nullopt,
-        R"doc(
-            Add ``input_b``, scaled by ``alpha``, from ``input_a``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "cq_id", "Command queue id", "integer", "default to 0", "No"
-                "input_a", "Tensor addalpha is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "alpha", "Alpha value", "float", "default to 1.0f", "No"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                "queue_id", "Command queue id", "integer", "default to 0", "No"
         )doc");
 
     m_tensor.def(
@@ -716,10 +710,18 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
 
     m_tensor.def(
         "full_like",
-        &full_like,
+        [](const Tensor& reference_tensor,
+           float value,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return full_like(queue_id, reference_tensor, value, output_mem_config, output_tensor);
+        },
         py::arg("input").noconvert(),
         py::arg("fill_value"),
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        py::arg("queue_id").noconvert() = 0,
         R"doc(
             Returns a new tensor filled with the scalar value shaped like reference tensor ``arg0``.
 
@@ -733,13 +735,22 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "input", "Reference Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "fill_value", "Fill value", "float", "", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                "queue_id", "Command queue id", "integer", "default to 0", "No"
         )doc");
 
     m_tensor.def(
         "zeros_like",
-        &zeros_like,
+        [](const Tensor& reference_tensor,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return zeros_like(queue_id, reference_tensor, output_mem_config, output_tensor);
+        },
         py::arg("input").noconvert(),
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        py::arg("queue_id").noconvert() = 0,
         R"doc(
             Returns a new tensor filled with zeros shaped like reference tensor ``input``.
 
@@ -752,6 +763,8 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
 
                 "input", "Reference Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                "queue_id", "Command queue id", "integer", "default to 0", "No"
         )doc");
 
     m_tensor.def(


### PR DESCRIPTION
Add cq_id support to add_bw,  mul_bw, where, where_bw, zeros_like, full_like
(these are dependent ops to support composite/backward ops)

CI test: https://github.com/tenstorrent/tt-metal/actions/runs/9536469542

Updated test cases to pass cq_id/queue_id to the above ops