### PR TITLE
#9258: Re-add wheel into release assets

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -105,9 +105,6 @@ jobs:
         with:
           name: changelog
       - name: Assert wheels exist
-        # Issue #3443 wants us to delete the wheel from the release assets.
-        # We are still committed to making this eventually work for proper
-        # releases to allow for easier installing for Python users.
         run: ls -arhl metal_libs-*+*.whl
       - name: Release
         # A major release has not been tagged yet, so we need to do this to avoid
@@ -122,4 +119,5 @@ jobs:
             VERSION
             CHANGELOG.txt
             infra/machine_setup/scripts/setup_hugepages.py
+            metal_libs-*+*.whl
           fail_on_unmatched_files: true


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9258

### Problem description

We want to run the now-working wheel back into release assets.

### What's changed

Release assets now has the wheel that we make in `eager-package-main`.

Users can now download from releases pages.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
