### PR TITLE
#8682: Add binary mod support for WH_B0

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -411,6 +411,8 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.unary_remainder
 
+.. autofunction:: tt_lib.tensor.remainder
+
 .. autofunction:: tt_lib.tensor.atan
 
 .. autofunction:: tt_lib.tensor.atanh

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -500,6 +500,10 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_unary_remainder,
         "pytorch_op": pytorch_ops.unary_remainder,
     },
+    "eltwise-remainder": {
+        "tt_op": tt_lib_ops.eltwise_remainder,
+        "pytorch_op": pytorch_ops.remainder,
+    },
     "eltwise-unary_ne": {
         "tt_op": tt_lib_ops.eltwise_unary_ne,
         "pytorch_op": pytorch_ops.unary_ne,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_remainder.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_remainder.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import random
+from functools import partial
+import tt_lib as ttl
+
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+from models.utility_functions import skip_for_grayskull
+
+mem_configs = [
+    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+]
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [[1, 1, 32, 32], [1, 1, 32, 32]],
+        [[1, 1, 320, 384], [1, 1, 320, 384]],
+        [[1, 3, 320, 384], [1, 3, 320, 384]],
+    ],
+)
+@pytest.mark.parametrize(
+    "dst_mem_config",
+    mem_configs,
+)
+@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
+class TestRemainder:
+    def test_run_remainder_Binary(
+        self,
+        input_shapes,
+        dst_mem_config,
+        device,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ] + [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ]
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update({"output_mem_config": dst_mem_config})
+        comparison_func = comparison_funcs.comp_pcc
+
+        run_single_pytorch_test(
+            "eltwise-remainder",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -545,6 +545,11 @@ def unary_remainder(x, *args, **kwargs):
     return result
 
 
+def remainder(x, y, *args, **kwargs):
+    result = torch.remainder(x, y)
+    return result
+
+
 def unary_ne(x, *args, **kwargs):
     value = kwargs.pop("scalar")
     result = torch.ne(x, value)

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2576,6 +2576,7 @@ bmm = make_binary_op(ttl.tensor.bmm)
 
 eltwise_scatter = make_binary_op(ttl.tensor.scatter)
 eltwise_nextafter = make_binary_op(ttl.tensor.nextafter)
+eltwise_remainder = make_binary_op(ttl.tensor.remainder)
 eltwise_isfinite = make_unary_op(ttl.tensor.isfinite)
 eltwise_isinf = make_unary_op(ttl.tensor.isinf)
 eltwise_isposinf = make_unary_op(ttl.tensor.isposinf)

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -195,6 +195,11 @@ Tensor div_no_nan(
     float value,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+Tensor remainder(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 Tensor trunc(const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 Tensor round(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -1173,6 +1173,22 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+        m_tensor.def("remainder",&remainder,
+            py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs the element-wise modulus on two tensors ``input_a`` and ``input_b``.Support provided only for Wormhole_B0.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input_a", "Numerator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input_b", "Denominator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
         m_tensor.def("trunc",&trunc,
             py::arg("input").noconvert(),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
             Performs the element-wise trunc operation on ``input``. Support provided only for Wormhole_B0.


### PR DESCRIPTION
Issue #8682 [ #8680 ]
### Binary MOD support in WH_B0

**Details :** 

- Test File : `tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_remainder.py`
- Comparison : `comp_pcc`
- Working and Tested Range (for both inputs) : [ -100, 100 ]
- Implementation details : Used Typecast to avoid precision issues in bfloat16 datatype
- CI :

   - [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9597499069) - PASSED
   - [[post-commit] Fast Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9595337078) - PASSED
   - [[post-commit] Slow Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9595343882) - PASSED
  
