### PR TITLE
#9224: skip tensor deallocate if device is closed

### DIFF
--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -107,6 +107,9 @@ void Tensor::deallocate(bool force) {
                         std::visit([](auto&& buffer) { buffer.reset(); }, storage.buffer);
                     }
                 } else if constexpr (std::is_same_v<T, DeviceStorage>) {
+                    if (this->workers.at(0) == nullptr or not this->workers.at(0)->is_initialized()) {
+                        return;
+                    }
                     if (this->workers.at(0)->in_main_thread() or not this->tensor_attributes->main_thread_tensor) {
                         if (not this->tensor_attributes->main_thread_tensor) {
                             TT_ASSERT(
@@ -172,6 +175,9 @@ void Tensor::deallocate(bool force) {
                         TT_THROW("Cannot deallocate tensor with borrowed storage!");
                     }
                 } else if constexpr (std::is_same_v<T, MultiDeviceStorage>) {
+                    if (this->workers.at(0) == nullptr or not this->workers.at(0)->is_initialized()) {
+                        return;
+                    }
                     if (this->workers.at(0)->in_main_thread() or not this->tensor_attributes->main_thread_tensor) {
                         // If owned by the main thread, deallocate this tensor only from the main thread. If owned by
                         // worker thread, allow deallocation in worker and use shared_ptr ref count, since this is a


### PR DESCRIPTION
### Ticket
- [Link to Github Issue.](https://github.com/tenstorrent/tt-metal/issues/9224)

### Problem description
- Some models have tensors going out of scope after device close,

### What's changed
 - added check to skip buffer deallocation if that is the case
 - fix segfaults related to Tensors on destructor

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
