### PR TITLE
#9361: Install Clang-17 and gdb 14.2

### DIFF
--- a/dockerfile/ubuntu-20.04-amd64.Dockerfile
+++ b/dockerfile/ubuntu-20.04-amd64.Dockerfile
@@ -39,4 +39,19 @@ RUN python3 -m pip config set global.extra-index-url https://download.pytorch.or
 RUN python3 -m pip install -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt
 RUN python3 -m pip install -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
 
+# Install Clang-17
+RUN cd $TT_METAL_INFRA_DIR \
+    && wget https://apt.llvm.org/llvm.sh \
+    && chmod u+x llvm.sh \
+    && ./llvm.sh 17
+
+# Install compatible gdb debugger for clang-17
+RUN cd $TT_METAL_INFRA_DIR \
+    && wget https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz \
+    && tar -xvf gdb-14.2.tar.gz \
+    && cd gdb-14.2 \
+    && ./configure \
+    && make -j$(nproc)
+ENV PATH="$TT_METAL_INFRA_DIR/gdb-14.2/gdb:$PATH"
+
 CMD ["tail", "-f", "/dev/null"]

--- a/scripts/docker/requirements_dev.txt
+++ b/scripts/docker/requirements_dev.txt
@@ -4,3 +4,4 @@ acl
 jq
 openssh-server
 vim
+libmpfr-dev 


### PR DESCRIPTION
Installs Clang-17 and gdb14.2
gdb14.2 is added to PATH 

tested by compiling docker image and checking if gdb can be invoked by cli