### PR TITLE
#8482: Add trace region in DRAM. Trace buffer is no longer preallocated

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -317,7 +317,7 @@ def all_devices(request, device_params):
 
 
 @pytest.fixture(scope="function")
-def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
+def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
     import ttnn
 
     device_ids = ttnn.get_device_ids()
@@ -326,33 +326,8 @@ def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
     except (ValueError, AttributeError):
         num_devices_requested = len(device_ids)
 
-    device_mesh = ttnn.open_device_mesh(ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested])
-
-    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
-    yield device_mesh
-
-    import tt_lib as ttl
-
-    for device in device_mesh.get_devices():
-        ttl.device.DumpDeviceProfiler(device)
-        ttl.device.DeallocateBuffers(device)
-
-    ttnn.close_device_mesh(device_mesh)
-    del device_mesh
-
-
-@pytest.fixture(scope="function")
-def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
-    import ttnn
-
-    device_ids = ttnn.get_pcie_device_ids()
-    try:
-        num_pcie_devices_requested = min(request.param, len(device_ids))
-    except (ValueError, AttributeError):
-        num_pcie_devices_requested = len(device_ids)
-
     device_mesh = ttnn.open_device_mesh(
-        ttnn.DeviceGrid(1, num_pcie_devices_requested), device_ids[:num_pcie_devices_requested]
+        ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested], **device_params
     )
 
     logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
@@ -369,7 +344,34 @@ def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
 
 
 @pytest.fixture(scope="function")
-def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
+def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
+    import ttnn
+
+    device_ids = ttnn.get_pcie_device_ids()
+    try:
+        num_pcie_devices_requested = min(request.param, len(device_ids))
+    except (ValueError, AttributeError):
+        num_pcie_devices_requested = len(device_ids)
+
+    device_mesh = ttnn.open_device_mesh(
+        ttnn.DeviceGrid(1, num_pcie_devices_requested), device_ids[:num_pcie_devices_requested], **device_params
+    )
+
+    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
+    yield device_mesh
+
+    import tt_lib as ttl
+
+    for device in device_mesh.get_devices():
+        ttl.device.DumpDeviceProfiler(device)
+        ttl.device.DeallocateBuffers(device)
+
+    ttnn.close_device_mesh(device_mesh)
+    del device_mesh
+
+
+@pytest.fixture(scope="function")
+def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
     import ttnn
 
     if ttnn.get_num_devices() < 8:
@@ -380,7 +382,9 @@ def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0):
     except (ValueError, AttributeError):
         num_devices_requested = len(device_ids)
 
-    device_mesh = ttnn.open_device_mesh(ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested])
+    device_mesh = ttnn.open_device_mesh(
+        ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested], **device_params
+    )
 
     logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
     yield device_mesh

--- a/models/demos/resnet/tests/test_perf_resnet.py
+++ b/models/demos/resnet/tests/test_perf_resnet.py
@@ -115,7 +115,7 @@ def run_trace_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_m
     tt_lib.device.DumpDeviceProfiler(device)
 
     # Capture
-    tid = tt_lib.device.BeginTraceCapture(device, 0, 1500000)
+    tid = tt_lib.device.BeginTraceCapture(device, 0)
     tt_output_res = tt_resnet50(tt_image_res)
     tt_lib.device.EndTraceCapture(device, 0, tid)
     tt_lib.device.DumpDeviceProfiler(device)
@@ -200,7 +200,7 @@ def run_trace_2cq_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, n
     reshard_out = tt_lib.tensor.reshard(tt_image_res, reshard_mem_config)
     tt_lib.device.RecordEvent(device, 0, op_event)
 
-    tid = tt_lib.device.BeginTraceCapture(device, 0, 1500000)
+    tid = tt_lib.device.BeginTraceCapture(device, 0)
     tt_output_res = tt_resnet50(reshard_out, final_out_mem_config=interleaved_dram_mem_config)
     reshard_out = tt_lib.tensor.allocate_tensor_on_device(
         reshard_out.shape, reshard_out.dtype, reshard_out.layout, device, reshard_mem_config
@@ -357,7 +357,7 @@ def test_perf_bare_metal(
 
 
 @skip_for_wormhole_b0(reason_str="Not tested on single WH")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1500000}], indirect=True)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",

--- a/tests/tt_eager/python_api_testing/trace_testing/misc/test_average_pool.py
+++ b/tests/tt_eager/python_api_testing/trace_testing/misc/test_average_pool.py
@@ -35,6 +35,7 @@ def shape_padded(shape):
     ],
 )
 @pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 11264}], indirect=True)
 def test_run_average_pool(act_shape, dtype, device, use_program_cache, enable_async):
     device.enable_async(enable_async)
 
@@ -68,7 +69,7 @@ def test_run_average_pool(act_shape, dtype, device, use_program_cache, enable_as
     run_ops(ttact_res)
     # Trace
     logger.info("Start Trace capture")
-    tid = ttl.device.BeginTraceCapture(device, 0, 11264)
+    tid = ttl.device.BeginTraceCapture(device, 0)
     out_res = run_ops(ttact_res)
     ttl.device.EndTraceCapture(device, 0, tid)
     logger.info("Trace captured")

--- a/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
+++ b/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
@@ -36,6 +36,7 @@ from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_ze
     ],
 )
 @pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 34816}], indirect=True)
 def test_bert_linear(
     device,
     fidelity,
@@ -171,7 +172,7 @@ def test_bert_linear(
     run_ops(in0_t_res)
     # Capture
     logger.info("Start Trace capture")
-    tid = ttl.device.BeginTraceCapture(device, 0, 34816)
+    tid = ttl.device.BeginTraceCapture(device, 0)
     output_t_res = run_ops(in0_t_res)
     ttl.device.EndTraceCapture(device, 0, tid)
     logger.info("Trace captured")

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -18,17 +18,6 @@ public:
         uint64_t program_id = program.get_id();
         if (this->slow_dispatch_) {
             tt::tt_metal::detail::LaunchProgram(device, program);
-        } else if (this->metal_trace_) {
-            CommandQueue& cq = device->command_queue();
-            if (trace_captured.find(program_id) == trace_captured.end()) {
-                uint32_t tid = tt::tt_metal::BeginTraceCapture(device, cq.id(), 2048);
-                EnqueueProgram(cq, program, false);
-                tt::tt_metal::EndTraceCapture(device, cq.id(), tid);
-                trace_captured[program_id] = tid;
-            }
-            log_debug(tt::LogTest, "Executing trace for program {}", program_id);
-            tt::tt_metal::ReplayTrace(device, cq.id(), trace_captured[program_id], false);
-            Finish(cq);
         } else {
             CommandQueue& cq = device->command_queue();
             EnqueueProgram(cq, program, false);
@@ -58,7 +47,6 @@ public:
 protected:
     tt::ARCH arch_;
     vector<Device*> devices_;
-    bool metal_trace_;
     bool slow_dispatch_;
     bool has_remote_devices_;
 
@@ -69,8 +57,7 @@ protected:
             tt::log_info(tt::LogTest, "Running test using Slow Dispatch");
             slow_dispatch_ = true;
         } else {
-            metal_trace_ = tt::parse_env("TT_METAL_TRACE_MODE", false);
-            tt::log_info(tt::LogTest, "Running test using Fast Dispatch, Metal Trace = {}", metal_trace_ ? "ON" : "OFF");
+            tt::log_info(tt::LogTest, "Running test using Fast Dispatch");
             slow_dispatch_ = false;
         }
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueTrace.cpp
@@ -91,7 +91,8 @@ constexpr bool kBlocking = true;
 constexpr bool kNonBlocking = false;
 vector<bool> blocking_flags = {kBlocking, kNonBlocking};
 
-TEST_F(CommandQueueFixture, InstantiateTraceSanity) {
+TEST_F(SingleDeviceTraceFixture, InstantiateTraceSanity) {
+    Setup(2048);
     CommandQueue& command_queue = this->device_->command_queue();
 
     Buffer input(this->device_, 2048, 2048, BufferType::DRAM);
@@ -102,7 +103,7 @@ TEST_F(CommandQueueFixture, InstantiateTraceSanity) {
     Buffer output(this->device_, 2048, 2048, BufferType::DRAM);
     auto simple_program = std::make_shared<Program>(create_simple_unary_program(input, output));
     EnqueueProgram(command_queue, simple_program, true);
-    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id(), 1280);
+    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
     EnqueueProgram(command_queue, simple_program, kNonBlocking);
     EndTraceCapture(this->device_, command_queue.id(), tid);
 
@@ -122,7 +123,8 @@ TEST_F(CommandQueueFixture, InstantiateTraceSanity) {
     ReleaseTrace(this->device_, tid);
 }
 
-TEST_F(CommandQueueFixture, EnqueueProgramTraceCapture) {
+TEST_F(SingleDeviceTraceFixture, EnqueueProgramTraceCapture) {
+    Setup(2048);
     Buffer input(this->device_, 2048, 2048, BufferType::DRAM);
     Buffer output(this->device_, 2048, 2048, BufferType::DRAM);
 
@@ -145,7 +147,7 @@ TEST_F(CommandQueueFixture, EnqueueProgramTraceCapture) {
 
     EnqueueWriteBuffer(command_queue, input, input_data.data(), true);
 
-    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id(), 2048);
+    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
     EnqueueProgram(command_queue, simple_program, false);
     EndTraceCapture(this->device_, command_queue.id(), tid);
 
@@ -158,7 +160,8 @@ TEST_F(CommandQueueFixture, EnqueueProgramTraceCapture) {
     ReleaseTrace(this->device_, tid);
 }
 
-TEST_F(CommandQueueFixture, EnqueueProgramDeviceCapture) {
+TEST_F(SingleDeviceTraceFixture, EnqueueProgramDeviceCapture) {
+    Setup(2048);
     Buffer input(this->device_, 2048, 2048, BufferType::DRAM);
     Buffer output(this->device_, 2048, 2048, BufferType::DRAM);
 
@@ -184,7 +187,7 @@ TEST_F(CommandQueueFixture, EnqueueProgramDeviceCapture) {
         EnqueueReadBuffer(command_queue, output, eager_output_data.data(), true);
     }
 
-    // DEVICE CAPTURE AND REPLAY MODE
+    // THIS->DEVICE_ CAPTURE AND REPLAY MODE
     bool has_trace = false;
     uint32_t tid = 0;
     for (int i = 0; i < 1; i++) {
@@ -192,7 +195,7 @@ TEST_F(CommandQueueFixture, EnqueueProgramDeviceCapture) {
 
         if (!has_trace) {
             // Program must be cached first
-            tid = BeginTraceCapture(this->device_, command_queue.id(), 2048);
+            tid = BeginTraceCapture(this->device_, command_queue.id());
             EnqueueProgram(command_queue, simple_program, false);
             EndTraceCapture(this->device_, command_queue.id(), tid);
             has_trace = true;
@@ -208,7 +211,8 @@ TEST_F(CommandQueueFixture, EnqueueProgramDeviceCapture) {
     ReleaseTrace(this->device_, tid);
 }
 
-TEST_F(CommandQueueFixture, EnqueueTwoProgramTrace) {
+TEST_F(SingleDeviceTraceFixture, EnqueueTwoProgramTrace) {
+    Setup(6144);
     // Get command queue from device for this test, since its running in async mode
     CommandQueue& command_queue = this->device_->command_queue();
 
@@ -262,7 +266,7 @@ TEST_F(CommandQueueFixture, EnqueueTwoProgramTrace) {
     }
 
     // Capture trace on a trace queue
-    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id(), 4096);
+    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
     EnqueueProgram(command_queue, op0, kNonBlocking);
     EnqueueProgram(command_queue, op1, kNonBlocking);
     EndTraceCapture(this->device_, command_queue.id(), tid);
@@ -283,7 +287,8 @@ TEST_F(CommandQueueFixture, EnqueueTwoProgramTrace) {
     }
 }
 
-TEST_F(CommandQueueFixture, EnqueueMultiProgramTraceBenchmark) {
+TEST_F(SingleDeviceTraceFixture, EnqueueMultiProgramTraceBenchmark) {
+    Setup(6144);
     CommandQueue& command_queue = this->device_->command_queue();
 
     std::shared_ptr<Buffer> input = std::make_shared<Buffer>(this->device_, 2048, 2048, BufferType::DRAM);
@@ -340,7 +345,7 @@ TEST_F(CommandQueueFixture, EnqueueMultiProgramTraceBenchmark) {
     }
 
     // Capture trace on a trace queue
-    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id(), 6144);
+    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
     for (uint32_t i = 0; i < num_programs; i++) {
         EnqueueProgram(command_queue, programs[i], kNonBlocking);
     }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -99,3 +99,35 @@ class CommandQueueSingleCardFixture : public ::testing::Test {
     tt::ARCH arch_;
     size_t num_devices_;
 };
+
+class SingleDeviceTraceFixture: public ::testing::Test {
+protected:
+    Device* device_;
+    tt::ARCH arch_;
+
+    void Setup(const size_t buffer_size, const uint8_t num_hw_cqs = 1) {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            tt::log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
+            GTEST_SKIP();
+        }
+        if (num_hw_cqs > 1) {
+            // Running multi-CQ test. User must set this explicitly.
+            auto num_cqs = getenv("TT_METAL_NUM_HW_CQS");
+            if (num_cqs == nullptr or strcmp(num_cqs, "2")) {
+                TT_THROW("This suite must be run with TT_METAL_NUM_HW_CQS=2");
+                GTEST_SKIP();
+            }
+        }
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        const int device_id = 0;
+        this->device_ = tt::tt_metal::CreateDevice(device_id, num_hw_cqs, 0, buffer_size);;
+    }
+
+    void TearDown() override {
+        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+            tt::tt_metal::CloseDevice(this->device_);
+        }
+    }
+
+};

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueTrace.cpp
@@ -75,8 +75,8 @@ Program create_simple_unary_program(const Buffer& input, const Buffer& output) {
 // the eager mode results
 namespace basic_tests {
 
-TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTrace) {
-
+TEST_F(SingleDeviceTraceFixture, EnqueueOneProgramTrace) {
+    Setup(2048, 2);
     Buffer input(this->device_, 2048, 2048, BufferType::DRAM);
     Buffer output(this->device_, 2048, 2048, BufferType::DRAM);
 
@@ -103,7 +103,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTrace) {
 
     EnqueueWriteBuffer(data_movement_queue, input, input_data.data(), true);
 
-    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id(), 2048);
+    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
     EnqueueProgram(command_queue, simple_program, false);
     EndTraceCapture(this->device_, command_queue.id(), tid);
 
@@ -116,8 +116,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTrace) {
     ReleaseTrace(this->device_, tid);
 }
 
-TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTraceLoops) {
-
+TEST_F(SingleDeviceTraceFixture, EnqueueOneProgramTraceLoops) {
+    Setup(4096, 2);
     Buffer input(this->device_, 2048, 2048, BufferType::DRAM);
     Buffer output(this->device_, 2048, 2048, BufferType::DRAM);
 
@@ -149,7 +149,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTraceLoops) {
         EnqueueWriteBuffer(data_movement_queue, input, input_data.data(), true);
 
         if (not trace_captured) {
-            trace_id = BeginTraceCapture(this->device_, command_queue.id(), 4096);
+            trace_id = BeginTraceCapture(this->device_, command_queue.id());
             EnqueueProgram(command_queue, simple_program, false);
             EndTraceCapture(this->device_, command_queue.id(), trace_id);
             trace_captured = true;
@@ -167,8 +167,8 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTraceLoops) {
     ReleaseTrace(this->device_, trace_id);
 }
 
-TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTraceBenchmark) {
-
+TEST_F(SingleDeviceTraceFixture, EnqueueOneProgramTraceBenchmark) {
+    Setup(6144, 2);
     Buffer input(this->device_, 2048, 2048, BufferType::DRAM);
     Buffer output(this->device_, 2048, 2048, BufferType::DRAM);
 
@@ -223,7 +223,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, EnqueueOneProgramTraceBenchmark) {
     }
 
     // Capture trace on a trace queue
-    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id(), 6144);
+    uint32_t tid = BeginTraceCapture(this->device_, command_queue.id());
     EnqueueProgram(command_queue, simple_program, false);
     EndTraceCapture(this->device_, command_queue.id(), tid);
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
@@ -34,3 +34,35 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
     tt::tt_metal::Device* device_;
     tt::ARCH arch_;
 };
+
+class SingleDeviceTraceFixture: public ::testing::Test {
+protected:
+    Device* device_;
+    tt::ARCH arch_;
+
+    void Setup(const size_t buffer_size, const uint8_t num_hw_cqs = 1) {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            tt::log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
+            GTEST_SKIP();
+        }
+        if (num_hw_cqs > 1) {
+            // Running multi-CQ test. User must set this explicitly.
+            auto num_cqs = getenv("TT_METAL_NUM_HW_CQS");
+            if (num_cqs == nullptr or strcmp(num_cqs, "2")) {
+                TT_THROW("This suite must be run with TT_METAL_NUM_HW_CQS=2");
+                GTEST_SKIP();
+            }
+        }
+        this->arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        const int device_id = 0;
+        this->device_ = tt::tt_metal::CreateDevice(device_id, num_hw_cqs, 0, buffer_size);;
+    }
+
+    void TearDown() override {
+        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+            tt::tt_metal::CloseDevice(this->device_);
+        }
+    }
+
+};

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -15,6 +15,7 @@ from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, L
 @pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)])
 @pytest.mark.parametrize("use_all_gather", [True, False])
 @pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 33792}], indirect=True)
 def test_multi_device_single_trace(pcie_device_mesh, shape, use_all_gather, enable_async):
     if pcie_device_mesh.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
@@ -40,7 +41,7 @@ def test_multi_device_single_trace(pcie_device_mesh, shape, use_all_gather, enab
 
     # Capture Trace
     logger.info("Capture Trace")
-    tid = ttnn.begin_trace_capture(pcie_device_mesh, trace_buffer_size=106496, cq_id=0)
+    tid = ttnn.begin_trace_capture(pcie_device_mesh, cq_id=0)
     output_tensor = run_op_chain(input_0_dev, input_1_dev)
     ttnn.end_trace_capture(pcie_device_mesh, tid, cq_id=0)
 
@@ -97,15 +98,15 @@ def test_multi_device_single_trace(pcie_device_mesh, shape, use_all_gather, enab
         pcie_device_mesh.get_device(device_id).enable_async(False)
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)])
+@pytest.mark.parametrize(
+    "shape",
+    [(1, 3, 1024, 1024), (1, 1, 1024, 1024), (1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)],
+)
 @pytest.mark.parametrize("use_all_gather", [True, False])
 @pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 99328}], indirect=True)
 def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enable_async):
-    if use_all_gather:
-        # Currently all-gather tests pass only if blocking == False
-        if shape == (1, 1, 32, 32) or shape == (1, 3, 512, 512) or shape == (1, 3, 32, 32):
-            pytest.skip("This configuration is not working with all-gather")
-
+    torch.manual_seed(0)
     if pcie_device_mesh.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
 
@@ -129,7 +130,13 @@ def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enabl
         return single_dev_output
 
     def run_op_chain_1(input_0, input_1, weight):
-        single_dev_output = ttnn.tanh(ttnn.mul(ttnn.sub(input_0, input_1), weight))
+        single_dev_output = ttnn.tanh(ttnn.mul(ttnn.sub(input_0, input_1), weight)) @ ttnn.softmax(weight, dim=1)
+        if use_all_gather:
+            return ttnn.all_gather(single_dev_output, dim=0, num_links=1)
+        return single_dev_output
+
+    def run_op_chain_2(input_0, input_1, weight):
+        single_dev_output = ttnn.neg(ttnn.mul(input_0, input_1)) @ ttnn.gelu(weight)
         if use_all_gather:
             return ttnn.all_gather(single_dev_output, dim=0, num_links=1)
         return single_dev_output
@@ -137,22 +144,30 @@ def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enabl
     # Compile program binaries
     run_op_chain(input_0_dev, input_1_dev, weight_dev)
     run_op_chain_1(input_0_dev, input_1_dev, weight_dev)
+    run_op_chain_2(input_0_dev, input_1_dev, weight_dev)
 
     # Capture Trace 0
     logger.info("Capture Trace 0")
-    tid = ttnn.begin_trace_capture(pcie_device_mesh, trace_buffer_size=106496, cq_id=0)
+    tid = ttnn.begin_trace_capture(pcie_device_mesh, cq_id=0)
     output_tensor = run_op_chain(input_0_dev, input_1_dev, weight_dev)
     ttnn.end_trace_capture(pcie_device_mesh, tid, cq_id=0)
 
     # Capture Trace 1
     logger.info("Capture Trace 1")
-    tid_1 = ttnn.begin_trace_capture(pcie_device_mesh, trace_buffer_size=26624, cq_id=0)
+    tid_1 = ttnn.begin_trace_capture(pcie_device_mesh, cq_id=0)
     output_tensor_1 = run_op_chain_1(input_0_dev, input_1_dev, weight_dev)
     ttnn.end_trace_capture(pcie_device_mesh, tid_1, cq_id=0)
 
+    # Capture Trace 1
+    logger.info("Capture Trace 2")
+    tid_2 = ttnn.begin_trace_capture(pcie_device_mesh, cq_id=0)
+    output_tensor_2 = run_op_chain_2(input_0_dev, input_1_dev, weight_dev)
+    ttnn.end_trace_capture(pcie_device_mesh, tid_2, cq_id=0)
+
     # Execute and verify trace against pytorch
     torch_silu = torch.nn.SiLU()
-    for i in range(50):
+    torch_softmax = torch.nn.Softmax(dim=1)
+    for i in range(15):
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
             (pcie_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -171,7 +186,11 @@ def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enabl
 
         torch_output_golden_1 = torch.tanh(
             torch.mul(torch.sub(torch_input_tensor_0, torch_input_tensor_1), torch_weight)
-        )
+        ) @ torch_softmax(torch_weight)
+
+        torch_output_golden_2 = torch.neg(
+            torch.mul(torch_input_tensor_0, torch_input_tensor_1)
+        ) @ torch.nn.functional.gelu(torch_weight)
 
         # Convert torch tensors to TTNN Multi-Device Host Tensors
         ttnn_input_tensor_0 = ttnn.from_torch(
@@ -190,39 +209,53 @@ def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enabl
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev)
         ttnn.copy_host_to_device_tensor(ttnn_weight, weight_dev)
 
-        logger.info("Execute Trace 0")
         # Execute trace
+        logger.info("Execute Trace 0")
         ttnn.execute_trace(pcie_device_mesh, tid, cq_id=0, blocking=False)
         logger.info("Execute Trace 1")
         ttnn.execute_trace(pcie_device_mesh, tid_1, cq_id=0, blocking=False)
+        logger.info("Execute Trace 2")
+        ttnn.execute_trace(pcie_device_mesh, tid_2, cq_id=0, blocking=False)
         if use_all_gather:
             # Device All-Gather: Iterate through tensors on all devices. Ensure they match the full tensor
             logger.info("Read Back Trace 0 Outputs")
             device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(output_tensor)
             for device_tensor in device_tensors:
                 device_tensor_torch = ttnn.to_torch(device_tensor)
-                assert_with_pcc(device_tensor_torch, torch_output_golden, pcc=0.99)
+                assert_with_pcc(device_tensor_torch, torch_output_golden, pcc=0.96)
 
             logger.info("Read Back Trace 1 Outputs")
             device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(output_tensor_1)
             for device_tensor in device_tensors:
                 device_tensor_torch = ttnn.to_torch(device_tensor)
-                assert_with_pcc(device_tensor_torch, torch_output_golden_1, pcc=0.99)
+                assert_with_pcc(device_tensor_torch, torch_output_golden_1, pcc=0.96)
+
+            logger.info("Read Back Trace 2 Outputs")
+            device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(output_tensor_2)
+            for device_tensor in device_tensors:
+                device_tensor_torch = ttnn.to_torch(device_tensor)
+                assert_with_pcc(device_tensor_torch, torch_output_golden_2, pcc=0.0)
         else:
             # Perform host All-Gather
             ttnn_torch_output_tensor = ttnn.to_torch(
                 output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
             )
-            assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.99)
+            assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.96)
 
             ttnn_torch_output_tensor = ttnn.to_torch(
                 output_tensor_1, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
             )
-            assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden_1, pcc=0.99)
+            assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden_1, pcc=0.96)
+
+            ttnn_torch_output_tensor = ttnn.to_torch(
+                output_tensor_2, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+            )
+            assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden_2, pcc=0.96)
 
     # Release trace buffer once workload is complete
     ttnn.release_trace(pcie_device_mesh, tid)
     ttnn.release_trace(pcie_device_mesh, tid_1)
+    ttnn.release_trace(pcie_device_mesh, tid_2)
 
     for device_id in pcie_device_mesh.get_device_ids():
         pcie_device_mesh.get_device(device_id).enable_async(False)

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -30,10 +30,11 @@ void DeviceModule(py::module &m_device) {
     auto pyDevice = py::class_<Device, std::unique_ptr<Device, py::nodelete>>(m_device, "Device", "Class describing a Tenstorrent accelerator device.");
     pyDevice
         .def(
-            py::init<>([](int device_id, size_t l1_small_size) { return CreateDevice(device_id, 1, l1_small_size); }),
+            py::init<>([](int device_id, size_t l1_small_size, size_t trace_region_size) { return Device(device_id, 1, l1_small_size, trace_region_size); }),
             "Create device.",
             py::arg("device_id"),
-            py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE)
+            py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE,
+            py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE)
         .def("id", &Device::id, "Device's ID")
         .def("arch", &Device::arch, "Device's arch")
         .def(
@@ -76,7 +77,7 @@ void DeviceModule(py::module &m_device) {
         )doc");
     m_device.def(
         "CreateDevice",
-        [](int device_id, uint8_t num_hw_cqs, size_t l1_small_size) { return CreateDevice(device_id, num_hw_cqs, l1_small_size); },
+        [](int device_id, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size) { return CreateDevice(device_id, num_hw_cqs, l1_small_size, trace_region_size); },
         R"doc(
         Creates an instance of TT device.
 
@@ -88,11 +89,12 @@ void DeviceModule(py::module &m_device) {
     )doc",
         py::arg("device_id"),
         py::arg("num_hw_cqs") = 1,
-        py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE);
+        py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE,
+        py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE);
     m_device.def(
         "CreateDevices",
-        [](std::vector<int> device_ids, uint8_t num_hw_cqs, size_t l1_small_size) {
-            return tt::tt_metal::detail::CreateDevices(device_ids, num_hw_cqs, l1_small_size);
+        [](std::vector<int> device_ids, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size) {
+            return tt::tt_metal::detail::CreateDevices(device_ids, num_hw_cqs, l1_small_size, trace_region_size);
         },
         R"doc(
         Creates an instance of TT device.
@@ -105,7 +107,8 @@ void DeviceModule(py::module &m_device) {
     )doc",
         py::arg("device_ids"),
         py::arg("num_hw_cqs") = 1,
-        py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE);
+        py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE,
+        py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE);
     m_device.def("CloseDevice", &CloseDevice, R"doc(
         Reset an instance of TT accelerator device to default state and relinquish connection to device.
 
@@ -212,10 +215,10 @@ void DeviceModule(py::module &m_device) {
         Deallocate all buffers associated with Device handle
     )doc");
     m_device.def("BeginTraceCapture",
-        [] (Device* device, const uint8_t cq_id, const uint32_t trace_buff_size) {
+        [] (Device* device, const uint8_t cq_id) {
             uint32_t tid = Trace::next_id();
-            device->push_work([device, cq_id, tid, trace_buff_size] () mutable {
-                device->begin_trace(cq_id, tid, trace_buff_size);
+            device->push_work([device, cq_id, tid] () mutable {
+                device->begin_trace(cq_id, tid);
             });
             return tid;
         }, R"doc(
@@ -276,6 +279,7 @@ void DeviceModule(py::module &m_device) {
     )doc");
 
     m_device.attr("DEFAULT_L1_SMALL_SIZE") = py::int_(DEFAULT_L1_SMALL_SIZE);
+    m_device.attr("DEFAULT_TRACE_REGION_SIZE") = py::int_(DEFAULT_TRACE_REGION_SIZE);
 }
 
 void ProfilerModule(py::module &m_profiler) {

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -45,6 +45,7 @@ namespace tt::tt_metal{
             std::vector<chip_id_t> device_ids,
             const uint8_t num_hw_cqs = 1,
             const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+            const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
             const std::vector<uint32_t> &l1_bank_remap = {});
 
         void CloseDevices(std::map<chip_id_t, Device *> devices);

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -68,6 +68,7 @@ Device *CreateDevice(
     chip_id_t device_id,
     const uint8_t num_hw_cqs = 1,
     const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
+    const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
     const std::vector<uint32_t> &l1_bank_remap = {});
 
 /**
@@ -461,9 +462,8 @@ void Finish(CommandQueue& cq);
  * |-----------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
  * | device          | The device holding being traced.                                       | Device *                      |                                    | Yes      |
  * | cq_id           | The command queue id associated with the trace.                        | uint8_t                       |                                    | Yes      |
- * | trace_buff_size | The size of the trace buffer to pre-allocate.                          | uint32_t                      |                                    | Yes      |
 */
-uint32_t BeginTraceCapture(Device *device, const uint8_t cq_id, const uint32_t trace_buff_size);
+uint32_t BeginTraceCapture(Device *device, const uint8_t cq_id);
 
 /**
  * Completes capture on a trace, if captured commands do not conform to the rules of the trace, the trace will be invalidated.

--- a/tt_metal/hostdevcommon/common_values.hpp
+++ b/tt_metal/hostdevcommon/common_values.hpp
@@ -17,6 +17,7 @@ constexpr static std::uint32_t NOTIFY_HOST_KERNEL_COMPLETE_VALUE = 512;
 // DRAM_buffer_addr % 32 == L1_buffer_addr % 32 == 0
 constexpr static std::uint32_t ADDRESS_ALIGNMENT = 32;
 constexpr static std::size_t DEFAULT_L1_SMALL_SIZE = 0;  //(1 << 15);  // 32KB
+constexpr static std::size_t DEFAULT_TRACE_REGION_SIZE = 0;
 
 // Number of entries for each core/shard in dispatch command
 constexpr static std::uint32_t NUM_ENTRIES_PER_SHARD = 3;    //per shard/core 3 entries (uint32_t each)

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -117,7 +117,7 @@ struct Allocator {
     allocator::BankManager dram_manager;
     allocator::BankManager l1_manager;
     allocator::BankManager l1_small_manager;
-
+    allocator::BankManager trace_buffer_manager;
     // TODO: Track lowest l1 addresses!
 
     std::unordered_map<uint32_t, uint32_t> bank_id_to_dram_channel;

--- a/tt_metal/impl/allocator/allocator_types.hpp
+++ b/tt_metal/impl/allocator/allocator_types.hpp
@@ -41,6 +41,7 @@ struct AllocatorConfig {
     size_t worker_l1_size = 0;
     size_t l1_bank_size = 0;
     size_t l1_small_size = 0;
+    size_t trace_region_size = 0;
     std::unordered_map<CoreCoord, AllocCoreType> core_type_from_noc_coord_table = {};
     std::unordered_map<int, int> worker_log_to_physical_routing_x = {};
     std::unordered_map<int, int> worker_log_to_physical_routing_y = {};

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -248,7 +248,7 @@ Buffer &Buffer::operator=(Buffer &&other) {
 
 void Buffer::allocate() {
     TT_ASSERT(this->device_ != nullptr);
-    // L1 buffers are allocated top down!
+    // L1 and Trace buffers (which live in DRAM) are allocated top down!
     bool bottom_up = this->buffer_type_ == BufferType::DRAM;
     detail::AllocateBuffer(this, bottom_up);
     detail::BUFFER_MAP.insert({this->device_->id(), this->address_}, this);
@@ -266,7 +266,8 @@ CoreCoord Buffer::logical_core_from_bank_id(uint32_t bank_id) const {
 
 CoreCoord Buffer::noc_coordinates(uint32_t bank_id) const {
     switch (this->buffer_type_) {
-        case BufferType::DRAM: {
+        case BufferType::DRAM:
+        case BufferType::TRACE: {
             auto dram_channel = this->dram_channel_from_bank_id(bank_id);
             return this->device_->dram_core_from_dram_channel(dram_channel);
         }

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -29,6 +29,7 @@ enum class BufferType {
     L1,
     SYSTEM_MEMORY,
     L1_SMALL,
+    TRACE,
 };
 
 enum class TensorMemoryLayout {
@@ -206,7 +207,8 @@ class Buffer {
     }
 
     bool is_l1() const { return buffer_type() == BufferType::L1 or buffer_type() == BufferType::L1_SMALL; }
-    bool is_dram() const { return buffer_type() == BufferType::DRAM; }
+    bool is_dram() const { return buffer_type() == BufferType::DRAM || buffer_type() == BufferType::TRACE; }
+    bool is_trace() const { return buffer_type() == BufferType::TRACE; }
 
     TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
 

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -57,6 +57,7 @@ class Device {
         chip_id_t device_id,
         const uint8_t num_hw_cqs,
         std::size_t l1_small_size,
+        std::size_t trace_region_size,
         const std::vector<uint32_t> &l1_bank_remap = {},
         bool minimal = false,
         uint32_t worker_core = 0);
@@ -197,7 +198,7 @@ class Device {
     CommandQueue& command_queue(size_t cq_id = 0);
 
     // Metal trace device capture mode
-    void begin_trace(const uint8_t cq_id, const uint32_t tid, const uint32_t trace_buff_size);
+    void begin_trace(const uint8_t cq_id, const uint32_t tid);
     void end_trace(const uint8_t cq_id, const uint32_t tid);
     void replay_trace(const uint8_t cq_id, const uint32_t tid, const bool blocking);
     void release_trace(const uint32_t tid);
@@ -208,9 +209,9 @@ class Device {
 
     // Checks that the given arch is on the given pci_slot and that it's responding
     // Puts device into reset
-    bool initialize(const uint8_t num_hw_cqs, size_t l1_small_size, const std::vector<uint32_t> &l1_bank_remap = {}, bool minimal = false);
+    bool initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap = {}, bool minimal = false);
     void initialize_cluster();
-    void initialize_allocator(size_t l1_small_size, const std::vector<uint32_t> &l1_bank_remap = {});
+    void initialize_allocator(size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap = {});
     void initialize_build();
     void build_firmware();
     void initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg);
@@ -297,7 +298,7 @@ class Device {
         return (std::hash<std::thread::id>{}(std::this_thread::get_id()) == this->work_executor.get_parent_thread_id())
                 or get_worker_mode() == WorkExecutorMode::SYNCHRONOUS;
     }
-
+   uint32_t trace_buffers_size = 0;
    private:
     std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
 };

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -27,15 +27,16 @@ class DevicePool {
         std::vector<chip_id_t> device_ids,
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
+        size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         const std::vector<uint32_t> &l1_bank_remap = {},
         bool skip_remote_devices = false) noexcept {
         log_debug(tt::LogMetal, "DevicePool initialize");
         if (_inst == nullptr) {
-            static DevicePool device_pool(device_ids, num_hw_cqs, l1_small_size, l1_bank_remap, skip_remote_devices);
+            static DevicePool device_pool(device_ids, num_hw_cqs, l1_small_size, trace_region_size, l1_bank_remap, skip_remote_devices);
             _inst = &device_pool;
             _inst->init_firmware_on_active_devices();
         } else {
-            _inst->add_devices_to_pool(device_ids, num_hw_cqs, l1_small_size, l1_bank_remap, skip_remote_devices);
+            _inst->add_devices_to_pool(device_ids, num_hw_cqs, l1_small_size, trace_region_size, l1_bank_remap, skip_remote_devices);
             _inst->init_firmware_on_active_devices();
         }
     }
@@ -51,10 +52,12 @@ class DevicePool {
         std::vector<chip_id_t> device_ids,
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
+        size_t trace_region_size,
         const std::vector<uint32_t> &l1_bank_remap,
         bool skip_remote_devices);
     uint8_t num_hw_cqs;
     size_t l1_small_size;
+    size_t trace_region_size;
     std::vector<uint32_t> l1_bank_remap;
     std::mutex lock;
     std::vector<std::unique_ptr<Device>> devices;
@@ -70,6 +73,7 @@ class DevicePool {
         std::vector<chip_id_t> device_ids,
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
+        size_t trace_region_size,
         const std::vector<uint32_t> &l1_bank_remap,
         bool skip_remote_devices);
     static DevicePool *_inst;

--- a/tt_metal/impl/device/multi_device.cpp
+++ b/tt_metal/impl/device/multi_device.cpp
@@ -14,7 +14,7 @@ namespace ttnn {
 namespace multi_device {
 
 
-DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids, size_t l1_small_size)
+DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size)
     : device_grid(device_grid)
 {
     auto [num_rows, num_cols] = device_grid;
@@ -42,7 +42,7 @@ DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_id
     } else {
         mmio_device_ids = device_ids;
     }
-    managed_devices = tt::tt_metal::detail::CreateDevices(mmio_device_ids, 1, l1_small_size);
+    managed_devices = tt::tt_metal::detail::CreateDevices(mmio_device_ids, 1, l1_small_size, trace_region_size);
     if (is_galaxy) {
         DeviceIds galaxy_device_ids;
         for (const auto &[dev_id, dev]: managed_devices) {

--- a/tt_metal/impl/device/multi_device.hpp
+++ b/tt_metal/impl/device/multi_device.hpp
@@ -24,7 +24,7 @@ public:
     std::map<chip_id_t, Device *> managed_devices;
     std::vector<std::pair<int, Device *>> mesh_devices;
 
-    DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size);
+    DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size);
     ~DeviceMesh();
 
     DeviceMesh(const DeviceMesh &) = delete;

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -74,7 +74,7 @@ EnqueueReadBufferCommand::EnqueueReadBufferCommand(
 void EnqueueReadInterleavedBufferCommand::add_prefetch_relay(HugepageDeviceCommand& command) {
     uint32_t padded_page_size = align(this->buffer.page_size(), ADDRESS_ALIGNMENT);
     command.add_prefetch_relay_paged(
-        this->buffer.buffer_type() == BufferType::DRAM,
+        this->buffer.is_dram(),
         this->src_page_index,
         this->buffer.address(),
         padded_page_size,
@@ -151,7 +151,7 @@ EnqueueWriteBufferCommand::EnqueueWriteBufferCommand(
 }
 
 void EnqueueWriteInterleavedBufferCommand::add_dispatch_write(HugepageDeviceCommand& command_sequence) {
-    uint8_t is_dram = uint8_t(this->buffer.buffer_type() == BufferType::DRAM);
+    uint8_t is_dram = uint8_t(this->buffer.is_dram());
     TT_ASSERT(
         this->dst_page_index <= 0xFFFF,
         "Page offset needs to fit within range of uint16_t, bank_base_address was computed incorrectly!");
@@ -1351,7 +1351,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
                 num_total_pages -= num_pages_to_read;
             }
             uint32_t bank_base_address = buffer.address();
-            if (buffer.buffer_type() == BufferType::DRAM) {
+            if (buffer.is_dram()) {
                 bank_base_address += buffer.device()->bank_offset(
                     BufferType::DRAM, buffer.device()->dram_channel_from_logical_core(cores[core_id]));
             }
@@ -1517,7 +1517,7 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
             }
             uint32_t curr_page_idx_in_shard = 0;
             uint32_t bank_base_address = buffer.address();
-            if (buffer.buffer_type() == BufferType::DRAM) {
+            if (buffer.is_dram()) {
                 bank_base_address += buffer.device()->bank_offset(
                     BufferType::DRAM, buffer.device()->dram_channel_from_logical_core(cores[core_id]));
             }

--- a/tt_metal/impl/trace/trace.hpp
+++ b/tt_metal/impl/trace/trace.hpp
@@ -28,8 +28,7 @@ class Trace {
     // Thread-safe accessors to manage trace instances
     static void validate_instance(const TraceBuffer& trace_buffer);
     static void initialize_buffer(CommandQueue& cq, std::shared_ptr<TraceBuffer> trace_buffer);
-    static std::shared_ptr<TraceBuffer> create_trace_buffer(
-        const CommandQueue& cq, shared_ptr<detail::TraceDescriptor> desc, uint32_t unpadded_size);
+    static std::shared_ptr<TraceBuffer> create_empty_trace_buffer();
 };
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/pybind11/device.hpp
+++ b/ttnn/cpp/pybind11/device.hpp
@@ -20,6 +20,7 @@ void py_module(py::module& module) {
         py::kw_only(),
         py::arg("device_id"),
         py::arg("l1_small_size"),
+        py::arg("trace_region_size"),
         py::return_value_policy::reference);
 
     module.def("close_device", &ttnn::close_device, py::arg("device"), py::kw_only());

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -19,11 +19,12 @@ namespace multi_device {
 void py_module(py::module& module) {
     py::class_<DeviceMesh>(module, "DeviceMesh")
         .def(
-            py::init<DeviceGrid, std::vector<int>, size_t>(),
+            py::init<DeviceGrid, std::vector<int>, size_t, size_t>(),
             py::kw_only(),
             py::arg("device_grid"),
             py::arg("device_ids"),
-            py::arg("l1_small_size"))
+            py::arg("l1_small_size"),
+            py::arg("trace_region_size"))
         .def("get_device", &ttnn::multi_device::DeviceMesh::get_device, py::return_value_policy::reference)
         .def("get_num_devices", &ttnn::multi_device::DeviceMesh::num_devices)
         .def("get_device_ids", &ttnn::multi_device::DeviceMesh::get_device_ids)
@@ -40,7 +41,8 @@ void py_module(py::module& module) {
         py::kw_only(),
         py::arg("device_grid"),
         py::arg("device_ids"),
-        py::arg("l1_small_size"));
+        py::arg("l1_small_size"),
+        py::arg("trace_region_size"));
 
     module.def("close_device_mesh", &close_device_mesh, py::arg("device_mesh"), py::kw_only());
     module.def(

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -176,10 +176,9 @@ void py_module(py::module& module) {
 
     module.def(
         "begin_trace_capture",
-        py::overload_cast<Device*, const uint32_t, const uint8_t>(&ttnn::operations::core::begin_trace_capture),
+        py::overload_cast<Device*, const uint8_t>(&ttnn::operations::core::begin_trace_capture),
         py::arg("device"),
         py::kw_only(),
-        py::arg("trace_buffer_size"),
         py::arg("cq_id") = 0);
 
     module.def(
@@ -207,10 +206,9 @@ void py_module(py::module& module) {
 
     module.def(
         "begin_trace_capture",
-        py::overload_cast<DeviceMesh*, const uint32_t, const uint8_t>(&ttnn::operations::core::begin_trace_capture),
+        py::overload_cast<DeviceMesh*, const uint8_t>(&ttnn::operations::core::begin_trace_capture),
         py::arg("device_mesh"),
         py::kw_only(),
-        py::arg("trace_buffer_size"),
         py::arg("cq_id") = 0);
 
     module.def(

--- a/ttnn/cpp/ttnn/device.cpp
+++ b/ttnn/cpp/ttnn/device.cpp
@@ -8,8 +8,8 @@ namespace ttnn {
 
 namespace device {
 
-Device &open_device(int device_id, size_t l1_small_size) {
-    tt::DevicePool::initialize({device_id}, 1, l1_small_size);
+Device &open_device(int device_id, size_t l1_small_size, size_t trace_region_size) {
+    tt::DevicePool::initialize({device_id}, 1, l1_small_size, trace_region_size);
     return *(tt::DevicePool::instance().get_active_device(device_id));
 }
 

--- a/ttnn/cpp/ttnn/device.hpp
+++ b/ttnn/cpp/ttnn/device.hpp
@@ -12,7 +12,7 @@ namespace device {
 
 using Device = ttnn::Device;
 
-Device &open_device(int device_id, size_t l1_small_size = DEFAULT_L1_SMALL_SIZE);
+Device &open_device(int device_id, size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
 void close_device(Device &device);
 void enable_program_cache(Device &device);
 void disable_and_clear_program_cache(Device &device);

--- a/ttnn/cpp/ttnn/multi_device.hpp
+++ b/ttnn/cpp/ttnn/multi_device.hpp
@@ -20,8 +20,8 @@ using DeviceGrid = std::pair<int, int>;
 using DeviceIds = std::vector<int>;
 
 
-inline DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size) {
-    return DeviceMesh(device_grid, device_ids, l1_small_size);
+inline DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size) {
+    return DeviceMesh(device_grid, device_ids, l1_small_size, trace_region_size);
 }
 
 inline void close_device_mesh(DeviceMesh &multi_device) {

--- a/ttnn/cpp/ttnn/operations/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core.hpp
@@ -194,11 +194,11 @@ inline Tensor reallocate(const Tensor& input_tensor, const std::optional<MemoryC
 }
 
 // Trace APIs - Single Device
-inline uint32_t begin_trace_capture(Device* device, const uint32_t trace_buff_size, const uint8_t cq_id) {
+inline uint32_t begin_trace_capture(Device* device, const uint8_t cq_id) {
     uint32_t tid = Trace::next_id();
     device->push_work(
-        [device, trace_buff_size, cq_id, tid] () mutable {
-            device->begin_trace(cq_id, tid, trace_buff_size);
+        [device, cq_id, tid] () mutable {
+            device->begin_trace(cq_id, tid);
         });
     return tid;
 }
@@ -233,13 +233,13 @@ inline void release_trace(Device* device, const uint32_t tid) {
 }
 
 // Trace APIs - Multi Device
-inline uint32_t begin_trace_capture(DeviceMesh* device, const uint32_t trace_buff_size, const uint8_t cq_id = 0) {
+inline uint32_t begin_trace_capture(DeviceMesh* device, const uint8_t cq_id = 0) {
     auto workers = device->get_devices();
     uint32_t tid = Trace::next_id();
     for (auto& worker : workers) {
         worker->push_work(
-            [worker, trace_buff_size, cq_id, tid] () mutable {
-                worker->begin_trace(cq_id, tid, trace_buff_size);
+            [worker, cq_id, tid] () mutable {
+                worker->begin_trace(cq_id, tid);
             });
     }
     return tid;

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -21,13 +21,19 @@ Device = ttl.device.Device
 Device.core_grid = property(get_device_core_grid)
 
 
-def open_device(device_id: int, l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE):
+def open_device(
+    device_id: int,
+    l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE,
+    trace_region_size: int = ttl.device.DEFAULT_TRACE_REGION_SIZE,
+):
     """
     open_device(device_id: int) -> ttnn.Device:
 
     Open a device with the given device_id. If the device is already open, return the existing device.
     """
-    return ttnn._ttnn.device.open_device(device_id=device_id, l1_small_size=l1_small_size)
+    return ttnn._ttnn.device.open_device(
+        device_id=device_id, l1_small_size=l1_small_size, trace_region_size=trace_region_size
+    )
 
 
 def close_device(device):

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -34,7 +34,10 @@ def get_device_ids() -> List[int]:
 
 
 def open_device_mesh(
-    device_grid: ttnn.DeviceGrid, device_ids: List[int], l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE
+    device_grid: ttnn.DeviceGrid,
+    device_ids: List[int],
+    l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE,
+    trace_region_size: int = ttl.device.DEFAULT_TRACE_REGION_SIZE,
 ):
     """
     open_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: int) -> ttnn.DeviceMesh:
@@ -44,7 +47,10 @@ def open_device_mesh(
     assert len(device_ids) > 0
 
     return ttnn._ttnn.multi_device.DeviceMesh(
-        device_grid=device_grid.as_tuple(), device_ids=device_ids, l1_small_size=l1_small_size
+        device_grid=device_grid.as_tuple(),
+        device_ids=device_ids,
+        l1_small_size=l1_small_size,
+        trace_region_size=trace_region_size,
     )
 
 
@@ -59,14 +65,19 @@ def close_device_mesh(device_mesh):
 
 @contextlib.contextmanager
 def create_device_mesh(
-    device_grid: ttnn.DeviceGrid, device_ids: List[int], l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE
+    device_grid: ttnn.DeviceGrid,
+    device_ids: List[int],
+    l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE,
+    trace_region_size: int = ttl.device.DEFAULT_TRACE_REGION_SIZE,
 ):
     """
     create_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: List[int]) -> ttnn.DeviceMesh
 
     Context manager for opening and closing a device.
     """
-    device_mesh = open_device_mesh(device_grid=device_grid, device_ids=device_ids, l1_small_size=l1_small_size)
+    device_mesh = open_device_mesh(
+        device_grid=device_grid, device_ids=device_ids, l1_small_size=l1_small_size, trace_region_size=trace_region_size
+    )
     try:
         yield device_mesh
     finally:


### PR DESCRIPTION
  - Resolves trace buffer corruption for multi-trace, where the intermediates of a previously run trace can corrupt the buffer for the current trace