### PR TITLE
#0: Update dataflow api comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -406,6 +406,10 @@ k_id[15]: tests/tt_metal/tt_metal/test_kernels/compute/matmul_large_block_zm.cpp
     - The waypoint field show the latest waypoint that each kernel has run past. The typical application of these is to put a waypoint before and after any kernel code that could hang, which can be used to pinpoint a hang from the log.
     - Further debug features are available, such as a debug ring buffer on each core. For more information, see the [Watcher documentation](docs/source/tt-metalium/tools/watcher.rst).
   - If you're able to deterministically reproduce the hang, the relevant kernel code can be instrumented with more debug features and iterated on to find the source of the hang.
+    - For multicast operations, you should check that the parameters are correct and you are calling the right variant of the method. Some examples of what to watch out for are the following:
+      - The number of destinations has to be non-zero.
+      - If the source node is in the destination set, you need to use the `loopback_src` variant of the method.
+      - The `loopback_src` variant will not do anything if the set of destination nodes consists entirely of the source node.
 - If a hang happens only when watcher is disabled, it is likely that the extra code added by watcher is affecting a timing-related issue. In this case you can try disabling certain watcher features to attempt to bring the timing closer.
   - The most invasive watcher features is the NoC sanitization, try disabling it with:
 ```

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1349,6 +1349,11 @@ void noc_async_write_multicast(
  * way of a synchronization mechanism. The same as *noc_async_write_multicast*
  * with preset size of 4 Bytes.
  *
+ * With this API, the multicast sender cannot be part of the multicast
+ * destinations. If the multicast sender has to be in the multicast
+ * destinations (i.e. must perform a local L1 write), the other API variant
+ * *noc_semaphore_set_multicast_loopback_src* can be used.
+ *
  * Return value: None
  *
  * | Argument               | Description                                                              | Type     | Valid Range                                               | Required |
@@ -1375,7 +1380,29 @@ void noc_semaphore_set_multicast(
         multicast_path_reserve);
     DEBUG_STATUS("NSMD");
 }
-
+/**
+ * Initiates an asynchronous write from a source address in L1 memory on the
+ * Tensix core executing this function call to a rectangular destination grid.
+ * The destinations are specified using a uint64_t encoding referencing an
+ * on-chip grid of nodes located at NOC coordinate range
+ * (x_start,y_start,x_end,y_end) and a local address created using
+ * *get_noc_multicast_addr* function. The size of data that is sent is 4 Bytes.
+ * This is usually used to set a semaphore value at the destination nodes, as a
+ * way of a synchronization mechanism. The same as *noc_async_write_multicast*
+ * with preset size of 4 Bytes.
+ *
+ * With this API, you cannot send data only to the source node. That is, if
+ * num_dests is 1 and the encoded destniation nodes consist of the node
+ * sending the data, then no data will be sent. The method call will be a no-op.
+ *
+ * Return value: None
+ *
+ * | Argument               | Description                                                              | Type     | Valid Range                                               | Required |
+ * |------------------------|--------------------------------------------------------------------------|----------|-----------------------------------------------------------|----------|
+ * | src_local_l1_addr      | Source address in local L1 memory                                        | uint32_t | 0..1MB                                                    | True     |
+ * | dst_noc_addr_multicast | Encoding of the destinations nodes (x_start,y_start,x_end,y_end)+address | uint64_t | DOX-TODO(insert a reference to what constitutes valid coords) | True     |
+ * | num_dests              | Number of destinations that the multicast source is targetting | uint32_t | 0..119                                                    | True     |
+ */
 inline
 void noc_semaphore_set_multicast_loopback_src(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr_multicast, std::uint32_t num_dests, bool linked = false, bool multicast_path_reserve = true) {

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -188,10 +188,10 @@ inline __attribute__((always_inline)) constexpr static std::uint32_t MUL_WITH_TI
  *
  * Return value: None
  *
- * | Argument  | Description                          | Type     | Valid Range | Required |
- * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31     | True     |
- * | num_tiles | The number of tiles to be pushed     | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
+ * | Argument  | Description                           | Type     | Valid Range | Required |
+ * |-----------|---------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
+ * | cb_id     | The index of the circular buffer (CB) | uint32_t | 0 to 31     | True     |
+ * | num_tiles | The number of tiles to be pushed      | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  */
 FORCE_INLINE
 void cb_push_back(const int32_t operand, const int32_t num_pages) {
@@ -229,10 +229,10 @@ void cb_push_back(const int32_t operand, const int32_t num_pages) {
  *
  * Return value: None
  *
- * | Argument  | Description                          | Type     | Valid Range | Required |
- * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31 | True     |
- * | num_tiles | The number of tiles to be popped     | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
+ * | Argument  | Description                           | Type     | Valid Range | Required |
+ * |-----------|---------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
+ * | cb_id     | The index of the circular buffer (CB) | uint32_t | 0 to 31 | True     |
+ * | num_tiles | The number of tiles to be popped      | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  */
 FORCE_INLINE
 void cb_pop_front(int32_t operand, int32_t num_pages) {
@@ -282,9 +282,9 @@ constexpr inline DataFormat get_dataformat(const std::int32_t operand) {
  *
  * Return value: None
  *
- * | Argument  | Description                          | Type     | Valid Range | Required |
- * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | operand   | The index of the cirular buffer (CB) | uint32_t | 0 to 31     | True     |
+ * | Argument  | Description                           | Type     | Valid Range | Required |
+ * |-----------|---------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
+ * | operand   | The index of the circular buffer (CB) | uint32_t | 0 to 31     | True     |
  */
 inline __attribute__((always_inline)) uint32_t get_write_ptr(uint32_t operand) {
     // return byte address (fifo_wr_ptr is 16B address)
@@ -300,9 +300,9 @@ inline __attribute__((always_inline)) uint32_t get_write_ptr(uint32_t operand) {
  *
  * Return value: None
  *
- * | Argument  | Description                          | Type     | Valid Range | Required |
- * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | operand   | The index of the cirular buffer (CB) | uint32_t | 0 to 31     | True     |
+ * | Argument  | Description                           | Type     | Valid Range | Required |
+ * |-----------|---------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
+ * | operand   | The index of the circular buffer (CB) | uint32_t | 0 to 31     | True     |
  */
 inline __attribute__((always_inline)) uint32_t get_read_ptr(uint32_t operand) {
 
@@ -329,10 +329,10 @@ inline void wait_for_sync_register_value(uint32_t addr, int32_t val) {
  *
  * Return value: None
  *
- * | Argument  | Description                          | Type     | Valid Range | Required |
- * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31     | True     |
- * | num_tiles | The number of free tiles to wait for | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
+ * | Argument  | Description                           | Type     | Valid Range | Required |
+ * |-----------|---------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
+ * | cb_id     | The index of the circular buffer (CB) | uint32_t | 0 to 31     | True     |
+ * | num_tiles | The number of free tiles to wait for  | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
  */
 FORCE_INLINE
 void cb_reserve_back(int32_t operand, int32_t num_pages) {
@@ -363,7 +363,7 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
 
 /**
  * A blocking call that waits for the specified number of tiles to be available in the specified circular buffer (CB).
- * This call is used by the consumer of the CB to wait for the producer to fill the CB with at least the specfied number
+ * This call is used by the consumer of the CB to wait for the producer to fill the CB with at least the specified number
  * of tiles. Important note: in case multiple calls of cb_wait_front(n) are issued without a paired cb_pop_front() call,
  * n is expected to be incremented by the user to be equal to a cumulative total of tiles. Example: 4 calls of
  * cb_wait_front(8) followed by a cb_pop_front(32) would produce incorrect behavior. Instead 4 calls of cb_wait_front()
@@ -378,10 +378,10 @@ void cb_reserve_back(int32_t operand, int32_t num_pages) {
  *
  * Return value: None
  *
- * | Argument  | Description                          | Type     | Valid Range | Required |
- * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
- * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31     | True     |
- * | num_tiles | The number of tiles to wait for      | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) |          |
+ * | Argument  | Description                           | Type     | Valid Range | Required |
+ * |-----------|---------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
+ * | cb_id     | The index of the circular buffer (CB) | uint32_t | 0 to 31     | True     |
+ * | num_tiles | The number of tiles to wait for       | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) |          |
  * */
 FORCE_INLINE
 void cb_wait_front(int32_t operand, int32_t num_pages) {
@@ -1295,9 +1295,10 @@ void noc_semaphore_set_remote(std::uint32_t src_local_l1_addr, std::uint64_t dst
  * destinations (i.e. must perform a local L1 write), the other API variant
  * *noc_async_write_multicast_loopback_src* can be used.
  *
- * Note: there is no restriction on the number of destinations, i.e. the
+ * Note: The number of destinations needs to be non-zero. Besides that,
+ * there is no restriction on the number of destinations, i.e. the
  * multicast destinations can span the full chip. However, as mentioned
- * previosuly, the multicast source cannot be part of the destinations. So, the
+ * previously, the multicast source cannot be part of the destinations. So, the
  * maximum number of destinations is 119.
  *
  * Return value: None
@@ -1392,7 +1393,7 @@ void noc_semaphore_set_multicast(
  * with preset size of 4 Bytes.
  *
  * With this API, you cannot send data only to the source node. That is, if
- * num_dests is 1 and the encoded destniation nodes consist of the node
+ * num_dests is 1 and the encoded destination nodes consist of the node
  * sending the data, then no data will be sent. The method call will be a no-op.
  *
  * Return value: None


### PR DESCRIPTION
`noc_semaphore_set_multicast_loopback_src` is a no-op if called with one destination that is the sender.

Documentation should be added to mention this.

Also, `noc_async_write_multicast` goes into an infinite loop if `num_dests` is 0. For this second one, I'm guessing a lot of other methods are susceptible to the problem. I'm not sure how many of them to deal with.

Also, given how often the methods are called, I'm not sure if the better approach is to
- add documentation saying not to call the methods with 0 or
- add in a check that makes the operation a no-op (would be an extra couple of fallthrough branches if want to quickly return when `num_dests` is 0 or `size` is 0).
