### PR TITLE
#9339: Add optional output to run_with_autoformat, bcast, mul_unary

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_unary_output.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_unary_output.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "mem_configs",
+    (
+        tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM),
+        tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1),
+    ),
+)
+@pytest.mark.parametrize("scalar", (3.2, -2.0))
+def test_unary_mul(input_shapes, mem_configs, scalar, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
+    mem_cfg = mem_configs
+
+    tt_output_tensor_on_device = tt_lib.tensor.mul_unary(input_tensor, scalar, output_mem_config=mem_cfg)
+    golden_tensor = torch.mul(in_data, scalar)
+
+    comp_pass = compare_pcc([tt_output_tensor_on_device], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("scalar", (3.2, -2.0))
+def test_unary_mul_output(input_shapes, device, scalar):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.mul_unary(input_tensor, scalar, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.mul(in_data, scalar)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("scalar", (3.2, -2.0))
+def test_unary_mul_output_scalar(input_shapes, device, scalar):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.mul_unary(scalar, input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.mul(scalar, in_data)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "mem_configs",
+    (
+        tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM),
+        tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1),
+    ),
+)
+def test_recip(input_shapes, mem_configs, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 100, device)
+
+    mem_cfg = mem_configs
+
+    tt_output_tensor_on_device = tt_lib.tensor.recip(input_tensor, output_mem_config=mem_cfg)
+    golden_tensor = torch.reciprocal(in_data)
+
+    comp_pass = compare_pcc([tt_output_tensor_on_device], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_recip_output(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.recip(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.reciprocal(in_data)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("scalar", (3.2, -2.0))
+def test_unary_div_output(input_shapes, device, scalar):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.div_unary(input_tensor, scalar, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.div(in_data, scalar)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("scalar", (3.2, -2.0))
+def test_unary_div_output_scalar(input_shapes, device, scalar):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.div_unary(scalar, input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.div(scalar, in_data)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("scalar", (3.2, -2.0))
+def test_unary_add_output(input_shapes, device, scalar):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.add_unary(input_tensor, scalar, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.add(in_data, scalar)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("scalar", (3.2, -2.0))
+def test_unary_add_output_scalar(input_shapes, device, scalar):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.add_unary(scalar, input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.add(scalar, in_data)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/reduce/reduce_op.cpp
+++ b/tt_eager/tt_dnn/op_library/reduce/reduce_op.cpp
@@ -182,7 +182,7 @@ Tensor reduce(const Tensor &input_tensor, ReduceOpMath reduce_math, ReduceOpDim 
         operation::launch_with_autoformat(
         [reduce_math, reduce_dim, pad_value, scaler, output_dtype, output_mem_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor = input_tensors.at(0);
-            return operation::run_with_autoformat(Reduce{reduce_math, reduce_dim, scaler, output_mem_config, output_dtype.value_or(input_tensor.get_dtype())}, {input_tensor}, {}, pad_value);
+            return operation::run_with_autoformat(Reduce{reduce_math, reduce_dim, scaler, output_mem_config, output_dtype.value_or(input_tensor.get_dtype())}, {input_tensor}, {}, {}, pad_value);
         }, {input_tensor}, output_tensors);
     }
     return output_tensors.at(0);

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -375,6 +375,7 @@ Tensors run_with_autoformat(
     const DeviceOperation<Tensors>& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors,
+    const OptionalTensors& optional_output_tensors,
     const float pad_value,
     const bool pad_c,
     uint8_t cq_id) {
@@ -414,7 +415,7 @@ Tensors run_with_autoformat(
         }
     }
 
-    auto output_tensors = run<Tensors>(operation, formatted_input_tensors, formatted_optional_input_tensors, {}, cq_id);
+    auto output_tensors = run<Tensors>(operation, formatted_input_tensors, formatted_optional_input_tensors, optional_output_tensors, cq_id);
 
     TT_ASSERT(output_tensors.size() == output_shapes.size());
 
@@ -434,6 +435,7 @@ Tensors run_with_autoformat(
     const std::vector<Layout>& output_layouts,
     const OptionalConstTensors& optional_input_tensors,
     const std::vector<std::optional<FormatParams>>& optional_input_formatting,
+    const OptionalTensors& optional_output_tensors,
     uint8_t cq_id) {
     ZoneScoped;
     Device* device = detail::get_device(input_tensors, optional_input_tensors);
@@ -472,7 +474,7 @@ Tensors run_with_autoformat(
         }
     }
 
-    auto output_tensors = run<Tensors>(operation, formatted_input_tensors, formatted_optional_input_tensors, {std::nullopt}, cq_id);
+    auto output_tensors = run<Tensors>(operation, formatted_input_tensors, formatted_optional_input_tensors, optional_output_tensors, cq_id);
 
     TT_ASSERT(output_tensors.size() == output_shapes.size());
     TT_ASSERT(output_tensors.size() == output_layouts.size());

--- a/tt_eager/tt_dnn/op_library/run_operation.hpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.hpp
@@ -341,6 +341,7 @@ Tensors run_with_autoformat(
     const DeviceOperation<Tensors>& operation,
     const Tensors& input_tensors,
     const OptionalConstTensors& optional_input_tensors = {},
+    const OptionalTensors& optional_output_tensors = {},
     const float pad_value = 0,
     const bool pad_c = false,
     uint8_t cq_id = 0
@@ -351,13 +352,14 @@ inline auto run_with_autoformat(
     ConcreteOperation&& concrete_op,
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
+    const std::vector<std::optional<Tensor>>& optional_output_tensors = {},
     const float pad_value = 0,
     const bool pad_c = false,
     uint8_t cq_id = 0
 )-> Tensors {
     using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     const auto operation = DeviceOperation<Tensors>(concrete_op);
-    return run_with_autoformat(operation, input_tensors, optional_input_tensors, pad_value, pad_c, cq_id);
+    return run_with_autoformat(operation, input_tensors, optional_input_tensors, optional_output_tensors, pad_value, pad_c, cq_id);
 }
 
 Tensors run_with_autoformat(
@@ -367,6 +369,7 @@ Tensors run_with_autoformat(
     const std::vector<Layout>& output_layouts,
     const OptionalConstTensors& optional_input_tensors = {},
     const std::vector<std::optional<FormatParams>>& optional_input_formatting = {},
+    const OptionalTensors& optional_output_tensors = {},
     uint8_t cq_id = 0
 );
 template<typename ConcreteOperation>
@@ -377,11 +380,12 @@ inline auto run_with_autoformat(
     const std::vector<Layout>& output_layouts,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors = {},
     const std::vector<std::optional<FormatParams>>& optional_input_formatting = {},
+    const OptionalTensors& optional_output_tensors = {},
     uint8_t cq_id = 0
 )-> ProgramOutputTensors<ConcreteOperation> {
     using OutputTensors = ProgramOutputTensors<ConcreteOperation>;
     const auto operation = DeviceOperation<OutputTensors>(concrete_op);
-    return run_with_autoformat(operation, input_tensors, input_formatting, output_layouts, optional_input_tensors, optional_input_formatting, cq_id);
+    return run_with_autoformat(operation, input_tensors, input_formatting, output_layouts, optional_input_tensors, optional_input_formatting, optional_output_tensors, cq_id);
 }
 
 void launch_op(

--- a/tt_eager/tt_dnn/op_library/transpose/transpose_op.cpp
+++ b/tt_eager/tt_dnn/op_library/transpose/transpose_op.cpp
@@ -182,7 +182,7 @@ inline Tensor transpose_(const Tensor &a, TransposeOpDim transpose_dim, const Me
     }
 
     // TODO: Add pad_n to run_with_autoformat when needed
-    return operation::run_with_autoformat(Transpose{transpose_dim, output_mem_config}, {a}, {}, 0, pad_c /*, pad_n */).at(0);
+    return operation::run_with_autoformat(Transpose{transpose_dim, output_mem_config}, {a}, {}, {}, 0, pad_c /*, pad_n */).at(0);
 }
 
 Tensor transpose(const Tensor &a, std::int64_t dim1, std::int64_t dim2, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_lib/csrc/operations/primary/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/module.hpp
@@ -820,6 +820,8 @@ void py_module(py::module& m_primary) {
         py::arg("dim"),
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("in_place") = false,
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        py::arg("queue_id").noconvert() = 0,
         R"doc(
         Perform a binary elementwise operation ``math_op`` between tensors ``input_a`` and ``input_b``, where values from tensor ``input_b`` are broadcast.
 
@@ -846,6 +848,7 @@ void py_module(py::module& m_primary) {
             "dim", "Dimension on which to broadcast", "BcastOpDim", "W, H, HW", "Yes"
             "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             "in_place", "Whether to perform bcast in place, without allocating space for output tensor", "Bool", "Default is false", "No"
+            "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
     )doc");
 
     py::enum_<MorehSoftmaxOpParallelizationStrategy>(m_primary, "MorehSoftmaxOpParallelizationStrategy")


### PR DESCRIPTION
Add optional output to run_with_autoformat 
Add queue_id support to these ops.
1. for bcast to support add/div/mul_unary ops
2. for unary ops - recip

CI test: https://github.com/tenstorrent/tt-metal/actions/runs/9519527871

What's been changed ?
- To add output_tensor, queue_id support to `mul_unary`, `bcast` op was also modified to support `output_tensor`, `queue_id`
- `run_with_autoformat` operation modified to pass optional output_tensor to `run` operation

What's the expected result?

- `mul_unary` expected functionality when output_tensor is passed

- `tt_lib.tensor.mul_unary(input_tensor, scalar, output_tensor=output_tensor, queue_id=queue_id)`

<img width="1512" alt="Screenshot 2024-06-10 at 5 59 35 PM" src="https://github.com/tenstorrent/tt-metal/assets/156762498/5ad11995-5722-4615-b91b-a39710b1f1b9">
