### PR TITLE
#9375: No inline for large profiling functions

### DIFF
--- a/docs/source/tt-metalium/tools/device_program_profiler.rst
+++ b/docs/source/tt-metalium/tools/device_program_profiler.rst
@@ -24,7 +24,6 @@ The commands to build and run the ``full_buffer`` example after following :ref:`
 
     cd $TT_METAL_HOME
     scripts/build_scripts/build_with_profiler_opt.sh
-    make programming_examples
     TT_METAL_DEVICE_PROFILER=1 ./build/programming_examples/profiler/test_full_buffer
 
 The generated csv is ``profile_log_device.csv`` and is saved under ``{$TT_METAL_HOME}/generated/profiler/.logs`` by default.

--- a/docs/source/tt-metalium/tools/tracy_profiler.rst
+++ b/docs/source/tt-metalium/tools/tracy_profiler.rst
@@ -53,8 +53,7 @@ Build with the ``ENABLE_TRACY=1`` flag is required for profiling with tracy.
 
 ..  code-block:: sh
 
-    make clean
-    make build ENABLE_TRACY=1
+    scripts/build_scripts/build_with_profiler_opt.sh
 
 With this build variant, all C++ marked zones will be profiled.
 

--- a/tests/scripts/test_moreh_microbenchmark.py
+++ b/tests/scripts/test_moreh_microbenchmark.py
@@ -560,8 +560,8 @@ def test_matmul_dram(arch, freq, r, c, test_vector):
     "arch, freq, test_vector, dtype, fidel, matmul_block, num_blocks, packer_l1_acc, fp32_dest_acc, interm_cb_dtype, subblock_index, baseline",
     [
         # ########################### 512 512 512 x 8 subblock 4 2 ################################
-        ("wormhole_b0", 1000, np.array([[512, 512, 512]]), 0, 0, 0, 8, 0, 0, 0, 0, 1661931.0),
-        ("wormhole_b0", 1000, np.array([[512, 512, 512]]), 0, 1, 0, 8, 0, 0, 0, 0, 1661960.0),
+        ("wormhole_b0", 1000, np.array([[512, 512, 512]]), 0, 0, 0, 8, 0, 0, 0, 0, 1718887.0),
+        ("wormhole_b0", 1000, np.array([[512, 512, 512]]), 0, 1, 0, 8, 0, 0, 0, 0, 1718906.0),
         ("wormhole_b0", 1000, np.array([[512, 512, 512]]), 0, 0, 1, 8, 0, 0, 0, 0, 717089.0),
         ("wormhole_b0", 1000, np.array([[512, 512, 512]]), 0, 1, 1, 8, 0, 0, 0, 0, 1233930.0),
         ("wormhole_b0", 1000, np.array([[512, 512, 512]]), 0, 0, 1, 8, 1, 0, 0, 0, 664492.0),


### PR DESCRIPTION
### Ticket
#9375 

### Problem description
WH remote chip runs with dispatch core profiling caused hangs

### What's changed
Not inlining large functions fixes the issue. These changes were planned to come in as cleanup regardless 

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/9472915458
- [x] Device perf regression https://github.com/tenstorrent/tt-metal/actions/runs/9472916969
- [x] uBenchmark https://github.com/tenstorrent/tt-metal/actions/runs/9472921685
- [x] T3K profiler regression https://github.com/tenstorrent/tt-metal/actions/runs/9472923028